### PR TITLE
Make sure the build updates the Visual Studio 2015 extension version

### DIFF
--- a/Microsoft.Research/ManagedContract.Setup/buildMSI10.xml
+++ b/Microsoft.Research/ManagedContract.Setup/buildMSI10.xml
@@ -235,7 +235,13 @@
        Query="//vsx:Metadata/vsx:Identity/@Version"
        Value="$(CCNetLabel)"
        XmlInputPath="VSIX\VS12.extension.vsixmanifest" />
-	  
+
+    <XmlPoke
+       Namespaces="$(Vsix20Namespace)"
+       Query="//vsx:Metadata/vsx:Identity/@Version"
+       Value="$(CCNetLabel)"
+       XmlInputPath="VSIX\VS14.extension.vsixmanifest" />
+
   </Target>
 
   <!--==========================================================


### PR DESCRIPTION
Previously the build was not updating the extension manifest for the Visual Studio 2015 extension. This meant that the extension manager in Visual Studio 2015 would show the wrong extension version number after an otherwise proper installation.