### PR TITLE
Removed invalid preconditions for Socket.SetSocketOption

### DIFF
--- a/Microsoft.Research/Contracts/System/System.Net.Sockets.Socket.cs
+++ b/Microsoft.Research/Contracts/System/System.Net.Sockets.Socket.cs
@@ -313,9 +313,6 @@ namespace System.Net.Sockets
     public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, object optionValue)
     {
       Contract.Requires(optionValue != null);
-      Contract.Requires((int)optionLevel == 41);
-      Contract.Requires((int)optionName == 12 || (int)optionName == 13);
-
     }
     public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Byte[] optionValue)
     {


### PR DESCRIPTION
The requirements for `SocketOptionLevel` and `SocketOptionName` parameters are too complicated to be included in contracts, at least for now.

Fixes #11
Supersedes #46