### PR TITLE
Reformat code in Microsoft.Contracts10

### DIFF
--- a/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.cs
+++ b/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //
 //  This file is included when building a contract declarative assembly
@@ -21,8 +10,8 @@
 
 namespace System.Diagnostics.Contracts
 {
-  [AttributeUsage(global::System.AttributeTargets.Assembly)]
-  internal sealed class ContractDeclarativeAssemblyAttribute : global::System.Attribute
-  {
-  }
+    [AttributeUsage(global::System.AttributeTargets.Assembly)]
+    internal sealed class ContractDeclarativeAssemblyAttribute : global::System.Attribute
+    {
+    }
 }

--- a/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.vb
+++ b/Foxtrot/Contracts/ContractDeclarativeAssemblyAttribute.vb
@@ -1,16 +1,5 @@
-' CodeContracts
-' 
-' Copyright (c) Microsoft Corporation
-' 
-' All rights reserved. 
-' 
-' MIT License
-' 
-' Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-' 
-' The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-' 
-' THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+' Copyright (c) Microsoft. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 '
 '  This file is included when building a contract declarative assembly
@@ -19,6 +8,6 @@
 <Assembly: ContractDeclarativeAssemblyAttribute()> 
 
 NotInheritable Class ContractDeclarativeAssemblyAttribute
-  Inherits Global.System.Attribute
+    Inherits Global.System.Attribute
 End Class
 

--- a/Foxtrot/Contracts/ContractExtensions.cs
+++ b/Foxtrot/Contracts/ContractExtensions.cs
@@ -1,59 +1,53 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //
 //  Include this file in your project if your project uses
 //  ContractArgumentValidator or ContractAbbreviator methods
 //
+
 using System;
 
 namespace System.Diagnostics.Contracts
 {
-  /// <summary>
-  /// Enables factoring legacy if-then-throw into separate methods for reuse and full control over
-  /// thrown exception and arguments
-  /// </summary>
-  [AttributeUsage(AttributeTargets.Method, AllowMultiple=false)]
-  [Conditional("CONTRACTS_FULL")]
-  internal sealed class ContractArgumentValidatorAttribute : global::System.Attribute
-  {
-  }
+    /// <summary>
+    /// Enables factoring legacy if-then-throw into separate methods for reuse and full control over
+    /// thrown exception and arguments
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [Conditional("CONTRACTS_FULL")]
+    internal sealed class ContractArgumentValidatorAttribute : global::System.Attribute
+    {
+    }
 
-  /// <summary>
-  /// Enables writing abbreviations for contracts that get copied to other methods
-  /// </summary>
-  [AttributeUsage(AttributeTargets.Method, AllowMultiple=false)]
-  [Conditional("CONTRACTS_FULL")]
-  internal sealed class ContractAbbreviatorAttribute : global::System.Attribute
-  {
-  }
+    /// <summary>
+    /// Enables writing abbreviations for contracts that get copied to other methods
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [Conditional("CONTRACTS_FULL")]
+    internal sealed class ContractAbbreviatorAttribute : global::System.Attribute
+    {
+    }
 
-  /// <summary>
-  /// Allows setting contract and tool options at assembly, type, or method granularity.
-  /// </summary>
-  [AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]
-  [Conditional("CONTRACTS_FULL")]
-  internal sealed class ContractOptionAttribute : global::System.Attribute
-  {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "category", Justification = "Build-time only attribute")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "setting", Justification = "Build-time only attribute")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "toggle", Justification = "Build-time only attribute")]
-    public ContractOptionAttribute(string category, string setting, bool toggle) { }
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "category", Justification = "Build-time only attribute")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "setting", Justification = "Build-time only attribute")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "value", Justification = "Build-time only attribute")]
-    public ContractOptionAttribute(string category, string setting, string value) { }
-  }
+    /// <summary>
+    /// Allows setting contract and tool options at assembly, type, or method granularity.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    [Conditional("CONTRACTS_FULL")]
+    internal sealed class ContractOptionAttribute : global::System.Attribute
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "category", Justification = "Build-time only attribute")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "setting", Justification = "Build-time only attribute")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "toggle", Justification = "Build-time only attribute")]
+        public ContractOptionAttribute(string category, string setting, bool toggle)
+        {
+        }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "category", Justification = "Build-time only attribute")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "setting", Justification = "Build-time only attribute")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "value", Justification = "Build-time only attribute")]
+        public ContractOptionAttribute(string category, string setting, string value)
+        {
+        }
+    }
 }
 

--- a/Foxtrot/Contracts/ContractExtensions.vb
+++ b/Foxtrot/Contracts/ContractExtensions.vb
@@ -1,16 +1,5 @@
-' CodeContracts
-' 
-' Copyright (c) Microsoft Corporation
-' 
-' All rights reserved. 
-' 
-' MIT License
-' 
-' Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-' 
-' The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-' 
-' THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+' Copyright (c) Microsoft. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 '
 '  Include this file in your project if you want to use

