### PR TITLE
Fix for issue #42

### DIFF
--- a/Microsoft.Research/Contracts/Microsoft.VisualBasic.Contracts/Microsoft.VisualBasic10.vbproj
+++ b/Microsoft.Research/Contracts/Microsoft.VisualBasic.Contracts/Microsoft.VisualBasic10.vbproj
@@ -14,7 +14,7 @@
     <AssemblyName>Microsoft.VisualBasic</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <CodeContractsReferenceAssembly>Build</CodeContractsReferenceAssembly>
-    <MyType>Windows</MyType>
+    <MyType>Empty</MyType>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
MyType Empty is a type which should be used to disable My namespace in VB assemblies.
This fixes issue #42 and along with other pull requests enables compilation under VS2015.