### PR TITLE
Fixed two issues where Clousot missed errors

### DIFF
--- a/Microsoft.Research/Analyzers/Arithmetic Analysis/ArithmeticObligations.cs
+++ b/Microsoft.Research/Analyzers/Arithmetic Analysis/ArithmeticObligations.cs
@@ -105,8 +105,9 @@ namespace Microsoft.Research.CodeAnalysis
               }
             }
           }
-
-          if (this.myOptions.DivOverflowObligations && op == BinaryOperator.Div)
+          
+          if (this.myOptions.DivOverflowObligations
+              && (op == BinaryOperator.Div || op == BinaryOperator.Rem))
           {
             var type = valueContext.GetType(methodContext.CFG.Post(pc), s1);
             if (type.IsNormal && mdDecoder.IsIntegerType(type.Value))

--- a/Microsoft.Research/RegressionTest/Basic/SimpleArrayAccesses/SimpleArrayAccesses.cs
+++ b/Microsoft.Research/RegressionTest/Basic/SimpleArrayAccesses/SimpleArrayAccesses.cs
@@ -166,6 +166,28 @@ namespace Bounds_Test
       bool[] b = new bool[l];     // here must be correct
       b[l - 1] = true;
     }
+
+    // Two errors
+    [ClousotRegressionTest]
+    [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"The length of the array may be negative (dimension 0)", PrimaryILOffset = 2, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"The length of the array may be negative (dimension 1)", PrimaryILOffset = 2, MethodILOffset = 0)]
+    bool[,] NewArray3(int n, int m)
+    {
+      bool[,] b = new bool[n, m];
+      return b;
+    }
+
+    // Two errors
+    [ClousotRegressionTest]
+    [RegressionOutcome(Outcome = ProofOutcome.False, Message = @"Cannot create an array of negative length (dimension 0)", PrimaryILOffset = 18, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.False, Message = @"Cannot create an array of negative length (dimension 1)", PrimaryILOffset = 18, MethodILOffset = 0)]
+    bool[,] NewArray4(int n, int m)
+    {
+      Contract.Requires(n < 0 && m < 0);
+
+      bool[,] b = new bool[n, m];
+      return b;
+    }
  }
 
   class DirectArrayAccessesWithUInts

--- a/Microsoft.Research/RegressionTest/Basic/TestArithmetics/TestArithmetic.cs
+++ b/Microsoft.Research/RegressionTest/Basic/TestArithmetics/TestArithmetic.cs
@@ -121,6 +121,7 @@ namespace TestArithmetics
 
     [ClousotRegressionTest]
     [RegressionOutcome(Outcome = ProofOutcome.Top, Message = "Possible division by zero", PrimaryILOffset = 3, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"Possible overflow in division (MinValue / -1)", PrimaryILOffset = 3, MethodILOffset = 0)]
     public int Rem_Wrong(int a, int b)
     {
       return a % b;
@@ -128,6 +129,7 @@ namespace TestArithmetics
 
     [ClousotRegressionTest]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = "Division by zero ok", PrimaryILOffset = 16, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"Possible overflow in division (MinValue / -1)", PrimaryILOffset = 16, MethodILOffset = 0)]
     public int Rem_OK(int a, int b)
     {
       Contract.Requires(b != 0);
@@ -685,6 +687,41 @@ namespace TestArithmetics
       Contract.Requires(!(x == Int32.MinValue && y == -1));
       return x /y; 
     }    
