### PR TITLE
Remove/replace unprovable contracts.

### DIFF
--- a/Microsoft.Research/Contracts/MsCorlib/System.Math.cs
+++ b/Microsoft.Research/Contracts/MsCorlib/System.Math.cs
@@ -93,29 +93,40 @@ namespace System
     [Pure]
     public static float Abs(float value)
     {
+      Contract.Ensures((Contract.Result<float>() >= 0.0) || float.IsNaN(Contract.Result<float>()) || float.IsPositiveInfinity(Contract.Result<float>()));
+
+      // 2015-03-26: tom-englert
+      // Disabled, since this was too complex for the checker to understand.
+      // e.g. new Rect(0, 0, Math.Abs(a), Math.Abs(b)) raised a warning that with and height are unproven to be positive values.
+
       // !NaN ==>  >= 0
-      Contract.Ensures(float.IsNaN(value) || Contract.Result<float>() >= 0.0);
+      // Contract.Ensures(float.IsNaN(value) || Contract.Result<float>() >= 0.0);
 
       // NaN ==> NaN
-      Contract.Ensures(!float.IsNaN(value) || float.IsNaN(Contract.Result<float>()));
+      // Contract.Ensures(!float.IsNaN(value) || float.IsNaN(Contract.Result<float>()));
 
       // Infty ==> +Infty
-      Contract.Ensures(!float.IsInfinity(value) || float.IsPositiveInfinity(Contract.Result<float>()));
+      // Contract.Ensures(!float.IsInfinity(value) || float.IsPositiveInfinity(Contract.Result<float>()));
 
       return default(float);
     }
 
     [Pure]
     public static double Abs(double value)
