### PR TITLE
Added an ability to specify localdb name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 
+Microsoft.Research/CCDoc/Sandcastle/Sandcastle.zip

--- a/Microsoft.Research/Clousot.Cache/SQLCacheModel.cs
+++ b/Microsoft.Research/Clousot.Cache/SQLCacheModel.cs
@@ -701,10 +701,9 @@ namespace Microsoft.Research.CodeAnalysis.Caching
 
   public class LocalDbClousotCacheFactory : SQLClousotCacheFactory
   {
-    public LocalDbClousotCacheFactory()
-      : base(@"(LocalDb)\v11.0", true)
-    {
-    }
+    public LocalDbClousotCacheFactory(string dbName)
+      : base(dbName, true)
+    {}
 
     protected override SqlConnectionStringBuilder BuildConnectionString(IClousotCacheOptions options)
     {

--- a/Microsoft.Research/ClousotMain/ClousotMain.cs
+++ b/Microsoft.Research/ClousotMain/ClousotMain.cs
@@ -297,8 +297,10 @@ namespace Microsoft.Research.CodeAnalysis
             {
               cacheAccessorFactories = new IClousotCacheFactory[]{
                 new SQLClousotCacheFactory(options.CacheServer) ,
-                  //new SQLClousotCacheFactory(@"localhost\sqlexpress", true),
-                new LocalDbClousotCacheFactory(),
+                // Looking for MSSQLLocalDB first and falling back to older (v11.0) version otherwise.
+                new LocalDbClousotCacheFactory(@"(LocalDb)\MSSQLLocalDB"),
+                new LocalDbClousotCacheFactory(@"(LocalDb)\v11.0"),
+                //new SQLClousotCacheFactory(@"localhost\sqlexpress", true),
               };
             }
             else


### PR DESCRIPTION
Fix for #80 

This fix allows to run CCCheck on the machine with only VS2015 installed.

Please note, that new version (i.e. (LocalDb)\MSSqlLocalDb) is also available on machine with VS2013 installed. So minor performance degradation would be only for computers with ONLY VS2012 and VS2010 only.

We can enhance this strategy in the future, but this fix unblocks us to release VS2015 support (without such kind of fix CCCheck will fail unless the user manually change the options and disables caching).