+  }
+
+  public class TestModOverflow
+  {
+    [ClousotRegressionTest]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 16, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"Possible overflow in division (MinValue / -1)", PrimaryILOffset = 16, MethodILOffset = 0)]
+    public static int Mod(int x, int y)
+    {
+      Contract.Requires(y != 0);
+
+      return x % y;
+    }
+
+    [ClousotRegressionTest]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 46, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 46, MethodILOffset = 0)]
+    public static int ModWithContracts(int x, int y)
+    {
+      Contract.Requires(x != Int32.MinValue);
+      Contract.Requires(y != -1);
+      Contract.Requires(y != 0);
+
+      return x % y;
+    }
+
+    [ClousotRegressionTest]
+    [RegressionOutcome(Outcome=ProofOutcome.True,Message=@"Division by zero ok",PrimaryILOffset=40,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.True,Message=@"No overflow",PrimaryILOffset=40,MethodILOffset=0)]
+    public static int ModWithWeakerContract(int x, int y)
+    {
+      Contract.Requires(y != 0);
+      Contract.Requires(!(x == Int32.MinValue && y == -1));
+      return x % y;
+    }
   }
 }
 

--- a/Microsoft.Research/RegressionTest/Basic/TestIntervals/IntervalsTest.cs
+++ b/Microsoft.Research/RegressionTest/Basic/TestIntervals/IntervalsTest.cs
@@ -115,6 +115,7 @@ namespace TestIntervals
     [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"ensures unproven: Contract.Result<int>() >= 0. The static checker determined that the condition '((i - 1) / 2) >= 0' should hold on entry. Nevertheless, the condition may be too strong for the callers. If you think it is ok, add a precondition to document it: Contract.Requires(((i - 1) / 2) >= 0);", PrimaryILOffset = 11, MethodILOffset = 30)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 23, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 29, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 18, MethodILOffset = 0)]
     public int Rem_Wrong(int i)
     {
       Contract.Ensures(Contract.Result<int>() >= 0);
@@ -133,6 +134,7 @@ namespace TestIntervals
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"ensures is valid", PrimaryILOffset = 23, MethodILOffset = 42)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 35, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 41, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 30, MethodILOffset = 0)]
     public int Rem_Ok(int i)
     {
       Contract.Requires(i >= 0);
@@ -147,6 +149,7 @@ namespace TestIntervals
     [ClousotRegressionTest]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 33, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"ensures unproven: Contract.Result<int>() > 0. Is it an off-by-one? The static checker can prove ((value % divisor)) > (0 - 1) instead", PrimaryILOffset = 26, MethodILOffset = 34)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 33, MethodILOffset = 0)]
     public int Rem_PosPos_Wrong(int value, int divisor)
     {
       Contract.Requires(value > 0);
@@ -160,6 +163,7 @@ namespace TestIntervals
     [ClousotRegressionTest]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 36, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"ensures is valid", PrimaryILOffset = 29, MethodILOffset = 37)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 36, MethodILOffset = 0)]
     public int Rem_PosPos_Ok(int value, int divisor)
     {
       Contract.Requires(value > 0);
@@ -173,6 +177,7 @@ namespace TestIntervals
     [ClousotRegressionTest]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 33, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.Top, Message = @"ensures unproven: Contract.Result<int>() < 0", PrimaryILOffset = 26, MethodILOffset = 34)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 33, MethodILOffset = 0)]
     public int Rem_NegPos_Wrong(int value, int divisor)
     {
       Contract.Requires(value < 0);
@@ -186,6 +191,7 @@ namespace TestIntervals
     [ClousotRegressionTest]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 36, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"ensures is valid", PrimaryILOffset = 29, MethodILOffset = 37)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 36, MethodILOffset = 0)]
     public int Rem_NegPos_Ok(int value, int divisor)
     {
       Contract.Requires(value < 0);
@@ -816,6 +822,7 @@ namespace Multiplication
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = "Division by zero ok", PrimaryILOffset = 38, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = "Division by zero ok", PrimaryILOffset = 51, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 51, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 38, MethodILOffset = 0)]
     public static long Exp_Reflector(long x, long y)
     {
       Contract.Requires(y >= 0L);
@@ -848,6 +855,7 @@ namespace Multiplication
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = "Division by zero ok", PrimaryILOffset = 38, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = "Division by zero ok", PrimaryILOffset = 51, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 51, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 38, MethodILOffset = 0)]
     public static long Exp(long x, long y)
     {
       Contract.Requires(y >= 0);
@@ -882,7 +890,9 @@ namespace Rational
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 47, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"ensures is valid", PrimaryILOffset = 26, MethodILOffset = 44)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"ensures is valid", PrimaryILOffset = 26, MethodILOffset = 54)]
-     private static int GCD(int x, int y)
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 47, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 37, MethodILOffset = 0)]
+    private static int GCD(int x, int y)
     {
       Contract.Requires(x > 0);
       Contract.Requires(y > 0);
@@ -1283,6 +1293,7 @@ namespace BugFromCloudDev
 	[ClousotRegressionTest]
 	[RegressionOutcome(Outcome=ProofOutcome.True,Message="Division by zero ok",PrimaryILOffset=12,MethodILOffset=0)]
 	[RegressionOutcome(Outcome=ProofOutcome.False,Message="assert is false",PrimaryILOffset=18,MethodILOffset=0)]
+    [RegressionOutcome(Outcome=ProofOutcome.True,Message=@"No overflow",PrimaryILOffset=12,MethodILOffset=0)]
     public void UnreachedWithLongRem()
     {
       if ((m_totalMessages % 10000) == 0)

--- a/Microsoft.Research/RegressionTest/Basic/TestNumericalDisequalities/SimpleBranching.cs
+++ b/Microsoft.Research/RegressionTest/Basic/TestNumericalDisequalities/SimpleBranching.cs
@@ -169,6 +169,7 @@ namespace BugRepro
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"Division by zero ok", PrimaryILOffset = 36, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"assert is valid", PrimaryILOffset = 20, MethodILOffset = 0)]
     [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 36, MethodILOffset = 0)]
