### PR TITLE
Fixed path to Microsoft.CodeContractAnalysis.targets for MSBuild v12.0.

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -635,7 +635,7 @@
       Include Code Analysis target if present
     ======================================================================-->
   <PropertyGroup>
-    <CodeContractAnalysisTargets>$(CodeContractsInstallDir)MsBuild\v4.0\Microsoft.CodeContractAnalysis.targets</CodeContractAnalysisTargets>
+    <CodeContractAnalysisTargets>$(CodeContractsInstallDir)MsBuild\v12.0\Microsoft.CodeContractAnalysis.targets</CodeContractAnalysisTargets>
   </PropertyGroup>
   <Import Project="$(CodeContractAnalysisTargets)" Condition="Exists('$(CodeContractAnalysisTargets)')"/>
 


### PR DESCRIPTION
Change requested in #30 "MSBuild 12.0 Microsoft.CodeContracts.targets imports wrong ContractAnalysis.targets"