### PR TITLE
Possible fix for issue #51

### DIFF
--- a/Foxtrot/Foxtrot/Extractor.cs
+++ b/Foxtrot/Foxtrot/Extractor.cs
@@ -2504,7 +2504,7 @@ namespace Microsoft.Contracts.Foxtrot {
     ///       - assignment to state
     ///       - unconditional branch
     ///       
-    /// Wrinkle: in Rosly, the initial async state is also 0, not -1.
+    /// Wrinkle: in Roslyn, the initial async state is also -1.
     /// The context uses the linker version to determine if this assembly was Roslyn generated.
     /// 
     /// Another wrinkle is async methods that are not really async and C# still emits a closure etc, but
@@ -2830,7 +2830,7 @@ namespace Microsoft.Contracts.Foxtrot {
             return Pair.For(0, EvalKind.IsDisposingTest);
           }
           if (name.Contains("<>") && name.Contains("__state")) {
-            var initialState = isAsync && !isRoslyn ? -1 : 0;
+            var initialState = isAsync ? -1 : 0;
             return Pair.For(initialState, EvalKind.IsStateValue);
           }
         }


### PR DESCRIPTION
According to the Roslyn sources ([here](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineStates.cs) and [here](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs#L173)) the initial state of a state machine that Roslyn creates for an async method is -1. Code Contracts assumes that for Roslyn, the initial state is 0 and thus fails in rewriting async methods compiled by Roslyn. See #51 for more details.