### PR TITLE
Removed invalid preconditions for System.NetSockets.Socket.SetSocketOption(SocketOptionLevel, SocketOptionName, object)

### DIFF
--- a/Microsoft.Research/Contracts/System/System.Net.Sockets.Socket.cs
+++ b/Microsoft.Research/Contracts/System/System.Net.Sockets.Socket.cs
@@ -313,9 +313,6 @@ namespace System.Net.Sockets
     public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, object optionValue)
     {
       Contract.Requires(optionValue != null);
-      Contract.Requires((int)optionLevel == 41);
-      Contract.Requires((int)optionName == 12 || (int)optionName == 13);
-
     }
     public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Byte[] optionValue)
     {


### PR DESCRIPTION
Requirements for SocketOptionLevel and SocketOptionName parameters are too compilated to be included in contracts. At least for now.
Resolves issue #11.