+    [RegressionOutcome(Outcome = ProofOutcome.True, Message = @"No overflow", PrimaryILOffset = 11, MethodILOffset = 0)]
     private static int GetDefaultChunkSize<TSource>()
     {      
       // This test is here because it was a bug in the SimpleDisequalities AD

--- a/Microsoft.Research/RegressionTest/Inference/Preconditions-Backwards.cs
+++ b/Microsoft.Research/RegressionTest/Inference/Preconditions-Backwards.cs
@@ -951,6 +951,8 @@ namespace UserRepro
    {
      [ClousotRegressionTest]
      [RegressionOutcome("Contract.Requires(((a % b) == 0 || a != 0));")]
+     [RegressionOutcome("Contract.Requires((a != Int32.MinValue || b != -1));")]
+     [RegressionOutcome("Contract.Requires(((a % b) == 0 || (b != Int32.MinValue || a != -1)));")]
      private static bool AreBothWaysDivisibleBy2(int a, int b)
      {
        Contract.Requires(b != 0);

--- a/Microsoft.Research/RegressionTest/TestFrameworkOOB/UserFeedback.cs
+++ b/Microsoft.Research/RegressionTest/TestFrameworkOOB/UserFeedback.cs
@@ -1917,6 +1917,8 @@ namespace TestFrameworkOOB.Properties
         [RegressionOutcome(Outcome=ProofOutcome.Top,Message="assert unproven",PrimaryILOffset=163,MethodILOffset=0)]
         [RegressionOutcome(Outcome=ProofOutcome.Top,Message="assert unproven",PrimaryILOffset=184,MethodILOffset=0)]
         [RegressionOutcome(Outcome=ProofOutcome.True,Message=@"No overflow (caused by a negative array size)",PrimaryILOffset=3,MethodILOffset=0)]
+        [RegressionOutcome(Outcome=ProofOutcome.True,Message="Array creation : ok (dimension 0)",PrimaryILOffset=108,MethodILOffset=0)]
+        [RegressionOutcome(Outcome=ProofOutcome.True,Message="Array creation : ok (dimension 1)",PrimaryILOffset=108,MethodILOffset=0)]
         static PropertyState()
         {
             s_allStates = new[]


### PR DESCRIPTION
This adds two additional checks:
1) Check for overflow in modulo operations (MinValue % -1).
2) Check that the sizes of a multidimensional array are non-negative on creation.