### PR TITLE
Fixed usage of deafult(T) in contract abbreviators.

### DIFF
--- a/Foxtrot/Foxtrot/Checker.cs
+++ b/Foxtrot/Foxtrot/Checker.cs
@@ -1870,7 +1870,7 @@ namespace Microsoft.Contracts.Foxtrot {
           {
             // F: no idea why this is != null
             Contract.Assume(assignment.Target.Type != null);
-            if (ue.Operand is Local && (assignment.Target.Type.IsPrimitive || assignment.Target.Type is Struct || assignment.Target.Type.IsStructural))
+            if (ue.Operand is Local && (assignment.Target.Type.IsPrimitive || assignment.Target.Type.IsStructural || assignment.Target.Type.IsTypeArgument || assignment.Target.Type is Struct || assignment.Target.Type is EnumNode))
             {
               targetIsLocal = true;
             }

--- a/System.Compiler/Nodes.cs
+++ b/System.Compiler/Nodes.cs
@@ -7798,6 +7798,23 @@ namespace System.Compiler{
         base.DeclaringType = value;
       }
     }
+    /// <summary>
+    /// Gets a value that indicates whether the current type node is a type argument of a generic member or type.
+    /// </summary>
+    private bool isTypeArgument;
+    public bool IsTypeArgument
+    { 
+        get
+        {
+            return this.isTypeArgument;
+        }
+    }
+
+    public void MarkAsTypeArgument()
+    {
+        this.isTypeArgument = true;
+    }
+
     private TypeFlags flags;
     public TypeFlags Flags{
       get{return this.flags;}
@@ -9568,6 +9585,11 @@ namespace System.Compiler{
       CC.Contract.Assume(declaringType != null || this.DeclaringType == null);
       CC.Contract.Assume(declaringType == null || this.DeclaringType == declaringType || this.DeclaringType == declaringType.Template);
       
+      for (int i = 0; i < consolidatedTemplateArguments.Count; ++i)
+      {
+        consolidatedTemplateArguments[i].MarkAsTypeArgument();
+      }
+
       var duplicator = new Duplicator(module, declaringType);
       duplicator.RecordOriginalAsTemplate = true;
       duplicator.SkipBodies = true;

--- a/System.Compiler/Nodes.cs
+++ b/System.Compiler/Nodes.cs
@@ -7798,10 +7798,12 @@ namespace System.Compiler{
         base.DeclaringType = value;
       }
     }
+
+    private bool isTypeArgument;
+
     /// <summary>
     /// Gets a value that indicates whether the current type node is a type argument of a generic member or type.
     /// </summary>
-    private bool isTypeArgument;
     public bool IsTypeArgument
     { 
         get


### PR DESCRIPTION
Should fix #29 (Malfromed Contract. Found Requires after assignment)