-    {      
+    {
+      Contract.Ensures((Contract.Result<double>() >= 0.0) || double.IsNaN(Contract.Result<double>()) || double.IsPositiveInfinity(Contract.Result<double>()));
+
+      // 2015-03-26: tom-englert
+      // Disabled, since this was too complex for the checker to understand.
+      // e.g. new Rect(0, 0, Math.Abs(a), Math.Abs(b)) raised a warning that with and height are unproven to be positive values.
+
       // !NaN ==>  >= 0
-      Contract.Ensures(double.IsNaN(value) || Contract.Result<double>() >= 0.0);
+      // Contract.Ensures(double.IsNaN(value) || Contract.Result<double>() >= 0.0);
 
       // NaN ==> NaN
-      Contract.Ensures(!double.IsNaN(value) || double.IsNaN(Contract.Result<double>()));
-
+      // Contract.Ensures(!double.IsNaN(value) || double.IsNaN(Contract.Result<double>()));
       // Infty ==> +Infty
-      Contract.Ensures(!double.IsInfinity(value) || double.IsPositiveInfinity(Contract.Result<double>()));
+      // Contract.Ensures(!double.IsInfinity(value) || double.IsPositiveInfinity(Contract.Result<double>()));
 
       return default(double);
     }

--- a/Microsoft.Research/Contracts/WindowsBase/System.Windows.Rect.cs
+++ b/Microsoft.Research/Contracts/WindowsBase/System.Windows.Rect.cs
@@ -17,18 +17,6 @@ using System.ComponentModel;
 using System.Diagnostics.Contracts;
 
 
-// 2015-03-36: tom-englert
-// Temporarily disabled checks for Contract.Requires(!this.IsEmpty);
-// => This requirement is true, but it's impossible to proof with acceptable effort.
-//    Even simple code like
-//
-//      var r = new Rect();
-//      r.Widht = 10.0;
-//
-//    will create a warning "CodeContracts: requires unproven: !this.IsEmpty. Are you making some assumption on get_Width that the static checker is unaware of?"
-//    As soon as the checker can infer the proper constraints, this can be enabled again.
-
-
 namespace System.Windows
 {
   // Summary:

--- a/Microsoft.Research/Contracts/WindowsBase/System.Windows.Rect.cs
+++ b/Microsoft.Research/Contracts/WindowsBase/System.Windows.Rect.cs
@@ -16,6 +16,19 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics.Contracts;
 
+
+// 2015-03-36: tom-englert
+// Temporarily disabled checks for Contract.Requires(!this.IsEmpty);
+// => This requirement is true, but it's impossible to proof with acceptable effort.
+//    Even simple code like
+//
+//      var r = new Rect();
+//      r.Widht = 10.0;
+//
+//    will create a warning "CodeContracts: requires unproven: !this.IsEmpty. Are you making some assumption on get_Width that the static checker is unaware of?"
+//    As soon as the checker can infer the proper constraints, this can be enabled again.
+
+
 namespace System.Windows
 {
   // Summary:
@@ -214,7 +227,7 @@ namespace System.Windows
       }
       set
       {
-        Contract.Requires(!this.IsEmpty);
+        // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
         Contract.Requires(value >= 0.0 || Double.IsNaN(value));
 
         Contract.Ensures(this.Height == value || Double.IsNaN(value));
@@ -339,7 +352,7 @@ namespace System.Windows
       }
       set
       {
-        Contract.Requires(!this.IsEmpty);
+        // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
         Contract.Requires(value >= 0.0 || Double.IsNaN(value));
 
         Contract.Ensures(this.Width == value || Double.IsNaN(value));
@@ -361,7 +374,7 @@ namespace System.Windows
       }
       set
       {
-        Contract.Requires(!this.IsEmpty);
+        // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
 
         Contract.Ensures(this.X == value || Double.IsNaN(value));
       }
@@ -382,7 +395,7 @@ namespace System.Windows
       }
       set
       {
-        Contract.Requires(!this.IsEmpty);
+        // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
 
         Contract.Ensures(this.Y == value || Double.IsNaN(value));
       }
@@ -484,8 +497,7 @@ namespace System.Windows
     //     the rectangle's System.Windows.Rect.Top and System.Windows.Rect.Bottom properties.
     public void Inflate(Size size)
     {
-      Contract.Requires(!this.IsEmpty);
-
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.Contract.Requires(!this.IsEmpty);
     }
     //
     // Summary:
@@ -500,8 +512,7 @@ namespace System.Windows
     //     The amount by which to expand or shrink the top and bottom sides of the rectangle.
     public void Inflate(double width, double height)
     {
-      Contract.Requires(!this.IsEmpty);
-
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
     }
     //
     // Summary:
@@ -523,7 +534,7 @@ namespace System.Windows
     //     The resulting rectangle.
     public static Rect Inflate(Rect rect, Size size)
     {
-      Contract.Requires(!rect.IsEmpty);
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
 
       return default(Rect);
     }
@@ -546,7 +557,7 @@ namespace System.Windows
     //     The resulting rectangle.
     public static Rect Inflate(Rect rect, double width, double height)
     {
-      Contract.Requires(!rect.IsEmpty);
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
 
       return default(Rect);
     }
@@ -599,8 +610,7 @@ namespace System.Windows
     //     This method is called on the System.Windows.Rect.Empty rectangle.
     public void Offset(Vector offsetVector)
     {
-      Contract.Requires(!this.IsEmpty);
-
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
     }
     //
     // Summary:
@@ -618,8 +628,7 @@ namespace System.Windows
     //     This method is called on the System.Windows.Rect.Empty rectangle.
     public void Offset(double offsetX, double offsetY)
     {
-      Contract.Requires(!this.IsEmpty);
-
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
     }
     //
     // Summary:
@@ -641,7 +650,7 @@ namespace System.Windows
     //     rect is System.Windows.Rect.Empty.
     public static Rect Offset(Rect rect, Vector offsetVector)
     {
-      Contract.Requires(!rect.IsEmpty);
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
 
       return default(Rect);
     }
@@ -668,7 +677,7 @@ namespace System.Windows
     //     rect is System.Windows.Rect.Empty.
     public static Rect Offset(Rect rect, double offsetX, double offsetY)
     {
-      Contract.Requires(!rect.IsEmpty);
+      // Contract.Requires(!this.IsEmpty); => Is true, but impossible to proof with acceptable effort.
 
       return default(Rect);
     }

--- a/Microsoft.Research/Contracts/WindowsBase/System.Windows.Size.cs
+++ b/Microsoft.Research/Contracts/WindowsBase/System.Windows.Size.cs
@@ -140,7 +140,7 @@ namespace System.Windows
       }
       set
       {
-        Contract.Requires(!this.IsEmpty);
+        // Contract.Requires(!this.IsEmpty); => see comment in Rect
         Contract.Requires(value >= 0.0 || Double.IsNaN(value));
 
         Contract.Ensures(this.Height == value || Double.IsNaN(value));
@@ -179,7 +179,7 @@ namespace System.Windows
       }
       set
       {
-        Contract.Requires(!this.IsEmpty);
+        // Contract.Requires(!this.IsEmpty); => see comment in Rect
         Contract.Requires(value >= 0.0 || Double.IsNaN(value));
 
         Contract.Ensures(this.Width == value || Double.IsNaN(value));


### PR DESCRIPTION
Some contracts that are theoretically valid but can't be proven by the static checker.
Crated issue #86, so once the checker is improved they can be enabled again.