### PR TITLE
Make sure VS2012 users receive proper update notifications

### DIFF
--- a/Microsoft.Research/ContractAdornments/Extension/source.extension.vsixmanifest
+++ b/Microsoft.Research/ContractAdornments/Extension/source.extension.vsixmanifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
-  <Identifier Id="ContractAdornments.MicrosoftResearch.1fb66ab7-53ec-479b-bd35-e9dd5be0426b">
+  <Identifier Id="ContractAdornments.MicrosoftResearch.2fb66ab7-53ec-479b-bd35-e9dd5be0426b">
     <Name>Code Contracts Editor Extensions</Name>
     <Author>Microsoft Research</Author>
     <Version>1.8.10107.10</Version>


### PR DESCRIPTION
This commit changes the ID of the Editor Extensions VSIX to match the ID used by the previous [Code Contracts Editor Extensions VS2012](https://visualstudiogallery.msdn.microsoft.com/02de7066-b6ca-42b3-8b3c-2562c7fa024f) extension. By using the same ID, existing users of this extension will receive and upgrade notification after the next release of the editor extensions are made available. Visual Studio 2010 users will not receive this notification even though the extension can be installed in that environment, but that is acceptable since Visual Studio 2010 did not originally have a notification feature.