### PR TITLE
Changed sn.exe resolution to use TargetFrameworkSDKToolsDirectory

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v12.0/Microsoft.CodeContracts.targets
@@ -278,14 +278,16 @@
          PropertyName="CodeContractsSdkPath" />
     </GetFrameworkSdkPath>
     <PropertyGroup>
-      <CodeContractsSnExe>"$(CodeContractsSdkPath)Bin\NETFX 4.5.1 Tools\sn.exe"</CodeContractsSnExe>
+      <!-- SN is in the Framework SDK tools path, but TargetFrameworkSDKToolsDirectory isn't always available  -->
+      <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' != '' ">$(TargetFrameworkSDKToolsDirectory)sn.exe</CodeContractsSnExe>
+      <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe</CodeContractsSnExe>
     </PropertyGroup>
     <Exec
        Condition="'$(KeyOriginatorFile)' != ''"   
-       Command='$(CodeContractsSnExe) /R "@(IntermediateAssembly)" "$(KeyOriginatorFile)"' />
+       Command='&quot;$(CodeContractsSnExe)&quot; /R "@(IntermediateAssembly)" "$(KeyOriginatorFile)"' />
     <Exec
        Condition="'$(KeyContainerName)' != ''"   
-       Command='$(CodeContractsSnExe) /Rc "@(IntermediateAssembly)" "$(KeyContainerName)"' />
+       Command='&quot;$(CodeContractsSnExe)&quot; /Rc "@(IntermediateAssembly)" "$(KeyContainerName)"' />
   </Target>
   
   <Target

--- a/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
+++ b/Microsoft.Research/ManagedContract.Setup/MSBuild/v14.0/Microsoft.CodeContracts.targets
@@ -289,14 +289,16 @@
          PropertyName="CodeContractsSdkPath" />
     </GetFrameworkSdkPath>
     <PropertyGroup>
-      <CodeContractsSnExe>"$(CodeContractsSdkPath)Bin\NETFX 4.6 Tools\sn.exe"</CodeContractsSnExe>
+      <!-- SN is in the Framework SDK tools path, but TargetFrameworkSDKToolsDirectory isn't always available  -->
+      <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' != '' ">$(TargetFrameworkSDKToolsDirectory)sn.exe</CodeContractsSnExe>
+      <CodeContractsSnExe Condition=" '$(TargetFrameworkSDKToolsDirectory)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.6 Tools\sn.exe</CodeContractsSnExe>
     </PropertyGroup>
     <Exec
        Condition="'$(KeyOriginatorFile)' != ''"   
-       Command='$(CodeContractsSnExe) /R "@(IntermediateAssembly)" "$(KeyOriginatorFile)"' />
+       Command='&quot;$(CodeContractsSnExe)&quot; /R "@(IntermediateAssembly)" "$(KeyOriginatorFile)"' />
     <Exec
        Condition="'$(KeyContainerName)' != ''"   
-       Command='$(CodeContractsSnExe) /Rc "@(IntermediateAssembly)" "$(KeyContainerName)"' />
+       Command='&quot;$(CodeContractsSnExe)&quot; /Rc "@(IntermediateAssembly)" "$(KeyContainerName)"' />
   </Target>
   
   <Target


### PR DESCRIPTION
New solution follows a common pattern for sn.exe resolution.

Example could be found in roslyn codebase:
https://github.com/dotnet/roslyn/blob/f87d725fb90a713f94732bf035124c3c8df25acb/build/Targets/VSL.Settings.targets#L224