--- a/Foxtrot/Contracts/Contracts.cs
+++ b/Foxtrot/Contracts/Contracts.cs
@@ -1,27 +1,9 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
 /*============================================================
 **
-** Class:  Contract
 ** 
-** <OWNER>briangru,mbarnett</OWNER>
 **
 ** Purpose: The contract class allows for expressing preconditions,
 ** postconditions, and object invariants about methods in source
@@ -60,8 +42,8 @@ using System.Security;
 using System.Security.Permissions;
 #endif
 
-namespace System.Diagnostics.Contracts {
-
+namespace System.Diagnostics.Contracts
+{
     #region Attributes
 
     /// <summary>
@@ -88,7 +70,8 @@ namespace System.Diagnostics.Contracts {
             _typeWithContracts = typeContainingContracts;
         }
 
-        public Type TypeContainingContracts {
+        public Type TypeContainingContracts
+        {
             get { return _typeWithContracts; }
         }
     }
@@ -107,7 +90,8 @@ namespace System.Diagnostics.Contracts {
             _typeIAmAContractFor = typeContractsAreFor;
         }
 
-        public Type TypeContractsAreFor {
+        public Type TypeContractsAreFor
+        {
             get { return _typeIAmAContractFor; }
         }
     }
@@ -160,7 +144,7 @@ namespace System.Diagnostics.Contracts {
     [Conditional("CONTRACTS_FULL")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
     [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "Thank you very much, but we like the names we've defined for the accessors")]
-    internal sealed class MutabilityAttribute : Attribute 
+    internal sealed class MutabilityAttribute : Attribute
     {
         private Mutability _mutabilityMarker;
 
@@ -169,7 +153,8 @@ namespace System.Diagnostics.Contracts {
             _mutabilityMarker = mutabilityMarker;
         }
 
-        public Mutability Mutability {
+        public Mutability Mutability
+        {
             get { return _mutabilityMarker; }
         }
     }
@@ -185,14 +170,15 @@ namespace System.Diagnostics.Contracts {
     /// Apply this attribute to a property to apply to both the getter and setter.
     /// </remarks>
     [Conditional("CONTRACTS_FULL")]
-    [AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
     public sealed class ContractVerificationAttribute : Attribute
     {
         private string _value;
 
         public ContractVerificationAttribute(string value) { _value = value; }
 
-        public string Value {
+        public string Value
+        {
             get { return _value; }
         }
 
@@ -215,7 +201,8 @@ namespace System.Diagnostics.Contracts {
             _publicName = name;
         }
 
-        public String Name {
+        public String Name
+        {
             get { return _publicName; }
         }
     }
@@ -253,7 +240,8 @@ namespace System.Diagnostics.Contracts {
 #endif
         public static void Assume(bool condition)
         {
-            if (!condition) {
+            if (!condition)
+            {
                 ReportFailure(ContractFailureKind.Assume, null, null, null);
             }
         }
@@ -274,7 +262,8 @@ namespace System.Diagnostics.Contracts {
 #endif
         public static void Assume(bool condition, String userMessage)
         {
-            if (!condition) {
+            if (!condition)
+            {
                 ReportFailure(ContractFailureKind.Assume, userMessage, null, null);
             }
         }
@@ -720,7 +709,7 @@ namespace System.Diagnostics.Contracts {
         /// The runtime value is 2^64 - 1 or 2^32 - 1.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1802", Justification = "FxCop is confused")]
-        static readonly ulong MaxWritableExtent = (UIntPtr.Size == 4) ? UInt32.MaxValue : UInt64.MaxValue;
+        private static readonly ulong MaxWritableExtent = (UIntPtr.Size == 4) ? UInt32.MaxValue : UInt64.MaxValue;
 
         /// <summary>
         /// Allows specifying a writable extent for a UIntPtr, similar to SAL's writable extent.
@@ -751,7 +740,7 @@ namespace System.Diagnostics.Contracts {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
 #endif
         public static ulong WritableBytes(IntPtr startAddress) { return MaxWritableExtent - (ulong)startAddress; }
-        
+
         /// <summary>
         /// Allows specifying a writable extent for a UIntPtr, similar to SAL's writable extent.
         /// NOTE: this is for static checking only. No useful runtime code can be generated for this
@@ -851,7 +840,8 @@ namespace System.Diagnostics.Contracts {
         #endregion
     }
 
-    public enum ContractFailureKind {
+    public enum ContractFailureKind
+    {
         Precondition,
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Postcondition")]
         Postcondition,
@@ -861,8 +851,6 @@ namespace System.Diagnostics.Contracts {
         Assert,
         Assume,
     }
-
-
 }
 
 

--- a/Foxtrot/Contracts/ContractsMSR.cs
+++ b/Foxtrot/Contracts/ContractsMSR.cs
@@ -1,27 +1,9 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
 /*============================================================
 **
-** Class:  Contract
 ** 
-** <OWNER>maf,mbarnett,briangru</OWNER>
 **
 ** Implementation details of MSR library.
 **
@@ -54,8 +36,8 @@ using System.Security;
 using System.Security.Permissions;
 #endif
 
-namespace System.Diagnostics.Contracts {
-
+namespace System.Diagnostics.Contracts
+{
     public static partial class Contract
     {
         #region Private Methods
@@ -161,14 +143,16 @@ namespace System.Diagnostics.Contracts {
         /// not pop up an assert dialog box or trigger escalation policy.  Hooking this event requires 
         /// full trust.
         /// </summary>
-        public static event EventHandler<ContractFailedEventArgs> ContractFailed {
+        public static event EventHandler<ContractFailedEventArgs> ContractFailed
+        {
 #if FEATURE_UNTRUSTED_CALLERS
             [SecurityCritical]
 #if FEATURE_LINK_DEMAND
             [SecurityPermission(SecurityAction.LinkDemand, Unrestricted = true)]
 #endif
 #endif
-            add {
+            add
+            {
                 Internal.ContractHelper.InternalContractFailed += value;
             }
 #if FEATURE_UNTRUSTED_CALLERS
@@ -177,7 +161,8 @@ namespace System.Diagnostics.Contracts {
             [SecurityPermission(SecurityAction.LinkDemand, Unrestricted = true)]
 #endif
 #endif
-            remove {
+            remove
+            {
                 Internal.ContractHelper.InternalContractFailed -= value;
             }
         }
@@ -214,7 +199,8 @@ namespace System.Diagnostics.Contracts {
         public Exception OriginalException { get { return _originalException; } }
 
         // Whether the event handler "handles" this contract failure, or to fail via escalation policy.
-        public bool Handled {
+        public bool Handled
+        {
             get { return _handled; }
         }
 
@@ -229,7 +215,8 @@ namespace System.Diagnostics.Contracts {
             _handled = true;
         }
 
-        public bool Unwind {
+        public bool Unwind
+        {
             get { return _unwind; }
         }
 
@@ -244,7 +231,8 @@ namespace System.Diagnostics.Contracts {
             _unwind = true;
         }
 
-        internal void SetUnwindNoDemand() {
+        internal void SetUnwindNoDemand()
+        {
             _unwind = true;
         }
     }
@@ -257,9 +245,9 @@ namespace System.Diagnostics.Contracts {
     [SuppressMessage("Microsoft.Design", "CA1064:ExceptionsShouldBePublic")]
     internal sealed class ContractException : Exception
     {
-        readonly ContractFailureKind _Kind;
-        readonly string _UserMessage;
-        readonly string _Condition;
+        private readonly ContractFailureKind _Kind;
+        private readonly string _UserMessage;
+        private readonly string _Condition;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public ContractFailureKind Kind { get { return _Kind; } }
@@ -287,9 +275,9 @@ namespace System.Diagnostics.Contracts {
         public ContractException(ContractFailureKind kind, string failure, string userMessage, string condition, Exception innerException)
             : base(failure, innerException)
         {
-            this._Kind = kind;
-            this._UserMessage = userMessage;
-            this._Condition = condition;
+            _Kind = kind;
+            _UserMessage = userMessage;
+            _Condition = condition;
         }
 
 #if FEATURE_SERIALIZATION
@@ -345,7 +333,8 @@ namespace System.Diagnostics.Contracts.Internal
 #if FEATURE_UNTRUSTED_CALLERS
             [SecurityCritical]
 #endif
-            add {
+            add
+            {
                 // Eagerly prepare each event handler _marked with a reliability contract_, to 
                 // attempt to reduce out of memory exceptions while reporting contract violations.
                 // This only works if the new handler obeys the constraints placed on 
@@ -364,7 +353,8 @@ namespace System.Diagnostics.Contracts.Internal
 #if FEATURE_UNTRUSTED_CALLERS
             [SecurityCritical]
 #endif
-            remove {
+            remove
+            {
                 lock (lockObject)
                 {
                     contractFailedEvent -= value;
@@ -528,8 +518,6 @@ namespace System.Diagnostics.Contracts.Internal
                 }
             }
         }
-
-
     }
 }  // namespace System.Diagnostics.Contracts.Internal
 

--- a/Foxtrot/Contracts/Properties/AssemblyInfo.cs
+++ b/Foxtrot/Contracts/Properties/AssemblyInfo.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Reflection;


### PR DESCRIPTION
This reformat operation used dotnet/codeformatter@1d719e4e with `/rule-:FieldNames`.