### PR TITLE
Reformat code in Abstract Domains

### DIFF
--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/AbstractDomainFactories.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/AbstractDomainFactories.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,217 +8,217 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  [ContractClass(typeof(IFactoryContracts<>))]
-  public interface IFactory<T>
-  {
-    IFactory<T> FactoryWithName(T name);
-
-    T IdentityForAnd { get; }
-    T IdentityForOr { get; }
-    T IdentityForAdd { get; }
-
-    T Null { get; }
-
-    T Constant(Int32 constant);
-    T Constant(Int64 constant);
-    T Constant(Rational constant);
-    T Constant(bool constant);
-    T Constant(double constant);
-
-    T Variable(object variable);
-
-    T Add(T left, T right);
-    T Sub(T left, T right);
-    T Mul(T left, T right);
-    T Div(T left, T right);
-
-    T EqualTo(T left, T right);
-    T NotEqualTo(T left, T right);
-    T LessThan(T left, T right);
-    T LessEqualThan(T left, T right);
-
-    T And(T left, T right);
-    T Or(T left, T right);
-
-    T ArrayIndex(T array, T index);
-
-    T ForAll(T inf, T sup, T body);
-    T Exists(T inf, T sup, T body);
-
-    bool TryGetName(out T name);
-    bool TryGetBoundVariable(out T boundVariable);
-    bool TryArrayLengthName(T array, out T name);
-
-    List<T> SplitAnd(T t);
-  }
-
-  #region Contracts
-  
-  [ContractClassFor(typeof(IFactory<>))]
-  abstract class IFactoryContracts<T>
-  : IFactory<T>
-  {
-    #region IFactory<T> Members
-
-    public IFactory<T> FactoryWithName(T name)
+    [ContractClass(typeof(IFactoryContracts<>))]
+    public interface IFactory<T>
     {
-      Contract.Ensures(Contract.Result<IFactory<T>>() != null);
+        IFactory<T> FactoryWithName(T name);
 
-      throw new NotImplementedException();
+        T IdentityForAnd { get; }
+        T IdentityForOr { get; }
+        T IdentityForAdd { get; }
+
+        T Null { get; }
+
+        T Constant(Int32 constant);
+        T Constant(Int64 constant);
+        T Constant(Rational constant);
+        T Constant(bool constant);
+        T Constant(double constant);
+
+        T Variable(object variable);
+
+        T Add(T left, T right);
+        T Sub(T left, T right);
+        T Mul(T left, T right);
+        T Div(T left, T right);
+
+        T EqualTo(T left, T right);
+        T NotEqualTo(T left, T right);
+        T LessThan(T left, T right);
+        T LessEqualThan(T left, T right);
+
+        T And(T left, T right);
+        T Or(T left, T right);
+
+        T ArrayIndex(T array, T index);
+
+        T ForAll(T inf, T sup, T body);
+        T Exists(T inf, T sup, T body);
+
+        bool TryGetName(out T name);
+        bool TryGetBoundVariable(out T boundVariable);
+        bool TryArrayLengthName(T array, out T name);
+
+        List<T> SplitAnd(T t);
     }
 
-    public T Constant(int constant)
+    #region Contracts
+
+    [ContractClassFor(typeof(IFactory<>))]
+    internal abstract class IFactoryContracts<T>
+    : IFactory<T>
     {
-      throw new NotImplementedException();
-    }
+        #region IFactory<T> Members
 
-    public T Constant(long constant)
-    {
-      throw new NotImplementedException();
-    }
+        public IFactory<T> FactoryWithName(T name)
+        {
+            Contract.Ensures(Contract.Result<IFactory<T>>() != null);
 
-    public T Constant(Rational constant)
-    {
-      throw new NotImplementedException();
-    }
+            throw new NotImplementedException();
+        }
 
-    public T Constant(bool constant)
-    {
-      throw new NotImplementedException();
-    }
+        public T Constant(int constant)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T Constant(double constant)
-    {
-      throw new NotImplementedException();
-    }
+        public T Constant(long constant)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T Variable(object variable)
-    {
-      throw new NotImplementedException();
-    }
+        public T Constant(Rational constant)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T Add(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T Constant(bool constant)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T Sub(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T Constant(double constant)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T Mul(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T Variable(object variable)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T Div(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T Add(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T EqualTo(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T Sub(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T NotEqualTo(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T Mul(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T LessThan(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T Div(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T LessEqualThan(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T EqualTo(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T And(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T NotEqualTo(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T Or(T left, T right)
-    {
-      throw new NotImplementedException();
-    }
+        public T LessThan(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T IdentityForAnd
-    {
-      get { throw new NotImplementedException(); }
-    }
+        public T LessEqualThan(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T IdentityForOr
-    {
-      get { throw new NotImplementedException(); }
-    }
+        public T And(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T IdentityForAdd
-    {
-      get { throw new NotImplementedException(); }
-    }
+        public T Or(T left, T right)
+        {
+            throw new NotImplementedException();
+        }
 
-    public T ArrayIndex(T array, T Index)
-    {
-      throw new NotImplementedException();
-    }
+        public T IdentityForAnd
+        {
+            get { throw new NotImplementedException(); }
+        }
 
-    public T ForAll(T inf, T sup, T body)
-    {
-      Contract.Requires(inf != null);
-      Contract.Requires(sup != null);
-      Contract.Requires(body != null);
+        public T IdentityForOr
+        {
+            get { throw new NotImplementedException(); }
+        }
 
-      throw new NotImplementedException();
-    }
-    
-    public T Exists(T inf, T sup, T body)
-    {
-      Contract.Requires(inf != null);
-      Contract.Requires(sup != null);
-      Contract.Requires(body != null);
+        public T IdentityForAdd
+        {
+            get { throw new NotImplementedException(); }
+        }
 
-      throw new NotImplementedException();
-    }
+        public T ArrayIndex(T array, T Index)
+        {
+            throw new NotImplementedException();
+        }
 
-    public bool TryGetName(out T name)
-    {
-      throw new NotImplementedException();
-    }
+        public T ForAll(T inf, T sup, T body)
+        {
+            Contract.Requires(inf != null);
+            Contract.Requires(sup != null);
+            Contract.Requires(body != null);
 
-    public bool TryArrayLengthName(T array, out T name)
-    {
-      throw new NotImplementedException();
-    }
+            throw new NotImplementedException();
+        }
 
-    public bool TryGetBoundVariable(out T name)
-    {
-      throw new NotImplementedException();
-    }
+        public T Exists(T inf, T sup, T body)
+        {
+            Contract.Requires(inf != null);
+            Contract.Requires(sup != null);
+            Contract.Requires(body != null);
 
-    public List<T> SplitAnd(T t)
-    {
-      Contract.Ensures(Contract.Result<List<T>>() != null);
+            throw new NotImplementedException();
+        }
 
-      throw new NotImplementedException();
+        public bool TryGetName(out T name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryArrayLengthName(T array, out T name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetBoundVariable(out T name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<T> SplitAnd(T t)
+        {
+            Contract.Ensures(Contract.Result<List<T>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IFactory<T> Members
+
+
+        public T Null
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
     }
 
     #endregion
-
-    #region IFactory<T> Members
-
-
-    public T Null
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    #endregion
-  }
-
-  #endregion
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArraySegmentation.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArraySegmentation.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -26,3918 +15,3901 @@ using System.Linq;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  public static class ArrayOptions
-  {
-    [ThreadStatic]
-    static public bool Trace;
-  }
-
-  [ContractVerification(true)]
-  [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-!this.IsNormal || !this.limits.GetLastElement().IsEmpty")]
-  public class ArraySegmentation<AbstractDomain, Variable, Expression>
-    : IAbstractDomainForEnvironments<Variable, Expression>
-    where AbstractDomain : class, IAbstractDomainForArraySegmentationAbstraction<AbstractDomain, Variable>
-  {
-    #region Object Identity
-
-    private static int NextId = 0;
-    private static int UniformCount = 0;
-    
-    #endregion
-
-    #region State
-
-    private enum State { BOTTOM, NORMAL, TOP }
-
-    readonly private ExpressionManager<Variable, Expression> expManager;
-
-    readonly private ArraySegmentationTestTrueVisitor testTrue;
-    readonly private ArraySegmentationTestFalseVisitor testFalse;
-
-    readonly private NonNullList<SegmentLimit<Variable>> limits;
-    readonly private NonNullList<AbstractDomain> elements;                       // F: We assume non-relational domains for the moment
-
-    readonly private int Id = NextId++;
-
-    readonly private AbstractDomain bottomElement;
-
-    private State state;
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    public static class ArrayOptions
     {
-      Contract.Invariant(this.limits != null);
-      Contract.Invariant(this.elements != null);
-      Contract.Invariant(this.expManager != null);
-      Contract.Invariant(this.testTrue != null);
-      Contract.Invariant(this.testFalse != null);
-      Contract.Invariant(this.bottomElement != null);
-      Contract.Invariant(!this.IsNormal || this.elements.Count +1 == this.limits.Count);
-      Contract.Invariant(!this.IsNormal || !this.limits.GetLastElement().IsEmpty); // We only check it at runtime
+        [ThreadStatic]
+        static public bool Trace;
     }
 
-    #endregion
-
-    #region Constructor
-
-    public ArraySegmentation(
-      SegmentLimit<Variable> lowerBounds, AbstractDomain value, SegmentLimit<Variable> upperBounds,
-      AbstractDomain bottomElement,
-       ExpressionManager<Variable, Expression> expManager)
-      : this(bottomElement, expManager)
+    [ContractVerification(true)]
+    [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-!this.IsNormal || !this.limits.GetLastElement().IsEmpty")]
+    public class ArraySegmentation<AbstractDomain, Variable, Expression>
+      : IAbstractDomainForEnvironments<Variable, Expression>
+      where AbstractDomain : class, IAbstractDomainForArraySegmentationAbstraction<AbstractDomain, Variable>
     {
-      Contract.Requires(lowerBounds != null);
-      Contract.Requires(value != null);
-      Contract.Requires(upperBounds != null);
-      Contract.Requires(bottomElement != null);
-      Contract.Requires(expManager != null);
+        #region Object Identity
 
-      this.limits = new NonNullList<SegmentLimit<Variable>>() { lowerBounds, upperBounds };
-      this.elements = new NonNullList<AbstractDomain>() { value };
-      this.state = State.NORMAL;
+        private static int NextId = 0;
+        private static int UniformCount = 0;
 
-      this.testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
-      this.testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
+        #endregion
 
-      this.testTrue.FalseVisitor = this.testFalse;
-      this.testFalse.TrueVisitor = this.testTrue;
-    }
-     
-    public ArraySegmentation(NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements, 
-      AbstractDomain bottomElement, ExpressionManager<Variable, Expression> expManager)
-      : this(true, limits, elements, bottomElement, expManager)
-    {
-      Contract.Requires(limits != null);
-      Contract.Requires(elements != null);
-      Contract.Requires(bottomElement != null);
-      Contract.Requires(expManager != null);
-      Contract.Requires(limits.Count == elements.Count + 1);
+        #region State
 
-      // F: those are needed because of a weakness of the equality
-      Contract.Ensures(this.limits.Count <= limits.Count);
-      Contract.Ensures(this.elements.Count <= elements.Count);
+        private enum State { BOTTOM, NORMAL, TOP }
 
-    }
-     
-    private ArraySegmentation(AbstractDomain bottomElement, ExpressionManager<Variable, Expression> expManager)
-    {
-      Contract.Requires(bottomElement != null);
-      Contract.Requires(expManager!= null);
+        readonly private ExpressionManager<Variable, Expression> expManager;
 
-      this.expManager = expManager;
+        readonly private ArraySegmentationTestTrueVisitor testTrue;
+        readonly private ArraySegmentationTestFalseVisitor testFalse;
 
-      this.limits = new NonNullList<SegmentLimit<Variable>>();
-      this.elements = new NonNullList<AbstractDomain>();
+        readonly private NonNullList<SegmentLimit<Variable>> limits;
+        readonly private NonNullList<AbstractDomain> elements;                       // F: We assume non-relational domains for the moment
 
-      this.testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
-      this.testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
+        readonly private int Id = NextId++;
 
-      this.testTrue.FalseVisitor = this.testFalse;
-      this.testFalse.TrueVisitor = this.testTrue;
+        readonly private AbstractDomain bottomElement;
 
-      this.bottomElement = bottomElement;
+        private State state;
 
-      this.state = State.TOP;
-    }
-
-    private ArraySegmentation(bool forceSimplification, NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements,
-      AbstractDomain bottomElement, ExpressionManager<Variable, Expression> expManager)
-      : this(bottomElement, expManager)
-    {
-      Contract.Requires(limits != null);
-      Contract.Requires(elements != null);
-      Contract.Requires(bottomElement != null);
-      Contract.Requires(expManager!= null);
-      Contract.Requires(limits.Count == elements.Count + 1);
-
-      // F: those are needed because of a weakness of the equality
-      Contract.Ensures(this.limits.Count <= limits.Count);
-      Contract.Ensures(this.elements.Count <= elements.Count);
-
-      if (forceSimplification)
-      {
-        bool isBottom;
-        RemoveTriviallyEmptySegments(limits, elements, out this.limits, out this.elements, out isBottom);
-
-        this.state = isBottom ? State.BOTTOM : State.NORMAL;
-      }
-      else
-      {
-        this.limits = limits;
-        this.elements = elements;
-        this.state = State.NORMAL;
-      }
-      this.testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
-      this.testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
-
-      this.testTrue.FalseVisitor = this.testFalse;
-      this.testFalse.TrueVisitor = this.testTrue;
-    }
-
-    /// <param name="emptySegment">If true, constructs the empty segment, if false the bottom one</param>
-    private ArraySegmentation(bool emptySegment, 
-      AbstractDomain bottomElement,  ExpressionManager<Variable, Expression> expManager)
-      : this(bottomElement, expManager)
-    {
-      Contract.Requires(bottomElement != null);
-      Contract.Requires(expManager != null);
-
-      var lowerBound = new SegmentLimit<Variable>(NormalizedExpression<Variable>.For(0), false);
-      var upperBound = new SegmentLimit<Variable>(NormalizedExpression<Variable>.For(0), emptySegment);
-
-      this.limits = new NonNullList<SegmentLimit<Variable>>() { lowerBound, upperBound };
-      this.elements = new NonNullList<AbstractDomain>() {  };
-      this.state = emptySegment? State.NORMAL: State.BOTTOM;
-
-      this.testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
-      this.testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
-
-      this.testTrue.FalseVisitor = this.testFalse;
-      this.testFalse.TrueVisitor = this.testTrue;
-    }
- 
-    private ArraySegmentation(ArraySegmentation<AbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(this.expManager == other.expManager);
-      Contract.Ensures(this.testTrue == other.testTrue);
-      Contract.Ensures(this.testFalse == other.testFalse);
-      Contract.Ensures(this.state == other.state);
-
-      Contract.Ensures(this.limits != null);
-      Contract.Ensures(this.elements != null);
-      Contract.Ensures(this.limits.Count == other.limits.Count);
-      Contract.Ensures(this.elements.Count == other.elements.Count);
-
-      Contract.Assume(other.limits != null);  // F: we are not assuming the object invariant
-      Contract.Assume(other.elements != null);
-
-      this.limits = new NonNullList<SegmentLimit<Variable>>(other.limits);
-      this.elements = new NonNullList<AbstractDomain>(other.elements);
-  
-      Contract.Assert(this.limits.Count == other.limits.Count);
-      Contract.Assert(this.elements.Count == other.elements.Count);
-
-      // We assume the other object invariant
-      Contract.Assume(other.expManager!= null);
-
-      Contract.Assume(other.testTrue != null);
-      Contract.Assume(other.testFalse != null);
-
-      Contract.Assume(Contract.ForAll(this.limits, l => l != null)); 
-
-      this.expManager = other.expManager;
-
-      this.testTrue = other.testTrue;
-      this.testFalse = other.testFalse;
-
-      Contract.Assume(other.IsTop || other.elements.Count > 0);
-      this.state = other.state;
-
-      Contract.Assume(other.bottomElement != null);
-
-      this.bottomElement = other.bottomElement;
-    }
-
-    #endregion
-
-    #region IAbstractDomainForEnvironments<Variable,Expression> Members
-
-    public string ToString(Expression exp)
-    {
-      return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get {
-        Contract.Ensures(Contract.Result<bool>() == (this.state == State.BOTTOM));
-        return this.state == State.BOTTOM; }
-    }
-
-     
-    public bool IsTop
-    {
-      get {
-        Contract.Ensures(Contract.Result<bool>() == (this.state == State.TOP)); 
- 
-        return this.state == State.TOP; 
-      }
-    }
-
-    public bool IsEmptyArray
-    {
-      get
-      {
-        Contract.Ensures(!Contract.Result<bool>() || (this.state == State.NORMAL));
-
-        if (this.IsTop || this.IsBottom)
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          return false;
+            Contract.Invariant(limits != null);
+            Contract.Invariant(elements != null);
+            Contract.Invariant(expManager != null);
+            Contract.Invariant(testTrue != null);
+            Contract.Invariant(testFalse != null);
+            Contract.Invariant(bottomElement != null);
+            Contract.Invariant(!this.IsNormal || elements.Count + 1 == limits.Count);
+            Contract.Invariant(!this.IsNormal || !limits.GetLastElement().IsEmpty); // We only check it at runtime
         }
 
-        if (this.elements.Count == 0)
+        #endregion
+
+        #region Constructor
+
+        public ArraySegmentation(
+          SegmentLimit<Variable> lowerBounds, AbstractDomain value, SegmentLimit<Variable> upperBounds,
+          AbstractDomain bottomElement,
+           ExpressionManager<Variable, Expression> expManager)
+          : this(bottomElement, expManager)
         {
-          this.state = State.NORMAL;
-          return true;
+            Contract.Requires(lowerBounds != null);
+            Contract.Requires(value != null);
+            Contract.Requires(upperBounds != null);
+            Contract.Requires(bottomElement != null);
+            Contract.Requires(expManager != null);
+
+            limits = new NonNullList<SegmentLimit<Variable>>() { lowerBounds, upperBounds };
+            elements = new NonNullList<AbstractDomain>() { value };
+            state = State.NORMAL;
+
+            testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
+            testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
+
+            testTrue.FalseVisitor = testFalse;
+            testFalse.TrueVisitor = testTrue;
         }
 
-        if (this.limits.Count > 1)
+        public ArraySegmentation(NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements,
+          AbstractDomain bottomElement, ExpressionManager<Variable, Expression> expManager)
+          : this(true, limits, elements, bottomElement, expManager)
         {
-          Contract.Assert(!this.limits.IsEmpty);
-          // If there is a common variable in the first and last set of bounds
-          if (!this.limits[0].Intersection(this.limits.GetLastElement()).IsEmpty)
-          {
-            if (this.limits.GetLastElement().IsConditional)
+            Contract.Requires(limits != null);
+            Contract.Requires(elements != null);
+            Contract.Requires(bottomElement != null);
+            Contract.Requires(expManager != null);
+            Contract.Requires(limits.Count == elements.Count + 1);
+
+            // F: those are needed because of a weakness of the equality
+            Contract.Ensures(this.limits.Count <= limits.Count);
+            Contract.Ensures(this.elements.Count <= elements.Count);
+        }
+
+        private ArraySegmentation(AbstractDomain bottomElement, ExpressionManager<Variable, Expression> expManager)
+        {
+            Contract.Requires(bottomElement != null);
+            Contract.Requires(expManager != null);
+
+            this.expManager = expManager;
+
+            limits = new NonNullList<SegmentLimit<Variable>>();
+            elements = new NonNullList<AbstractDomain>();
+
+            testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
+            testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
+
+            testTrue.FalseVisitor = testFalse;
+            testFalse.TrueVisitor = testTrue;
+
+            this.bottomElement = bottomElement;
+
+            state = State.TOP;
+        }
+
+        private ArraySegmentation(bool forceSimplification, NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements,
+          AbstractDomain bottomElement, ExpressionManager<Variable, Expression> expManager)
+          : this(bottomElement, expManager)
+        {
+            Contract.Requires(limits != null);
+            Contract.Requires(elements != null);
+            Contract.Requires(bottomElement != null);
+            Contract.Requires(expManager != null);
+            Contract.Requires(limits.Count == elements.Count + 1);
+
+            // F: those are needed because of a weakness of the equality
+            Contract.Ensures(this.limits.Count <= limits.Count);
+            Contract.Ensures(this.elements.Count <= elements.Count);
+
+            if (forceSimplification)
             {
-              this.state = State.NORMAL;
-              return true;
+                bool isBottom;
+                RemoveTriviallyEmptySegments(limits, elements, out this.limits, out this.elements, out isBottom);
+
+                state = isBottom ? State.BOTTOM : State.NORMAL;
             }
             else
             {
-              this.state = State.BOTTOM;
-              return false;
+                this.limits = limits;
+                this.elements = elements;
+                state = State.NORMAL;
             }
-          }
+            testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
+            testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
+
+            testTrue.FalseVisitor = testFalse;
+            testFalse.TrueVisitor = testTrue;
         }
 
-        return false;
-      }
-    }
-
-    public bool IsNormal
-    {
-      [SuppressMessage("Microsoft.Contracts", "EnsuresInMethod-!Contract.Result<bool>() || this.limits.Count >= 2")]
-      [SuppressMessage("Microsoft.Contracts", "EnsuresInMethod-!Contract.Result<bool>() || this.elements.Count +1 == this.limits.Count")]
-      get
-      {
-        Contract.Ensures(!Contract.Result<bool>() || this.limits.Count >= 2);
-        Contract.Ensures(!Contract.Result<bool>() || this.elements.Count +1 == this.limits.Count );
-
-        return !(this.IsEmptyArray || this.IsBottom || this.IsTop);
-      }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      var other = a as ArraySegmentation<AbstractDomain, Variable, Expression>;
-
-      Contract.Assume(other != null);
-
-      return this.LessEqual(other);
-    }
-     
-    public bool LessEqual(ArraySegmentation<AbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, other, out result))
-      {
-        return result;
-      }
-
-      if (this.IsEmptyArray)
-      {
-        return other.IsEmptyArray;
-      }
-
-      // F: Warnings for those are from the handling of constrained calls
-     // Contract.Assert(!this.IsTop);
-     // Contract.Assert(!other.IsTop);
-
-      Contract.Assume(this.elements.Count > 0);
-
-      Contract.Assume(other.limits != null);
-      Contract.Assume(other.elements != null);
-      Contract.Assume(other.elements.Count > 0);
-
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-      Contract.Assume(other.limits.Count == other.elements.Count + 1);
-
-      ArraySegmentation<AbstractDomain, Variable, Expression> leftReduced, rightReduced;
-      bool removedAtLeastOneLimitOnRight;
-
-      if (TryUnifySegments(SegmentUnificationOperation.LessEqual, this.DuplicateMe(), other.DuplicateMe(),
-        (AbstractDomain)this.elements[0].Bottom, (AbstractDomain)other.elements[0].Top,
-        out leftReduced, out rightReduced, out removedAtLeastOneLimitOnRight))
-      {
-
-        Contract.Assert(leftReduced.elements.Count == rightReduced.elements.Count);
-        Contract.Assert(leftReduced.limits.Count == rightReduced.limits.Count);
-
-        for (int i = 0; i < leftReduced.limits.Count; i++)
+        /// <param name="emptySegment">If true, constructs the empty segment, if false the bottom one</param>
+        private ArraySegmentation(bool emptySegment,
+          AbstractDomain bottomElement, ExpressionManager<Variable, Expression> expManager)
+          : this(bottomElement, expManager)
         {
-          if (leftReduced.limits[i].IsConditional && !rightReduced.limits[i].IsConditional)
-          {
-            return false;
-          }
+            Contract.Requires(bottomElement != null);
+            Contract.Requires(expManager != null);
+
+            var lowerBound = new SegmentLimit<Variable>(NormalizedExpression<Variable>.For(0), false);
+            var upperBound = new SegmentLimit<Variable>(NormalizedExpression<Variable>.For(0), emptySegment);
+
+            limits = new NonNullList<SegmentLimit<Variable>>() { lowerBound, upperBound };
+            elements = new NonNullList<AbstractDomain>() { };
+            state = emptySegment ? State.NORMAL : State.BOTTOM;
+
+            testTrue = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestTrueVisitor(this.expManager.Decoder);
+            testFalse = new ArraySegmentation<AbstractDomain, Variable, Expression>.ArraySegmentationTestFalseVisitor(this.expManager.Decoder);
+
+            testTrue.FalseVisitor = testFalse;
+            testFalse.TrueVisitor = testTrue;
         }
 
-        for (int i = 0; i < leftReduced.elements.Count; i++)
+        private ArraySegmentation(ArraySegmentation<AbstractDomain, Variable, Expression> other)
         {
-          var tmpElements = rightReduced.elements[i];
+            Contract.Requires(other != null);
 
-          Contract.Assert(tmpElements != null);
+            Contract.Ensures(expManager == other.expManager);
+            Contract.Ensures(testTrue == other.testTrue);
+            Contract.Ensures(testFalse == other.testFalse);
+            Contract.Ensures(state == other.state);
 
-          if (!leftReduced.elements[i].LessEqual(tmpElements))
-            return false;
+            Contract.Ensures(limits != null);
+            Contract.Ensures(elements != null);
+            Contract.Ensures(limits.Count == other.limits.Count);
+            Contract.Ensures(elements.Count == other.elements.Count);
+
+            Contract.Assume(other.limits != null);  // F: we are not assuming the object invariant
+            Contract.Assume(other.elements != null);
+
+            limits = new NonNullList<SegmentLimit<Variable>>(other.limits);
+            elements = new NonNullList<AbstractDomain>(other.elements);
+
+            Contract.Assert(limits.Count == other.limits.Count);
+            Contract.Assert(elements.Count == other.elements.Count);
+
+            // We assume the other object invariant
+            Contract.Assume(other.expManager != null);
+
+            Contract.Assume(other.testTrue != null);
+            Contract.Assume(other.testFalse != null);
+
+            Contract.Assume(Contract.ForAll(limits, l => l != null));
+
+            expManager = other.expManager;
+
+            testTrue = other.testTrue;
+            testFalse = other.testFalse;
+
+            Contract.Assume(other.IsTop || other.elements.Count > 0);
+            state = other.state;
+
+            Contract.Assume(other.bottomElement != null);
+
+            bottomElement = other.bottomElement;
         }
 
-        return !removedAtLeastOneLimitOnRight;
-      }
-      else
-      {
-        return false;
-      }
-    }
+        #endregion
 
+        #region IAbstractDomainForEnvironments<Variable,Expression> Members
 
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { return this.Bottom; }
-    }
-
-    public ArraySegmentation<AbstractDomain, Variable, Expression> Bottom
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);        
-
-        var tmp = new ArraySegmentation<AbstractDomain, Variable, Expression>(this.bottomElement, this.expManager);
-        tmp.state = State.BOTTOM;
-
-        return tmp;
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { return this.Top; }
-    }
-
-     
-    public ArraySegmentation<AbstractDomain, Variable, Expression> Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-        
-        return new ArraySegmentation<AbstractDomain, Variable, Expression>(this.bottomElement, this.expManager);
-      }
-    }
-
-    public ArraySegmentation<AbstractDomain, Variable, Expression> EmptyArray
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-        return new ArraySegmentation<AbstractDomain, Variable, Expression>(true, this.bottomElement, this.expManager);
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var other = a as ArraySegmentation<AbstractDomain, Variable, Expression>;
-
-      Contract.Assume(other != null);
-
-      return this.Join(other);
-    }
-
-     
-    public ArraySegmentation<AbstractDomain, Variable, Expression> Join(ArraySegmentation<AbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-      
-      ArraySegmentation<AbstractDomain, Variable, Expression> left, right, trivialResult;
-
-      if (ArrayOptions.Trace)
-      {
-        Console.WriteLine("Join of:\n{0}\n{1}", this.ToString(), other.ToString());
-      }
-
-      if (AbstractDomainsHelper.TryTrivialJoinRefinedWithEmptyArrays(this, other, out trivialResult))
-      {
-        if (ArrayOptions.Trace)
+        public string ToString(Expression exp)
         {
-          Console.WriteLine("Result {0}", trivialResult.ToString());
+            return ExpressionPrinter.ToString(exp, expManager.Decoder);
         }
 
-        return trivialResult;
-      }
+        #endregion
 
+        #region IAbstractDomain Members
 
-      Contract.Assume(other.elements != null);
-      Contract.Assume(other.limits != null);
-
-      Contract.Assume(this.elements.Count > 0);
-      Contract.Assume(other.elements.Count > 0);
-
-      Contract.Assume(this.limits.Count == this.elements.Count +1);
-      Contract.Assume(other.limits.Count == other.elements.Count +1);
-
-      // Different upper bounds
-      if (this.limits[this.limits.Count - 1].Join(other.limits[other.limits.Count - 1]).IsEmpty)
-      {
-        return this.Top;
-      }
-
-      var bott = (AbstractDomain)this.elements[0].Bottom;
-
-      var dup_this = this.DuplicateMe();
-      var dup_other = other.DuplicateMe();
-      bool dummy;
-      if (TryUnifySegments(SegmentUnificationOperation.Join, dup_this, dup_other, bott, bott, out left, out right, out dummy))
-      {
-
-        Contract.Assert(left.limits.Count > 0);
-        Contract.Assert(right.limits.Count > 0);
-        Contract.Assert(left.limits.Count == right.limits.Count);
-        Contract.Assert(left.elements.Count == right.elements.Count);
-        Contract.Assert(left.limits.Count == left.elements.Count + 1);
-
-        var resultLimits = new NonNullList<SegmentLimit<Variable>>();
-        var resultElements = new NonNullList<AbstractDomain>();
-
-        var last = left.limits.Count - 1;
-
-        for (var i = 0; i < last; i++)
+        public bool IsBottom
         {
-          var segment = left.limits[i].Join(right.limits[i]);
-          var l = left.elements[i];
-          var r = right.elements[i];
-          var element = (AbstractDomain)l.Join(r);
-          
-          resultLimits.Add(segment);
-          resultElements.Add(element);
-        }
-
-        resultLimits.Add(left.limits[last].Join(right.limits[last]));
-
-        Contract.Assert(resultLimits.Count == resultElements.Count + 1);
-
-        var result = new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, this.bottomElement, this.expManager);
-
-        if (ArrayOptions.Trace)
-        {
-          Console.WriteLine("Join result:\n{0}:", result.ToString());
-        }
-
-        return result;
-      }
-      else
-      {
-        return this.Top;
-      }
-    }
-     
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      var other = a as ArraySegmentation<AbstractDomain, Variable, Expression>;
-
-      Contract.Assume(other != null);
-
-      return this.Meet(other);
-    }
-
-    [Pure] 
-    public ArraySegmentation<AbstractDomain, Variable, Expression> Meet(ArraySegmentation<AbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-      
-      ArraySegmentation<AbstractDomain, Variable, Expression> left, right, trivialResult;
-
-      if (ArrayOptions.Trace)
-      {
-        Console.WriteLine("Meet of:\n{0}\n{1}", this.ToString(), other.ToString());
-      }
-
-      if (AbstractDomainsHelper.TryTrivialMeet(this, other, out trivialResult))
-      {
-        if (ArrayOptions.Trace)
-        {
-          Console.WriteLine("Result {0}", trivialResult.ToString());
-        }
-
-        return trivialResult;
-      }
-
-      if (this.IsEmptyArray)        
-      {
-        if (other.IsEmptyArray)
-        {
-          return this;
-        }
-        return this.Bottom;
-      }
-      else if (other.IsEmptyArray)
-      {
-        return this.Bottom;
-      }
-
-      if (this.IsIncludedIn(other))
-      {
-        return this;
-      }
-      if (other.IsIncludedIn(this))
-      {
-        return other;
-      }
-
-     // Contract.Assert(!this.IsTop);
-     // Contract.Assert(!other.IsTop);
-
-      // F: those assumptions should go away once we will have the assertion above proven and the right object invariant
-      Contract.Assume(this.elements.Count > 0);
-      Contract.Assume(this.limits.Count == this.elements.Count +1);
-
-      Contract.Assert(other.elements != null);
-      Contract.Assert(other.limits != null);
-
-      Contract.Assume(other.elements.Count > 0);
-      Contract.Assume(other.limits.Count == other.elements.Count + 1);
-
-      var bott = (AbstractDomain)this.elements[0].Bottom;
-
-      var dup_this = this.DuplicateMe();
-      var dup_other = other.DuplicateMe();
-
-      Contract.Assert(dup_this.limits.Count > 0);
-
-      // If different upper bounds, then merge them together (we know they should be the same)
-      var upperBounds = dup_this.limits[dup_this.limits.Count - 1].Join(dup_other.limits[dup_other.limits.Count - 1]);
-      if (upperBounds.IsEmpty)
-      {
-        var union = dup_this.limits[dup_this.limits.Count - 1].Meet(dup_other.limits[dup_other.limits.Count - 1]);
-
-        dup_this.limits[dup_this.limits.Count - 1] = union;
-        dup_other.limits[dup_other.limits.Count - 1] = union;
-      }
-
-      bool dummy;
-      if (TryUnifySegments(SegmentUnificationOperation.Meet, dup_this, dup_other, bott, bott, out left, out right, out dummy))
-      {
-
-        Contract.Assert(left.limits.Count == right.limits.Count);
-        Contract.Assert(left.elements.Count == right.elements.Count);
-        Contract.Assert(left.limits.Count == left.elements.Count +1);
-
-        var resultLimits = new NonNullList<SegmentLimit<Variable>>();
-        var resultElements = new NonNullList<AbstractDomain>();
-
-        var last = left.limits.Count - 1;
-
-        for (var i = 0; i < last; i++)
-        {
-          var segment = left.limits[i].Meet(right.limits[i]);
-          var element = (AbstractDomain)left.elements[i].Meet(right.elements[i]);
-
-          // refinement
-          if (i < last - 1)
-          {
-            IAbstractDomain oldValueLeft = null;
-            if (this.TryMeetAllValuesInTheLimits(left.limits[i], left.limits[i + 1], TopNumericalDomain<Variable, Expression>.Singleton, ref oldValueLeft)
-              && !oldValueLeft.IsTop)
+            get
             {
-              element = (AbstractDomain)element.Meet(oldValueLeft);
+                Contract.Ensures(Contract.Result<bool>() == (state == State.BOTTOM));
+                return state == State.BOTTOM;
             }
-            IAbstractDomain oldValueRight = null;
-            if (other.TryMeetAllValuesInTheLimits(right.limits[i], right.limits[i + 1], TopNumericalDomain<Variable, Expression>.Singleton, ref oldValueRight)
-              && !oldValueRight.IsTop)
+        }
+
+
+        public bool IsTop
+        {
+            get
             {
-              element = (AbstractDomain)element.Meet(oldValueRight);
+                Contract.Ensures(Contract.Result<bool>() == (state == State.TOP));
+
+                return state == State.TOP;
             }
-          }
-
-          resultLimits.Add(segment);
-          resultElements.Add(element);
         }
 
-        resultLimits.Add(left.limits[last].Join(right.limits[last]));
-
-        Contract.Assert(resultLimits.Count == resultElements.Count + 1);
-
-        var result = new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, this.bottomElement, this.expManager);
-
-        if (ArrayOptions.Trace)
+        public bool IsEmptyArray
         {
-          Console.WriteLine("Meet result:\n{0}:", result.ToString());
-        }
-
-        return result;
-      }
-      else
-      {
-        if (ArrayOptions.Trace)
-        {
-          Console.WriteLine("Unification failed. Meet returns top");
-        }
-
-        return this.Top;
-      }
-    }
-
-     
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      var other = prev as ArraySegmentation<AbstractDomain, Variable, Expression>;
-
-      Contract.Assume(other != null);
-
-      return this.Widening(other);
-    }
-
-     
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-other != null")]
-    public ArraySegmentation<AbstractDomain, Variable, Expression> Widening(ArraySegmentation<AbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);      
-
-      ArraySegmentation<AbstractDomain, Variable, Expression> left, right;
-
-      if (this.IsTop)
-      {
-        return this;
-      }
-
-      if (this.IsEmptyArray)
-      {
-        if (other.IsEmptyArray)
-        {
-          return this;
-        }
-
-        return this.Top;
-      }
-
-      Contract.Assert(!this.IsTop);
-
-      Contract.Assume(this.elements.Count > 0);
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-      
-      Contract.Assume(other.elements != null);
-      Contract.Assume(other.limits != null);
-
-      Contract.Assume(other.elements.Count > 0);
-      Contract.Assume(other.limits.Count == other.elements.Count + 1);
-
-      var bott = (AbstractDomain)this.elements[0].Bottom;
-      bool dummy;
-      if (TryUnifySegments(SegmentUnificationOperation.Widening, this, other, bott, bott, out left, out right, out dummy))
-      {
-        Contract.Assert(left.limits.Count == right.limits.Count);
-        Contract.Assert(left.elements.Count == right.elements.Count);
-        Contract.Assert(left.limits.Count == left.elements.Count + 1);
-
-        var resultLimits = new NonNullList<SegmentLimit<Variable>>();
-        var resultElements = new NonNullList<AbstractDomain>();
-
-        var last = left.limits.Count - 1;
-
-        for (var i = 0; i < last; i++)
-        {
-          var segment = left.limits[i].Widening(right.limits[i]);
-          var element = (AbstractDomain)left.elements[i].Widening(right.elements[i]);
-
-          resultLimits.Add(segment);
-          resultElements.Add(element);
-        }
-
-        resultLimits.Add(left.limits[last].Widening(right.limits[last]));
-
-        Contract.Assert(resultLimits.Count == resultElements.Count + 1);
-
-        return new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, this.bottomElement, this.expManager);
-      }
-      else
-      {
-        return this.Top;
-      }
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      return DuplicateMe();
-    }
-
-    [Pure]
-    public ArraySegmentation<AbstractDomain, Variable, Expression> DuplicateMe()
-    {
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>().state == this.state);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>().limits.Count == this.limits.Count);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>().elements.Count == this.elements.Count);
-
-      // F: TODO - one day have a better infernce for the fields assigned in the constructor
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(this);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    [Pure]
-    public List<Variable> Variables
-    {
-      get 
-      {
-        var result = new List<Variable>();
-        if (this.IsBottom || this.IsTop)
-          return result;
-
-        foreach (var limit in this.limits)
-        {
-          Contract.Assume(limit != null);
-
-          foreach (var exp in limit)
-          {
-            Contract.Assume(exp != null);
-            int dummy;
-            Variable v;
-            if (exp.IsVariable(out v) || exp.IsAddition(out v, out dummy))
+            get
             {
-              result.Add(v);
-            }
-          }
-        }
+                Contract.Ensures(!Contract.Result<bool>() || (state == State.NORMAL));
 
-        return result;
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      // do nothing
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-
-    }
-
-    public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-      return this.TestTrue(guard);
-    }
-
-    public ArraySegmentation<AbstractDomain, Variable, Expression> TestTrue(Expression guard)
-    {
-      Contract.Requires(guard != null);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      return this.testTrue.Visit(guard, this);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      return this.TestFalse(guard);
-    }
-
-    public ArraySegmentation<AbstractDomain, Variable, Expression> TestFalse(Expression guard)
-    {
-      Contract.Requires(guard != null);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      return this.testFalse.Visit(guard, this);
-    }
-
-     
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() == CheckOutcome.Top);
-
-      return CheckOutcome.Top;
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Variable,Expression> Members
-
-    [SuppressMessage("Microsoft.Contracts", "Assert-1-0")]
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      // It should not be called
-      Contract.Assert(false);
-    }
-
-    
-    public bool TryAssignInParallelFunctional(
-      Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert, 
-      out ArraySegmentation<AbstractDomain, Variable, Expression> result)
-    {
-      #region Contracts
-      Contract.Requires(sourcesToTargets != null);
-      Contract.Requires(convert != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-
-      #endregion
-      
-      if (this.IsEmptyArray || this.IsBottom || this.IsTop)
-      {
-        result = this;
-        return true;
-      }
-
-      Contract.Assume(this.elements.Count > 0);
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-
-      var newLimits = new NonNullList<SegmentLimit<Variable>>();
-      var newElements = new NonNullList<AbstractDomain>();
-
-      for (var i = 0; i < this.limits.Count - 1; i++)
-      {
-        var currLimits = this.limits[i];
-
-        foreach (var x in this.limits[i + 1])
-        {
-          if (x != null)
-          {
-            Variable v;
-            int k;
-            if (x.IsAddition(out v, out k) && k == -1 && currLimits.Contains(NormalizedExpression<Variable>.For(v)))
-            {
-              currLimits = currLimits.Add(NormalizedExpression<Variable>.For(v));
-            }
-          }
-        }
-
-        var newLimit = currLimits.AssignInParallel(sourcesToTargets, convert, this.expManager.Decoder);
-
-        if (!newLimit.IsEmpty)
-        {
-          newLimits.Add(newLimit);
-          newElements.Add(this.elements[i]);        // F TODO: This should be changed when we'll go relational
-        }
-        else
-        {  //  We are abstracting this segment limit, so we have to join the element values
-
-          Contract.Assume(newElements.Count > 0);   // The reason why that holds is because the first segment *always* contains 0, therefore we always have at least one element
-
-          var last = newElements.Count - 1;
-          newElements[last] = (AbstractDomain)newElements[last].Join(this.elements[i]);
-        }
-      }
-
-      Contract.Assert(newLimits.Count > 0);   // It holds because the first segment always contains 0 
-      Contract.Assume(!newLimits[0].IsBottom);
-
-      var lastLimit = this.limits[this.limits.Count - 1].AssignInParallel(sourcesToTargets, convert, this.expManager.Decoder);
-
-      if (lastLimit.IsEmpty)
-      {
-        // We reach this point when, for some reason, we cannot get a name for the length of the array
-        result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
-        return false;
-      }
-
-      newLimits.Add(lastLimit);
-
-      Contract.Assert(newLimits.Count == newElements.Count +1); // the List.Add contract is not strong enough
-
-      var renamedNewElements = newElements.ConvertAll(x => x.Rename(sourcesToTargets));
-
-      result = new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, renamedNewElements, this.bottomElement, this.expManager);
-      return true;
-    }
-
-    #endregion
-
-    #region Helper checking functions
-
-    static public FlatAbstractDomain<bool> IsEqual(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Requires(segment != null);
-
-      // 1. Try in the Segment
-      if (segment.Contains(exp))
-        return CheckOutcome.True;
-
-      // 2. Try in the ArraySegmentation (TODO)
-      return CheckOutcome.Top;
-    }
-
-    #endregion
-
-    #region GetAbstractValue
-     
-    public bool TryGetAbstractValue(NormalizedExpression<Variable> index, 
-      INumericalAbstractDomainQuery<Variable, Expression> oracle, out IAbstractDomain result)
-    {
-      #region Contracts
-
-      Contract.Requires(index != null);
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-      
-      #endregion
-
-      var info = new SearchInfo();
-
-      var bounds = oracle.BoundsFor(ToExp(index)).AsInterval;
-
-      if (bounds.IsBottom)
-      {
-        result = Interval.UnreachedInterval;
-
-        return true;
-      }
-
-      IAbstractDomain result1 = null, result2 = null;
-
-      int low, upp;
-      if (bounds.IsFiniteAndInt32(out low, out upp) && TrySearchBounds(ToNormExp(low), ToNormExp(upp+1), oracle, ref info))
-      {
-        Contract.Assert(info.Low >= 0);
-        result1 = JoinValuesInASubrange(info.Low, info.UppMerge);
-      }
-
-      if (TrySearchBounds(index, index, oracle, ref info))
-      {
-        Contract.Assert(info.Low >= 0);
-        result2 = JoinValuesInASubrange(info.Low, info.UppMerge);
-      }
-
-      if (result1 != null)
-      {
-        if (result2 != null)
-        {
-          result = result1.Meet(result2);
-          return true;
-        }
-
-        result = result1;
-        return true;
-      }
-      else if (result2 != null)
-      {
-        result = result2;
-        return true;
-      }
-      else
-      {
-        result = default(IAbstractDomain);
-        return false;
-      }
-    }
-
-    public bool TryGetAbstractValue(NormalizedExpression<Variable> lower, NormalizedExpression<Variable> upper,
-      INumericalAbstractDomain<Variable, Expression> oracle, out IAbstractDomain result)
-    {
-      #region Contracts
-      Contract.Requires(lower != null);
-      Contract.Requires(upper != null);
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result)!= null);
-      #endregion
-
-      var si = default(SearchInfo);
-      if(this.TrySearchBounds(lower, upper, oracle, ref si))
-      {
-        result = JoinValuesInASubrange(si.Low, si.UppMerge, this.bottomElement);
-        return true;
-      }
-
-      result = default(IAbstractDomain);
-      return false;
-    }
-
-    public bool TryMeetAllValuesInTheLimits(SegmentLimit<Variable> lower, SegmentLimit<Variable> upper,
-      INumericalAbstractDomain<Variable, Expression> oracle, ref IAbstractDomain result)
-    {
-      Contract.Requires(lower != null);
-      Contract.Requires(upper != null);
-      Contract.Requires(oracle != null);
-      Contract.Requires(result == null);
-
-      Contract.Ensures(!Contract.Result<bool>() || result != null);
-
-      foreach (var low in lower)
-      {
-        if (low == null)
-          continue;
-
-        foreach (var upp in upper)
-        {
-          if (upp == null)
-            continue;
-
-          IAbstractDomain tmpValue;
-          if (TryGetAbstractValue(low, upp, oracle, out tmpValue))
-          {
-            result = result != null? result.Meet(tmpValue) : tmpValue;
-          }
-          else
-          {
-            result = null;
-            return false;
-          }
-        }
-      }
-
-      return result != null;
-    }
-
-    #endregion
-
-    #region AssumeAbstractValue
-    
-    /// <summary>
-    /// The segmentation is update only if the abstract value does not overwrite some information we already had.
-    /// Differently stated, this methos succeeds only if it guarantees a refinement of the segmentation
-    /// </summary>
-    public bool TryAssumeAbstractValue(
-      NormalizedExpression<Variable> index, 
-      AbstractDomain value,
-      INumericalAbstractDomainQuery<Variable, Expression> oracle,
-      out ArraySegmentation<AbstractDomain, Variable, Expression> result)
-    {
-      #region Contracts
-
-      Contract.Requires(index != null);
-      Contract.Requires(value != null);
-      Contract.Requires(oracle != null);
-
-      #endregion
-
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-
-      var info = new SearchInfo();
-      if (this.IsNormal && TrySearchBoundsForAddingASegment(index, oracle, ref info))
-      {
-        return TrySetAbstractValueInternal(false, index, value, oracle, info, out result);
-      }
-
-      result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
-      return false;
-    }
-
-    private bool TrySetAbstractValueInternal(
-      bool allowOverwrite,
-      NormalizedExpression<Variable> index, 
-      AbstractDomain value, INumericalAbstractDomainQuery<Variable, Expression> oracle, SearchInfo info,
-      out ArraySegmentation<AbstractDomain, Variable, Expression> result)
-    {
-      #region Contracts 
-      Contract.Requires(index != null);
-      Contract.Requires(value != null);
-      Contract.Requires(oracle != null);
-
-      Contract.Requires(0 <= info.Low);
-      Contract.Requires(0 <= info.Upp);
-      Contract.Requires(info.Low < this.elements.Count + 1);
-      Contract.Requires(info.Upp <= info.UppMerge);
-      Contract.Requires(info.Upp <= this.elements.Count);
-      Contract.Requires(info.UppMerge < this.limits.Count);
-      Contract.Requires(this.limits.Count == this.elements.Count + 1);
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-      #endregion
-
-      // The new values
-      NonNullList<SegmentLimit<Variable>> newLimits;
-      NonNullList<AbstractDomain> newElements;
-
-      CopyPrefix(info.Low, out newLimits, out newElements);
-
-      result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
-
-      #region Set the prefix
-
-      // Case 1 : { L } val ...   && L == index so we generate { L, index } val ...
-      if (info.IsLowerBoundEqual)
-      {
-        newLimits.Add(this.limits[info.Low].Add(index));
-        newElements.Add(value);
-
-        Contract.Assert(newLimits.Count == newElements.Count);
-      }
-      else // Case 2 : { L } val  { L1 } val1 { L2 } ... && L < index so we generate { L } Join(val) { index } ...
-        if (info.IsLowerBoundStrict)
-        {
-          // { L }
-          newLimits.Add(this.limits[info.Low]);
-
-          if (!allowOverwrite)
-            return false;
-
-          // Join(val)
-          var joinValues = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
-          newElements.Add(joinValues);
-
-          // { index }
-          newLimits.Add(new SegmentLimit<Variable>(index, false));
-
-          // value
-          newElements.Add(value);
-
-          Contract.Assert(newLimits.Count == newElements.Count);
-        }
-        else if (info.IsUpperBoundEqual)
-        {
-          if (!allowOverwrite)
-            return false;
-
-          // { L }
-          newLimits.Add(this.limits[info.Low]);
-
-          // Join(val)
-          var joinValues = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
-          newElements.Add(joinValues);
-
-          // { index }
-          newLimits.Add(new SegmentLimit<Variable>(index, true));
-
-          // value
-          newElements.Add(value);
-
-          Contract.Assert(newLimits.Count == newElements.Count);
-
-        }
-        else if (info.IsLowerBoundStrictlySmallerThanUpp)
-        {    // Case 3 : { L } val { L1 } &&  L <= index < L1 so we generate {L} prevVal { index }? val ...
-          if (!allowOverwrite)
-            return false;
-
-          // { L }
-          newLimits.Add(this.limits[info.Low]);
-
-          // Join(val)
-          var joinValues = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
-          newElements.Add(joinValues);
-
-          // { index }
-          newLimits.Add(new SegmentLimit<Variable>(index, true));
-
-          // { value }
-          newElements.Add(value);
-
-          Contract.Assert(newLimits.Count == newElements.Count);
-        }
-        else // Case 4 : { L } val  { L1 } val1 { L2 } ... && L <= index so we generate { L } Join(val)  ...
-        // So we abstract away the index  
-        {
-          if (!allowOverwrite)
-            return false;
-
-          // { L }
-          newLimits.Add(this.limits[info.Low]);
-
-          // Join(val)
-          var joinVal = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
-
-          joinVal = (AbstractDomain)joinVal.Join(value);
-
-          // Join(val) join value
-          newElements.Add(joinVal);
-
-          Contract.Assert(newLimits.Count == newElements.Count);
-        }
-
-      #endregion
-
-      // F: here it seems that the WP do not go back enough
-      Contract.Assert(info.Upp < this.limits.Count);
-
-      #region Set the upper limit
-
-      int upp;
-
-      // Case 1 : ...  { U } ... && index + 1 < U so we generate {index+1} \join(val) { U } ...  
-      if (info.IsUpperBoundStrict)
-      {
-        if (!allowOverwrite)
-          return false;
-
-        // { index + 1 }
-        newLimits.Add(new SegmentLimit<Variable>(index.PlusOne(), false));
-
-        // Join(Val)
-        newElements.Add(JoinValuesInASubrange(info.Low, info.Upp, value.Bottom));
-
-        // { U }
-        var uppLimit = this.limits[info.Upp];
-
-        Contract.Assert(uppLimit != null);
-
-        newLimits.Add(new SegmentLimit<Variable>(uppLimit, false));
-
-        upp = info.Upp + 1;
-
-        Contract.Assert(newLimits.Count == newElements.Count + 1);
-      }
-      else  // Case 2 : .... { U } ... && index + 1 == U so we generate { U, index+1 } ...
-        if (info.IsUpperBoundEqual)
-        {
-          // update the previous bound with the info that it is -1
-          Contract.Assume(newLimits.GetLastElement().Contains(index));
-          newLimits[newLimits.Count - 1] = newLimits.GetLastElement().Add(this.limits[info.Upp].MinusOne());
-
-          // { index + 1, U }
-          newLimits.Add(this.limits[info.Upp].Add(index.PlusOne()));
-
-          upp = info.Upp + 1;
-
-          Contract.Assert(newLimits.Count == newElements.Count + 1);
-        }
-        else // Case 3 : ...  { U }[?] ... && index + 1 <= U so we generate {index+1} \join(val) { U }[?] ...  
-        {
-          var nextLimits = new Set<NormalizedExpression<Variable>>(index.PlusOne());
-          if (newLimits[newLimits.Count - 1].Contains(index))
-          {
-            foreach (var exp in newLimits[newLimits.Count - 1])
-            {
-              // a limit can be null (with no semantic meaning)
-              if (exp != null)
-              {
-                nextLimits.Add(exp.PlusOne());
-              }
-            }
-          }
-
-          // { index + 1 }
-          newLimits.Add(new SegmentLimit<Variable>(nextLimits, false));
-
-          // Join(Val)
-          newElements.Add(JoinValuesInASubrange(info.Low, info.Upp, value.Bottom));
-
-          Contract.Assert(newElements.Count > 0); // F: Weakness of List.Add
-
-          // { U }
-          bool a, b;
-
-          // If we cannot prove that index +1 <= U, then we abstract away U
-          if (!this.LessEqual(index.PlusOne(), this.limits[info.UppMerge], oracle, out a, out b))
-          {
-            if (!allowOverwrite)
-              return false;
-
-            if (info.UppMerge < this.elements.Count)
-            {
-              var prev = this.elements[info.UppMerge];
-
-              newElements[newElements.Count - 1] = (AbstractDomain)newElements[newElements.Count - 1].Join(prev);
-              info.UppMerge++;
-            }
-            else  // Special case for the last element
-            {
-              Contract.Assume(info.UppMerge > 0);   // F: At the moment, I am not 100% sure why it is the case.
-              var prev = this.elements[info.UppMerge - 1];
-              newElements[newElements.Count - 1] = (AbstractDomain)newElements[newElements.Count - 1].Join(prev);
-            }
-
-            var uppMergeLimits = this.limits[info.UppMerge];
-
-            Contract.Assert(uppMergeLimits != null);
-
-            newLimits.Add(new SegmentLimit<Variable>(uppMergeLimits, true));
-
-            upp = info.UppMerge + 1;
-          }
-          else
-          {
-
-            var uppMergeLimits = this.limits[info.UppMerge];
-
-            Contract.Assert(uppMergeLimits != null);
-
-            newLimits.Add(new SegmentLimit<Variable>(uppMergeLimits, true));
-
-            upp = info.UppMerge + 1;
-          }
-          Contract.Assert(newLimits.Count == newElements.Count + 1);
-        }
-
-      #endregion
-
-      // Set the remaining
-      CopySuffix(Math.Min(this.limits.Count, upp), newLimits, newElements);
-
-      result = new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-      return true;
-    }
-   
-    #endregion
-
-    #region SetAbstractValue
-
-    public bool TrySetAbstractValue(NormalizedExpression<Variable> index, 
-      AbstractDomain value,
-      INumericalAbstractDomainQuery<Variable, Expression> oracle,
-      out ArraySegmentation<AbstractDomain, Variable, Expression> result)
-    {
-      #region Contracts
-      
-      Contract.Requires(index != null);
-      Contract.Requires(value != null);
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-
-      #endregion
-
-      Contract.Assume(this.limits.Count == this.elements.Count +1);
-
-      var info = new SearchInfo();
-      if (this.IsNormal)
-      {
-        if (TrySearchBoundsForAddingASegment(index, oracle, ref info))
-        {
-          return TrySetAbstractValueInternal(true, index, value, oracle, info, out result);
-        }
-      }
-
-      result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
-      return false;
-    }
-
-     
-    public bool TrySetAbstractValue(NormalizedExpression<Variable> lowIndex, NormalizedExpression<Variable> uppIndex,
-      AbstractDomain value,
-      INumericalAbstractDomainQuery<Variable, Expression> oracle,
-      out ArraySegmentation<AbstractDomain, Variable, Expression> result)
-    {
-      #region Contracts
-      Contract.Requires(lowIndex != null);
-      Contract.Requires(uppIndex != null);
-      Contract.Requires(oracle != null);
-
-      Contract.Requires(value != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-      #endregion
-
-      // F: we need some more checking code above to determine that we call this method only on normal abstract states
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-      
-      var info = new SearchInfo();
-      if (TrySearchBounds(lowIndex, uppIndex, oracle, ref info))
-      {
-        // F: We should put it here as otherwise the WP do not go back enough
-        Contract.Assert(info.Low >= 0);
-        Contract.Assert(info.Upp > 0); 
-        Contract.Assert(info.Low < this.elements.Count);
-        Contract.Assert(info.Upp <= this.elements.Count);
-
-        NonNullList<SegmentLimit<Variable>> newLimits;
-        NonNullList<AbstractDomain> newElements;
-
-        this.CopyPrefix(info.Low, out newLimits, out newElements);
-
-        newLimits.Add(this.limits[info.Low]);
-
-        Contract.Assert(info.Low < this.elements.Count);
-
-        var smash = this.JoinValuesInASubrange(info.Low, info.Upp);
-
-        smash = (AbstractDomain) smash.Join(value);
-
-        this.CopySuffix(info.Upp, newLimits, newElements);
-
-        Contract.Assert(info.Upp > 0);
-
-        // The reason why this is true is because either CopyPrefix or CopySuffix added at least one element to newElements
-        Contract.Assume(newElements.Count > 0); 
-
-        newElements[Math.Min(info.Upp - 1, newElements.Count-1)] = smash;
-
-        Contract.Assert(newLimits.Count == newElements.Count + 1);
-
-        result = new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-        return true;
-      }
-
-      result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
-      return false;
-    }
-
-     
-    private AbstractDomain JoinValuesInASubrange(int low, int upp, IAbstractDomain bottom)
-    {
-      #region Contracts
-      Contract.Requires(bottom != null);
-      Contract.Requires(upp <= this.elements.Count);
-
-      Contract.Ensures(Contract.Result<AbstractDomain>() != null);
-      #endregion
-
-      var joinVal = bottom;
-      for (var i = Math.Max(0, low); i < upp; i++)
-      {
-        joinVal = joinVal.Join(this.elements[i]);
-      }
-
-      var tmp = (AbstractDomain)joinVal;
-      Contract.Assert(tmp != null);
-
-      return tmp;
-    }
-     
-    [Pure]
-    private AbstractDomain JoinValuesInASubrange(int low, int upp)
-    {
-      #region Contracts
-      Contract.Requires(low >= 0);
-      
-      Contract.Requires(low <= upp);
-
-      Contract.Requires(low < this.elements.Count);
-      Contract.Requires(upp <= this.elements.Count);
-
-      Contract.Ensures(Contract.Result<AbstractDomain>() != null);
-      #endregion
-
-      IAbstractDomain joinVal = this.elements[low];
-
-      Contract.Assert(joinVal != null); 
-
-      for (var i = low + 1; i < upp; i++)
-      {
-        joinVal = joinVal.Join(this.elements[i]);
-        Contract.Assert(joinVal != null);
-      }
-
-      // F: Sticking the assumption here until NN analysis will track "if reference then NN"
-      var tmp = (AbstractDomain)joinVal;
-      Contract.Assert( tmp != null);
-
-      return tmp;
-    }
-
-    [Pure]     
-    private void CopyPrefix(int limit, out NonNullList<SegmentLimit<Variable>> newLimits, out NonNullList<AbstractDomain> newElements)
-    {
-      #region Contracts
-
-      Contract.Requires(limit >= -1);
-      Contract.Requires(limit < this.limits.Count);
-      Contract.Requires(this.limits.Count == this.elements.Count + 1);
-
-      Contract.Ensures(Contract.ValueAtReturn(out newLimits) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out newElements) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out newLimits).Count == Contract.ValueAtReturn(out newElements).Count);
-
-      #endregion
-
-      newLimits = new NonNullList<SegmentLimit<Variable>>();
-      newElements = new NonNullList<AbstractDomain>();
-
-      for (var i = 0; i < limit; i++)
-      {
-        newLimits.Add(this.limits[i]);
-        newElements.Add(this.elements[i]);
-
-        Contract.Assert(newLimits.Count == newElements.Count); // F: because of Add
-      }
-    }
-
-    [Pure]
-     
-    private void CopySuffix(int start, NonNullList<SegmentLimit<Variable>> newLimits, NonNullList<AbstractDomain> newElements)
-    {
-      Contract.Requires(newLimits != null);
-      Contract.Requires(newElements != null);
-
-      Contract.Requires(start >= 0);
-      Contract.Requires(start <= this.limits.Count);
-
-      for (var i = start; i < this.limits.Count; i++)
-      {
-        newLimits.Add(this.limits[i]);
-      }
-
-      for (var i = Math.Max(start - 1, 0); i < this.elements.Count; i++)
-      {
-        newElements.Add(this.elements[i]);
-      }
-    }
-
-    #endregion
-
-    #region Limits
-
-    public IEnumerable<SegmentLimit<Variable>> Limits
-    {
-      get
-      {
-        return this.limits;
-      }
-    }
-
-    public SegmentLimit<Variable> LastLimit
-    {
-      get
-      {
-        Contract.Requires(this.IsNormal && !this.IsEmptyArray);
-        Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
-
-        return this.limits[this.limits.Count - 1];
-      }
-    }
-
-    #endregion
-
-    #region Elements
-    public IEnumerable<AbstractDomain> Elements
-    {
-      [ContractVerification(false)]
-      get
-      {
-        Contract.Ensures(this.elements != null);
-        Contract.Ensures(Contract.ForAll(Contract.Result<IEnumerable<AbstractDomain>>(), x => x != null));
-
-        return this.elements;
-      }
-    }
-    #endregion
-
-    #region Search bounds (TrySearchBounds* methods)
-
-    /// <summary>
-    /// Return the largest index of a segment such that limits[index] \leq exp
-    /// </summary>
-     
-    public bool TrySearchBoundsForAddingASegment(
-      NormalizedExpression<Variable> exp, INumericalAbstractDomainQuery<Variable, Expression> oracle, 
-      ref SearchInfo info)
-    {
-      #region Contracts
-
-      Contract.Requires(exp != null);
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(-1 <= info.Low);
-      Contract.Ensures(0 <= info.Upp);
-      Contract.Ensures(0 <= info.UppMerge);
-
-      Contract.Ensures(info.Upp <= info.UppMerge);
-
-      Contract.Ensures(info.Upp <= this.limits.Count);
-      Contract.Ensures(info.UppMerge <= this.limits.Count);      
-      Contract.Ensures(info.Low < this.limits.Count);
-
-      // If we find the bounds, then they are within the bounds of limits
-      Contract.Ensures(!Contract.Result<bool>() || info.Low >= 0);
-
-      Contract.Ensures(!Contract.Result<bool>() || info.Upp < this.limits.Count);
-      Contract.Ensures(!Contract.Result<bool>() || info.UppMerge < this.limits.Count);
-
-      Contract.Ensures(!Contract.Result<bool>() || info.Upp <= this.elements.Count);
-      Contract.Ensures(!Contract.Result<bool>() || info.UppMerge <= this.elements.Count);
-
-      #endregion
-
-      info.Low = -1;
-      info.Upp = this.limits.Count;
-      info.UppMerge = this.limits.Count;
-      info.IsLowerBoundEqual = false;
-      info.IsUpperBoundStrict = false;
-
-      // Search the lower bound
-      for (var i = 0; i < this.limits.Count; i++)
-      {
-        if (!GreaterEqualThan(exp, this.limits[i], oracle, out info.IsLowerBoundEqual, out info.IsLowerBoundStrict) || info.IsLowerBoundEqual)
-        {
-          info.Low = info.IsLowerBoundEqual ? i : i - 1;
-
-          if (!info.IsLowerBoundEqual && info.Low >= 0)
-          {
-            info.IsLowerBoundStrict = ExistsLessThan(this.limits[info.Low], exp, oracle);
-          }
-
-          break;
-        }
-      }
-      if (info.Low < 0)
-      {
-        return false;
-      }
-
-      info.Upp =  info.Low + 1;
-
-      while (info.Upp < this.limits.Count && !ExistsLessThan(exp, this.limits[info.Upp], oracle))
-      {
-        info.Upp++;
-      }
-
-      if (info.Upp >= this.limits.Count)
-      {
-        return false;
-      }
-
-      info.UppMerge = info.Upp;
-
-      var expPlusOne = exp.PlusOne();
-
-      // \exists l. exp+1 == l
-      info.IsUpperBoundEqual = Equal(expPlusOne, this.limits[info.Upp], oracle);
-
-      // \exists l. exp+1 < l
-      info.IsUpperBoundStrict = LessThan(expPlusOne, this.limits[info.Upp], oracle);
-
-
-      for (var i = info.Upp; i < this.limits.Count; i++)
-      {
-        if (this.limits[i].IsConditional)
-        {
-          info.UppMerge = i;
-        }
-        else
-        {
-          break;
-        }
-      }
-
-      info.IsLowerBoundStrictlySmallerThanUpp = ExistsLessThan(exp, this.limits[info.Upp], oracle);
-
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-
-      return true;
-    }
-     
-    public bool TrySearchBounds(NormalizedExpression<Variable> lowExp, NormalizedExpression<Variable> uppExp,
-      INumericalAbstractDomainQuery<Variable, Expression> oracle, ref SearchInfo info)
-    {
-      #region Contracts
-      Contract.Requires(lowExp != null);
-      Contract.Requires(uppExp != null);
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(info.Low >= -1);
-      Contract.Ensures(info.Upp >= 0);
-      //Contract.Ensures(info.UppMerge >= 0);
-
-      Contract.Ensures(info.Low <= info.Upp);
-      Contract.Ensures(info.Low <= this.elements.Count);
-
-      Contract.Ensures(info.Upp == info.UppMerge);
-
-      Contract.Ensures(info.Upp <= this.limits.Count);
-
-      Contract.Ensures(!Contract.Result<bool>() || info.Low >= 0);
-      Contract.Ensures(!Contract.Result<bool>() || info.Upp > 0);
-
-      Contract.Ensures(!Contract.Result<bool>() || info.Low < this.elements.Count);
-
-      Contract.Ensures(!Contract.Result<bool>() || info.Low <= info.Upp);
-      
-      Contract.Ensures(!Contract.Result<bool>() || info.Upp < this.limits.Count);
-      Contract.Ensures(!Contract.Result<bool>() || info.Upp <= this.elements.Count);
-      
-      #endregion
-
-      // Let's search the lower bound
-      info.Low = -1;
-      info.Upp = info.UppMerge = 0;
-
-      if (this.IsEmptyArray || !this.IsNormal)
-      {
-        return false;
-      }
-
-      Contract.Assert(this.elements.Count >= 1);
-      Contract.Assert(this.limits.Count == this.elements.Count + 1);
-
-      // Fast, syntactic search for the lower bound
-      var found = false;
-      for (var i = 0; i < this.limits.Count-1; i++)
-      {
-        if (this.limits[i].Contains(lowExp))
-        {
-          info.Low = i;
-          Contract.Assert(info.Low < this.elements.Count);
-          
-          info.IsLowerBoundEqual = true;
-          info.IsLowerBoundStrict = false;
-          found = true;
-          break;
-        }
-      }
-
-      Contract.Assert(this.limits.Count == this.elements.Count + 1);
-
-      // Semantic search
-      if (!found)
-      {
-        Contract.Assert(this.elements.Count < this.limits.Count); // ok we can prove it
-        for (var i = 0; i < this.limits.Count; i++)
-        {
-          if (!GreaterEqualThan(lowExp, this.limits[i], oracle, out info.IsLowerBoundEqual, out info.IsLowerBoundStrict) || info.IsLowerBoundEqual) // We found our index!
-          {
-            info.Low = info.IsLowerBoundEqual ? i : i - 1;
-            
-            Contract.Assume(info.Low < this.elements.Count, "we cannot prove it, because i <= this.elements.Count, maybe there is a reason why it holds, or my code is buggy");
-
-            break;
-          }
-        }
-
-
-        if (info.Low < 0 || info.Low == this.elements.Count)  // We did not find any lower bound
-        {
-          info.Low = -1;  // This is to make sure that 
-
-          return false;
-        }
-      }
-
-      Contract.Assert(info.Low >= 0); // If we reach that point, we found a lower bound. 
-      Contract.Assert(info.Low < this.elements.Count); 
-
-      // Let's search the upper bound 
-
-      var uppExpAsBoxedExpression = ToExp(uppExp);
-      Func<NormalizedExpression<Variable>, bool> semanticEquality = (NormalizedExpression<Variable> limit) => { return oracle.CheckIfEqual(ToExp(limit), uppExpAsBoxedExpression).IsTrue();};
-
-      // Syntactic search
-      for (var i = info.Low+1; i < this.limits.Count; i++)
-      {
-        // Found?
-        var limits = this.limits[i];
-        if (limits.Contains(uppExp) || (uppExpAsBoxedExpression != null && limits.Any(semanticEquality)))
-        {
-          info.Upp = info.UppMerge = i;
-          info.IsUpperBoundEqual = true;
-          info.IsUpperBoundStrict = false;
-
-          info.IsLowerBoundStrictlySmallerThanUpp = ExistsLessThan(lowExp, this.limits[info.Upp], oracle);
-
-          return true;
-        }
-      }
-      
-      // Semantic search
-      info.Upp = this.limits.Count;
-
-      for (var i = this.limits.Count - 1; i >= 0; i--)
-      {
-        if (!LessEqual(uppExp, this.limits[i], oracle, out info.IsUpperBoundEqual, out info.IsUpperBoundStrict) || 
-          info.IsUpperBoundEqual || !info.IsUpperBoundStrict)
-        {
-          // There are two reasons why we are here.
-          // The first is that the uppExp is to the left of the bound (i.e. limits[i] is no more a lower bound for uppEx)
-          // In this case, we know that it was the case for limits[i+1], so we set info.Upp = i+1
-          // The second is because we hit the exact bound for uppExp.
-          // In this case, we know that we have to consider the next element as well
-
-          info.Upp = Math.Min(i+1, this.limits.Count-1);
-
-          // The reason why this is true is because of the global invariant of the segmentation, that is we cannot have malformed segmentations { a } el { b } where a > b
-          // This is definitively out-of-reach of what Clousot can prove today
-          Contract.Assume(info.Low <= info.Upp);
-          break;
-        }
-      }
-
-      info.UppMerge = info.Upp;
-
-      if (info.Upp == this.limits.Count)
-      {
-        // Make it not meaningful
-        info.Low = -1;  
-      
-        return false;
-      }
-
-      Contract.Assert(info.Upp < this.limits.Count);
-
-      info.IsLowerBoundStrictlySmallerThanUpp = ExistsLessThan(lowExp, this.limits[info.Upp], oracle);
-
-      return true;
-    }
-
-
-    #endregion
-
-    #region SegmentLimitsQuery
-     
-    public bool Equal(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-
-      if (segment.Contains(exp))
-        return true;
-
-      foreach (var limit in segment)
-      {
-        if (limit != null && oracle.CheckIfEqual(ToExp(exp), ToExp(limit)).IsTrue())
-        {
-          return true;
-        }
-      }
-
-      return false;
-    }
-     
-    public bool LessEqual(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle, 
-      out bool equal, out bool strict)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-
-      if (segment.Contains(exp))
-      {
-        equal = true;
-        strict = false;
-        return true;
-      }
-
-      var expExp = ToExp(exp);
-
-      foreach (var limit in segment)
-      {
-        if(limit == null) continue;
-
-        var limitExp = ToExp(limit);
-        var res = oracle.CheckIfLessEqualThan(expExp, limitExp);
-        if (res.IsTrue())
-        {
-          equal = oracle.CheckIfEqual(expExp, limitExp).IsTrue();
-          strict = oracle.CheckIfLessThan(expExp, limitExp).IsTrue();
-          return true;
-        }
-      }
-
-      equal = false;
-      strict = false;
-      return false;
-    }
-
-    public bool LessEqual(SegmentLimit<Variable> segment, NormalizedExpression<Variable> exp,  
-      INumericalAbstractDomainQuery<Variable, Expression> oracle,
-     out bool equal, out bool strict)
-    {
-      #region Contracts
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-      #endregion
-
-      if (segment.Contains(exp))
-      {
-        equal = true;
-        strict = false;
-        return true;
-      }
-
-      var expExp = ToExp(exp);
-
-      foreach (var limit in segment)
-      {
-        if (limit == null) continue;
-
-        var limitExp = ToExp(limit);
-        var res = oracle.CheckIfLessEqualThan(limitExp, expExp);
-        if (res.IsTrue())
-        {
-          equal = oracle.CheckIfEqual(limitExp, expExp).IsTrue();
-          strict = oracle.CheckIfLessThan(limitExp, expExp).IsTrue();
-          return true;
-        }
-      }
-
-      equal = false;
-      strict = false;
-      return false;
-    }
-  
-    [Pure]
-    public bool GreaterEqualThan(
-      NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle, 
-      out bool equal, out bool strict)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-
-      if (segment.Contains(exp))
-      {
-        equal = true;
-        strict = false;
-        return true;
-      }
-
-      var expExp = ToExp(exp);
-
-      foreach (var limit in segment)
-      {
-        if (limit == null)
-          continue;
-
-        var limitExp = ToExp(limit);
-        var res = oracle.CheckIfLessEqualThan(limitExp, expExp);
-        if (res.IsTrue())
-        {
-          equal = oracle.CheckIfEqual(expExp, limitExp).IsTrue();
-          strict = oracle.CheckIfLessThan(limitExp, expExp).IsTrue();
-          return true;
-        }
-        if (res.IsFalse())
-        {
-          equal = false;
-          strict = true;
-          return false;
-        }
-      }
-
-      equal = false;
-      strict = false;
-      return false;
-    }    
-     
-    public bool LessThan(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-
-      foreach (var limit in segment)
-      {
-        if (limit != null && oracle.CheckIfLessThan(ToExp(exp), ToExp(limit)).IsTrue())
-        {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    public bool LessThan(SegmentLimit<Variable> segment, NormalizedExpression<Variable> exp, INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-
-      foreach (var limit in segment)
-      {
-
-        if (limit != null && oracle.CheckIfLessThan(ToExp(limit), ToExp(exp)).IsTrue())
-        {
-          return true;
-        }
-      }
-
-      return false;
-
-    }
-     
-    public bool ExistsLessThan(SegmentLimit<Variable> segment, 
-      NormalizedExpression<Variable> exp, INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-
-      foreach (var limit in segment)
-      {
-        if (limit != null && oracle.CheckIfLessThan(ToExp(limit), ToExp(exp)).IsTrue())
-        {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    public bool ExistsLessThan(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment,
-      INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(segment != null);
-      Contract.Requires(oracle != null);
-
-      foreach (var limit in segment)
-      {
-        if (limit != null && oracle.CheckIfLessThan(ToExp(exp), ToExp(limit)).IsTrue())
-        {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    #endregion
-
-    #region TestTrueEqual
-     
-    public ArraySegmentation<AbstractDomain, Variable, Expression>
-      TestTrueEqualAsymmetric(NormalizedExpression<Variable> v, NormalizedExpression<Variable> normExpression)
-    {
-      Contract.Requires(v != null);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      if (!this.IsNormal)
-      {
-        return this;
-      }
-
-      Contract.Assert(this.elements.Count + 1== this.limits.Count); // assertion needed to prove the precondition later
-
-      var newElements = new NonNullList<AbstractDomain>(this.elements);
-      var newLimits = new NonNullList<SegmentLimit<Variable>>(this.limits.Count);
-
-      for (var i = 0; i < this.limits.Count; i++)
-      {
-        var limit = this.limits[i];
-        if (limit.Contains(normExpression))
-        {
-          var updatedLimits = limit.Add(v);
-
-          Contract.Assert(updatedLimits != null);
-
-          newLimits.InsertOrAdd(i , updatedLimits);
-
-          if (i < this.limits.Count - 1) 
-          {
-            var nextLimit = this.limits[i + 1];
-            if (nextLimit.IsSuccessorOf(updatedLimits))
-            {
-              newLimits.InsertOrAdd(i + 1, nextLimit.Add(v.PlusOne()));
-              i++; // Skip one iteration
-            }
-          }
-        }
-        else
-        {
-          newLimits.InsertOrAdd(i, limit);
-        }
-      }
-      Contract.Assume(this.limits.Count == this.elements.Count + 1, "for some reason we lose the assertion above");
-
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-    }
-
-     
-    public ArraySegmentation<AbstractDomain, Variable, Expression>
-      TestTrueEqualAsymmetric(Set<NormalizedExpression<Variable>> vars, NormalizedExpression<Variable> normExpression)
-    {
-      Contract.Requires(vars != null);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      if (!this.IsNormal)
-      {
-        return this;
-      }
-
-      Contract.Assert(this.elements.Count + 1 == this.limits.Count); // assertion needed to prove the precondition later
-
-      var newElements = new NonNullList<AbstractDomain>(this.elements);
-      var newLimits = new NonNullList<SegmentLimit<Variable>>(this.limits.Count);
-
-      int i;
-      for (i = 0; i < this.limits.Count; i++)
-      {
-        var limit = this.limits[i];
-        if (limit.Contains(normExpression))
-        {
-          newLimits.InsertOrAdd(i, limit.Add(vars));
-        }
-        else
-        {
-          newLimits.InsertOrAdd(i, limit);
-        }
-      }
-      Contract.Assume(this.limits.Count == this.elements.Count + 1, "for some reason we lose the assertion above");
-      Contract.Assert(newLimits.Count == newElements.Count + 1);
-      return new ArraySegmentation<AbstractDomain,Variable,Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-    }
-
-    #endregion
-
-    #region TestTrueLessThan
-     
-    public ArraySegmentation<AbstractDomain, Variable, Expression> TestTrueLessThan(NormalizedExpression<Variable> left, NormalizedExpression<Variable> right)
-    {
-      for (int i = 0; i < this.limits.Count - 1; i++)
-      {
-        var leftLimit = this.limits[i];
-        var rightLimit = this.limits[i + 1];
-
-        Contract.Assert(leftLimit != null);
-        Contract.Assert(rightLimit != null);
-
-        if (leftLimit.Contains(left) && rightLimit.Contains(right))
-        {
-          if (rightLimit.IsConditional)
-          {
-            var result = this.DuplicateMe();
-            result.limits[i + 1] = new SegmentLimit<Variable>(rightLimit, false);
-
-            return result;
-          }
-          else
-          {
-            return this;
-          }
-        }
-      }
-
-      return this;
-    }
-
-    #endregion
-
-    #region TestTrueWithIntConstants
-     
-    public ArraySegmentation<AbstractDomain, Variable, Expression> 
-      TestTrueWithIntConstants(List<Pair<NormalizedExpression<Variable>, NormalizedExpression<Variable>>> intConstants)
-    {
-      Contract.Requires(intConstants != null);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      if (intConstants.Count == 0 || this.IsBottom || this.IsTop)
-      {
-        return this;
-      }
-
-      var newLimits = new NonNullList<SegmentLimit<Variable>>(this.limits);
-      var newElements = new NonNullList<AbstractDomain>(this.elements);
-
-      foreach (var pair in intConstants)
-      {
-        int i = 0;
-        for (; i < newLimits.Count; i++)
-        {
-          var newLimits_i = newLimits[i];
-          if (newLimits_i.Contains(pair.One))
-          {
-            newLimits[i] = newLimits_i.Add(pair.Two);
-            break;
-          }
-
-          if (newLimits_i.Contains(pair.Two))
-          {
-            newLimits[i] = newLimits_i.Add(pair.One);
-            break;
-          }
-        }
-      }
-
-      Contract.Assume(newLimits.Count == newElements.Count+1);
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-    }
-
-    #endregion
-
-    #region TestTrueFromNumericalstate
-
-
-    #region
-    internal ArraySegmentation<AbstractDomain, Variable, Expression> TestTrueInformationForTheSegments(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      #region Contracts
-
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      #endregion
-
-      if (!this.IsNormal)
-      {
-        return this;
-      }
-
-      Contract.Assert(this.limits.Count >= 2, "should become an assertion");
-
-      Contract.Assert(this.elements.Count + 1 == this.limits.Count); // assertion needed to prove the precondition later
-
-      var resultLimits = new NonNullList<SegmentLimit<Variable>>(this.limits);
-
-      Contract.Assert(resultLimits.Count == this.limits.Count);
-
-      var resultElements = new NonNullList<AbstractDomain>(this.elements.Count);
-
-      for (var i = 0; i < this.elements.Count; i++)
-      {
-        var newSegment = this.elements[i].AssumeInformationFrom(oracle);
-
-        resultElements.Add(newSegment);
-      }
-
-      Contract.Assert(resultElements.Count == this.elements.Count);
-
-      Contract.Assume(this.elements.Count + 1 == this.limits.Count, "for some reason we lose the assertion above"); // assertion needed to prove the precondition later
-
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, this.bottomElement, this.expManager);
-    }
-    #endregion
-
-    #endregion
-
-    #region Reductions
-     
-    public ArraySegmentation<AbstractDomain, Variable, Expression> ReduceWith(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      #region Contracts
-
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      #endregion
-
-      if (this.IsEmptyArray || this.IsBottom || this.IsTop)
-      {
-        return this;
-      }
-
-      // We need the expressions encoder to push the information.
-      // If we do not have one, we just gave up
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (!this.expManager.TryGetEncoder(out encoder))
-      {
-        return this;
-      }
-
-      Contract.Assert(encoder != null, "to help wp");
-
-      // F: Should become an assertion
-      Contract.Assume(this.limits.Count >= 2);
-
-      var resultLimits = new NonNullList<SegmentLimit<Variable>>();
-      var resultElements = new NonNullList<AbstractDomain>();
-
-      var refined = false;
-
-      resultLimits.Add(this.limits[0]);
-
-      Contract.Assert(resultLimits.Count == 1);
-
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-
-      for (var i = 1; i < this.limits.Count; i++)
-      {               
-        Contract.Assert(i <= this.elements.Count); 
-
-        var curr = this.limits[i];
-
-        Contract.Assert(curr != null);
-
-        if (curr.IsConditional)
-        {
-          var prev = resultLimits[resultLimits.Count - 1];
-
-          Contract.Assert(prev != null);
-
-          foreach (var p in prev)
-          {
-            Contract.Assume(p != null);
-
-            foreach (var c in curr)
-            {
-              #region Body
-              Contract.Assume(c != null);
-
-              var pExp = p.Convert(encoder);
-              var cExp = c.Convert(encoder);
-//              var isEq = PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.CheckIfEqual, () => oracle.CheckIfEqual(pExp, cExp));
-              var isEq = PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.CheckIfEqual, () => oracle.CheckIfEqualIncomplete(pExp, cExp));
-
-              if (isEq.IsTrue())    // The segment is empty, so we remove it
-              {
-                // { 0, a } [0, 0] { a }? 
-                if (this.limits.Count == 2)
+                if (this.IsTop || this.IsBottom)
                 {
-                  return this.limits[1].IsConditional? this : this.Bottom;
+                    return false;
                 }
 
-                resultLimits[resultLimits.Count - 1] = new SegmentLimit<Variable>(prev.Meet(curr), prev.IsConditional);
+                if (elements.Count == 0)
+                {
+                    state = State.NORMAL;
+                    return true;
+                }
 
-                refined = true;
+                if (limits.Count > 1)
+                {
+                    Contract.Assert(!limits.IsEmpty);
+                    // If there is a common variable in the first and last set of bounds
+                    if (!limits[0].Intersection(limits.GetLastElement()).IsEmpty)
+                    {
+                        if (limits.GetLastElement().IsConditional)
+                        {
+                            state = State.NORMAL;
+                            return true;
+                        }
+                        else
+                        {
+                            state = State.BOTTOM;
+                            return false;
+                        }
+                    }
+                }
 
-                goto nextLoopIteration;
-              }
-
-              // The ? can go away
-              if (isEq.IsFalse() || oracle.CheckIfLessThanIncomplete(pExp, cExp).IsTrue())                   
-              {
-                resultElements.Add(this.elements[i - 1]);
-                resultLimits.Add(new SegmentLimit<Variable>(curr, false));
-
-                Contract.Assert(resultLimits.Count > 0);
-                Contract.Assert(resultElements.Count > 0);
-
-                refined = true;
-
-                goto nextLoopIteration;
-              }
-              #endregion
+                return false;
             }
-          }
         }
 
-        resultElements.Add(this.elements[i - 1]);
-        resultLimits.Add(curr);
-
-      nextLoopIteration:
-        
-        ;
-      }
-
-      Contract.Assert(resultLimits.Count == resultElements.Count +1 );
-
-      // It may be the case that the reduction has smashed together all the limits, by proving all be the same
-      if (resultLimits.Count <= 1)
-      {
-       return EmptyArray;
-      }
-
-      return refined ?
-        new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, this.bottomElement, this.expManager) :
-        this;
-    }
-
-    #endregion    
-
-    #region Normal Form
-    static private void RemoveTriviallyEmptySegments(NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements,
-      out NonNullList<SegmentLimit<Variable>> newLimits, out NonNullList<AbstractDomain> newElements, out bool isBottom)
-    {
-      Contract.Requires(limits != null);
-      Contract.Requires(elements != null);
-      Contract.Requires(limits.Count == elements.Count + 1);
-      
-      Contract.Ensures(Contract.ValueAtReturn(out newLimits) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out newElements) != null);
-
-      Contract.Ensures(Contract.ValueAtReturn(out newLimits).Count <= limits.Count);
-      Contract.Ensures(Contract.ValueAtReturn(out newElements).Count <= elements.Count);
-
-      newLimits = new NonNullList<SegmentLimit<Variable>>();
-      newElements = new NonNullList<AbstractDomain>();
-      isBottom = false;
-
-      Contract.Assert(newLimits.Count <= limits.Count);
-      Contract.Assert(newElements.Count <= elements.Count);
-
-      for (var i = 0; i < limits.Count; i++)
-      {
-        // F: If we reach this point, it means that we still have some limit to consider, not added to the newLimits
-        Contract.Assume(newLimits.Count < limits.Count);
-        var prevLimit = limits[i];
-
-        if (i == limits.Count - 1)
+        public bool IsNormal
         {
-          newLimits.Add(prevLimit);
-        }
-        else
-        {
-          // F: If we reach this point, it means that we still have some element to consider, not added to the newElements
-          Contract.Assume(newElements.Count < elements.Count);
-
-          var nextLimit = limits[i + 1];
-
-          if (nextLimit.IsConditional)
-          { 
-            // Case 1: So common that we make it a special case
-            // We have {a, x } {a, y}?
-            if (HaveASameBound(prevLimit, nextLimit))
+            [SuppressMessage("Microsoft.Contracts", "EnsuresInMethod-!Contract.Result<bool>() || this.limits.Count >= 2")]
+            [SuppressMessage("Microsoft.Contracts", "EnsuresInMethod-!Contract.Result<bool>() || this.elements.Count +1 == this.limits.Count")]
+            get
             {
-              newLimits.Add(new SegmentLimit<Variable>(nextLimit.Meet(prevLimit), false));
-              if (
-                /* i < elements.Count && */               // REDUNDANT inferred by CC
-                i + 1 < limits.Count - 1 // it is not the last limit
-                )
-              {
+                Contract.Ensures(!Contract.Result<bool>() || limits.Count >= 2);
+                Contract.Ensures(!Contract.Result<bool>() || elements.Count + 1 == limits.Count);
+
+                return !(this.IsEmptyArray || this.IsBottom || this.IsTop);
+            }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            var other = a as ArraySegmentation<AbstractDomain, Variable, Expression>;
+
+            Contract.Assume(other != null);
+
+            return this.LessEqual(other);
+        }
+
+        public bool LessEqual(ArraySegmentation<AbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, other, out result))
+            {
+                return result;
+            }
+
+            if (this.IsEmptyArray)
+            {
+                return other.IsEmptyArray;
+            }
+
+            // F: Warnings for those are from the handling of constrained calls
+            // Contract.Assert(!this.IsTop);
+            // Contract.Assert(!other.IsTop);
+
+            Contract.Assume(elements.Count > 0);
+
+            Contract.Assume(other.limits != null);
+            Contract.Assume(other.elements != null);
+            Contract.Assume(other.elements.Count > 0);
+
+            Contract.Assume(limits.Count == elements.Count + 1);
+            Contract.Assume(other.limits.Count == other.elements.Count + 1);
+
+            ArraySegmentation<AbstractDomain, Variable, Expression> leftReduced, rightReduced;
+            bool removedAtLeastOneLimitOnRight;
+
+            if (TryUnifySegments(SegmentUnificationOperation.LessEqual, this.DuplicateMe(), other.DuplicateMe(),
+              (AbstractDomain)elements[0].Bottom, (AbstractDomain)other.elements[0].Top,
+              out leftReduced, out rightReduced, out removedAtLeastOneLimitOnRight))
+            {
+                Contract.Assert(leftReduced.elements.Count == rightReduced.elements.Count);
+                Contract.Assert(leftReduced.limits.Count == rightReduced.limits.Count);
+
+                for (int i = 0; i < leftReduced.limits.Count; i++)
+                {
+                    if (leftReduced.limits[i].IsConditional && !rightReduced.limits[i].IsConditional)
+                    {
+                        return false;
+                    }
+                }
+
+                for (int i = 0; i < leftReduced.elements.Count; i++)
+                {
+                    var tmpElements = rightReduced.elements[i];
+
+                    Contract.Assert(tmpElements != null);
+
+                    if (!leftReduced.elements[i].LessEqual(tmpElements))
+                        return false;
+                }
+
+                return !removedAtLeastOneLimitOnRight;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { return this.Bottom; }
+        }
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> Bottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+                var tmp = new ArraySegmentation<AbstractDomain, Variable, Expression>(bottomElement, expManager);
+                tmp.state = State.BOTTOM;
+
+                return tmp;
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { return this.Top; }
+        }
+
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+                return new ArraySegmentation<AbstractDomain, Variable, Expression>(bottomElement, expManager);
+            }
+        }
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> EmptyArray
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+                return new ArraySegmentation<AbstractDomain, Variable, Expression>(true, bottomElement, expManager);
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var other = a as ArraySegmentation<AbstractDomain, Variable, Expression>;
+
+            Contract.Assume(other != null);
+
+            return this.Join(other);
+        }
+
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> Join(ArraySegmentation<AbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            ArraySegmentation<AbstractDomain, Variable, Expression> left, right, trivialResult;
+
+            if (ArrayOptions.Trace)
+            {
+                Console.WriteLine("Join of:\n{0}\n{1}", this.ToString(), other.ToString());
+            }
+
+            if (AbstractDomainsHelper.TryTrivialJoinRefinedWithEmptyArrays(this, other, out trivialResult))
+            {
+                if (ArrayOptions.Trace)
+                {
+                    Console.WriteLine("Result {0}", trivialResult.ToString());
+                }
+
+                return trivialResult;
+            }
+
+
+            Contract.Assume(other.elements != null);
+            Contract.Assume(other.limits != null);
+
+            Contract.Assume(elements.Count > 0);
+            Contract.Assume(other.elements.Count > 0);
+
+            Contract.Assume(limits.Count == elements.Count + 1);
+            Contract.Assume(other.limits.Count == other.elements.Count + 1);
+
+            // Different upper bounds
+            if (limits[limits.Count - 1].Join(other.limits[other.limits.Count - 1]).IsEmpty)
+            {
+                return this.Top;
+            }
+
+            var bott = (AbstractDomain)elements[0].Bottom;
+
+            var dup_this = this.DuplicateMe();
+            var dup_other = other.DuplicateMe();
+            bool dummy;
+            if (TryUnifySegments(SegmentUnificationOperation.Join, dup_this, dup_other, bott, bott, out left, out right, out dummy))
+            {
+                Contract.Assert(left.limits.Count > 0);
+                Contract.Assert(right.limits.Count > 0);
+                Contract.Assert(left.limits.Count == right.limits.Count);
+                Contract.Assert(left.elements.Count == right.elements.Count);
+                Contract.Assert(left.limits.Count == left.elements.Count + 1);
+
+                var resultLimits = new NonNullList<SegmentLimit<Variable>>();
+                var resultElements = new NonNullList<AbstractDomain>();
+
+                var last = left.limits.Count - 1;
+
+                for (var i = 0; i < last; i++)
+                {
+                    var segment = left.limits[i].Join(right.limits[i]);
+                    var l = left.elements[i];
+                    var r = right.elements[i];
+                    var element = (AbstractDomain)l.Join(r);
+
+                    resultLimits.Add(segment);
+                    resultElements.Add(element);
+                }
+
+                resultLimits.Add(left.limits[last].Join(right.limits[last]));
+
+                Contract.Assert(resultLimits.Count == resultElements.Count + 1);
+
+                var result = new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, bottomElement, expManager);
+
+                if (ArrayOptions.Trace)
+                {
+                    Console.WriteLine("Join result:\n{0}:", result.ToString());
+                }
+
+                return result;
+            }
+            else
+            {
+                return this.Top;
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            var other = a as ArraySegmentation<AbstractDomain, Variable, Expression>;
+
+            Contract.Assume(other != null);
+
+            return this.Meet(other);
+        }
+
+        [Pure]
+        public ArraySegmentation<AbstractDomain, Variable, Expression> Meet(ArraySegmentation<AbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            ArraySegmentation<AbstractDomain, Variable, Expression> left, right, trivialResult;
+
+            if (ArrayOptions.Trace)
+            {
+                Console.WriteLine("Meet of:\n{0}\n{1}", this.ToString(), other.ToString());
+            }
+
+            if (AbstractDomainsHelper.TryTrivialMeet(this, other, out trivialResult))
+            {
+                if (ArrayOptions.Trace)
+                {
+                    Console.WriteLine("Result {0}", trivialResult.ToString());
+                }
+
+                return trivialResult;
+            }
+
+            if (this.IsEmptyArray)
+            {
+                if (other.IsEmptyArray)
+                {
+                    return this;
+                }
+                return this.Bottom;
+            }
+            else if (other.IsEmptyArray)
+            {
+                return this.Bottom;
+            }
+
+            if (this.IsIncludedIn(other))
+            {
+                return this;
+            }
+            if (other.IsIncludedIn(this))
+            {
+                return other;
+            }
+
+            // Contract.Assert(!this.IsTop);
+            // Contract.Assert(!other.IsTop);
+
+            // F: those assumptions should go away once we will have the assertion above proven and the right object invariant
+            Contract.Assume(elements.Count > 0);
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            Contract.Assert(other.elements != null);
+            Contract.Assert(other.limits != null);
+
+            Contract.Assume(other.elements.Count > 0);
+            Contract.Assume(other.limits.Count == other.elements.Count + 1);
+
+            var bott = (AbstractDomain)elements[0].Bottom;
+
+            var dup_this = this.DuplicateMe();
+            var dup_other = other.DuplicateMe();
+
+            Contract.Assert(dup_this.limits.Count > 0);
+
+            // If different upper bounds, then merge them together (we know they should be the same)
+            var upperBounds = dup_this.limits[dup_this.limits.Count - 1].Join(dup_other.limits[dup_other.limits.Count - 1]);
+            if (upperBounds.IsEmpty)
+            {
+                var union = dup_this.limits[dup_this.limits.Count - 1].Meet(dup_other.limits[dup_other.limits.Count - 1]);
+
+                dup_this.limits[dup_this.limits.Count - 1] = union;
+                dup_other.limits[dup_other.limits.Count - 1] = union;
+            }
+
+            bool dummy;
+            if (TryUnifySegments(SegmentUnificationOperation.Meet, dup_this, dup_other, bott, bott, out left, out right, out dummy))
+            {
+                Contract.Assert(left.limits.Count == right.limits.Count);
+                Contract.Assert(left.elements.Count == right.elements.Count);
+                Contract.Assert(left.limits.Count == left.elements.Count + 1);
+
+                var resultLimits = new NonNullList<SegmentLimit<Variable>>();
+                var resultElements = new NonNullList<AbstractDomain>();
+
+                var last = left.limits.Count - 1;
+
+                for (var i = 0; i < last; i++)
+                {
+                    var segment = left.limits[i].Meet(right.limits[i]);
+                    var element = (AbstractDomain)left.elements[i].Meet(right.elements[i]);
+
+                    // refinement
+                    if (i < last - 1)
+                    {
+                        IAbstractDomain oldValueLeft = null;
+                        if (this.TryMeetAllValuesInTheLimits(left.limits[i], left.limits[i + 1], TopNumericalDomain<Variable, Expression>.Singleton, ref oldValueLeft)
+                          && !oldValueLeft.IsTop)
+                        {
+                            element = (AbstractDomain)element.Meet(oldValueLeft);
+                        }
+                        IAbstractDomain oldValueRight = null;
+                        if (other.TryMeetAllValuesInTheLimits(right.limits[i], right.limits[i + 1], TopNumericalDomain<Variable, Expression>.Singleton, ref oldValueRight)
+                          && !oldValueRight.IsTop)
+                        {
+                            element = (AbstractDomain)element.Meet(oldValueRight);
+                        }
+                    }
+
+                    resultLimits.Add(segment);
+                    resultElements.Add(element);
+                }
+
+                resultLimits.Add(left.limits[last].Join(right.limits[last]));
+
+                Contract.Assert(resultLimits.Count == resultElements.Count + 1);
+
+                var result = new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, bottomElement, expManager);
+
+                if (ArrayOptions.Trace)
+                {
+                    Console.WriteLine("Meet result:\n{0}:", result.ToString());
+                }
+
+                return result;
+            }
+            else
+            {
+                if (ArrayOptions.Trace)
+                {
+                    Console.WriteLine("Unification failed. Meet returns top");
+                }
+
+                return this.Top;
+            }
+        }
+
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            var other = prev as ArraySegmentation<AbstractDomain, Variable, Expression>;
+
+            Contract.Assume(other != null);
+
+            return this.Widening(other);
+        }
+
+
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-other != null")]
+        public ArraySegmentation<AbstractDomain, Variable, Expression> Widening(ArraySegmentation<AbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            ArraySegmentation<AbstractDomain, Variable, Expression> left, right;
+
+            if (this.IsTop)
+            {
+                return this;
+            }
+
+            if (this.IsEmptyArray)
+            {
+                if (other.IsEmptyArray)
+                {
+                    return this;
+                }
+
+                return this.Top;
+            }
+
+            Contract.Assert(!this.IsTop);
+
+            Contract.Assume(elements.Count > 0);
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            Contract.Assume(other.elements != null);
+            Contract.Assume(other.limits != null);
+
+            Contract.Assume(other.elements.Count > 0);
+            Contract.Assume(other.limits.Count == other.elements.Count + 1);
+
+            var bott = (AbstractDomain)elements[0].Bottom;
+            bool dummy;
+            if (TryUnifySegments(SegmentUnificationOperation.Widening, this, other, bott, bott, out left, out right, out dummy))
+            {
+                Contract.Assert(left.limits.Count == right.limits.Count);
+                Contract.Assert(left.elements.Count == right.elements.Count);
+                Contract.Assert(left.limits.Count == left.elements.Count + 1);
+
+                var resultLimits = new NonNullList<SegmentLimit<Variable>>();
+                var resultElements = new NonNullList<AbstractDomain>();
+
+                var last = left.limits.Count - 1;
+
+                for (var i = 0; i < last; i++)
+                {
+                    var segment = left.limits[i].Widening(right.limits[i]);
+                    var element = (AbstractDomain)left.elements[i].Widening(right.elements[i]);
+
+                    resultLimits.Add(segment);
+                    resultElements.Add(element);
+                }
+
+                resultLimits.Add(left.limits[last].Widening(right.limits[last]));
+
+                Contract.Assert(resultLimits.Count == resultElements.Count + 1);
+
+                return new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, bottomElement, expManager);
+            }
+            else
+            {
+                return this.Top;
+            }
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            return DuplicateMe();
+        }
+
+        [Pure]
+        public ArraySegmentation<AbstractDomain, Variable, Expression> DuplicateMe()
+        {
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>().state == state);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>().limits.Count == limits.Count);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>().elements.Count == elements.Count);
+
+            // F: TODO - one day have a better infernce for the fields assigned in the constructor
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(this);
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        [Pure]
+        public List<Variable> Variables
+        {
+            get
+            {
+                var result = new List<Variable>();
+                if (this.IsBottom || this.IsTop)
+                    return result;
+
+                foreach (var limit in limits)
+                {
+                    Contract.Assume(limit != null);
+
+                    foreach (var exp in limit)
+                    {
+                        Contract.Assume(exp != null);
+                        int dummy;
+                        Variable v;
+                        if (exp.IsVariable(out v) || exp.IsAddition(out v, out dummy))
+                        {
+                            result.Add(v);
+                        }
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            // do nothing
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+        }
+
+        public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            return this.TestTrue(guard);
+        }
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> TestTrue(Expression guard)
+        {
+            Contract.Requires(guard != null);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            return testTrue.Visit(guard, this);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            return this.TestFalse(guard);
+        }
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> TestFalse(Expression guard)
+        {
+            Contract.Requires(guard != null);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            return testFalse.Visit(guard, this);
+        }
+
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() == CheckOutcome.Top);
+
+            return CheckOutcome.Top;
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Variable,Expression> Members
+
+        [SuppressMessage("Microsoft.Contracts", "Assert-1-0")]
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            // It should not be called
+            Contract.Assert(false);
+        }
+
+
+        public bool TryAssignInParallelFunctional(
+          Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert,
+          out ArraySegmentation<AbstractDomain, Variable, Expression> result)
+        {
+            #region Contracts
+            Contract.Requires(sourcesToTargets != null);
+            Contract.Requires(convert != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+
+            #endregion
+
+            if (this.IsEmptyArray || this.IsBottom || this.IsTop)
+            {
+                result = this;
+                return true;
+            }
+
+            Contract.Assume(elements.Count > 0);
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            var newLimits = new NonNullList<SegmentLimit<Variable>>();
+            var newElements = new NonNullList<AbstractDomain>();
+
+            for (var i = 0; i < limits.Count - 1; i++)
+            {
+                var currLimits = limits[i];
+
+                foreach (var x in limits[i + 1])
+                {
+                    if (x != null)
+                    {
+                        Variable v;
+                        int k;
+                        if (x.IsAddition(out v, out k) && k == -1 && currLimits.Contains(NormalizedExpression<Variable>.For(v)))
+                        {
+                            currLimits = currLimits.Add(NormalizedExpression<Variable>.For(v));
+                        }
+                    }
+                }
+
+                var newLimit = currLimits.AssignInParallel(sourcesToTargets, convert, expManager.Decoder);
+
+                if (!newLimit.IsEmpty)
+                {
+                    newLimits.Add(newLimit);
+                    newElements.Add(elements[i]);        // F TODO: This should be changed when we'll go relational
+                }
+                else
+                {  //  We are abstracting this segment limit, so we have to join the element values
+                    Contract.Assume(newElements.Count > 0);   // The reason why that holds is because the first segment *always* contains 0, therefore we always have at least one element
+
+                    var last = newElements.Count - 1;
+                    newElements[last] = (AbstractDomain)newElements[last].Join(elements[i]);
+                }
+            }
+
+            Contract.Assert(newLimits.Count > 0);   // It holds because the first segment always contains 0 
+            Contract.Assume(!newLimits[0].IsBottom);
+
+            var lastLimit = limits[limits.Count - 1].AssignInParallel(sourcesToTargets, convert, expManager.Decoder);
+
+            if (lastLimit.IsEmpty)
+            {
+                // We reach this point when, for some reason, we cannot get a name for the length of the array
+                result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
+                return false;
+            }
+
+            newLimits.Add(lastLimit);
+
+            Contract.Assert(newLimits.Count == newElements.Count + 1); // the List.Add contract is not strong enough
+
+            var renamedNewElements = newElements.ConvertAll(x => x.Rename(sourcesToTargets));
+
+            result = new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, renamedNewElements, bottomElement, expManager);
+            return true;
+        }
+
+        #endregion
+
+        #region Helper checking functions
+
+        static public FlatAbstractDomain<bool> IsEqual(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            Contract.Requires(segment != null);
+
+            // 1. Try in the Segment
+            if (segment.Contains(exp))
+                return CheckOutcome.True;
+
+            // 2. Try in the ArraySegmentation (TODO)
+            return CheckOutcome.Top;
+        }
+
+        #endregion
+
+        #region GetAbstractValue
+
+        public bool TryGetAbstractValue(NormalizedExpression<Variable> index,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle, out IAbstractDomain result)
+        {
+            #region Contracts
+
+            Contract.Requires(index != null);
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+
+            #endregion
+
+            var info = new SearchInfo();
+
+            var bounds = oracle.BoundsFor(ToExp(index)).AsInterval;
+
+            if (bounds.IsBottom)
+            {
+                result = Interval.UnreachedInterval;
+
+                return true;
+            }
+
+            IAbstractDomain result1 = null, result2 = null;
+
+            int low, upp;
+            if (bounds.IsFiniteAndInt32(out low, out upp) && TrySearchBounds(ToNormExp(low), ToNormExp(upp + 1), oracle, ref info))
+            {
+                Contract.Assert(info.Low >= 0);
+                result1 = JoinValuesInASubrange(info.Low, info.UppMerge);
+            }
+
+            if (TrySearchBounds(index, index, oracle, ref info))
+            {
+                Contract.Assert(info.Low >= 0);
+                result2 = JoinValuesInASubrange(info.Low, info.UppMerge);
+            }
+
+            if (result1 != null)
+            {
+                if (result2 != null)
+                {
+                    result = result1.Meet(result2);
+                    return true;
+                }
+
+                result = result1;
+                return true;
+            }
+            else if (result2 != null)
+            {
+                result = result2;
+                return true;
+            }
+            else
+            {
+                result = default(IAbstractDomain);
+                return false;
+            }
+        }
+
+        public bool TryGetAbstractValue(NormalizedExpression<Variable> lower, NormalizedExpression<Variable> upper,
+          INumericalAbstractDomain<Variable, Expression> oracle, out IAbstractDomain result)
+        {
+            #region Contracts
+            Contract.Requires(lower != null);
+            Contract.Requires(upper != null);
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+            #endregion
+
+            var si = default(SearchInfo);
+            if (this.TrySearchBounds(lower, upper, oracle, ref si))
+            {
+                result = JoinValuesInASubrange(si.Low, si.UppMerge, bottomElement);
+                return true;
+            }
+
+            result = default(IAbstractDomain);
+            return false;
+        }
+
+        public bool TryMeetAllValuesInTheLimits(SegmentLimit<Variable> lower, SegmentLimit<Variable> upper,
+          INumericalAbstractDomain<Variable, Expression> oracle, ref IAbstractDomain result)
+        {
+            Contract.Requires(lower != null);
+            Contract.Requires(upper != null);
+            Contract.Requires(oracle != null);
+            Contract.Requires(result == null);
+
+            Contract.Ensures(!Contract.Result<bool>() || result != null);
+
+            foreach (var low in lower)
+            {
+                if (low == null)
+                    continue;
+
+                foreach (var upp in upper)
+                {
+                    if (upp == null)
+                        continue;
+
+                    IAbstractDomain tmpValue;
+                    if (TryGetAbstractValue(low, upp, oracle, out tmpValue))
+                    {
+                        result = result != null ? result.Meet(tmpValue) : tmpValue;
+                    }
+                    else
+                    {
+                        result = null;
+                        return false;
+                    }
+                }
+            }
+
+            return result != null;
+        }
+
+        #endregion
+
+        #region AssumeAbstractValue
+
+        /// <summary>
+        /// The segmentation is update only if the abstract value does not overwrite some information we already had.
+        /// Differently stated, this methos succeeds only if it guarantees a refinement of the segmentation
+        /// </summary>
+        public bool TryAssumeAbstractValue(
+          NormalizedExpression<Variable> index,
+          AbstractDomain value,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle,
+          out ArraySegmentation<AbstractDomain, Variable, Expression> result)
+        {
+            #region Contracts
+
+            Contract.Requires(index != null);
+            Contract.Requires(value != null);
+            Contract.Requires(oracle != null);
+
+            #endregion
+
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            var info = new SearchInfo();
+            if (this.IsNormal && TrySearchBoundsForAddingASegment(index, oracle, ref info))
+            {
+                return TrySetAbstractValueInternal(false, index, value, oracle, info, out result);
+            }
+
+            result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
+            return false;
+        }
+
+        private bool TrySetAbstractValueInternal(
+          bool allowOverwrite,
+          NormalizedExpression<Variable> index,
+          AbstractDomain value, INumericalAbstractDomainQuery<Variable, Expression> oracle, SearchInfo info,
+          out ArraySegmentation<AbstractDomain, Variable, Expression> result)
+        {
+            #region Contracts 
+            Contract.Requires(index != null);
+            Contract.Requires(value != null);
+            Contract.Requires(oracle != null);
+
+            Contract.Requires(0 <= info.Low);
+            Contract.Requires(0 <= info.Upp);
+            Contract.Requires(info.Low < elements.Count + 1);
+            Contract.Requires(info.Upp <= info.UppMerge);
+            Contract.Requires(info.Upp <= elements.Count);
+            Contract.Requires(info.UppMerge < limits.Count);
+            Contract.Requires(limits.Count == elements.Count + 1);
+
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+            #endregion
+
+            // The new values
+            NonNullList<SegmentLimit<Variable>> newLimits;
+            NonNullList<AbstractDomain> newElements;
+
+            CopyPrefix(info.Low, out newLimits, out newElements);
+
+            result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
+
+            #region Set the prefix
+
+            // Case 1 : { L } val ...   && L == index so we generate { L, index } val ...
+            if (info.IsLowerBoundEqual)
+            {
+                newLimits.Add(limits[info.Low].Add(index));
+                newElements.Add(value);
+
+                Contract.Assert(newLimits.Count == newElements.Count);
+            }
+            else // Case 2 : { L } val  { L1 } val1 { L2 } ... && L < index so we generate { L } Join(val) { index } ...
+              if (info.IsLowerBoundStrict)
+            {
+                // { L }
+                newLimits.Add(limits[info.Low]);
+
+                if (!allowOverwrite)
+                    return false;
+
+                // Join(val)
+                var joinValues = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
+                newElements.Add(joinValues);
+
+                // { index }
+                newLimits.Add(new SegmentLimit<Variable>(index, false));
+
+                // value
+                newElements.Add(value);
+
+                Contract.Assert(newLimits.Count == newElements.Count);
+            }
+            else if (info.IsUpperBoundEqual)
+            {
+                if (!allowOverwrite)
+                    return false;
+
+                // { L }
+                newLimits.Add(limits[info.Low]);
+
+                // Join(val)
+                var joinValues = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
+                newElements.Add(joinValues);
+
+                // { index }
+                newLimits.Add(new SegmentLimit<Variable>(index, true));
+
+                // value
+                newElements.Add(value);
+
+                Contract.Assert(newLimits.Count == newElements.Count);
+            }
+            else if (info.IsLowerBoundStrictlySmallerThanUpp)
+            {    // Case 3 : { L } val { L1 } &&  L <= index < L1 so we generate {L} prevVal { index }? val ...
+                if (!allowOverwrite)
+                    return false;
+
+                // { L }
+                newLimits.Add(limits[info.Low]);
+
+                // Join(val)
+                var joinValues = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
+                newElements.Add(joinValues);
+
+                // { index }
+                newLimits.Add(new SegmentLimit<Variable>(index, true));
+
+                // { value }
+                newElements.Add(value);
+
+                Contract.Assert(newLimits.Count == newElements.Count);
+            }
+            else // Case 4 : { L } val  { L1 } val1 { L2 } ... && L <= index so we generate { L } Join(val)  ...
+                 // So we abstract away the index  
+            {
+                if (!allowOverwrite)
+                    return false;
+
+                // { L }
+                newLimits.Add(limits[info.Low]);
+
+                // Join(val)
+                var joinVal = JoinValuesInASubrange(info.Low, info.Upp, value.Bottom);
+
+                joinVal = (AbstractDomain)joinVal.Join(value);
+
+                // Join(val) join value
+                newElements.Add(joinVal);
+
+                Contract.Assert(newLimits.Count == newElements.Count);
+            }
+
+            #endregion
+
+            // F: here it seems that the WP do not go back enough
+            Contract.Assert(info.Upp < limits.Count);
+
+            #region Set the upper limit
+
+            int upp;
+
+            // Case 1 : ...  { U } ... && index + 1 < U so we generate {index+1} \join(val) { U } ...  
+            if (info.IsUpperBoundStrict)
+            {
+                if (!allowOverwrite)
+                    return false;
+
+                // { index + 1 }
+                newLimits.Add(new SegmentLimit<Variable>(index.PlusOne(), false));
+
+                // Join(Val)
+                newElements.Add(JoinValuesInASubrange(info.Low, info.Upp, value.Bottom));
+
+                // { U }
+                var uppLimit = limits[info.Upp];
+
+                Contract.Assert(uppLimit != null);
+
+                newLimits.Add(new SegmentLimit<Variable>(uppLimit, false));
+
+                upp = info.Upp + 1;
+
+                Contract.Assert(newLimits.Count == newElements.Count + 1);
+            }
+            else  // Case 2 : .... { U } ... && index + 1 == U so we generate { U, index+1 } ...
+              if (info.IsUpperBoundEqual)
+            {
+                // update the previous bound with the info that it is -1
+                Contract.Assume(newLimits.GetLastElement().Contains(index));
+                newLimits[newLimits.Count - 1] = newLimits.GetLastElement().Add(limits[info.Upp].MinusOne());
+
+                // { index + 1, U }
+                newLimits.Add(limits[info.Upp].Add(index.PlusOne()));
+
+                upp = info.Upp + 1;
+
+                Contract.Assert(newLimits.Count == newElements.Count + 1);
+            }
+            else // Case 3 : ...  { U }[?] ... && index + 1 <= U so we generate {index+1} \join(val) { U }[?] ...  
+            {
+                var nextLimits = new Set<NormalizedExpression<Variable>>(index.PlusOne());
+                if (newLimits[newLimits.Count - 1].Contains(index))
+                {
+                    foreach (var exp in newLimits[newLimits.Count - 1])
+                    {
+                        // a limit can be null (with no semantic meaning)
+                        if (exp != null)
+                        {
+                            nextLimits.Add(exp.PlusOne());
+                        }
+                    }
+                }
+
+                // { index + 1 }
+                newLimits.Add(new SegmentLimit<Variable>(nextLimits, false));
+
+                // Join(Val)
+                newElements.Add(JoinValuesInASubrange(info.Low, info.Upp, value.Bottom));
+
+                Contract.Assert(newElements.Count > 0); // F: Weakness of List.Add
+
+                // { U }
+                bool a, b;
+
+                // If we cannot prove that index +1 <= U, then we abstract away U
+                if (!this.LessEqual(index.PlusOne(), limits[info.UppMerge], oracle, out a, out b))
+                {
+                    if (!allowOverwrite)
+                        return false;
+
+                    if (info.UppMerge < elements.Count)
+                    {
+                        var prev = elements[info.UppMerge];
+
+                        newElements[newElements.Count - 1] = (AbstractDomain)newElements[newElements.Count - 1].Join(prev);
+                        info.UppMerge++;
+                    }
+                    else  // Special case for the last element
+                    {
+                        Contract.Assume(info.UppMerge > 0);   // F: At the moment, I am not 100% sure why it is the case.
+                        var prev = elements[info.UppMerge - 1];
+                        newElements[newElements.Count - 1] = (AbstractDomain)newElements[newElements.Count - 1].Join(prev);
+                    }
+
+                    var uppMergeLimits = limits[info.UppMerge];
+
+                    Contract.Assert(uppMergeLimits != null);
+
+                    newLimits.Add(new SegmentLimit<Variable>(uppMergeLimits, true));
+
+                    upp = info.UppMerge + 1;
+                }
+                else
+                {
+                    var uppMergeLimits = limits[info.UppMerge];
+
+                    Contract.Assert(uppMergeLimits != null);
+
+                    newLimits.Add(new SegmentLimit<Variable>(uppMergeLimits, true));
+
+                    upp = info.UppMerge + 1;
+                }
+                Contract.Assert(newLimits.Count == newElements.Count + 1);
+            }
+
+            #endregion
+
+            // Set the remaining
+            CopySuffix(Math.Min(limits.Count, upp), newLimits, newElements);
+
+            result = new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
+            return true;
+        }
+
+        #endregion
+
+        #region SetAbstractValue
+
+        public bool TrySetAbstractValue(NormalizedExpression<Variable> index,
+          AbstractDomain value,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle,
+          out ArraySegmentation<AbstractDomain, Variable, Expression> result)
+        {
+            #region Contracts
+
+            Contract.Requires(index != null);
+            Contract.Requires(value != null);
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+
+            #endregion
+
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            var info = new SearchInfo();
+            if (this.IsNormal)
+            {
+                if (TrySearchBoundsForAddingASegment(index, oracle, ref info))
+                {
+                    return TrySetAbstractValueInternal(true, index, value, oracle, info, out result);
+                }
+            }
+
+            result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
+            return false;
+        }
+
+
+        public bool TrySetAbstractValue(NormalizedExpression<Variable> lowIndex, NormalizedExpression<Variable> uppIndex,
+          AbstractDomain value,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle,
+          out ArraySegmentation<AbstractDomain, Variable, Expression> result)
+        {
+            #region Contracts
+            Contract.Requires(lowIndex != null);
+            Contract.Requires(uppIndex != null);
+            Contract.Requires(oracle != null);
+
+            Contract.Requires(value != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+            #endregion
+
+            // F: we need some more checking code above to determine that we call this method only on normal abstract states
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            var info = new SearchInfo();
+            if (TrySearchBounds(lowIndex, uppIndex, oracle, ref info))
+            {
+                // F: We should put it here as otherwise the WP do not go back enough
+                Contract.Assert(info.Low >= 0);
+                Contract.Assert(info.Upp > 0);
+                Contract.Assert(info.Low < elements.Count);
+                Contract.Assert(info.Upp <= elements.Count);
+
+                NonNullList<SegmentLimit<Variable>> newLimits;
+                NonNullList<AbstractDomain> newElements;
+
+                this.CopyPrefix(info.Low, out newLimits, out newElements);
+
+                newLimits.Add(limits[info.Low]);
+
+                Contract.Assert(info.Low < elements.Count);
+
+                var smash = this.JoinValuesInASubrange(info.Low, info.Upp);
+
+                smash = (AbstractDomain)smash.Join(value);
+
+                this.CopySuffix(info.Upp, newLimits, newElements);
+
+                Contract.Assert(info.Upp > 0);
+
+                // The reason why this is true is because either CopyPrefix or CopySuffix added at least one element to newElements
+                Contract.Assume(newElements.Count > 0);
+
+                newElements[Math.Min(info.Upp - 1, newElements.Count - 1)] = smash;
+
+                Contract.Assert(newLimits.Count == newElements.Count + 1);
+
+                result = new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
+                return true;
+            }
+
+            result = default(ArraySegmentation<AbstractDomain, Variable, Expression>);
+            return false;
+        }
+
+
+        private AbstractDomain JoinValuesInASubrange(int low, int upp, IAbstractDomain bottom)
+        {
+            #region Contracts
+            Contract.Requires(bottom != null);
+            Contract.Requires(upp <= elements.Count);
+
+            Contract.Ensures(Contract.Result<AbstractDomain>() != null);
+            #endregion
+
+            var joinVal = bottom;
+            for (var i = Math.Max(0, low); i < upp; i++)
+            {
+                joinVal = joinVal.Join(elements[i]);
+            }
+
+            var tmp = (AbstractDomain)joinVal;
+            Contract.Assert(tmp != null);
+
+            return tmp;
+        }
+
+        [Pure]
+        private AbstractDomain JoinValuesInASubrange(int low, int upp)
+        {
+            #region Contracts
+            Contract.Requires(low >= 0);
+
+            Contract.Requires(low <= upp);
+
+            Contract.Requires(low < elements.Count);
+            Contract.Requires(upp <= elements.Count);
+
+            Contract.Ensures(Contract.Result<AbstractDomain>() != null);
+            #endregion
+
+            IAbstractDomain joinVal = elements[low];
+
+            Contract.Assert(joinVal != null);
+
+            for (var i = low + 1; i < upp; i++)
+            {
+                joinVal = joinVal.Join(elements[i]);
+                Contract.Assert(joinVal != null);
+            }
+
+            // F: Sticking the assumption here until NN analysis will track "if reference then NN"
+            var tmp = (AbstractDomain)joinVal;
+            Contract.Assert(tmp != null);
+
+            return tmp;
+        }
+
+        [Pure]
+        private void CopyPrefix(int limit, out NonNullList<SegmentLimit<Variable>> newLimits, out NonNullList<AbstractDomain> newElements)
+        {
+            #region Contracts
+
+            Contract.Requires(limit >= -1);
+            Contract.Requires(limit < limits.Count);
+            Contract.Requires(limits.Count == elements.Count + 1);
+
+            Contract.Ensures(Contract.ValueAtReturn(out newLimits) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out newElements) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out newLimits).Count == Contract.ValueAtReturn(out newElements).Count);
+
+            #endregion
+
+            newLimits = new NonNullList<SegmentLimit<Variable>>();
+            newElements = new NonNullList<AbstractDomain>();
+
+            for (var i = 0; i < limit; i++)
+            {
+                newLimits.Add(limits[i]);
                 newElements.Add(elements[i]);
 
-                Contract.Assert(newElements.Count <= elements.Count);
-              }
-              i++; // skip the next
-              goto nextLoopIteration;
+                Contract.Assert(newLimits.Count == newElements.Count); // F: because of Add
             }
+        }
 
-            // Case 2:
-            // We have a sequence of conditionals { a, x } { b }? { a, y }? ==> {a, b, x, y }            
-            // Repro: method 2937 of System.Design.dll, v.2.0 with -bounds -arrays -nonnull
-            for (int lastConditionalIndex = i + 2; lastConditionalIndex < limits.Count; lastConditionalIndex++)
+        [Pure]
+
+        private void CopySuffix(int start, NonNullList<SegmentLimit<Variable>> newLimits, NonNullList<AbstractDomain> newElements)
+        {
+            Contract.Requires(newLimits != null);
+            Contract.Requires(newElements != null);
+
+            Contract.Requires(start >= 0);
+            Contract.Requires(start <= limits.Count);
+
+            for (var i = start; i < limits.Count; i++)
             {
-              var upperLimit = limits[lastConditionalIndex];
-              if (upperLimit.IsConditional)
-              {
-                // Ok we found a match!
-                if (HaveASameBound(prevLimit, upperLimit))
-                {
-                  var unionLimit = prevLimit;
-                  for (var j = i; j <= lastConditionalIndex; j++)
-                  {
-                    unionLimit = unionLimit.Meet(limits[j]);
-                  }
-                  newLimits.Add(unionLimit);    // The new limits are the union of all the limits
-
-                  // Add this only if it is not the last limit
-                  if (/*i < elements.Count && */ // REDUNDANT inferred by CC
-                    lastConditionalIndex < limits.Count - 1)
-                  {
-                    newElements.Add(elements[i]); // The new elements are simply the one of the first limit
-                    Contract.Assert(newElements.Count <= elements.Count);
-
-                  }
-
-                  i = lastConditionalIndex;
-
-                  goto nextLoopIteration;
-                }
-              }
-              else
-              {
-                break;
-              }
+                newLimits.Add(limits[i]);
             }
 
+            for (var i = Math.Max(start - 1, 0); i < elements.Count; i++)
+            {
+                newElements.Add(elements[i]);
+            }
+        }
+
+        #endregion
+
+        #region Limits
+
+        public IEnumerable<SegmentLimit<Variable>> Limits
+        {
+            get
+            {
+                return limits;
+            }
+        }
+
+        public SegmentLimit<Variable> LastLimit
+        {
+            get
+            {
+                Contract.Requires(this.IsNormal && !this.IsEmptyArray);
+                Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+                return limits[limits.Count - 1];
+            }
+        }
+
+        #endregion
+
+        #region Elements
+        public IEnumerable<AbstractDomain> Elements
+        {
+            [ContractVerification(false)]
+            get
+            {
+                Contract.Ensures(elements != null);
+                Contract.Ensures(Contract.ForAll(Contract.Result<IEnumerable<AbstractDomain>>(), x => x != null));
+
+                return elements;
+            }
+        }
+        #endregion
+
+        #region Search bounds (TrySearchBounds* methods)
+
+        /// <summary>
+        /// Return the largest index of a segment such that limits[index] \leq exp
+        /// </summary>
+
+        public bool TrySearchBoundsForAddingASegment(
+          NormalizedExpression<Variable> exp, INumericalAbstractDomainQuery<Variable, Expression> oracle,
+          ref SearchInfo info)
+        {
+            #region Contracts
+
+            Contract.Requires(exp != null);
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(-1 <= info.Low);
+            Contract.Ensures(0 <= info.Upp);
+            Contract.Ensures(0 <= info.UppMerge);
+
+            Contract.Ensures(info.Upp <= info.UppMerge);
+
+            Contract.Ensures(info.Upp <= limits.Count);
+            Contract.Ensures(info.UppMerge <= limits.Count);
+            Contract.Ensures(info.Low < limits.Count);
+
+            // If we find the bounds, then they are within the bounds of limits
+            Contract.Ensures(!Contract.Result<bool>() || info.Low >= 0);
+
+            Contract.Ensures(!Contract.Result<bool>() || info.Upp < limits.Count);
+            Contract.Ensures(!Contract.Result<bool>() || info.UppMerge < limits.Count);
+
+            Contract.Ensures(!Contract.Result<bool>() || info.Upp <= elements.Count);
+            Contract.Ensures(!Contract.Result<bool>() || info.UppMerge <= elements.Count);
+
+            #endregion
+
+            info.Low = -1;
+            info.Upp = limits.Count;
+            info.UppMerge = limits.Count;
+            info.IsLowerBoundEqual = false;
+            info.IsUpperBoundStrict = false;
+
+            // Search the lower bound
+            for (var i = 0; i < limits.Count; i++)
+            {
+                if (!GreaterEqualThan(exp, limits[i], oracle, out info.IsLowerBoundEqual, out info.IsLowerBoundStrict) || info.IsLowerBoundEqual)
+                {
+                    info.Low = info.IsLowerBoundEqual ? i : i - 1;
+
+                    if (!info.IsLowerBoundEqual && info.Low >= 0)
+                    {
+                        info.IsLowerBoundStrict = ExistsLessThan(limits[info.Low], exp, oracle);
+                    }
+
+                    break;
+                }
+            }
+            if (info.Low < 0)
+            {
+                return false;
+            }
+
+            info.Upp = info.Low + 1;
+
+            while (info.Upp < limits.Count && !ExistsLessThan(exp, limits[info.Upp], oracle))
+            {
+                info.Upp++;
+            }
+
+            if (info.Upp >= limits.Count)
+            {
+                return false;
+            }
+
+            info.UppMerge = info.Upp;
+
+            var expPlusOne = exp.PlusOne();
+
+            // \exists l. exp+1 == l
+            info.IsUpperBoundEqual = Equal(expPlusOne, limits[info.Upp], oracle);
+
+            // \exists l. exp+1 < l
+            info.IsUpperBoundStrict = LessThan(expPlusOne, limits[info.Upp], oracle);
+
+
+            for (var i = info.Upp; i < limits.Count; i++)
+            {
+                if (limits[i].IsConditional)
+                {
+                    info.UppMerge = i;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            info.IsLowerBoundStrictlySmallerThanUpp = ExistsLessThan(exp, limits[info.Upp], oracle);
+
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            return true;
+        }
+
+        public bool TrySearchBounds(NormalizedExpression<Variable> lowExp, NormalizedExpression<Variable> uppExp,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle, ref SearchInfo info)
+        {
+            #region Contracts
+            Contract.Requires(lowExp != null);
+            Contract.Requires(uppExp != null);
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(info.Low >= -1);
+            Contract.Ensures(info.Upp >= 0);
+            //Contract.Ensures(info.UppMerge >= 0);
+
+            Contract.Ensures(info.Low <= info.Upp);
+            Contract.Ensures(info.Low <= elements.Count);
+
+            Contract.Ensures(info.Upp == info.UppMerge);
+
+            Contract.Ensures(info.Upp <= this.limits.Count);
+
+            Contract.Ensures(!Contract.Result<bool>() || info.Low >= 0);
+            Contract.Ensures(!Contract.Result<bool>() || info.Upp > 0);
+
+            Contract.Ensures(!Contract.Result<bool>() || info.Low < elements.Count);
+
+            Contract.Ensures(!Contract.Result<bool>() || info.Low <= info.Upp);
+
+            Contract.Ensures(!Contract.Result<bool>() || info.Upp < this.limits.Count);
+            Contract.Ensures(!Contract.Result<bool>() || info.Upp <= elements.Count);
+
+            #endregion
+
+            // Let's search the lower bound
+            info.Low = -1;
+            info.Upp = info.UppMerge = 0;
+
+            if (this.IsEmptyArray || !this.IsNormal)
+            {
+                return false;
+            }
+
+            Contract.Assert(elements.Count >= 1);
+            Contract.Assert(limits.Count == elements.Count + 1);
+
+            // Fast, syntactic search for the lower bound
+            var found = false;
+            for (var i = 0; i < limits.Count - 1; i++)
+            {
+                if (limits[i].Contains(lowExp))
+                {
+                    info.Low = i;
+                    Contract.Assert(info.Low < elements.Count);
+
+                    info.IsLowerBoundEqual = true;
+                    info.IsLowerBoundStrict = false;
+                    found = true;
+                    break;
+                }
+            }
+
+            Contract.Assert(limits.Count == elements.Count + 1);
+
+            // Semantic search
+            if (!found)
+            {
+                Contract.Assert(elements.Count < limits.Count); // ok we can prove it
+                for (var i = 0; i < limits.Count; i++)
+                {
+                    if (!GreaterEqualThan(lowExp, limits[i], oracle, out info.IsLowerBoundEqual, out info.IsLowerBoundStrict) || info.IsLowerBoundEqual) // We found our index!
+                    {
+                        info.Low = info.IsLowerBoundEqual ? i : i - 1;
+
+                        Contract.Assume(info.Low < elements.Count, "we cannot prove it, because i <= this.elements.Count, maybe there is a reason why it holds, or my code is buggy");
+
+                        break;
+                    }
+                }
+
+
+                if (info.Low < 0 || info.Low == elements.Count)  // We did not find any lower bound
+                {
+                    info.Low = -1;  // This is to make sure that 
+
+                    return false;
+                }
+            }
+
+            Contract.Assert(info.Low >= 0); // If we reach that point, we found a lower bound. 
+            Contract.Assert(info.Low < elements.Count);
+
+            // Let's search the upper bound 
+
+            var uppExpAsBoxedExpression = ToExp(uppExp);
+            Func<NormalizedExpression<Variable>, bool> semanticEquality = (NormalizedExpression<Variable> limit) => { return oracle.CheckIfEqual(ToExp(limit), uppExpAsBoxedExpression).IsTrue(); };
+
+            // Syntactic search
+            for (var i = info.Low + 1; i < this.limits.Count; i++)
+            {
+                // Found?
+                var limits = this.limits[i];
+                if (limits.Contains(uppExp) || (uppExpAsBoxedExpression != null && limits.Any(semanticEquality)))
+                {
+                    info.Upp = info.UppMerge = i;
+                    info.IsUpperBoundEqual = true;
+                    info.IsUpperBoundStrict = false;
+
+                    info.IsLowerBoundStrictlySmallerThanUpp = ExistsLessThan(lowExp, this.limits[info.Upp], oracle);
+
+                    return true;
+                }
+            }
+
+            // Semantic search
+            info.Upp = this.limits.Count;
+
+            for (var i = limits.Count - 1; i >= 0; i--)
+            {
+                if (!LessEqual(uppExp, limits[i], oracle, out info.IsUpperBoundEqual, out info.IsUpperBoundStrict) ||
+                  info.IsUpperBoundEqual || !info.IsUpperBoundStrict)
+                {
+                    // There are two reasons why we are here.
+                    // The first is that the uppExp is to the left of the bound (i.e. limits[i] is no more a lower bound for uppEx)
+                    // In this case, we know that it was the case for limits[i+1], so we set info.Upp = i+1
+                    // The second is because we hit the exact bound for uppExp.
+                    // In this case, we know that we have to consider the next element as well
+
+                    info.Upp = Math.Min(i + 1, limits.Count - 1);
+
+                    // The reason why this is true is because of the global invariant of the segmentation, that is we cannot have malformed segmentations { a } el { b } where a > b
+                    // This is definitively out-of-reach of what Clousot can prove today
+                    Contract.Assume(info.Low <= info.Upp);
+                    break;
+                }
+            }
+
+            info.UppMerge = info.Upp;
+
+            if (info.Upp == this.limits.Count)
+            {
+                // Make it not meaningful
+                info.Low = -1;
+
+                return false;
+            }
+
+            Contract.Assert(info.Upp < this.limits.Count);
+
+            info.IsLowerBoundStrictlySmallerThanUpp = ExistsLessThan(lowExp, this.limits[info.Upp], oracle);
+
+            return true;
+        }
+
+
+        #endregion
+
+        #region SegmentLimitsQuery
+
+        public bool Equal(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+
+            if (segment.Contains(exp))
+                return true;
+
+            foreach (var limit in segment)
+            {
+                if (limit != null && oracle.CheckIfEqual(ToExp(exp), ToExp(limit)).IsTrue())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool LessEqual(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle,
+          out bool equal, out bool strict)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+
+            if (segment.Contains(exp))
+            {
+                equal = true;
+                strict = false;
+                return true;
+            }
+
+            var expExp = ToExp(exp);
+
+            foreach (var limit in segment)
+            {
+                if (limit == null) continue;
+
+                var limitExp = ToExp(limit);
+                var res = oracle.CheckIfLessEqualThan(expExp, limitExp);
+                if (res.IsTrue())
+                {
+                    equal = oracle.CheckIfEqual(expExp, limitExp).IsTrue();
+                    strict = oracle.CheckIfLessThan(expExp, limitExp).IsTrue();
+                    return true;
+                }
+            }
+
+            equal = false;
+            strict = false;
+            return false;
+        }
+
+        public bool LessEqual(SegmentLimit<Variable> segment, NormalizedExpression<Variable> exp,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle,
+         out bool equal, out bool strict)
+        {
+            #region Contracts
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+            #endregion
+
+            if (segment.Contains(exp))
+            {
+                equal = true;
+                strict = false;
+                return true;
+            }
+
+            var expExp = ToExp(exp);
+
+            foreach (var limit in segment)
+            {
+                if (limit == null) continue;
+
+                var limitExp = ToExp(limit);
+                var res = oracle.CheckIfLessEqualThan(limitExp, expExp);
+                if (res.IsTrue())
+                {
+                    equal = oracle.CheckIfEqual(limitExp, expExp).IsTrue();
+                    strict = oracle.CheckIfLessThan(limitExp, expExp).IsTrue();
+                    return true;
+                }
+            }
+
+            equal = false;
+            strict = false;
+            return false;
+        }
+
+        [Pure]
+        public bool GreaterEqualThan(
+          NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle,
+          out bool equal, out bool strict)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+
+            if (segment.Contains(exp))
+            {
+                equal = true;
+                strict = false;
+                return true;
+            }
+
+            var expExp = ToExp(exp);
+
+            foreach (var limit in segment)
+            {
+                if (limit == null)
+                    continue;
+
+                var limitExp = ToExp(limit);
+                var res = oracle.CheckIfLessEqualThan(limitExp, expExp);
+                if (res.IsTrue())
+                {
+                    equal = oracle.CheckIfEqual(expExp, limitExp).IsTrue();
+                    strict = oracle.CheckIfLessThan(limitExp, expExp).IsTrue();
+                    return true;
+                }
+                if (res.IsFalse())
+                {
+                    equal = false;
+                    strict = true;
+                    return false;
+                }
+            }
+
+            equal = false;
+            strict = false;
+            return false;
+        }
+
+        public bool LessThan(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment, INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+
+            foreach (var limit in segment)
+            {
+                if (limit != null && oracle.CheckIfLessThan(ToExp(exp), ToExp(limit)).IsTrue())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool LessThan(SegmentLimit<Variable> segment, NormalizedExpression<Variable> exp, INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+
+            foreach (var limit in segment)
+            {
+                if (limit != null && oracle.CheckIfLessThan(ToExp(limit), ToExp(exp)).IsTrue())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool ExistsLessThan(SegmentLimit<Variable> segment,
+          NormalizedExpression<Variable> exp, INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+
+            foreach (var limit in segment)
+            {
+                if (limit != null && oracle.CheckIfLessThan(ToExp(limit), ToExp(exp)).IsTrue())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool ExistsLessThan(NormalizedExpression<Variable> exp, SegmentLimit<Variable> segment,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(segment != null);
+            Contract.Requires(oracle != null);
+
+            foreach (var limit in segment)
+            {
+                if (limit != null && oracle.CheckIfLessThan(ToExp(exp), ToExp(limit)).IsTrue())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region TestTrueEqual
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression>
+          TestTrueEqualAsymmetric(NormalizedExpression<Variable> v, NormalizedExpression<Variable> normExpression)
+        {
+            Contract.Requires(v != null);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            if (!this.IsNormal)
+            {
+                return this;
+            }
+
+            Contract.Assert(elements.Count + 1 == limits.Count); // assertion needed to prove the precondition later
+
+            var newElements = new NonNullList<AbstractDomain>(elements);
+            var newLimits = new NonNullList<SegmentLimit<Variable>>(limits.Count);
+
+            for (var i = 0; i < limits.Count; i++)
+            {
+                var limit = limits[i];
+                if (limit.Contains(normExpression))
+                {
+                    var updatedLimits = limit.Add(v);
+
+                    Contract.Assert(updatedLimits != null);
+
+                    newLimits.InsertOrAdd(i, updatedLimits);
+
+                    if (i < limits.Count - 1)
+                    {
+                        var nextLimit = limits[i + 1];
+                        if (nextLimit.IsSuccessorOf(updatedLimits))
+                        {
+                            newLimits.InsertOrAdd(i + 1, nextLimit.Add(v.PlusOne()));
+                            i++; // Skip one iteration
+                        }
+                    }
+                }
+                else
+                {
+                    newLimits.InsertOrAdd(i, limit);
+                }
+            }
+            Contract.Assume(limits.Count == elements.Count + 1, "for some reason we lose the assertion above");
+
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
+        }
+
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression>
+          TestTrueEqualAsymmetric(Set<NormalizedExpression<Variable>> vars, NormalizedExpression<Variable> normExpression)
+        {
+            Contract.Requires(vars != null);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            if (!this.IsNormal)
+            {
+                return this;
+            }
+
+            Contract.Assert(elements.Count + 1 == limits.Count); // assertion needed to prove the precondition later
+
+            var newElements = new NonNullList<AbstractDomain>(elements);
+            var newLimits = new NonNullList<SegmentLimit<Variable>>(limits.Count);
+
+            int i;
+            for (i = 0; i < limits.Count; i++)
+            {
+                var limit = limits[i];
+                if (limit.Contains(normExpression))
+                {
+                    newLimits.InsertOrAdd(i, limit.Add(vars));
+                }
+                else
+                {
+                    newLimits.InsertOrAdd(i, limit);
+                }
+            }
+            Contract.Assume(limits.Count == elements.Count + 1, "for some reason we lose the assertion above");
+            Contract.Assert(newLimits.Count == newElements.Count + 1);
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
+        }
+
+        #endregion
+
+        #region TestTrueLessThan
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> TestTrueLessThan(NormalizedExpression<Variable> left, NormalizedExpression<Variable> right)
+        {
+            for (int i = 0; i < limits.Count - 1; i++)
+            {
+                var leftLimit = limits[i];
+                var rightLimit = limits[i + 1];
+
+                Contract.Assert(leftLimit != null);
+                Contract.Assert(rightLimit != null);
+
+                if (leftLimit.Contains(left) && rightLimit.Contains(right))
+                {
+                    if (rightLimit.IsConditional)
+                    {
+                        var result = this.DuplicateMe();
+                        result.limits[i + 1] = new SegmentLimit<Variable>(rightLimit, false);
+
+                        return result;
+                    }
+                    else
+                    {
+                        return this;
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        #endregion
+
+        #region TestTrueWithIntConstants
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression>
+          TestTrueWithIntConstants(List<Pair<NormalizedExpression<Variable>, NormalizedExpression<Variable>>> intConstants)
+        {
+            Contract.Requires(intConstants != null);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            if (intConstants.Count == 0 || this.IsBottom || this.IsTop)
+            {
+                return this;
+            }
+
+            var newLimits = new NonNullList<SegmentLimit<Variable>>(limits);
+            var newElements = new NonNullList<AbstractDomain>(elements);
+
+            foreach (var pair in intConstants)
+            {
+                int i = 0;
+                for (; i < newLimits.Count; i++)
+                {
+                    var newLimits_i = newLimits[i];
+                    if (newLimits_i.Contains(pair.One))
+                    {
+                        newLimits[i] = newLimits_i.Add(pair.Two);
+                        break;
+                    }
+
+                    if (newLimits_i.Contains(pair.Two))
+                    {
+                        newLimits[i] = newLimits_i.Add(pair.One);
+                        break;
+                    }
+                }
+            }
+
+            Contract.Assume(newLimits.Count == newElements.Count + 1);
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
+        }
+
+        #endregion
+
+        #region TestTrueFromNumericalstate
+
+
+        #region
+        internal ArraySegmentation<AbstractDomain, Variable, Expression> TestTrueInformationForTheSegments(INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            #region Contracts
+
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            #endregion
+
+            if (!this.IsNormal)
+            {
+                return this;
+            }
+
+            Contract.Assert(limits.Count >= 2, "should become an assertion");
+
+            Contract.Assert(elements.Count + 1 == limits.Count); // assertion needed to prove the precondition later
+
+            var resultLimits = new NonNullList<SegmentLimit<Variable>>(limits);
+
+            Contract.Assert(resultLimits.Count == limits.Count);
+
+            var resultElements = new NonNullList<AbstractDomain>(elements.Count);
+
+            for (var i = 0; i < elements.Count; i++)
+            {
+                var newSegment = elements[i].AssumeInformationFrom(oracle);
+
+                resultElements.Add(newSegment);
+            }
+
+            Contract.Assert(resultElements.Count == elements.Count);
+
+            Contract.Assume(elements.Count + 1 == limits.Count, "for some reason we lose the assertion above"); // assertion needed to prove the precondition later
+
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, bottomElement, expManager);
+        }
+        #endregion
+
+        #endregion
+
+        #region Reductions
+
+        public ArraySegmentation<AbstractDomain, Variable, Expression> ReduceWith(INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            #region Contracts
+
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+
+            #endregion
+
+            if (this.IsEmptyArray || this.IsBottom || this.IsTop)
+            {
+                return this;
+            }
+
+            // We need the expressions encoder to push the information.
+            // If we do not have one, we just gave up
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (!expManager.TryGetEncoder(out encoder))
+            {
+                return this;
+            }
+
+            Contract.Assert(encoder != null, "to help wp");
+
+            // F: Should become an assertion
+            Contract.Assume(limits.Count >= 2);
+
+            var resultLimits = new NonNullList<SegmentLimit<Variable>>();
+            var resultElements = new NonNullList<AbstractDomain>();
+
+            var refined = false;
+
+            resultLimits.Add(limits[0]);
+
+            Contract.Assert(resultLimits.Count == 1);
+
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            for (var i = 1; i < limits.Count; i++)
+            {
+                Contract.Assert(i <= elements.Count);
+
+                var curr = limits[i];
+
+                Contract.Assert(curr != null);
+
+                if (curr.IsConditional)
+                {
+                    var prev = resultLimits[resultLimits.Count - 1];
+
+                    Contract.Assert(prev != null);
+
+                    foreach (var p in prev)
+                    {
+                        Contract.Assume(p != null);
+
+                        foreach (var c in curr)
+                        {
+                            #region Body
+                            Contract.Assume(c != null);
+
+                            var pExp = p.Convert(encoder);
+                            var cExp = c.Convert(encoder);
+                            //              var isEq = PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.CheckIfEqual, () => oracle.CheckIfEqual(pExp, cExp));
+                            var isEq = PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.CheckIfEqual, () => oracle.CheckIfEqualIncomplete(pExp, cExp));
+
+                            if (isEq.IsTrue())    // The segment is empty, so we remove it
+                            {
+                                // { 0, a } [0, 0] { a }? 
+                                if (limits.Count == 2)
+                                {
+                                    return limits[1].IsConditional ? this : this.Bottom;
+                                }
+
+                                resultLimits[resultLimits.Count - 1] = new SegmentLimit<Variable>(prev.Meet(curr), prev.IsConditional);
+
+                                refined = true;
+
+                                goto nextLoopIteration;
+                            }
+
+                            // The ? can go away
+                            if (isEq.IsFalse() || oracle.CheckIfLessThanIncomplete(pExp, cExp).IsTrue())
+                            {
+                                resultElements.Add(elements[i - 1]);
+                                resultLimits.Add(new SegmentLimit<Variable>(curr, false));
+
+                                Contract.Assert(resultLimits.Count > 0);
+                                Contract.Assert(resultElements.Count > 0);
+
+                                refined = true;
+
+                                goto nextLoopIteration;
+                            }
+                            #endregion
+                        }
+                    }
+                }
+
+                resultElements.Add(elements[i - 1]);
+                resultLimits.Add(curr);
+
+            nextLoopIteration:
+
+                ;
+            }
+
+            Contract.Assert(resultLimits.Count == resultElements.Count + 1);
+
+            // It may be the case that the reduction has smashed together all the limits, by proving all be the same
+            if (resultLimits.Count <= 1)
+            {
+                return EmptyArray;
+            }
+
+            return refined ?
+              new ArraySegmentation<AbstractDomain, Variable, Expression>(resultLimits, resultElements, bottomElement, expManager) :
+              this;
+        }
+
+        #endregion
+
+        #region Normal Form
+        static private void RemoveTriviallyEmptySegments(NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements,
+          out NonNullList<SegmentLimit<Variable>> newLimits, out NonNullList<AbstractDomain> newElements, out bool isBottom)
+        {
+            Contract.Requires(limits != null);
+            Contract.Requires(elements != null);
+            Contract.Requires(limits.Count == elements.Count + 1);
+
+            Contract.Ensures(Contract.ValueAtReturn(out newLimits) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out newElements) != null);
+
+            Contract.Ensures(Contract.ValueAtReturn(out newLimits).Count <= limits.Count);
+            Contract.Ensures(Contract.ValueAtReturn(out newElements).Count <= elements.Count);
+
+            newLimits = new NonNullList<SegmentLimit<Variable>>();
+            newElements = new NonNullList<AbstractDomain>();
+            isBottom = false;
+
+            Contract.Assert(newLimits.Count <= limits.Count);
             Contract.Assert(newElements.Count <= elements.Count);
 
-            int leftConst, rightConst;
-            if (prevLimit.TryFindConstant(out leftConst) && nextLimit.TryFindConstant(out rightConst) && leftConst < rightConst)
+            for (var i = 0; i < limits.Count; i++)
             {
-              // remove the conditional on the next limit
-              limits[i + 1] = new SegmentLimit<Variable>(nextLimit, false);
+                // F: If we reach this point, it means that we still have some limit to consider, not added to the newLimits
+                Contract.Assume(newLimits.Count < limits.Count);
+                var prevLimit = limits[i];
+
+                if (i == limits.Count - 1)
+                {
+                    newLimits.Add(prevLimit);
+                }
+                else
+                {
+                    // F: If we reach this point, it means that we still have some element to consider, not added to the newElements
+                    Contract.Assume(newElements.Count < elements.Count);
+
+                    var nextLimit = limits[i + 1];
+
+                    if (nextLimit.IsConditional)
+                    {
+                        // Case 1: So common that we make it a special case
+                        // We have {a, x } {a, y}?
+                        if (HaveASameBound(prevLimit, nextLimit))
+                        {
+                            newLimits.Add(new SegmentLimit<Variable>(nextLimit.Meet(prevLimit), false));
+                            if (
+                              /* i < elements.Count && */               // REDUNDANT inferred by CC
+                              i + 1 < limits.Count - 1 // it is not the last limit
+                              )
+                            {
+                                newElements.Add(elements[i]);
+
+                                Contract.Assert(newElements.Count <= elements.Count);
+                            }
+                            i++; // skip the next
+                            goto nextLoopIteration;
+                        }
+
+                        // Case 2:
+                        // We have a sequence of conditionals { a, x } { b }? { a, y }? ==> {a, b, x, y }            
+                        // Repro: method 2937 of System.Design.dll, v.2.0 with -bounds -arrays -nonnull
+                        for (int lastConditionalIndex = i + 2; lastConditionalIndex < limits.Count; lastConditionalIndex++)
+                        {
+                            var upperLimit = limits[lastConditionalIndex];
+                            if (upperLimit.IsConditional)
+                            {
+                                // Ok we found a match!
+                                if (HaveASameBound(prevLimit, upperLimit))
+                                {
+                                    var unionLimit = prevLimit;
+                                    for (var j = i; j <= lastConditionalIndex; j++)
+                                    {
+                                        unionLimit = unionLimit.Meet(limits[j]);
+                                    }
+                                    newLimits.Add(unionLimit);    // The new limits are the union of all the limits
+
+                                    // Add this only if it is not the last limit
+                                    if (/*i < elements.Count && */ // REDUNDANT inferred by CC
+                                      lastConditionalIndex < limits.Count - 1)
+                                    {
+                                        newElements.Add(elements[i]); // The new elements are simply the one of the first limit
+                                        Contract.Assert(newElements.Count <= elements.Count);
+                                    }
+
+                                    i = lastConditionalIndex;
+
+                                    goto nextLoopIteration;
+                                }
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+
+                        Contract.Assert(newElements.Count <= elements.Count);
+
+                        int leftConst, rightConst;
+                        if (prevLimit.TryFindConstant(out leftConst) && nextLimit.TryFindConstant(out rightConst) && leftConst < rightConst)
+                        {
+                            // remove the conditional on the next limit
+                            limits[i + 1] = new SegmentLimit<Variable>(nextLimit, false);
+                        }
+                    }
+                    else
+                    {
+                        // Let's search for a contraddiction
+                        if (HaveASameBound(prevLimit, nextLimit))
+                        {
+                            isBottom = true;
+                        }
+                    }
+
+                    newLimits.Add(prevLimit);
+                    newElements.Add(elements[i]);
+
+                    Contract.Assert(newElements.Count <= elements.Count);
+                }
+
+            nextLoopIteration:
+                ;
+            }
+        }
+        #endregion
+
+        #region Simplification
+        /// <summary>
+        /// The AssignInParallel may have produced a state as ... { a, b } e { a }? ...
+        /// that we can can simplify to { a, b}
+        /// </summary>         
+        [Pure]
+        public ArraySegmentation<AbstractDomain, Variable, Expression> Simplify()
+        {
+            if (this.IsEmptyArray || this.IsBottom || this.IsTop)
+            {
+                return this;
             }
 
-          }
-          else
-          {
-            // Let's search for a contraddiction
-            if (HaveASameBound(prevLimit, nextLimit))
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            NonNullList<SegmentLimit<Variable>> newLimits;
+            NonNullList<AbstractDomain> newElements;
+
+            bool isBottom;
+            RemoveTriviallyEmptySegments(limits, elements, out newLimits, out newElements, out isBottom);
+
+            Contract.Assume(newLimits.Count == newElements.Count + 1);
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
+        }
+
+        [Pure]
+        private static bool HaveASameBound(SegmentLimit<Variable> left, SegmentLimit<Variable> right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            // F: TODO implement a more efficient algorithm
+            return left.Intersection(right).Count != 0;
+        }
+        #endregion
+
+        #region Purification
+        [Pure]
+        public ArraySegmentation<AbstractDomain, Variable, Expression> Purify(List<Variable> vars)
+        {
+            Contract.Requires(vars != null);
+
+            if (!this.IsNormal)
             {
-              isBottom = true;
+                return this;
             }
-          }
 
-          newLimits.Add(prevLimit);
-          newElements.Add(elements[i]);
-
-          Contract.Assert(newElements.Count <= elements.Count);
-        }
-
-      nextLoopIteration:
-        ;
-      }
-
-    }
-    #endregion
-
-    #region Simplification
-    /// <summary>
-    /// The AssignInParallel may have produced a state as ... { a, b } e { a }? ...
-    /// that we can can simplify to { a, b}
-    /// </summary>         
-    [Pure]
-    public ArraySegmentation<AbstractDomain, Variable, Expression> Simplify()
-    {
-      if (this.IsEmptyArray || this.IsBottom || this.IsTop)
-      {
-        return this;
-      }
-
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-
-      NonNullList<SegmentLimit<Variable>> newLimits;
-      NonNullList<AbstractDomain> newElements;
-
-      bool isBottom;
-      RemoveTriviallyEmptySegments(this.limits, this.elements, out newLimits, out newElements, out isBottom);
- 
-      Contract.Assume(newLimits.Count == newElements.Count + 1);
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-    }
-
-    [Pure]
-    private static bool HaveASameBound(SegmentLimit<Variable> left, SegmentLimit<Variable> right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      // F: TODO implement a more efficient algorithm
-      return left.Intersection(right).Count != 0;
-    }
-    #endregion
-
-    #region Purification
-    [Pure]
-    public ArraySegmentation<AbstractDomain, Variable, Expression> Purify(List<Variable> vars)
-    {
-      Contract.Requires(vars != null);
-
-      if (!this.IsNormal)
-      {
-        return this;
-      }
-
-      Contract.Assert(this.limits.Count > 1);
-      Contract.Assert(this.elements.Count >= 1);
+            Contract.Assert(limits.Count > 1);
+            Contract.Assert(elements.Count >= 1);
 
 
-      if (vars.Count == 0)
-      {
-        return this.Bottom;
-      }
-
-      var newLimits = new NonNullList<SegmentLimit<Variable>>();
-      var newElements = new NonNullList<AbstractDomain>();
-
-      int i = 0, j = 0;
-
-      #region First Limit
-      var currLimit = this.limits[i];
-      var newLimit = new Set<NormalizedExpression<Variable>>();
-      
-      int dummyInt;
-      Variable v;
-      foreach (var exp in currLimit)
-      {
-        Contract.Assume(exp != null);
-        if (exp.IsConstant(out dummyInt))
-        {
-          newLimit.Add(exp);
-        }
-        else if (exp.IsVariable(out v) || exp.IsAddition(out v, out dummyInt))
-        {
-          if (vars.Contains(v))
-          {
-            newLimit.Add(exp);
-          }
-        }
-      }
-
-      newLimits.Add(new SegmentLimit<Variable>(newLimit, currLimit.IsConditional));
-      newElements.Add(this.elements[i]);
-      
-      #endregion
-
-      #region All the othe cases
-      for (i = 1, j = 1; i < this.limits.Count; i++)
-      {
-        Contract.Assert(j <= i);
-
-        currLimit = this.limits[i];
-        newLimit = new Set<NormalizedExpression<Variable>>();
-        foreach (var exp in currLimit)
-        {
-          Contract.Assume(exp != null);
-          if (exp.IsConstant(out dummyInt))
-          {
-            newLimit.Add(exp);
-          }
-          else 
-            if (exp.IsVariable(out v) || exp.IsAddition(out v, out dummyInt))
-          {
-            // this
-            if (vars.Contains(v))
+            if (vars.Count == 0)
             {
-              newLimit.Add(exp);
+                return this.Bottom;
             }
-          }
+
+            var newLimits = new NonNullList<SegmentLimit<Variable>>();
+            var newElements = new NonNullList<AbstractDomain>();
+
+            int i = 0, j = 0;
+
+            #region First Limit
+            var currLimit = limits[i];
+            var newLimit = new Set<NormalizedExpression<Variable>>();
+
+            int dummyInt;
+            Variable v;
+            foreach (var exp in currLimit)
+            {
+                Contract.Assume(exp != null);
+                if (exp.IsConstant(out dummyInt))
+                {
+                    newLimit.Add(exp);
+                }
+                else if (exp.IsVariable(out v) || exp.IsAddition(out v, out dummyInt))
+                {
+                    if (vars.Contains(v))
+                    {
+                        newLimit.Add(exp);
+                    }
+                }
+            }
+
+            newLimits.Add(new SegmentLimit<Variable>(newLimit, currLimit.IsConditional));
+            newElements.Add(elements[i]);
+
+            #endregion
+
+            #region All the othe cases
+            for (i = 1, j = 1; i < limits.Count; i++)
+            {
+                Contract.Assert(j <= i);
+
+                currLimit = limits[i];
+                newLimit = new Set<NormalizedExpression<Variable>>();
+                foreach (var exp in currLimit)
+                {
+                    Contract.Assume(exp != null);
+                    if (exp.IsConstant(out dummyInt))
+                    {
+                        newLimit.Add(exp);
+                    }
+                    else
+                      if (exp.IsVariable(out v) || exp.IsAddition(out v, out dummyInt))
+                    {
+                        // this
+                        if (vars.Contains(v))
+                        {
+                            newLimit.Add(exp);
+                        }
+                    }
+                }
+
+                if (!newLimit.IsEmpty)
+                {
+                    // this
+                    newLimits.Add(new SegmentLimit<Variable>(newLimit, currLimit.IsConditional));
+                    if (i < elements.Count) // Remember: there is one more limit than elements
+                    {
+                        newElements.Add(elements[i]);
+                    }
+                    j++;
+                }
+                // this
+                else
+                {
+                    Contract.Assert(j > 0); // This should always be true, as the first segment cannot be empty
+                    Contract.Assert(newElements.Count >= 1);
+
+                    if (i < elements.Count) // Remember: there is one more limit than elements
+                    {
+                        Contract.Assume(j - 1 < newElements.Count);
+                        newElements[j - 1] = (AbstractDomain)newElements[j - 1].Join(elements[i]);
+                    }
+                }
+            }
+            #endregion
+
+            Contract.Assume(newLimits.Count == newElements.Count + 1);// F: Hard to prove because it depends onthe algorithmical knowledge that we insert in newLimits only once more that newElements
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
         }
 
-        if (!newLimit.IsEmpty)
+        #endregion
+
+        #region Conversion
+
+        [Pure]
+        public Expression ToExp(NormalizedExpression<Variable> exp)
         {
-          // this
-          newLimits.Add(new SegmentLimit<Variable>(newLimit, currLimit.IsConditional));
-          if (i < this.elements.Count) // Remember: there is one more limit than elements
-          {
-            newElements.Add(this.elements[i]);
-          }
-          j++;
-        }
-          // this
-        else
-        {
-          Contract.Assert(j > 0); // This should always be true, as the first segment cannot be empty
-          Contract.Assert(newElements.Count >= 1);
+            Contract.Requires(exp != null);
 
-          if (i < this.elements.Count) // Remember: there is one more limit than elements
-          {
-            Contract.Assume(j -1 < newElements.Count);
-            newElements[j - 1] = (AbstractDomain)newElements[j - 1].Join(this.elements[i]);
-          }
-
-        }
-      }
-      #endregion
-
-      Contract.Assume(newLimits.Count == newElements.Count + 1);// F: Hard to prove because it depends onthe algorithmical knowledge that we insert in newLimits only once more that newElements
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-    }
-
-    #endregion
-
-    #region Conversion
-
-    [Pure]
-    public Expression ToExp(NormalizedExpression<Variable> exp)
-    {
-      Contract.Requires(exp != null);
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.expManager.TryGetEncoder(out encoder))
-      {
-        return exp.Convert(encoder);
-      }
-      else
-      {
-        return default(Expression);
-      }
-    }
-
-    // Just a shortcut
-    [Pure]
-    public static NormalizedExpression<Variable> ToNormExp(int x)
-    {
-      Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
-      
-      return NormalizedExpression<Variable>.For(x);
-    }
-
-    #endregion
-
-    #region Segment Unification
-
-    private enum SegmentUnificationOperation { LessEqual, Join, Widening, Meet }
-
-    [ContractVerification(false)]
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!left.limits[0].Join(right.limits[0]).IsEmpty (Malformed segments: Both should contain at least 0)")] 
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!left.limits[left.limits.Count - 1].Join(right.limits[right.limits.Count - 1]).IsEmpty (Malformed segments: Both should contain the array length)")] 
-    private bool TryUnifySegments(SegmentUnificationOperation operation, ArraySegmentation<AbstractDomain, Variable, Expression> left, ArraySegmentation<AbstractDomain, Variable, Expression> right,
-      AbstractDomain neutralLeft, AbstractDomain neutralRight,
-      out ArraySegmentation<AbstractDomain, Variable, Expression> leftReduced, out ArraySegmentation<AbstractDomain, Variable, Expression> rightReduced,
-      out bool removedAtLeastOneLimitForRight)
-    {
-      #region Contracts
-      Contract.Requires(left.elements.Count > 0);
-      Contract.Requires(right.elements.Count > 0);
-      
-      Contract.Requires(left.limits.Count  == left.elements.Count + 1);
-      Contract.Requires(right.limits.Count == right.elements.Count +1);
-
-      Contract.Requires(neutralLeft != null);
-      Contract.Requires(neutralRight != null);
-
-      // Those two preconditions are two complex to be checked at static time, so we mask them at all the call sites
-      Contract.Requires(!left.limits[0].Join(right.limits[0]).IsEmpty, "Malformed segments: Both should contain at least 0");
-      Contract.Requires(!left.limits[left.limits.Count - 1].Join(right.limits[right.limits.Count - 1]).IsEmpty, "Malformed segments: Both should contain the array length");
-      
-        // At least one element
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).elements.Count > 0); 
-        
-        // Unification worked          
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).limits.Count == Contract.ValueAtReturn(out rightReduced).limits.Count);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).elements.Count == Contract.ValueAtReturn(out rightReduced).elements.Count);
-      
-        // Consistency      
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).limits.Count == Contract.ValueAtReturn(out leftReduced).elements.Count + 1);
-
-      #endregion
-
-      if (ArrayOptions.Trace)
-      {
-        Console.WriteLine("#{0}: Uniforming\n{1}\n{2}", UniformCount++, left.ToString(), right.ToString());
-      }
-
-      removedAtLeastOneLimitForRight = false;
-      var unificationIteration = 0;
-      
-      var newLeftLimits = new NonNullList<SegmentLimit<Variable>>();
-      var newRightLimits = new NonNullList<SegmentLimit<Variable>>();
-
-      var newLeftElements = new NonNullList<AbstractDomain>();
-      var newRightElements = new NonNullList<AbstractDomain>();
-
-      // Initialization
-      var leftCount = 0;
-      var rightCount = 0;
-
-      // 
-      var old_leftCount = -1;
-      var old_rightCount = -1;
-
-      // Step 1: Purify the abstract elements. This is a new introduction from our technical report
-      // The idea is to remove the extra-variables appearing only in one segmentation, to improve the precision of the step 2 below
-      // Essentially extra temp variables can be introduce lose of precision in the step 2 because we use a lookahead of 1 
-      // 
-      // ** Example 
-      // Input:
-      // {0}      a { sv4    } b { sv5 }  
-      // {0, sv2} c { sv4 -1 } d { sv4 }
-      // We get (after 2 iterations)
-      // {0} a       {sv4}  b { sv5  }
-      // {0} neutral {sv2}? c {sv4-1 } d { sv4}
-      // And as we do not see any relation between sv4 and sv2, and we cannot see that sv4 will appear later, we abstract sv4
-      // The purification algorithm gets rid of the unnecessary sv2 variable
-
-      if (operation == SegmentUnificationOperation.Join || operation == SegmentUnificationOperation.Widening)
-      {
-        left = left.Purify(right.Variables);
-        right = right.Purify(left.Variables);
-      }
-      if (ArrayOptions.Trace)
-      {
-        Console.WriteLine("After purification \n{0}\n{1}", left.ToString(), right.ToString());
-      }
-
-      // Step 2: Unify the segments      
-      // TODO: do we need a wider lookahead? Purification seems ok, and larger lookahead may slow down things (quadratically)
-      while (leftCount < left.limits.Count || rightCount <= right.limits.Count)
-      {                
-        // Loop invariants
-          // Consistency: "The elements and the limits are in sync"  
-        Contract.Assert(newLeftElements.Count == newRightElements.Count); 
-        Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
-       
-          // Progress: "We add at least one <segment, element> at each iteration"
-        //Contract.Assert(leftCount + rightCount > old_leftCount + old_rightCount);
-
-        old_leftCount = leftCount;
-        old_rightCount = rightCount;
-
-        Trace(unificationIteration, newLeftLimits, newLeftElements);
-        Trace(unificationIteration, newRightLimits, newRightElements);
-
-        unificationIteration++;
-
-        // Case 1: Last element in both the lists
-        if (leftCount == left.limits.Count - 1 && rightCount == right.limits.Count - 1)
-        {
-          Contract.Assume(leftCount >= 1);
-          Contract.Assume(rightCount >= 1);
-
-          // Simply add the elements
-          newLeftLimits.Add(left.limits.GetLastElement());
-          newRightLimits.Add(right.limits.GetLastElement());
-
-          break;  // we are done!
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (expManager.TryGetEncoder(out encoder))
+            {
+                return exp.Convert(encoder);
+            }
+            else
+            {
+                return default(Expression);
+            }
         }
 
-        // Case 2 : Last element of left, but still elements in right: we should refine left!
-        if (leftCount == left.limits.Count - 1 && rightCount < right.limits.Count - 1)
+        // Just a shortcut
+        [Pure]
+        public static NormalizedExpression<Variable> ToNormExp(int x)
         {
-          Contract.Assume(leftCount >= 1);
-          Contract.Assume(rightCount >= 1);
+            Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
 
-          // Try to split
-          var leftLimit = left.limits[leftCount];
-          var rightLimit = right.limits[rightCount];
-          if (rightLimit.IsSubSetOf(leftLimit))
-          {
-            SplitSegment(right, left, neutralLeft, newRightLimits, newLeftLimits, newRightElements, newLeftElements, ref rightCount, ref leftCount);
-          }
-          else
-          {
-            bool limitRemoved;
-
-            RefineSegmentation(operation == SegmentUnificationOperation.Widening, right, left,
-              neutralLeft, newRightLimits, newLeftLimits, newRightElements, newLeftElements, ref rightCount, out limitRemoved);
-
-            removedAtLeastOneLimitForRight = removedAtLeastOneLimitForRight || limitRemoved;
-          }
-          Contract.Assert(newLeftElements.Count == newRightElements.Count);
-          Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
-
-          continue;
+            return NormalizedExpression<Variable>.For(x);
         }
 
-        // Case 3: "Almost" the symmetric of 2
-        if (leftCount < left.limits.Count - 1 && rightCount == right.limits.Count - 1)
+        #endregion
+
+        #region Segment Unification
+
+        private enum SegmentUnificationOperation { LessEqual, Join, Widening, Meet }
+
+        [ContractVerification(false)]
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!left.limits[0].Join(right.limits[0]).IsEmpty (Malformed segments: Both should contain at least 0)")]
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!left.limits[left.limits.Count - 1].Join(right.limits[right.limits.Count - 1]).IsEmpty (Malformed segments: Both should contain the array length)")]
+        private bool TryUnifySegments(SegmentUnificationOperation operation, ArraySegmentation<AbstractDomain, Variable, Expression> left, ArraySegmentation<AbstractDomain, Variable, Expression> right,
+          AbstractDomain neutralLeft, AbstractDomain neutralRight,
+          out ArraySegmentation<AbstractDomain, Variable, Expression> leftReduced, out ArraySegmentation<AbstractDomain, Variable, Expression> rightReduced,
+          out bool removedAtLeastOneLimitForRight)
         {
-          Contract.Assume(leftCount >= 1);
-          Contract.Assume(rightCount >= 1);
+            #region Contracts
+            Contract.Requires(left.elements.Count > 0);
+            Contract.Requires(right.elements.Count > 0);
 
-          // Try to split
-          var leftLimit = left.limits[leftCount];
-          var rightLimit = right.limits[rightCount];
-          if (leftLimit.IsSubSetOf(rightLimit))
-          {
-            SplitSegment(left, right, neutralRight, newLeftLimits, newRightLimits, newLeftElements, newRightElements, ref leftCount, ref rightCount);
-          }
-          else if (!leftLimit.Intersection(rightLimit).IsEmpty)
-          {
-            var intersection = leftLimit.Intersection(rightLimit);
-            left.limits[leftCount] = new SegmentLimit<Variable>(intersection, leftLimit.IsEmpty);
-            right.limits[rightCount] = new SegmentLimit<Variable>(intersection, rightLimit.IsEmpty);
+            Contract.Requires(left.limits.Count == left.elements.Count + 1);
+            Contract.Requires(right.limits.Count == right.elements.Count + 1);
 
-            left.limits.InsertOrAdd(leftCount+1, new SegmentLimit<Variable>(leftLimit.Difference(intersection), true));
-            right.limits.InsertOrAdd(rightCount+1, new SegmentLimit<Variable>(rightLimit.Difference(intersection), true));
+            Contract.Requires(neutralLeft != null);
+            Contract.Requires(neutralRight != null);
 
-            if(leftCount <= left.elements.Count)
-              left.elements.InsertOrAdd(leftCount, neutralLeft);
+            // Those two preconditions are two complex to be checked at static time, so we mask them at all the call sites
+            Contract.Requires(!left.limits[0].Join(right.limits[0]).IsEmpty, "Malformed segments: Both should contain at least 0");
+            Contract.Requires(!left.limits[left.limits.Count - 1].Join(right.limits[right.limits.Count - 1]).IsEmpty, "Malformed segments: Both should contain the array length");
 
-             if (rightCount <= right.elements.Count) 
-              right.elements.InsertOrAdd(rightCount, neutralRight);
+            // At least one element
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).elements.Count > 0);
 
-            newLeftLimits.Add(left.limits[leftCount]);
-            newRightLimits.Add(right.limits[rightCount]);
+            // Unification worked          
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).limits.Count == Contract.ValueAtReturn(out rightReduced).limits.Count);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).elements.Count == Contract.ValueAtReturn(out rightReduced).elements.Count);
+
+            // Consistency      
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leftReduced).limits.Count == Contract.ValueAtReturn(out leftReduced).elements.Count + 1);
+
+            #endregion
+
+            if (ArrayOptions.Trace)
+            {
+                Console.WriteLine("#{0}: Uniforming\n{1}\n{2}", UniformCount++, left.ToString(), right.ToString());
+            }
+
+            removedAtLeastOneLimitForRight = false;
+            var unificationIteration = 0;
+
+            var newLeftLimits = new NonNullList<SegmentLimit<Variable>>();
+            var newRightLimits = new NonNullList<SegmentLimit<Variable>>();
+
+            var newLeftElements = new NonNullList<AbstractDomain>();
+            var newRightElements = new NonNullList<AbstractDomain>();
+
+            // Initialization
+            var leftCount = 0;
+            var rightCount = 0;
+
+            // 
+            var old_leftCount = -1;
+            var old_rightCount = -1;
+
+            // Step 1: Purify the abstract elements. This is a new introduction from our technical report
+            // The idea is to remove the extra-variables appearing only in one segmentation, to improve the precision of the step 2 below
+            // Essentially extra temp variables can be introduce lose of precision in the step 2 because we use a lookahead of 1 
+            // 
+            // ** Example 
+            // Input:
+            // {0}      a { sv4    } b { sv5 }  
+            // {0, sv2} c { sv4 -1 } d { sv4 }
+            // We get (after 2 iterations)
+            // {0} a       {sv4}  b { sv5  }
+            // {0} neutral {sv2}? c {sv4-1 } d { sv4}
+            // And as we do not see any relation between sv4 and sv2, and we cannot see that sv4 will appear later, we abstract sv4
+            // The purification algorithm gets rid of the unnecessary sv2 variable
+
+            if (operation == SegmentUnificationOperation.Join || operation == SegmentUnificationOperation.Widening)
+            {
+                left = left.Purify(right.Variables);
+                right = right.Purify(left.Variables);
+            }
+            if (ArrayOptions.Trace)
+            {
+                Console.WriteLine("After purification \n{0}\n{1}", left.ToString(), right.ToString());
+            }
+
+            // Step 2: Unify the segments      
+            // TODO: do we need a wider lookahead? Purification seems ok, and larger lookahead may slow down things (quadratically)
+            while (leftCount < left.limits.Count || rightCount <= right.limits.Count)
+            {
+                // Loop invariants
+                // Consistency: "The elements and the limits are in sync"  
+                Contract.Assert(newLeftElements.Count == newRightElements.Count);
+                Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
+
+                // Progress: "We add at least one <segment, element> at each iteration"
+                //Contract.Assert(leftCount + rightCount > old_leftCount + old_rightCount);
+
+                old_leftCount = leftCount;
+                old_rightCount = rightCount;
+
+                Trace(unificationIteration, newLeftLimits, newLeftElements);
+                Trace(unificationIteration, newRightLimits, newRightElements);
+
+                unificationIteration++;
+
+                // Case 1: Last element in both the lists
+                if (leftCount == left.limits.Count - 1 && rightCount == right.limits.Count - 1)
+                {
+                    Contract.Assume(leftCount >= 1);
+                    Contract.Assume(rightCount >= 1);
+
+                    // Simply add the elements
+                    newLeftLimits.Add(left.limits.GetLastElement());
+                    newRightLimits.Add(right.limits.GetLastElement());
+
+                    break;  // we are done!
+                }
+
+                // Case 2 : Last element of left, but still elements in right: we should refine left!
+                if (leftCount == left.limits.Count - 1 && rightCount < right.limits.Count - 1)
+                {
+                    Contract.Assume(leftCount >= 1);
+                    Contract.Assume(rightCount >= 1);
+
+                    // Try to split
+                    var leftLimit = left.limits[leftCount];
+                    var rightLimit = right.limits[rightCount];
+                    if (rightLimit.IsSubSetOf(leftLimit))
+                    {
+                        SplitSegment(right, left, neutralLeft, newRightLimits, newLeftLimits, newRightElements, newLeftElements, ref rightCount, ref leftCount);
+                    }
+                    else
+                    {
+                        bool limitRemoved;
+
+                        RefineSegmentation(operation == SegmentUnificationOperation.Widening, right, left,
+                          neutralLeft, newRightLimits, newLeftLimits, newRightElements, newLeftElements, ref rightCount, out limitRemoved);
+
+                        removedAtLeastOneLimitForRight = removedAtLeastOneLimitForRight || limitRemoved;
+                    }
+                    Contract.Assert(newLeftElements.Count == newRightElements.Count);
+                    Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
+
+                    continue;
+                }
+
+                // Case 3: "Almost" the symmetric of 2
+                if (leftCount < left.limits.Count - 1 && rightCount == right.limits.Count - 1)
+                {
+                    Contract.Assume(leftCount >= 1);
+                    Contract.Assume(rightCount >= 1);
+
+                    // Try to split
+                    var leftLimit = left.limits[leftCount];
+                    var rightLimit = right.limits[rightCount];
+                    if (leftLimit.IsSubSetOf(rightLimit))
+                    {
+                        SplitSegment(left, right, neutralRight, newLeftLimits, newRightLimits, newLeftElements, newRightElements, ref leftCount, ref rightCount);
+                    }
+                    else if (!leftLimit.Intersection(rightLimit).IsEmpty)
+                    {
+                        var intersection = leftLimit.Intersection(rightLimit);
+                        left.limits[leftCount] = new SegmentLimit<Variable>(intersection, leftLimit.IsEmpty);
+                        right.limits[rightCount] = new SegmentLimit<Variable>(intersection, rightLimit.IsEmpty);
+
+                        left.limits.InsertOrAdd(leftCount + 1, new SegmentLimit<Variable>(leftLimit.Difference(intersection), true));
+                        right.limits.InsertOrAdd(rightCount + 1, new SegmentLimit<Variable>(rightLimit.Difference(intersection), true));
+
+                        if (leftCount <= left.elements.Count)
+                            left.elements.InsertOrAdd(leftCount, neutralLeft);
+
+                        if (rightCount <= right.elements.Count)
+                            right.elements.InsertOrAdd(rightCount, neutralRight);
+
+                        newLeftLimits.Add(left.limits[leftCount]);
+                        newRightLimits.Add(right.limits[rightCount]);
+
+                        newLeftElements.Add(neutralLeft);
+                        newRightElements.Add(neutralRight);
+
+                        leftCount++;
+                        rightCount++;
+                    }
+                    else
+                    {
+                        bool removedALimitOnTheLeft;
+                        RefineSegmentation(operation == SegmentUnificationOperation.Widening, left, right,
+                          neutralRight, newLeftLimits, newRightLimits, newLeftElements, newRightElements, ref leftCount, out removedALimitOnTheLeft);
+                    }
+
+                    Contract.Assert(newLeftElements.Count == newRightElements.Count);
+                    Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
+
+                    continue;
+                }
+
+                // If something goes wrong, we silently swallow it and continue
+                if (leftCount >= left.limits.Count || rightCount >= right.limits.Count)
+                {
+                    leftCount++;
+                    rightCount++;
+                    continue;
+                }
+
+                // Caching useful dictionary accesses
+                var currentLeftLimits = left.limits[leftCount];
+                var currentRightLimits = right.limits[rightCount];
+
+                // F: Those assumptions may not be true, so we want to check at runtime
+                Contract.Assume(leftCount < left.elements.Count);
+                Contract.Assume(rightCount < right.elements.Count);
+
+                var currentLeftElements = left.elements[leftCount];
+                var currentRightElements = right.elements[rightCount];
+
+                Contract.Assert(currentLeftLimits != null);
+                Contract.Assert(currentRightLimits != null);
+
+                // Case 4: 
+                // Case 4.a  left.limits[leftCount] == right.limits[rightCount]
+                if (SegmentLimit<Variable>.HaveTheSameElements(currentLeftLimits, currentRightLimits))
+                {
+                    newLeftLimits.Add(currentLeftLimits);
+                    newRightLimits.Add(currentRightLimits);
+
+                    newLeftElements.Add(currentLeftElements);
+                    newRightElements.Add(currentRightElements);
+
+                    leftCount++;
+                    rightCount++;
+
+                    continue;
+                }
+
+                // Case 4.b left.limits[leftCount] < right.limits[rightCount] ==> We should split right
+                if (currentLeftLimits.IsSubSetOf(currentRightLimits))
+                {
+                    // < { a } P; { a, b } P'> --> < { a } P; { a } neutral { b }? P'>
+                    SplitSegment(left, right, neutralRight, newLeftLimits, newRightLimits,
+                      newLeftElements, newRightElements, ref leftCount, ref rightCount);
+
+                    Contract.Assert(newLeftElements.Count == newRightElements.Count);
+                    Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
+                    Contract.Assert(right.limits.Count == right.elements.Count + 1);
+
+                    continue;
+                }
+
+                // Case 4.c left.limits[leftCount] > right.limts[rightCount] ==> We should split left
+                if (currentRightLimits.IsSubSetOf(currentLeftLimits))
+                {
+                    // < { a, b} P; { a } P' > --> < {a} neutral {b}? P; { a } P'>
+                    SplitSegment(right, left, neutralLeft, newRightLimits, newLeftLimits,
+                      newRightElements, newLeftElements, ref rightCount, ref leftCount);
+
+                    Contract.Assert(newLeftElements.Count == newRightElements.Count);
+                    Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
+                    Contract.Assert(right.limits.Count == right.elements.Count + 1);
+
+                    continue;
+                }
+
+                // Case 5 : We cannot unify, and so we have to abstract some of the limits
+
+                // 5.a Keep only the intersection
+                var commonLimits = currentLeftLimits.Intersection(currentRightLimits);
+
+                if (!commonLimits.IsEmpty)
+                {
+                    KeepOnlyIntersection(left, right, neutralLeft, neutralRight, newLeftLimits, newRightLimits, newLeftElements, newRightElements,
+                      ref leftCount, ref rightCount, currentLeftLimits, currentRightLimits, currentLeftElements, currentRightElements, commonLimits);
+
+                    continue;
+                }
+
+                Contract.Assume(leftCount >= 1);
+                Contract.Assume(rightCount >= 1);
+
+                // 5.b Try to keep some bounds
+                if (rightCount < right.limits.Count - 1 && !(currentLeftLimits.Join(right.limits[rightCount + 1]).IsEmpty))
+                {
+                    Contract.Assume(newRightElements.Count >= 1);
+
+                    JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
+                }
+                else if (leftCount < left.limits.Count - 1 && !(left.limits[leftCount + 1].Join(currentRightLimits).IsEmpty))
+                {
+                    Contract.Assume(newLeftElements.Count >= 1);
+
+                    JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
+                }
+                else
+                { // This the case in which we may have to drop both limits.
+                  // We try to refine precision by performing some lookahead
+
+                    // 1-lookahed
+                    if (currentLeftLimits.IsAtLeftOf(currentRightLimits))
+                    {
+                        Contract.Assume(newLeftElements.Count >= 1);
+
+                        JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
+
+                        continue;
+                    }
+
+                    // 1-lookahed
+                    if (currentRightLimits.IsAtLeftOf(currentLeftLimits))
+                    {
+                        Contract.Assume(newRightElements.Count >= 1);
+
+                        JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
+
+                        continue;
+                    }
+
+                    // If one of the two contains a constant, we try to keep it
+                    if (currentLeftLimits.ContainsConstant)
+                    {
+                        Contract.Assume(newRightElements.Count >= 1);
+
+                        JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
+
+                        continue;
+                    }
+
+                    if (currentRightLimits.ContainsConstant)
+                    {
+                        Contract.Assume(newLeftElements.Count >= 1);
+
+                        JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
+
+                        continue;
+                    }
+
+                    // else - no hope, let's just abstract the two limits
+                    Contract.Assume(newLeftElements.Count > 0);
+
+                    JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
+
+                    Contract.Assume(newRightElements.Count > 0);
+
+                    JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
+                }
+                continue;
+            }
+
+            if ((newLeftLimits.Count > 0 && newLeftLimits.GetLastElement().IsEmpty) || (newRightLimits.Count > 0 && newRightLimits.GetLastElement().IsEmpty))
+            {
+                // We want this program point to be unreached, but in order to make the implemetation robust, 
+                // if we get a malformed list of limits, were the last limit is empty we just return fail
+                if (ArrayOptions.Trace)
+                {
+                    Console.WriteLine("*** Internal error in Unification. Giving up and returning top");
+                }
+
+                leftReduced = rightReduced = null;
+
+                return false;
+            }
+            else
+            {
+                Contract.Assume(newLeftLimits.Count == newLeftElements.Count + 1);
+                Contract.Assume(newRightLimits.Count == newRightElements.Count + 1);
+
+                leftReduced = new ArraySegmentation<AbstractDomain, Variable, Expression>(false,
+                  newLeftLimits, newLeftElements, bottomElement, expManager);
+                rightReduced = new ArraySegmentation<AbstractDomain, Variable, Expression>(false,
+                  newRightLimits, newRightElements, bottomElement, expManager);
+
+                Contract.Assume(leftReduced.elements.Count > 0);
+                Contract.Assert(leftReduced.limits.Count == rightReduced.limits.Count);
+            }
+
+            if (ArrayOptions.Trace)
+            {
+                Console.WriteLine("After Unification:\n{0}\n{1}", leftReduced.ToString(), rightReduced.ToString());
+            }
+
+            return true;
+        }
+
+        private static void RefineSegmentation(bool isWidening,
+          ArraySegmentation<AbstractDomain, Variable, Expression> refiningSegmentation,
+          ArraySegmentation<AbstractDomain, Variable, Expression> refineeSegmentation,
+          AbstractDomain neutralElement,
+          NonNullList<SegmentLimit<Variable>> newLimitsForRefinee, NonNullList<SegmentLimit<Variable>> newLimitsForRefining,
+          NonNullList<AbstractDomain> newElementsForRefinee, NonNullList<AbstractDomain> newElementsForRefining,
+          ref int count, out bool removedAtLeastOneLimit)
+        {
+            #region Contract
+
+            Contract.Requires(neutralElement != null);
+            Contract.Requires(refiningSegmentation != null);
+            Contract.Requires(refineeSegmentation != null);
+            Contract.Requires(newLimitsForRefinee != null);
+            Contract.Requires(newLimitsForRefining != null);
+            Contract.Requires(newElementsForRefinee != null);
+            Contract.Requires(newElementsForRefining != null);
+
+            Contract.Requires(newElementsForRefinee.Count == newElementsForRefining.Count);
+            Contract.Requires(newLimitsForRefinee.Count == newLimitsForRefining.Count);
+
+            Contract.Requires(count >= 1);
+
+            Contract.Requires(newElementsForRefinee.Count >= 1);
+
+            Contract.Ensures(count >= Contract.OldValue(count));
+            Contract.Ensures(newLimitsForRefinee.Count == newLimitsForRefining.Count);
+
+            #endregion
+
+            removedAtLeastOneLimit = false;
+
+            // REDUNDANT inferred by CC
+            /*
+            var lastElementForRefining = newElementsForRefining.Count > 0
+              ? newElementsForRefining.GetLastElement()
+              : neutralElement;
+            */
+
+            var lastElementForRefining = newElementsForRefining.GetLastElement();
+
+            var old_count = count;
+
+            // F: this is the object invariant of refininingSegmentation, that we do not assume here
+            Contract.Assume(refiningSegmentation.elements != null);
+            Contract.Assume(refiningSegmentation.limits != null);
+            Contract.Assume(refineeSegmentation.limits != null);
+            Contract.Assume(refiningSegmentation.elements.Count == refiningSegmentation.limits.Count - 1);
+
+            for (int i = count; i < refiningSegmentation.limits.Count - 1; i++)
+            {
+                var limit = refiningSegmentation.limits[i];
+
+                if (isWidening)
+                {
+                    limit = limit.KeepOnlyConstantExpressionIfAny();
+                }
+
+                if (!limit.IsEmpty && !limit.IsConditional && !isWidening)
+                {
+                    // Update the refining
+                    newLimitsForRefining.Add(limit);
+                    newElementsForRefining.Add(refiningSegmentation.elements[i]);
+                    // Update the refinee
+                    if (count <= refineeSegmentation.limits.Count - 1 && !limit.Intersection(refineeSegmentation.limits[count]).IsEmpty)
+                    {
+                        newLimitsForRefinee.Add(new SegmentLimit<Variable>(limit, true));
+                        newElementsForRefinee.Add(neutralElement);
+
+                        var newPostLimit = refineeSegmentation.limits[count].Difference(limit);
+                        refineeSegmentation.limits[count] = new SegmentLimit<Variable>(newPostLimit, true);
+                    }
+                    else
+                    {
+                        newLimitsForRefinee.Add(limit);
+                        newElementsForRefinee.Add(lastElementForRefining);
+                    }
+                }
+                else
+                {
+                    // If we reached this branch, it means that we abstracted away the limit
+                    removedAtLeastOneLimit = true;
+
+                    var lastElementIndex = Math.Max(0, newElementsForRefinee.Count - 1);
+                    newElementsForRefinee[lastElementIndex] = (AbstractDomain)newElementsForRefinee[lastElementIndex].Join(refiningSegmentation.elements[i]);
+                }
+                count++;
+            }
+
+            Contract.Assert(old_count <= count); // F: we need the assert here to help Clousot proving the postcondition
+        }
+
+        [Pure]
+        private static void JoinElementsAndMoveForward(
+          NonNullList<AbstractDomain> newElements, ref int count, AbstractDomain currentElements)
+        {
+            Contract.Requires(count >= 1);
+            Contract.Requires(newElements != null);
+            Contract.Requires(newElements.Count >= 1);
+
+            Contract.Ensures(count == Contract.OldValue(count) + 1);
+
+            var pos = Math.Min(count - 1, newElements.Count - 1); // We take the min to handle the case for the last element
+
+            newElements[pos] = (AbstractDomain)currentElements.Join(newElements[pos]);
+
+            count++;
+        }
+
+        private static void KeepOnlyIntersection(
+          ArraySegmentation<AbstractDomain, Variable, Expression> left, ArraySegmentation<AbstractDomain, Variable, Expression> right,
+          AbstractDomain neutralLeft, AbstractDomain neutralRight,
+          NonNullList<SegmentLimit<Variable>> newLeftLimits, NonNullList<SegmentLimit<Variable>> newRightLimits,
+          NonNullList<AbstractDomain> newLeftElements, NonNullList<AbstractDomain> newRightElements,
+          ref int leftCount, ref int rightCount,
+          SegmentLimit<Variable> currentLeftLimits, SegmentLimit<Variable> currentRightLimits,
+          AbstractDomain currentLeftElements, AbstractDomain currentRightElements,
+          Set<NormalizedExpression<Variable>> commonLimits)
+        {
+            #region Contracts 
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Requires(neutralLeft != null);
+            Contract.Requires(neutralRight != null);
+            Contract.Requires(commonLimits != null);
+            Contract.Requires(currentLeftLimits != null);
+            Contract.Requires(currentRightLimits != null);
+            Contract.Requires(currentLeftElements != null);
+            Contract.Requires(currentRightElements != null);
+            Contract.Requires(newLeftLimits != null);
+            Contract.Requires(newRightLimits != null);
+            Contract.Requires(newLeftElements != null);
+            Contract.Requires(newRightElements != null);
+
+            Contract.Requires(leftCount >= 0);
+            Contract.Requires(rightCount >= 0);
+
+            // F: Those two are because we do not assume invariants for parameters
+            Contract.Requires(left.elements != null);
+            Contract.Requires(right.elements != null);
+
+            Contract.Requires(leftCount < left.elements.Count);
+            Contract.Requires(rightCount < right.elements.Count);
+
+            Contract.Ensures(leftCount == Contract.OldValue(leftCount) + 1);
+            Contract.Ensures(rightCount == Contract.OldValue(rightCount) + 1);
+
+            #endregion
+
+            newLeftLimits.Add(new SegmentLimit<Variable>(commonLimits, currentLeftLimits.IsConditional));
+            newRightLimits.Add(new SegmentLimit<Variable>(commonLimits, currentRightLimits.IsConditional));
 
             newLeftElements.Add(neutralLeft);
             newRightElements.Add(neutralRight);
 
+            var diffLeft = currentLeftLimits.Difference(commonLimits);
+            var diffRight = currentRightLimits.Difference(commonLimits);
+
+            // Small optimization: we increment here the pointers 
+            // instead that at the end of the method, as we need to insert a new pair <limit, element>
             leftCount++;
             rightCount++;
-          }
-          else
-          {
-            bool removedALimitOnTheLeft;
-            RefineSegmentation(operation == SegmentUnificationOperation.Widening, left, right,
-              neutralRight, newLeftLimits, newRightLimits, newLeftElements, newRightElements, ref leftCount, out removedALimitOnTheLeft);
-          }
 
-          Contract.Assert(newLeftElements.Count == newRightElements.Count);
-          Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
+            // F: Adding those two assumptions, as we do not materialize the object invariants for parameters
+            Contract.Assume(left.limits != null);
+            Contract.Assume(right.limits != null);
+            Contract.Assume(left.limits.Count == left.elements.Count + 1);
+            Contract.Assume(right.limits.Count == right.elements.Count + 1);
 
-          continue;
+            Contract.Assert(leftCount <= left.elements.Count);
+
+            left.limits.InsertOrAdd(leftCount, new SegmentLimit<Variable>(diffLeft, true));
+
+            Contract.Assert(leftCount <= left.elements.Count);
+
+            left.elements.InsertOrAdd(leftCount, currentLeftElements);
+
+            right.limits.InsertOrAdd(rightCount, new SegmentLimit<Variable>(diffRight, true));
+            right.elements.InsertOrAdd(rightCount, currentRightElements);
         }
 
-        // If something goes wrong, we silently swallow it and continue
-        if (leftCount >= left.limits.Count || rightCount >= right.limits.Count)
+
+        private static void SplitSegment(
+          ArraySegmentation<AbstractDomain, Variable, Expression> splitter, ArraySegmentation<AbstractDomain, Variable, Expression> splittee,
+          AbstractDomain splitteeNeutralElement,
+          NonNullList<SegmentLimit<Variable>> newSplitterLimits, NonNullList<SegmentLimit<Variable>> newSplitteeLimits,
+          NonNullList<AbstractDomain> newSplitterElements, NonNullList<AbstractDomain> newSplitteeElements,
+          ref int splitterCount, ref int splitteeCount)
         {
-          leftCount++;
-          rightCount++;
-          continue;
-        }
-
-        // Caching useful dictionary accesses
-        var currentLeftLimits = left.limits[leftCount];
-        var currentRightLimits = right.limits[rightCount];
-
-        // F: Those assumptions may not be true, so we want to check at runtime
-        Contract.Assume(leftCount < left.elements.Count);
-        Contract.Assume(rightCount < right.elements.Count);
-
-        var currentLeftElements = left.elements[leftCount];
-        var currentRightElements = right.elements[rightCount];
-
-        Contract.Assert(currentLeftLimits != null);
-        Contract.Assert(currentRightLimits != null);
-
-        // Case 4: 
-        // Case 4.a  left.limits[leftCount] == right.limits[rightCount]
-        if (SegmentLimit<Variable>.HaveTheSameElements(currentLeftLimits, currentRightLimits))
-        {
-          newLeftLimits.Add(currentLeftLimits);
-          newRightLimits.Add(currentRightLimits);
-
-          newLeftElements.Add(currentLeftElements);
-          newRightElements.Add(currentRightElements);
-
-          leftCount++;
-          rightCount++;
-
-          continue;
-        }
-
-        // Case 4.b left.limits[leftCount] < right.limits[rightCount] ==> We should split right
-        if (currentLeftLimits.IsSubSetOf(currentRightLimits))
-        {
-          // < { a } P; { a, b } P'> --> < { a } P; { a } neutral { b }? P'>
-          SplitSegment(left, right, neutralRight, newLeftLimits, newRightLimits,
-            newLeftElements, newRightElements, ref leftCount, ref rightCount);
-
-          Contract.Assert(newLeftElements.Count == newRightElements.Count);
-          Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
-          Contract.Assert(right.limits.Count == right.elements.Count + 1);
-
-          continue;
-        }
+            #region Contracts
 
-        // Case 4.c left.limits[leftCount] > right.limts[rightCount] ==> We should split left
-        if (currentRightLimits.IsSubSetOf(currentLeftLimits))
-        {
-          // < { a, b} P; { a } P' > --> < {a} neutral {b}? P; { a } P'>
-          SplitSegment(right, left, neutralLeft, newRightLimits, newLeftLimits, 
-            newRightElements, newLeftElements, ref rightCount, ref leftCount);
-
-          Contract.Assert(newLeftElements.Count == newRightElements.Count);
-          Contract.Assert(newLeftLimits.Count == newRightLimits.Count);
-          Contract.Assert(right.limits.Count == right.elements.Count + 1);
-
-          continue;
-        }
-
-        // Case 5 : We cannot unify, and so we have to abstract some of the limits
-
-        // 5.a Keep only the intersection
-        var commonLimits = currentLeftLimits.Intersection(currentRightLimits);
-     
-        if (!commonLimits.IsEmpty)
-        {
-          KeepOnlyIntersection(left, right, neutralLeft, neutralRight, newLeftLimits, newRightLimits, newLeftElements, newRightElements, 
-            ref leftCount, ref rightCount, currentLeftLimits, currentRightLimits, currentLeftElements, currentRightElements, commonLimits);         
-
-          continue;
-        }
-
-        Contract.Assume(leftCount >= 1);
-        Contract.Assume(rightCount >= 1);
-
-        // 5.b Try to keep some bounds
-        if (rightCount < right.limits.Count - 1 && !(currentLeftLimits.Join(right.limits[rightCount + 1]).IsEmpty))
-        {
-          Contract.Assume(newRightElements.Count >= 1);
-
-          JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
-        }        
-        else if (leftCount < left.limits.Count - 1 && !(left.limits[leftCount + 1].Join(currentRightLimits).IsEmpty))
-        {
-          Contract.Assume(newLeftElements.Count >= 1);
-
-          JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
-        }
-        else 
-        { // This the case in which we may have to drop both limits.
-          // We try to refine precision by performing some lookahead
-          
-          // 1-lookahed
-          if (currentLeftLimits.IsAtLeftOf(currentRightLimits))
-          {
-            Contract.Assume(newLeftElements.Count >= 1);
-
-            JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
-
-            continue;
-          }
+            Contract.Requires(splitter != null);
+            Contract.Requires(splittee != null);
 
-          // 1-lookahed
-          if (currentRightLimits.IsAtLeftOf(currentLeftLimits))
-          {
-            Contract.Assume(newRightElements.Count >= 1);
+            Contract.Requires(splitter.limits != null);
+            Contract.Requires(splittee.limits != null);
 
-            JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
+            Contract.Requires(splitter.elements != null);
+            Contract.Requires(splittee.elements != null);
 
-            continue;
-          }
+            Contract.Requires(splitteeNeutralElement != null);
 
-          // If one of the two contains a constant, we try to keep it
-          if (currentLeftLimits.ContainsConstant)
-          {
-            Contract.Assume(newRightElements.Count >= 1);
+            Contract.Requires(newSplitterLimits != null);
+            Contract.Requires(newSplitteeLimits != null);
+            Contract.Requires(newSplitterElements != null);
+            Contract.Requires(newSplitteeElements != null);
 
-            JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
+            Contract.Requires(splitterCount >= 0);
+            Contract.Requires(splitterCount < splitter.elements.Count);
 
-            continue;
-          }
+            Contract.Requires(splitteeCount >= 0);
 
-          if (currentRightLimits.ContainsConstant)
-          {
-            Contract.Assume(newLeftElements.Count >= 1);
+            Contract.Requires(splitteeCount < splittee.limits.Count);
 
-            JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
+            Contract.Requires(newSplitterLimits.Count == newSplitteeLimits.Count);
+            Contract.Requires(newSplitterElements.Count == newSplitteeElements.Count);
 
-            continue;
-          }
+            Contract.Requires(splitter.limits.Count == splitter.elements.Count + 1);
 
-          // else - no hope, let's just abstract the two limits
-          Contract.Assume(newLeftElements.Count > 0);
+            Contract.Ensures(newSplitterLimits.Count == newSplitteeLimits.Count);
+            Contract.Ensures(newSplitterElements.Count == newSplitteeElements.Count);
 
-          JoinElementsAndMoveForward(newLeftElements, ref leftCount, currentLeftElements);
+            Contract.Ensures(Contract.ValueAtReturn(out splitterCount) == Contract.OldValue(splitterCount) + 1);
+            Contract.Ensures(Contract.ValueAtReturn(out splitteeCount) == Contract.OldValue(splitteeCount) + 1);
 
-          Contract.Assume(newRightElements.Count > 0);
+            Contract.Ensures(splittee.limits.Count == Contract.OldValue(splittee.limits.Count) + 1);
+            Contract.Ensures(splittee.elements.Count <= Contract.OldValue(splittee.elements.Count) + 1);
 
-          JoinElementsAndMoveForward(newRightElements, ref rightCount, currentRightElements);
-        }
-        continue;
-      }
+            #endregion
 
-      if ((newLeftLimits.Count > 0 && newLeftLimits.GetLastElement().IsEmpty) || (newRightLimits.Count > 0 && newRightLimits.GetLastElement().IsEmpty))
-      {
-        // We want this program point to be unreached, but in order to make the implemetation robust, 
-        // if we get a malformed list of limits, were the last limit is empty we just return fail
-        if (ArrayOptions.Trace)
-        {
-          Console.WriteLine("*** Internal error in Unification. Giving up and returning top");
-        }
-
-        leftReduced = rightReduced = null;
-
-        return false;
-      }
-      else
-      {
-        Contract.Assume(newLeftLimits.Count == newLeftElements.Count + 1);
-        Contract.Assume(newRightLimits.Count == newRightElements.Count + 1);
-
-        leftReduced = new ArraySegmentation<AbstractDomain, Variable, Expression>(false,
-          newLeftLimits, newLeftElements, this.bottomElement, this.expManager);
-        rightReduced = new ArraySegmentation<AbstractDomain, Variable, Expression>(false,
-          newRightLimits, newRightElements, this.bottomElement, this.expManager);
-
-        Contract.Assume(leftReduced.elements.Count > 0);
-        Contract.Assert(leftReduced.limits.Count == rightReduced.limits.Count);
-      }
-
-      if (ArrayOptions.Trace)
-      {
-        Console.WriteLine("After Unification:\n{0}\n{1}", leftReduced.ToString(), rightReduced.ToString());
-      }
-
-      return true;
-    }
-
-    private static void RefineSegmentation(bool isWidening,
-      ArraySegmentation<AbstractDomain, Variable, Expression> refiningSegmentation, 
-      ArraySegmentation<AbstractDomain, Variable, Expression> refineeSegmentation,
-      AbstractDomain neutralElement, 
-      NonNullList<SegmentLimit<Variable>> newLimitsForRefinee, NonNullList<SegmentLimit<Variable>> newLimitsForRefining, 
-      NonNullList<AbstractDomain> newElementsForRefinee, NonNullList<AbstractDomain> newElementsForRefining, 
-      ref int count, out bool removedAtLeastOneLimit)
-    {
-      #region Contract
-
-      Contract.Requires(neutralElement != null);
-      Contract.Requires(refiningSegmentation != null);
-      Contract.Requires(refineeSegmentation != null);
-      Contract.Requires(newLimitsForRefinee != null);
-      Contract.Requires(newLimitsForRefining != null);
-      Contract.Requires(newElementsForRefinee != null);
-      Contract.Requires(newElementsForRefining != null);
-
-      Contract.Requires(newElementsForRefinee.Count == newElementsForRefining.Count);
-      Contract.Requires(newLimitsForRefinee.Count == newLimitsForRefining.Count);
-
-      Contract.Requires(count >= 1);
-
-      Contract.Requires(newElementsForRefinee.Count >= 1);
-
-      Contract.Ensures(count >= Contract.OldValue(count));
-      Contract.Ensures(newLimitsForRefinee.Count == newLimitsForRefining.Count);
-
-      #endregion
-
-      removedAtLeastOneLimit = false;
-
-      // REDUNDANT inferred by CC
-      /*
-      var lastElementForRefining = newElementsForRefining.Count > 0
-        ? newElementsForRefining.GetLastElement()
-        : neutralElement;
-      */
-
-      var lastElementForRefining = newElementsForRefining.GetLastElement();
-
-      var old_count = count;
-
-      // F: this is the object invariant of refininingSegmentation, that we do not assume here
-      Contract.Assume(refiningSegmentation.elements != null);
-      Contract.Assume(refiningSegmentation.limits != null);
-      Contract.Assume(refineeSegmentation.limits != null);
-      Contract.Assume(refiningSegmentation.elements.Count  == refiningSegmentation.limits.Count -1);
-
-      for (int i = count; i < refiningSegmentation.limits.Count - 1; i++)
-      {
-        var limit = refiningSegmentation.limits[i];
-
-        if (isWidening)
-        {
-          limit = limit.KeepOnlyConstantExpressionIfAny();
-        }
-
-        if (!limit.IsEmpty && !limit.IsConditional && !isWidening)
-        {          
-          // Update the refining
-          newLimitsForRefining.Add(limit);
-          newElementsForRefining.Add(refiningSegmentation.elements[i]);
-          // Update the refinee
-          if (count <= refineeSegmentation.limits.Count - 1 && !limit.Intersection(refineeSegmentation.limits[count]).IsEmpty)
-          {
-            newLimitsForRefinee.Add(new SegmentLimit<Variable>(limit, true));
-            newElementsForRefinee.Add(neutralElement);
-
-            var newPostLimit = refineeSegmentation.limits[count].Difference(limit);
-            refineeSegmentation.limits[count] = new SegmentLimit<Variable>(newPostLimit, true);
-          }
-          else
-          {
-            newLimitsForRefinee.Add(limit);
-            newElementsForRefinee.Add(lastElementForRefining);
-          }
-        }
-        else
-        {
-          // If we reached this branch, it means that we abstracted away the limit
-          removedAtLeastOneLimit = true;
-
-          var lastElementIndex = Math.Max(0, newElementsForRefinee.Count - 1);
-          newElementsForRefinee[lastElementIndex] = (AbstractDomain)newElementsForRefinee[lastElementIndex].Join(refiningSegmentation.elements[i]);
-        }
-        count++;
-      }
-
-      Contract.Assert(old_count <= count); // F: we need the assert here to help Clousot proving the postcondition
-    }
-
-    [Pure]
-    private static void JoinElementsAndMoveForward(
-      NonNullList<AbstractDomain> newElements, ref int count, AbstractDomain currentElements)
-    {
-      Contract.Requires(count >= 1);
-      Contract.Requires(newElements != null);
-      Contract.Requires(newElements.Count >= 1);
-
-      Contract.Ensures(count == Contract.OldValue(count) +1);
-
-      var pos = Math.Min(count - 1, newElements.Count - 1); // We take the min to handle the case for the last element
-
-      newElements[pos] = (AbstractDomain)currentElements.Join(newElements[pos]);
-
-      count++;
-    }
-
-    private static void KeepOnlyIntersection(
-      ArraySegmentation<AbstractDomain, Variable, Expression> left, ArraySegmentation<AbstractDomain, Variable, Expression> right, 
-      AbstractDomain neutralLeft, AbstractDomain neutralRight, 
-      NonNullList<SegmentLimit<Variable>> newLeftLimits, NonNullList<SegmentLimit<Variable>> newRightLimits, 
-      NonNullList<AbstractDomain> newLeftElements, NonNullList<AbstractDomain> newRightElements, 
-      ref int leftCount, ref int rightCount, 
-      SegmentLimit<Variable> currentLeftLimits, SegmentLimit<Variable> currentRightLimits, 
-      AbstractDomain currentLeftElements, AbstractDomain currentRightElements, 
-      Set<NormalizedExpression<Variable>> commonLimits)
-    {
-      #region Contracts 
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Requires(neutralLeft != null);
-      Contract.Requires(neutralRight != null);
-      Contract.Requires(commonLimits != null);
-      Contract.Requires(currentLeftLimits != null);
-      Contract.Requires(currentRightLimits != null);
-      Contract.Requires(currentLeftElements != null);
-      Contract.Requires(currentRightElements != null);
-      Contract.Requires(newLeftLimits != null);
-      Contract.Requires(newRightLimits != null);
-      Contract.Requires(newLeftElements != null);
-      Contract.Requires(newRightElements != null);
-
-      Contract.Requires(leftCount >= 0);
-      Contract.Requires(rightCount >= 0);
-
-      // F: Those two are because we do not assume invariants for parameters
-      Contract.Requires(left.elements != null);
-      Contract.Requires(right.elements != null);
-
-      Contract.Requires(leftCount < left.elements.Count);
-      Contract.Requires(rightCount < right.elements.Count);
-
-      Contract.Ensures(leftCount == Contract.OldValue(leftCount) + 1);
-      Contract.Ensures(rightCount == Contract.OldValue(rightCount) + 1);
-
-      #endregion
-
-      newLeftLimits.Add(new SegmentLimit<Variable>(commonLimits, currentLeftLimits.IsConditional));
-      newRightLimits.Add(new SegmentLimit<Variable>(commonLimits, currentRightLimits.IsConditional));
-
-      newLeftElements.Add(neutralLeft);
-      newRightElements.Add(neutralRight);
-
-      var diffLeft = currentLeftLimits.Difference(commonLimits);
-      var diffRight = currentRightLimits.Difference(commonLimits);
-
-      // Small optimization: we increment here the pointers 
-      // instead that at the end of the method, as we need to insert a new pair <limit, element>
-      leftCount++;
-      rightCount++;
-
-      // F: Adding those two assumptions, as we do not materialize the object invariants for parameters
-      Contract.Assume(left.limits != null);
-      Contract.Assume(right.limits != null);
-      Contract.Assume(left.limits.Count == left.elements.Count + 1);
-      Contract.Assume(right.limits.Count == right.elements.Count + 1);
-
-      Contract.Assert(leftCount <= left.elements.Count);
-
-      left.limits.InsertOrAdd(leftCount, new SegmentLimit<Variable>(diffLeft, true));
-
-      Contract.Assert(leftCount <= left.elements.Count);
-
-      left.elements.InsertOrAdd(leftCount, currentLeftElements);
-
-      right.limits.InsertOrAdd(rightCount, new SegmentLimit<Variable>(diffRight, true));
-      right.elements.InsertOrAdd(rightCount, currentRightElements);
-    }
-
-     
-    private static void SplitSegment(
-      ArraySegmentation<AbstractDomain, Variable, Expression> splitter, ArraySegmentation<AbstractDomain, Variable, Expression> splittee, 
-      AbstractDomain splitteeNeutralElement,
-      NonNullList<SegmentLimit<Variable>> newSplitterLimits, NonNullList<SegmentLimit<Variable>> newSplitteeLimits, 
-      NonNullList<AbstractDomain> newSplitterElements, NonNullList<AbstractDomain> newSplitteeElements, 
-      ref int splitterCount, ref int splitteeCount)
-    {
-      #region Contracts
-
-      Contract.Requires(splitter != null);
-      Contract.Requires(splittee != null);
-
-      Contract.Requires(splitter.limits != null);
-      Contract.Requires(splittee.limits != null);
-
-      Contract.Requires(splitter.elements != null);
-      Contract.Requires(splittee.elements != null);
-      
-      Contract.Requires(splitteeNeutralElement != null);
-      
-      Contract.Requires(newSplitterLimits != null);
-      Contract.Requires(newSplitteeLimits != null);
-      Contract.Requires(newSplitterElements != null);
-      Contract.Requires(newSplitteeElements != null);
-
-      Contract.Requires(splitterCount >= 0);
-      Contract.Requires(splitterCount < splitter.elements.Count);
-
-      Contract.Requires(splitteeCount >= 0);
-      
-      Contract.Requires(splitteeCount < splittee.limits.Count);
-
-      Contract.Requires(newSplitterLimits.Count == newSplitteeLimits.Count);
-      Contract.Requires(newSplitterElements.Count == newSplitteeElements.Count);
-
-      Contract.Requires(splitter.limits.Count == splitter.elements.Count + 1);
-
-      Contract.Ensures(newSplitterLimits.Count == newSplitteeLimits.Count);
-      Contract.Ensures(newSplitterElements.Count == newSplitteeElements.Count);
-
-      Contract.Ensures(Contract.ValueAtReturn(out splitterCount) == Contract.OldValue(splitterCount) + 1);
-      Contract.Ensures(Contract.ValueAtReturn(out splitteeCount) == Contract.OldValue(splitteeCount) + 1);
-
-      Contract.Ensures(splittee.limits.Count == Contract.OldValue(splittee.limits.Count) + 1);
-      Contract.Ensures(splittee.elements.Count <= Contract.OldValue(splittee.elements.Count) + 1);
-
-      #endregion      
-      
-      var common = splitter.limits[splitterCount];
-
-      Contract.Assert(common != null);
-
-      var reminder = splittee.limits[splitteeCount].Difference(common);
-
-      // 1. Add the common limits
-      newSplitterLimits.Add(common);
-      newSplitteeLimits.Add(new SegmentLimit<Variable>(common, splitterCount != 0 ? true : false));
-
-      // 2. Add the elements
-      newSplitterElements.Add(splitter.elements[splitterCount]);
-
-      newSplitteeElements.Add(splitteeNeutralElement);
-
-      // 3. Increase the pointers (small optimization)
-      splitterCount++;
-      splitteeCount++;
-
-      //Contract.Assert(splitteeCount < splittee.elements.Count);
-
-      // 4. Push the reminder limit and the element onto the splittee
-      splittee.limits.InsertOrAdd(splitteeCount, new SegmentLimit<Variable>(reminder, true));
-
-        // We check it because it can be the last element in the sequence, so there is nothing to do then
-      if (splitteeCount - 1 < splittee.elements.Count)
-      {
-        splittee.elements.InsertOrAdd(splitteeCount, splittee.elements[splitteeCount - 1]);
-      }
-    }
-
-    #endregion
-
-    #region Segmentation inclusions
-
-    /// <summary>
-    /// Check if this segmentation is included in the other.
-    /// This is useful for the meet (and LessEqual) because the segment unification can be too rough, and throw away segments in the meet
-    /// </summary>
-    /// <param name="other"></param>
-    /// <returns></returns>
-    [Pure]
-    private bool IsIncludedIn(ArraySegmentation<AbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      if (this.IsBottom || other.IsTop)
-      {
-        return true;
-      }
-
-      if (other.IsBottom)
-      {
-        return false;
-      }
-
-      Contract.Assume(this.IsNormal);
-
-      // We can start from 1, as we know that '0' is in the first limit of all the segmentations
-      var lastI = 0;
-      var lastJ = 0;
-
-      Contract.Assume(other.limits != null, "assuming object invariant");
-      Contract.Assume(other.IsNormal, "assuming object invariant");
-
-      for (var j = 1; j < other.limits.Count; j++)
-      {
-        // the limit other.limits[i] should be contained in one of this limits
-        for (var i = lastI+1; i < this.limits.Count; i++)
-        {
-          Contract.Assert(this.limits.Count == this.elements.Count + 1);
-          Contract.Assert(other.limits.Count == other.elements.Count +1);
-
-          var intersection = this.limits[i].Intersect(other.limits[j]);
-          if (intersection.Any())
-          {
-            var thisElements = this.JoinValuesInASubrange(lastI, i);
-            var otherElements = other.JoinValuesInASubrange(lastJ, j);
-
-            if (thisElements.LessEqual(otherElements))
+            var common = splitter.limits[splitterCount];
+
+            Contract.Assert(common != null);
+
+            var reminder = splittee.limits[splitteeCount].Difference(common);
+
+            // 1. Add the common limits
+            newSplitterLimits.Add(common);
+            newSplitteeLimits.Add(new SegmentLimit<Variable>(common, splitterCount != 0 ? true : false));
+
+            // 2. Add the elements
+            newSplitterElements.Add(splitter.elements[splitterCount]);
+
+            newSplitteeElements.Add(splitteeNeutralElement);
+
+            // 3. Increase the pointers (small optimization)
+            splitterCount++;
+            splitteeCount++;
+
+            //Contract.Assert(splitteeCount < splittee.elements.Count);
+
+            // 4. Push the reminder limit and the element onto the splittee
+            splittee.limits.InsertOrAdd(splitteeCount, new SegmentLimit<Variable>(reminder, true));
+
+            // We check it because it can be the last element in the sequence, so there is nothing to do then
+            if (splitteeCount - 1 < splittee.elements.Count)
             {
-              lastJ = j;
-              lastI = i;
-              goto NextLimit;
+                splittee.elements.InsertOrAdd(splitteeCount, splittee.elements[splitteeCount - 1]);
             }
-            else
+        }
+
+        #endregion
+
+        #region Segmentation inclusions
+
+        /// <summary>
+        /// Check if this segmentation is included in the other.
+        /// This is useful for the meet (and LessEqual) because the segment unification can be too rough, and throw away segments in the meet
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        [Pure]
+        private bool IsIncludedIn(ArraySegmentation<AbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            if (this.IsBottom || other.IsTop)
             {
-              return false;
+                return true;
             }
-          }
-        }
 
-        return false;
-      NextLimit: ;
-      }
-
-      return true;
-    }
-
-    #endregion
-
-    #region Smash all the values in the segment
-    [Pure]     
-    public ArraySegmentation<AbstractDomain, Variable, Expression> SmashAndWeakUpdateWith(AbstractDomain valueIntv)
-    {
-      Contract.Requires(valueIntv != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-
-      if (this.limits.Count <= 1)
-      {
-        return this.Top;
-      }
-
-      var join = valueIntv;
-
-      foreach (var x in this.elements)
-      {
-        Contract.Assume(x != null); // F: TODO the contract on the NonNullist GetEnumerator
-
-        join = (AbstractDomain)join.Join(x);
-
-        Contract.Assert(join != null);
-      }
-
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(
-        this.limits[0], join, this.limits[this.limits.Count-1],
-        this.bottomElement, this.expManager);
-    }
-    #endregion
-
-    #region JoinAllTheValues
-
-    public AbstractDomain JoinAll(AbstractDomain bottom)
-    {
-      #region Contract
-
-      Contract.Requires(bottom != null);
-
-      Contract.Ensures(Contract.Result<AbstractDomain>() != null);
-
-      #endregion
-
-      if (this.IsEmptyArray || this.IsTop)
-      {
-        return (AbstractDomain) bottom.Top;
-      }
-      if (this.IsBottom)
-      {
-        return bottom;
-      }
-
-      var result = bottom;
-      foreach (var element in this.elements)
-      {
-        result = (AbstractDomain) result.Join(element);
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region ToString
-
-    public override string ToString()
-    {
-      if (this.IsEmptyArray)
-        return "Empty array";
-      if (this.IsBottom)
-        return "Bottom (_|_)";
-      if (this.IsTop)
-        return "Top";
-
-      // F: making it an assume until we have a better handling of disjunctions in object-invariants
-      Contract.Assume(this.limits.Count == this.elements.Count + 1);
-
-      var result = new StringBuilder();
-
-      if (/*ArrayOptions.Trace*/ true)
-      {
-        result.AppendFormat("#{0}", this.Id);
-      }
-
-      result.AppendFormat("{0} ", ToString(limits, elements));
-
-      return result.ToString();
-    }
-     
-    static private string ToString(NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements)
-    {
-      Contract.Requires(limits != null);
-      Contract.Requires(elements != null);
-      Contract.Requires(limits.Count - elements.Count >= 0);
-      Contract.Requires(1 >= limits.Count - elements.Count);
-
-      if (limits.Count == 0)
-      {
-        return "Empty";
-      }
-
-      var result = new StringBuilder();
-      result.AppendFormat("{0} ", limits[0].ToString());
-
-      for (var i = 1; i < limits.Count; i++)
-      {
-        Contract.Assert(i - 1 < limits.Count);
-        Contract.Assert(elements.Count <= limits.Count);
-        Contract.Assert(i - 1 < elements.Count); 
-
-        result.AppendFormat("{0} ", elements[i - 1]);
-        result.AppendFormat("{0} ", limits[i]);
-      }
-
-      return result.ToString();
-    }
-
-    [Pure]
-    [ContractVerification(false)]
-    static private void Trace(int iteration, NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements)
-    {
-      Contract.Requires(limits != null);
-      Contract.Requires(elements != null);
-
-      if (ArrayOptions.Trace)
-      {
-        Console.WriteLine(iteration+ " : " + ToString(limits, elements));
-      }
-    }
-    #endregion
-
-    #region TestTue and TestFalse
-
-    private class ArraySegmentationTestTrueVisitor
-      : TestTrueVisitor<ArraySegmentation<AbstractDomain, Variable, Expression>, Variable, Expression>
-    {
-
-      public ArraySegmentationTestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      #region Implementation of overridden
-      public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
-      {
-        return data;
-      }
-
-      public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
-      {
-        return data;
-      }
-
-      public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
-      {
-        if (data != null)
-        {
-          NormalizedExpression<Variable> leftNorm, rightNorm;
-          var isLeftOk = NormalizedExpression<Variable>.TryConvertFrom(left, this.Decoder, out leftNorm);
-          var isRightOk = NormalizedExpression<Variable>.TryConvertFrom(right, this.Decoder, out rightNorm);
-
-          if (isLeftOk && isRightOk)
-          {
-            return data.TestTrueLessThan(leftNorm, rightNorm);
-          }
-        }
-
-        return data;
-      }
-
-      public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
-      {
-        return data;
-      }
-
-      public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitVariable(Variable var, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
-      {
-        return data;
-      }
-      #endregion
-    }
-
-    private class ArraySegmentationTestFalseVisitor
-      : TestFalseVisitor<ArraySegmentation<AbstractDomain, Variable, Expression>, Variable, Expression>
-    {
-
-      public ArraySegmentationTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitVariable(Variable variable, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
-      {
-        return data;
-      }
-    }
-
-    #endregion
-
-    #region Atomic handling for Array.Copy
-    [Pure]
-    public ArraySegmentation<AbstractDomain, Variable, Expression>
-      CopyFrom
-      (ArraySegmentation<AbstractDomain, Variable, Expression> sourceSegmentation, Expression length,
-      INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      #region Contracts
-      Contract.Requires(sourceSegmentation != null);
-      Contract.Requires(oracle != null);
-      Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
-      #endregion
-
-      if (this.IsEmptyArray || this.IsBottom)
-      {
-        return this;
-      }
-
-      if (this.IsTop)
-      {
-        return new ArraySegmentation<AbstractDomain, Variable, Expression>(sourceSegmentation);
-      }
-
-      // Let's search for the upper bound
-
-      var lengthNormalized = NormalizedExpression<Variable>.For(this.expManager.Decoder.UnderlyingVariable(length));
-
-      var i = 0;
-      bool strict = false, equal = false;
-      for (; i < this.limits.Count; i++)
-      {
-        if (LessEqual(this.limits[i], lengthNormalized, oracle, out equal, out strict))
-        {
-          // ok
-        }
-        else
-        {
-          break;
-        }
-      }
-
-      if (i == 0)
-      {
-        return this.Top;
-      }
-
-      Contract.Assume(sourceSegmentation.limits != null);
-      Contract.Assume(sourceSegmentation.elements != null);
-      Contract.Assume(sourceSegmentation.limits.Count == sourceSegmentation.elements.Count + 1);
-
-      var newLimits = new NonNullList<SegmentLimit<Variable>>();
-      var newElements = new NonNullList<AbstractDomain>();
-
-      // Add all the limits
-      var count = 0;
-      foreach (var limit in sourceSegmentation.limits)
-      {
-        Contract.Assume(limit != null);
-        newLimits.Add(limit);
-        count++;
-      }
-      Contract.Assert(count == newLimits.Count);
-      Contract.Assume(newLimits.Count == sourceSegmentation.limits.Count); // F: cannot prove because we miss the relation between the iterator and the original # of elements
-
-      // Add all the abstract values
-      count = 0;
-      foreach (var el in sourceSegmentation.elements)
-      {
-        Contract.Assume(el != null);
-        newElements.Add(el);
-        count++;
-      }
-      Contract.Assert(count == newElements.Count);
-      Contract.Assume(newElements.Count== sourceSegmentation.elements.Count);
-
-      Contract.Assert(newElements.Count + 1== newLimits.Count);
-      if (!equal)
-      {
-        // Add whatever remains here
-        for (var j = i; j < this.limits.Count; j++)
-        {
-          newLimits.Add(this.limits[j]);
-        }
-        for (var j = Math.Max(0, i-1); j < this.elements.Count; j++)
-        {
-          newElements.Add(this.elements[j]);
-        }
-        Contract.Assume(newLimits.Count == newElements.Count + 1);
-      }
-      return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, this.bottomElement, this.expManager);
-    }
-    #endregion
-
-    #region PrettyPrinting
-
-    private const string ForAllTemplate = "Contract.Forall({0}, {1}, {2})";
-
-    [ContractVerification(false)]
-    public List<string> PrettyPrint(string arrayName, 
-      Func<Variable, string> variableNamePrettyPrinter,
-      Func<AbstractDomain, string> abstractElementPrettyPrinter)
-    {
-      Contract.Requires(arrayName != null);
-      Contract.Requires(variableNamePrettyPrinter != null);
-      Contract.Requires(abstractElementPrettyPrinter != null);
-
-      Contract.Ensures(Contract.Result<List<string>>() != null);
-      Contract.Ensures(Contract.ForAll(Contract.Result<List<string>>(), x => x != null));
-
-      var result = new List<string>();
-
-      for (var i = 0; i < this.limits.Count-1; i++)
-      {
-        string inf = null, sup = null;
-
-        foreach (var l in this.limits[i])
-        {
-          inf = l.PrettyPrint(variableNamePrettyPrinter);
-          if (inf != null)
-            break;
-        }
-
-        foreach (var u in this.limits[i + 1])
-        {
-          sup = u.PrettyPrint(variableNamePrettyPrinter);
-          if (sup != null)
-            break;
-        }
-
-        if (inf != null && sup != null)
-        {
-          var arrayElement = abstractElementPrettyPrinter(this.elements[i]);
-          if (arrayElement != null)
-          {
-            result.Add(String.Format(ForAllTemplate, inf, sup, arrayElement));
-          }
-        }
-      }
-      return result;
-    }
-
-    #endregion
-
-    #region To
-    public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsEmptyArray || !this.IsNormal)
-      {
-        return factory.IdentityForAnd;
-      }
-
-      var result = new List<T>();
-
-      for (var i = 0; i < this.limits.Count - 1; i++)
-      {
-        Contract.Assert(this.limits.Count == this.elements.Count + 1);
-
-        T inf = default(T), sup = default(T);
-        bool infOk = false, supOk = false;
-
-        foreach (var l in this.limits[i])
-        {
-          if (l == null)
-          {
-            return factory.IdentityForAnd;
-          }
-          if (l.TryPrettyPrint(factory, out inf))
-          {
-            infOk = true;
-            break;
-          }
-        }
-
-        if (!infOk)
-        {
-          continue;
-        }
-
-        foreach (var u in this.limits[i + 1])
-        {
-          Contract.Assume(u != null);
-          if (u.TryPrettyPrint(factory, out sup))
-          {
-            // REDUNDANT inferred by CC
-            /*
-            if (u == null)
+            if (other.IsBottom)
             {
-              return factory.IdentityForAnd;
+                return false;
             }
-            */
-            supOk = true;
-            break;
-          }
+
+            Contract.Assume(this.IsNormal);
+
+            // We can start from 1, as we know that '0' is in the first limit of all the segmentations
+            var lastI = 0;
+            var lastJ = 0;
+
+            Contract.Assume(other.limits != null, "assuming object invariant");
+            Contract.Assume(other.IsNormal, "assuming object invariant");
+
+            for (var j = 1; j < other.limits.Count; j++)
+            {
+                // the limit other.limits[i] should be contained in one of this limits
+                for (var i = lastI + 1; i < limits.Count; i++)
+                {
+                    Contract.Assert(limits.Count == elements.Count + 1);
+                    Contract.Assert(other.limits.Count == other.elements.Count + 1);
+
+                    var intersection = limits[i].Intersect(other.limits[j]);
+                    if (intersection.Any())
+                    {
+                        var thisElements = this.JoinValuesInASubrange(lastI, i);
+                        var otherElements = other.JoinValuesInASubrange(lastJ, j);
+
+                        if (thisElements.LessEqual(otherElements))
+                        {
+                            lastJ = j;
+                            lastI = i;
+                            goto NextLimit;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return false;
+            NextLimit:;
+            }
+
+            return true;
         }
 
-        Contract.Assert(infOk);
+        #endregion
 
-        if (supOk)
+        #region Smash all the values in the segment
+        [Pure]
+        public ArraySegmentation<AbstractDomain, Variable, Expression> SmashAndWeakUpdateWith(AbstractDomain valueIntv)
         {
-          if (sup == null || inf == null)
-          {
-            // "invariant: supOk ==> sup != null"
+            Contract.Requires(valueIntv != null);
 
-            return factory.IdentityForAnd;
-          }
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
 
-          var body = this.elements[i].To(factory);
-          if (!object.Equals(body, default(T)) && !object.Equals(body, factory.IdentityForAnd))
-          {
-            foreach (var splitted in factory.SplitAnd(body))
+            if (limits.Count <= 1)
             {
-              if (splitted == null)
-              {
+                return this.Top;
+            }
+
+            var join = valueIntv;
+
+            foreach (var x in elements)
+            {
+                Contract.Assume(x != null); // F: TODO the contract on the NonNullist GetEnumerator
+
+                join = (AbstractDomain)join.Join(x);
+
+                Contract.Assert(join != null);
+            }
+
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(
+              limits[0], join, limits[limits.Count - 1],
+              bottomElement, expManager);
+        }
+        #endregion
+
+        #region JoinAllTheValues
+
+        public AbstractDomain JoinAll(AbstractDomain bottom)
+        {
+            #region Contract
+
+            Contract.Requires(bottom != null);
+
+            Contract.Ensures(Contract.Result<AbstractDomain>() != null);
+
+            #endregion
+
+            if (this.IsEmptyArray || this.IsTop)
+            {
+                return (AbstractDomain)bottom.Top;
+            }
+            if (this.IsBottom)
+            {
+                return bottom;
+            }
+
+            var result = bottom;
+            foreach (var element in elements)
+            {
+                result = (AbstractDomain)result.Join(element);
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region ToString
+
+        public override string ToString()
+        {
+            if (this.IsEmptyArray)
+                return "Empty array";
+            if (this.IsBottom)
+                return "Bottom (_|_)";
+            if (this.IsTop)
+                return "Top";
+
+            // F: making it an assume until we have a better handling of disjunctions in object-invariants
+            Contract.Assume(limits.Count == elements.Count + 1);
+
+            var result = new StringBuilder();
+
+            if (/*ArrayOptions.Trace*/ true)
+            {
+                result.AppendFormat("#{0}", Id);
+            }
+
+            result.AppendFormat("{0} ", ToString(limits, elements));
+
+            return result.ToString();
+        }
+
+        static private string ToString(NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements)
+        {
+            Contract.Requires(limits != null);
+            Contract.Requires(elements != null);
+            Contract.Requires(limits.Count - elements.Count >= 0);
+            Contract.Requires(1 >= limits.Count - elements.Count);
+
+            if (limits.Count == 0)
+            {
+                return "Empty";
+            }
+
+            var result = new StringBuilder();
+            result.AppendFormat("{0} ", limits[0].ToString());
+
+            for (var i = 1; i < limits.Count; i++)
+            {
+                Contract.Assert(i - 1 < limits.Count);
+                Contract.Assert(elements.Count <= limits.Count);
+                Contract.Assert(i - 1 < elements.Count);
+
+                result.AppendFormat("{0} ", elements[i - 1]);
+                result.AppendFormat("{0} ", limits[i]);
+            }
+
+            return result.ToString();
+        }
+
+        [Pure]
+        [ContractVerification(false)]
+        static private void Trace(int iteration, NonNullList<SegmentLimit<Variable>> limits, NonNullList<AbstractDomain> elements)
+        {
+            Contract.Requires(limits != null);
+            Contract.Requires(elements != null);
+
+            if (ArrayOptions.Trace)
+            {
+                Console.WriteLine(iteration + " : " + ToString(limits, elements));
+            }
+        }
+        #endregion
+
+        #region TestTue and TestFalse
+
+        private class ArraySegmentationTestTrueVisitor
+          : TestTrueVisitor<ArraySegmentation<AbstractDomain, Variable, Expression>, Variable, Expression>
+        {
+            public ArraySegmentationTestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            #region Implementation of overridden
+            public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
+            {
+                return data;
+            }
+
+            public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
+            {
+                return data;
+            }
+
+            public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
+            {
+                if (data != null)
+                {
+                    NormalizedExpression<Variable> leftNorm, rightNorm;
+                    var isLeftOk = NormalizedExpression<Variable>.TryConvertFrom(left, this.Decoder, out leftNorm);
+                    var isRightOk = NormalizedExpression<Variable>.TryConvertFrom(right, this.Decoder, out rightNorm);
+
+                    if (isLeftOk && isRightOk)
+                    {
+                        return data.TestTrueLessThan(leftNorm, rightNorm);
+                    }
+                }
+
+                return data;
+            }
+
+            public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
+            {
+                return data;
+            }
+
+            public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitVariable(Variable var, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
+            {
+                return data;
+            }
+            #endregion
+        }
+
+        private class ArraySegmentationTestFalseVisitor
+          : TestFalseVisitor<ArraySegmentation<AbstractDomain, Variable, Expression>, Variable, Expression>
+        {
+            public ArraySegmentationTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            public override ArraySegmentation<AbstractDomain, Variable, Expression> VisitVariable(Variable variable, Expression original, ArraySegmentation<AbstractDomain, Variable, Expression> data)
+            {
+                return data;
+            }
+        }
+
+        #endregion
+
+        #region Atomic handling for Array.Copy
+        [Pure]
+        public ArraySegmentation<AbstractDomain, Variable, Expression>
+          CopyFrom
+          (ArraySegmentation<AbstractDomain, Variable, Expression> sourceSegmentation, Expression length,
+          INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            #region Contracts
+            Contract.Requires(sourceSegmentation != null);
+            Contract.Requires(oracle != null);
+            Contract.Ensures(Contract.Result<ArraySegmentation<AbstractDomain, Variable, Expression>>() != null);
+            #endregion
+
+            if (this.IsEmptyArray || this.IsBottom)
+            {
+                return this;
+            }
+
+            if (this.IsTop)
+            {
+                return new ArraySegmentation<AbstractDomain, Variable, Expression>(sourceSegmentation);
+            }
+
+            // Let's search for the upper bound
+
+            var lengthNormalized = NormalizedExpression<Variable>.For(expManager.Decoder.UnderlyingVariable(length));
+
+            var i = 0;
+            bool strict = false, equal = false;
+            for (; i < limits.Count; i++)
+            {
+                if (LessEqual(limits[i], lengthNormalized, oracle, out equal, out strict))
+                {
+                    // ok
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (i == 0)
+            {
+                return this.Top;
+            }
+
+            Contract.Assume(sourceSegmentation.limits != null);
+            Contract.Assume(sourceSegmentation.elements != null);
+            Contract.Assume(sourceSegmentation.limits.Count == sourceSegmentation.elements.Count + 1);
+
+            var newLimits = new NonNullList<SegmentLimit<Variable>>();
+            var newElements = new NonNullList<AbstractDomain>();
+
+            // Add all the limits
+            var count = 0;
+            foreach (var limit in sourceSegmentation.limits)
+            {
+                Contract.Assume(limit != null);
+                newLimits.Add(limit);
+                count++;
+            }
+            Contract.Assert(count == newLimits.Count);
+            Contract.Assume(newLimits.Count == sourceSegmentation.limits.Count); // F: cannot prove because we miss the relation between the iterator and the original # of elements
+
+            // Add all the abstract values
+            count = 0;
+            foreach (var el in sourceSegmentation.elements)
+            {
+                Contract.Assume(el != null);
+                newElements.Add(el);
+                count++;
+            }
+            Contract.Assert(count == newElements.Count);
+            Contract.Assume(newElements.Count == sourceSegmentation.elements.Count);
+
+            Contract.Assert(newElements.Count + 1 == newLimits.Count);
+            if (!equal)
+            {
+                // Add whatever remains here
+                for (var j = i; j < limits.Count; j++)
+                {
+                    newLimits.Add(limits[j]);
+                }
+                for (var j = Math.Max(0, i - 1); j < elements.Count; j++)
+                {
+                    newElements.Add(elements[j]);
+                }
+                Contract.Assume(newLimits.Count == newElements.Count + 1);
+            }
+            return new ArraySegmentation<AbstractDomain, Variable, Expression>(newLimits, newElements, bottomElement, expManager);
+        }
+        #endregion
+
+        #region PrettyPrinting
+
+        private const string ForAllTemplate = "Contract.Forall({0}, {1}, {2})";
+
+        [ContractVerification(false)]
+        public List<string> PrettyPrint(string arrayName,
+          Func<Variable, string> variableNamePrettyPrinter,
+          Func<AbstractDomain, string> abstractElementPrettyPrinter)
+        {
+            Contract.Requires(arrayName != null);
+            Contract.Requires(variableNamePrettyPrinter != null);
+            Contract.Requires(abstractElementPrettyPrinter != null);
+
+            Contract.Ensures(Contract.Result<List<string>>() != null);
+            Contract.Ensures(Contract.ForAll(Contract.Result<List<string>>(), x => x != null));
+
+            var result = new List<string>();
+
+            for (var i = 0; i < limits.Count - 1; i++)
+            {
+                string inf = null, sup = null;
+
+                foreach (var l in limits[i])
+                {
+                    inf = l.PrettyPrint(variableNamePrettyPrinter);
+                    if (inf != null)
+                        break;
+                }
+
+                foreach (var u in limits[i + 1])
+                {
+                    sup = u.PrettyPrint(variableNamePrettyPrinter);
+                    if (sup != null)
+                        break;
+                }
+
+                if (inf != null && sup != null)
+                {
+                    var arrayElement = abstractElementPrettyPrinter(elements[i]);
+                    if (arrayElement != null)
+                    {
+                        result.Add(String.Format(ForAllTemplate, inf, sup, arrayElement));
+                    }
+                }
+            }
+            return result;
+        }
+
+        #endregion
+
+        #region To
+        public T To<T>(IFactory<T> factory)
+        {
+            if (this.IsEmptyArray || !this.IsNormal)
+            {
                 return factory.IdentityForAnd;
-              }
-
-              var forall = factory.ForAll(inf, sup, splitted);
-              result.Add(forall);
             }
-          }
-        }
-      }
 
-      var formula = default(T);
-      var first = true;
-      foreach (var f in result)
-      {
-        if (first)
-        {
-          formula = f;
-          first = false;
-        }
-        else
-        {
-          formula = factory.And(formula, f);
-        }
-      }
+            var result = new List<T>();
 
-      return formula;
+            for (var i = 0; i < limits.Count - 1; i++)
+            {
+                Contract.Assert(limits.Count == elements.Count + 1);
+
+                T inf = default(T), sup = default(T);
+                bool infOk = false, supOk = false;
+
+                foreach (var l in limits[i])
+                {
+                    if (l == null)
+                    {
+                        return factory.IdentityForAnd;
+                    }
+                    if (l.TryPrettyPrint(factory, out inf))
+                    {
+                        infOk = true;
+                        break;
+                    }
+                }
+
+                if (!infOk)
+                {
+                    continue;
+                }
+
+                foreach (var u in limits[i + 1])
+                {
+                    Contract.Assume(u != null);
+                    if (u.TryPrettyPrint(factory, out sup))
+                    {
+                        // REDUNDANT inferred by CC
+                        /*
+                        if (u == null)
+                        {
+                          return factory.IdentityForAnd;
+                        }
+                        */
+                        supOk = true;
+                        break;
+                    }
+                }
+
+                Contract.Assert(infOk);
+
+                if (supOk)
+                {
+                    if (sup == null || inf == null)
+                    {
+                        // "invariant: supOk ==> sup != null"
+
+                        return factory.IdentityForAnd;
+                    }
+
+                    var body = elements[i].To(factory);
+                    if (!object.Equals(body, default(T)) && !object.Equals(body, factory.IdentityForAnd))
+                    {
+                        foreach (var splitted in factory.SplitAnd(body))
+                        {
+                            if (splitted == null)
+                            {
+                                return factory.IdentityForAnd;
+                            }
+
+                            var forall = factory.ForAll(inf, sup, splitted);
+                            result.Add(forall);
+                        }
+                    }
+                }
+            }
+
+            var formula = default(T);
+            var first = true;
+            foreach (var f in result)
+            {
+                if (first)
+                {
+                    formula = f;
+                    first = false;
+                }
+                else
+                {
+                    formula = factory.And(formula, f);
+                }
+            }
+
+            return formula;
+        }
+
+        #endregion
     }
 
-    #endregion    
-  }
-
-  #region Search Info structure
-  public struct SearchInfo
-  {
-    public int Low;
-    public int Upp;
-    public int UppMerge;
-    public bool IsLowerBoundEqual;
-    public bool IsLowerBoundStrict;
-    public bool IsLowerBoundStrictlySmallerThanUpp;
-    public bool IsUpperBoundEqual;
-    public bool IsUpperBoundStrict;
-
-    public SearchInfo(int low, int upp, int uppMerge, 
-      bool isLowerBoundEqual, bool isLowerBoundStrict, bool isLowerBoundStrictlySmallerThanUpp,
-      bool isUpperBoundEqual, bool isUpperBoundStrict)
+    #region Search Info structure
+    public struct SearchInfo
     {
-      this.Low = low;
-      this.Upp = upp;
-      this.UppMerge = uppMerge;
-      this.IsLowerBoundEqual = isLowerBoundEqual;
-      this.IsLowerBoundStrict = isLowerBoundStrict;
-      this.IsLowerBoundStrictlySmallerThanUpp = isLowerBoundStrictlySmallerThanUpp;
-      this.IsUpperBoundEqual = isUpperBoundEqual;
-      this.IsUpperBoundStrict = isUpperBoundStrict;
+        public int Low;
+        public int Upp;
+        public int UppMerge;
+        public bool IsLowerBoundEqual;
+        public bool IsLowerBoundStrict;
+        public bool IsLowerBoundStrictlySmallerThanUpp;
+        public bool IsUpperBoundEqual;
+        public bool IsUpperBoundStrict;
+
+        public SearchInfo(int low, int upp, int uppMerge,
+          bool isLowerBoundEqual, bool isLowerBoundStrict, bool isLowerBoundStrictlySmallerThanUpp,
+          bool isUpperBoundEqual, bool isUpperBoundStrict)
+        {
+            this.Low = low;
+            this.Upp = upp;
+            this.UppMerge = uppMerge;
+            this.IsLowerBoundEqual = isLowerBoundEqual;
+            this.IsLowerBoundStrict = isLowerBoundStrict;
+            this.IsLowerBoundStrictlySmallerThanUpp = isLowerBoundStrictlySmallerThanUpp;
+            this.IsUpperBoundEqual = isUpperBoundEqual;
+            this.IsUpperBoundStrict = isUpperBoundStrict;
+        }
+
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+
+            result.AppendFormat("Low : {0} ", Low);
+            result.AppendFormat("Upp : {0} ", Upp);
+            result.AppendFormat("UppMerge : {0} ", UppMerge);
+            result.AppendFormat("IsLowerBoundEqual: {0} ", IsLowerBoundEqual);
+            result.AppendFormat("IsLowerBoundStrictlySmallerThanUpp: {0} ", IsLowerBoundStrictlySmallerThanUpp);
+            result.AppendFormat("IsUpperBoundStrict: {0} ", IsUpperBoundStrict);
+            result.AppendFormat("IsUpperBoundEqual: {0} ", IsUpperBoundEqual);
+            result.AppendFormat("IsUpperBoundStrict: {0}\n", IsUpperBoundStrict);
+
+            return result.ToString();
+        }
     }
-
-    public override string ToString()
-    {
-      var result = new StringBuilder();
-
-      result.AppendFormat("Low : {0} ", Low);
-      result.AppendFormat("Upp : {0} ", Upp);
-      result.AppendFormat("UppMerge : {0} ", UppMerge);
-      result.AppendFormat("IsLowerBoundEqual: {0} ", IsLowerBoundEqual);
-      result.AppendFormat("IsLowerBoundStrictlySmallerThanUpp: {0} ", IsLowerBoundStrictlySmallerThanUpp);
-      result.AppendFormat("IsUpperBoundStrict: {0} ", IsUpperBoundStrict);
-      result.AppendFormat("IsUpperBoundEqual: {0} ", IsUpperBoundEqual);
-      result.AppendFormat("IsUpperBoundStrict: {0}\n", IsUpperBoundStrict);
-
-      return result.ToString();
-    }
-  }
-  #endregion
+    #endregion
 }
 

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArraySegmentationEnvironment.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArraySegmentationEnvironment.cs
@@ -1,17 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,304 +9,302 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  [ContractVerification(true)]
-  public class ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>
-    : FunctionalAbstractDomainEnvironment<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>, Variable, ArraySegmentation<AbstractDomain, Variable, Expression>, Variable, Expression>
-    where AbstractDomain : class, IAbstractDomainForArraySegmentationAbstraction<AbstractDomain, Variable>
-  {
-    
-    #region Constructor
-    public ArraySegmentationEnvironment(ExpressionManager<Variable, Expression> expManager)
-      : base(expManager)
+    [ContractVerification(true)]
+    public class ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>
+      : FunctionalAbstractDomainEnvironment<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>, Variable, ArraySegmentation<AbstractDomain, Variable, Expression>, Variable, Expression>
+      where AbstractDomain : class, IAbstractDomainForArraySegmentationAbstraction<AbstractDomain, Variable>
     {
-      Contract.Requires(expManager!= null);
-    }
-
-    private ArraySegmentationEnvironment( ExpressionManager<Variable, Expression> expManager, List<List<Variable>> buckets)
-      : this(expManager)
-    {
-      Contract.Requires(expManager != null);
-      Contract.Requires(buckets != null);
-    }
-
-    private ArraySegmentationEnvironment(ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> other)
-      : base(other)
-    {
-      Contract.Requires(other != null);
-    }
-    #endregion
-
-    public void Update(Variable v, ArraySegmentation<AbstractDomain, Variable, Expression> newVal)
-    {
-      Contract.Requires(newVal != null);
-
-      this[v] = newVal;
-    }
-
-    public override List<Variable> Variables
-    {
-      get 
-      {
-        var result = new List<Variable>();
-
-        var bounds = new Set<Variable>();
-
-        foreach (var pair in this.Elements)
+        #region Constructor
+        public ArraySegmentationEnvironment(ExpressionManager<Variable, Expression> expManager)
+          : base(expManager)
         {
-          result.Add(pair.Key);
-
-          Contract.Assume(pair.Value != null);
-
-          bounds.AddRange(pair.Value.Variables);
+            Contract.Requires(expManager != null);
         }
 
-        result.AddRange(bounds);
-
-        return result;
-      }
-    }
-
-    public override object Clone()
-    {
-      return DuplicateMe();
-    }
-
-    public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> DuplicateMe()
-    {
-      return new ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>(this);
-    }
-
-    protected override ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> Factory()
-    {
-      return new ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>(this.ExpressionManager);
-    }
-
-    public override void Assign(Expression x, Expression exp)
-    {
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        pair.Value.Assign(x, exp);
-      }
-    }
-
-    public override void ProjectVariable(Variable var)
-    {
-      if (this.ContainsKey(var))
-      {
-        this.RemoveElement(var);
-      }
-      
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        pair.Value.ProjectVariable(var);
-      }
-    }
-
-    public override void RemoveVariable(Variable var)
-    {
-      if (this.ContainsKey(var))
-      {
-        this.RemoveElement(var);
-      }
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        pair.Value.RemoveVariable(var);
-      }
-    }
-
-    public override void RenameVariable(Variable OldName, Variable NewName)
-    {
-      ArraySegmentation<AbstractDomain, Variable, Expression> entry;
-      if (this.TryGetValue(OldName, out entry))
-      {
-        this.RemoveElement(OldName);
-        this.AddElement(NewName, entry);
-      }
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        pair.Value.RenameVariable(OldName, NewName);
-      }
-    }
-
-    public override ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestTrue(Expression guard)
-    {
-      Contract.Assume(guard != null);
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        var newElem = pair.Value.TestTrue(guard);
-        result.AddElement(pair.Key, newElem);
-      }
-
-      return result;
-    }
-
-    public override ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestFalse(Expression guard)
-    {
-      Contract.Assume(guard != null);
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        var newElem = pair.Value.TestFalse(guard);
-
-        result.AddElement(pair.Key, newElem);
-      }
-
-      return result; 
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        var outcome = pair.Value.CheckIfHolds(exp);
-
-        if(!outcome.IsTop)
-          return outcome;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public override void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      var newMaps = this.Factory();
-
-      foreach (var pair in this.Elements)
-      {
-        FList<Variable> newNames;
-        if (sourcesToTargets.TryGetValue(pair.Key, out newNames))
+        private ArraySegmentationEnvironment(ExpressionManager<Variable, Expression> expManager, List<List<Variable>> buckets)
+          : this(expManager)
         {
-          Contract.Assume(pair.Value != null);
-          ArraySegmentation<AbstractDomain, Variable,Expression> renamedElement;
-          if (pair.Value.TryAssignInParallelFunctional(sourcesToTargets, convert, out renamedElement))
-          {
-            renamedElement = renamedElement.Simplify();
+            Contract.Requires(expManager != null);
+            Contract.Requires(buckets != null);
+        }
 
-            foreach (var name in newNames.GetEnumerable())
+        private ArraySegmentationEnvironment(ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> other)
+          : base(other)
+        {
+            Contract.Requires(other != null);
+        }
+        #endregion
+
+        public void Update(Variable v, ArraySegmentation<AbstractDomain, Variable, Expression> newVal)
+        {
+            Contract.Requires(newVal != null);
+
+            this[v] = newVal;
+        }
+
+        public override List<Variable> Variables
+        {
+            get
             {
-              newMaps.AddElement(name, renamedElement);
+                var result = new List<Variable>();
+
+                var bounds = new Set<Variable>();
+
+                foreach (var pair in this.Elements)
+                {
+                    result.Add(pair.Key);
+
+                    Contract.Assume(pair.Value != null);
+
+                    bounds.AddRange(pair.Value.Variables);
+                }
+
+                result.AddRange(bounds);
+
+                return result;
             }
-          }
         }
-        // else, it is abstracted away...
-      }
 
-      // We need constants....
-      // So we want to add all the knowledge const == var the possible
-      var decoder = this.ExpressionManager.Decoder;
-      foreach (var pair in sourcesToTargets)
-      {
-        int value;
-        var sourceExp = convert(pair.Key);
-        if (decoder.TryValueOf(sourceExp, ExpressionType.Int32, out value))
+        public override object Clone()
         {
-          var k = NormalizedExpression<Variable>.For(value);
-          var eq = new Set<NormalizedExpression<Variable>>();
-          foreach (var v in pair.Value.GetEnumerable())
-          {
-            eq.Add(NormalizedExpression<Variable>.For(v));
-          }
-
-          newMaps = newMaps.TestTrueEqualAsymmetric(eq, k);
+            return DuplicateMe();
         }
-      }
 
-      this.CopyAndTransferOwnership(newMaps);
+        public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> DuplicateMe()
+        {
+            return new ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>(this);
+        }
+
+        protected override ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> Factory()
+        {
+            return new ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>(this.ExpressionManager);
+        }
+
+        public override void Assign(Expression x, Expression exp)
+        {
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                pair.Value.Assign(x, exp);
+            }
+        }
+
+        public override void ProjectVariable(Variable var)
+        {
+            if (this.ContainsKey(var))
+            {
+                this.RemoveElement(var);
+            }
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                pair.Value.ProjectVariable(var);
+            }
+        }
+
+        public override void RemoveVariable(Variable var)
+        {
+            if (this.ContainsKey(var))
+            {
+                this.RemoveElement(var);
+            }
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                pair.Value.RemoveVariable(var);
+            }
+        }
+
+        public override void RenameVariable(Variable OldName, Variable NewName)
+        {
+            ArraySegmentation<AbstractDomain, Variable, Expression> entry;
+            if (this.TryGetValue(OldName, out entry))
+            {
+                this.RemoveElement(OldName);
+                this.AddElement(NewName, entry);
+            }
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                pair.Value.RenameVariable(OldName, NewName);
+            }
+        }
+
+        public override ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestTrue(Expression guard)
+        {
+            Contract.Assume(guard != null);
+
+            var result = Factory();
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                var newElem = pair.Value.TestTrue(guard);
+                result.AddElement(pair.Key, newElem);
+            }
+
+            return result;
+        }
+
+        public override ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestFalse(Expression guard)
+        {
+            Contract.Assume(guard != null);
+
+            var result = Factory();
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                var newElem = pair.Value.TestFalse(guard);
+
+                result.AddElement(pair.Key, newElem);
+            }
+
+            return result;
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                var outcome = pair.Value.CheckIfHolds(exp);
+
+                if (!outcome.IsTop)
+                    return outcome;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public override void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            var newMaps = this.Factory();
+
+            foreach (var pair in this.Elements)
+            {
+                FList<Variable> newNames;
+                if (sourcesToTargets.TryGetValue(pair.Key, out newNames))
+                {
+                    Contract.Assume(pair.Value != null);
+                    ArraySegmentation<AbstractDomain, Variable, Expression> renamedElement;
+                    if (pair.Value.TryAssignInParallelFunctional(sourcesToTargets, convert, out renamedElement))
+                    {
+                        renamedElement = renamedElement.Simplify();
+
+                        foreach (var name in newNames.GetEnumerable())
+                        {
+                            newMaps.AddElement(name, renamedElement);
+                        }
+                    }
+                }
+                // else, it is abstracted away...
+            }
+
+            // We need constants....
+            // So we want to add all the knowledge const == var the possible
+            var decoder = this.ExpressionManager.Decoder;
+            foreach (var pair in sourcesToTargets)
+            {
+                int value;
+                var sourceExp = convert(pair.Key);
+                if (decoder.TryValueOf(sourceExp, ExpressionType.Int32, out value))
+                {
+                    var k = NormalizedExpression<Variable>.For(value);
+                    var eq = new Set<NormalizedExpression<Variable>>();
+                    foreach (var v in pair.Value.GetEnumerable())
+                    {
+                        eq.Add(NormalizedExpression<Variable>.For(v));
+                    }
+
+                    newMaps = newMaps.TestTrueEqualAsymmetric(eq, k);
+                }
+            }
+
+            this.CopyAndTransferOwnership(newMaps);
+        }
+
+        public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>
+          TestTrueEqualAsymmetric(NormalizedExpression<Variable> v, NormalizedExpression<Variable> normExpression)
+        {
+            Contract.Requires(v != null);
+            Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
+
+            var result = Factory();
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+
+                result[pair.Key] = pair.Value.TestTrueEqualAsymmetric(v, normExpression);
+            }
+
+            return result;
+        }
+
+        public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestTrueEqualAsymmetric(Set<NormalizedExpression<Variable>> vars, NormalizedExpression<Variable> normExpression)
+        {
+            #region Contract
+
+            Contract.Requires(vars != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
+
+            #endregion
+
+            var result = Factory();
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+
+                result[pair.Key] = pair.Value.TestTrueEqualAsymmetric(vars, normExpression);
+            }
+
+            return result;
+        }
+
+        public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> ReduceWith(INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            #region Contracts
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
+            #endregion
+
+            var result = Factory();
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                var reduced = pair.Value.ReduceWith(oracle);
+                result.AddElement(pair.Key, reduced);
+            }
+
+            return result;
+        }
+
+        public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestTrueInformationForTheSegments(INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            #region Contracts
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
+            #endregion
+
+            var result = Factory();
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+                var reduced = pair.Value.TestTrueInformationForTheSegments(oracle);
+                result.AddElement(pair.Key, reduced);
+            }
+
+            return result;
+        }
     }
-
-    public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> 
-      TestTrueEqualAsymmetric(NormalizedExpression<Variable> v, NormalizedExpression<Variable> normExpression)
-    {
-      Contract.Requires(v != null);
-      Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        
-        result[pair.Key] = pair.Value.TestTrueEqualAsymmetric(v, normExpression);
-      }
-
-      return result;
-    }
-
-    public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestTrueEqualAsymmetric(Set<NormalizedExpression<Variable>> vars, NormalizedExpression<Variable> normExpression)
-    {
-      #region Contract
-      
-      Contract.Requires(vars != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
-
-      #endregion
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-
-        result[pair.Key] = pair.Value.TestTrueEqualAsymmetric(vars, normExpression);
-      }
-
-      return result;
-    }
-
-    public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> ReduceWith(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      #region Contracts
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
-      #endregion
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        var reduced = pair.Value.ReduceWith(oracle);
-        result.AddElement(pair.Key, reduced);
-      }
-
-      return result;
-    }
-
-    public ArraySegmentationEnvironment<AbstractDomain, Variable, Expression> TestTrueInformationForTheSegments(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      #region Contracts
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(Contract.Result<ArraySegmentationEnvironment<AbstractDomain, Variable, Expression>>() != null);
-      #endregion
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-        var reduced = pair.Value.TestTrueInformationForTheSegments(oracle);
-        result.AddElement(pair.Key, reduced);
-      }
-
-      return result;
-
-    }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArrayState.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/ArrayState.cs
@@ -1,17 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,388 +10,388 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  [ContractVerification(true)]
-  public class ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>
-    : ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain>,
-    IAbstractDomainForEnvironments<Variable, Expression>
-    where NumericalAbstractDomain : class, INumericalAbstractDomain<Variable, Expression>
-    where ArrayAbstractDomain : class, IAbstractDomainForEnvironments<Variable, Expression>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    [ContractVerification(true)]
+    public class ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>
+      : ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain>,
+      IAbstractDomainForEnvironments<Variable, Expression>
+      where NumericalAbstractDomain : class, INumericalAbstractDomain<Variable, Expression>
+      where ArrayAbstractDomain : class, IAbstractDomainForEnvironments<Variable, Expression>
     {
-      Contract.Invariant(this.expManager != null);
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(expManager != null);
+        }
+
+        #region Private state
+
+        private readonly ExpressionManager<Variable, Expression> expManager;
+
+        private readonly Optional additionalState;
+
+        #endregion
+
+        public ArrayStateAD(
+          NumericalAbstractDomain numericalAbstractDomain, ArrayAbstractDomain arrayAbstractDomain,
+           ExpressionManager<Variable, Expression> expManager)
+          : base(numericalAbstractDomain, arrayAbstractDomain)
+        {
+            Contract.Requires(numericalAbstractDomain != null);
+            Contract.Requires(arrayAbstractDomain != null);
+            Contract.Requires(expManager != null);
+
+            this.expManager = expManager;
+
+            additionalState = new Optional();
+        }
+
+        public ArrayStateAD(
+          NumericalAbstractDomain numericalAbstractDomain, ArrayAbstractDomain arrayAbstractDomain,
+          object additionalState,
+           ExpressionManager<Variable, Expression> expManager)
+          : this(numericalAbstractDomain, arrayAbstractDomain, expManager)
+        {
+            Contract.Requires(arrayAbstractDomain != null);
+            Contract.Requires(numericalAbstractDomain != null);
+            Contract.Requires(expManager != null);
+            Contract.Requires(!(additionalState is Optional));
+
+            this.additionalState = new Optional(additionalState);
+        }
+
+        [System.Diagnostics.DebuggerHidden]
+        public NumericalAbstractDomain Numerical
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<NumericalAbstractDomain>() != null);
+
+
+                return this.Left;
+            }
+        }
+
+        public ArrayAbstractDomain Array
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ArrayAbstractDomain>() != null);
+
+                return this.Right;
+            }
+        }
+
+        public object OtherAbstractStates
+        {
+            get
+            {
+                object value;
+                additionalState.HasValue(out value);
+
+                return value;
+            }
+        }
+
+        public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>
+          MakeNewWithUpdatedArrayState(ArrayAbstractDomain newState)
+        {
+            Contract.Requires(newState != null);
+
+            return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>
+              (this.Numerical, newState, expManager);
+        }
+
+
+        #region Implementation of abstract methods
+
+        public override ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain> Reduce(NumericalAbstractDomain left, ArrayAbstractDomain right)
+        {
+            return this.Factory(left, right);
+        }
+
+        protected override ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain> Factory(NumericalAbstractDomain left, ArrayAbstractDomain right)
+        {
+            Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain>>() != null);
+
+            return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>(left, right, expManager);
+        }
+
+        static public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> For(
+          NumericalAbstractDomain left, ArrayAbstractDomain right,
+           ExpressionManager<Variable, Expression> expManager)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Requires(expManager != null);
+
+            Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);
+
+            return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>(left, right, expManager);
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!(other is Optional)", Justification = "We do not track dynamic types")]
+        static public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> For<OtherAbstractDomain>(
+          NumericalAbstractDomain left, ArrayAbstractDomain right, OtherAbstractDomain other,
+          ExpressionManager<Variable, Expression> expManager)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Requires(other != null);
+            Contract.Requires(expManager != null);
+
+            Contract.Requires(!(other is Optional));
+
+            Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);
+
+            return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>(left, right, other, expManager);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            return base.LessEqual(a);
+        }
+
+        public bool LessEqual(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> a)
+        {
+            Contract.Requires(a != null);
+
+            return base.LessEqual(a);
+        }
+
+        new public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Bottom
+        {
+            get
+            {
+                return base.Bottom as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
+            }
+        }
+
+        new public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Top
+        {
+            get
+            {
+                return base.Top as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var other = a as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
+
+            Contract.Assume(other != null);
+
+            return this.Join(other);
+        }
+
+        public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Join(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            return (ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>)base.Join(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            var other = a as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
+
+            Contract.Assume(other != null);
+
+            return this.Meet(other);
+        }
+
+        public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Meet(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            return (ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>)base.Meet(other);
+        }
+
+        public override IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            var other = prev as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
+
+            Contract.Assume(other != null);
+
+            return this.Widening(other);
+        }
+
+        public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Widening(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);
+
+            var leftWiden = (NumericalAbstractDomain)this.Left.Widening(other.Left);
+            var rightWiden = (ArrayAbstractDomain)this.Right.Widening(other.Right);
+
+            var f = Factory(leftWiden, rightWiden) as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
+
+            Contract.Assume(f != null);
+
+            return f;
+        }
+
+        #endregion
+
+        #region Duplicate
+
+        public override object Clone()
+        {
+            return this.Duplicate();
+        }
+
+        public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Duplicate()
+        {
+            Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);
+
+            var leftDup = (NumericalAbstractDomain)this.Left.Clone();
+            var rightDup = (ArrayAbstractDomain)this.Right.Clone();
+
+            object value;
+            if (additionalState.HasValue(out value) /*&& value != null*/)
+            {
+                Contract.Assume(!(value is Optional));
+
+                var dup = value;  // F: !!! Should call clone?
+
+                return For(leftDup, rightDup, dup, expManager);
+            }
+
+            return For(leftDup, rightDup, expManager);
+        }
+        #endregion
+
+
+        #region IAbstractDomainForEnvironments<Variable,Expression> Members
+
+        public string ToString(Expression exp)
+        {
+            return this.Left.ToString(exp);
+        }
+
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            var baseStr = base.ToString();
+            object value;
+            if (additionalState.HasValue(out value) /*&& value != null*/)
+            {
+                baseStr += "\n" + value.ToString();
+            }
+
+            return baseStr.ToString();
+        }
+        #endregion
+
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        public List<Variable> Variables
+        {
+            get { return this.Left.Variables.SetUnion(this.Right.Variables); }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            this.Left.AddVariable(var);
+            this.Right.AddVariable(var);
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+            this.Left.Assign(x, exp);
+            this.Right.Assign(x, exp);
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            this.Left.ProjectVariable(var);
+            this.Right.ProjectVariable(var);
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            this.Left.RemoveVariable(var);
+            this.Right.RemoveVariable(var);
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            this.Left.RenameVariable(OldName, NewName);
+            this.Right.RenameVariable(OldName, NewName);
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            var leftRes = (NumericalAbstractDomain)this.Left.TestTrue(guard);
+            var rightRes = (ArrayAbstractDomain)this.Right.TestTrue(guard);
+
+            return For(leftRes, rightRes, expManager);
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            var leftRes = (NumericalAbstractDomain)this.Left.TestFalse(guard);
+            var rightRes = (ArrayAbstractDomain)this.Right.TestFalse(guard);
+
+            return For(leftRes, rightRes, expManager);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            // TODO : right!!!
+            return this.Left.CheckIfHolds(exp);
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Variable,Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            this.Left.AssignInParallel(sourcesToTargets, convert);
+            this.Right.AssignInParallel(sourcesToTargets, convert);
+        }
+
+        #endregion
+
+        private struct Optional
+        {
+            readonly private object value;
+
+            public Optional(object value)
+            {
+                this.value = value;
+            }
+
+            public bool HasValue(out object value)
+            {
+                Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
+                value = this.value;
+                return this.value != null;
+            }
+
+            public override string ToString()
+            {
+                if (value == null)
+                    return "";
+                else
+                    return value.ToString();
+            }
+        }
     }
-
-    #region Private state
-
-    private readonly ExpressionManager<Variable, Expression> expManager;
-
-    private readonly Optional additionalState;
-
-    #endregion
-
-    public ArrayStateAD(
-      NumericalAbstractDomain numericalAbstractDomain, ArrayAbstractDomain arrayAbstractDomain,
-       ExpressionManager<Variable, Expression> expManager)
-      : base(numericalAbstractDomain, arrayAbstractDomain)
-    {
-      Contract.Requires(numericalAbstractDomain != null);
-      Contract.Requires(arrayAbstractDomain != null);
-      Contract.Requires(expManager != null);
-
-      this.expManager = expManager;
-
-      this.additionalState = new Optional();
-    }
-
-    public ArrayStateAD(
-      NumericalAbstractDomain numericalAbstractDomain, ArrayAbstractDomain arrayAbstractDomain,
-      object additionalState,
-       ExpressionManager<Variable, Expression> expManager)
-      : this(numericalAbstractDomain, arrayAbstractDomain, expManager)
-    {
-      Contract.Requires(arrayAbstractDomain != null);
-      Contract.Requires(numericalAbstractDomain != null);
-      Contract.Requires(expManager != null);
-      Contract.Requires(!(additionalState is Optional));
-
-      this.additionalState = new Optional(additionalState);
-    }
-
-    [System.Diagnostics.DebuggerHidden]
-    public NumericalAbstractDomain Numerical
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<NumericalAbstractDomain>() != null);
-        
-
-        return this.Left;
-      }
-    }
-
-    public ArrayAbstractDomain Array
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ArrayAbstractDomain>() != null);
-
-        return this.Right;
-      }
-    }
-
-    public object OtherAbstractStates
-    {
-      get
-      {
-        object value;
-        this.additionalState.HasValue(out value);
-
-        return value;
-      }
-    }
-
-    public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> 
-      MakeNewWithUpdatedArrayState(ArrayAbstractDomain newState)
-    {
-      Contract.Requires(newState != null);
-
-      return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>
-        (this.Numerical, newState, this.expManager);
-    }
-
-
-    #region Implementation of abstract methods
-
-    public override ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain> Reduce(NumericalAbstractDomain left, ArrayAbstractDomain right)
-    {
-      return this.Factory(left, right);
-    }
-
-    protected override ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain> Factory(NumericalAbstractDomain left, ArrayAbstractDomain right)
-    {
-      Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<NumericalAbstractDomain, ArrayAbstractDomain>>() != null);      
-
-      return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>(left, right, this.expManager);
-    }
-
-    static public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> For(
-      NumericalAbstractDomain left, ArrayAbstractDomain right, 
-       ExpressionManager<Variable, Expression> expManager)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Requires(expManager != null);
-
-      Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);
-      
-      return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>(left, right, expManager);
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!(other is Optional)", Justification="We do not track dynamic types")]
-    static public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> For<OtherAbstractDomain>(
-      NumericalAbstractDomain left, ArrayAbstractDomain right, OtherAbstractDomain other,
-      ExpressionManager<Variable, Expression> expManager)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Requires(other != null);
-      Contract.Requires(expManager != null);
-
-      Contract.Requires(!(other is Optional));
-
-      Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);      
-
-      return new ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>(left, right, other, expManager);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      return base.LessEqual(a);
-    }
-
-    public bool LessEqual(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> a)
-    {
-      Contract.Requires(a  != null);
-
-      return base.LessEqual(a);
-    }
-
-    new public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Bottom
-    {
-      get
-      {
-        return  base.Bottom as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
-      }
-    }
-
-    new public  ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Top
-    {
-      get
-      {
-        return base.Top as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var other = a as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
-
-      Contract.Assume(other != null);
-
-      return this.Join(other);
-    }
-
-    public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Join(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      return (ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>) base.Join(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      var other = a as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
-
-      Contract.Assume(other != null);
-
-      return this.Meet(other);
-    }
-
-    public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Meet(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      return (ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>)base.Meet(other);
-    }
-
-    public override IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      var other = prev as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
-
-      Contract.Assume(other != null);
-
-      return this.Widening(other);
-    }
-
-    public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Widening(ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);      
-
-      var leftWiden = (NumericalAbstractDomain) this.Left.Widening(other.Left);
-      var rightWiden = (ArrayAbstractDomain)this.Right.Widening(other.Right);
-
-      var f =  Factory(leftWiden, rightWiden) as ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>;
-
-      Contract.Assume(f != null);
-
-      return f;
-    }
-
-    #endregion
-
-    #region Duplicate
-
-    public override object Clone()
-    {
-      return this.Duplicate();
-    }
-
-    public ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression> Duplicate()
-    {
-      Contract.Ensures(Contract.Result<ArrayStateAD<NumericalAbstractDomain, ArrayAbstractDomain, Variable, Expression>>() != null);
-      
-      var leftDup = (NumericalAbstractDomain) this.Left.Clone();
-      var rightDup = (ArrayAbstractDomain)this.Right.Clone();
-
-      object value;
-      if (this.additionalState.HasValue(out value) /*&& value != null*/)
-      {
-        Contract.Assume(!(value is Optional));
-
-        var dup = value;  // F: !!! Should call clone?
-
-        return For(leftDup, rightDup, dup, this.expManager);
-      }
-
-      return For(leftDup, rightDup, this.expManager);
-    }
-    #endregion 
-
-  
-    #region IAbstractDomainForEnvironments<Variable,Expression> Members
-
-    public string ToString(Expression exp)
-    {
-      return this.Left.ToString(exp);
-    }
-
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      var baseStr = base.ToString();
-      object value;
-      if (this.additionalState.HasValue(out value) /*&& value != null*/)
-      {
-        baseStr += "\n" + value.ToString();
-      }
-
-      return baseStr.ToString();
-    }
-    #endregion
-
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    public List<Variable> Variables
-    {
-      get { return this.Left.Variables.SetUnion(this.Right.Variables); }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      this.Left.AddVariable(var);
-      this.Right.AddVariable(var);
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      this.Left.Assign(x, exp);
-      this.Right.Assign(x, exp);
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      this.Left.ProjectVariable(var);
-      this.Right.ProjectVariable(var);
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      this.Left.RemoveVariable(var);
-      this.Right.RemoveVariable(var);
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      this.Left.RenameVariable(OldName, NewName);
-      this.Right.RenameVariable(OldName, NewName);
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      var leftRes = (NumericalAbstractDomain)this.Left.TestTrue(guard);
-      var rightRes = (ArrayAbstractDomain)this.Right.TestTrue(guard);
-
-      return For(leftRes, rightRes, this.expManager);
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      var leftRes = (NumericalAbstractDomain)this.Left.TestFalse(guard);
-      var rightRes = (ArrayAbstractDomain)this.Right.TestFalse(guard);
-
-      return For(leftRes, rightRes, this.expManager);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      // TODO : right!!!
-      return this.Left.CheckIfHolds(exp);
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Variable,Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      this.Left.AssignInParallel(sourcesToTargets, convert);
-      this.Right.AssignInParallel(sourcesToTargets, convert);
-    }
-
-    #endregion
-
-    private struct Optional
-    {
-      readonly private object value;
-
-      public Optional(object value)
-      {
-        this.value = value;
-      }
-
-      public bool HasValue(out object value)
-      {
-        Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
-        value = this.value;
-        return this.value != null;
-      }
-
-      public override string ToString()
-      {
-        if (this.value == null)
-          return "";
-        else
-          return this.value.ToString();
-      }
-    }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/NormalizedExpressions.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/NormalizedExpressions.cs
@@ -1,17 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using Microsoft.Research.AbstractDomains.Expressions;
@@ -20,522 +8,520 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains
 {
-
-  /// <summary>
-  /// NormalizedExpressions are mathematical expressions to be used as array limits.
-  /// They have a limited form *on purpose*
-  /// 
-  /// NormalizedExpression ::= Constant | Var | Var + Constant
-  /// </summary>
-  [ContractVerification(true)]
-  [ContractClass(typeof(NormalizedExpressionContracts<>))]
-  abstract public class NormalizedExpression<Variable>
-  {
-    abstract public bool IsConstant(out int value);
-
-    abstract public bool IsVariable(out Variable var);
-
-    abstract public bool IsAddition(out Variable var, out int value);
-
-    abstract public NormalizedExpression<Variable> PlusOne();
-
-    abstract public NormalizedExpression<Variable> MinusOne();
-
-    abstract public Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder);
-
-    virtual public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
+    /// <summary>
+    /// NormalizedExpressions are mathematical expressions to be used as array limits.
+    /// They have a limited form *on purpose*
+    /// 
+    /// NormalizedExpression ::= Constant | Var | Var + Constant
+    /// </summary>
+    [ContractVerification(true)]
+    [ContractClass(typeof(NormalizedExpressionContracts<>))]
+    abstract public class NormalizedExpression<Variable>
     {
-      Contract.Requires(factory != null);
+        abstract public bool IsConstant(out int value);
 
-      result = default(T);
-      return false;
-    }
+        abstract public bool IsVariable(out Variable var);
 
-    [Pure]
-    static public NormalizedExpression<Variable> For(int value)
-    {
-      Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
-      
-      return new ConstantExpression(value);
-    }
+        abstract public bool IsAddition(out Variable var, out int value);
 
-    [Pure]
-    static public NormalizedExpression<Variable> For(Variable var)
-    {
-      Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
+        abstract public NormalizedExpression<Variable> PlusOne();
 
-      return new VariableExpression(var);
-    }
+        abstract public NormalizedExpression<Variable> MinusOne();
 
-    [Pure]
-    static public NormalizedExpression<Variable> For(Variable var, int value)
-    {
-      Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
+        abstract public Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder);
 
-      return value == 0 ? For(var) : new Addition(var, value);
-    }
-
-    [Pure]
-    static public bool TryConvertFrom<Expression>(
-      Expression exp, IExpressionDecoder<Variable, Expression> decoder, 
-      out NormalizedExpression<Variable> result)
-    {
-      Contract.Requires(exp != null);
-
-      if (decoder == null)
-      {
-        result = default(NormalizedExpression<Variable>);
-        return false;
-      }
-
-      var reader = new TryConvertRead<Expression>(decoder);
-
-      return reader.TryConvert(exp, out result);
-    }
-
-    [Pure]
-    static public bool TryConvertFrom<Expression>(
-      Expression exp, ExpressionManagerWithEncoder<Variable, Expression> expManager,
-      out NormalizedExpression<Variable> result)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(expManager != null);
-
-      if (TryConvertFrom(exp, expManager.Decoder, out result))
-      {
-        return true;
-      }
-
-      //if (expManager.Encoder != null)
-      {
-        Polynomial<Variable, Expression> normalized;
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, expManager.Decoder, out normalized))
+        virtual public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
         {
-          return TryConvertFrom(normalized.ToPureExpression(expManager.Encoder), expManager.Decoder, out result);
-        }
-      }
+            Contract.Requires(factory != null);
 
-      result = default(NormalizedExpression<Variable>);
-      return false;
+            result = default(T);
+            return false;
+        }
+
+        [Pure]
+        static public NormalizedExpression<Variable> For(int value)
+        {
+            Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
+
+            return new ConstantExpression(value);
+        }
+
+        [Pure]
+        static public NormalizedExpression<Variable> For(Variable var)
+        {
+            Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
+
+            return new VariableExpression(var);
+        }
+
+        [Pure]
+        static public NormalizedExpression<Variable> For(Variable var, int value)
+        {
+            Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
+
+            return value == 0 ? For(var) : new Addition(var, value);
+        }
+
+        [Pure]
+        static public bool TryConvertFrom<Expression>(
+          Expression exp, IExpressionDecoder<Variable, Expression> decoder,
+          out NormalizedExpression<Variable> result)
+        {
+            Contract.Requires(exp != null);
+
+            if (decoder == null)
+            {
+                result = default(NormalizedExpression<Variable>);
+                return false;
+            }
+
+            var reader = new TryConvertRead<Expression>(decoder);
+
+            return reader.TryConvert(exp, out result);
+        }
+
+        [Pure]
+        static public bool TryConvertFrom<Expression>(
+          Expression exp, ExpressionManagerWithEncoder<Variable, Expression> expManager,
+          out NormalizedExpression<Variable> result)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(expManager != null);
+
+            if (TryConvertFrom(exp, expManager.Decoder, out result))
+            {
+                return true;
+            }
+
+            //if (expManager.Encoder != null)
+            {
+                Polynomial<Variable, Expression> normalized;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, expManager.Decoder, out normalized))
+                {
+                    return TryConvertFrom(normalized.ToPureExpression(expManager.Encoder), expManager.Decoder, out result);
+                }
+            }
+
+            result = default(NormalizedExpression<Variable>);
+            return false;
+        }
+
+        internal class ConstantExpression
+          : NormalizedExpression<Variable>
+        {
+            private readonly int value;
+
+            public ConstantExpression(int value)
+            {
+                this.value = value;
+            }
+
+            public override bool IsAddition(out Variable var, out int value)
+            {
+                var = default(Variable);
+                value = default(int);
+
+                return false;
+            }
+
+            public override bool IsConstant(out int value)
+            {
+                value = this.value;
+
+                return true;
+            }
+
+            public override bool IsVariable(out Variable var)
+            {
+                var = default(Variable);
+
+                return false;
+            }
+
+            public override NormalizedExpression<Variable> PlusOne()
+            {
+                return new ConstantExpression(value + 1);
+            }
+
+            public override NormalizedExpression<Variable> MinusOne()
+            {
+                return new ConstantExpression(value - 1);
+            }
+
+            override public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
+            {
+                result = factory.Constant(value);
+                return true;
+            }
+
+            public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
+            {
+                return encoder.ConstantFor(value);
+            }
+
+            public override string ToString()
+            {
+                return value.ToString();
+            }
+
+            public override int GetHashCode()
+            {
+                return value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                var that = obj as ConstantExpression;
+
+                if (that == null)
+                    return false;
+
+                return value == that.value;
+            }
+        }
+
+        internal class VariableExpression
+          : NormalizedExpression<Variable>
+        {
+            private readonly Variable var;
+
+            public VariableExpression(Variable var)
+            {
+                this.var = var;
+            }
+
+            public override bool IsAddition(out Variable var, out int value)
+            {
+                var = default(Variable);
+                value = default(int);
+
+                return false;
+            }
+
+            public override bool IsVariable(out Variable var)
+            {
+                var = this.var;
+
+                return true;
+            }
+
+            public override bool IsConstant(out int value)
+            {
+                value = default(int);
+
+                return false;
+            }
+
+            public override NormalizedExpression<Variable> PlusOne()
+            {
+                return new Addition(var, 1);
+            }
+
+            public override NormalizedExpression<Variable> MinusOne()
+            {
+                return new Addition(var, -1);
+            }
+
+            override public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
+            {
+                result = factory.Variable(var);
+                return result != null;
+            }
+
+            public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
+            {
+                return encoder.VariableFor(var);
+            }
+
+            public override string ToString()
+            {
+                return var.ToString();
+            }
+
+            public override int GetHashCode()
+            {
+                return var.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                var that = obj as VariableExpression;
+
+                if (that == null)
+                    return false;
+
+                return var.Equals(that.var);
+            }
+        }
+
+        internal class Addition
+          : NormalizedExpression<Variable>
+        {
+            private readonly Variable var;
+            private readonly int value;
+
+            public Addition(Variable var, int value)
+            {
+                this.var = var;
+                this.value = value;
+            }
+
+            public override bool IsAddition(out Variable var, out int value)
+            {
+                var = this.var;
+                value = this.value;
+
+                return true;
+            }
+
+            public override bool IsConstant(out int value)
+            {
+                value = default(int);
+
+                return false;
+            }
+
+            public override bool IsVariable(out Variable var)
+            {
+                var = default(Variable);
+
+                return false;
+            }
+
+            public override NormalizedExpression<Variable> PlusOne()
+            {
+                return For(var, value + 1);
+            }
+
+            public override NormalizedExpression<Variable> MinusOne()
+            {
+                return For(var, value - 1);
+            }
+
+            override public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
+            {
+                result = factory.Add(factory.Variable(var), factory.Constant(value));
+
+                return true;
+            }
+
+
+            public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
+            {
+                return encoder.CompoundExpressionFor(ExpressionType.Int32,
+                  ExpressionOperator.Addition,
+                  encoder.VariableFor(var),
+                  encoder.ConstantFor(value));
+            }
+
+            public override string ToString()
+            {
+                return string.Format("{0} {1} {2}", var.ToString(), value > 0 ? "+" : "", value.ToString());
+            }
+
+            public override int GetHashCode()
+            {
+                return value + var.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                var that = obj as Addition;
+
+                if (that == null)
+                    return false;
+
+                return value == that.value && that.var.Equals(var);
+            }
+        }
+
+        private class TryConvertRead<Expression>
+          : GenericExpressionVisitor<Void, Boolean, Variable, Expression>
+        {
+            private NormalizedExpression<Variable> result;
+
+            public TryConvertRead(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+
+                result = default(NormalizedExpression<Variable>);
+            }
+
+            //[SuppressMessage("Microsoft.Contracts", "Ensures-22-42", Justification="Depends on overriding")]
+            public sealed override bool Visit(Expression exp, Void data)
+            {
+                Contract.Ensures(!Contract.Result<bool>() || result != null);
+
+                result = default(NormalizedExpression<Variable>);
+                return base.Visit(exp, data);
+            }
+
+            public bool TryConvert(Expression exp, out NormalizedExpression<Variable> result)
+            {
+                Contract.Requires(exp != null);
+                Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+                Contract.Ensures(this.result == Contract.ValueAtReturn(out result));
+
+                if (this.Visit(exp, Void.Value))
+                {
+                    Contract.Assert(this.result != null);
+                    result = this.result;
+                    return true;
+                }
+
+                this.result = result = default(NormalizedExpression<Variable>);
+                return false;
+            }
+
+            public override bool VisitAddition(Expression left, Expression right, Expression original, Void data)
+            {
+                NormalizedExpression<Variable> leftNorm, rightNorm;
+                if (this.TryConvert(left, out leftNorm))
+                {
+                    Contract.Assert(leftNorm != null);
+
+                    if (this.TryConvert(right, out rightNorm))
+                    {
+                        Contract.Assert(rightNorm != null);
+
+                        // All the cases. We declare all the variables here, 
+                        // so to leverage the definite assignment analysis of 
+                        // the compiler to check we are doing everything right
+                        int leftConst, rightCont;
+                        Variable leftVar, rightVar;
+                        if (leftNorm.IsConstant(out leftConst))
+                        {
+                            // K + K
+                            if (rightNorm.IsConstant(out rightCont))
+                            {
+                                result = NormalizedExpression<Variable>.For(leftConst + rightCont);  // Can overflow, we do not care has it may be the concrete semantics
+                                return true;
+                            }
+                            // K + V
+                            if (rightNorm.IsVariable(out rightVar))
+                            {
+                                result = NormalizedExpression<Variable>.For(rightVar, leftConst);
+                                return true;
+                            }
+                        }
+                        else if (leftNorm.IsVariable(out leftVar))
+                        {
+                            // V + K
+                            if (rightNorm.IsConstant(out rightCont))
+                            {
+                                result = NormalizedExpression<Variable>.For(leftVar, rightCont);
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                return Default(data);
+            }
+
+            public override bool VisitConstant(Expression left, Void data)
+            {
+                Int32 value;
+                if (this.Decoder.TryValueOf<Int32>(left, ExpressionType.Int32, out value))
+                {
+                    result = NormalizedExpression<Variable>.For(value);
+                    return true;
+                }
+
+                return false;
+            }
+
+            public override bool VisitConvertToInt32(Expression left, Expression original, Void data)
+            {
+                return this.Visit(left, data);
+            }
+
+            public override bool VisitSubtraction(Expression left, Expression right, Expression original, Void data)
+            {
+                NormalizedExpression<Variable> leftNorm, rightNorm;
+                if (this.TryConvert(left, out leftNorm))
+                {
+                    Contract.Assert(leftNorm != null);
+
+                    if (this.TryConvert(right, out rightNorm))
+                    {
+                        Contract.Assert(rightNorm != null);
+
+                        // All the cases. We declare all the variables here, 
+                        // so to leverage the definite assignment analysis of 
+                        // the compiler to check we are doing everything right
+                        int leftConst, rightConst;
+                        Variable leftVar;
+                        if (rightNorm.IsConstant(out rightConst) && rightConst != Int32.MinValue)
+                        {
+                            // K - K
+                            if (leftNorm.IsConstant(out leftConst))
+                            {
+                                result = NormalizedExpression<Variable>.For(leftConst - rightConst);  // Can overflow, we do not care has it may be the concrete semantics
+                                return true;
+                            }
+                            // V - K
+                            if (leftNorm.IsVariable(out leftVar))
+                            {
+                                result = NormalizedExpression<Variable>.For(leftVar, -rightConst);
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                return Default(data);
+            }
+
+            public override bool VisitVariable(Variable variable, Expression original, Void data)
+            {
+                result = NormalizedExpression<Variable>.For(variable);
+                return true;
+            }
+
+            protected override bool Default(Void data)
+            {
+                result = default(NormalizedExpression<Variable>);
+                return false;
+            }
+
+            public override string ToString()
+            {
+                return result == null ? "null" : result.ToString();
+            }
+        }
     }
 
-    internal class ConstantExpression
+    [ContractClassFor(typeof(NormalizedExpression<>))]
+    internal abstract class NormalizedExpressionContracts<Variable>
       : NormalizedExpression<Variable>
     {
-      readonly int value;
-
-      public ConstantExpression(int value)
-      {
-        this.value = value;
-      }
-
-      public override bool IsAddition(out Variable var, out int value)
-      {
-        var = default(Variable);
-        value = default(int);
-
-        return false;
-      }
-
-      public override bool IsConstant(out int value)
-      {
-        value = this.value;
-
-        return true;
-      }
-
-      public override bool IsVariable(out Variable var)
-      {
-        var = default(Variable);
-
-        return false;
-      }
-
-      public override NormalizedExpression<Variable> PlusOne()
-      {
-        return new ConstantExpression(this.value + 1);
-      }
-
-      public override NormalizedExpression<Variable> MinusOne()
-      {
-        return new ConstantExpression(this.value - 1);
-      }
-
-      override public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
-      {
-        result = factory.Constant(this.value);
-        return true;
-      }
-
-      public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
-      {
-        return encoder.ConstantFor(this.value);
-      }
-
-      public override string ToString()
-      {
-        return this.value.ToString();
-      }
-
-      public override int GetHashCode()
-      {
-        return this.value;
-      }
-
-      public override bool Equals(object obj)
-      {
-        var that = obj as ConstantExpression;
-
-        if (that == null)
-          return false;
-
-        return this.value == that.value;
-      }
-    }
-
-    internal class VariableExpression
-      : NormalizedExpression<Variable>
-    {
-      readonly Variable var;
-
-      public VariableExpression(Variable var)
-      {
-        this.var = var;
-      }
-
-      public override bool IsAddition(out Variable var, out int value)
-      {
-        var = default(Variable);
-        value = default(int);
-
-        return false;
-      }
-
-      public override bool IsVariable(out Variable var)
-      {
-        var = this.var;
-
-        return true;
-      }
-
-      public override bool IsConstant(out int value)
-      {
-        value = default(int);
-
-        return false;
-      }
-
-      public override NormalizedExpression<Variable> PlusOne()
-      {
-        return new Addition(this.var, 1);
-      }
-
-      public override NormalizedExpression<Variable> MinusOne()
-      {
-        return new Addition(this.var, -1);
-      }
-
-      override public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
-      {
-        result = factory.Variable(this.var);
-        return result != null;
-      }
-
-      public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
-      {
-        return encoder.VariableFor(this.var);
-      }
-
-      public override string ToString()
-      {
-        return this.var.ToString();
-      }
-
-      public override int GetHashCode()
-      {
-        return this.var.GetHashCode();
-      }
-
-      public override bool Equals(object obj)
-      {
-        var that = obj as VariableExpression;
-
-        if (that == null)
-          return false;
-
-        return this.var.Equals(that.var);
-      }
-    }
-
-    internal class Addition
-      : NormalizedExpression<Variable>
-    {
-      readonly Variable var;
-      readonly int value;
-
-      public Addition(Variable var, int value)
-      {
-        this.var = var;
-        this.value = value;
-      }
-
-      public override bool IsAddition(out Variable var, out int value)
-      {
-        var = this.var;
-        value = this.value;
-
-        return true;
-      }
-
-      public override bool IsConstant(out int value)
-      {
-        value = default(int);
-
-        return false;
-      }
-
-      public override bool IsVariable(out Variable var)
-      {
-        var = default(Variable);
-
-        return false;
-      }
-
-      public override NormalizedExpression<Variable> PlusOne()
-      {
-        return For(this.var, value + 1); 
-      }
-
-      public override NormalizedExpression<Variable> MinusOne()
-      {
-        return For(this.var, value - 1);
-      }
-
-      override public bool TryPrettyPrint<T>(IFactory<T> factory, out T result)
-      {
-        result = factory.Add(factory.Variable(this.var), factory.Constant(this.value));
-
-        return true;
-      }
-
-
-      public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
-      {
-        return encoder.CompoundExpressionFor(ExpressionType.Int32,
-          ExpressionOperator.Addition,
-          encoder.VariableFor(this.var),
-          encoder.ConstantFor(this.value));
-      }
-
-      public override string ToString()
-      {
-        return string.Format("{0} {1} {2}", this.var.ToString(), this.value > 0 ? "+" : "", this.value.ToString());
-      }
-
-      public override int GetHashCode()
-      {
-        return this.value + this.var.GetHashCode();
-      }
-
-      public override bool Equals(object obj)
-      {
-        var that = obj as Addition;
-
-        if (that == null)
-          return false;
-
-        return this.value == that.value && that.var.Equals(this.var);
-      }
-    }
-
-    private class TryConvertRead<Expression>
-      : GenericExpressionVisitor<Void, Boolean, Variable, Expression>
-    {
-      private NormalizedExpression<Variable> result;
-
-      public TryConvertRead(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-
-        this.result = default(NormalizedExpression<Variable>);
-      }
-
-      //[SuppressMessage("Microsoft.Contracts", "Ensures-22-42", Justification="Depends on overriding")]
-      public sealed override bool Visit(Expression exp, Void data)
-      {
-        Contract.Ensures(!Contract.Result<bool>() || this.result != null);
-
-        this.result = default(NormalizedExpression<Variable>);
-        return base.Visit(exp, data);
-      }
-
-      public bool TryConvert(Expression exp, out NormalizedExpression<Variable> result)
-      {
-        Contract.Requires(exp != null);
-        Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-        Contract.Ensures(this.result == Contract.ValueAtReturn(out result));
-
-        if (this.Visit(exp, Void.Value))
+        public override NormalizedExpression<Variable> PlusOne()
         {
-          Contract.Assert(this.result != null);
-          result = this.result;
-          return true;
+            Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
+
+            return default(NormalizedExpression<Variable>);
         }
 
-        this.result = result = default(NormalizedExpression<Variable>);
-        return false;
-      }
-
-      public override bool VisitAddition(Expression left, Expression right, Expression original, Void data)
-      {
-        NormalizedExpression<Variable> leftNorm, rightNorm;
-        if (this.TryConvert(left, out leftNorm))
+        public override NormalizedExpression<Variable> MinusOne()
         {
-          Contract.Assert(leftNorm != null);
+            Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
 
-          if(this.TryConvert(right, out rightNorm))
-          {
-            Contract.Assert(rightNorm != null);
-
-            // All the cases. We declare all the variables here, 
-            // so to leverage the definite assignment analysis of 
-            // the compiler to check we are doing everything right
-            int leftConst, rightCont;
-            Variable leftVar, rightVar;
-            if (leftNorm.IsConstant(out leftConst))
-            {
-              // K + K
-              if (rightNorm.IsConstant(out rightCont))
-              {
-                this.result = NormalizedExpression<Variable>.For(leftConst + rightCont);  // Can overflow, we do not care has it may be the concrete semantics
-                return true;
-              }
-              // K + V
-              if (rightNorm.IsVariable(out rightVar))
-              {
-                this.result = NormalizedExpression<Variable>.For(rightVar, leftConst);
-                return true;
-              }
-            }
-            else if (leftNorm.IsVariable(out leftVar))
-            {
-              // V + K
-              if (rightNorm.IsConstant(out rightCont))
-              {
-                this.result = NormalizedExpression<Variable>.For(leftVar, rightCont);
-                return true;
-              }
-            }
-          }
+            return default(NormalizedExpression<Variable>);
         }
 
-        return Default(data);
-      }
-
-      public override bool VisitConstant(Expression left, Void data)
-      {
-        Int32 value;
-        if(this.Decoder.TryValueOf<Int32>(left, ExpressionType.Int32, out value))
+        public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
         {
-          this.result = NormalizedExpression<Variable>.For(value);
-          return true;
+            Contract.Requires(encoder != null);
+
+            return default(Expression);
         }
 
-        return false;
-      }
+        abstract public override bool IsConstant(out int value);
 
-      public override bool VisitConvertToInt32(Expression left, Expression original, Void data)
-      {
-        return this.Visit(left, data);
-      }
+        abstract public override bool IsVariable(out Variable var);
 
-      public override bool VisitSubtraction(Expression left, Expression right, Expression original, Void data)
-      {
-        NormalizedExpression<Variable> leftNorm, rightNorm;
-        if (this.TryConvert(left, out leftNorm))
-        {
-          Contract.Assert(leftNorm != null);
-
-          if (this.TryConvert(right, out rightNorm))
-          {
-            Contract.Assert(rightNorm != null);
-
-            // All the cases. We declare all the variables here, 
-            // so to leverage the definite assignment analysis of 
-            // the compiler to check we are doing everything right
-            int leftConst, rightConst;
-            Variable leftVar;
-            if (rightNorm.IsConstant(out rightConst) && rightConst != Int32.MinValue)
-            {
-              // K - K
-              if (leftNorm.IsConstant(out leftConst))
-              {
-                this.result = NormalizedExpression<Variable>.For(leftConst - rightConst);  // Can overflow, we do not care has it may be the concrete semantics
-                return true;
-              }
-              // V - K
-              if (leftNorm.IsVariable(out leftVar))
-              {
-                this.result = NormalizedExpression<Variable>.For(leftVar, -rightConst);
-                return true;
-              }
-            }
-          }
-        }
-
-        return Default(data);
-      }
-
-      public override bool VisitVariable(Variable variable, Expression original, Void data)
-      {
-        this.result = NormalizedExpression<Variable>.For(variable);
-        return true;
-      }
-
-      protected override bool Default(Void data)
-      {
-        this.result = default(NormalizedExpression<Variable>);
-        return false;
-      }
-
-      public override string ToString()
-      {
-        return this.result == null ? "null" : this.result.ToString();
-      }
+        abstract public override bool IsAddition(out Variable var, out int value);
     }
-  }
-
-  [ContractClassFor(typeof(NormalizedExpression<>))]
-  abstract class NormalizedExpressionContracts<Variable>
-    : NormalizedExpression<Variable>
-  {
-    public override NormalizedExpression<Variable> PlusOne()
-    {
-      Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
-
-      return default(NormalizedExpression<Variable>);
-    }
-
-    public override NormalizedExpression<Variable> MinusOne()
-    {
-      Contract.Ensures(Contract.Result<NormalizedExpression<Variable>>() != null);
-
-      return default(NormalizedExpression<Variable>);
-    }
-
-    public override Expression Convert<Expression>(IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(encoder != null);
-
-      return default(Expression);
-    }
-
-    abstract public override bool IsConstant(out int value);
-
-    abstract public override bool IsVariable(out Variable var);
-
-    abstract public override bool IsAddition(out Variable var, out int value);
-
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/SegmentLimit.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Array/SegmentLimit.cs
@@ -1,17 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -24,608 +12,608 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  /// <summary>
-  /// The limit for an array segment.
-  /// Should be immutable
-  /// </summary>
-  [ContractVerification(true)]
-  public class SegmentLimit<Variable>
-    : IAbstractDomain, IEnumerable<NormalizedExpression<Variable>> 
-  {
-    #region Private State
-
-    readonly private Set<NormalizedExpression<Variable>> expressions; // \gamma(...) = \forall x, y \in expressions. \gamma(x) == \gamma(y)
-
-    private Set<NormalizedExpression<Variable>> Expressions
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
-
-        return this.expressions;
-      }
-    }
-    
-    readonly public bool IsConditional;
-
-    #endregion
-
-    #region Object Invariant
-  
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.expressions != null);
-    }
-
-    #endregion
-
-    #region Constructor
-
-    public SegmentLimit(NormalizedExpression<Variable> expression, bool isConditional)
-      : this(new Set<NormalizedExpression<Variable>>() { expression }, isConditional)
-    {
-      Contract.Requires(expression != null);
-    }
-
-    public SegmentLimit(Set<NormalizedExpression<Variable>> expressions, bool isConditional)
-    {
-      Contract.Requires(expressions != null);
-      // F: TODO
-      //Contract.Requires(Contract.ForAll(expressions, exp => exp != null));
-
-      this.expressions = expressions;
-      this.IsConditional = isConditional;
-    }
-
-    public SegmentLimit(SegmentLimit<Variable> expressions, bool isConditional)
-      : this(new Set<NormalizedExpression<Variable>>(expressions.Expressions), isConditional)  // F: TODO : Share the set
-    {
-      Contract.Requires(expressions != null);
-    }
-
-    #endregion
-
-    #region Utility 
-
     /// <summary>
-    /// Returns true iff <code>this</code> segment limit contains <code>exp</code>
+    /// The limit for an array segment.
+    /// Should be immutable
     /// </summary>
-    [Pure]
-    public bool Contains(NormalizedExpression<Variable> exp)
-    {
-      return this.expressions.Contains(exp);
-    }
-
     [ContractVerification(true)]
-    public SegmentLimit<Variable> Add(NormalizedExpression<Variable> element)
+    public class SegmentLimit<Variable>
+      : IAbstractDomain, IEnumerable<NormalizedExpression<Variable>>
     {
-      Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+        #region Private State
 
-      var newSet = new Set<NormalizedExpression<Variable>>();
-      newSet.AddRange(this.expressions);
-      newSet.Add(element);
+        readonly private Set<NormalizedExpression<Variable>> expressions; // \gamma(...) = \forall x, y \in expressions. \gamma(x) == \gamma(y)
 
-      return new SegmentLimit<Variable>(newSet, this.IsConditional);
-    }
-
-    [ContractVerification(true)]
-    public SegmentLimit<Variable> Add(Set<NormalizedExpression<Variable>> elements)
-    {
-      Contract.Requires(elements != null);
-      Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
-
-      var newSet = new Set<NormalizedExpression<Variable>>();
-      newSet.AddRange(this.expressions);
-      newSet.AddRange(elements);
-
-      return new SegmentLimit<Variable>(newSet, this.IsConditional);
-    }
-
-
-    [Pure]
-    public SegmentLimit<Variable> KeepOnlyConstantExpressionIfAny()
-    {
-      Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);      
-
-      if (this.IsEmpty)
-        return this;
-
-      foreach (var e in this.expressions)
-      {
-        Contract.Assume(e != null);
-
-        int dummy;
-        if (e.IsConstant(out dummy))
-          return new SegmentLimit<Variable>(e, this.IsConditional);
-      }
-
-      return new SegmentLimit<Variable>(new Set<NormalizedExpression<Variable>>(), true);
-    }
-
-    public bool IsEmpty
-    {
-      get
-      {
-        return this.expressions.Count == 0;
-      }
-    }
-
-    #endregion
-
-    #region AssignInParallel
-    public SegmentLimit<Variable> AssignInParallel<Expression>(Dictionary<Variable, FList<Variable>> sourceToTargets, Converter<Variable, Expression> convert, 
-      IExpressionDecoder<Variable, Expression> decoder)
-    {
-      #region Contracts
-      Contract.Requires(sourceToTargets != null);
-      Contract.Requires(convert != null);
-      Contract.Requires(decoder != null);
-
-      Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
-      #endregion
-
-      var newSet = new Set<NormalizedExpression<Variable>>();
-
-      foreach (var x in this.expressions)
-      {
-        Contract.Assume(x != null);
-
-        FList<Variable> targets;
-
-        int value;
-        Variable var;
-        if (x.IsConstant(out value))
+        private Set<NormalizedExpression<Variable>> Expressions
         {
-          newSet.Add(x);
-        }
-        else if (x.IsVariable(out var))
-        {
-          if (sourceToTargets.TryGetValue(var, out targets))
-          {
-            Contract.Assume(targets!= null);
-
-            foreach (var newName in targets.GetEnumerable())
+            get
             {
-              newSet.Add(NormalizedExpression<Variable>.For(newName));
+                Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
+
+                return expressions;
             }
-          }
         }
-        else if (x.IsAddition(out var, out value))
+
+        readonly public bool IsConditional;
+
+        #endregion
+
+        #region Object Invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          if (sourceToTargets.TryGetValue(var, out targets))
-          {
-            Contract.Assume(targets != null);
-            foreach (var newName in targets.GetEnumerable())
+            Contract.Invariant(expressions != null);
+        }
+
+        #endregion
+
+        #region Constructor
+
+        public SegmentLimit(NormalizedExpression<Variable> expression, bool isConditional)
+          : this(new Set<NormalizedExpression<Variable>>() { expression }, isConditional)
+        {
+            Contract.Requires(expression != null);
+        }
+
+        public SegmentLimit(Set<NormalizedExpression<Variable>> expressions, bool isConditional)
+        {
+            Contract.Requires(expressions != null);
+            // F: TODO
+            //Contract.Requires(Contract.ForAll(expressions, exp => exp != null));
+
+            this.expressions = expressions;
+            this.IsConditional = isConditional;
+        }
+
+        public SegmentLimit(SegmentLimit<Variable> expressions, bool isConditional)
+          : this(new Set<NormalizedExpression<Variable>>(expressions.Expressions), isConditional)  // F: TODO : Share the set
+        {
+            Contract.Requires(expressions != null);
+        }
+
+        #endregion
+
+        #region Utility 
+
+        /// <summary>
+        /// Returns true iff <code>this</code> segment limit contains <code>exp</code>
+        /// </summary>
+        [Pure]
+        public bool Contains(NormalizedExpression<Variable> exp)
+        {
+            return expressions.Contains(exp);
+        }
+
+        [ContractVerification(true)]
+        public SegmentLimit<Variable> Add(NormalizedExpression<Variable> element)
+        {
+            Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+            var newSet = new Set<NormalizedExpression<Variable>>();
+            newSet.AddRange(expressions);
+            newSet.Add(element);
+
+            return new SegmentLimit<Variable>(newSet, this.IsConditional);
+        }
+
+        [ContractVerification(true)]
+        public SegmentLimit<Variable> Add(Set<NormalizedExpression<Variable>> elements)
+        {
+            Contract.Requires(elements != null);
+            Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+            var newSet = new Set<NormalizedExpression<Variable>>();
+            newSet.AddRange(expressions);
+            newSet.AddRange(elements);
+
+            return new SegmentLimit<Variable>(newSet, this.IsConditional);
+        }
+
+
+        [Pure]
+        public SegmentLimit<Variable> KeepOnlyConstantExpressionIfAny()
+        {
+            Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+            if (this.IsEmpty)
+                return this;
+
+            foreach (var e in expressions)
             {
-              newSet.Add(NormalizedExpression<Variable>.For(newName, value));
+                Contract.Assume(e != null);
+
+                int dummy;
+                if (e.IsConstant(out dummy))
+                    return new SegmentLimit<Variable>(e, this.IsConditional);
             }
-          }
 
-          // This is a special case to handle renaming for a[p++] = ...
-          // We have (var + value) --> var
-          Variable source;
-          if(IsATarget(var, sourceToTargets, out source))
-          {
-            Variable v;
-            int k;
-            if(decoder.TryMatchVarPlusConst(convert(source), out v, out k) && v.Equals(var) && k == value)
+            return new SegmentLimit<Variable>(new Set<NormalizedExpression<Variable>>(), true);
+        }
+
+        public bool IsEmpty
+        {
+            get
             {
-              newSet.Add(NormalizedExpression<Variable>.For(var));
-            }            
-          }
+                return expressions.Count == 0;
+            }
         }
-      }
 
-      return new SegmentLimit<Variable>(newSet, this.IsConditional);
-    }
+        #endregion
 
-    private bool IsATarget(Variable var, Dictionary<Variable, FList<Variable>> sourceToTargets, out Variable source)
-    {
-      Contract.Requires(sourceToTargets != null);
-
-      foreach (var pair in sourceToTargets)
-      {
-        var m = pair.Value;
-        Contract.Assume(m != null);
-
-        foreach (var t in m.GetEnumerable())
+        #region AssignInParallel
+        public SegmentLimit<Variable> AssignInParallel<Expression>(Dictionary<Variable, FList<Variable>> sourceToTargets, Converter<Variable, Expression> convert,
+          IExpressionDecoder<Variable, Expression> decoder)
         {
-          if (t.Equals(var))
-          {
-            source = pair.Key;
-            return true;
-          }
+            #region Contracts
+            Contract.Requires(sourceToTargets != null);
+            Contract.Requires(convert != null);
+            Contract.Requires(decoder != null);
+
+            Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+            #endregion
+
+            var newSet = new Set<NormalizedExpression<Variable>>();
+
+            foreach (var x in expressions)
+            {
+                Contract.Assume(x != null);
+
+                FList<Variable> targets;
+
+                int value;
+                Variable var;
+                if (x.IsConstant(out value))
+                {
+                    newSet.Add(x);
+                }
+                else if (x.IsVariable(out var))
+                {
+                    if (sourceToTargets.TryGetValue(var, out targets))
+                    {
+                        Contract.Assume(targets != null);
+
+                        foreach (var newName in targets.GetEnumerable())
+                        {
+                            newSet.Add(NormalizedExpression<Variable>.For(newName));
+                        }
+                    }
+                }
+                else if (x.IsAddition(out var, out value))
+                {
+                    if (sourceToTargets.TryGetValue(var, out targets))
+                    {
+                        Contract.Assume(targets != null);
+                        foreach (var newName in targets.GetEnumerable())
+                        {
+                            newSet.Add(NormalizedExpression<Variable>.For(newName, value));
+                        }
+                    }
+
+                    // This is a special case to handle renaming for a[p++] = ...
+                    // We have (var + value) --> var
+                    Variable source;
+                    if (IsATarget(var, sourceToTargets, out source))
+                    {
+                        Variable v;
+                        int k;
+                        if (decoder.TryMatchVarPlusConst(convert(source), out v, out k) && v.Equals(var) && k == value)
+                        {
+                            newSet.Add(NormalizedExpression<Variable>.For(var));
+                        }
+                    }
+                }
+            }
+
+            return new SegmentLimit<Variable>(newSet, this.IsConditional);
         }
-      }
 
-      source = default(Variable);
-      return false;
-    }
-
-    #endregion
-
-    #region Inclusions, equality, etc.
-
-    [Pure]
-    static public bool HaveTheSameElements(SegmentLimit<Variable> left, SegmentLimit<Variable> right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return left.expressions.Equals(right.expressions);
-    }
-
-    [Pure]
-    static public bool IsSubsetOf(SegmentLimit<Variable> left, SegmentLimit<Variable> right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return left.Expressions.IsSubset(right.Expressions);
-    }
-
-    [Pure]
-    public bool IsSubSetOf(SegmentLimit<Variable> right)
-    {
-      Contract.Requires(right != null);
-
-      return IsSubsetOf(this, right);
-    }
-
-    [Pure]
-    public Set<NormalizedExpression<Variable>> Intersection(SegmentLimit<Variable> right)
-    {
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);  
-     
-      return this.expressions.Intersection(right.Expressions);
-    }
-
-    [Pure]
-    public Set<NormalizedExpression<Variable>> Union(SegmentLimit<Variable> right)
-    {
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
-
-      return this.expressions.Union(right.Expressions);
-    }
-
-    [Pure]
-    public Set<NormalizedExpression<Variable>> Difference(SegmentLimit<Variable> right)
-    {
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);    
-
-      return this.expressions.Difference(right.Expressions);
-    }
-
-    [Pure]
-    public Set<NormalizedExpression<Variable>> Difference(Set<NormalizedExpression<Variable>> right)
-    {
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);      
-
-      return this.expressions.Difference(right);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    virtual public bool IsBottom
-    {
-      get 
-      {
-        return false;
-      }
-    }
-
-    public bool IsTop
-    {
-      get 
-      {
-        return /*this.expressions != null && */expressions.Count == 0;
-      }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      var other = a as SegmentLimit<Variable>;
-
-      Contract.Assume(other != null);
-
-      return this.LessEqual(other);
-    }
-
-    [Pure]
-    public bool LessEqual(SegmentLimit<Variable> other)
-    {
-      Contract.Requires(other != null);
-
-      if (this.IsBottom)
-        return true;
-     
-      if (other.IsBottom)
-        return false;
-
-
-     return (!this.IsConditional || other.IsConditional) && this.expressions.IsSubset(other.Expressions);
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { return this.Bottom; }
-    }
-
-    public SegmentLimit<Variable> Bottom
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);        
-
-        return new BottomSegmentLimit();
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { return this.Top; }
-    }
-
-    public SegmentLimit<Variable> Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
-        
-        return new SegmentLimit<Variable>(new Set<NormalizedExpression<Variable>>(), true);
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var tmp = a as SegmentLimit<Variable>;
-
-      Contract.Assume(tmp != null);
-
-      return this.Join(tmp);
-    }
-
-    [Pure]
-    public SegmentLimit<Variable> Join(SegmentLimit<Variable> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);      
-
-      SegmentLimit<Variable> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
-      {
-        return result;
-      }
-  
-      var set = this.expressions.Intersection(other.Expressions);
-      var isconditional = this.IsConditional || other.IsConditional;
-
-      return new SegmentLimit<Variable>(set, isconditional);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      var tmp = a as SegmentLimit<Variable>;
-
-      Contract.Assume(tmp != null);
-
-      return this.Meet(tmp);
-    }
-
-    [Pure]
-    public SegmentLimit<Variable> Meet(SegmentLimit<Variable> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);      
-
-      SegmentLimit<Variable> result;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
-      {
-        return result;
-      }
-
-      var set = this.expressions.Union(other.Expressions);
-      var isconditional = this.IsConditional && other.IsConditional;
-
-      return new SegmentLimit<Variable>(set, isconditional);
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      var other = prev as SegmentLimit<Variable>;
-
-      Contract.Assume(other != null);
-
-      return this.Widening(other);
-    }
-
-    [Pure]
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-other != null")]
-    public SegmentLimit<Variable> Widening(SegmentLimit<Variable> other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
-      
-      // F: ... We assume finitely many expressions ...
-      return this.Join(other);
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      return factory.IdentityForAnd;
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      return this;
-    }
-
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      if (this.IsBottom)
-        return "bott";
-      if (this.IsTop)
-        return "{}?";
-
-      var res = new StringBuilder();
-
-      res.Append(this.expressions.ToString());
-      if (this.IsConditional)
-      {
-        res.Append('?');
-      }
-
-      return "{ " + res.ToString() + "}";
-    }
-    #endregion
-
-    #region IEnumerable<NormalizedExpression<Variable>> Members
-
-    public IEnumerator<NormalizedExpression<Variable>> GetEnumerator()
-    {
-      return this.expressions.GetEnumerator();
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-
-    #endregion
-
-    #region Look up Utils
-    [Pure]
-    public bool ContainsConstant
-    {
-      get
-      {
-        foreach (var e in this.expressions)
+        private bool IsATarget(Variable var, Dictionary<Variable, FList<Variable>> sourceToTargets, out Variable source)
         {
-          Contract.Assume(e != null);
+            Contract.Requires(sourceToTargets != null);
 
-          int dummy;
-          if (e.IsConstant(out dummy))
-            return true;
+            foreach (var pair in sourceToTargets)
+            {
+                var m = pair.Value;
+                Contract.Assume(m != null);
+
+                foreach (var t in m.GetEnumerable())
+                {
+                    if (t.Equals(var))
+                    {
+                        source = pair.Key;
+                        return true;
+                    }
+                }
+            }
+
+            source = default(Variable);
+            return false;
         }
 
-        return false;
-      }
-    }
+        #endregion
 
-    /// <returns>
-    /// true if this segment limit is the successor of the other
-    /// </returns>
-    [Pure]
-    public bool IsSuccessorOf(SegmentLimit<Variable> segmentLimit)
-    {
-      Contract.Requires(segmentLimit != null);
+        #region Inclusions, equality, etc.
 
-      foreach (var limit in segmentLimit)
-      {
-        Contract.Assume(limit != null);
-
-        if(this.Contains(limit.PlusOne()))
+        [Pure]
+        static public bool HaveTheSameElements(SegmentLimit<Variable> left, SegmentLimit<Variable> right)
         {
-          return true;
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return left.expressions.Equals(right.expressions);
         }
-      }
 
-      return false;
-    }
-
-    [Pure]
-    internal bool IsAtLeftOf(SegmentLimit<Variable> segmentLimit)
-    {
-      Contract.Requires(segmentLimit != null);
-
-      int vThis, vSegmentLimit;
-      if (this.TryFindConstant(out vThis) && segmentLimit.TryFindConstant(out vSegmentLimit))
-      {
-        return vThis < vSegmentLimit;
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public bool TryFindConstant(out int val)
-    {      
-      foreach (var limit in this.expressions)
-      {
-        if (limit != null && limit.IsConstant(out val))
+        [Pure]
+        static public bool IsSubsetOf(SegmentLimit<Variable> left, SegmentLimit<Variable> right)
         {
-          return true;
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return left.Expressions.IsSubset(right.Expressions);
         }
-      }
 
-      val = default(Int32);
-      return false;
-    }
-    #endregion
-
-    #region Bottom Segment
-    private class BottomSegmentLimit : SegmentLimit<Variable>
-    {
-      [ContractVerification(false)]
-      public BottomSegmentLimit()
-        : base((SegmentLimit<Variable>) null, false)    // F: Here we are violating the base class invariant...
-      { }
-
-      public override bool IsBottom
-      {
-        get
+        [Pure]
+        public bool IsSubSetOf(SegmentLimit<Variable> right)
         {
-          return true;
+            Contract.Requires(right != null);
+
+            return IsSubsetOf(this, right);
         }
-      }
 
-      public override string ToString()
-      {
-        return "Bottom segment";
-      }
-    }
-    #endregion
-
-    public Set<NormalizedExpression<Variable>> MinusOne()
-    {
-      Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
-
-       var result = new Set<NormalizedExpression<Variable>>();
-       
-      if (this.IsNormal())
-      {
-        foreach (var limit in this.expressions)
+        [Pure]
+        public Set<NormalizedExpression<Variable>> Intersection(SegmentLimit<Variable> right)
         {
-          if (limit != null)
-          {
-            result.Add(limit.MinusOne());
-          }
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
+
+            return expressions.Intersection(right.Expressions);
         }
 
-        return result;
-      }
+        [Pure]
+        public Set<NormalizedExpression<Variable>> Union(SegmentLimit<Variable> right)
+        {
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
 
-      return result;
+            return expressions.Union(right.Expressions);
+        }
+
+        [Pure]
+        public Set<NormalizedExpression<Variable>> Difference(SegmentLimit<Variable> right)
+        {
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
+
+            return expressions.Difference(right.Expressions);
+        }
+
+        [Pure]
+        public Set<NormalizedExpression<Variable>> Difference(Set<NormalizedExpression<Variable>> right)
+        {
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
+
+            return expressions.Difference(right);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        virtual public bool IsBottom
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return /*this.expressions != null && */expressions.Count == 0;
+            }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            var other = a as SegmentLimit<Variable>;
+
+            Contract.Assume(other != null);
+
+            return this.LessEqual(other);
+        }
+
+        [Pure]
+        public bool LessEqual(SegmentLimit<Variable> other)
+        {
+            Contract.Requires(other != null);
+
+            if (this.IsBottom)
+                return true;
+
+            if (other.IsBottom)
+                return false;
+
+
+            return (!this.IsConditional || other.IsConditional) && expressions.IsSubset(other.Expressions);
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { return this.Bottom; }
+        }
+
+        public SegmentLimit<Variable> Bottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+                return new BottomSegmentLimit();
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { return this.Top; }
+        }
+
+        public SegmentLimit<Variable> Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+                return new SegmentLimit<Variable>(new Set<NormalizedExpression<Variable>>(), true);
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var tmp = a as SegmentLimit<Variable>;
+
+            Contract.Assume(tmp != null);
+
+            return this.Join(tmp);
+        }
+
+        [Pure]
+        public SegmentLimit<Variable> Join(SegmentLimit<Variable> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+            SegmentLimit<Variable> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
+            {
+                return result;
+            }
+
+            var set = expressions.Intersection(other.Expressions);
+            var isconditional = this.IsConditional || other.IsConditional;
+
+            return new SegmentLimit<Variable>(set, isconditional);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            var tmp = a as SegmentLimit<Variable>;
+
+            Contract.Assume(tmp != null);
+
+            return this.Meet(tmp);
+        }
+
+        [Pure]
+        public SegmentLimit<Variable> Meet(SegmentLimit<Variable> other)
+        {
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+            SegmentLimit<Variable> result;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
+            {
+                return result;
+            }
+
+            var set = expressions.Union(other.Expressions);
+            var isconditional = this.IsConditional && other.IsConditional;
+
+            return new SegmentLimit<Variable>(set, isconditional);
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            var other = prev as SegmentLimit<Variable>;
+
+            Contract.Assume(other != null);
+
+            return this.Widening(other);
+        }
+
+        [Pure]
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-other != null")]
+        public SegmentLimit<Variable> Widening(SegmentLimit<Variable> other)
+        {
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<SegmentLimit<Variable>>() != null);
+
+            // F: ... We assume finitely many expressions ...
+            return this.Join(other);
+        }
+
+        public T To<T>(IFactory<T> factory)
+        {
+            return factory.IdentityForAnd;
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            return this;
+        }
+
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            if (this.IsBottom)
+                return "bott";
+            if (this.IsTop)
+                return "{}?";
+
+            var res = new StringBuilder();
+
+            res.Append(expressions.ToString());
+            if (this.IsConditional)
+            {
+                res.Append('?');
+            }
+
+            return "{ " + res.ToString() + "}";
+        }
+        #endregion
+
+        #region IEnumerable<NormalizedExpression<Variable>> Members
+
+        public IEnumerator<NormalizedExpression<Variable>> GetEnumerator()
+        {
+            return expressions.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+
+        #region Look up Utils
+        [Pure]
+        public bool ContainsConstant
+        {
+            get
+            {
+                foreach (var e in expressions)
+                {
+                    Contract.Assume(e != null);
+
+                    int dummy;
+                    if (e.IsConstant(out dummy))
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <returns>
+        /// true if this segment limit is the successor of the other
+        /// </returns>
+        [Pure]
+        public bool IsSuccessorOf(SegmentLimit<Variable> segmentLimit)
+        {
+            Contract.Requires(segmentLimit != null);
+
+            foreach (var limit in segmentLimit)
+            {
+                Contract.Assume(limit != null);
+
+                if (this.Contains(limit.PlusOne()))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        internal bool IsAtLeftOf(SegmentLimit<Variable> segmentLimit)
+        {
+            Contract.Requires(segmentLimit != null);
+
+            int vThis, vSegmentLimit;
+            if (this.TryFindConstant(out vThis) && segmentLimit.TryFindConstant(out vSegmentLimit))
+            {
+                return vThis < vSegmentLimit;
+            }
+
+            return false;
+        }
+
+        [Pure]
+        public bool TryFindConstant(out int val)
+        {
+            foreach (var limit in expressions)
+            {
+                if (limit != null && limit.IsConstant(out val))
+                {
+                    return true;
+                }
+            }
+
+            val = default(Int32);
+            return false;
+        }
+        #endregion
+
+        #region Bottom Segment
+        private class BottomSegmentLimit : SegmentLimit<Variable>
+        {
+            [ContractVerification(false)]
+            public BottomSegmentLimit()
+              : base((SegmentLimit<Variable>)null, false)    // F: Here we are violating the base class invariant...
+            { }
+
+            public override bool IsBottom
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override string ToString()
+            {
+                return "Bottom segment";
+            }
+        }
+        #endregion
+
+        public Set<NormalizedExpression<Variable>> MinusOne()
+        {
+            Contract.Ensures(Contract.Result<Set<NormalizedExpression<Variable>>>() != null);
+
+            var result = new Set<NormalizedExpression<Variable>>();
+
+            if (this.IsNormal())
+            {
+                foreach (var limit in expressions)
+                {
+                    if (limit != null)
+                    {
+                        result.Add(limit.MinusOne());
+                    }
+                }
+
+                return result;
+            }
+
+            return result;
+        }
     }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/DebugUtils.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/DebugUtils.cs
@@ -1,90 +1,78 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Some helper classes for tracing the behavior of the abstract domain, and the definition of the exception to be thrown when some error occured in the abstract domains
 
 namespace Microsoft.Research.AbstractDomains
 {
-  using System;
-  using System.IO;
-  using System.Text;
-  using System.Collections.Generic;
-  using System.Diagnostics;
-  using System.CodeDom.Compiler;
-  using System.Xml;
-  using System.Runtime.InteropServices;
-  using Microsoft.Research.CodeAnalysis;
-  using System.Diagnostics.Contracts;
- 
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.CodeDom.Compiler;
+    using System.Xml;
+    using System.Runtime.InteropServices;
+    using Microsoft.Research.CodeAnalysis;
+    using System.Diagnostics.Contracts;
 
 
-  /// <summary>
-  /// A class that does nothing....
-  /// </summary>
+
+    /// <summary>
+    /// A class that does nothing....
+    /// </summary>
 #if SUBPOLY_ONLY
-  internal
+    internal
 #else
-  public 
+    public
 #endif
     class NullTextWriter : TextWriter
-  {
-    public override Encoding Encoding
     {
-      get { return Encoding.ASCII; }
-    }
-  }
-
-  /// <summary>
-  /// Exception to be thrown when an error occured in the abstract domains
-  /// </summary>
- [Serializable]
-  public class AbstractInterpretationException : Exception
-  {
-    public AbstractInterpretationException(string  msg)
-      : base(msg)
-    {
-      Contract.Requires(msg != null);
+        public override Encoding Encoding
+        {
+            get { return Encoding.ASCII; }
+        }
     }
 
-    public AbstractInterpretationException()
-      : base()
+    /// <summary>
+    /// Exception to be thrown when an error occured in the abstract domains
+    /// </summary>
+    [Serializable]
+    public class AbstractInterpretationException : Exception
     {
-    }
-  }
+        public AbstractInterpretationException(string msg)
+          : base(msg)
+        {
+            Contract.Requires(msg != null);
+        }
 
-  /// <summary>
-  /// Exception to be thrown when there is something not implemented yet
-  /// </summary>
-  [Serializable]
-  public class AbstractInterpretationTODOException : Exception
-  {
-    public AbstractInterpretationTODOException(string msg)
-      : base(msg)
+        public AbstractInterpretationException()
+          : base()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Exception to be thrown when there is something not implemented yet
+    /// </summary>
+    [Serializable]
+    public class AbstractInterpretationTODOException : Exception
     {
-      Contract.Requires(msg != null);
-    }
+        public AbstractInterpretationTODOException(string msg)
+          : base(msg)
+        {
+            Contract.Requires(msg != null);
+        }
 
-    public AbstractInterpretationTODOException()
-      : base()
-    {
+        public AbstractInterpretationTODOException()
+          : base()
+        {
+        }
     }
-  }
-
 
 #if SUBPOLY_ONLY
-  public class TimeoutExceptionFixpointComputation : Exception
-  {
-  }
+    public class TimeoutExceptionFixpointComputation : Exception
+    {
+    }
 #endif
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Enum/Enum.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Enum/Enum.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using Microsoft.Research.DataStructures;
@@ -19,499 +8,498 @@ using System;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  [ContractVerification(true)]
-  public class EnumDefined<Variable, Type, Expression> 
-    : IAbstractDomainWithRenaming<EnumDefined<Variable, Type, Expression>, Variable>,
-    IAbstractDomainForEnvironments<Variable, Expression>
-  {
-    #region Object invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    [ContractVerification(true)]
+    public class EnumDefined<Variable, Type, Expression>
+      : IAbstractDomainWithRenaming<EnumDefined<Variable, Type, Expression>, Variable>,
+      IAbstractDomainForEnvironments<Variable, Expression>
     {
-      Contract.Invariant(this.conditions != null);
-      Contract.Invariant(this.defined != null);
-    }
-
-    #endregion
-
-    #region State
-
-    enum State { Bottom, Normal, Top }
-
-    readonly private SimpleImmutableFunctional<Variable, SetOfConstraints<Pair<Type, Variable>>> conditions;     // map var1 <-> <type, var2> with the meaning that var1 is true iff var2 is defined for enum type
-    readonly private SetOfConstraints<Pair<Type, Variable>> defined;            // sets of <var, type> with the meaning that var is defined for type 
-    readonly private State state;
-    
-    #endregion
-
-    #region Constructors
-
-    private EnumDefined(
-      SimpleImmutableFunctional<Variable, SetOfConstraints<Pair<Type, Variable>>> conditions, 
-      SetOfConstraints<Pair<Type, Variable>> defined)
-    {
-      Contract.Requires(conditions != null);
-      Contract.Requires(defined != null);
-
-      this.conditions = conditions;
-      this.defined = defined;
-
-      if (conditions.IsBottom || defined.IsBottom)
-      {
-        this.state = State.Bottom;
-      }
-      else if (conditions.IsTop && defined.IsTop)
-      {
-        this.state = State.Top;
-      }
-      else
-      {
-        this.state = State.Normal;
-      }
-    }
-
-    private EnumDefined(Dictionary<Variable, SetOfConstraints<Pair<Type, Variable>>> conditions, Set<Pair<Type, Variable>> defined)
-      : this(
-      new SimpleImmutableFunctional<Variable, SetOfConstraints<Pair<Type, Variable>>>(conditions),
-      new SetOfConstraints<Pair<Type, Variable>>(defined, false)
-      )
-    {
-      Contract.Requires(conditions != null);
-      Contract.Requires(defined != null);
-    }
-
-    private EnumDefined(State state)
-      : this
-      (
-      SimpleImmutableFunctional<Variable,SetOfConstraints<Pair<Type,Variable>>>.Unknown, 
-      SetOfConstraints<Pair<Type, Variable>>.Unknown
-      )
-    {
-      Contract.Requires(state != State.Normal);
-
-      this.state = state;
-    }
-    #endregion
-
-    #region Assumptions
-
-    [Pure]
-    public EnumDefined<Variable, Type, Expression> AssumeTypeIff(Variable condition, Type type, Variable variable)
-    {
-      Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
-
-      SetOfConstraints<Pair<Type, Variable>> constraints;
-      if (this.conditions.TryGetValue(condition, out constraints))
-      {
-        constraints = constraints.Add(new Pair<Type, Variable>(type, variable));
-      }
-      else
-      {
-        constraints = new SetOfConstraints<Pair<Type, Variable>>(new Pair<Type, Variable>(type, variable));
-      }
-
-      var newConditions = this.conditions.Add(condition, constraints);
-
-      return new EnumDefined<Variable, Type, Expression>(newConditions, this.defined);
-    }
-
-    [Pure]
-    public EnumDefined<Variable, Type, Expression> AssumeCondition(Variable condition)
-    {
-      Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
-
-      SetOfConstraints<Pair<Type, Variable>> constraints;
-      if (this.conditions.TryGetValue(condition, out constraints))
-      {
-        var newDefinitions = this.defined;
-        foreach (var pair in constraints.Values)
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          newDefinitions = newDefinitions.Add(pair);
+            Contract.Invariant(conditions != null);
+            Contract.Invariant(defined != null);
         }
 
-        return new EnumDefined<Variable, Type, Expression>(this.conditions, newDefinitions);
-      }
-      else
-      {
-        return this;
-      }
-    }
+        #endregion
 
-    [Pure]
-    public EnumDefined<Variable, Type, Expression> AssumeCondition(Type type, Variable var)
-    {
-      Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+        #region State
 
-      var newDefinitions = this.defined.Add(new Pair<Type, Variable>(type, var));
+        private enum State { Bottom, Normal, Top }
 
-      return new EnumDefined<Variable, Type, Expression>(this.conditions, newDefinitions);
-    }
+        readonly private SimpleImmutableFunctional<Variable, SetOfConstraints<Pair<Type, Variable>>> conditions;     // map var1 <-> <type, var2> with the meaning that var1 is true iff var2 is defined for enum type
+        readonly private SetOfConstraints<Pair<Type, Variable>> defined;            // sets of <var, type> with the meaning that var is defined for type 
+        readonly private State state;
 
-    #endregion
+        #endregion
 
-    #region Statics
-    public static EnumDefined<Variable, Type, Expression> Unknown
-    {
-      get
-      {
-        return new EnumDefined<Variable, Type, Expression>(State.Top);
-      }
-    }
-    #endregion
+        #region Constructors
 
-    #region IAbstractDomainWithRenaming<Enum<Variable, Expression>,Variable> Members
-
-    public EnumDefined<Variable, Type, Expression> Rename(Dictionary<Variable, FList<Variable>> renaming)
-    {
-      if (!this.IsNormal())
-      {
-        return this;
-      }
-      var newConditions = new Dictionary<Variable, SetOfConstraints<Pair<Type, Variable>>>();
-
-      foreach (var pair in this.conditions.Elements)
-      {
-        FList<Variable> newNames;
-        if (renaming.TryGetValue(pair.Key, out newNames))
+        private EnumDefined(
+          SimpleImmutableFunctional<Variable, SetOfConstraints<Pair<Type, Variable>>> conditions,
+          SetOfConstraints<Pair<Type, Variable>> defined)
         {
-          var newPairs = new Set<Pair<Type, Variable>>();
-          Contract.Assume(pair.Value != null);
+            Contract.Requires(conditions != null);
+            Contract.Requires(defined != null);
 
-          foreach (var equalities in pair.Value.Values)
-          {
-            FList<Variable> newRight;
-            if (renaming.TryGetValue(equalities.Two, out newRight))
+            this.conditions = conditions;
+            this.defined = defined;
+
+            if (conditions.IsBottom || defined.IsBottom)
             {
-              foreach (var y in newRight.GetEnumerable())
-              {
-                newPairs.Add(new Pair<Type, Variable>(equalities.One, y));
-              }
+                state = State.Bottom;
             }
-          }
-
-          foreach (var newName in newNames.GetEnumerable())
-          {
-            newConditions[newName] = new SetOfConstraints<Pair<Type, Variable>>(newPairs);
-          }
+            else if (conditions.IsTop && defined.IsTop)
+            {
+                state = State.Top;
+            }
+            else
+            {
+                state = State.Normal;
+            }
         }
-      }
 
-      var newDefinitions = new Set<Pair<Type, Variable>>();
-
-      foreach (var equalities in this.defined.Values)
-      {
-        FList<Variable> newRight;
-        if (renaming.TryGetValue(equalities.Two, out newRight))
+        private EnumDefined(Dictionary<Variable, SetOfConstraints<Pair<Type, Variable>>> conditions, Set<Pair<Type, Variable>> defined)
+          : this(
+          new SimpleImmutableFunctional<Variable, SetOfConstraints<Pair<Type, Variable>>>(conditions),
+          new SetOfConstraints<Pair<Type, Variable>>(defined, false)
+          )
         {
-          foreach (var y in newRight.GetEnumerable())
-          {
-            newDefinitions.Add(new Pair<Type, Variable>(equalities.One, y));
-          }
+            Contract.Requires(conditions != null);
+            Contract.Requires(defined != null);
         }
-      }
 
-      return new EnumDefined<Variable, Type, Expression>(newConditions, newDefinitions);
-    }
-
-    #endregion
-
-    #region Abstract Domain operations
-
-    public bool IsBottom
-    {
-      get { return this.state == State.Bottom; }
-    }
-
-    public bool IsTop
-    {
-      get { return this.state == State.Top; }
-    }
-
-    public EnumDefined<Variable, Type, Expression> Bottom
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
-
-        return new EnumDefined<Variable, Type, Expression>(State.Bottom);
-      }
-    }
-
-    public EnumDefined<Variable, Type, Expression> Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
-
-        return new EnumDefined<Variable, Type, Expression>(State.Top);
-      }
-    }
-
-    public bool LessEqual(EnumDefined<Variable, Type, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      bool direct;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, other, out direct))
-      {
-        return direct;
-      }
-
-      Contract.Assume(other.conditions != null);
-      Contract.Assume(other.defined != null);
-
-      return this.conditions.LessEqual(other.conditions) && this.defined.LessEqual(other.defined);
-    }
-
-    public EnumDefined<Variable, Type, Expression> Join(EnumDefined<Variable, Type, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
-
-      EnumDefined<Variable, Type, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
-      {
-        return result;
-      }
-
-      Contract.Assume(other.conditions != null);
-      Contract.Assume(other.defined != null);
-
-      return new EnumDefined<Variable, Type, Expression>(this.conditions.Join(other.conditions), this.defined.Join(other.defined));
-    }
-
-    public EnumDefined<Variable, Type, Expression> Meet(EnumDefined<Variable, Type, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
-
-      EnumDefined<Variable, Type, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
-      {
-        return result;
-      }
-
-      Contract.Assume(other.conditions != null);
-      Contract.Assume(other.defined != null);
-
-      return new EnumDefined<Variable, Type, Expression>(this.conditions.Meet(other.conditions), this.defined.Meet(other.defined));
-    }
-
-
-    public EnumDefined<Variable, Type, Expression> Widening(EnumDefined<Variable, Type, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
-
-      return this.Join(other);
-    }
-    #endregion
-
-    #region Implementation of the interfaces
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      var other = a as EnumDefined<Variable, Type, Expression>;
-      Contract.Assume(other != null);
-      return this.LessEqual(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { return this.Bottom; }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { return this.Top; }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var other = a as EnumDefined<Variable, Type, Expression>;
-      Contract.Assume(other != null);
-      return this.Join(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      var other = a as EnumDefined<Variable, Type, Expression>;
-      Contract.Assume(other != null);
-      return this.Meet(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      var other = prev as EnumDefined<Variable, Type, Expression>;
-      Contract.Assume(other != null);
-      return this.Widening(other);
-    }
-
-    T IAbstractDomain.To<T>(IFactory<T> factory)
-    {
-      return factory.IdentityForAnd;
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    object ICloneable.Clone()
-    {
-      return this;
-    }
-
-    #endregion
-
-    #region IAbstractDomainForEnvironments<Variable,Expression> Members
-
-    virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-    }
-
-
-    public string ToString(Expression exp)
-    {
-      return "not implemented";
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    public List<Variable> Variables
-    {
-      get 
-      {
-        var result = new List<Variable>();
-
-        foreach (var pair in this.conditions.Elements)
+        private EnumDefined(State state)
+          : this
+          (
+          SimpleImmutableFunctional<Variable, SetOfConstraints<Pair<Type, Variable>>>.Unknown,
+          SetOfConstraints<Pair<Type, Variable>>.Unknown
+          )
         {
-          result.Add(pair.Key);
-          Contract.Assume(pair.Value != null);
-          foreach (var p in pair.Value.Values)
-          {
-            result.Add(p.Two);
-          }
-        }
+            Contract.Requires(state != State.Normal);
 
-        foreach (var pair in this.defined.Values)
+            this.state = state;
+        }
+        #endregion
+
+        #region Assumptions
+
+        [Pure]
+        public EnumDefined<Variable, Type, Expression> AssumeTypeIff(Variable condition, Type type, Variable variable)
         {
-          result.Add(pair.Two);
+            Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+            SetOfConstraints<Pair<Type, Variable>> constraints;
+            if (conditions.TryGetValue(condition, out constraints))
+            {
+                constraints = constraints.Add(new Pair<Type, Variable>(type, variable));
+            }
+            else
+            {
+                constraints = new SetOfConstraints<Pair<Type, Variable>>(new Pair<Type, Variable>(type, variable));
+            }
+
+            var newConditions = conditions.Add(condition, constraints);
+
+            return new EnumDefined<Variable, Type, Expression>(newConditions, defined);
         }
 
-        return result;
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-        // does nothing
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      // does nothing
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      // does nothing
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      // does nothing
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      // does nothing
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      return this;
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      return this;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Variable,Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      // We should not invoke it
-      throw new Exception();
-    }
-
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      if (this.IsBottom)
-        return "_|_";
-      if (this.IsTop)
-        return "Top";
-      else
-        return string.Format("({0}\n {1})", this.conditions.ToString(), this.defined.ToString());
-    }
-    #endregion
-
-    #region Checking
-    public FlatAbstractDomain<bool> CheckIfVariableIsDefined(Variable var, Type type)
-    {
-      if (this.IsBottom)
-      {
-        return CheckOutcome.Bottom;
-      }
-
-      if (this.IsTop)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var goal = new Pair<Type, Variable>(type, var);
-
-      foreach (var pair in this.defined.Values)
-      {
-        if (goal.Equals(pair))
+        [Pure]
+        public EnumDefined<Variable, Type, Expression> AssumeCondition(Variable condition)
         {
-          return CheckOutcome.True;
+            Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+            SetOfConstraints<Pair<Type, Variable>> constraints;
+            if (conditions.TryGetValue(condition, out constraints))
+            {
+                var newDefinitions = defined;
+                foreach (var pair in constraints.Values)
+                {
+                    newDefinitions = newDefinitions.Add(pair);
+                }
+
+                return new EnumDefined<Variable, Type, Expression>(conditions, newDefinitions);
+            }
+            else
+            {
+                return this;
+            }
         }
-      }
 
-      return CheckOutcome.Top;
+        [Pure]
+        public EnumDefined<Variable, Type, Expression> AssumeCondition(Type type, Variable var)
+        {
+            Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+            var newDefinitions = defined.Add(new Pair<Type, Variable>(type, var));
+
+            return new EnumDefined<Variable, Type, Expression>(conditions, newDefinitions);
+        }
+
+        #endregion
+
+        #region Statics
+        public static EnumDefined<Variable, Type, Expression> Unknown
+        {
+            get
+            {
+                return new EnumDefined<Variable, Type, Expression>(State.Top);
+            }
+        }
+        #endregion
+
+        #region IAbstractDomainWithRenaming<Enum<Variable, Expression>,Variable> Members
+
+        public EnumDefined<Variable, Type, Expression> Rename(Dictionary<Variable, FList<Variable>> renaming)
+        {
+            if (!this.IsNormal())
+            {
+                return this;
+            }
+            var newConditions = new Dictionary<Variable, SetOfConstraints<Pair<Type, Variable>>>();
+
+            foreach (var pair in conditions.Elements)
+            {
+                FList<Variable> newNames;
+                if (renaming.TryGetValue(pair.Key, out newNames))
+                {
+                    var newPairs = new Set<Pair<Type, Variable>>();
+                    Contract.Assume(pair.Value != null);
+
+                    foreach (var equalities in pair.Value.Values)
+                    {
+                        FList<Variable> newRight;
+                        if (renaming.TryGetValue(equalities.Two, out newRight))
+                        {
+                            foreach (var y in newRight.GetEnumerable())
+                            {
+                                newPairs.Add(new Pair<Type, Variable>(equalities.One, y));
+                            }
+                        }
+                    }
+
+                    foreach (var newName in newNames.GetEnumerable())
+                    {
+                        newConditions[newName] = new SetOfConstraints<Pair<Type, Variable>>(newPairs);
+                    }
+                }
+            }
+
+            var newDefinitions = new Set<Pair<Type, Variable>>();
+
+            foreach (var equalities in defined.Values)
+            {
+                FList<Variable> newRight;
+                if (renaming.TryGetValue(equalities.Two, out newRight))
+                {
+                    foreach (var y in newRight.GetEnumerable())
+                    {
+                        newDefinitions.Add(new Pair<Type, Variable>(equalities.One, y));
+                    }
+                }
+            }
+
+            return new EnumDefined<Variable, Type, Expression>(newConditions, newDefinitions);
+        }
+
+        #endregion
+
+        #region Abstract Domain operations
+
+        public bool IsBottom
+        {
+            get { return state == State.Bottom; }
+        }
+
+        public bool IsTop
+        {
+            get { return state == State.Top; }
+        }
+
+        public EnumDefined<Variable, Type, Expression> Bottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+                return new EnumDefined<Variable, Type, Expression>(State.Bottom);
+            }
+        }
+
+        public EnumDefined<Variable, Type, Expression> Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+                return new EnumDefined<Variable, Type, Expression>(State.Top);
+            }
+        }
+
+        public bool LessEqual(EnumDefined<Variable, Type, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            bool direct;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, other, out direct))
+            {
+                return direct;
+            }
+
+            Contract.Assume(other.conditions != null);
+            Contract.Assume(other.defined != null);
+
+            return conditions.LessEqual(other.conditions) && defined.LessEqual(other.defined);
+        }
+
+        public EnumDefined<Variable, Type, Expression> Join(EnumDefined<Variable, Type, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+            EnumDefined<Variable, Type, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
+            {
+                return result;
+            }
+
+            Contract.Assume(other.conditions != null);
+            Contract.Assume(other.defined != null);
+
+            return new EnumDefined<Variable, Type, Expression>(conditions.Join(other.conditions), defined.Join(other.defined));
+        }
+
+        public EnumDefined<Variable, Type, Expression> Meet(EnumDefined<Variable, Type, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+            EnumDefined<Variable, Type, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
+            {
+                return result;
+            }
+
+            Contract.Assume(other.conditions != null);
+            Contract.Assume(other.defined != null);
+
+            return new EnumDefined<Variable, Type, Expression>(conditions.Meet(other.conditions), defined.Meet(other.defined));
+        }
+
+
+        public EnumDefined<Variable, Type, Expression> Widening(EnumDefined<Variable, Type, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<EnumDefined<Variable, Type, Expression>>() != null);
+
+            return this.Join(other);
+        }
+        #endregion
+
+        #region Implementation of the interfaces
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            var other = a as EnumDefined<Variable, Type, Expression>;
+            Contract.Assume(other != null);
+            return this.LessEqual(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { return this.Bottom; }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { return this.Top; }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var other = a as EnumDefined<Variable, Type, Expression>;
+            Contract.Assume(other != null);
+            return this.Join(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            var other = a as EnumDefined<Variable, Type, Expression>;
+            Contract.Assume(other != null);
+            return this.Meet(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            var other = prev as EnumDefined<Variable, Type, Expression>;
+            Contract.Assume(other != null);
+            return this.Widening(other);
+        }
+
+        T IAbstractDomain.To<T>(IFactory<T> factory)
+        {
+            return factory.IdentityForAnd;
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        object ICloneable.Clone()
+        {
+            return this;
+        }
+
+        #endregion
+
+        #region IAbstractDomainForEnvironments<Variable,Expression> Members
+
+        virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+        }
+
+
+        public string ToString(Expression exp)
+        {
+            return "not implemented";
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        public List<Variable> Variables
+        {
+            get
+            {
+                var result = new List<Variable>();
+
+                foreach (var pair in conditions.Elements)
+                {
+                    result.Add(pair.Key);
+                    Contract.Assume(pair.Value != null);
+                    foreach (var p in pair.Value.Values)
+                    {
+                        result.Add(p.Two);
+                    }
+                }
+
+                foreach (var pair in defined.Values)
+                {
+                    result.Add(pair.Two);
+                }
+
+                return result;
+            }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            // does nothing
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+            // does nothing
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            // does nothing
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            // does nothing
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            // does nothing
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            return this;
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            return this;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return CheckOutcome.Top;
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Variable,Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            // We should not invoke it
+            throw new Exception();
+        }
+
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            if (this.IsBottom)
+                return "_|_";
+            if (this.IsTop)
+                return "Top";
+            else
+                return string.Format("({0}\n {1})", conditions.ToString(), defined.ToString());
+        }
+        #endregion
+
+        #region Checking
+        public FlatAbstractDomain<bool> CheckIfVariableIsDefined(Variable var, Type type)
+        {
+            if (this.IsBottom)
+            {
+                return CheckOutcome.Bottom;
+            }
+
+            if (this.IsTop)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var goal = new Pair<Type, Variable>(type, var);
+
+            foreach (var pair in defined.Values)
+            {
+                if (goal.Equals(pair))
+                {
+                    return CheckOutcome.True;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+        #endregion
+
+        #region Inspect state
+
+        public IEnumerable<Pair<Type, Variable>> DefinedVariables
+        {
+            get
+            {
+                Contract.Requires(this.IsNormal());
+                Contract.Ensures(Contract.Result<IEnumerable<Pair<Type, Variable>>>() != null);
+
+                return defined.Values;
+            }
+        }
+
+        #endregion
     }
-    #endregion
-
-    #region Inspect state
-
-    public IEnumerable<Pair<Type, Variable>> DefinedVariables
-    {
-      get
-      {
-        Contract.Requires(this.IsNormal());
-        Contract.Ensures(Contract.Result<IEnumerable<Pair<Type, Variable>>>() != null);
-
-        return this.defined.Values;
-      }
-    }
-    
-    #endregion
-  }
-    
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/Evaluator.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/Evaluator.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,709 +10,708 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains.Expressions
 {
-  [ContractVerification(true)]
-  public static class EvaluateArithmeticWithOverflow
-  {
-    static public bool TryBinary(ExpressionOperator op, Int64 e1, Int64 e2, out Int32 res)
+    [ContractVerification(true)]
+    public static class EvaluateArithmeticWithOverflow
     {
-      return new EvalInt32().VisitBinary(op, e1, e2, out res);
-    }
+        static public bool TryBinary(ExpressionOperator op, Int64 e1, Int64 e2, out Int32 res)
+        {
+            return new EvalInt32().VisitBinary(op, e1, e2, out res);
+        }
 
-    static public bool TryBinary(ExpressionOperator op, Int64 e1, Int64 e2, out UInt32 res)
-    {
-      return new EvalUInt32().VisitBinary(op, e1, e2, out res);
-    }
+        static public bool TryBinary(ExpressionOperator op, Int64 e1, Int64 e2, out UInt32 res)
+        {
+            return new EvalUInt32().VisitBinary(op, e1, e2, out res);
+        }
 
-    static public bool TryBinary<In>(ExpressionType targetType, ExpressionOperator op, In e1, In e2, out object res)
-      where In: struct
-    {
-      res = default(object);
-      
-      switch (targetType)
-      {
-        case ExpressionType.Int32:
-          {
-            var unboxed1 = e1.ForceInt64();
-            var unboxed2 = e2.ForceInt64();
-            Int32 cheat;
-            if (unboxed1.HasValue && unboxed2.HasValue &&
-              TryBinary(op, unboxed1.Value, unboxed2.Value, out cheat))
+        static public bool TryBinary<In>(ExpressionType targetType, ExpressionOperator op, In e1, In e2, out object res)
+          where In : struct
+        {
+            res = default(object);
+
+            switch (targetType)
             {
-              res = cheat;
-              return true;
-            }
-            return false;
-          }
+                case ExpressionType.Int32:
+                    {
+                        var unboxed1 = e1.ForceInt64();
+                        var unboxed2 = e2.ForceInt64();
+                        Int32 cheat;
+                        if (unboxed1.HasValue && unboxed2.HasValue &&
+                          TryBinary(op, unboxed1.Value, unboxed2.Value, out cheat))
+                        {
+                            res = cheat;
+                            return true;
+                        }
+                        return false;
+                    }
 
-        case ExpressionType.UInt32:
-          {
-            var unboxed1 = e1.ForceInt64();
-            var unboxed2 = e2.ForceInt64();
-            UInt32 cheat;
-            if (unboxed1.HasValue && unboxed2.HasValue &&
-              TryBinary(op, unboxed1.Value, unboxed2.Value, out cheat))
+                case ExpressionType.UInt32:
+                    {
+                        var unboxed1 = e1.ForceInt64();
+                        var unboxed2 = e2.ForceInt64();
+                        UInt32 cheat;
+                        if (unboxed1.HasValue && unboxed2.HasValue &&
+                          TryBinary(op, unboxed1.Value, unboxed2.Value, out cheat))
+                        {
+                            res = cheat;
+                            return true;
+                        }
+                        return false;
+                    }
+
+
+                case ExpressionType.Int8:
+                case ExpressionType.Int16:
+                case ExpressionType.Int64:
+
+                case ExpressionType.UInt8:
+                case ExpressionType.UInt16:
+                case ExpressionType.UInt64:
+
+                case ExpressionType.String:
+                case ExpressionType.Bool:
+                case ExpressionType.Float32:
+                case ExpressionType.Float64:
+                case ExpressionType.Unknown:
+                    {
+                        return false;
+                    }
+            }
+
+            Contract.Assert(false);  // Should be unreachable
+            return false;
+        }
+
+
+        private class EvalInt32 : GenericConstEvalVisitor<Int64, Int32>
+        {
+            protected override bool VisitAddition(long left, long right, out int r)
             {
-              res = cheat;
-              return true;
+                r = (Int32)left + (Int32)right;
+                return true;
             }
+
+            protected override bool VisitAnd(long left, long right, out int r)
+            {
+                r = (Int32)left & (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitConvertToInt32(long left, out int r)
+            {
+                r = (Int32)left;
+                return true;
+            }
+
+            protected override bool VisitDivision(long left, long right, out int r)
+            {
+                if (right == 0 || (((int)left) == Int32.MinValue && ((int)right == -1)))
+                {
+                    r = default(int);
+                    return false;
+                }
+                r = (Int32)left / (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitEqual(long left, long right, out int r)
+            {
+                r = (Int32)left == (Int32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitGreaterEqualThan(long left, long right, out int r)
+            {
+                r = (Int32)left >= (Int32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitGreaterEqualThan_Un(long left, long right, out int r)
+            {
+                r = (UInt32)left >= (UInt32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitGreaterThan(long left, long right, out int r)
+            {
+                r = (Int32)left > (Int32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitLessEqualThan(long left, long right, out int r)
+            {
+                r = (Int32)left <= (Int32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitGreaterThan_Un(long left, long right, out int r)
+            {
+                r = (UInt32)left > (UInt32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitLessEqualThan_Un(long left, long right, out int r)
+            {
+                r = (UInt32)left <= (UInt32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitLessThan(long left, long right, out int r)
+            {
+                r = (Int32)left < (Int32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitLessThan_Un(long left, long right, out int r)
+            {
+                r = (UInt32)left < (UInt32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitModulus(long left, long right, out int r)
+            {
+                if (right == 0)
+                {
+                    r = default(int);
+                    return false;
+                }
+                r = (Int32)left % (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitShiftLeft(long left, long right, out int r)
+            {
+                r = (Int32)left << (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitShiftRight(long left, long right, out int r)
+            {
+                r = (Int32)left >> (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitMultiplication(long left, long right, out int r)
+            {
+                r = (Int32)left * (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitNot(long left, out int r)
+            {
+                r = ~((Int32)left);
+                return true;
+            }
+
+            protected override bool VisitNotEqual(long left, long right, out int r)
+            {
+                r = (Int32)left != (Int32)right ? 1 : 0;
+                return true;
+            }
+
+            protected override bool VisitSubtraction(long left, long right, out int r)
+            {
+                r = (Int32)(left - right);
+                return true;
+            }
+
+            protected override bool VisitUnaryMinus(long left, out int r)
+            {
+                var asInt = (Int32)left;
+
+                if (asInt == Int32.MinValue)
+                {
+                    r = default(int);
+                    return false;
+                }
+
+                r = -asInt;
+                return true;
+            }
+
+            protected override bool VisitXor(long left, long right, out int r)
+            {
+                r = (Int32)left ^ (Int32)right;
+                return true;
+            }
+        }
+
+        private class EvalUInt32 : GenericConstEvalVisitor<Int64, UInt32>
+        {
+            protected override bool VisitAddition(long left, long right, out uint r)
+            {
+                r = (UInt32)left + (UInt32)right;
+                return true;
+            }
+
+            protected override bool VisitAnd(long left, long right, out uint r)
+            {
+                r = (UInt32)left & (UInt32)right;
+                return true;
+            }
+
+            protected override bool VisitConvertToUInt32(long left, out uint r)
+            {
+                r = (UInt32)left;
+                return true;
+            }
+
+            protected override bool VisitDivision(long left, long right, out uint r)
+            {
+                if (right == 0)
+                {
+                    r = default(int);
+                    return false;
+                }
+                r = (UInt32)left / (UInt32)right;
+                return true;
+            }
+
+            protected override bool VisitEqual(long left, long right, out uint r)
+            {
+                r = (UInt32)left == (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitGreaterEqualThan(long left, long right, out uint r)
+            {
+                r = (UInt32)left >= (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitGreaterEqualThan_Un(long left, long right, out uint r)
+            {
+                r = (UInt32)left >= (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitGreaterThan(long left, long right, out uint r)
+            {
+                r = (UInt32)left > (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitLessEqualThan(long left, long right, out uint r)
+            {
+                r = (UInt32)left <= (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitGreaterThan_Un(long left, long right, out uint r)
+            {
+                r = (UInt32)left > (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitLessEqualThan_Un(long left, long right, out uint r)
+            {
+                r = (UInt32)left <= (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitLessThan(long left, long right, out uint r)
+            {
+                r = (UInt32)left < (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitLessThan_Un(long left, long right, out uint r)
+            {
+                r = (UInt32)left < (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitModulus(long left, long right, out uint r)
+            {
+                if (right == 0)
+                {
+                    r = default(int);
+                    return false;
+                }
+                r = (UInt32)left % (UInt32)right;
+                return true;
+            }
+
+            protected override bool VisitShiftLeft(long left, long right, out uint r)
+            {
+                r = (UInt32)left << (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitShiftRight(long left, long right, out uint r)
+            {
+                r = (UInt32)left >> (Int32)right;
+                return true;
+            }
+
+            protected override bool VisitMultiplication(long left, long right, out uint r)
+            {
+                r = (UInt32)left * (UInt32)right;
+                return true;
+            }
+
+            protected override bool VisitNot(long left, out uint r)
+            {
+                r = ~((UInt32)left);
+                return true;
+            }
+
+            protected override bool VisitNotEqual(long left, long right, out uint r)
+            {
+                r = (UInt32)left != (UInt32)right ? 1u : 0u;
+                return true;
+            }
+
+            protected override bool VisitSubtraction(long left, long right, out uint r)
+            {
+                r = (UInt32)left - (UInt32)right;
+                return true;
+            }
+
+            protected override bool VisitUnaryMinus(long left, out uint r)
+            {
+                if (left == Int64.MinValue)
+                {
+                    r = default(uint);
+                    return false;
+                }
+                r = (UInt32)(-left);
+                return true;
+            }
+
+            protected override bool VisitXor(long left, long right, out uint r)
+            {
+                r = (UInt32)left ^ (UInt32)right;
+                return true;
+            }
+        }
+    }
+
+    [ContractVerification(true)]
+    abstract public class GenericConstEvalVisitor<In, Out>
+    {
+        protected bool Default(out Out r)
+        {
+            r = default(Out);
             return false;
-          }
-
-
-        case ExpressionType.Int8:
-        case ExpressionType.Int16:
-        case ExpressionType.Int64:
-
-        case ExpressionType.UInt8:
-        case ExpressionType.UInt16:
-        case ExpressionType.UInt64:
-
-        case ExpressionType.String:
-        case ExpressionType.Bool:
-        case ExpressionType.Float32:
-        case ExpressionType.Float64:
-        case ExpressionType.Unknown:
-          {
-            return false;
-          }
-      }
-
-      Contract.Assert(false);  // Should be unreachable
-      return false;
-    }
-
- 
-    private class EvalInt32 : GenericConstEvalVisitor<Int64, Int32>
-    {
-      protected override bool VisitAddition(long left, long right, out int r)
-      {
-        r = (Int32)left + (Int32)right;
-        return true;
-      }
-
-      protected override bool VisitAnd(long left, long right, out int r)
-      {
-        r = (Int32)left & (Int32)right;
-        return true;
-      }
-
-      protected override bool VisitConvertToInt32(long left, out int r)
-      {
-          r = (Int32)left;
-          return true;
-      }
-
-      protected override bool VisitDivision(long left, long right, out int r)
-      {
-        if (right == 0 || (((int)left) == Int32.MinValue && ((int)right == -1)))
-        {
-          r = default(int);
-          return false;
         }
-        r = (Int32)left / (Int32)right;
-        return true;
-      }
 
-      protected override bool VisitEqual(long left, long right, out int r)
-      {
-        r = (Int32)left == (Int32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitGreaterEqualThan(long left, long right, out int r)
-      {
-        r = (Int32)left >= (Int32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitGreaterEqualThan_Un(long left, long right, out int r)
-      {
-        r = (UInt32)left >= (UInt32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitGreaterThan(long left, long right, out int r)
-      {
-        r = (Int32)left > (Int32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitLessEqualThan(long left, long right, out int r)
-      {
-        r = (Int32)left <= (Int32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitGreaterThan_Un(long left, long right, out int r)
-      {
-        r = (UInt32)left > (UInt32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitLessEqualThan_Un(long left, long right, out int r)
-      {
-        r = (UInt32)left <= (UInt32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitLessThan(long left, long right, out int r)
-      {
-        r = (Int32)left < (Int32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitLessThan_Un(long left, long right, out int r)
-      {
-        r = (UInt32)left < (UInt32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitModulus(long left, long right, out int r)
-      {
-        if (right == 0)
+        public bool VisitBinary(ExpressionOperator op, In left, In right, out Out r)
         {
-          r = default(int);
-          return false;
+            try
+            {
+                switch (op)
+                {
+                    #region All the cases
+                    case ExpressionOperator.Addition:
+                        return VisitAddition(left, right, out r);
+
+                    case ExpressionOperator.And:
+                        return VisitAnd(left, right, out r);
+
+                    case ExpressionOperator.Division:
+                        return VisitDivision(left, right, out r);
+
+                    case ExpressionOperator.Equal:
+                    case ExpressionOperator.Equal_Obj:
+                        return VisitEqual(left, right, out r);
+
+                    case ExpressionOperator.GreaterEqualThan:
+                        return VisitGreaterEqualThan(left, right, out r);
+
+                    case ExpressionOperator.GreaterEqualThan_Un:
+                        return VisitGreaterEqualThan_Un(left, right, out r);
+
+                    case ExpressionOperator.GreaterThan:
+                        return VisitGreaterThan(left, right, out r);
+
+                    case ExpressionOperator.GreaterThan_Un:
+                        return VisitGreaterThan_Un(left, right, out r);
+
+                    case ExpressionOperator.LessEqualThan:
+                        return VisitLessEqualThan(left, right, out r);
+
+                    case ExpressionOperator.LessEqualThan_Un:
+                        return VisitLessEqualThan_Un(left, right, out r);
+
+                    case ExpressionOperator.LessThan:
+                        return VisitLessThan(left, right, out r);
+
+                    case ExpressionOperator.LessThan_Un:
+                        return VisitLessThan_Un(left, right, out r);
+
+                    case ExpressionOperator.LogicalAnd:
+                        return VisitLogicalAnd(left, right, out r);
+
+                    case ExpressionOperator.LogicalOr:
+                        return VisitLogicalOr(left, right, out r);
+
+                    case ExpressionOperator.Modulus:
+                        return VisitModulus(left, right, out r);
+
+                    case ExpressionOperator.Multiplication:
+                        return VisitMultiplication(left, right, out r);
+
+                    case ExpressionOperator.NotEqual:
+                        return VisitNotEqual(left, right, out r);
+
+                    case ExpressionOperator.Or:
+                        return VisitOr(left, right, out r);
+
+                    case ExpressionOperator.ShiftLeft:
+                        return VisitShiftLeft(left, right, out r);
+
+                    case ExpressionOperator.ShiftRight:
+                        return VisitShiftRight(left, right, out r);
+
+                    case ExpressionOperator.Subtraction:
+                        return VisitSubtraction(left, right, out r);
+
+                    case ExpressionOperator.Unknown:
+                        return VisitUnknown(left, out r);
+
+                    case ExpressionOperator.WritableBytes:
+                        return VisitWritableBytes(left, right, out r);
+
+                    case ExpressionOperator.Xor:
+                        return VisitXor(left, right, out r);
+
+                    default:
+                        // We do not care for the other cases
+                        return Default(out r);
+                        #endregion
+                }
+            }
+            catch (ArithmeticException)
+            {
+                r = default(Out);
+                return false;
+            }
         }
-        r = (Int32)left % (Int32)right;
-        return true;      
-      }
 
-      protected override bool VisitShiftLeft(long left, long right, out int r)
-      {
-        r = (Int32)left << (Int32)right;
-        return true;
-      }
-
-      protected override bool VisitShiftRight(long left, long right, out int r)
-      {
-        r = (Int32)left >> (Int32)right;
-        return true;
-      }
-
-      protected override bool VisitMultiplication(long left, long right, out int r)
-      {
-        r = (Int32)left * (Int32)right;
-        return true;
-      }
-
-      protected override bool VisitNot(long left, out int r)
-      {
-        r = ~((Int32)left);
-        return true;
-      }
-
-      protected override bool VisitNotEqual(long left, long right, out int r)
-      {
-        r = (Int32)left != (Int32)right ? 1 : 0;
-        return true;
-      }
-
-      protected override bool VisitSubtraction(long left, long right, out int r)
-      {
-        r = (Int32)(left -right);
-        return true;
-      }
-
-      protected override bool VisitUnaryMinus(long left, out int r)
-      {
-        var asInt = (Int32)left;
-
-        if (asInt == Int32.MinValue)
+        public bool VisitUnary(ExpressionOperator op, In left, out Out r)
         {
-          r = default(int);
-          return false;
+            try
+            {
+                switch (op)
+                {
+                    case ExpressionOperator.Constant:
+                        return VisitConstant(left, out r);
+
+                    case ExpressionOperator.ConvertToInt32:
+                        return VisitConvertToInt32(left, out r);
+
+                    case ExpressionOperator.ConvertToUInt8:
+                        return VisitConvertToUInt8(left, out r);
+
+                    case ExpressionOperator.ConvertToUInt16:
+                        return VisitConvertToUInt16(left, out r);
+
+                    case ExpressionOperator.ConvertToFloat32:
+                        return VisitConvertToFloat32(left, out r);
+
+                    case ExpressionOperator.ConvertToFloat64:
+                        return VisitConvertToFloat64(left, out r);
+
+                    case ExpressionOperator.ConvertToUInt32:
+                        return VisitConvertToUInt32(left, out r);
+
+                    case ExpressionOperator.LogicalNot:
+                        return VisitLogicalNot(left, out r);
+
+                    case ExpressionOperator.Not:
+                        return VisitNot(left, out r);
+
+                    case ExpressionOperator.SizeOf:
+                        return VisitSizeOf(left, out r);
+
+                    case ExpressionOperator.UnaryMinus:
+                        return VisitUnaryMinus(left, out r);
+
+                    default:
+                        return Default(out r);
+                }
+            }
+            catch (ArithmeticException)
+            {
+                return Default(out r);
+            }
         }
-        
-        r = -asInt;
-        return true;
-      }
 
-      protected override bool VisitXor(long left, long right, out int r)
-      {
-        r = (Int32)left ^ (Int32)right;
-        return true;
-      }
-    }
-
-    private class EvalUInt32 : GenericConstEvalVisitor<Int64, UInt32>
-    {
-      protected override bool VisitAddition(long left, long right, out uint r)
-      {
-        r = (UInt32)left + (UInt32)right;
-        return true;
-      }
-
-      protected override bool VisitAnd(long left, long right, out uint r)
-      {
-        r = (UInt32)left & (UInt32)right;
-        return true;
-      }
-
-      protected override bool VisitConvertToUInt32(long left, out uint r)
-      {
-        r = (UInt32)left;
-        return true;
-      }
-
-      protected override bool VisitDivision(long left, long right, out uint r)
-      {
-        if (right == 0)
+        #region All the cases
+        virtual protected bool VisitUnaryMinus(In left, out Out r)
         {
-          r = default(int);
-          return false;
-        }
-        r = (UInt32)left / (UInt32)right;
-        return true;
-      }
-
-      protected override bool VisitEqual(long left, long right, out uint r)
-      {
-        r = (UInt32)left == (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitGreaterEqualThan(long left, long right, out uint r)
-      {
-        r = (UInt32)left >= (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitGreaterEqualThan_Un(long left, long right, out uint r)
-      {
-        r = (UInt32)left >= (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitGreaterThan(long left, long right, out uint r)
-      {
-        r = (UInt32)left > (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitLessEqualThan(long left, long right, out uint r)
-      {
-        r = (UInt32)left <= (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitGreaterThan_Un(long left, long right, out uint r)
-      {
-        r = (UInt32)left > (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitLessEqualThan_Un(long left, long right, out uint r)
-      {
-        r = (UInt32)left <= (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitLessThan(long left, long right, out uint r)
-      {
-        r = (UInt32)left < (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitLessThan_Un(long left, long right, out uint r)
-      {
-        r = (UInt32)left < (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitModulus(long left, long right, out uint r)
-      {
-        if (right == 0)
-        {
-          r = default(int);
-          return false;
-        }
-        r = (UInt32)left % (UInt32)right;
-        return true;
-      }
-
-      protected override bool VisitShiftLeft(long left, long right, out uint r)
-      {
-        r = (UInt32)left << (Int32)right;
-        return true;
-      }
-
-      protected override bool VisitShiftRight(long left, long right, out uint r)
-      {
-        r = (UInt32)left >> (Int32)right;
-        return true;
-      }
-
-      protected override bool VisitMultiplication(long left, long right, out uint r)
-      {
-        r = (UInt32)left * (UInt32)right;
-        return true;
-      }
-
-      protected override bool VisitNot(long left, out uint r)
-      {
-        r = ~((UInt32)left);
-        return true;
-      }
-
-      protected override bool VisitNotEqual(long left, long right, out uint r)
-      {
-        r = (UInt32)left != (UInt32)right ? 1u : 0u;
-        return true;
-      }
-
-      protected override bool VisitSubtraction(long left, long right, out uint r)
-      {
-        r = (UInt32)left - (UInt32)right;
-        return true;
-      }
-
-      protected override bool VisitUnaryMinus(long left, out uint r)
-      {
-        if (left == Int64.MinValue)
-        {
-          r = default(uint);
-          return false;
-        }
-        r = (UInt32)(-left);
-        return true;
-      }
-
-      protected override bool VisitXor(long left, long right, out uint r)
-      {
-        r = (UInt32)left ^ (UInt32)right;
-        return true;
-      }
-    }
-  }
-
-  [ContractVerification(true)]
-  abstract public class GenericConstEvalVisitor<In, Out>
-  {
-    protected bool Default(out Out r)
-    {
-      r = default(Out);
-      return false;
-    }
-
-    public bool VisitBinary(ExpressionOperator op, In left, In right, out Out r)
-    {
-      try
-      {
-        switch (op)
-        {
-          #region All the cases
-          case ExpressionOperator.Addition:
-            return VisitAddition(left, right, out r);
-
-          case ExpressionOperator.And:
-            return VisitAnd(left, right, out r);
-
-          case ExpressionOperator.Division:
-            return VisitDivision(left, right, out r);
-
-          case ExpressionOperator.Equal:
-          case ExpressionOperator.Equal_Obj:
-            return VisitEqual(left, right, out r);
-
-          case ExpressionOperator.GreaterEqualThan:
-            return VisitGreaterEqualThan(left, right, out r);
-
-          case ExpressionOperator.GreaterEqualThan_Un:
-            return VisitGreaterEqualThan_Un(left, right, out r);
-
-          case ExpressionOperator.GreaterThan:
-            return VisitGreaterThan(left, right, out r);
-
-          case ExpressionOperator.GreaterThan_Un:
-            return VisitGreaterThan_Un(left, right, out r);
-
-          case ExpressionOperator.LessEqualThan:
-            return VisitLessEqualThan(left, right, out r);
-
-          case ExpressionOperator.LessEqualThan_Un:
-            return VisitLessEqualThan_Un(left, right, out r);
-
-          case ExpressionOperator.LessThan:
-            return VisitLessThan(left, right, out r);
-
-          case ExpressionOperator.LessThan_Un:
-            return VisitLessThan_Un(left, right, out r);
-
-          case ExpressionOperator.LogicalAnd:
-            return VisitLogicalAnd(left, right, out r);
-
-          case ExpressionOperator.LogicalOr:
-            return VisitLogicalOr(left, right, out r);
-
-          case ExpressionOperator.Modulus:
-            return VisitModulus(left, right, out r);
-
-          case ExpressionOperator.Multiplication:
-            return VisitMultiplication(left, right, out r);
-
-          case ExpressionOperator.NotEqual:
-            return VisitNotEqual(left, right, out r);
-
-          case ExpressionOperator.Or:
-            return VisitOr(left, right, out r);
-
-          case ExpressionOperator.ShiftLeft:
-            return VisitShiftLeft(left, right, out r);
-
-          case ExpressionOperator.ShiftRight:
-            return VisitShiftRight(left, right, out r);
-
-          case ExpressionOperator.Subtraction:
-            return VisitSubtraction(left, right, out r);
-
-          case ExpressionOperator.Unknown:
-            return VisitUnknown(left, out r);
-
-          case ExpressionOperator.WritableBytes:
-            return VisitWritableBytes(left, right, out r);
-
-          case ExpressionOperator.Xor:
-            return VisitXor(left, right, out r);
-
-          default:
-            // We do not care for the other cases
-            return Default(out r);
-          #endregion
-        }
-      }
-      catch (ArithmeticException)
-      {
-        r = default(Out);
-        return false;
-      }
-    }
-
-    public bool VisitUnary(ExpressionOperator op, In left, out Out r)
-    {
-      try
-      {
-        switch (op)
-        {
-          case ExpressionOperator.Constant:
-            return VisitConstant(left, out r);
-
-          case ExpressionOperator.ConvertToInt32:
-            return VisitConvertToInt32(left, out r);
-
-          case ExpressionOperator.ConvertToUInt8:
-            return VisitConvertToUInt8(left, out r);
-
-          case ExpressionOperator.ConvertToUInt16:
-            return VisitConvertToUInt16(left, out r);
-
-          case ExpressionOperator.ConvertToFloat32:
-            return VisitConvertToFloat32(left, out r);
-
-          case ExpressionOperator.ConvertToFloat64:
-            return VisitConvertToFloat64(left, out r);
-
-          case ExpressionOperator.ConvertToUInt32:
-            return VisitConvertToUInt32(left, out r);
-
-          case ExpressionOperator.LogicalNot:
-            return VisitLogicalNot(left, out r);
-
-          case ExpressionOperator.Not:
-            return VisitNot(left, out r);
-
-          case ExpressionOperator.SizeOf:
-            return VisitSizeOf(left, out r);
-
-          case ExpressionOperator.UnaryMinus:
-            return VisitUnaryMinus(left, out r);
-
-          default:
             return Default(out r);
         }
-      }
-      catch (ArithmeticException)
-      {
-        return Default(out r);
-      }
-    }
 
-    #region All the cases
-    virtual protected bool VisitUnaryMinus(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitSizeOf(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitSizeOf(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitNot(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitNot(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitLogicalNot(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitLogicalNot(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitConvertToUInt32(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitConvertToUInt32(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitConvertToFloat64(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitConvertToFloat64(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitConvertToFloat32(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitConvertToFloat32(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitConvertToUInt16(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitConvertToUInt16(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitConvertToUInt8(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitConvertToUInt8(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitConvertToInt32(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitConvertToInt32(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitConstant(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitConstant(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitXor(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitXor(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitWritableBytes(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitWritableBytes(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitUnknown(In left, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitUnknown(In left, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitSubtraction(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitSubtraction(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitShiftRight(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitShiftRight(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitShiftLeft(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitShiftLeft(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitOr(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitOr(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitNotEqual(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitNotEqual(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitMultiplication(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitMultiplication(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitModulus(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitModulus(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitLogicalOr(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitLogicalOr(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitLogicalAnd(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitLogicalAnd(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitLessThan_Un(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitLessThan_Un(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitLessThan(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitLessThan(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitLessEqualThan_Un(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitLessEqualThan_Un(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitLessEqualThan(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitLessEqualThan(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitGreaterThan_Un(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitGreaterThan_Un(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitGreaterThan(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitGreaterThan(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitGreaterEqualThan_Un(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitGreaterEqualThan_Un(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitGreaterEqualThan(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitGreaterEqualThan(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitEqual(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitEqual(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitDivision(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitDivision(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
+        virtual protected bool VisitAnd(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
 
-    virtual protected bool VisitAnd(In left, In right, out Out r)
-    {
-      return Default(out r);
+        virtual protected bool VisitAddition(In left, In right, out Out r)
+        {
+            return Default(out r);
+        }
+        #endregion
     }
-
-    virtual protected bool VisitAddition(In left, In right, out Out r)
-    {
-      return Default(out r);
-    }
-    #endregion
-  }
-
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/ExpressionManipulation.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/ExpressionManipulation.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Few classes for helping manipulating expressions
 // 
@@ -25,524 +14,523 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Expressions
 {
-  using System.Collections.Generic;
-  using System.Diagnostics.Contracts;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
 
-  /// <summary>
-  /// The default comparer for variables
-  /// </summary>
-  internal class ExpressionComparer<Variable> : IComparer<Variable>
-  {
     /// <summary>
-    /// Uses the <code>CompareTo</code> for strings to get the total order over strings
+    /// The default comparer for variables
     /// </summary>
-    public int Compare(Variable left, Variable right)
+    internal class ExpressionComparer<Variable> : IComparer<Variable>
     {
-      Contract.Assume(left != null); // cannot strengthen the interface contract
-      Contract.Assume(right != null);
-  
-      return left.ToString().CompareTo(right.ToString());
-    }
-  }
-
-
-  /// <summary>
-  /// Pretty print the expressions
-  /// </summary>
-  public static class ExpressionPrinter
-  {
-    private const int MaxHeight = 16;
-    private const string TRUE = "1";
-    [ThreadStatic]
-    private static bool ToStringInvokedFromTheOutside;
-
-    public static string ToGeqZero<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return "0 <= " + ToString(exp, decoder);
-    }
-
-    public static string ToLessThan<Variable, Expression>(Expression left, Expression right, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return ToString(left, decoder) + " < " + ToString(right, decoder);
-    }
-
-    /// <returns>A string representation of the expression exp</returns>
-    public static string ToString<Variable, Expression>(Expression  exp, IExpressionDecoder<Variable, Expression>  decoder)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      Contract.Assume(!ToStringInvokedFromTheOutside); // This method can be invoked just from the outside of the class
-
-      ToStringInvokedFromTheOutside = true;
-      
-      var result = ToString(exp, decoder, 0);
-      
-      ToStringInvokedFromTheOutside = false;
-
-      return result;
-    }
-
-    /// <returns>A string representation of the expression exp</returns>
-    public static string ToString<Variable, Expression>(Variable  exp, IExpressionDecoder<Variable, Expression>  decoder)
-    {
-      return decoder.NameOf(exp);
-    }
-
-    /// <returns>
-    /// A (textual representation of the) C# operator for <code>op</code>
-    /// </returns>
-    public static string ToString(ExpressionOperator op)
-    {
-      switch (op)
-      {
-        case ExpressionOperator.Addition:
-          return "+";
-        case ExpressionOperator.And:
-          return "&";
-        case ExpressionOperator.Constant:
-          return "<CONST>";
-        case ExpressionOperator.ConvertToInt32:
-          return "(Int32)";
-        case ExpressionOperator.ConvertToUInt16:
-          return "(UInt16)";
-        case ExpressionOperator.ConvertToUInt32:
-          return "(UInt32)";
-        case ExpressionOperator.ConvertToUInt8:
-          return "(UInt8)";
-        case ExpressionOperator.ConvertToFloat32:
-          return "(Single)";
-        case ExpressionOperator.ConvertToFloat64:
-          return "(Double)";
-        case ExpressionOperator.Division:
-          return "/";
-        case ExpressionOperator.Equal:
-          return "==";
-        case ExpressionOperator.Equal_Obj:
-          return "=Equals=";
-        case ExpressionOperator.GreaterEqualThan:
-          return ">=";
-        case ExpressionOperator.GreaterEqualThan_Un:
-          return ">=_un";
-        case ExpressionOperator.GreaterThan:
-          return ">";
-        case ExpressionOperator.GreaterThan_Un:
-          return ">_un";
-        case ExpressionOperator.LessEqualThan:
-          return "<=";
-        case ExpressionOperator.LessEqualThan_Un:
-          return "<=_un";
-        case ExpressionOperator.LessThan:
-          return "<";
-        case ExpressionOperator.LessThan_Un:
-          return "<_un";
-        case ExpressionOperator.LogicalAnd:
-          return "&&";
-        case ExpressionOperator.LogicalNot:
-          return "!";
-        case ExpressionOperator.LogicalOr:
-          return "||";
-        case ExpressionOperator.Modulus:
-          return "%";
-        case ExpressionOperator.Multiplication:
-          return "*";
-        case ExpressionOperator.Not:
-          return "!";
-        case ExpressionOperator.NotEqual:
-          return "!=";
-        case ExpressionOperator.Or:
-          return "|";
-        case ExpressionOperator.Xor:
-          return "^";
-        case ExpressionOperator.ShiftLeft:
-          return "<<";
-        case ExpressionOperator.ShiftRight:
-          return ">>";
-        case ExpressionOperator.SizeOf:
-          return "sizeof";
-        case ExpressionOperator.Subtraction:
-          return "-";
-        case ExpressionOperator.UnaryMinus:
-          return "-";
-        case ExpressionOperator.Unknown:
-          return "<???>";
-        case ExpressionOperator.Variable:
-          return "<VAR>";
-        case ExpressionOperator.WritableBytes:
-          return "<WritableBytes>";
-        default:
-          return "<????>";
-      }
-    }
-    
-    private static string ToString<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder, int height)
-    {
-      Contract.Requires(decoder != null);
-      Contract.Requires(height >= 0);
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      if (height > MaxHeight)
-      {
-        return "<too deep in the exp>";
-      }
-      else
-      {
-        switch (decoder.OperatorFor(exp))
+        /// <summary>
+        /// Uses the <code>CompareTo</code> for strings to get the total order over strings
+        /// </summary>
+        public int Compare(Variable left, Variable right)
         {
-          #region All the cases...
-          case ExpressionOperator.Addition:
-            return BinaryPrint("+", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height+1);
-          case ExpressionOperator.And:
-            return BinaryPrint("&", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Constant:
-            return ConstantPrint(exp, decoder, height + 1);
-          case ExpressionOperator.ConvertToInt32:
-            return UnaryPrint("(int32)", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.ConvertToUInt8:
-            return UnaryPrint("(uint8)", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.ConvertToUInt16:
-            return UnaryPrint("(uint16)", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.ConvertToUInt32:
-            return UnaryPrint("(uint32)", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.ConvertToFloat32:
-            return UnaryPrint("(Single)", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.ConvertToFloat64:
-            return UnaryPrint("(Double)", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Division:
-            return BinaryPrint("/", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Equal:
-            return BinaryPrint("==", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Equal_Obj:
-            return BinaryPrint("=Equals=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.GreaterEqualThan:
-            return BinaryPrint(">=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.GreaterEqualThan_Un:
-            return BinaryPrint(">=_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.GreaterThan:
-            return BinaryPrint(">", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.GreaterThan_Un:
-            return BinaryPrint(">_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.LessEqualThan:
-            return BinaryPrint("<=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.LessEqualThan_Un:
-            return BinaryPrint("<=_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.LessThan:
-            return BinaryPrint("<", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.LessThan_Un:
-            return BinaryPrint("<_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.LogicalAnd:
-            return BinaryPrint("&&", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.LogicalNot:
-            return UnaryPrint("!", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.LogicalOr:
-            return BinaryPrint("||", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Modulus:
-            return BinaryPrint("%", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Multiplication:
-            return BinaryPrint("*", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Not:
-            return UnaryPrint("!", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.NotEqual:
-            return BinaryPrint("!=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Or:
-            return BinaryPrint("|", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Xor:
-            return BinaryPrint("^", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.ShiftLeft:
-            return BinaryPrint("<<", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.ShiftRight:
-            return BinaryPrint(">>", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.SizeOf:
-            return SizeOfPrint(exp, decoder, height + 1);
-          case ExpressionOperator.Subtraction:
-            return BinaryPrint("-", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.UnaryMinus:
-            return UnaryPrint("-", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Variable:
-            return VariablePrint(decoder.UnderlyingVariable(exp), decoder, height + 1);
-          case ExpressionOperator.WritableBytes:
-            return exp.ToString();
-            // return UnaryPrint("WritableBytes", decoder.LeftExpressionFor(exp), decoder, height + 1);
-          case ExpressionOperator.Unknown:
-            return "<Unknown expression>";
-          default:
-            throw new AbstractInterpretationException("Error, unknown case!!!!" + decoder.OperatorFor(exp));
-          #endregion
+            Contract.Assume(left != null); // cannot strengthen the interface contract
+            Contract.Assume(right != null);
+
+            return left.ToString().CompareTo(right.ToString());
         }
-      }
     }
 
-    private static string UnaryPrint<Variable, Expression>(string p, Expression p_2, IExpressionDecoder<Variable, Expression> decoder, int height)
+
+    /// <summary>
+    /// Pretty print the expressions
+    /// </summary>
+    public static class ExpressionPrinter
     {
-      Contract.Requires(p != null);
-      Contract.Ensures(Contract.Result<string>() != null);
+        private const int MaxHeight = 16;
+        private const string TRUE = "1";
+        [ThreadStatic]
+        private static bool ToStringInvokedFromTheOutside;
 
-      string s = ToString(p_2, decoder, height + 1);
-      return p + "( " + s + " )";
+        public static string ToGeqZero<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return "0 <= " + ToString(exp, decoder);
+        }
+
+        public static string ToLessThan<Variable, Expression>(Expression left, Expression right, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return ToString(left, decoder) + " < " + ToString(right, decoder);
+        }
+
+        /// <returns>A string representation of the expression exp</returns>
+        public static string ToString<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            Contract.Assume(!ToStringInvokedFromTheOutside); // This method can be invoked just from the outside of the class
+
+            ToStringInvokedFromTheOutside = true;
+
+            var result = ToString(exp, decoder, 0);
+
+            ToStringInvokedFromTheOutside = false;
+
+            return result;
+        }
+
+        /// <returns>A string representation of the expression exp</returns>
+        public static string ToString<Variable, Expression>(Variable exp, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            return decoder.NameOf(exp);
+        }
+
+        /// <returns>
+        /// A (textual representation of the) C# operator for <code>op</code>
+        /// </returns>
+        public static string ToString(ExpressionOperator op)
+        {
+            switch (op)
+            {
+                case ExpressionOperator.Addition:
+                    return "+";
+                case ExpressionOperator.And:
+                    return "&";
+                case ExpressionOperator.Constant:
+                    return "<CONST>";
+                case ExpressionOperator.ConvertToInt32:
+                    return "(Int32)";
+                case ExpressionOperator.ConvertToUInt16:
+                    return "(UInt16)";
+                case ExpressionOperator.ConvertToUInt32:
+                    return "(UInt32)";
+                case ExpressionOperator.ConvertToUInt8:
+                    return "(UInt8)";
+                case ExpressionOperator.ConvertToFloat32:
+                    return "(Single)";
+                case ExpressionOperator.ConvertToFloat64:
+                    return "(Double)";
+                case ExpressionOperator.Division:
+                    return "/";
+                case ExpressionOperator.Equal:
+                    return "==";
+                case ExpressionOperator.Equal_Obj:
+                    return "=Equals=";
+                case ExpressionOperator.GreaterEqualThan:
+                    return ">=";
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    return ">=_un";
+                case ExpressionOperator.GreaterThan:
+                    return ">";
+                case ExpressionOperator.GreaterThan_Un:
+                    return ">_un";
+                case ExpressionOperator.LessEqualThan:
+                    return "<=";
+                case ExpressionOperator.LessEqualThan_Un:
+                    return "<=_un";
+                case ExpressionOperator.LessThan:
+                    return "<";
+                case ExpressionOperator.LessThan_Un:
+                    return "<_un";
+                case ExpressionOperator.LogicalAnd:
+                    return "&&";
+                case ExpressionOperator.LogicalNot:
+                    return "!";
+                case ExpressionOperator.LogicalOr:
+                    return "||";
+                case ExpressionOperator.Modulus:
+                    return "%";
+                case ExpressionOperator.Multiplication:
+                    return "*";
+                case ExpressionOperator.Not:
+                    return "!";
+                case ExpressionOperator.NotEqual:
+                    return "!=";
+                case ExpressionOperator.Or:
+                    return "|";
+                case ExpressionOperator.Xor:
+                    return "^";
+                case ExpressionOperator.ShiftLeft:
+                    return "<<";
+                case ExpressionOperator.ShiftRight:
+                    return ">>";
+                case ExpressionOperator.SizeOf:
+                    return "sizeof";
+                case ExpressionOperator.Subtraction:
+                    return "-";
+                case ExpressionOperator.UnaryMinus:
+                    return "-";
+                case ExpressionOperator.Unknown:
+                    return "<???>";
+                case ExpressionOperator.Variable:
+                    return "<VAR>";
+                case ExpressionOperator.WritableBytes:
+                    return "<WritableBytes>";
+                default:
+                    return "<????>";
+            }
+        }
+
+        private static string ToString<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder, int height)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(height >= 0);
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            if (height > MaxHeight)
+            {
+                return "<too deep in the exp>";
+            }
+            else
+            {
+                switch (decoder.OperatorFor(exp))
+                {
+                    #region All the cases...
+                    case ExpressionOperator.Addition:
+                        return BinaryPrint("+", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.And:
+                        return BinaryPrint("&", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Constant:
+                        return ConstantPrint(exp, decoder, height + 1);
+                    case ExpressionOperator.ConvertToInt32:
+                        return UnaryPrint("(int32)", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.ConvertToUInt8:
+                        return UnaryPrint("(uint8)", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.ConvertToUInt16:
+                        return UnaryPrint("(uint16)", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.ConvertToUInt32:
+                        return UnaryPrint("(uint32)", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.ConvertToFloat32:
+                        return UnaryPrint("(Single)", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.ConvertToFloat64:
+                        return UnaryPrint("(Double)", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Division:
+                        return BinaryPrint("/", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Equal:
+                        return BinaryPrint("==", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Equal_Obj:
+                        return BinaryPrint("=Equals=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.GreaterEqualThan:
+                        return BinaryPrint(">=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.GreaterEqualThan_Un:
+                        return BinaryPrint(">=_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.GreaterThan:
+                        return BinaryPrint(">", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.GreaterThan_Un:
+                        return BinaryPrint(">_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.LessEqualThan:
+                        return BinaryPrint("<=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.LessEqualThan_Un:
+                        return BinaryPrint("<=_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.LessThan:
+                        return BinaryPrint("<", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.LessThan_Un:
+                        return BinaryPrint("<_un", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.LogicalAnd:
+                        return BinaryPrint("&&", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.LogicalNot:
+                        return UnaryPrint("!", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.LogicalOr:
+                        return BinaryPrint("||", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Modulus:
+                        return BinaryPrint("%", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Multiplication:
+                        return BinaryPrint("*", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Not:
+                        return UnaryPrint("!", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.NotEqual:
+                        return BinaryPrint("!=", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Or:
+                        return BinaryPrint("|", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Xor:
+                        return BinaryPrint("^", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.ShiftLeft:
+                        return BinaryPrint("<<", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.ShiftRight:
+                        return BinaryPrint(">>", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.SizeOf:
+                        return SizeOfPrint(exp, decoder, height + 1);
+                    case ExpressionOperator.Subtraction:
+                        return BinaryPrint("-", decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.UnaryMinus:
+                        return UnaryPrint("-", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Variable:
+                        return VariablePrint(decoder.UnderlyingVariable(exp), decoder, height + 1);
+                    case ExpressionOperator.WritableBytes:
+                        return exp.ToString();
+                    // return UnaryPrint("WritableBytes", decoder.LeftExpressionFor(exp), decoder, height + 1);
+                    case ExpressionOperator.Unknown:
+                        return "<Unknown expression>";
+                    default:
+                        throw new AbstractInterpretationException("Error, unknown case!!!!" + decoder.OperatorFor(exp));
+                        #endregion
+                }
+            }
+        }
+
+        private static string UnaryPrint<Variable, Expression>(string p, Expression p_2, IExpressionDecoder<Variable, Expression> decoder, int height)
+        {
+            Contract.Requires(p != null);
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            string s = ToString(p_2, decoder, height + 1);
+            return p + "( " + s + " )";
+        }
+
+        private static string SizeOfPrint<Variable, Expression>(Expression sizeOfExp, IExpressionDecoder<Variable, Expression> decoder, int height)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            int size;
+            if (decoder.TrySizeOf(sizeOfExp, out size))
+            {
+                return size.ToString() + "(sizeof)";
+            }
+            else return "sizeof( ? )";
+        }
+
+        private static string VariablePrint<Variable, Expression>(Variable var, IExpressionDecoder<Variable, Expression> decoder, int height)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return decoder.NameOf(var);
+        }
+
+        private static string ConstantPrint<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder, int height)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            var tmp = new VisitorForConstantPrint<Variable, Expression>(decoder).Visit(exp, Unit.Value);
+
+            Contract.Assume(tmp != null); // F: to shut off Clousot for now
+
+            return tmp;
+        }
+
+        private static string BinaryPrint<Variable, Expression>(string p, Expression p_2, Expression p_3, IExpressionDecoder<Variable, Expression> decoder, int height)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            string s1 = ToString(p_2, decoder, height + 1);
+            string s2 = ToString(p_3, decoder, height + 1);
+
+            return p + "( " + s1 + ", " + s2 + " )";
+        }
+
+        private class VisitorForConstantPrint<Variable, Expression>
+          : GenericTypeExpressionVisitor<Variable, Expression, Unit, string>
+        {
+            private const string FAILED = "<cannot convert the value to a string>";
+
+            public VisitorForConstantPrint(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            public override string Default(Expression exp)
+            {
+                return exp.ToString();
+            }
+
+            public override string VisitBool(Expression exp, Unit input)
+            {
+                Boolean value;
+                return Decoder.TryValueOf<Boolean>(exp, ExpressionType.Bool, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitInt8(Expression exp, Unit input)
+            {
+                SByte value;
+                return Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitFloat32(Expression exp, Unit input)
+            {
+                Single value;
+                return Decoder.TryValueOf<Single>(exp, ExpressionType.Float32, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitFloat64(Expression exp, Unit input)
+            {
+                Double value;
+                return Decoder.TryValueOf<Double>(exp, ExpressionType.Float64, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitInt16(Expression exp, Unit input)
+            {
+                Int16 value;
+                return Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitInt32(Expression exp, Unit input)
+            {
+                Int32 value;
+                return Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitInt64(Expression exp, Unit input)
+            {
+                Int64 value;
+                return Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitString(Expression exp, Unit input)
+            {
+                String value;
+                return Decoder.TryValueOf<String>(exp, ExpressionType.String, out value) ? "\"" + value + "\"" : FAILED;
+            }
+
+            public override string VisitUInt8(Expression exp, Unit input)
+            {
+                Byte value;
+                return Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitUInt16(Expression exp, Unit input)
+            {
+                UInt16 value;
+                return Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value) ? value.ToString() : FAILED;
+            }
+
+            public override string VisitUInt32(Expression exp, Unit input)
+            {
+                UInt32 value;
+                return Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value) ? value.ToString() : FAILED;
+            }
+        }
+
+        /// <returns>
+        /// a string representing the conjunction of this value
+        /// </returns>
+        internal static string ToLogicalFormula(ExpressionOperator op, List<string> list)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            if (list.Count == 0)
+            {
+                return TRUE;
+            }
+            else if (list.Count == 1)
+            {
+                if (list[0].EndsWith("-> 1"))
+                    return list[0];
+                else
+                    return string.Format("{0} -> {1}", list[0], TRUE);
+            }
+            else if (list.Count == 2)
+            {
+                return ToStringBinary(op, list[0], list[1]);
+            }
+            else
+            {
+                int halfList = list.Count / 2;
+                string s1 = ToLogicalFormula(op, list.GetRange(0, halfList - 1));
+                string s2 = ToLogicalFormula(op, list.GetRange(halfList, list.Count - halfList));
+
+                return ToStringBinary(op, s1, s2);
+            }
+        }
+
+        internal static string ToStringBinary(ExpressionOperator expressionOperator, string left, string right)
+        {
+            if (expressionOperator != ExpressionOperator.And)
+            {
+                return string.Format("{0}({1}, {2})", ConvertToWords(expressionOperator), left, right);
+            }
+            else // Simplify the and to make Aprove happier
+            {
+                if (left.Equals(TRUE))
+                    return right;
+                if (right.Equals(TRUE))
+                    return left;
+                return string.Format("{0}, {1}", left, right, TRUE);
+            }
+        }
+
+        private static string ConvertToWords(ExpressionOperator op)
+        {
+            switch (op)
+            {
+                case ExpressionOperator.Addition:
+                    return "Add";
+                case ExpressionOperator.And:
+                    return "And";
+                case ExpressionOperator.Constant:
+                    return "Constant";
+                case ExpressionOperator.ConvertToInt32:
+                    return "Int32";
+                case ExpressionOperator.ConvertToFloat32:
+                    return "Single";
+                case ExpressionOperator.ConvertToFloat64:
+                    return "Double";
+                case ExpressionOperator.ConvertToUInt16:
+                    return "UInt16";
+                case ExpressionOperator.ConvertToUInt32:
+                    return "UInt32";
+                case ExpressionOperator.ConvertToUInt8:
+                    return "UInt8";
+                case ExpressionOperator.Division:
+                    return "Div";
+                case ExpressionOperator.Equal:
+                    return "Eq";
+                case ExpressionOperator.Equal_Obj:
+                    return "Eq_obj";
+                case ExpressionOperator.GreaterEqualThan:
+                    return "Cge";
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    return "Cge_un";
+                case ExpressionOperator.GreaterThan:
+                    return "Cgt";
+                case ExpressionOperator.GreaterThan_Un:
+                    return "Cgt_un";
+                case ExpressionOperator.LessEqualThan:
+                    return "Cle";
+                case ExpressionOperator.LessEqualThan_Un:
+                    return "Cle_un";
+                case ExpressionOperator.LessThan:
+                    return "Clt";
+                case ExpressionOperator.LessThan_Un:
+                    return "Clt_un";
+                case ExpressionOperator.LogicalAnd:
+                    return "And";
+                case ExpressionOperator.LogicalNot:
+                    return "Not";
+                case ExpressionOperator.LogicalOr:
+                    return "Or";
+                case ExpressionOperator.Modulus:
+                    return "Rem";
+                case ExpressionOperator.Multiplication:
+                    return "Mul";
+                case ExpressionOperator.Not:
+                    return "Not";
+                case ExpressionOperator.NotEqual:
+                    return "Neq";
+                case ExpressionOperator.Or:
+                    return "Or";
+                case ExpressionOperator.Xor:
+                    return "Xor";
+                case ExpressionOperator.ShiftLeft:
+                    return "Shl";
+                case ExpressionOperator.ShiftRight:
+                    return "Shr";
+                case ExpressionOperator.SizeOf:
+                    return "Sizeof";
+                case ExpressionOperator.Subtraction:
+                    return "Sub";
+                case ExpressionOperator.UnaryMinus:
+                    return "Minus";
+                case ExpressionOperator.Unknown:
+                    return "???";
+                case ExpressionOperator.Variable:
+                    return "Var";
+                case ExpressionOperator.WritableBytes:
+                    return "WB";
+                default:
+                    return "???";
+            }
+        }
     }
 
-    private static string SizeOfPrint<Variable, Expression>(Expression  sizeOfExp, IExpressionDecoder<Variable, Expression> decoder, int height)
+    /// <summary>
+    /// Convert an expression <code>Expression</code> into a Polynomial, and back
+    /// </summary>
+    public static class ArithmeticExpressionsConverter
     {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      int size;
-      if (decoder.TrySizeOf(sizeOfExp, out size))
-      {
-        return size.ToString() + "(sizeof)";
-      }
-      else return "sizeof( ? )";
     }
-
-    private static string VariablePrint<Variable, Expression>(Variable  var, IExpressionDecoder<Variable, Expression> decoder, int height)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return decoder.NameOf(var);
-    }
-
-    private static string ConstantPrint<Variable, Expression>(Expression  exp, IExpressionDecoder<Variable, Expression> decoder, int height)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);      
-
-      var tmp = new VisitorForConstantPrint<Variable, Expression>(decoder).Visit(exp, Unit.Value);
-
-      Contract.Assume(tmp != null); // F: to shut off Clousot for now
-
-      return tmp;
-    }
-
-    private static string BinaryPrint<Variable, Expression>(string p, Expression p_2, Expression p_3, IExpressionDecoder<Variable, Expression> decoder, int height)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      string s1 = ToString(p_2, decoder, height + 1);
-      string s2 = ToString(p_3, decoder, height + 1);
-
-      return p + "( " + s1 + ", " + s2 + " )";
-    }
-
-    private class VisitorForConstantPrint<Variable, Expression> 
-      : GenericTypeExpressionVisitor<Variable, Expression, Unit, string>
-    {
-      private const string FAILED = "<cannot convert the value to a string>";
-
-      public VisitorForConstantPrint(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      public override string Default(Expression exp)
-      {
-        return exp.ToString();
-      }
-
-      public override string VisitBool(Expression exp, Unit input)
-      {
-        Boolean value;
-        return Decoder.TryValueOf<Boolean>(exp, ExpressionType.Bool, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitInt8(Expression exp, Unit input)
-      {
-        SByte value;
-        return Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitFloat32(Expression exp, Unit input)
-      {
-        Single value;
-        return Decoder.TryValueOf<Single>(exp, ExpressionType.Float32, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitFloat64(Expression exp, Unit input)
-      {
-        Double value;
-        return Decoder.TryValueOf<Double>(exp, ExpressionType.Float64, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitInt16(Expression exp, Unit input)
-      {
-        Int16 value;
-        return Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitInt32(Expression exp, Unit input)
-      {
-        Int32 value;
-        return Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitInt64(Expression exp, Unit input)
-      {
-        Int64 value;
-        return Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitString(Expression exp, Unit input)
-      {
-        String value;
-        return Decoder.TryValueOf<String>(exp, ExpressionType.String, out value) ? "\"" + value + "\"" : FAILED;
-      }
-
-      public override string VisitUInt8(Expression exp, Unit input)
-      {
-        Byte value;
-        return Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitUInt16(Expression exp, Unit input)
-      {
-        UInt16 value;
-        return Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value) ? value.ToString() : FAILED;
-      }
-
-      public override string VisitUInt32(Expression exp, Unit input)
-      {
-        UInt32 value;
-        return Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value) ? value.ToString() : FAILED;
-      }
-    }
-
-    /// <returns>
-    /// a string representing the conjunction of this value
-    /// </returns>
-    internal static string ToLogicalFormula(ExpressionOperator op, List<string> list)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      if (list.Count == 0)
-      {
-        return TRUE;
-      }
-      else if (list.Count == 1)
-      {
-        if(list[0].EndsWith("-> 1"))
-          return list[0];
-        else
-          return string.Format("{0} -> {1}", list[0], TRUE);
-      }
-      else if (list.Count == 2)
-      {
-        return ToStringBinary(op, list[0], list[1]);
-      }
-      else
-      {
-        int halfList = list.Count / 2;
-        string s1 = ToLogicalFormula(op, list.GetRange(0, halfList - 1));
-        string s2 = ToLogicalFormula(op, list.GetRange(halfList, list.Count - halfList));
-
-        return ToStringBinary(op, s1, s2);
-      }
-    }
-
-    internal static string ToStringBinary(ExpressionOperator expressionOperator, string left, string right)
-    {
-      if (expressionOperator != ExpressionOperator.And)
-      {
-        return string.Format("{0}({1}, {2})", ConvertToWords(expressionOperator), left, right);
-      }
-      else // Simplify the and to make Aprove happier
-      {
-        if (left.Equals(TRUE))
-          return right;
-        if (right.Equals(TRUE))
-          return left;
-        return string.Format("{0}, {1}", left, right, TRUE);
-      }
-    }
-
-    private static string ConvertToWords(ExpressionOperator op)
-    {
-      switch (op)
-      {
-        case ExpressionOperator.Addition:
-          return "Add";
-        case ExpressionOperator.And:
-          return "And";
-        case ExpressionOperator.Constant:
-          return "Constant";
-        case ExpressionOperator.ConvertToInt32:
-          return "Int32";
-        case ExpressionOperator.ConvertToFloat32:
-          return "Single";
-        case ExpressionOperator.ConvertToFloat64:
-          return "Double";
-        case ExpressionOperator.ConvertToUInt16:
-          return "UInt16";
-        case ExpressionOperator.ConvertToUInt32:
-          return "UInt32";
-        case ExpressionOperator.ConvertToUInt8:
-          return "UInt8";
-        case ExpressionOperator.Division:
-          return "Div";
-        case ExpressionOperator.Equal:
-          return "Eq";
-        case ExpressionOperator.Equal_Obj:
-          return "Eq_obj";
-        case ExpressionOperator.GreaterEqualThan:
-          return "Cge";
-        case ExpressionOperator.GreaterEqualThan_Un:
-          return "Cge_un";
-        case ExpressionOperator.GreaterThan:
-          return "Cgt";
-        case ExpressionOperator.GreaterThan_Un:
-          return "Cgt_un";
-        case ExpressionOperator.LessEqualThan:
-          return "Cle";
-        case ExpressionOperator.LessEqualThan_Un:
-          return "Cle_un";
-        case ExpressionOperator.LessThan:
-          return "Clt";
-        case ExpressionOperator.LessThan_Un:
-          return "Clt_un";
-        case ExpressionOperator.LogicalAnd:
-          return "And";
-        case ExpressionOperator.LogicalNot:
-          return "Not";
-        case ExpressionOperator.LogicalOr:
-          return "Or";
-        case ExpressionOperator.Modulus:
-          return "Rem";
-        case ExpressionOperator.Multiplication:
-          return "Mul";
-        case ExpressionOperator.Not:
-          return "Not";
-        case ExpressionOperator.NotEqual:
-          return "Neq";
-        case ExpressionOperator.Or:
-          return "Or";
-        case ExpressionOperator.Xor:
-          return "Xor";
-        case ExpressionOperator.ShiftLeft:
-          return "Shl";
-        case ExpressionOperator.ShiftRight:
-          return "Shr";
-        case ExpressionOperator.SizeOf:
-          return "Sizeof";
-        case ExpressionOperator.Subtraction:
-          return "Sub";
-        case ExpressionOperator.UnaryMinus:
-          return "Minus";
-        case ExpressionOperator.Unknown:
-          return "???";
-        case ExpressionOperator.Variable:
-          return "Var";
-        case ExpressionOperator.WritableBytes:
-          return "WB";
-        default:
-          return "???";
-      }
-    }
-
-  }
-
-  /// <summary>
-  /// Convert an expression <code>Expression</code> into a Polynomial, and back
-  /// </summary>
-  public static class ArithmeticExpressionsConverter
-  {
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/Extensions.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/Extensions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,573 +10,567 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains.Expressions
 {
-  
-  [ContractVerification(true)]
-  public static class PolynomialExtensions
-  {
-    public static bool TryMatch_k1XPlusk2YEqualk3<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Rational k1, out Variable x, out Rational k2, out Variable y, out Rational k3)
+    [ContractVerification(true)]
+    public static class PolynomialExtensions
     {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k3), null));
-
-      if (pol.Right == null)
-      {
-        k1 = k2 = k3 = default(Rational);
-        x = y = default(Variable);
-
-        return false;
-      }
-
-      if (pol.Degree == 1  && pol.Relation.HasValue
-        && pol.Relation.Value == ExpressionOperator.Equal
-        && pol.Left.Length == 2 && pol.Right.Length == 1)
-      {
-        var m3 = pol.Right[0];
-
-        if (m3.IsConstant)
+        public static bool TryMatch_k1XPlusk2YEqualk3<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Rational k1, out Variable x, out Rational k2, out Variable y, out Rational k3)
         {
-          var m1 = pol.Left[0];
-          var m2 = pol.Left[1];
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k3), null));
 
-          if (m1.IsVariable(out x) && m2.IsVariable(out y))
-          {
-            k1 = m1.K;
-            k2 = m2.K;
-            k3 = m3.K;
+            if (pol.Right == null)
+            {
+                k1 = k2 = k3 = default(Rational);
+                x = y = default(Variable);
 
-            return true;
-          }
-        }
-      }
-      
-      k1 = k2 = k3 = default(Rational);
-      x = y = default(Variable);
-
-      return false;
-    }
-
-    public static bool TryMatch_XMinusYEqualk3<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable x, out Variable y, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
-
-      Rational k1, k2, k3;
-      if (pol.TryMatch_k1XPlusk2YEqualk3(out k1, out x, out k2, out y, out k3) && k1 == 1 && k2 == -1)
-      {
-        k = k3;
-
-        return true;
-      }
-
-      k = default(Rational);
-
-      return false;
-    }
-
-    public static bool TryMatch_YMinusK<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable y, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k),null));
-
-      if (pol.Relation == null && pol.Degree == 1)
-      {
-        var monomials = pol.Left;
-        if (monomials.Length == 2 && monomials[0].IsLinear && monomials[1].IsConstant)
-        {
-          k = monomials[1].K;
-
-          if (k < 0)
-          {
-            if(monomials[0].IsVariable(out y))
-              return true;
-          }
-        }
-      }
-
-      y = default(Variable);
-      k = default(Rational);
-      return false;
-    }
-
-    public static bool TryMatch_YPlusK<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable y, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
-
-      if (pol.Relation == null && pol.Degree == 1)
-      {
-        var monomials = pol.Left;
-        if (monomials.Length == 2 && monomials[0].IsLinear && monomials[0].K >= 0 && monomials[1].IsConstant)
-        {
-          k = monomials[1].K;
-
-          if (k > 0)
-          {
-            if(monomials[0].IsVariable(out y))
-              return true;
-          }
-        }
-      }
-
-      y = default(Variable);
-      k = default(Rational);
-
-      return false;
-    }
-
-    public static bool TryMatch_Y<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable y)
-    {
-      if (pol.Degree == 1 && pol.Relation == null && pol.Left.Length == 1)
-      {
-        if(pol.Left[0].IsVariable(out y))
-          return true;
-      }
-
-      y = default(Variable);
-      return false;
-    }
-
-    public static bool TryMatch_XPlusY<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable x, out Variable y)
-    {
-      x = default(Variable);
-      y = default(Variable);
-     
-      if (!pol.Relation.HasValue && pol.IsLinear && pol.Left.Length == 2)
-      {
-        var m1 = pol.Left[0];
-        var m2 = pol.Left[1];
-
-        return m1.K == 1 && m2.K == 1 && m1.IsVariable(out x) && m2.IsVariable(out y);
-      }
-
-      return false;
-    }
-
-    public static bool TryMatch_XMinusY<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable x, out Variable y)
-    {
-
-      if (!pol.Relation.HasValue && pol.IsLinear && pol.Left.Length == 2)
-      {
-        var m1 = pol.Left[0];
-        var m2 = pol.Left[1];
-
-        if (!m1.IsConstant && !m2.IsConstant)
-        {
-          if (m1.K == 1 && m2.K == -1)
-          {
-            x = m1.VariableAt(0);
-            y = m2.VariableAt(0);
-
-            return true;
-          }
-          if (m1.K == -1 && m2.K == 1)
-          {
-            x = m2.VariableAt(0);
-            y = m1.VariableAt(0);
-
-            return true;
-          }
-        }
-      }
-
-      x = default(Variable);
-      y = default(Variable);
-
-      return false;
-    }
-
-    public static bool TryMatch_k1XPlusk2YLessEqualThanK<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Rational k1, out Variable x1, out Rational k2, out Variable x2, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
-
-      if (pol.Left.Length == 2 && pol.IsOctagonForm && pol.Relation.HasValue && pol.Relation.Value.IsLessEqualThan() && pol.Right.Length > 0)
-      {
-        k1 = pol.Left[0].K;
-        var b1 = pol.Left[0].IsVariable(out x1);
-
-        k2 = pol.Left[1].K;
-        var b2 = pol.Left[1].IsVariable(out x2);
-
-        k = pol.Right[0].K;
-
-        return b1 && b2;
-      }
-
-      k1 = k2 = k = default(Rational);
-      x1 = x2 = default(Variable);
-      return false;
-    }
-
-    public static bool TryMatch_k1XPlusk2YLessThanK<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Rational k1, out Variable x1, out Rational k2, out Variable x2, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
-
-      if (pol.Left.Length == 2 && pol.IsOctagonForm && pol.Relation.HasValue && pol.Right.Length > 0)
-      {
-        k1 = pol.Left[0].K;
-        var b1 = pol.Left[0].IsVariable(out x1);
-
-        k2 = pol.Left[1].K;
-        var b2 = pol.Left[1].IsVariable(out x2);
-        if (pol.Relation.Value.IsLessThan())
-        {
-          k = pol.Right[0].K;
-
-          return true;
-        }
-        else if (pol.Relation.Value.IsLessEqualThan()) // == ExpressionOperator.LessEqualThan)
-        {
-          k = pol.Right[0].K + 1;
-
-          return true;
-        }
-      }
-
-      k1 = k2 = k = default(Rational);
-      x1 = x2 = default(Variable);
-      return false;
-    }
-
-    public static bool TryMatch_XPlusYLess_Equal_ThanZPlusK<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable x1, out Variable x2, out Variable x3, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
-
-      x1 = x2 = x3 = default(Variable);
-      k = default(Rational);
-
-      if (pol.Right == null)
-      {
-        return false;
-      }
-
-      var x = new Variable[3];
-      if (pol.Left.Length == 3)
-      {
-        var found = false;
-        for (int i = 0; i < 3; i++)
-        {
-          var mon = pol.Left[i];
-          if (!mon.IsLinear)
-          {
-            return false;
-          }
-          switch ((int)mon.K)
-          {
-            case 1:
-               mon.IsVariable(out x[i - (found ? 1 : 0)]);
-              break;
-            case -1:
-              if (found)
                 return false;
-              found = true;
-               mon.IsVariable(out x[2]);
-              break;
-            default:
-              return false;
-          }
-        }
-        if (!found)
-          return false;
-        if (pol.Right.Length == 1 && pol.Right[0].IsConstant)
-        {
-          k = pol.Right[0].K;
-          x1 = x[0];
-          x2 = x[1];
-          x3 = x[2];
-          return true;
-        }
-      }
-      return false;
-    }
+            }
 
-    public static bool TryMatch_XLess_Equal_ThanYPlusZPlusK<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable x1, out Variable x2, out Variable x3, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+            if (pol.Degree == 1 && pol.Relation.HasValue
+              && pol.Relation.Value == ExpressionOperator.Equal
+              && pol.Left.Length == 2 && pol.Right.Length == 1)
+            {
+                var m3 = pol.Right[0];
 
-      x1 = x2 = x3 = default(Variable);
-      k = default(Rational);
+                if (m3.IsConstant)
+                {
+                    var m1 = pol.Left[0];
+                    var m2 = pol.Left[1];
 
-      if (pol.Right == null)
-      {
-        return false;
-      }
+                    if (m1.IsVariable(out x) && m2.IsVariable(out y))
+                    {
+                        k1 = m1.K;
+                        k2 = m2.K;
+                        k3 = m3.K;
 
-      var x = new Variable[3];
-      if (pol.Left.Length == 3)
-      {
-        var found = false;
-        for (int i = 0; i < 3; i++)
-        {
-          var mon = pol.Left[i];
-          if (!mon.IsLinear)
+                        return true;
+                    }
+                }
+            }
+
+            k1 = k2 = k3 = default(Rational);
+            x = y = default(Variable);
+
             return false;
-          switch ((int)mon.K)
-          {
-            case -1:
-               mon.IsVariable(out x[i - (found ? 1 : 0)]);
-              break;
-            case 1:
-              if (found)
+        }
+
+        public static bool TryMatch_XMinusYEqualk3<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable x, out Variable y, out Rational k)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            Rational k1, k2, k3;
+            if (pol.TryMatch_k1XPlusk2YEqualk3(out k1, out x, out k2, out y, out k3) && k1 == 1 && k2 == -1)
+            {
+                k = k3;
+
+                return true;
+            }
+
+            k = default(Rational);
+
+            return false;
+        }
+
+        public static bool TryMatch_YMinusK<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable y, out Rational k)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            if (pol.Relation == null && pol.Degree == 1)
+            {
+                var monomials = pol.Left;
+                if (monomials.Length == 2 && monomials[0].IsLinear && monomials[1].IsConstant)
+                {
+                    k = monomials[1].K;
+
+                    if (k < 0)
+                    {
+                        if (monomials[0].IsVariable(out y))
+                            return true;
+                    }
+                }
+            }
+
+            y = default(Variable);
+            k = default(Rational);
+            return false;
+        }
+
+        public static bool TryMatch_YPlusK<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable y, out Rational k)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            if (pol.Relation == null && pol.Degree == 1)
+            {
+                var monomials = pol.Left;
+                if (monomials.Length == 2 && monomials[0].IsLinear && monomials[0].K >= 0 && monomials[1].IsConstant)
+                {
+                    k = monomials[1].K;
+
+                    if (k > 0)
+                    {
+                        if (monomials[0].IsVariable(out y))
+                            return true;
+                    }
+                }
+            }
+
+            y = default(Variable);
+            k = default(Rational);
+
+            return false;
+        }
+
+        public static bool TryMatch_Y<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable y)
+        {
+            if (pol.Degree == 1 && pol.Relation == null && pol.Left.Length == 1)
+            {
+                if (pol.Left[0].IsVariable(out y))
+                    return true;
+            }
+
+            y = default(Variable);
+            return false;
+        }
+
+        public static bool TryMatch_XPlusY<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable x, out Variable y)
+        {
+            x = default(Variable);
+            y = default(Variable);
+
+            if (!pol.Relation.HasValue && pol.IsLinear && pol.Left.Length == 2)
+            {
+                var m1 = pol.Left[0];
+                var m2 = pol.Left[1];
+
+                return m1.K == 1 && m2.K == 1 && m1.IsVariable(out x) && m2.IsVariable(out y);
+            }
+
+            return false;
+        }
+
+        public static bool TryMatch_XMinusY<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable x, out Variable y)
+        {
+            if (!pol.Relation.HasValue && pol.IsLinear && pol.Left.Length == 2)
+            {
+                var m1 = pol.Left[0];
+                var m2 = pol.Left[1];
+
+                if (!m1.IsConstant && !m2.IsConstant)
+                {
+                    if (m1.K == 1 && m2.K == -1)
+                    {
+                        x = m1.VariableAt(0);
+                        y = m2.VariableAt(0);
+
+                        return true;
+                    }
+                    if (m1.K == -1 && m2.K == 1)
+                    {
+                        x = m2.VariableAt(0);
+                        y = m1.VariableAt(0);
+
+                        return true;
+                    }
+                }
+            }
+
+            x = default(Variable);
+            y = default(Variable);
+
+            return false;
+        }
+
+        public static bool TryMatch_k1XPlusk2YLessEqualThanK<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Rational k1, out Variable x1, out Rational k2, out Variable x2, out Rational k)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            if (pol.Left.Length == 2 && pol.IsOctagonForm && pol.Relation.HasValue && pol.Relation.Value.IsLessEqualThan() && pol.Right.Length > 0)
+            {
+                k1 = pol.Left[0].K;
+                var b1 = pol.Left[0].IsVariable(out x1);
+
+                k2 = pol.Left[1].K;
+                var b2 = pol.Left[1].IsVariable(out x2);
+
+                k = pol.Right[0].K;
+
+                return b1 && b2;
+            }
+
+            k1 = k2 = k = default(Rational);
+            x1 = x2 = default(Variable);
+            return false;
+        }
+
+        public static bool TryMatch_k1XPlusk2YLessThanK<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Rational k1, out Variable x1, out Rational k2, out Variable x2, out Rational k)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            if (pol.Left.Length == 2 && pol.IsOctagonForm && pol.Relation.HasValue && pol.Right.Length > 0)
+            {
+                k1 = pol.Left[0].K;
+                var b1 = pol.Left[0].IsVariable(out x1);
+
+                k2 = pol.Left[1].K;
+                var b2 = pol.Left[1].IsVariable(out x2);
+                if (pol.Relation.Value.IsLessThan())
+                {
+                    k = pol.Right[0].K;
+
+                    return true;
+                }
+                else if (pol.Relation.Value.IsLessEqualThan()) // == ExpressionOperator.LessEqualThan)
+                {
+                    k = pol.Right[0].K + 1;
+
+                    return true;
+                }
+            }
+
+            k1 = k2 = k = default(Rational);
+            x1 = x2 = default(Variable);
+            return false;
+        }
+
+        public static bool TryMatch_XPlusYLess_Equal_ThanZPlusK<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable x1, out Variable x2, out Variable x3, out Rational k)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            x1 = x2 = x3 = default(Variable);
+            k = default(Rational);
+
+            if (pol.Right == null)
+            {
                 return false;
-              found = true;
-               mon.IsVariable(out x[2]);
-              break;
-            default:
-              return false;
-          }
+            }
+
+            var x = new Variable[3];
+            if (pol.Left.Length == 3)
+            {
+                var found = false;
+                for (int i = 0; i < 3; i++)
+                {
+                    var mon = pol.Left[i];
+                    if (!mon.IsLinear)
+                    {
+                        return false;
+                    }
+                    switch ((int)mon.K)
+                    {
+                        case 1:
+                            mon.IsVariable(out x[i - (found ? 1 : 0)]);
+                            break;
+                        case -1:
+                            if (found)
+                                return false;
+                            found = true;
+                            mon.IsVariable(out x[2]);
+                            break;
+                        default:
+                            return false;
+                    }
+                }
+                if (!found)
+                    return false;
+                if (pol.Right.Length == 1 && pol.Right[0].IsConstant)
+                {
+                    k = pol.Right[0].K;
+                    x1 = x[0];
+                    x2 = x[1];
+                    x3 = x[2];
+                    return true;
+                }
+            }
+            return false;
         }
-        if (!found)
-          return false;
-        if (pol.Right.Length == 1 && pol.Right[0].IsConstant)
+
+        public static bool TryMatch_XLess_Equal_ThanYPlusZPlusK<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable x1, out Variable x2, out Variable x3, out Rational k)
         {
-          k = pol.Right[0].K;
-          x1 = x[2];
-          x2 = x[0];
-          x3 = x[1];
-          return true;
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            x1 = x2 = x3 = default(Variable);
+            k = default(Rational);
+
+            if (pol.Right == null)
+            {
+                return false;
+            }
+
+            var x = new Variable[3];
+            if (pol.Left.Length == 3)
+            {
+                var found = false;
+                for (int i = 0; i < 3; i++)
+                {
+                    var mon = pol.Left[i];
+                    if (!mon.IsLinear)
+                        return false;
+                    switch ((int)mon.K)
+                    {
+                        case -1:
+                            mon.IsVariable(out x[i - (found ? 1 : 0)]);
+                            break;
+                        case 1:
+                            if (found)
+                                return false;
+                            found = true;
+                            mon.IsVariable(out x[2]);
+                            break;
+                        default:
+                            return false;
+                    }
+                }
+                if (!found)
+                    return false;
+                if (pol.Right.Length == 1 && pol.Right[0].IsConstant)
+                {
+                    k = pol.Right[0].K;
+                    x1 = x[2];
+                    x2 = x[0];
+                    x3 = x[1];
+                    return true;
+                }
+            }
+            return false;
         }
-      }
-      return false;
-    }
 
-    public static bool TryMatch_XMinusYPlusK<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable x, out Variable y, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
-
-      if (!pol.Relation.HasValue && pol.IsLinear)
-      {
-        if (pol.Left.Length == 3)
+        public static bool TryMatch_XMinusYPlusK<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable x, out Variable y, out Rational k)
         {
-          var left0 = pol.Left[0];
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
 
-          if (left0.K == 1 && pol.Left[1].K == -1 && pol.Left[2].IsConstant)
-          {
-            left0.IsVariable(out x);
-            var b = pol.Left[1].IsVariable(out y);
-            k = pol.Left[2].K;
+            if (!pol.Relation.HasValue && pol.IsLinear)
+            {
+                if (pol.Left.Length == 3)
+                {
+                    var left0 = pol.Left[0];
 
-            return b;
-          }
-          else if (left0.K == -1 && pol.Left[1].K == 1 && pol.Left[2].IsConstant)
-          {
-            left0.IsVariable(out y);
-            var b = pol.Left[1].IsVariable(out x);
-            k = pol.Left[2].K;
+                    if (left0.K == 1 && pol.Left[1].K == -1 && pol.Left[2].IsConstant)
+                    {
+                        left0.IsVariable(out x);
+                        var b = pol.Left[1].IsVariable(out y);
+                        k = pol.Left[2].K;
 
-            return b;
-          }
+                        return b;
+                    }
+                    else if (left0.K == -1 && pol.Left[1].K == 1 && pol.Left[2].IsConstant)
+                    {
+                        left0.IsVariable(out y);
+                        var b = pol.Left[1].IsVariable(out x);
+                        k = pol.Left[2].K;
 
+                        return b;
+                    }
+                }
+                else if (pol.Left.Length == 2 && pol.Left[0].Degree == 1 && pol.Left[1].Degree == 1)
+                {
+                    if (pol.Left[0].K == 1 && pol.Left[1].K == -1)
+                    {
+                        x = pol.Left[0].VariableAt(0);
+                        y = pol.Left[1].VariableAt(0);
+                        k = Rational.For(0);
+
+                        return true;
+                    }
+                    else if (pol.Left[0].K == -1 && pol.Left[1].K == 1)
+                    {
+                        y = pol.Left[0].VariableAt(0);
+                        x = pol.Left[1].VariableAt(0);
+                        k = Rational.For(0);
+
+                        return true;
+                    }
+                }
+            }
+
+            x = y = default(Variable);
+            k = default(Rational);
+            return false;
         }
-        else if (pol.Left.Length == 2 && pol.Left[0].Degree == 1 && pol.Left[1].Degree == 1)
+
+        public static bool TryMatch_k1XLessThank2<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Rational k1, out Variable x, out Rational k2)
         {
-          if (pol.Left[0].K == 1 && pol.Left[1].K == -1)
-          {
-            x = pol.Left[0].VariableAt(0);
-            y = pol.Left[1].VariableAt(0);
-            k = Rational.For(0);
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
 
-            return true;
-          }
-          else if (pol.Left[0].K == -1 && pol.Left[1].K == 1)
-          {
-            y = pol.Left[0].VariableAt(0);
-            x = pol.Left[1].VariableAt(0);
-            k = Rational.For(0);
-
-            return true;
-          }
-
+            if (pol.Relation.HasValue && pol.Relation.Value.IsLessThan())
+            {
+                return pol.HelperForTryMatch_k1Xopk2(out k1, out x, out k2);
+            }
+            else
+            {
+                x = default(Variable);
+                k1 = k2 = default(Rational);
+                return false;
+            }
         }
 
-      }
-
-      x = y = default(Variable);
-      k = default(Rational);
-      return false;
-    }
-
-    public static bool TryMatch_k1XLessThank2<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Rational k1, out Variable x, out Rational k2)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
-
-      if (pol.Relation.HasValue && pol.Relation.Value.IsLessThan())
-      {
-        return pol.HelperForTryMatch_k1Xopk2(out k1, out x, out k2);
-      }
-      else
-      {
-        x = default(Variable);
-        k1 = k2 = default(Rational);
-        return false;
-      }
-    }
-
-    public static bool TryMatch_k1XLessEqualThank2<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Rational k1, out Variable x, out Rational k2)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
-
-      if (pol.Relation.HasValue && pol.Relation.Value.IsLessEqualThan())
-      {
-        return HelperForTryMatch_k1Xopk2(pol, out k1, out x, out k2);
-      }
-      else
-      {
-        x = default(Variable);
-        k1 = k2 = default(Rational);
-        return false;
-      }
-    }
-
-    public static bool TryMatch_kY<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Variable y, out Rational k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.ReferenceEquals(Contract.ValueAtReturn(out k), null));
-
-      if (pol.Relation == null && pol.Left.Length == 1 && pol.Left[0].Degree == 1)
-      {
-        y = pol.Left[0].VariableAt(0);
-        k = pol.Left[0].K;
-        return true;
-      }
-     
-      y = default(Variable);
-      k = default(Rational);
-      return false;
-    }
-
-    private static bool HelperForTryMatch_k1Xopk2<Variable, Expression>(
-      this Polynomial<Variable, Expression> pol,
-      out Rational k1, out Variable x, out Rational k2)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
-
-      if (pol.IsLinear && pol.Degree != 0 && pol.Left.Length == 1 && pol.Right != null && pol.Right.Length == 1)
-      {
-        k1 = pol.Left[0].K;
-        var b = pol.Left[0].IsVariable(out x);
-        k2 = pol.Right[0].K;
-
-        Contract.Assume(pol.Right[0].IsConstant);  // no var
-
-        return b;
-      }
-
-      x = default(Variable);
-      k1 = k2 = default(Rational);
-      return false;
-    }
-  }
-
-  public static class ObjectExtensions
-  {
-    static public Int32? ForceInt32(this object value)
-    {
-      var ic = value as IConvertible;
-      if (ic != null)
-      {
-        try
+        public static bool TryMatch_k1XLessEqualThank2<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Rational k1, out Variable x, out Rational k2)
         {
-          return ic.ToInt32(null);
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
+
+            if (pol.Relation.HasValue && pol.Relation.Value.IsLessEqualThan())
+            {
+                return HelperForTryMatch_k1Xopk2(pol, out k1, out x, out k2);
+            }
+            else
+            {
+                x = default(Variable);
+                k1 = k2 = default(Rational);
+                return false;
+            }
         }
-        catch
+
+        public static bool TryMatch_kY<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Variable y, out Rational k)
         {
-        }
-      }
-      return null;
-    }
+            Contract.Ensures(!Contract.Result<bool>() || !object.ReferenceEquals(Contract.ValueAtReturn(out k), null));
 
-    static public Int64? ForceInt64(this object value)
-    {
-      var ic = value as IConvertible;
-      if (ic != null)
-      {
-        try
+            if (pol.Relation == null && pol.Left.Length == 1 && pol.Left[0].Degree == 1)
+            {
+                y = pol.Left[0].VariableAt(0);
+                k = pol.Left[0].K;
+                return true;
+            }
+
+            y = default(Variable);
+            k = default(Rational);
+            return false;
+        }
+
+        private static bool HelperForTryMatch_k1Xopk2<Variable, Expression>(
+          this Polynomial<Variable, Expression> pol,
+          out Rational k1, out Variable x, out Rational k2)
         {
-          return ic.ToInt64(null);
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k1), null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k2), null));
+
+            if (pol.IsLinear && pol.Degree != 0 && pol.Left.Length == 1 && pol.Right != null && pol.Right.Length == 1)
+            {
+                k1 = pol.Left[0].K;
+                var b = pol.Left[0].IsVariable(out x);
+                k2 = pol.Right[0].K;
+
+                Contract.Assume(pol.Right[0].IsConstant);  // no var
+
+                return b;
+            }
+
+            x = default(Variable);
+            k1 = k2 = default(Rational);
+            return false;
         }
-        catch
+    }
+
+    public static class ObjectExtensions
+    {
+        static public Int32? ForceInt32(this object value)
         {
+            var ic = value as IConvertible;
+            if (ic != null)
+            {
+                try
+                {
+                    return ic.ToInt32(null);
+                }
+                catch
+                {
+                }
+            }
+            return null;
         }
-      }
-      return null;
+
+        static public Int64? ForceInt64(this object value)
+        {
+            var ic = value as IConvertible;
+            if (ic != null)
+            {
+                try
+                {
+                    return ic.ToInt64(null);
+                }
+                catch
+                {
+                }
+            }
+            return null;
+        }
     }
 
-  }
-
-  [ContractVerification(true)]
-  public static class ExpressionTypeExtensions
-  {
-    public static bool IsFloatingPointType(this ExpressionType type)
+    [ContractVerification(true)]
+    public static class ExpressionTypeExtensions
     {
-      return type == ExpressionType.Float32 || type == ExpressionType.Float64;
+        public static bool IsFloatingPointType(this ExpressionType type)
+        {
+            return type == ExpressionType.Float32 || type == ExpressionType.Float64;
+        }
+
+        public static bool IsUnsignedType(this ExpressionType type)
+        {
+            return type == ExpressionType.UInt8 || type == ExpressionType.UInt16 || type == ExpressionType.UInt32 || type == ExpressionType.UInt64;
+        }
     }
 
-    public static bool IsUnsignedType(this ExpressionType type)
+    [ContractVerification(true)]
+    public static class ExpressionOperatorExtensions
     {
-      return type == ExpressionType.UInt8 || type == ExpressionType.UInt16 || type == ExpressionType.UInt32 || type == ExpressionType.UInt64;
-    }
-  } 
+        public static bool IsRelationalOperator(this ExpressionOperator op)
+        {
+            switch (op)
+            {
+                case ExpressionOperator.And:
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                case ExpressionOperator.GreaterEqualThan:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                case ExpressionOperator.GreaterThan:
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.LessEqualThan:
+                case ExpressionOperator.LessEqualThan_Un:
+                case ExpressionOperator.LessThan:
+                case ExpressionOperator.LessThan_Un:
+                case ExpressionOperator.NotEqual:
+                case ExpressionOperator.Or:
+                case ExpressionOperator.Xor:
+                    return true;
 
-  [ContractVerification(true)]
-  public static class ExpressionOperatorExtensions
-  {
-    public static bool IsRelationalOperator(this ExpressionOperator op)
-    {
-      switch (op)
-      {
-        case ExpressionOperator.And:
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-        case ExpressionOperator.GreaterEqualThan:
-        case ExpressionOperator.GreaterEqualThan_Un:
-        case ExpressionOperator.GreaterThan:
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.LessEqualThan:
-        case ExpressionOperator.LessEqualThan_Un:
-        case ExpressionOperator.LessThan:
-        case ExpressionOperator.LessThan_Un:
-        case ExpressionOperator.NotEqual:
-        case ExpressionOperator.Or:
-        case ExpressionOperator.Xor:
-          return true;
-
-        default:
-          return false;
-      }
+                default:
+                    return false;
+            }
+        }
     }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/InterfacesForExpressions.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/InterfacesForExpressions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The interfaces for the pure expressions used internally by the abstract domains
 // When instantiating the framework for an analysis, these are the interfaces that must implemented
@@ -22,562 +11,559 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Expressions
 {
-  #region The expressions and the types that are understood by the abstract domains
-
-  /// <summary>
-  /// The expressions that are recognized by the abstract domains.
-  /// 
-  /// Those will be replaced by BinaryOp and UnaryOp
-  /// </summary>
-  public enum ExpressionOperator
-  {
-    Constant, Variable,                                                         // Basic
-    Not, And, Or, Xor,                                                          // Bitwise
-    LogicalAnd, LogicalOr, LogicalNot,                                          // Booleans
-    Equal, NotEqual,
-    Equal_Obj, 
-    LessThan, LessThan_Un,                                                      // Comparison
-    LessEqualThan, LessEqualThan_Un,
-    GreaterThan, GreaterThan_Un, 
-    GreaterEqualThan, GreaterEqualThan_Un,
-    Addition, Subtraction, Multiplication, Division, Modulus, UnaryMinus,       // Arithmetic
-    Addition_Overflow, Subtraction_Overflow, Multiplication_Overflow,
-    ShiftLeft, ShiftRight,                                                      // Shifting operations
-    ConvertToInt8, ConvertToInt16, ConvertToInt32, ConvertToInt64,              // Conversions to int
-    ConvertToUInt8, ConvertToUInt16, ConvertToUInt32, ConvertToUInt64,          // Conversions to Uint
-    ConvertToFloat32, ConvertToFloat64,
-    SizeOf,                                                                     // SizeOf
-    WritableBytes,                                                              // The writable bytes of a pointer
-    Unknown                                                                     // All the other cases  
-    // TODO: Add type expressions as "cast", "is", "as"
-  }
-
-  public enum ExpressionType
-  {
-    Unknown, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Bool, String, Float32, Float64
-  }
-  #endregion
-
-  #region Interfaces for Expression decoders and encoders
-
-  /// <summary>
-  /// The decoder for instructions, used to let communicate the "syntax" with the abstract domains
-  /// </summary>
-  /// <typeparam name="Expression">The type of expressions that will be decoded </typeparam>
-  [ContractClass(typeof(IExpressionDecoderContracts<,>))]
-  public interface IExpressionDecoder<Variable, Expression> 
-  {
-    /// <returns>
-    /// The operator for the expression <code>exp</code>
-    /// </returns>
-    [Pure]
-    ExpressionOperator OperatorFor(Expression exp);
+    #region The expressions and the types that are understood by the abstract domains
 
     /// <summary>
-    /// The expression on the left for the <code>exp</code> object
+    /// The expressions that are recognized by the abstract domains.
+    /// 
+    /// Those will be replaced by BinaryOp and UnaryOp
     /// </summary>
-    /// <param name="exp">The expression</param>
-    /// <returns>The left expression, that must be not-null</returns>
-    [Pure]
-    Expression LeftExpressionFor(Expression exp);
+    public enum ExpressionOperator
+    {
+        Constant, Variable,                                                         // Basic
+        Not, And, Or, Xor,                                                          // Bitwise
+        LogicalAnd, LogicalOr, LogicalNot,                                          // Booleans
+        Equal, NotEqual,
+        Equal_Obj,
+        LessThan, LessThan_Un,                                                      // Comparison
+        LessEqualThan, LessEqualThan_Un,
+        GreaterThan, GreaterThan_Un,
+        GreaterEqualThan, GreaterEqualThan_Un,
+        Addition, Subtraction, Multiplication, Division, Modulus, UnaryMinus,       // Arithmetic
+        Addition_Overflow, Subtraction_Overflow, Multiplication_Overflow,
+        ShiftLeft, ShiftRight,                                                      // Shifting operations
+        ConvertToInt8, ConvertToInt16, ConvertToInt32, ConvertToInt64,              // Conversions to int
+        ConvertToUInt8, ConvertToUInt16, ConvertToUInt32, ConvertToUInt64,          // Conversions to Uint
+        ConvertToFloat32, ConvertToFloat64,
+        SizeOf,                                                                     // SizeOf
+        WritableBytes,                                                              // The writable bytes of a pointer
+        Unknown                                                                     // All the other cases  
+                                                                                    // TODO: Add type expressions as "cast", "is", "as"
+    }
+
+    public enum ExpressionType
+    {
+        Unknown, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Bool, String, Float32, Float64
+    }
+    #endregion
+
+    #region Interfaces for Expression decoders and encoders
 
     /// <summary>
-    /// The expression on the right for the <code>exp</code> object.
-    /// If there is no expression on the right, then an exception of type <code>AbstractInterpretationException</code> is thrown
+    /// The decoder for instructions, used to let communicate the "syntax" with the abstract domains
     /// </summary>
-    /// <param name="exp">The expression</param>
-    /// <returns>The right expression, if any. Otherwise an exception is thrown</returns>
-    [Pure]
-    Expression RightExpressionFor(Expression exp);
+    /// <typeparam name="Expression">The type of expressions that will be decoded </typeparam>
+    [ContractClass(typeof(IExpressionDecoderContracts<,>))]
+    public interface IExpressionDecoder<Variable, Expression>
+    {
+        /// <returns>
+        /// The operator for the expression <code>exp</code>
+        /// </returns>
+        [Pure]
+        ExpressionOperator OperatorFor(Expression exp);
+
+        /// <summary>
+        /// The expression on the left for the <code>exp</code> object
+        /// </summary>
+        /// <param name="exp">The expression</param>
+        /// <returns>The left expression, that must be not-null</returns>
+        [Pure]
+        Expression LeftExpressionFor(Expression exp);
+
+        /// <summary>
+        /// The expression on the right for the <code>exp</code> object.
+        /// If there is no expression on the right, then an exception of type <code>AbstractInterpretationException</code> is thrown
+        /// </summary>
+        /// <param name="exp">The expression</param>
+        /// <returns>The right expression, if any. Otherwise an exception is thrown</returns>
+        [Pure]
+        Expression RightExpressionFor(Expression exp);
+
+        /// <summary>
+        /// If <code>exp</code> is in the form "(conv_op)e1" then it returns e1.
+        /// Otherwise it returns exp;
+        /// </summary>
+        [Pure]
+        Expression Stripped(Expression exp);
+
+        [Pure]
+        IEnumerable<Expression> Disjunctions(Expression exp);
+
+        /// <returns>
+        /// <code>true</code> iff <code>exp</code> is null
+        /// </returns>
+        [Pure]
+        bool IsNull(Expression exp);
+
+        /// <summary>
+        /// The type of the expression <code>exp</code> (e.g. Int32, Int16, UInt32, String...)
+        /// </summary>
+        [Pure]
+        ExpressionType TypeOf(Expression exp);
+
+        /// <summary>
+        /// If the expression has the associated info, it is returned.
+        /// </summary>
+        /// <returns>true if success, false, if no information</returns>
+        [Pure]
+        bool TryGetAssociatedExpression(Expression exp, AssociatedInfo infoKind, out Expression info);
+
+        /// <summary>
+        /// If the expression has the associated info, it is returned.
+        /// </summary>
+        /// <param name="pc">Try to find information associated at given pc (e.g., for variables)</param>
+        /// <returns>true if success, false, if no information</returns>
+        [Pure]
+        bool TryGetAssociatedExpression(APC pc, Expression exp, AssociatedInfo infoKind, out Expression info);
+
+        [Pure]
+        bool IsVariable(Expression exp);
+
+        /// <summary>
+        /// Slack Variables are the ones generated by some abstract domains like SubPolyhedra, also called beta or fresh variables
+        /// </summary>
+        /// <returns></returns>
+        [Pure]
+        bool IsSlackVariable(Variable v);
+
+        /// <summary>
+        /// A Variable managed from the underlying framework
+        /// </summary>
+        [Pure]
+        bool IsFrameworkVariable(Variable v);
+
+        /// <summary>
+        /// Just an helper, as it is used so many times
+        /// </summary>
+        /// <param name="v"></param>
+        /// <returns></returns>
+        [Pure]
+        bool IsSlackOrFrameworkVariable(Variable v);
+
+        [Pure]
+        bool IsConstant(Expression exp);
+
+        [Pure]
+        bool IsConstantInt(Expression exp, out int val);
+
+        [Pure]
+        bool IsNaN(Expression exp);
+
+        [Pure]
+        bool IsWritableBytes(Expression exp);
+
+        [Pure]
+        bool IsUnaryExpression(Expression exp);
+
+        [Pure]
+        bool IsBinaryExpression(Expression exp);
+
+        [Pure]
+        bool IsSizeOf(Expression exp);
+
+        [Pure]
+        Variable UnderlyingVariable(Expression exp);
+
+        /// <summary>
+        /// If expression is a constant, this gets the underlying representation of the constant
+        /// </summary>
+        [Pure]
+        object Constant(Expression exp);
+
+        [Pure]
+        bool TrySizeOf(Expression type, out int value);
+
+        /// <summary>
+        /// The set of variables defined in the expression <code>exp</code>
+        /// </summary>
+        [Pure]
+        Set<Variable> VariablesIn(Expression exp);
+
+        /// <summary>
+        /// The value of the expression. 
+        /// It makes sense only if <code>exp</code> is a constant
+        /// </summary>
+        /// <param name="aiType">The type that is expected, in the abstract interpretation world</param>
+        /// <typeparam name="T">The value of the constant depends on its type. So before of invoking <code>ValueOf</code> it is important to determine its type</typeparam>
+        [Pure]
+        bool TryValueOf<T>(Expression exp, ExpressionType aiType, out T value);
+
+        /// <summary>
+        /// The name of the variable.
+        /// It makes sense only if <code>exp</code> is a variable
+        /// </summary>
+        [Pure]
+        string NameOf(Variable exp);
+    }
 
     /// <summary>
-    /// If <code>exp</code> is in the form "(conv_op)e1" then it returns e1.
-    /// Otherwise it returns exp;
+    /// The encoder for instructions: given an abstract interpretation expression (whatever it means) it builds an Expression
     /// </summary>
-    [Pure]
-    Expression Stripped(Expression exp);
-
-    [Pure]
-    IEnumerable<Expression> Disjunctions(Expression exp);
-
-    /// <returns>
-    /// <code>true</code> iff <code>exp</code> is null
-    /// </returns>
-    [Pure]
-    bool IsNull(Expression exp);
-
-    /// <summary>
-    /// The type of the expression <code>exp</code> (e.g. Int32, Int16, UInt32, String...)
-    /// </summary>
-    [Pure]
-    ExpressionType TypeOf(Expression exp);
-
-    /// <summary>
-    /// If the expression has the associated info, it is returned.
-    /// </summary>
-    /// <returns>true if success, false, if no information</returns>
-    [Pure]
-    bool TryGetAssociatedExpression(Expression exp, AssociatedInfo infoKind, out Expression info);
-
-    /// <summary>
-    /// If the expression has the associated info, it is returned.
-    /// </summary>
-    /// <param name="pc">Try to find information associated at given pc (e.g., for variables)</param>
-    /// <returns>true if success, false, if no information</returns>
-    [Pure]
-    bool TryGetAssociatedExpression(APC pc, Expression exp, AssociatedInfo infoKind, out Expression info);
-
-    [Pure]
-    bool IsVariable(Expression exp);
-    
-    /// <summary>
-    /// Slack Variables are the ones generated by some abstract domains like SubPolyhedra, also called beta or fresh variables
-    /// </summary>
-    /// <returns></returns>
-    [Pure]
-    bool IsSlackVariable(Variable v);
-
-    /// <summary>
-    /// A Variable managed from the underlying framework
-    /// </summary>
-    [Pure]
-    bool IsFrameworkVariable(Variable v);
-
-    /// <summary>
-    /// Just an helper, as it is used so many times
-    /// </summary>
-    /// <param name="v"></param>
-    /// <returns></returns>
-    [Pure]
-    bool IsSlackOrFrameworkVariable(Variable v);
-
-    [Pure]
-    bool IsConstant(Expression exp);
-
-    [Pure]
-    bool IsConstantInt(Expression exp, out int val);
-
-    [Pure]
-    bool IsNaN(Expression exp);
-
-    [Pure]
-    bool IsWritableBytes(Expression exp);
-
-    [Pure]
-    bool IsUnaryExpression(Expression exp);
-
-    [Pure]
-    bool IsBinaryExpression(Expression exp);
-
-    [Pure]
-    bool IsSizeOf(Expression exp);
-
-    [Pure]
-    Variable UnderlyingVariable(Expression exp);
-
-    /// <summary>
-    /// If expression is a constant, this gets the underlying representation of the constant
-    /// </summary>
-    [Pure]
-    object Constant(Expression exp);
-
-    [Pure]
-    bool TrySizeOf(Expression type, out int value);
-
-    /// <summary>
-    /// The set of variables defined in the expression <code>exp</code>
-    /// </summary>
-    [Pure]
-    Set<Variable> VariablesIn(Expression exp);
-
-    /// <summary>
-    /// The value of the expression. 
-    /// It makes sense only if <code>exp</code> is a constant
-    /// </summary>
-    /// <param name="aiType">The type that is expected, in the abstract interpretation world</param>
-    /// <typeparam name="T">The value of the constant depends on its type. So before of invoking <code>ValueOf</code> it is important to determine its type</typeparam>
-    [Pure]
-    bool TryValueOf<T>(Expression exp, ExpressionType aiType, out T value);     
-
-    /// <summary>
-    /// The name of the variable.
-    /// It makes sense only if <code>exp</code> is a variable
-    /// </summary>
-    [Pure]
-    string NameOf(Variable exp);
-
-  }
-
-  /// <summary>
-  /// The encoder for instructions: given an abstract interpretation expression (whatever it means) it builds an Expression
-  /// </summary>
-  /// <typeparam name="TargetExpression">The target type for expressions </typeparam>
-  [ContractClass(typeof(IExpressionEncoderContracts<,>))]
-  public interface IExpressionEncoder<Variable, TargetExpression>
-  {
-    // F: This is for debugging only 
-    void ResetFreshVariableCounter();
-    
-    /// <summary>
-    /// Obtain a fresh variable of C# type <code>T</code>
-    /// </summary>
-    [Pure]
-    Variable FreshVariable<T>();
-
-    [Pure]
-    TargetExpression VariableFor(Variable v);
-
-    [Pure]
-    TargetExpression ConstantFor(object value);
-
-    /// <returns>
-    /// The expression in <code>TargetExpression</code> that corresponds to <code>left</code>
-    /// </returns>
-    [Pure]
-    TargetExpression CompoundExpressionFor(ExpressionType type, ExpressionOperator op, TargetExpression left);
-
-    /// <returns>
-    /// The expression in <code>TargerExpression</code> that corresponds to <code>op(left, right)</code>
-    /// </returns>
-    [Pure]
-    TargetExpression CompoundExpressionFor(ExpressionType type, ExpressionOperator op, TargetExpression left, TargetExpression right);
-
-    /// <summary>
-    /// Substitute all the occurrences of <code>x</code> in <code>source</code> with the expression <code>exp</code>.
-    /// <code>x</code> must be a variable
-    /// </summary>
-    [Pure]
-    TargetExpression Substitute(TargetExpression source, TargetExpression x, TargetExpression exp);
-    }
-
-  #endregion
-
-  #region Contracts
-  [ContractClassFor(typeof(IExpressionDecoder<,>))]
-  abstract class IExpressionDecoderContracts<Variable, Expression>
-    : IExpressionDecoder<Variable, Expression>
-  {
-    #region IExpressionDecoder<Variable,Expression> Members
-
-    ExpressionOperator IExpressionDecoder<Variable, Expression>.OperatorFor(Expression exp)
+    /// <typeparam name="TargetExpression">The target type for expressions </typeparam>
+    [ContractClass(typeof(IExpressionEncoderContracts<,>))]
+    public interface IExpressionEncoder<Variable, TargetExpression>
     {
-      //Contract.Requires(exp != null);
+        // F: This is for debugging only 
+        void ResetFreshVariableCounter();
 
-      throw new System.NotImplementedException();
-    }
+        /// <summary>
+        /// Obtain a fresh variable of C# type <code>T</code>
+        /// </summary>
+        [Pure]
+        Variable FreshVariable<T>();
 
-    Expression IExpressionDecoder<Variable, Expression>.LeftExpressionFor(Expression exp)
-    {
-      //Contract.Requires(exp != null);
+        [Pure]
+        TargetExpression VariableFor(Variable v);
 
-      Contract.Ensures(Contract.Result<Expression>() != null);
-      
+        [Pure]
+        TargetExpression ConstantFor(object value);
 
-      throw new System.NotImplementedException();
-    }
+        /// <returns>
+        /// The expression in <code>TargetExpression</code> that corresponds to <code>left</code>
+        /// </returns>
+        [Pure]
+        TargetExpression CompoundExpressionFor(ExpressionType type, ExpressionOperator op, TargetExpression left);
 
-    Expression IExpressionDecoder<Variable, Expression>.RightExpressionFor(Expression exp)
-    {
-      //Contract.Requires(exp != null);
+        /// <returns>
+        /// The expression in <code>TargerExpression</code> that corresponds to <code>op(left, right)</code>
+        /// </returns>
+        [Pure]
+        TargetExpression CompoundExpressionFor(ExpressionType type, ExpressionOperator op, TargetExpression left, TargetExpression right);
 
-      Contract.Ensures(Contract.Result<Expression>() != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    Expression IExpressionDecoder<Variable, Expression>.Stripped(Expression exp)
-    {
-      //Contract.Requires(exp != null);
-
-      Contract.Ensures(Contract.Result<Expression>() != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsNull(Expression exp)
-    {
-      //Contract.Requires(exp != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    ExpressionType IExpressionDecoder<Variable, Expression>.TypeOf(Expression exp)
-    {
-      //Contract.Requires(exp != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.TryGetAssociatedExpression(Expression exp, AssociatedInfo infoKind, out Expression info)
-    {
-      //Contract.Requires(exp != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.TryGetAssociatedExpression(APC pc, Expression exp, AssociatedInfo infoKind, out Expression info)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsVariable(Expression exp)
-    {
-      //Contract.Requires(exp != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsSlackVariable(Variable v)
-    {
-      //Contract.Requires(v != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsFrameworkVariable(Variable v)
-    {
-      //Contract.Requires(v != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsSlackOrFrameworkVariable(Variable v)
-    {
-      //Contract.Requires(v != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsConstant(Expression exp)
-    {
-      //Contract.Requires(exp != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsConstantInt(Expression exp, out int val)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsNaN(Expression exp)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsWritableBytes(Expression exp)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsUnaryExpression(Expression exp)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsBinaryExpression(Expression exp)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.IsSizeOf(Expression exp)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    Variable IExpressionDecoder<Variable, Expression>.UnderlyingVariable(Expression exp)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    object IExpressionDecoder<Variable, Expression>.Constant(Expression exp)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.TrySizeOf(Expression type, out int value)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    Set<Variable> IExpressionDecoder<Variable, Expression>.VariablesIn(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<Set<Variable>>() != null);
-
-      throw new System.NotImplementedException();
-    }
-
-    bool IExpressionDecoder<Variable, Expression>.TryValueOf<T>(Expression exp, ExpressionType aiType, out T value)
-    {
-      throw new System.NotImplementedException();
-    }
-
-    string IExpressionDecoder<Variable, Expression>.NameOf(Variable exp)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      
-      throw new System.NotImplementedException();
+        /// <summary>
+        /// Substitute all the occurrences of <code>x</code> in <code>source</code> with the expression <code>exp</code>.
+        /// <code>x</code> must be a variable
+        /// </summary>
+        [Pure]
+        TargetExpression Substitute(TargetExpression source, TargetExpression x, TargetExpression exp);
     }
 
     #endregion
 
-
-    public IEnumerable<Expression> Disjunctions(Expression exp)
+    #region Contracts
+    [ContractClassFor(typeof(IExpressionDecoder<,>))]
+    internal abstract class IExpressionDecoderContracts<Variable, Expression>
+      : IExpressionDecoder<Variable, Expression>
     {
-      Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);
-      throw new System.NotImplementedException();
+        #region IExpressionDecoder<Variable,Expression> Members
+
+        ExpressionOperator IExpressionDecoder<Variable, Expression>.OperatorFor(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionDecoder<Variable, Expression>.LeftExpressionFor(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionDecoder<Variable, Expression>.RightExpressionFor(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionDecoder<Variable, Expression>.Stripped(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsNull(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        ExpressionType IExpressionDecoder<Variable, Expression>.TypeOf(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.TryGetAssociatedExpression(Expression exp, AssociatedInfo infoKind, out Expression info)
+        {
+            //Contract.Requires(exp != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.TryGetAssociatedExpression(APC pc, Expression exp, AssociatedInfo infoKind, out Expression info)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsVariable(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsSlackVariable(Variable v)
+        {
+            //Contract.Requires(v != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsFrameworkVariable(Variable v)
+        {
+            //Contract.Requires(v != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsSlackOrFrameworkVariable(Variable v)
+        {
+            //Contract.Requires(v != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsConstant(Expression exp)
+        {
+            //Contract.Requires(exp != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsConstantInt(Expression exp, out int val)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsNaN(Expression exp)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsWritableBytes(Expression exp)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsUnaryExpression(Expression exp)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsBinaryExpression(Expression exp)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.IsSizeOf(Expression exp)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        Variable IExpressionDecoder<Variable, Expression>.UnderlyingVariable(Expression exp)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        object IExpressionDecoder<Variable, Expression>.Constant(Expression exp)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.TrySizeOf(Expression type, out int value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        Set<Variable> IExpressionDecoder<Variable, Expression>.VariablesIn(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<Set<Variable>>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        bool IExpressionDecoder<Variable, Expression>.TryValueOf<T>(Expression exp, ExpressionType aiType, out T value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        string IExpressionDecoder<Variable, Expression>.NameOf(Variable exp)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        #endregion
+
+
+        public IEnumerable<Expression> Disjunctions(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);
+            throw new System.NotImplementedException();
+        }
     }
-  }
 
-  [ContractClassFor(typeof(IExpressionEncoder<,>))]
-  abstract class IExpressionEncoderContracts<Variable, Expression>
-    : IExpressionEncoder<Variable, Expression>
-  {
-    #region IExpressionEncoder<Variable,Expression> Members
-
-    void IExpressionEncoder<Variable, Expression>.ResetFreshVariableCounter()
+    [ContractClassFor(typeof(IExpressionEncoder<,>))]
+    internal abstract class IExpressionEncoderContracts<Variable, Expression>
+      : IExpressionEncoder<Variable, Expression>
     {
-      throw new System.NotImplementedException();
+        #region IExpressionEncoder<Variable,Expression> Members
+
+        void IExpressionEncoder<Variable, Expression>.ResetFreshVariableCounter()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        Variable IExpressionEncoder<Variable, Expression>.FreshVariable<T>()
+        {
+            Contract.Ensures(Contract.Result<Variable>() != null);
+
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionEncoder<Variable, Expression>.VariableFor(Variable v)
+        {
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionEncoder<Variable, Expression>.ConstantFor(object value)
+        {
+            Contract.Requires(value != null);
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionEncoder<Variable, Expression>.CompoundExpressionFor(ExpressionType type, ExpressionOperator op, Expression left)
+        {
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionEncoder<Variable, Expression>.CompoundExpressionFor(ExpressionType type, ExpressionOperator op, Expression left, Expression right)
+        {
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        Expression IExpressionEncoder<Variable, Expression>.Substitute(Expression source, Expression x, Expression exp)
+        {
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            throw new System.NotImplementedException();
+        }
+
+        #endregion
+    }
+    #endregion
+
+    #region ExpressionManager
+
+    [ContractVerification(true)]
+    public class ExpressionManager<Variable, Expression>
+    {
+        #region Object Invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(decoder != null);
+            Contract.Invariant(this.TimeOut != null);
+        }
+
+        #endregion
+
+        #region State
+
+        public TimeOutChecker TimeOut { private set; get; }
+
+        readonly private IExpressionDecoder<Variable, Expression> decoder;
+        readonly protected IExpressionEncoder<Variable, Expression> encoder; // can be null
+
+        public IExpressionDecoder<Variable, Expression> Decoder { get { Contract.Ensures(Contract.Result<IExpressionDecoder<Variable, Expression>>() != null); return decoder; } }
+
+        public Logger Log;
+
+        #endregion
+
+        #region Constructor
+
+        public ExpressionManager(TimeOutChecker timeout, IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder = null, Logger log = null)
+        {
+            Contract.Requires(decoder != null);
+
+            Contract.Ensures(this.decoder == decoder);
+            Contract.Ensures(this.encoder == encoder);
+            Contract.Ensures(this.TimeOut != null);
+
+            this.TimeOut = timeout ?? DFARoot.TimeOut;
+
+            Contract.Assume(this.TimeOut != null, "weakeness with ?? ?");
+
+            this.decoder = decoder;
+            this.encoder = encoder;
+            this.Log = log == null ? VoidLogger.Log : log;
+        }
+
+        #endregion
+
+        #region Try
+
+        public bool TryGetEncoder(out IExpressionEncoder<Variable, Expression> encoder)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out encoder) != null);
+
+            encoder = this.encoder;
+
+            return encoder != null;
+        }
+
+        #endregion
     }
 
-    Variable IExpressionEncoder<Variable, Expression>.FreshVariable<T>()
+    /// <summary>
+    /// Instance of this class are sure that the Encoder != null
+    /// </summary>
+    [ContractVerification(true)]
+    public class ExpressionManagerWithEncoder<Variable, Expression>
+      : ExpressionManager<Variable, Expression>
     {
-      Contract.Ensures(Contract.Result<Variable>() != null);
-      
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.encoder != null);
+        }
 
-      throw new System.NotImplementedException();
-    }
+        public ExpressionManagerWithEncoder(TimeOutChecker timeout, IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder, Logger log = null)
+           : base(timeout, decoder, encoder)
+        {
+            Contract.Requires(timeout != null);
+            Contract.Requires(decoder != null);
+            Contract.Requires(encoder != null);
+        }
 
-    Expression IExpressionEncoder<Variable, Expression>.VariableFor(Variable v)
-    {
-      Contract.Ensures(Contract.Result<Expression>() != null);      
-
-      throw new System.NotImplementedException();
-    }
-
-    Expression IExpressionEncoder<Variable, Expression>.ConstantFor(object value)
-    {
-      Contract.Requires(value != null);
-      Contract.Ensures(Contract.Result<Expression>() != null);      
-
-      throw new System.NotImplementedException();
-    }
-
-    Expression IExpressionEncoder<Variable, Expression>.CompoundExpressionFor(ExpressionType type, ExpressionOperator op, Expression left)
-    {
-      Contract.Ensures(Contract.Result<Expression>() != null);
-      
-
-      throw new System.NotImplementedException();
-    }
-
-    Expression IExpressionEncoder<Variable, Expression>.CompoundExpressionFor(ExpressionType type, ExpressionOperator op, Expression left, Expression right)
-    {
-      Contract.Ensures(Contract.Result<Expression>() != null);      
-
-      throw new System.NotImplementedException();
-    }
-
-    Expression IExpressionEncoder<Variable, Expression>.Substitute(Expression source, Expression x, Expression exp)
-    {
-      Contract.Ensures(Contract.Result<Expression>() != null);      
-
-      throw new System.NotImplementedException();
+        public IExpressionEncoder<Variable, Expression> Encoder { get { Contract.Ensures(Contract.Result<IExpressionEncoder<Variable, Expression>>() != null); return this.encoder; } }
     }
 
     #endregion
-  }
-  #endregion
-
-  #region ExpressionManager
-  
-  [ContractVerification(true)]
-  public class ExpressionManager<Variable, Expression>
-  {
-    #region Object Invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.decoder != null);
-      Contract.Invariant(this.TimeOut != null);
-    }
-
-    #endregion
-
-    #region State
-
-    public TimeOutChecker TimeOut { private set; get; }
-    
-    readonly private IExpressionDecoder<Variable, Expression> decoder;
-    readonly protected IExpressionEncoder<Variable, Expression> encoder; // can be null
-
-    public IExpressionDecoder<Variable, Expression> Decoder { get { Contract.Ensures(Contract.Result<IExpressionDecoder<Variable, Expression>>() != null); return this.decoder; } }
-
-    public Logger Log;
-
-    #endregion
-
-    #region Constructor
-
-    public ExpressionManager(TimeOutChecker timeout, IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder = null, Logger log = null)
-    {
-      Contract.Requires(decoder != null);
-
-      Contract.Ensures(this.decoder == decoder);
-      Contract.Ensures(this.encoder == encoder);
-      Contract.Ensures(this.TimeOut != null);
-
-      this.TimeOut = timeout?? DFARoot.TimeOut;
-
-      Contract.Assume(this.TimeOut != null, "weakeness with ?? ?");
-
-      this.decoder = decoder;
-      this.encoder = encoder;
-      this.Log = log == null? VoidLogger.Log : log;
-    }
-
-    #endregion
-
-    #region Try
-
-    public bool TryGetEncoder(out IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out encoder) != null);
-
-      encoder = this.encoder;
-
-      return encoder != null;
-    }
-    
-    #endregion
-  }
-
-  /// <summary>
-  /// Instance of this class are sure that the Encoder != null
-  /// </summary>
-  [ContractVerification(true)]
-  public class ExpressionManagerWithEncoder<Variable, Expression>
-    : ExpressionManager<Variable, Expression>
-  {
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.encoder != null);
-    }
-
-    public ExpressionManagerWithEncoder(TimeOutChecker timeout, IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder, Logger log = null)
-       : base(timeout, decoder, encoder)
-    {
-      Contract.Requires(timeout != null);
-      Contract.Requires(decoder != null);
-      Contract.Requires(encoder != null);
-    }
-
-    public IExpressionEncoder<Variable, Expression> Encoder { get { Contract.Ensures(Contract.Result<IExpressionEncoder<Variable, Expression>>() != null); return this.encoder; } }
-
-  }
-
-  #endregion
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/Polynomials.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/Polynomials.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #define UseSymbolicValuesForAdditions
 
@@ -26,3214 +15,3200 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Expressions
 {
-  using System.Collections.Generic;
-  using System.Diagnostics.Contracts;
-  using System.Diagnostics.CodeAnalysis;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Diagnostics.CodeAnalysis;
 
-  /// <summary>
-  /// A Polynomial is a triple <code>(op, left, right)</code> where <code>op</code> is the binary operator (e.g. <code>==</code>), <code>left</code> the list of monomes on the left and
-  /// <code>right</code> the list of constant monomes on the right.
-  /// The list stands for the "addition"
-  /// </summary>
-  [ContractVerification(false)]
-  public struct Polynomial<Variable, Expression>
-  {
-    #region Static fields
+    /// <summary>
+    /// A Polynomial is a triple <code>(op, left, right)</code> where <code>op</code> is the binary operator (e.g. <code>==</code>), <code>left</code> the list of monomes on the left and
+    /// <code>right</code> the list of constant monomes on the right.
+    /// The list stands for the "addition"
+    /// </summary>
+    [ContractVerification(false)]
+    public struct Polynomial<Variable, Expression>
+    {
+        #region Static fields
 
-    // TODO: figure out the statistics
+        // TODO: figure out the statistics
 #if false
-    static readonly private FIFOCache<Expression, Polynomial<Variable, Expression>> cache_PolynomialForm = new FIFOCache<Expression, Polynomial<Variable, Expression>>();
-    static readonly private FIFOCache<Polynomial<Variable, Expression>, Polynomial<Variable, Expression>> cache_CanonicalForms = new FIFOCache<Polynomial<Variable, Expression>, Polynomial<Variable, Expression>>();
+        private static readonly FIFOCache<Expression, Polynomial<Variable, Expression>> cache_PolynomialForm = new FIFOCache<Expression, Polynomial<Variable, Expression>>();
+        private static readonly FIFOCache<Polynomial<Variable, Expression>, Polynomial<Variable, Expression>> cache_CanonicalForms = new FIFOCache<Polynomial<Variable, Expression>, Polynomial<Variable, Expression>>();
 #endif
-    #endregion
+        #endregion
 
-    #region Private fields
-    private ExpressionOperator? relation;
+        #region Private fields
+        private ExpressionOperator? relation;
 
-    private Monomial<Variable>[] left;
-    private Monomial<Variable>[] right;
+        private Monomial<Variable>[] left;
+        private Monomial<Variable>[] right;
 
-    // Cached values
-    private bool? Cached_IsLinear;
-    private int? Cached_Degree;
-    private bool? Cached_IsTautology;
-    private Set<Variable> Cached_Vars;
+        // Cached values
+        private bool? Cached_IsLinear;
+        private int? Cached_Degree;
+        private bool? Cached_IsTautology;
+        private Set<Variable> Cached_Vars;
 
-    #endregion
+        #endregion
 
-    #region Object invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.left != null);
-      Contract.Invariant(this.relation.HasValue || right == null);
-      Contract.Invariant(!this.relation.HasValue || this.relation.Value.IsBinary());
-    }
-
-    #endregion
-
-    #region Getters
-    /// <summary>
-    /// The relation of the polynomial, or null if it is a spourious polynomial
-    /// </summary>
-    public ExpressionOperator? Relation
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ExpressionOperator?>().HasValue == this.relation.HasValue);
-
-        return this.relation;
-      }
-    }
-
-    /// <summary>
-    /// The variables defined in this polynomial
-    /// </summary>
-    public IReadonlySet<Variable> Variables
-    {
-      get
-      {
-        if (Cached_Vars == null)
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          var result = new Set<Variable>();
-
-          foreach (var m in this.Left)
-          {
-            result.AddRange(m.Variables);
-          }
-
-          if (this.Relation != null)
-          {
-            foreach (var m in this.Right)
-            {
-              result.AddRange(m.Variables);
-            }
-          }
-
-          Cached_Vars = result;
+            Contract.Invariant(left != null);
+            Contract.Invariant(relation.HasValue || right == null);
+            Contract.Invariant(!relation.HasValue || relation.Value.IsBinary());
         }
 
-        return Cached_Vars;
-      }
-    }
+        #endregion
 
-    /// <summary>
-    /// The list of monomials on the Left of the relational operator
-    /// </summary>
-    public Monomial<Variable>[] Left
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Monomial<Variable>[]>() != null);
-
-        return this.left;
-      }
-    }
-
-    /// <summary>
-    /// The list of monomials on the Right of the relational operator.
-    /// Precondition: <code>this.Relation != null</code>
-    /// </summary>
-    public Monomial<Variable>[] Right
-    {
-      [SuppressMessage("Microsoft.Contracts", "Ensures-20-41", Justification = "Algorithmical knowledge")]
-      get
-      {
-        Contract.Ensures(Contract.Result<Monomial<Variable>[]>() == null || Contract.Result<Monomial<Variable>[]>().Length >= 0);
-
-        return this.right;
-      }
-    }
-
-    /// <summary>
-    /// The Left part of this polynomial as an instance of <code>Polynomial</code>
-    /// </summary>
-    public Polynomial<Variable, Expression> LeftAsPolynomial
-    {
-      get
-      {
-        Polynomial<Variable, Expression> result;
-        TryToPolynomialForm(this.left, out result); // We know that it never fails...
-
-        return result;
-      }
-    }
-
-
-    /// <summary>
-    /// Is a simple tautology?
-    /// </summary>
-    public bool IsTautology
-    {
-      get
-      {
-        if (this.Relation == null)
-          return false;
-
-        if (Cached_IsTautology.HasValue)
-          return Cached_IsTautology.Value;
-
-        if (this.Left.Length == 1 && this.Right.Length == 1)
+        #region Getters
+        /// <summary>
+        /// The relation of the polynomial, or null if it is a spourious polynomial
+        /// </summary>
+        public ExpressionOperator? Relation
         {
-          if (this.Left[0].IsConstant && this.Right[0].IsConstant)
-          {
-            bool result;
-
-            switch (this.Relation)
+            get
             {
-              case ExpressionOperator.Equal:
-              case ExpressionOperator.Equal_Obj:
-                result = this.Right[0].K == this.Left[0].K;
-                break;
+                Contract.Ensures(Contract.Result<ExpressionOperator?>().HasValue == relation.HasValue);
 
-              case ExpressionOperator.GreaterEqualThan:
-              case ExpressionOperator.GreaterEqualThan_Un:
-                result = this.Left[0].K >= this.Right[0].K;
-                break;
-
-              case ExpressionOperator.GreaterThan:
-              case ExpressionOperator.GreaterThan_Un:
-                result = this.Left[0].K > this.Right[0].K;
-                break;
-
-              case ExpressionOperator.LessEqualThan:
-              case ExpressionOperator.LessEqualThan_Un:
-                result = this.Left[0].K <= this.Right[0].K;
-                break;
-
-              case ExpressionOperator.LessThan:
-              case ExpressionOperator.LessThan_Un:
-                result = this.Left[0].K < this.Right[0].K;
-                break;
-
-              case ExpressionOperator.NotEqual:
-                result = this.Right[0].K != this.Left[0].K;
-                break;
-
-              default:
-                result = false;
-                break;
+                return relation;
             }
-
-            Cached_IsTautology = result;
-            return result;
-          }
         }
 
-        Cached_IsTautology = false;
-        return false;
-      }
-    }
-
-
-    /// <summary>
-    /// Is a simple inconsistence?
-    /// </summary>
-    public bool IsInconsistent
-    {
-      get
-      {
-        if (this.Relation == null)
-          return false;
-
-        if (this.Left.Length == 1 && this.Right.Length == 1)
+        /// <summary>
+        /// The variables defined in this polynomial
+        /// </summary>
+        public IReadonlySet<Variable> Variables
         {
-          if (this.Left[0].IsConstant && this.Right[0].IsConstant)
-          {
-            switch (this.Relation)
+            get
             {
-              case ExpressionOperator.Equal:
-              case ExpressionOperator.Equal_Obj:
-                return this.Right[0].K != this.Left[0].K;
+                if (Cached_Vars == null)
+                {
+                    var result = new Set<Variable>();
 
-              case ExpressionOperator.GreaterEqualThan:
-              case ExpressionOperator.GreaterEqualThan_Un:
-                return this.Left[0].K < this.Right[0].K;
+                    foreach (var m in this.Left)
+                    {
+                        result.AddRange(m.Variables);
+                    }
 
-              case ExpressionOperator.GreaterThan:
-              case ExpressionOperator.GreaterThan_Un:
-                return this.Left[0].K <= this.Right[0].K;
+                    if (this.Relation != null)
+                    {
+                        foreach (var m in this.Right)
+                        {
+                            result.AddRange(m.Variables);
+                        }
+                    }
 
-              case ExpressionOperator.LessEqualThan:
-              case ExpressionOperator.LessEqualThan_Un:
-                return this.Left[0].K > this.Right[0].K;
+                    Cached_Vars = result;
+                }
 
-              case ExpressionOperator.LessThan:
-              case ExpressionOperator.LessThan_Un:
-                return this.Left[0].K >= this.Right[0].K;
+                return Cached_Vars;
+            }
+        }
 
-              case ExpressionOperator.NotEqual:
-                return this.Right[0].K == this.Left[0].K;
+        /// <summary>
+        /// The list of monomials on the Left of the relational operator
+        /// </summary>
+        public Monomial<Variable>[] Left
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Monomial<Variable>[]>() != null);
 
-              default:
+                return left;
+            }
+        }
+
+        /// <summary>
+        /// The list of monomials on the Right of the relational operator.
+        /// Precondition: <code>this.Relation != null</code>
+        /// </summary>
+        public Monomial<Variable>[] Right
+        {
+            [SuppressMessage("Microsoft.Contracts", "Ensures-20-41", Justification = "Algorithmical knowledge")]
+            get
+            {
+                Contract.Ensures(Contract.Result<Monomial<Variable>[]>() == null || Contract.Result<Monomial<Variable>[]>().Length >= 0);
+
+                return right;
+            }
+        }
+
+        /// <summary>
+        /// The Left part of this polynomial as an instance of <code>Polynomial</code>
+        /// </summary>
+        public Polynomial<Variable, Expression> LeftAsPolynomial
+        {
+            get
+            {
+                Polynomial<Variable, Expression> result;
+                TryToPolynomialForm(left, out result); // We know that it never fails...
+
+                return result;
+            }
+        }
+
+
+        /// <summary>
+        /// Is a simple tautology?
+        /// </summary>
+        public bool IsTautology
+        {
+            get
+            {
+                if (this.Relation == null)
+                    return false;
+
+                if (Cached_IsTautology.HasValue)
+                    return Cached_IsTautology.Value;
+
+                if (this.Left.Length == 1 && this.Right.Length == 1)
+                {
+                    if (this.Left[0].IsConstant && this.Right[0].IsConstant)
+                    {
+                        bool result;
+
+                        switch (this.Relation)
+                        {
+                            case ExpressionOperator.Equal:
+                            case ExpressionOperator.Equal_Obj:
+                                result = this.Right[0].K == this.Left[0].K;
+                                break;
+
+                            case ExpressionOperator.GreaterEqualThan:
+                            case ExpressionOperator.GreaterEqualThan_Un:
+                                result = this.Left[0].K >= this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.GreaterThan:
+                            case ExpressionOperator.GreaterThan_Un:
+                                result = this.Left[0].K > this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.LessEqualThan:
+                            case ExpressionOperator.LessEqualThan_Un:
+                                result = this.Left[0].K <= this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.LessThan:
+                            case ExpressionOperator.LessThan_Un:
+                                result = this.Left[0].K < this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.NotEqual:
+                                result = this.Right[0].K != this.Left[0].K;
+                                break;
+
+                            default:
+                                result = false;
+                                break;
+                        }
+
+                        Cached_IsTautology = result;
+                        return result;
+                    }
+                }
+
+                Cached_IsTautology = false;
                 return false;
             }
-          }
         }
 
-        return false;
-      }
-    }
 
-    /// <summary>
-    /// Is it in the form of <code>a*x + b *y \leq c</code>, with a, b \in  {+1, -1, 0}, and c \in Rational 
-    /// </summary>
-    public bool IsOctagonForm
-    {
-      get
-      {
-        Contract.Ensures(!Contract.Result<bool>() || this.Degree <= 1);
-        Contract.Ensures(!Contract.Result<bool>() || this.Right != null);
-
-        if (this.Relation == null)
+        /// <summary>
+        /// Is a simple inconsistence?
+        /// </summary>
+        public bool IsInconsistent
         {
-          return false;
-        }
-        if (this.Left.Length == 0)
-        {
-          return false;
-        }
-        if (!this.IsLinear)
-        {
-          return false;
-        }
-        if (!(this.Left.Length <= 2 && this.Right.Length == 1))   // Something in the form of m1 + m2 <= m3
-        {
-          return false;
-        }
-        var m0K = this.Left[0].K;
-
-        if (!(m0K == -1 || m0K == 1 || m0K.IsZero))     // m1.K must be -1, 0 or +1
-        {
-          return false;
-        }
-        if (this.Left.Length == 2)
-        {
-          var m1K = this.Left[1].K;
-          if (!(m1K == -1 || m1K == 1 || m1K.IsZero)) // m2.K must be -1, 0 or +1
-          {
-            return false;
-          }
-        }
-        if (!this.Right[0].IsConstant)                          // m3 must be a constant
-        {
-          return false;
-        }
-
-        Contract.Assert(this.Right != null);
-
-        return true;                                            // If we reached this point, then it is an octagon
-      }
-    }
-
-    public bool IsLinear
-    {
-      get
-      {
-        if (Cached_IsLinear.HasValue)
-        {
-          return Cached_IsLinear.Value;
-        }
-
-        foreach (var m in this.Left)
-        { // all the monomial on the left must be linear
-          if (!m.IsLinear)
-          {
-            Cached_IsLinear = false;
-            return false;
-          }
-        }
-        if (this.Relation != null)
-        {
-          foreach (var m in this.Right)
-          { // all the monomial on the right must be linear
-            if (!m.IsLinear)
+            get
             {
-              Cached_IsLinear = false;
-              return false;
+                if (this.Relation == null)
+                    return false;
+
+                if (this.Left.Length == 1 && this.Right.Length == 1)
+                {
+                    if (this.Left[0].IsConstant && this.Right[0].IsConstant)
+                    {
+                        switch (this.Relation)
+                        {
+                            case ExpressionOperator.Equal:
+                            case ExpressionOperator.Equal_Obj:
+                                return this.Right[0].K != this.Left[0].K;
+
+                            case ExpressionOperator.GreaterEqualThan:
+                            case ExpressionOperator.GreaterEqualThan_Un:
+                                return this.Left[0].K < this.Right[0].K;
+
+                            case ExpressionOperator.GreaterThan:
+                            case ExpressionOperator.GreaterThan_Un:
+                                return this.Left[0].K <= this.Right[0].K;
+
+                            case ExpressionOperator.LessEqualThan:
+                            case ExpressionOperator.LessEqualThan_Un:
+                                return this.Left[0].K > this.Right[0].K;
+
+                            case ExpressionOperator.LessThan:
+                            case ExpressionOperator.LessThan_Un:
+                                return this.Left[0].K >= this.Right[0].K;
+
+                            case ExpressionOperator.NotEqual:
+                                return this.Right[0].K == this.Left[0].K;
+
+                            default:
+                                return false;
+                        }
+                    }
+                }
+
+                return false;
             }
-          }
-          Cached_IsLinear = true;
-          return true;
-        }
-        else
-        {
-          Cached_IsLinear = true;
-          return true;
-        }
-      }
-    }
-
-    public bool IsLinearOctagon
-    {
-      get
-      {
-        if (!this.IsLinear)
-        {
-          return false;
-        }
-        else if (this.IsOctagonForm)
-        {
-          return true;
-        }
-        else if (!this.Relation.HasValue)
-        {
-          if (this.Left.Length > 2)
-          {
-            return false;
-          }
-          else if (this.Left.Length == 1)
-          {   // is the case that we have <k, 1> or <+/- 1, x> ?
-            return (this.Left[0].IsConstant || this.Left[0].K == 1 || this.Left[0].K == -1);
-          }
-          else
-          {
-            Contract.Assume(this.Left.Length == 2, "Error cannot have an empty left on a Polynomial");
-
-            return (this.Left[0].IsLinear && (this.Left[0].K == 1 || this.Left[0].K == -1) && this.Left[1].IsConstant);
-          }
-        }
-        else
-        {
-          return false;
-        }
-      }
-    }
-
-    private bool IsIntConstant(out long kLeft)
-    {
-      kLeft = default(long);
-
-      if (this.Relation.HasValue)
-        return false;
-
-      return this.Left.Length == 1 && this.Left[0].IsIntConstant(out kLeft);
-    }
-
-    public int Degree
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-
-        if (this.Cached_Degree.HasValue)
-        {
-          Contract.Assume(this.Cached_Degree.Value >= 0);
-          return this.Cached_Degree.Value;
         }
 
-        int max = 0;
-        foreach (var m in this.Left)
+        /// <summary>
+        /// Is it in the form of <code>a*x + b *y \leq c</code>, with a, b \in  {+1, -1, 0}, and c \in Rational 
+        /// </summary>
+        public bool IsOctagonForm
         {
-          if (m.Degree > max)
-            max = m.Degree;
-        }
-        if (this.Right != null)
-        {
-          foreach (var m in this.Right)
-          {
-            if (m.Degree > max)
-              max = m.Degree;
-          }
-        }
-
-        this.Cached_Degree = max;
-        return max;
-      }
-    }
-
-    /// <summary>
-    /// Is in the form of k1 * x \leq k2 ?
-    /// </summary>
-    public bool IsIntervalForm
-    {
-      get
-      {
-        if (this.Relation != ExpressionOperator.LessEqualThan) // Must be "<="
-        {
-          return false;
-        }
-        if (!(this.Left.Length == 1 && this.Right.Length == 1))   // Must be "m1 <= m2"
-        {
-          return false;
-        }
-        if (!(this.Left[0].Degree == 1))                 // Must be "m1 == k1 * x"
-        {
-          return false;
-        }
-        if (!this.Right[0].IsConstant)                  // Must be "m2 == k2"
-        {
-          return false;
-        }
-
-        return true;    // It is "k1 * x <= k2 "
-      }
-    }
-
-    private bool IsMonomial(out Monomial<Variable> m)
-    {
-      if (!this.relation.HasValue && this.left.Length == 1)
-      {
-        m = this.left[0];
-        return true;
-      }
-      else
-      {
-        m = default(Monomial<Variable>);
-        return false;
-      }
-    }
-
-    #endregion
-
-    #region Constructors
-
-    [ContractVerification(false)]
-    private Polynomial(Monomial<Variable> monome)
-    {
-      this.relation = null;
-
-      var this_left = new Monomial<Variable>[] { monome };
-
-      this.left = this_left;
-
-      this.right = null;
-
-      Cached_IsLinear = Cached_IsTautology = null;
-      Cached_Degree = null;
-      Cached_Vars = null;
-    }
-
-    /// <summary>
-    /// If <code>monomes == (k1, xs1) ... (kn, xsn)</code> then it constructs the polynome <code>k1*xs1 +  ... + kn* xsn</code>
-    /// </summary>
-    [ContractVerification(false)]
-    private Polynomial(Monomial<Variable>[] monomes)
-    {
-      Contract.Requires(monomes != null);
-
-      this.relation = null;
-      this.left = monomes;
-      this.right = null;
-
-      Cached_IsLinear = Cached_IsTautology = null;
-      Cached_Degree = null;
-      Cached_Vars = null;
-    }
-
-    /// <summary>
-    /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
-    /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
-    /// </summary>
-    /// <param name="op">Must be a binary operator</param>
-    [ContractVerification(false)]
-    private Polynomial(ExpressionOperator op, Monomial<Variable>[] left, Monomial<Variable>[] right)
-    {
-      Contract.Requires(op.IsBinary());
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.ValueAtReturn(out this.left) == left);
-      Contract.Ensures(Contract.ValueAtReturn(out this.right) == right);
-
-      this.relation = op;
-      this.left = left;
-      this.right = right;
-      
-      Cached_IsLinear = Cached_IsTautology = null;
-      Cached_Degree = null;
-      Cached_Vars = null; 
-    }
-
-    /// <summary>
-    /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1)</code>, then it constructs the polynome standing for 
-    /// <code> k1*xs1 +  ... + kn* xsn op c1*ys1</code>
-    /// </summary>
-    /// <param name="op">Must be a binary operator</param>
-    [ContractVerification(false)]
-    private Polynomial(ExpressionOperator op, Monomial<Variable>[] left, Monomial<Variable> right)
-    {
-      Contract.Requires(op.IsBinary());
-      Contract.Requires(left != null);
-      Contract.Requires(!object.ReferenceEquals(right, null));
-
-      this.relation = op;
-      this.left = left;
-      this.right = new Monomial<Variable>[] { right };
-
-      Cached_IsLinear = Cached_IsTautology = null;
-      Cached_Degree = null;
-      Cached_Vars = null;
-    }
-
-    /// <summary>
-    /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
-    /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
-    /// </summary>
-    /// <param name="op">Must be a binary operator</param>
-    /// <param name="left">shoukd be such that left.Relation == null</param>
-    /// <param name="right">shoukd be such that right.Relation == null</param>
-    [ContractVerification(false)]
-    private Polynomial(ExpressionOperator op, Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right)
-    {
-      Contract.Requires(op.IsBinary());
-      Contract.Requires(!left.Relation.HasValue);
-      Contract.Requires(!right.Relation.HasValue);
-
-      Contract.Assume(left.left != null);
-      Contract.Assume(right.left != null);
-
-      this.relation = op;
-      this.left = left.left;
-      this.right = right.left;
-
-      Cached_IsLinear = Cached_IsTautology = null;
-      Cached_Degree = null;
-      Cached_Vars = null;
-    }
-
-    [ContractVerification(false)]
-    private Polynomial(Polynomial<Variable, Expression> other)
-    {
-      Contract.Requires(!object.ReferenceEquals(other, null));
-
-      Contract.Assume(other.left != null);
-
-      this.relation = other.relation;
-      this.left = DuplicateFrom(other.left);
-      this.right = other.right != null ? DuplicateFrom(other.right) : null;
-
-      Cached_IsLinear = Cached_IsTautology = null;
-      Cached_Degree = null;
-      Cached_Vars = null;
-    }
-
-    #endregion
-
-
-    #region Manipulation of the polynomial: Creates a Polynomial from a PureExpression and puts it into a canonical form
-
-    /// <summary>
-    /// Convert the pure expression <code>exp</code> into a polynomial, that is somehow simpler to handle.
-    /// Essentially, it gets rid of all the parentheses, it performs the(simple) multiplications, additions, etc.
-    /// </summary>
-    /// <param name="exp">The expression that will be decoded</param>
-    /// <param name="decoder">The decoder for the expression</param>
-    /// <param name="result">If the result is true, then it returns a polynomial into a canonical form</param>
-    static public bool TryToPolynomialForm(Expression exp, IExpressionDecoder<Variable, Expression> decoder,
-      out Polynomial<Variable, Expression> result)
-    {
-      Contract.Requires(decoder != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result).Left != null);
-
-      if (TryToPolynomialFormInternal(exp, decoder, out result))
-      {
-        try
-        {
-          if (result.TryToCanonicalForm(out result))
-          {
-            return true;
-          }
-        }
-        catch (ArithmeticExceptionRational)
-        {
-        }
-      }
-
-      return false;
-    }
-
-    private static bool TryToPolynomialFormInternal(Expression exp,
-      IExpressionDecoder<Variable, Expression> decoder, out Polynomial<Variable, Expression> result)
-    {
-      Contract.Requires(decoder != null);
-
-      return new TryToPolynomialVisitor(decoder).Visit(exp, out result);
-    }
-
-
-    /// <summary>
-    /// Convert the pure expression <code>left op right</code> into a polynomial, that is somehow simpler to handle.
-    /// Essentially, it gets rid of all the parenthesis, it performs the(simple) multiplications, additions, etc.
-    /// </summary>
-    /// <param name="result">if the result is true, it is a polynomial in canonical form</param>
-    static public bool TryToPolynomialForm(ExpressionOperator op, Expression left, Expression right,
-      IExpressionDecoder<Variable, Expression> decoder, out Polynomial<Variable, Expression> result)
-    {
-      Contract.Requires(op.IsBinary());
-      Contract.Requires(decoder != null);
-
-      if (!decoder.OperatorFor(left).IsRelationalOperator()
-        && !decoder.OperatorFor(right).IsRelationalOperator())
-      {
-        Polynomial<Variable, Expression> leftAsPol, rightAsPol;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(left, decoder, out leftAsPol)  // We can convert to polynomial
-          && Polynomial<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol)
-          && !leftAsPol.Relation.HasValue && !rightAsPol.Relation.HasValue                      // the polynomial are polynomial forms indeed
-          )
-        {
-          try
-          {
-            result = new Polynomial<Variable, Expression>(op, leftAsPol, rightAsPol);
-
-            if (result.TryToCanonicalForm(out result))
+            get
             {
-              return true;
+                Contract.Ensures(!Contract.Result<bool>() || this.Degree <= 1);
+                Contract.Ensures(!Contract.Result<bool>() || this.Right != null);
+
+                if (this.Relation == null)
+                {
+                    return false;
+                }
+                if (this.Left.Length == 0)
+                {
+                    return false;
+                }
+                if (!this.IsLinear)
+                {
+                    return false;
+                }
+                if (!(this.Left.Length <= 2 && this.Right.Length == 1))   // Something in the form of m1 + m2 <= m3
+                {
+                    return false;
+                }
+                var m0K = this.Left[0].K;
+
+                if (!(m0K == -1 || m0K == 1 || m0K.IsZero))     // m1.K must be -1, 0 or +1
+                {
+                    return false;
+                }
+                if (this.Left.Length == 2)
+                {
+                    var m1K = this.Left[1].K;
+                    if (!(m1K == -1 || m1K == 1 || m1K.IsZero)) // m2.K must be -1, 0 or +1
+                    {
+                        return false;
+                    }
+                }
+                if (!this.Right[0].IsConstant)                          // m3 must be a constant
+                {
+                    return false;
+                }
+
+                Contract.Assert(this.Right != null);
+
+                return true;                                            // If we reached this point, then it is an octagon
             }
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            // We swallow it, and contine by failing
-          }
         }
-      }
 
-      result = default(Polynomial<Variable, Expression>);
-      return false;
-    }
-
-    static public bool TryToPolynomialForm(ExpressionOperator op, Variable left, Expression right,
-      IExpressionDecoder<Variable, Expression> decoder, out Polynomial<Variable, Expression> result)
-    {
-      Contract.Requires(op.IsBinary());
-      Contract.Requires(decoder != null);
-
-      if (decoder.OperatorFor(right).IsRelationalOperator())
-      {
-        result = default(Polynomial<Variable, Expression>);
-        return false;
-      }
-      else
-      {
-        Polynomial<Variable, Expression> rightAsPol;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol) && !rightAsPol.Relation.HasValue)
+        public bool IsLinear
         {
-          try
-          {
-
-            var leftAsPol = new Polynomial<Variable, Expression>(new Monomial<Variable>[] { new Monomial<Variable>(left) });
-
-            var tmp = new Polynomial<Variable, Expression>(op, leftAsPol, rightAsPol);
-            if (tmp.TryToCanonicalForm(out result))
+            get
             {
-              return true;
+                if (Cached_IsLinear.HasValue)
+                {
+                    return Cached_IsLinear.Value;
+                }
+
+                foreach (var m in this.Left)
+                { // all the monomial on the left must be linear
+                    if (!m.IsLinear)
+                    {
+                        Cached_IsLinear = false;
+                        return false;
+                    }
+                }
+                if (this.Relation != null)
+                {
+                    foreach (var m in this.Right)
+                    { // all the monomial on the right must be linear
+                        if (!m.IsLinear)
+                        {
+                            Cached_IsLinear = false;
+                            return false;
+                        }
+                    }
+                    Cached_IsLinear = true;
+                    return true;
+                }
+                else
+                {
+                    Cached_IsLinear = true;
+                    return true;
+                }
+            }
+        }
+
+        public bool IsLinearOctagon
+        {
+            get
+            {
+                if (!this.IsLinear)
+                {
+                    return false;
+                }
+                else if (this.IsOctagonForm)
+                {
+                    return true;
+                }
+                else if (!this.Relation.HasValue)
+                {
+                    if (this.Left.Length > 2)
+                    {
+                        return false;
+                    }
+                    else if (this.Left.Length == 1)
+                    {   // is the case that we have <k, 1> or <+/- 1, x> ?
+                        return (this.Left[0].IsConstant || this.Left[0].K == 1 || this.Left[0].K == -1);
+                    }
+                    else
+                    {
+                        Contract.Assume(this.Left.Length == 2, "Error cannot have an empty left on a Polynomial");
+
+                        return (this.Left[0].IsLinear && (this.Left[0].K == 1 || this.Left[0].K == -1) && this.Left[1].IsConstant);
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        private bool IsIntConstant(out long kLeft)
+        {
+            kLeft = default(long);
+
+            if (this.Relation.HasValue)
+                return false;
+
+            return this.Left.Length == 1 && this.Left[0].IsIntConstant(out kLeft);
+        }
+
+        public int Degree
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                if (Cached_Degree.HasValue)
+                {
+                    Contract.Assume(Cached_Degree.Value >= 0);
+                    return Cached_Degree.Value;
+                }
+
+                int max = 0;
+                foreach (var m in this.Left)
+                {
+                    if (m.Degree > max)
+                        max = m.Degree;
+                }
+                if (this.Right != null)
+                {
+                    foreach (var m in this.Right)
+                    {
+                        if (m.Degree > max)
+                            max = m.Degree;
+                    }
+                }
+
+                Cached_Degree = max;
+                return max;
+            }
+        }
+
+        /// <summary>
+        /// Is in the form of k1 * x \leq k2 ?
+        /// </summary>
+        public bool IsIntervalForm
+        {
+            get
+            {
+                if (this.Relation != ExpressionOperator.LessEqualThan) // Must be "<="
+                {
+                    return false;
+                }
+                if (!(this.Left.Length == 1 && this.Right.Length == 1))   // Must be "m1 <= m2"
+                {
+                    return false;
+                }
+                if (!(this.Left[0].Degree == 1))                 // Must be "m1 == k1 * x"
+                {
+                    return false;
+                }
+                if (!this.Right[0].IsConstant)                  // Must be "m2 == k2"
+                {
+                    return false;
+                }
+
+                return true;    // It is "k1 * x <= k2 "
+            }
+        }
+
+        private bool IsMonomial(out Monomial<Variable> m)
+        {
+            if (!relation.HasValue && left.Length == 1)
+            {
+                m = left[0];
+                return true;
             }
             else
             {
-              return false;
+                m = default(Monomial<Variable>);
+                return false;
             }
-          }
-          catch (ArithmeticExceptionRational)
-          {
+        }
+
+        #endregion
+
+        #region Constructors
+
+        [ContractVerification(false)]
+        private Polynomial(Monomial<Variable> monome)
+        {
+            relation = null;
+
+            var this_left = new Monomial<Variable>[] { monome };
+
+            left = this_left;
+
+            right = null;
+
+            Cached_IsLinear = Cached_IsTautology = null;
+            Cached_Degree = null;
+            Cached_Vars = null;
+        }
+
+        /// <summary>
+        /// If <code>monomes == (k1, xs1) ... (kn, xsn)</code> then it constructs the polynome <code>k1*xs1 +  ... + kn* xsn</code>
+        /// </summary>
+        [ContractVerification(false)]
+        private Polynomial(Monomial<Variable>[] monomes)
+        {
+            Contract.Requires(monomes != null);
+
+            relation = null;
+            left = monomes;
+            right = null;
+
+            Cached_IsLinear = Cached_IsTautology = null;
+            Cached_Degree = null;
+            Cached_Vars = null;
+        }
+
+        /// <summary>
+        /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
+        /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
+        /// </summary>
+        /// <param name="op">Must be a binary operator</param>
+        [ContractVerification(false)]
+        private Polynomial(ExpressionOperator op, Monomial<Variable>[] left, Monomial<Variable>[] right)
+        {
+            Contract.Requires(op.IsBinary());
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.ValueAtReturn(out this.left) == left);
+            Contract.Ensures(Contract.ValueAtReturn(out this.right) == right);
+
+            relation = op;
+            this.left = left;
+            this.right = right;
+
+            Cached_IsLinear = Cached_IsTautology = null;
+            Cached_Degree = null;
+            Cached_Vars = null;
+        }
+
+        /// <summary>
+        /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1)</code>, then it constructs the polynome standing for 
+        /// <code> k1*xs1 +  ... + kn* xsn op c1*ys1</code>
+        /// </summary>
+        /// <param name="op">Must be a binary operator</param>
+        [ContractVerification(false)]
+        private Polynomial(ExpressionOperator op, Monomial<Variable>[] left, Monomial<Variable> right)
+        {
+            Contract.Requires(op.IsBinary());
+            Contract.Requires(left != null);
+            Contract.Requires(!object.ReferenceEquals(right, null));
+
+            relation = op;
+            this.left = left;
+            this.right = new Monomial<Variable>[] { right };
+
+            Cached_IsLinear = Cached_IsTautology = null;
+            Cached_Degree = null;
+            Cached_Vars = null;
+        }
+
+        /// <summary>
+        /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
+        /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
+        /// </summary>
+        /// <param name="op">Must be a binary operator</param>
+        /// <param name="left">shoukd be such that left.Relation == null</param>
+        /// <param name="right">shoukd be such that right.Relation == null</param>
+        [ContractVerification(false)]
+        private Polynomial(ExpressionOperator op, Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right)
+        {
+            Contract.Requires(op.IsBinary());
+            Contract.Requires(!left.Relation.HasValue);
+            Contract.Requires(!right.Relation.HasValue);
+
+            Contract.Assume(left.left != null);
+            Contract.Assume(right.left != null);
+
+            relation = op;
+            this.left = left.left;
+            this.right = right.left;
+
+            Cached_IsLinear = Cached_IsTautology = null;
+            Cached_Degree = null;
+            Cached_Vars = null;
+        }
+
+        [ContractVerification(false)]
+        private Polynomial(Polynomial<Variable, Expression> other)
+        {
+            Contract.Requires(!object.ReferenceEquals(other, null));
+
+            Contract.Assume(other.left != null);
+
+            relation = other.relation;
+            left = DuplicateFrom(other.left);
+            right = other.right != null ? DuplicateFrom(other.right) : null;
+
+            Cached_IsLinear = Cached_IsTautology = null;
+            Cached_Degree = null;
+            Cached_Vars = null;
+        }
+
+        #endregion
+
+
+        #region Manipulation of the polynomial: Creates a Polynomial from a PureExpression and puts it into a canonical form
+
+        /// <summary>
+        /// Convert the pure expression <code>exp</code> into a polynomial, that is somehow simpler to handle.
+        /// Essentially, it gets rid of all the parentheses, it performs the(simple) multiplications, additions, etc.
+        /// </summary>
+        /// <param name="exp">The expression that will be decoded</param>
+        /// <param name="decoder">The decoder for the expression</param>
+        /// <param name="result">If the result is true, then it returns a polynomial into a canonical form</param>
+        static public bool TryToPolynomialForm(Expression exp, IExpressionDecoder<Variable, Expression> decoder,
+          out Polynomial<Variable, Expression> result)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result).Left != null);
+
+            if (TryToPolynomialFormInternal(exp, decoder, out result))
+            {
+                try
+                {
+                    if (result.TryToCanonicalForm(out result))
+                    {
+                        return true;
+                    }
+                }
+                catch (ArithmeticExceptionRational)
+                {
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryToPolynomialFormInternal(Expression exp,
+          IExpressionDecoder<Variable, Expression> decoder, out Polynomial<Variable, Expression> result)
+        {
+            Contract.Requires(decoder != null);
+
+            return new TryToPolynomialVisitor(decoder).Visit(exp, out result);
+        }
+
+
+        /// <summary>
+        /// Convert the pure expression <code>left op right</code> into a polynomial, that is somehow simpler to handle.
+        /// Essentially, it gets rid of all the parenthesis, it performs the(simple) multiplications, additions, etc.
+        /// </summary>
+        /// <param name="result">if the result is true, it is a polynomial in canonical form</param>
+        static public bool TryToPolynomialForm(ExpressionOperator op, Expression left, Expression right,
+          IExpressionDecoder<Variable, Expression> decoder, out Polynomial<Variable, Expression> result)
+        {
+            Contract.Requires(op.IsBinary());
+            Contract.Requires(decoder != null);
+
+            if (!decoder.OperatorFor(left).IsRelationalOperator()
+              && !decoder.OperatorFor(right).IsRelationalOperator())
+            {
+                Polynomial<Variable, Expression> leftAsPol, rightAsPol;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(left, decoder, out leftAsPol)  // We can convert to polynomial
+                  && Polynomial<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol)
+                  && !leftAsPol.Relation.HasValue && !rightAsPol.Relation.HasValue                      // the polynomial are polynomial forms indeed
+                  )
+                {
+                    try
+                    {
+                        result = new Polynomial<Variable, Expression>(op, leftAsPol, rightAsPol);
+
+                        if (result.TryToCanonicalForm(out result))
+                        {
+                            return true;
+                        }
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        // We swallow it, and contine by failing
+                    }
+                }
+            }
+
             result = default(Polynomial<Variable, Expression>);
             return false;
-          }
-
-        }
-        else
-        {
-          result = default(Polynomial<Variable, Expression>);
-
-          return false;
-        }
-      }
-    }
-
-
-    /// <param name="result">If the result is true, it is a polynomial in canonical form</param>
-    static public bool TryToPolynomialForm(
-      ExpressionOperator op,
-      Polynomial<Variable, Expression> left,
-      Polynomial<Variable, Expression> right,
-      out Polynomial<Variable, Expression> result)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result).left != null);
-      Contract.Ensures(!Contract.Result<bool>() || op != ExpressionOperator.LessEqualThan || Contract.ValueAtReturn(out result).Relation == ExpressionOperator.LessEqualThan);
-
-      if (!op.IsBinary() || left.Relation != null || right.Relation != null)
-      {
-        result = default(Polynomial<Variable, Expression>);
-        return false;
-      }
-      else
-      {
-        try
-        {
-          Contract.Assert(right.Relation == null);
-
-          // here we return a new Polynomial. An alternative is to return a polynomial in canonical form
-          result = new Polynomial<Variable, Expression>(op, left, right);
-          if (result.TryToCanonicalForm(out result))
-          {
-            return true;
-          }
-        }
-        catch (ArithmeticExceptionRational)
-        {
-          // If there is an exception in the rationals, then we simply fail
-        }
-      }
-      result = default(Polynomial<Variable, Expression>);
-      return false;
-    }
-
-    /// <param name="result">The result: a polynomial in canonical form</param>
-    /// <returns>Always true</returns>
-    static public bool TryToPolynomialForm(
-      ExpressionOperator expressionOperator, Monomial<Variable>[] left, Monomial<Variable>[] right,
-      out Polynomial<Variable, Expression> result)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Requires(expressionOperator.IsBinary());
-
-      Contract.Ensures(!object.ReferenceEquals(Contract.ValueAtReturn(out result), null));
-
-      result = new Polynomial<Variable, Expression>(expressionOperator, left, right);
-      return result.TryToCanonicalForm(out result);
-    }
-
-    static public bool TryToPolynomialForm(
-      bool canonicalByConstruction,
-      ExpressionOperator expressionOperator, Monomial<Variable>[] left, Monomial<Variable>[] right,
-      out Polynomial<Variable, Expression> result)
-    {
-      Contract.Requires(expressionOperator.IsBinary());
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<bool>() == true);
-      Contract.Ensures(!object.ReferenceEquals(Contract.ValueAtReturn(out result), null));
-
-      if (canonicalByConstruction)
-      {
-        result = new Polynomial<Variable, Expression>(expressionOperator, left, right);
-
-        return true;
-      }
-      else
-      {
-        return TryToPolynomialForm(expressionOperator, left, right, out result);
-      }
-    }
-
-
-    /// <summary>
-    /// Convert the list of monomials <code>monomials</code> into a Polynomial in canonical form
-    /// </summary>
-    /// <param name="pol">The polynomial in canonical form</param>
-    /// <returns>Always true</returns>
-    static public bool TryToPolynomialForm(Monomial<Variable>[] monomials, out Polynomial<Variable, Expression> pol)
-    {
-      Contract.Requires(monomials != null);
-
-      if (monomials.Length > 1)
-      {
-        pol = new Polynomial<Variable, Expression>(monomials);
-
-        return pol.TryToCanonicalForm(out pol);
-      }
-      else
-      {
-        pol = new Polynomial<Variable, Expression>(monomials);
-
-        return true;
-      }
-    }
-
-    static public bool TryToPolynomialForm(bool canonicalByConstruction, Monomial<Variable>[] monomials, out Polynomial<Variable, Expression> pol)
-    {
-      Contract.Requires(monomials != null);
-
-      if (canonicalByConstruction)
-      {
-        pol = new Polynomial<Variable, Expression>(monomials);
-        return true;
-      }
-      else
-      {
-        return TryToPolynomialForm(monomials, out pol);
-      }
-    }
-
-    #endregion
-
-    #region Manipulation of the polynomial : Add a monome
-    public Polynomial<Variable, Expression> AddMonomialToTheLeft(Monomial<Variable> m)
-    {
-
-      var tmpLeft = new Monomial<Variable>[this.left.Length + 1];
-
-      Array.Copy(this.left, tmpLeft, this.left.Length);
-      tmpLeft[this.left.Length] = m;
-
-      var tmpright = this.right != null ? DuplicateFrom(this.right) : null;
-
-      Polynomial<Variable, Expression> tmp, result;
-      if (this.relation.HasValue)
-      {
-        tmp = new Polynomial<Variable, Expression>(this.relation.Value, tmpLeft, tmpright);
-      }
-      else
-      {
-        tmp = new Polynomial<Variable, Expression>(tmpLeft);
-      }
-
-      tmp.TryToCanonicalForm(out result);
-
-      return result;
-    }
-
-    public Polynomial<Variable, Expression> AddMonomialToTheLeft(Monomial<Variable>[] m)
-    {
-      Contract.Requires(m != null);
-
-      Contract.Ensures(!Object.ReferenceEquals(Contract.Result<Polynomial<Variable, Expression>>(), null));
-
-      var tmpleft = new Monomial<Variable>[this.left.Length + m.Length];
-
-      Array.Copy(this.left, tmpleft, this.left.Length);
-      Array.Copy(m, 0, tmpleft, this.left.Length, m.Length);
-
-      var tmpright = this.right != null ? DuplicateFrom(this.right) : null;
-
-      var tmp = new Polynomial<Variable, Expression>(this.relation.Value, tmpleft, tmpright);
-
-      Polynomial<Variable, Expression> result;
-
-      tmp.TryToCanonicalForm(out result);
-
-      return result;
-    }
-
-    #endregion
-
-    #region ToCanonicalForm, ToPureExpression, Renaming
-    /// <summary>
-    /// Put this Polynomial into a canonical form, meaning that all the monomial involving variables are on the left, all the constants on the right, and all the easy arithmetic operations are performed
-    /// </summary>
-    /// <returns>The canonical form of this polynomial</returns>
-    private bool TryToCanonicalForm(out Polynomial<Variable, Expression> result)
-    {
-      // Two main cases: this polynomial is binded by a relation, or it is just a sequence of monomials
-      if (this.Relation.HasValue)
-      {
-        Contract.Assume(this.right != null);
-        switch (this.Relation.Value)
-        {
-          case ExpressionOperator.GreaterEqualThan:
-            SwapOperands(ExpressionOperator.LessEqualThan);
-            break;
-
-          case ExpressionOperator.GreaterEqualThan_Un:
-            SwapOperands(ExpressionOperator.LessEqualThan_Un);
-            break;
-
-          case ExpressionOperator.GreaterThan:
-            SwapOperands(ExpressionOperator.LessThan);
-            break;
-
-          case ExpressionOperator.GreaterThan_Un:
-            SwapOperands(ExpressionOperator.LessThan_Un);
-            break;
         }
 
-        Polynomial<Variable, Expression> moved;
-        if (this.TryMoveConstantsAndMonomes(out moved))
+        static public bool TryToPolynomialForm(ExpressionOperator op, Variable left, Expression right,
+          IExpressionDecoder<Variable, Expression> decoder, out Polynomial<Variable, Expression> result)
         {
-          Contract.Assume(this.relation.HasValue);
+            Contract.Requires(op.IsBinary());
+            Contract.Requires(decoder != null);
 
-          Monomial<Variable>[] simplifiedLeft, simplifiedRight;
-          if (TrySimplifyMonomes(moved.left, out simplifiedLeft) && TrySimplifyMonomes(moved.right, out simplifiedRight))
-          {
-            Contract.Assume(simplifiedRight.Length == 1, "At this point we expected just a constant on the right side...");
-
-            if (TryReduceCoefficents(simplifiedLeft, simplifiedRight))
+            if (decoder.OperatorFor(right).IsRelationalOperator())
             {
-              Contract.Assert(this.relation.Value.IsBinary());
-
-              result = new Polynomial<Variable, Expression>(this.relation.Value, simplifiedLeft, simplifiedRight);
-              return true;
+                result = default(Polynomial<Variable, Expression>);
+                return false;
             }
-          }
-        }
-        else
-        {
-          // Do nothing, we will return false;
-        }
-      }
-      else
-      {
-        Monomial<Variable>[] simplified;
-        if (TrySimplifyMonomes(this.left, out simplified))
-        {
-          result = new Polynomial<Variable, Expression>(simplified);
-          return true;
-        }
-      }
-
-      result = default(Polynomial<Variable, Expression>);
-      return false;
-    }
-
-    /// <summary>
-    /// Swap in place
-    /// Works with side effects!!!
-    /// </summary>
-    private void SwapOperands(ExpressionOperator newOperator)
-    {
-      Contract.Requires(this.right != null);
-
-      Contract.Ensures(this.relation.HasValue);
-      Contract.Ensures(this.left == Contract.OldValue(this.right));
-      Contract.Ensures(this.right == Contract.OldValue(this.left));
-
-      this.relation = newOperator;
-
-      var tmp = this.left;
-      this.left = this.right;
-      this.right = tmp;
-    }
-
-    /// <summary>
-    /// Convert this polynomial into a pure expression
-    /// </summary>
-    public Expression ToPureExpression(IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(encoder != null);
-
-      Contract.Ensures(Contract.Result<Expression>() != null);
-
-      return ToPureExpressionForm(this, encoder);
-    }
-
-    /// <summary>
-    /// Convert a polynomial into a pure expression
-    /// </summary>
-    /// <param name="encoder">The encoder for constructing an expression</param>
-    static private Expression ToPureExpressionForm(Polynomial<Variable, Expression> p, IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(!object.ReferenceEquals(p, null));
-      Contract.Requires(encoder != null);
-
-      Contract.Ensures(Contract.Result<Expression>() != null);
-
-      var eLeft = ConvertToPureExpression(p.left, encoder);
-      if (p.Relation.HasValue)
-      {
-        var eRight = ConvertToPureExpression(p.right, encoder);
-        return encoder.CompoundExpressionFor(ExpressionType.Bool, p.Relation.Value, eLeft, eRight);
-      }
-      else
-      {
-        return eLeft;
-      }
-    }
-
-
-    /// <returns>true if the polynomial is linear, and in such a case a list representation</returns>
-    public bool TryToList(out List<Pair<Rational, Variable>> val)
-    {
-      if (this.Relation.HasValue)
-      {
-        long k;
-        if (this.Relation.Value == ExpressionOperator.Equal && this.right[0].IsIntConstant(out k) && k == 0)
-        {
-          // ok
-        }
-        else
-        {
-          val = default(List<Pair<Rational, Variable>>);
-          return false;
-        }
-      }
-
-      val = new List<Pair<Rational, Variable>>();
-
-      foreach (var m in this.left)
-      {
-        if (m.IsLinear)
-        {
-          val.Add(new Pair<Rational, Variable>(m.K, m.VariableAt(0)));
-        }
-        else
-        {
-          val = default(List<Pair<Rational, Variable>>);
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    /// <summary>
-    /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
-    /// </summary>
-    public Polynomial<Variable, Expression> Rename(Variable x, Variable xNew)
-    {
-      return Rename(true, x, xNew);
-    }
-
-    /// <summary>
-    /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
-    /// </summary>
-    public Polynomial<Variable, Expression> Rename(bool canonical, Variable x, Variable xNew)
-    {
-      // Improve: Use sharing when the renamed polynomial is the same
-
-      var leftResult = new List<Monomial<Variable>>();
-      var rightResult = new List<Monomial<Variable>>();
-
-      foreach (var m in this.Left)
-      {
-        leftResult.Add(m.Rename(x, xNew));
-      }
-      if (this.Relation.HasValue)
-      {
-        foreach (var m in this.Right)
-        {
-          rightResult.Add(m.Rename(x, xNew));
-        }
-      }
-
-      Polynomial<Variable, Expression> result = this.Relation.HasValue
-        ? new Polynomial<Variable, Expression>(this.Relation.Value, leftResult.ToArray(), rightResult.ToArray())
-        : new Polynomial<Variable, Expression>(leftResult.ToArray());
-
-      if (canonical)
-      {
-        result.TryToCanonicalForm(out result);
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region Equivalence of polynomials
-
-    public bool IsEquivalentTo(Polynomial<Variable, Expression> other)
-    {
-      Polynomial<Variable, Expression> left, right;
-      if (!this.TryToCanonicalForm(out left) || !other.TryToCanonicalForm(out right))
-      {
-        return false;
-      }
-
-      if (!SimpleEquivalence(left, right))
-      {
-        return false;
-      }
-      else
-      { // At this point we know they have the same cardinality
-
-        if (!UniformCoefficents(left, right))
-        {
-          return false;
-        }
-
-        foreach (var m in left.Left)
-        {
-          if (!ContainsMonomialEquivalentTo(right.left, m))
-            return false;
-        }
-
-        if (left.Relation.HasValue)
-        {
-          Contract.Assume(right.Relation.HasValue);
-
-          foreach (var m in left.Right)
-          {
-            if (!ContainsMonomialEquivalentTo(right.right, m))
-              return false;
-          }
-        }
-
-        // right contains all the monomials in left, and right has the same cardinality of left, so they are equivalent
-        return true;
-      }
-    }
-
-    private static bool SimpleEquivalence(Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right)
-    {
-      if (left.Degree != right.Degree)
-        return false;
-      if (left.Left.Length != right.Left.Length)
-        return false;
-      if (left.Relation != right.Relation)
-        return false;
-      if ((!left.Relation.HasValue && !right.Relation.HasValue) && (left.Right.Length != right.Right.Length))
-        return false;
-
-      return true;
-    }
-
-    private static bool UniformCoefficents(Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right)
-    {
-      Contract.Requires(left.left != null);
-      Contract.Requires(right.left != null);
-
-      var listLeft = left.left;
-      var listRight = right.left;
-
-      if (listLeft.Length == 0)
-      {
-        if (listRight.Length == 0)
-        {
-          return true;
-        }
-        else
-        {
-          listLeft = left.right;
-          listRight = right.right;
-        }
-      }
-
-      var mLeft = listLeft[0];
-      Monomial<Variable>? mRight = null;
-
-      foreach (var m in listRight)
-      {
-        if (mLeft.Degree != m.Degree)
-          continue;
-
-        foreach (var v in mLeft.Variables)
-        {
-          if (!m.ContainsVariable(v))
-            goto nextMonomial;
-        }
-
-        mRight = m;   // We found a monomial with the same variables
-        break;
-
-      nextMonomial:
-        ;
-      }
-
-      if (mRight.HasValue)
-      {
-        var kLeft = mLeft.K;
-        var kRight = mRight.Value.K;
-
-        if (kLeft != kRight)
-        {
-          if (kRight == 0)
-            return true;
-
-          var k = kLeft / kRight;
-
-          for (int i = 0; i < right.Left.Length; i++)
-          {
-            right.Left[i].K = right.Left[i].K * k;
-          }
-
-          if (right.Relation.HasValue)
-          {
-            for (int i = 0; i < right.Right.Length; i++)
-            {
-              right.Right[i].K = right.Right[i].K * k;
-            }
-          }
-        }
-
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
-
-    private static bool ContainsMonomialEquivalentTo(Monomial<Variable>[] l, Monomial<Variable> toFind)
-    {
-      foreach (var m in l)
-      {
-        if (m.K != toFind.K)
-          continue;
-
-        if (m.Degree != toFind.Degree)
-          continue;
-
-        foreach (var v in m.Variables)
-        {
-          if (!toFind.ContainsVariable(v))
-            goto nextMonomial;
-        }
-
-        // At this point, they have the same coefficent, and the same variables, so they are the same
-        return true;
-
-      nextMonomial:
-        ;
-      }
-
-      return false;
-    }
-
-    #endregion
-
-    #region Contains Dummy variables?
-
-    public bool ContainsDummyVariables(IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(decoder != null);
-
-      if (this.left == null)
-        return false;
-
-      foreach (var monomial in this.Left)
-      {
-        foreach (var x in monomial.Variables)
-        {
-          if (!decoder.IsSlackOrFrameworkVariable(x))
-          {
-            return true;
-          }
-        }
-      }
-
-      if (this.right != null)
-      {
-        foreach (var monomial in this.Right)
-        {
-          foreach (var x in monomial.Variables)
-          {
-            if (!decoder.IsSlackOrFrameworkVariable(x))
-            {
-              return true;
-            }
-          }
-        }
-      }
-
-      return false;
-    }
-
-    #endregion
-
-    #region Private methods
-    [ContractVerification(true)]
-    static private Monomial<Variable>[] DuplicateFrom(Monomial<Variable>[] original)
-    {
-      Contract.Requires(original != null);
-
-      Contract.Ensures(Contract.Result<Monomial<Variable>[]>() != null);
-      Contract.Ensures(Contract.Result<Monomial<Variable>[]>().Length == original.Length);
-
-      var result = new Monomial<Variable>[original.Length];
-
-      Array.Copy(original, result, original.Length);
-
-      return result;
-    }
-
-
-    /// <summary>
-    /// Move the constants to the right of the relation operator, and the monomial to the left.
-    /// It makes sense just if this.Relation is LessEqualThan, LessThan, Equal or NotEqual
-    /// </summary>
-    private bool TryMoveConstantsAndMonomes(out Polynomial<Variable, Expression> result)
-    {
-      Contract.Ensures(Contract.Result<bool>() == false || Contract.ValueAtReturn(out result).left != null);
-      Contract.Ensures(Contract.Result<bool>() == false || Contract.ValueAtReturn(out result).right != null);
-
-      Contract.Assume(this.relation.HasValue);   // It can be applied just to polynomials with a relation operator
-      Contract.Assume(this.right != null);
-
-      Contract.Assert(this.relation.Value.IsBinary());
-
-      var newLeft = new List<Monomial<Variable>>();
-      var newRight = new List<Monomial<Variable>>();
-
-      // Move all the constants to the right, and leave the non-constants on the left
-      foreach (var m in this.Left)
-      {
-        if (!m.IsConstant)    // k * xs, k != 0
-        {
-          newLeft.Add(m);
-        }
-        else                                // k * 1
-        {
-          if (m.K.IsMinValue) // overflow
-          {
-            result = default(Polynomial<Variable, Expression>);
-            return false;
-          }
-
-          newRight.Add(-m);
-        }
-      }
-
-      // Move all the non-constant monomials to the left, and leave the constants on the right
-      foreach (var m in this.right)
-      {
-        if (!m.IsConstant)              // k * xs, k != 0
-        {
-          newLeft.Add(-m);
-        }
-        else
-        {
-          newRight.Add(m);
-        }
-      }
-
-      // If there is nothing on the left or on the right, we add a zero
-      if (newLeft.Count == 0)
-      {
-        newLeft.Add(new Monomial<Variable>(0));
-      }
-      if (newRight.Count == 0)
-      {
-        newRight.Add(new Monomial<Variable>(0));
-      }
-
-      Contract.Assert(this.relation.Value.IsBinary());     // F: We can prove this assert thanks to the one above
-      result= new Polynomial<Variable, Expression>(this.relation.Value, newLeft.ToArray(), newRight.ToArray());
-      return true;
-    }
-
-    /// <summary>
-    /// Simplify the polinomial by performing basic arithmetic operations.
-    /// If one of the monomes is non-linear, then return false
-    /// </summary>
-    static private bool TrySimplifyMonomes(Monomial<Variable>[] monomes, out Monomial<Variable>[] result)
-    {
-      Contract.Requires(monomes != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-
-      // Shortcuts for common and simple cases
-      if (monomes.Length <= 1)
-      {
-        result = monomes;
-        return true;
-      }
-
-      // keep a cache between the variables of the monomials and the actual value. We use this data structure for performances
-      var cache = new Dictionary<ListEqual<Variable>, Monomial<Variable>>();
-
-      foreach (var m in monomes)
-      {
-        var vars = new ListEqual<Variable>(m.Degree, m.Variables);
-
-        // We assume that m.Variables is ordered
-        Monomial<Variable> oldMonomial;
-        if (cache.TryGetValue(vars, out oldMonomial))
-        {
-          // if the string is in the dictionary, we update the value of the coefficent
-          Rational newK;
-          if (Rational.TryAdd(oldMonomial.K, m.K, out newK))
-          {
-            var newMonomial = new Monomial<Variable>(newK, oldMonomial.Variables);
-            cache[vars] = newMonomial;  // Update the monomial
-          }
-          else // We give up
-          {
-            result = monomes;
-            return false;
-          }
-        }
-        else
-        {   // it is a new monomial, so we add it to the cache
-          cache.Add(vars, m);
-        }
-      }
-
-      var positive = new List<Monomial<Variable>>(cache.Count);
-      var negative = new List<Monomial<Variable>>(cache.Count);
-
-      Monomial<Variable>? constant = null;
-
-      foreach (var pair in cache)
-      {
-        var m = pair.Value;
-
-        if (m.K.IsNotZero)
-        {
-          if (m.IsConstant)
-          {
-            constant = m;
-          }
-          else if (m.K > 0)
-          {
-            positive.Add(m);
-          }
-          else
-          {
-            negative.Add(m);
-          }
-        }
-      }
-
-      var resultList = new List<Monomial<Variable>>(cache.Count);
-
-      resultList.InsertRange(0, negative);
-      resultList.InsertRange(0, positive);
-
-      if (constant.HasValue)
-      {
-        resultList.Insert(resultList.Count, constant.Value);
-      }
-
-      // If everything turned out to be zero, we want to keep just one
-      if (resultList.Count == 0)
-      {
-        resultList.Add(new Monomial<Variable>(0));
-      }
-
-      result = resultList.ToArray();
-
-      return true;
-    }
-
-    [ContractVerification(true)]
-    public class ListEqual<Element>
-    {
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.elements != null);
-      }
-
-      private Element[] elements;
-      private int? cachedHashCode;
-
-      public ListEqual(int len, IEnumerable<Element> arr)
-      {
-        Contract.Requires(len >=  0);
-        Contract.Requires(arr != null);
-
-        this.elements = new Element[len];
-        var i = 0;
-        foreach (var x in arr)
-        {
-          if (i >= len)
-            break;
-
-          this.elements[i++] = x;
-        }
-      }
-
-      public override int GetHashCode()
-      {
-        if (!this.cachedHashCode.HasValue)
-        {
-          var local = 0;
-          foreach (var x in this.elements)
-          {
-            local += x.GetHashCode();
-          }
-
-          this.cachedHashCode = local;
-        }
-        return this.cachedHashCode.Value;
-      }
-
-      public override bool Equals(object obj)
-      {
-        var asListEqual = obj as ListEqual<Element>;
-
-        if (asListEqual == null)
-        {
-          return false;
-        }
-
-        Contract.Assume(asListEqual.elements != null);
-
-        if (this.elements.Length != asListEqual.elements.Length)
-        {
-          return false;
-        }
-
-        // Such a common case that we specialize it
-        if (this.elements.Length == 1)
-        {
-          return this.elements[0].Equals(asListEqual.elements[0]);
-        }
-
-        // slow path
-        return this.elements.Intersect(asListEqual.elements).Count() == this.elements.Length;
-      }
-    }
-
-    #endregion
-
-    #region Overridden
-
-    public override string ToString()
-    {
-      return this.ToString(null);
-    }
-
-    public string ToString(Func<Variable, bool> except)
-    {
-      if (!this.relation.HasValue)
-      {
-        return ListToString(this.left, except);
-      }
-      else
-      {
-        var leftStr = ListToString(this.left, except);
-        var rightStr = ListToString(this.right, except);
-        var retVal = leftStr + " " + this.relation + " " + rightStr;
-
-        return retVal;
-      }
-
-    }
-
-    static private string ListToString(Monomial<Variable>[] l, Func<Variable, bool> except)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      if (l == null)
-      {
-        return "";
-      }
-
-      var s = new StringBuilder();
-      if (l.Length == 0)
-      {
-        return "()";
-      }
-      else
-      {
-        var elems = new List<string>();
-
-        foreach (var m in l)
-        {
-          if (except != null && m.Variables.Any(except))
-          {
-            continue;
-          }
-
-          elems.Add(m.ToString() + ", ");
-        }
-
-        // To simplify debugging
-        elems.Sort();
-
-        s.Append("(");
-
-        foreach (var str in elems)
-        {
-          s.Append(str);
-        }
-
-        s.Append(")");
-
-        string stmp = s.ToString();
-        if (stmp.Length > 4)
-        {
-          stmp = stmp.Remove(stmp.Length - 4, 3);
-        }
-        return stmp;
-      }
-    }
-    #endregion
-
-    #region Private helper methods
-    /// <returns>false if an arithmetic error may occur</returns>
-    [ContractVerification(true)]
-    private static bool TryReduceCoefficents(Monomial<Variable>[] simplifiedLeft, Monomial<Variable>[] simplifiedRight)
-    {
-      Contract.Requires(simplifiedLeft != null);
-      Contract.Requires(simplifiedRight != null);
-      Contract.Requires(simplifiedRight.Length > 0);
-
-      if (simplifiedRight[0].K.IsMinValue)
-      {
-        return false;
-      }
-
-      var r = Rational.Abs(simplifiedRight[0].K);
-
-      if (r.IsNotZero)
-      {
-        // We check that all can be divided by r. A better implementation should consider the GCD, and merge the two cycles
-        foreach (var m in simplifiedLeft)
-        {
-          if (!(m.K / r).IsInteger)
-          {
-            return true;
-          }
-        }
-
-        simplifiedRight[0].K = simplifiedRight[0].K / r;
-
-        for (int i = 0; i < simplifiedLeft.Length; i++)
-        {
-          simplifiedLeft[i].K = simplifiedLeft[i].K / r;
-        }
-      }
-
-      return true;
-    }
-
-    /// <summary>
-    /// Meaning: let <code>polLeft = (m1 + ... + mt)</code> and <code>polRight = (n1 + ... + nk)</code>, 
-    /// it returns the polynome <code>(m1 + ... + mt + n1 + ... + nk)</code>
-    /// </summary>
-    private static Polynomial<Variable, Expression> Concatenate(Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight)
-    {
-      var concat = new Monomial<Variable>[polLeft.Left.Length + polRight.Left.Length];
-
-      Array.Copy(polLeft.Left, concat, polLeft.Left.Length);
-      Array.Copy(polRight.Left, 0, concat, polLeft.Left.Length, polRight.Left.Length);
-
-      return new Polynomial<Variable, Expression>(concat);
-    }
-
-
-
-    private static bool TryToPolynomialFormHelperForMultiplication(
-      Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight, out Polynomial<Variable, Expression> result)
-    {
-      Contract.Requires(polLeft.left != null);
-      Contract.Requires(polRight.left != null);
-
-      var left = polLeft.left;
-      var right = polRight.left;
-      var multiplicationResult = new List<Monomial<Variable>>(left.Length * right.Length);
-
-      foreach (var l in left) // l = (k, xs)
-      {
-        foreach (var r in right)   // r  = (c, ys)
-        {
-          Rational resultCoeff; // result = (k*c, xs... ys)
-          if (!Rational.TryMul(l.K, r.K, out resultCoeff))
-          {
-            result = default(Polynomial<Variable, Expression>);
-            return false;
-          }
-
-          Contract.Assert(!object.Equals(resultCoeff, null));
-
-          var concat = new List<Variable>(l.Degree + r.Degree);
-          concat.AddRange(l.Variables);
-          concat.AddRange(r.Variables);
-
-          var resultMonomial = new Monomial<Variable>(resultCoeff, concat);
-
-          multiplicationResult.Add(resultMonomial);
-        }
-      }
-
-      result = new Polynomial<Variable, Expression>(multiplicationResult.ToArray());
-      return true;
-    }
-
-
-    [Pure]
-    private static bool TryMinus(Polynomial<Variable, Expression> p, out Polynomial<Variable, Expression> result)
-    {
-      if (p.Relation.HasValue)
-      {
-        result = default(Polynomial<Variable, Expression>);
-        return false;
-      }
-
-      var minusP = new Monomial<Variable>[p.Left.Length];
-      var counter = 0;
-      foreach (var m in p.Left)
-      {
-        var v = -m.K;
-        if (!v.IsInfinity)
-        {
-          var minusM = new Monomial<Variable>(v, m.Variables);
-          minusP[counter++] = minusM;
-        }
-        else  // Polynomial with an infinity component does not make sense, so we fail
-        {
-          result = default(Polynomial<Variable, Expression>);
-          return false;
-        }
-      }
-
-      result = new Polynomial<Variable, Expression>(minusP);
-      return true;
-    }
-
-    [Pure]
-    private static Expression ConvertToPureExpression(Monomial<Variable>[] p, IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(p != null);
-      Contract.Requires(encoder != null);
-
-      var result = default(Expression);
-      if (p.Length == 0)
-      {
-        return encoder.ConstantFor(0); //return new Constant<int>(0);
-      }
-      else
-      {
-        foreach (var m in p)
-        {
-          bool neg;
-          Expression newmonomial = ConvertToPureExpression(m, encoder, out neg);
-
-          if (result == null)
-          {
-            if (neg)
-              result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.UnaryMinus, newmonomial);
             else
-              result = newmonomial;
-          }
-          else if (neg)
-            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, result, newmonomial);  // result = result - m
-          else
-            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, result, newmonomial);  // result = result + m
-
-        }
-        return result;
-      }
-    }
-
-    private static Expression ConvertToPureExpression(Monomial<Variable> m, IExpressionEncoder<Variable, Expression>/*!*/ encoder, out bool neg)
-    {
-      Contract.Requires(encoder != null);
-
-      if (m.IsConstant)
-      {
-        neg = m.K < 0;
-        return Rational.Abs(m.K).ToExpression(encoder);
-      }
-      else
-      {
-        var result = default(Expression);
-        bool first = true;
-
-        neg = false;
-
-        if (m.K == -1)
-        {
-          neg = true;
-        }
-        else if (m.K != 1)
-        {
-          result = m.K.ToExpression(encoder);
-          first = false;
-        }
-
-        foreach (var v in m.Variables)
-        {
-          if (first)
-          {
-            result = encoder.VariableFor(v);
-            first = false;
-          }
-          else
-          {
-            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, result, encoder.VariableFor(v)); // result = result * v      
-          }
-        }
-
-        return result;
-      }
-
-    }
-
-    private static Monomial<Variable>[] ExtractWritableBytesExpression(
-      Expression e, IExpressionDecoder<Variable, Expression> decoder, out bool success)
-    {
-      Contract.Requires(decoder != null);
-      Contract.Ensures(!Contract.ValueAtReturn(out success) || Contract.Result<Monomial<Variable>[]>() != null);
-
-      Monomial<Variable>[] polLeft, polRight;
-      Monomial<Variable>[] result;
-      bool b1, b2;
-      Expression lng;
-
-      switch (decoder.OperatorFor(e))
-      {
-        case ExpressionOperator.Addition:
-          polLeft = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out b1);
-          polRight = ExtractWritableBytesExpression(decoder.RightExpressionFor(e), decoder, out b2);
-          success = b1 || b2;
-
-          if (polRight != null && polLeft != null)
-          {
-            for (var i = 0; i < polRight.Length; i++)
             {
-              polRight[i].K = -polRight[i].K;
+                Polynomial<Variable, Expression> rightAsPol;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol) && !rightAsPol.Relation.HasValue)
+                {
+                    try
+                    {
+                        var leftAsPol = new Polynomial<Variable, Expression>(new Monomial<Variable>[] { new Monomial<Variable>(left) });
+
+                        var tmp = new Polynomial<Variable, Expression>(op, leftAsPol, rightAsPol);
+                        if (tmp.TryToCanonicalForm(out result))
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        result = default(Polynomial<Variable, Expression>);
+                        return false;
+                    }
+                }
+                else
+                {
+                    result = default(Polynomial<Variable, Expression>);
+
+                    return false;
+                }
+            }
+        }
+
+
+        /// <param name="result">If the result is true, it is a polynomial in canonical form</param>
+        static public bool TryToPolynomialForm(
+          ExpressionOperator op,
+          Polynomial<Variable, Expression> left,
+          Polynomial<Variable, Expression> right,
+          out Polynomial<Variable, Expression> result)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result).left != null);
+            Contract.Ensures(!Contract.Result<bool>() || op != ExpressionOperator.LessEqualThan || Contract.ValueAtReturn(out result).Relation == ExpressionOperator.LessEqualThan);
+
+            if (!op.IsBinary() || left.Relation != null || right.Relation != null)
+            {
+                result = default(Polynomial<Variable, Expression>);
+                return false;
+            }
+            else
+            {
+                try
+                {
+                    Contract.Assert(right.Relation == null);
+
+                    // here we return a new Polynomial. An alternative is to return a polynomial in canonical form
+                    result = new Polynomial<Variable, Expression>(op, left, right);
+                    if (result.TryToCanonicalForm(out result))
+                    {
+                        return true;
+                    }
+                }
+                catch (ArithmeticExceptionRational)
+                {
+                    // If there is an exception in the rationals, then we simply fail
+                }
+            }
+            result = default(Polynomial<Variable, Expression>);
+            return false;
+        }
+
+        /// <param name="result">The result: a polynomial in canonical form</param>
+        /// <returns>Always true</returns>
+        static public bool TryToPolynomialForm(
+          ExpressionOperator expressionOperator, Monomial<Variable>[] left, Monomial<Variable>[] right,
+          out Polynomial<Variable, Expression> result)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Requires(expressionOperator.IsBinary());
+
+            Contract.Ensures(!object.ReferenceEquals(Contract.ValueAtReturn(out result), null));
+
+            result = new Polynomial<Variable, Expression>(expressionOperator, left, right);
+            return result.TryToCanonicalForm(out result);
+        }
+
+        static public bool TryToPolynomialForm(
+          bool canonicalByConstruction,
+          ExpressionOperator expressionOperator, Monomial<Variable>[] left, Monomial<Variable>[] right,
+          out Polynomial<Variable, Expression> result)
+        {
+            Contract.Requires(expressionOperator.IsBinary());
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<bool>() == true);
+            Contract.Ensures(!object.ReferenceEquals(Contract.ValueAtReturn(out result), null));
+
+            if (canonicalByConstruction)
+            {
+                result = new Polynomial<Variable, Expression>(expressionOperator, left, right);
+
+                return true;
+            }
+            else
+            {
+                return TryToPolynomialForm(expressionOperator, left, right, out result);
+            }
+        }
+
+
+        /// <summary>
+        /// Convert the list of monomials <code>monomials</code> into a Polynomial in canonical form
+        /// </summary>
+        /// <param name="pol">The polynomial in canonical form</param>
+        /// <returns>Always true</returns>
+        static public bool TryToPolynomialForm(Monomial<Variable>[] monomials, out Polynomial<Variable, Expression> pol)
+        {
+            Contract.Requires(monomials != null);
+
+            if (monomials.Length > 1)
+            {
+                pol = new Polynomial<Variable, Expression>(monomials);
+
+                return pol.TryToCanonicalForm(out pol);
+            }
+            else
+            {
+                pol = new Polynomial<Variable, Expression>(monomials);
+
+                return true;
+            }
+        }
+
+        static public bool TryToPolynomialForm(bool canonicalByConstruction, Monomial<Variable>[] monomials, out Polynomial<Variable, Expression> pol)
+        {
+            Contract.Requires(monomials != null);
+
+            if (canonicalByConstruction)
+            {
+                pol = new Polynomial<Variable, Expression>(monomials);
+                return true;
+            }
+            else
+            {
+                return TryToPolynomialForm(monomials, out pol);
+            }
+        }
+
+        #endregion
+
+        #region Manipulation of the polynomial : Add a monome
+        public Polynomial<Variable, Expression> AddMonomialToTheLeft(Monomial<Variable> m)
+        {
+            var tmpLeft = new Monomial<Variable>[left.Length + 1];
+
+            Array.Copy(left, tmpLeft, left.Length);
+            tmpLeft[left.Length] = m;
+
+            var tmpright = right != null ? DuplicateFrom(right) : null;
+
+            Polynomial<Variable, Expression> tmp, result;
+            if (relation.HasValue)
+            {
+                tmp = new Polynomial<Variable, Expression>(relation.Value, tmpLeft, tmpright);
+            }
+            else
+            {
+                tmp = new Polynomial<Variable, Expression>(tmpLeft);
             }
 
-            var tmpresult = new List<Monomial<Variable>>(polLeft);
-            tmpresult.AddRange(polRight);
+            tmp.TryToCanonicalForm(out result);
 
-            result = tmpresult.ToArray();
-          }
-          else
-          {
-            result = default(Monomial<Variable>[]);
-            success = false;
-          }
-          break;
+            return result;
+        }
 
-        //We don't expect other than k*x
-        case ExpressionOperator.Multiplication:
-          Polynomial<Variable, Expression> temp;
-          success = TryToPolynomialForm(e, decoder, out temp);
-          result = temp.left;
-          break;
+        public Polynomial<Variable, Expression> AddMonomialToTheLeft(Monomial<Variable>[] m)
+        {
+            Contract.Requires(m != null);
 
-        case ExpressionOperator.ConvertToInt32:
-        case ExpressionOperator.ConvertToUInt16:
-        case ExpressionOperator.ConvertToUInt32:
-        case ExpressionOperator.ConvertToUInt8:
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToFloat64:
-          result = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out success);
-          break;
+            Contract.Ensures(!Object.ReferenceEquals(Contract.Result<Polynomial<Variable, Expression>>(), null));
 
-        case ExpressionOperator.Variable:
+            var tmpleft = new Monomial<Variable>[left.Length + m.Length];
+
+            Array.Copy(left, tmpleft, left.Length);
+            Array.Copy(m, 0, tmpleft, left.Length, m.Length);
+
+            var tmpright = right != null ? DuplicateFrom(right) : null;
+
+            var tmp = new Polynomial<Variable, Expression>(relation.Value, tmpleft, tmpright);
+
+            Polynomial<Variable, Expression> result;
+
+            tmp.TryToCanonicalForm(out result);
+
+            return result;
+        }
+
+        #endregion
+
+        #region ToCanonicalForm, ToPureExpression, Renaming
+        /// <summary>
+        /// Put this Polynomial into a canonical form, meaning that all the monomial involving variables are on the left, all the constants on the right, and all the easy arithmetic operations are performed
+        /// </summary>
+        /// <returns>The canonical form of this polynomial</returns>
+        private bool TryToCanonicalForm(out Polynomial<Variable, Expression> result)
+        {
+            // Two main cases: this polynomial is binded by a relation, or it is just a sequence of monomials
+            if (this.Relation.HasValue)
+            {
+                Contract.Assume(right != null);
+                switch (this.Relation.Value)
+                {
+                    case ExpressionOperator.GreaterEqualThan:
+                        SwapOperands(ExpressionOperator.LessEqualThan);
+                        break;
+
+                    case ExpressionOperator.GreaterEqualThan_Un:
+                        SwapOperands(ExpressionOperator.LessEqualThan_Un);
+                        break;
+
+                    case ExpressionOperator.GreaterThan:
+                        SwapOperands(ExpressionOperator.LessThan);
+                        break;
+
+                    case ExpressionOperator.GreaterThan_Un:
+                        SwapOperands(ExpressionOperator.LessThan_Un);
+                        break;
+                }
+
+                Polynomial<Variable, Expression> moved;
+                if (this.TryMoveConstantsAndMonomes(out moved))
+                {
+                    Contract.Assume(relation.HasValue);
+
+                    Monomial<Variable>[] simplifiedLeft, simplifiedRight;
+                    if (TrySimplifyMonomes(moved.left, out simplifiedLeft) && TrySimplifyMonomes(moved.right, out simplifiedRight))
+                    {
+                        Contract.Assume(simplifiedRight.Length == 1, "At this point we expected just a constant on the right side...");
+
+                        if (TryReduceCoefficents(simplifiedLeft, simplifiedRight))
+                        {
+                            Contract.Assert(relation.Value.IsBinary());
+
+                            result = new Polynomial<Variable, Expression>(relation.Value, simplifiedLeft, simplifiedRight);
+                            return true;
+                        }
+                    }
+                }
+                else
+                {
+                    // Do nothing, we will return false;
+                }
+            }
+            else
+            {
+                Monomial<Variable>[] simplified;
+                if (TrySimplifyMonomes(left, out simplified))
+                {
+                    result = new Polynomial<Variable, Expression>(simplified);
+                    return true;
+                }
+            }
+
+            result = default(Polynomial<Variable, Expression>);
+            return false;
+        }
+
+        /// <summary>
+        /// Swap in place
+        /// Works with side effects!!!
+        /// </summary>
+        private void SwapOperands(ExpressionOperator newOperator)
+        {
+            Contract.Requires(right != null);
+
+            Contract.Ensures(relation.HasValue);
+            Contract.Ensures(left == Contract.OldValue(right));
+            Contract.Ensures(right == Contract.OldValue(left));
+
+            relation = newOperator;
+
+            var tmp = left;
+            left = right;
+            right = tmp;
+        }
+
+        /// <summary>
+        /// Convert this polynomial into a pure expression
+        /// </summary>
+        public Expression ToPureExpression(IExpressionEncoder<Variable, Expression> encoder)
+        {
+            Contract.Requires(encoder != null);
+
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            return ToPureExpressionForm(this, encoder);
+        }
+
+        /// <summary>
+        /// Convert a polynomial into a pure expression
+        /// </summary>
+        /// <param name="encoder">The encoder for constructing an expression</param>
+        static private Expression ToPureExpressionForm(Polynomial<Variable, Expression> p, IExpressionEncoder<Variable, Expression> encoder)
+        {
+            Contract.Requires(!object.ReferenceEquals(p, null));
+            Contract.Requires(encoder != null);
+
+            Contract.Ensures(Contract.Result<Expression>() != null);
+
+            var eLeft = ConvertToPureExpression(p.left, encoder);
+            if (p.Relation.HasValue)
+            {
+                var eRight = ConvertToPureExpression(p.right, encoder);
+                return encoder.CompoundExpressionFor(ExpressionType.Bool, p.Relation.Value, eLeft, eRight);
+            }
+            else
+            {
+                return eLeft;
+            }
+        }
+
+
+        /// <returns>true if the polynomial is linear, and in such a case a list representation</returns>
+        public bool TryToList(out List<Pair<Rational, Variable>> val)
+        {
+            if (this.Relation.HasValue)
+            {
+                long k;
+                if (this.Relation.Value == ExpressionOperator.Equal && right[0].IsIntConstant(out k) && k == 0)
+                {
+                    // ok
+                }
+                else
+                {
+                    val = default(List<Pair<Rational, Variable>>);
+                    return false;
+                }
+            }
+
+            val = new List<Pair<Rational, Variable>>();
+
+            foreach (var m in left)
+            {
+                if (m.IsLinear)
+                {
+                    val.Add(new Pair<Rational, Variable>(m.K, m.VariableAt(0)));
+                }
+                else
+                {
+                    val = default(List<Pair<Rational, Variable>>);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
+        /// </summary>
+        public Polynomial<Variable, Expression> Rename(Variable x, Variable xNew)
+        {
+            return Rename(true, x, xNew);
+        }
+
+        /// <summary>
+        /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
+        /// </summary>
+        public Polynomial<Variable, Expression> Rename(bool canonical, Variable x, Variable xNew)
+        {
+            // Improve: Use sharing when the renamed polynomial is the same
+
+            var leftResult = new List<Monomial<Variable>>();
+            var rightResult = new List<Monomial<Variable>>();
+
+            foreach (var m in this.Left)
+            {
+                leftResult.Add(m.Rename(x, xNew));
+            }
+            if (this.Relation.HasValue)
+            {
+                foreach (var m in this.Right)
+                {
+                    rightResult.Add(m.Rename(x, xNew));
+                }
+            }
+
+            Polynomial<Variable, Expression> result = this.Relation.HasValue
+              ? new Polynomial<Variable, Expression>(this.Relation.Value, leftResult.ToArray(), rightResult.ToArray())
+              : new Polynomial<Variable, Expression>(leftResult.ToArray());
+
+            if (canonical)
+            {
+                result.TryToCanonicalForm(out result);
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region Equivalence of polynomials
+
+        public bool IsEquivalentTo(Polynomial<Variable, Expression> other)
+        {
+            Polynomial<Variable, Expression> left, right;
+            if (!this.TryToCanonicalForm(out left) || !other.TryToCanonicalForm(out right))
+            {
+                return false;
+            }
+
+            if (!SimpleEquivalence(left, right))
+            {
+                return false;
+            }
+            else
+            { // At this point we know they have the same cardinality
+                if (!UniformCoefficents(left, right))
+                {
+                    return false;
+                }
+
+                foreach (var m in left.Left)
+                {
+                    if (!ContainsMonomialEquivalentTo(right.left, m))
+                        return false;
+                }
+
+                if (left.Relation.HasValue)
+                {
+                    Contract.Assume(right.Relation.HasValue);
+
+                    foreach (var m in left.Right)
+                    {
+                        if (!ContainsMonomialEquivalentTo(right.right, m))
+                            return false;
+                    }
+                }
+
+                // right contains all the monomials in left, and right has the same cardinality of left, so they are equivalent
+                return true;
+            }
+        }
+
+        private static bool SimpleEquivalence(Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right)
+        {
+            if (left.Degree != right.Degree)
+                return false;
+            if (left.Left.Length != right.Left.Length)
+                return false;
+            if (left.Relation != right.Relation)
+                return false;
+            if ((!left.Relation.HasValue && !right.Relation.HasValue) && (left.Right.Length != right.Right.Length))
+                return false;
+
+            return true;
+        }
+
+        private static bool UniformCoefficents(Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right)
+        {
+            Contract.Requires(left.left != null);
+            Contract.Requires(right.left != null);
+
+            var listLeft = left.left;
+            var listRight = right.left;
+
+            if (listLeft.Length == 0)
+            {
+                if (listRight.Length == 0)
+                {
+                    return true;
+                }
+                else
+                {
+                    listLeft = left.right;
+                    listRight = right.right;
+                }
+            }
+
+            var mLeft = listLeft[0];
+            Monomial<Variable>? mRight = null;
+
+            foreach (var m in listRight)
+            {
+                if (mLeft.Degree != m.Degree)
+                    continue;
+
+                foreach (var v in mLeft.Variables)
+                {
+                    if (!m.ContainsVariable(v))
+                        goto nextMonomial;
+                }
+
+                mRight = m;   // We found a monomial with the same variables
+                break;
+
+            nextMonomial:
+                ;
+            }
+
+            if (mRight.HasValue)
+            {
+                var kLeft = mLeft.K;
+                var kRight = mRight.Value.K;
+
+                if (kLeft != kRight)
+                {
+                    if (kRight == 0)
+                        return true;
+
+                    var k = kLeft / kRight;
+
+                    for (int i = 0; i < right.Left.Length; i++)
+                    {
+                        right.Left[i].K = right.Left[i].K * k;
+                    }
+
+                    if (right.Relation.HasValue)
+                    {
+                        for (int i = 0; i < right.Right.Length; i++)
+                        {
+                            right.Right[i].K = right.Right[i].K * k;
+                        }
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private static bool ContainsMonomialEquivalentTo(Monomial<Variable>[] l, Monomial<Variable> toFind)
+        {
+            foreach (var m in l)
+            {
+                if (m.K != toFind.K)
+                    continue;
+
+                if (m.Degree != toFind.Degree)
+                    continue;
+
+                foreach (var v in m.Variables)
+                {
+                    if (!toFind.ContainsVariable(v))
+                        goto nextMonomial;
+                }
+
+                // At this point, they have the same coefficent, and the same variables, so they are the same
+                return true;
+
+            nextMonomial:
+                ;
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region Contains Dummy variables?
+
+        public bool ContainsDummyVariables(IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+
+            if (left == null)
+                return false;
+
+            foreach (var monomial in this.Left)
+            {
+                foreach (var x in monomial.Variables)
+                {
+                    if (!decoder.IsSlackOrFrameworkVariable(x))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            if (right != null)
+            {
+                foreach (var monomial in this.Right)
+                {
+                    foreach (var x in monomial.Variables)
+                    {
+                        if (!decoder.IsSlackOrFrameworkVariable(x))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region Private methods
+        [ContractVerification(true)]
+        static private Monomial<Variable>[] DuplicateFrom(Monomial<Variable>[] original)
+        {
+            Contract.Requires(original != null);
+
+            Contract.Ensures(Contract.Result<Monomial<Variable>[]>() != null);
+            Contract.Ensures(Contract.Result<Monomial<Variable>[]>().Length == original.Length);
+
+            var result = new Monomial<Variable>[original.Length];
+
+            Array.Copy(original, result, original.Length);
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Move the constants to the right of the relation operator, and the monomial to the left.
+        /// It makes sense just if this.Relation is LessEqualThan, LessThan, Equal or NotEqual
+        /// </summary>
+        private bool TryMoveConstantsAndMonomes(out Polynomial<Variable, Expression> result)
+        {
+            Contract.Ensures(Contract.Result<bool>() == false || Contract.ValueAtReturn(out result).left != null);
+            Contract.Ensures(Contract.Result<bool>() == false || Contract.ValueAtReturn(out result).right != null);
+
+            Contract.Assume(relation.HasValue);   // It can be applied just to polynomials with a relation operator
+            Contract.Assume(right != null);
+
+            Contract.Assert(relation.Value.IsBinary());
+
+            var newLeft = new List<Monomial<Variable>>();
+            var newRight = new List<Monomial<Variable>>();
+
+            // Move all the constants to the right, and leave the non-constants on the left
+            foreach (var m in this.Left)
+            {
+                if (!m.IsConstant)    // k * xs, k != 0
+                {
+                    newLeft.Add(m);
+                }
+                else                                // k * 1
+                {
+                    if (m.K.IsMinValue) // overflow
+                    {
+                        result = default(Polynomial<Variable, Expression>);
+                        return false;
+                    }
+
+                    newRight.Add(-m);
+                }
+            }
+
+            // Move all the non-constant monomials to the left, and leave the constants on the right
+            foreach (var m in right)
+            {
+                if (!m.IsConstant)              // k * xs, k != 0
+                {
+                    newLeft.Add(-m);
+                }
+                else
+                {
+                    newRight.Add(m);
+                }
+            }
+
+            // If there is nothing on the left or on the right, we add a zero
+            if (newLeft.Count == 0)
+            {
+                newLeft.Add(new Monomial<Variable>(0));
+            }
+            if (newRight.Count == 0)
+            {
+                newRight.Add(new Monomial<Variable>(0));
+            }
+
+            Contract.Assert(relation.Value.IsBinary());     // F: We can prove this assert thanks to the one above
+            result = new Polynomial<Variable, Expression>(relation.Value, newLeft.ToArray(), newRight.ToArray());
+            return true;
+        }
+
+        /// <summary>
+        /// Simplify the polinomial by performing basic arithmetic operations.
+        /// If one of the monomes is non-linear, then return false
+        /// </summary>
+        static private bool TrySimplifyMonomes(Monomial<Variable>[] monomes, out Monomial<Variable>[] result)
+        {
+            Contract.Requires(monomes != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+
+            // Shortcuts for common and simple cases
+            if (monomes.Length <= 1)
+            {
+                result = monomes;
+                return true;
+            }
+
+            // keep a cache between the variables of the monomials and the actual value. We use this data structure for performances
+            var cache = new Dictionary<ListEqual<Variable>, Monomial<Variable>>();
+
+            foreach (var m in monomes)
+            {
+                var vars = new ListEqual<Variable>(m.Degree, m.Variables);
+
+                // We assume that m.Variables is ordered
+                Monomial<Variable> oldMonomial;
+                if (cache.TryGetValue(vars, out oldMonomial))
+                {
+                    // if the string is in the dictionary, we update the value of the coefficent
+                    Rational newK;
+                    if (Rational.TryAdd(oldMonomial.K, m.K, out newK))
+                    {
+                        var newMonomial = new Monomial<Variable>(newK, oldMonomial.Variables);
+                        cache[vars] = newMonomial;  // Update the monomial
+                    }
+                    else // We give up
+                    {
+                        result = monomes;
+                        return false;
+                    }
+                }
+                else
+                {   // it is a new monomial, so we add it to the cache
+                    cache.Add(vars, m);
+                }
+            }
+
+            var positive = new List<Monomial<Variable>>(cache.Count);
+            var negative = new List<Monomial<Variable>>(cache.Count);
+
+            Monomial<Variable>? constant = null;
+
+            foreach (var pair in cache)
+            {
+                var m = pair.Value;
+
+                if (m.K.IsNotZero)
+                {
+                    if (m.IsConstant)
+                    {
+                        constant = m;
+                    }
+                    else if (m.K > 0)
+                    {
+                        positive.Add(m);
+                    }
+                    else
+                    {
+                        negative.Add(m);
+                    }
+                }
+            }
+
+            var resultList = new List<Monomial<Variable>>(cache.Count);
+
+            resultList.InsertRange(0, negative);
+            resultList.InsertRange(0, positive);
+
+            if (constant.HasValue)
+            {
+                resultList.Insert(resultList.Count, constant.Value);
+            }
+
+            // If everything turned out to be zero, we want to keep just one
+            if (resultList.Count == 0)
+            {
+                resultList.Add(new Monomial<Variable>(0));
+            }
+
+            result = resultList.ToArray();
+
+            return true;
+        }
+
+        [ContractVerification(true)]
+        public class ListEqual<Element>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(elements != null);
+            }
+
+            private Element[] elements;
+            private int? cachedHashCode;
+
+            public ListEqual(int len, IEnumerable<Element> arr)
+            {
+                Contract.Requires(len >= 0);
+                Contract.Requires(arr != null);
+
+                elements = new Element[len];
+                var i = 0;
+                foreach (var x in arr)
+                {
+                    if (i >= len)
+                        break;
+
+                    elements[i++] = x;
+                }
+            }
+
+            public override int GetHashCode()
+            {
+                if (!cachedHashCode.HasValue)
+                {
+                    var local = 0;
+                    foreach (var x in elements)
+                    {
+                        local += x.GetHashCode();
+                    }
+
+                    cachedHashCode = local;
+                }
+                return cachedHashCode.Value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                var asListEqual = obj as ListEqual<Element>;
+
+                if (asListEqual == null)
+                {
+                    return false;
+                }
+
+                Contract.Assume(asListEqual.elements != null);
+
+                if (elements.Length != asListEqual.elements.Length)
+                {
+                    return false;
+                }
+
+                // Such a common case that we specialize it
+                if (elements.Length == 1)
+                {
+                    return elements[0].Equals(asListEqual.elements[0]);
+                }
+
+                // slow path
+                return elements.Intersect(asListEqual.elements).Count() == elements.Length;
+            }
+        }
+
+        #endregion
+
+        #region Overridden
+
+        public override string ToString()
+        {
+            return this.ToString(null);
+        }
+
+        public string ToString(Func<Variable, bool> except)
+        {
+            if (!relation.HasValue)
+            {
+                return ListToString(left, except);
+            }
+            else
+            {
+                var leftStr = ListToString(left, except);
+                var rightStr = ListToString(right, except);
+                var retVal = leftStr + " " + relation + " " + rightStr;
+
+                return retVal;
+            }
+        }
+
+        static private string ListToString(Monomial<Variable>[] l, Func<Variable, bool> except)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            if (l == null)
+            {
+                return "";
+            }
+
+            var s = new StringBuilder();
+            if (l.Length == 0)
+            {
+                return "()";
+            }
+            else
+            {
+                var elems = new List<string>();
+
+                foreach (var m in l)
+                {
+                    if (except != null && m.Variables.Any(except))
+                    {
+                        continue;
+                    }
+
+                    elems.Add(m.ToString() + ", ");
+                }
+
+                // To simplify debugging
+                elems.Sort();
+
+                s.Append("(");
+
+                foreach (var str in elems)
+                {
+                    s.Append(str);
+                }
+
+                s.Append(")");
+
+                string stmp = s.ToString();
+                if (stmp.Length > 4)
+                {
+                    stmp = stmp.Remove(stmp.Length - 4, 3);
+                }
+                return stmp;
+            }
+        }
+        #endregion
+
+        #region Private helper methods
+        /// <returns>false if an arithmetic error may occur</returns>
+        [ContractVerification(true)]
+        private static bool TryReduceCoefficents(Monomial<Variable>[] simplifiedLeft, Monomial<Variable>[] simplifiedRight)
+        {
+            Contract.Requires(simplifiedLeft != null);
+            Contract.Requires(simplifiedRight != null);
+            Contract.Requires(simplifiedRight.Length > 0);
+
+            if (simplifiedRight[0].K.IsMinValue)
+            {
+                return false;
+            }
+
+            var r = Rational.Abs(simplifiedRight[0].K);
+
+            if (r.IsNotZero)
+            {
+                // We check that all can be divided by r. A better implementation should consider the GCD, and merge the two cycles
+                foreach (var m in simplifiedLeft)
+                {
+                    if (!(m.K / r).IsInteger)
+                    {
+                        return true;
+                    }
+                }
+
+                simplifiedRight[0].K = simplifiedRight[0].K / r;
+
+                for (int i = 0; i < simplifiedLeft.Length; i++)
+                {
+                    simplifiedLeft[i].K = simplifiedLeft[i].K / r;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Meaning: let <code>polLeft = (m1 + ... + mt)</code> and <code>polRight = (n1 + ... + nk)</code>, 
+        /// it returns the polynome <code>(m1 + ... + mt + n1 + ... + nk)</code>
+        /// </summary>
+        private static Polynomial<Variable, Expression> Concatenate(Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight)
+        {
+            var concat = new Monomial<Variable>[polLeft.Left.Length + polRight.Left.Length];
+
+            Array.Copy(polLeft.Left, concat, polLeft.Left.Length);
+            Array.Copy(polRight.Left, 0, concat, polLeft.Left.Length, polRight.Left.Length);
+
+            return new Polynomial<Variable, Expression>(concat);
+        }
+
+
+
+        private static bool TryToPolynomialFormHelperForMultiplication(
+          Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight, out Polynomial<Variable, Expression> result)
+        {
+            Contract.Requires(polLeft.left != null);
+            Contract.Requires(polRight.left != null);
+
+            var left = polLeft.left;
+            var right = polRight.left;
+            var multiplicationResult = new List<Monomial<Variable>>(left.Length * right.Length);
+
+            foreach (var l in left) // l = (k, xs)
+            {
+                foreach (var r in right)   // r  = (c, ys)
+                {
+                    Rational resultCoeff; // result = (k*c, xs... ys)
+                    if (!Rational.TryMul(l.K, r.K, out resultCoeff))
+                    {
+                        result = default(Polynomial<Variable, Expression>);
+                        return false;
+                    }
+
+                    Contract.Assert(!object.Equals(resultCoeff, null));
+
+                    var concat = new List<Variable>(l.Degree + r.Degree);
+                    concat.AddRange(l.Variables);
+                    concat.AddRange(r.Variables);
+
+                    var resultMonomial = new Monomial<Variable>(resultCoeff, concat);
+
+                    multiplicationResult.Add(resultMonomial);
+                }
+            }
+
+            result = new Polynomial<Variable, Expression>(multiplicationResult.ToArray());
+            return true;
+        }
+
+
+        [Pure]
+        private static bool TryMinus(Polynomial<Variable, Expression> p, out Polynomial<Variable, Expression> result)
+        {
+            if (p.Relation.HasValue)
+            {
+                result = default(Polynomial<Variable, Expression>);
+                return false;
+            }
+
+            var minusP = new Monomial<Variable>[p.Left.Length];
+            var counter = 0;
+            foreach (var m in p.Left)
+            {
+                var v = -m.K;
+                if (!v.IsInfinity)
+                {
+                    var minusM = new Monomial<Variable>(v, m.Variables);
+                    minusP[counter++] = minusM;
+                }
+                else  // Polynomial with an infinity component does not make sense, so we fail
+                {
+                    result = default(Polynomial<Variable, Expression>);
+                    return false;
+                }
+            }
+
+            result = new Polynomial<Variable, Expression>(minusP);
+            return true;
+        }
+
+        [Pure]
+        private static Expression ConvertToPureExpression(Monomial<Variable>[] p, IExpressionEncoder<Variable, Expression> encoder)
+        {
+            Contract.Requires(p != null);
+            Contract.Requires(encoder != null);
+
+            var result = default(Expression);
+            if (p.Length == 0)
+            {
+                return encoder.ConstantFor(0); //return new Constant<int>(0);
+            }
+            else
+            {
+                foreach (var m in p)
+                {
+                    bool neg;
+                    Expression newmonomial = ConvertToPureExpression(m, encoder, out neg);
+
+                    if (result == null)
+                    {
+                        if (neg)
+                            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.UnaryMinus, newmonomial);
+                        else
+                            result = newmonomial;
+                    }
+                    else if (neg)
+                        result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, result, newmonomial);  // result = result - m
+                    else
+                        result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, result, newmonomial);  // result = result + m
+                }
+                return result;
+            }
+        }
+
+        private static Expression ConvertToPureExpression(Monomial<Variable> m, IExpressionEncoder<Variable, Expression>/*!*/ encoder, out bool neg)
+        {
+            Contract.Requires(encoder != null);
+
+            if (m.IsConstant)
+            {
+                neg = m.K < 0;
+                return Rational.Abs(m.K).ToExpression(encoder);
+            }
+            else
+            {
+                var result = default(Expression);
+                bool first = true;
+
+                neg = false;
+
+                if (m.K == -1)
+                {
+                    neg = true;
+                }
+                else if (m.K != 1)
+                {
+                    result = m.K.ToExpression(encoder);
+                    first = false;
+                }
+
+                foreach (var v in m.Variables)
+                {
+                    if (first)
+                    {
+                        result = encoder.VariableFor(v);
+                        first = false;
+                    }
+                    else
+                    {
+                        result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, result, encoder.VariableFor(v)); // result = result * v      
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        private static Monomial<Variable>[] ExtractWritableBytesExpression(
+          Expression e, IExpressionDecoder<Variable, Expression> decoder, out bool success)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Ensures(!Contract.ValueAtReturn(out success) || Contract.Result<Monomial<Variable>[]>() != null);
+
+            Monomial<Variable>[] polLeft, polRight;
+            Monomial<Variable>[] result;
+            bool b1, b2;
+            Expression lng;
+
+            switch (decoder.OperatorFor(e))
+            {
+                case ExpressionOperator.Addition:
+                    polLeft = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out b1);
+                    polRight = ExtractWritableBytesExpression(decoder.RightExpressionFor(e), decoder, out b2);
+                    success = b1 || b2;
+
+                    if (polRight != null && polLeft != null)
+                    {
+                        for (var i = 0; i < polRight.Length; i++)
+                        {
+                            polRight[i].K = -polRight[i].K;
+                        }
+
+                        var tmpresult = new List<Monomial<Variable>>(polLeft);
+                        tmpresult.AddRange(polRight);
+
+                        result = tmpresult.ToArray();
+                    }
+                    else
+                    {
+                        result = default(Monomial<Variable>[]);
+                        success = false;
+                    }
+                    break;
+
+                //We don't expect other than k*x
+                case ExpressionOperator.Multiplication:
+                    Polynomial<Variable, Expression> temp;
+                    success = TryToPolynomialForm(e, decoder, out temp);
+                    result = temp.left;
+                    break;
+
+                case ExpressionOperator.ConvertToInt32:
+                case ExpressionOperator.ConvertToUInt16:
+                case ExpressionOperator.ConvertToUInt32:
+                case ExpressionOperator.ConvertToUInt8:
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToFloat64:
+                    result = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out success);
+                    break;
+
+                case ExpressionOperator.Variable:
 #if !SUBPOLY_ONLY
-          if (decoder.TryGetAssociatedExpression(e, AssociatedInfo.WritableBytes, out lng))
-          {
-            var lngVar = decoder.UnderlyingVariable(lng);
-            var lngMonome = new Monomial<Variable>(lngVar);
-            success = true;
-            result = new Monomial<Variable>[] { lngMonome };
-          }
-          else
+                    if (decoder.TryGetAssociatedExpression(e, AssociatedInfo.WritableBytes, out lng))
+                    {
+                        var lngVar = decoder.UnderlyingVariable(lng);
+                        var lngMonome = new Monomial<Variable>(lngVar);
+                        success = true;
+                        result = new Monomial<Variable>[] { lngMonome };
+                    }
+                    else
 #endif
-          {
-            success = false;
-            result = new Monomial<Variable>[] { new Monomial<Variable>(decoder.UnderlyingVariable(e)) };
-          }
-          break;
+                    {
+                        success = false;
+                        result = new Monomial<Variable>[] { new Monomial<Variable>(decoder.UnderlyingVariable(e)) };
+                    }
+                    break;
 
-        default:
+                default:
 
-          Polynomial<Variable, Expression> poly;
-          success = TryToPolynomialForm(e, decoder, out poly);
+                    Polynomial<Variable, Expression> poly;
+                    success = TryToPolynomialForm(e, decoder, out poly);
 
-          if (success && poly.Relation == null)
-            result = poly.left;
-          else
-            result = null;
+                    if (success && poly.Relation == null)
+                        result = poly.left;
+                    else
+                        result = null;
 
-          break;
-      }
-      return result;
-    }
-
-    #endregion
-
-    private class TryToPolynomialVisitor : GenericExpressionVisitor<Unit, bool, Variable, Expression>
-    {
-      Polynomial<Variable, Expression> result;
-
-      public TryToPolynomialVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      public bool Visit(Expression exp, out Polynomial<Variable, Expression> res)
-      {
-        if (exp != null && this.Visit(exp, Unit.Value))
-        {
-          res = result;
-          return true;
-        }
-        else
-        {
-          res = default(Polynomial<Variable, Expression>);
-          return false;
-        }
-      }
-
-      public override bool VisitConstant(Expression left, Unit data)
-      {
-        var value = new VisitorForEvalConstant(this.Decoder).Visit(left, Unit.Value);
-
-        if (value.Two && !value.One.IsInfinity)
-        {
-          var constantMonome = new Monomial<Variable>(value.One);
-          result = new Polynomial<Variable, Expression>(constantMonome);
-
-          return true;
-        }
-        return false;
-      }
-
-      public override bool VisitAddition(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        var visitLeft = Visit(left, out  polLeft);
-        var visitRight = Visit(right, out polRight);
-
-        // Let's do the 4 cases 
-        // We converted left and right
-        if (visitLeft && visitRight)
-        {
-          Int64 kLeft, kRight;
-          object vv;
-          if (polLeft.IsIntConstant(out kLeft) && polRight.IsIntConstant(out kRight) &&
-            EvaluateArithmeticWithOverflow.TryBinary<Int64>(Decoder.TypeOf(original), ExpressionOperator.Addition, kLeft, kRight, out vv))
-          {
-            var asLong = vv.ForceInt64();
-            if (asLong.HasValue)
-            {
-              this.result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Rational.For(asLong.Value)));
-              return true;
+                    break;
             }
-          }
-
-          result = Concatenate(polLeft, polRight);
-          return true;
+            return result;
         }
+
+        #endregion
+
+        private class TryToPolynomialVisitor : GenericExpressionVisitor<Unit, bool, Variable, Expression>
+        {
+            private Polynomial<Variable, Expression> result;
+
+            public TryToPolynomialVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            public bool Visit(Expression exp, out Polynomial<Variable, Expression> res)
+            {
+                if (exp != null && this.Visit(exp, Unit.Value))
+                {
+                    res = result;
+                    return true;
+                }
+                else
+                {
+                    res = default(Polynomial<Variable, Expression>);
+                    return false;
+                }
+            }
+
+            public override bool VisitConstant(Expression left, Unit data)
+            {
+                var value = new VisitorForEvalConstant(this.Decoder).Visit(left, Unit.Value);
+
+                if (value.Two && !value.One.IsInfinity)
+                {
+                    var constantMonome = new Monomial<Variable>(value.One);
+                    result = new Polynomial<Variable, Expression>(constantMonome);
+
+                    return true;
+                }
+                return false;
+            }
+
+            public override bool VisitAddition(Expression left, Expression right, Expression original, Unit data)
+            {
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                var visitLeft = Visit(left, out polLeft);
+                var visitRight = Visit(right, out polRight);
+
+                // Let's do the 4 cases 
+                // We converted left and right
+                if (visitLeft && visitRight)
+                {
+                    Int64 kLeft, kRight;
+                    object vv;
+                    if (polLeft.IsIntConstant(out kLeft) && polRight.IsIntConstant(out kRight) &&
+                      EvaluateArithmeticWithOverflow.TryBinary<Int64>(Decoder.TypeOf(original), ExpressionOperator.Addition, kLeft, kRight, out vv))
+                    {
+                        var asLong = vv.ForceInt64();
+                        if (asLong.HasValue)
+                        {
+                            result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Rational.For(asLong.Value)));
+                            return true;
+                        }
+                    }
+
+                    result = Concatenate(polLeft, polRight);
+                    return true;
+                }
 
 #if UseSymbolicValuesForAdditions
 
-        // We converted left, but not right
-        if (visitLeft && !visitRight)
-        {
-          var monomialForRight = new Monomial<Variable>(this.Decoder.UnderlyingVariable(right));
+                // We converted left, but not right
+                if (visitLeft && !visitRight)
+                {
+                    var monomialForRight = new Monomial<Variable>(this.Decoder.UnderlyingVariable(right));
 
-          Int64 kLeft;
-          if (polLeft.IsIntConstant(out kLeft))
-          {
-            var monomials = new Monomial<Variable>[] { new Monomial<Variable>(Rational.For(kLeft)), monomialForRight };
-            this.result = new Polynomial<Variable, Expression>(monomials);
-          }
-          else
-          {
-            this.result = Concatenate(polLeft, new Polynomial<Variable, Expression>(monomialForRight));
-          }
+                    Int64 kLeft;
+                    if (polLeft.IsIntConstant(out kLeft))
+                    {
+                        var monomials = new Monomial<Variable>[] { new Monomial<Variable>(Rational.For(kLeft)), monomialForRight };
+                        result = new Polynomial<Variable, Expression>(monomials);
+                    }
+                    else
+                    {
+                        result = Concatenate(polLeft, new Polynomial<Variable, Expression>(monomialForRight));
+                    }
 
-          return true;
-        }
-        // We converted right, but not left
-        if (!visitLeft && visitRight)
-        {
-          var monomialForLeft = new Monomial<Variable>(this.Decoder.UnderlyingVariable(left));
-          Int64 kRight;
-          if (polRight.IsIntConstant(out kRight))
-          {
-            var monomials = new Monomial<Variable>[] { monomialForLeft, new Monomial<Variable>(Rational.For(kRight)) };
-            this.result = new Polynomial<Variable, Expression>(monomials);
-          }
-          else
-          {
-            this.result = Concatenate(new Polynomial<Variable, Expression>(monomialForLeft), polRight);
-          }
+                    return true;
+                }
+                // We converted right, but not left
+                if (!visitLeft && visitRight)
+                {
+                    var monomialForLeft = new Monomial<Variable>(this.Decoder.UnderlyingVariable(left));
+                    Int64 kRight;
+                    if (polRight.IsIntConstant(out kRight))
+                    {
+                        var monomials = new Monomial<Variable>[] { monomialForLeft, new Monomial<Variable>(Rational.For(kRight)) };
+                        result = new Polynomial<Variable, Expression>(monomials);
+                    }
+                    else
+                    {
+                        result = Concatenate(new Polynomial<Variable, Expression>(monomialForLeft), polRight);
+                    }
 
-          return true;
-        }
+                    return true;
+                }
 
-        if (!visitRight && !visitLeft)
-        {
-          var monomials = new Monomial<Variable>[] { new Monomial<Variable>(this.Decoder.UnderlyingVariable(left)), new Monomial<Variable>(this.Decoder.UnderlyingVariable(right)) };
-          this.result = new Polynomial<Variable, Expression>(monomials);
+                if (!visitRight && !visitLeft)
+                {
+                    var monomials = new Monomial<Variable>[] { new Monomial<Variable>(this.Decoder.UnderlyingVariable(left)), new Monomial<Variable>(this.Decoder.UnderlyingVariable(right)) };
+                    result = new Polynomial<Variable, Expression>(monomials);
 
-          return true;
-        }
+                    return true;
+                }
 
-        Contract.Assert(false);
-#endif        
-        return false;
-      }
-
-      public override bool VisitAddition_Overflow(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        if (Visit(left, out  polLeft) && Visit(right, out polRight))
-        {
-          result = Concatenate(polLeft, polRight);
-          return true;
-        }
-
-        return false;
-      }
-
-      public override bool VisitSubtraction(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        if (Visit(left, out polLeft) && Visit(right, out polRight))
-        {
-          Int64 kLeft, kRight;
-          object vv;
-          var type = Decoder.TypeOf(original);
-          if (polLeft.IsIntConstant(out kLeft) && polRight.IsIntConstant(out kRight) 
-            && 
-            (type != ExpressionType.Int32 || kRight != Int32.MinValue) 
-            && 
-            (type != ExpressionType.Int64 || kLeft != Int64.MinValue)
-            &&
-            EvaluateArithmeticWithOverflow.TryBinary<Int64>(type, ExpressionOperator.Subtraction, kLeft, kRight, out vv))
-          {
-            var asLong = vv.ForceInt64();
-            if (asLong.HasValue)
-            {
-              result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Rational.For(asLong.Value)));
-              return true;
-            }
-          }
-
-          return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
-        }
-
-        return false;
-      }
-
-      public override bool VisitSubtraction_Overflow(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        if (Visit(left, out polLeft) && Visit(right, out polRight))
-        {
-          return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
-        }
-        return false;
-      }
-
-      public override bool VisitModulus(Expression left, Expression right, Expression original, Unit data)
-      {
-        result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Decoder.UnderlyingVariable(original)));
-
-        return true;
-      }
-
-      public override bool VisitMultiplication(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        var isPolLeft = Visit(left, out polLeft);
-        var isPolRight = Visit(right, out polRight);
-
-        if (isPolLeft && isPolRight)
-        {
-          Int64 kLeft, kRight;
-          object vv;
-          if (polLeft.IsIntConstant(out kLeft) && polRight.IsIntConstant(out kRight) &&
-            EvaluateArithmeticWithOverflow.TryBinary<Int64>(Decoder.TypeOf(original), ExpressionOperator.Multiplication, kLeft, kRight, out vv))
-          {
-            var asLong = vv.ForceInt64();
-            if (asLong.HasValue)
-            {
-              result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Rational.For(asLong.Value)));
-              return true;
-            }
-          }
-
-          return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
-        }
-        // Handle the case exp * m
-        else if (isPolLeft || isPolRight)
-        {
-          Expression notPolynomial;
-
-          // Swap so that right is always the non-polynomial
-          if (isPolRight)
-          {
-            polLeft = polRight;
-            isPolLeft = true;
-
-            polRight = default(Polynomial<Variable, Expression>);
-            isPolRight = false;
-
-            notPolynomial = left;
-          }
-          else
-          {
-            notPolynomial = right;
-          }
-
-          Monomial<Variable> m;
-          if (polLeft.IsMonomial(out m) && TryMultiplyExpressionByMonomial(notPolynomial, m, out result))
-          {
-            return true;
-          }
-
-        }
-        return false;
-      }
-
-      public override bool VisitMultiplication_Overflow(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        var isPolLeft = Visit(left, out polLeft);
-        var isPolRight = Visit(right, out polRight);
-
-        if (isPolLeft && isPolRight)
-        {
-          return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
-        }
-        // Handle the case exp * m
-        else if (isPolLeft || isPolRight)
-        {
-          Expression notPolynomial;
-
-          // Swap so that right is always the non-polynomial
-          if (isPolRight)
-          {
-            polLeft = polRight;
-            isPolLeft = true;
-
-            polRight = default(Polynomial<Variable, Expression>);
-            isPolRight = false;
-
-            notPolynomial = left;
-          }
-          else
-          {
-            notPolynomial = right;
-          }
-
-          Monomial<Variable> m;
-          if (polLeft.IsMonomial(out m) && TryMultiplyExpressionByMonomial(notPolynomial, m, out result))
-          {
-            return true;
-          }
-
-        }
-        return false;
-      }
-
-      public override bool VisitShiftRight(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft;
-
-        int k;
-        if (this.Decoder.IsConstantInt(right, out k) && k >= 0)
-        {
-          if (Visit(left, out polLeft))
-          {
-            Rational coeff;
-
-            try
-            {
-              coeff = Rational.ToThePowerOfTwo(k);
-            }
-            catch (ArithmeticExceptionRational)
-            { // If we've got an exception, it means that we cannot convert this polynomial 
-              return false;
-            }
-
-            var mList = new List<Monomial<Variable>>();
-            foreach (var m in polLeft.Left)
-            {
-              Rational newCoeff;
-              if (Rational.TryDiv(m.K, coeff, out newCoeff) && newCoeff.IsInteger)
-              {
-                mList.Add(new Monomial<Variable>(newCoeff, m.Variables));
-              }
-              else
-              {
+                Contract.Assert(false);
+#endif
                 return false;
-              }
             }
-            result = new Polynomial<Variable, Expression>(mList.ToArray());
-            return true;
-          }
-        }
-        return false;
 
-      }
-
-      public override bool VisitSizeOf(Expression sizeofExp, Unit data)
-      {
-        int size;
-        if (this.Decoder.TrySizeOf(sizeofExp, out size))
-        {
-          result = new Polynomial<Variable, Expression>(new Monomial<Variable>(size));
-          return true;
-        }
-
-        return false;
-      }
-
-      public override bool VisitDivision(Expression left, Expression right, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        if (Visit(left, out polLeft) && Visit(right, out polRight))
-        {
-          return TryToPolynomialFormHelperForDivision(polLeft, polRight, out result);
-        }
-
-        return false;
-      }
-
-      public override bool VisitNot(Expression left, Unit data)
-      {
-        return false;
-      }
-
-      public override bool VisitUnaryMinus(Expression left, Expression original, Unit data)
-      {
-        Polynomial<Variable, Expression> polLeft;
-
-        if (Visit(left, out polLeft))
-        {
-          return TryMinus(polLeft, out result);
-        }
-
-        return false;
-      }
-
-      public override bool VisitWritableBytes(Expression left, Expression wholeExpression, Unit data)
-      {
-        bool success;
-        var monome = ExtractWritableBytesExpression(left, this.Decoder, out success);
-        if (success)
-        {
-          result = new Polynomial<Variable, Expression>(monome);
-          return true;
-        }
-
-        return false;
-      }
-
-      public override bool VisitConvertToInt8(Expression left, Expression original, Unit data)
-      {
-        if (this.Decoder.TypeOf(left) == ExpressionType.Int8)
-        {
-          return this.Visit(left, data);
-        }
-        else
-        {
-          var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(Decoder).Visit(
-            left, new IntervalEnvironment<Variable, Expression>(Decoder, VoidLogger.Log));
-
-          Rational v;
-          // Take care of polymorphism of constants
-          if (constValue.TryGetSingletonValue(out v))
-          {
-            var value = (short)v;
-            this.result = new Polynomial<Variable, Expression>(new Monomial<Variable>(value));
-          }
-          else
-          {
-            this.result = new Polynomial<Variable, Expression>(new Monomial<Variable>(this.Decoder.UnderlyingVariable(original)));
-          }
-
-          return true;
-        }
-      }
-
-      public override bool VisitConvertToInt32(Expression left, Expression original, Unit data)
-      {
-        return this.Visit(left, data);
-      }
-
-      public override bool VisitConvertToUInt16(Expression left, Expression original, Unit data)
-      {
-        var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(Decoder).Visit(
-          left, new IntervalEnvironment<Variable, Expression>(Decoder, VoidLogger.Log));
-
-        Rational v;
-        // Take care of polymorphism of constants
-        if (constValue.TryGetSingletonValue(out v) && v < 0)
-        {
-          var value = (UInt16)v;
-          this.result = new Polynomial<Variable, Expression>(new Monomial<Variable>(value));
-
-          return true;
-        }
-        else
-        {
-          return this.Visit(left, data);
-        }
-      }
-
-      public override bool VisitConvertToUInt32(Expression left, Expression original, Unit data)
-      {
-        var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(Decoder).Visit(
-          left, new IntervalEnvironment<Variable, Expression>(Decoder, VoidLogger.Log));
-
-        Rational v;
-        // We assume polynomials containing Int32 coefficients. If the constant is too large, we give up
-        if (constValue.TryGetSingletonValue(out v) && v < 0)
-        {
-          return false;
-        }
-        else
-        {
-          return Visit(left, out result);
-        }
-      }
-
-      public override bool VisitVariable(Variable variable, Expression original, Unit data)
-      {
-        result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Decoder.UnderlyingVariable(original)));
-
-        return true;
-      }
-
-      public override bool VisitEqual(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original);
-      }
-
-      public override bool VisitEqual_Obj(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original);
-      }
-
-      public override bool VisitNotEqual(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      public override bool VisitLessEqualThan(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original);
-      }
-      public override bool VisitLessEqualThan_Un(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      public override bool VisitLessThan(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      public override bool VisitLessThan_Un(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      public override bool VisitGreaterEqualThan(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      public override bool VisitGreaterEqualThan_Un(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      public override bool VisitGreaterThan(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      public override bool VisitGreaterThan_Un(Expression left, Expression right, Expression original, Unit data)
-      {
-        return HelperForRelations(left, right, original); ;
-      }
-
-      private bool HelperForRelations(Expression left, Expression right, Expression original)
-      {
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        if (Visit(left, out polLeft) && Visit(right, out polRight) && !polLeft.Relation.HasValue && !polRight.Relation.HasValue)
-        {
-          var op = this.Decoder.OperatorFor(original);  // Doing it instead of passing as parameter as I am lazy
-          result = new Polynomial<Variable, Expression>(op, polLeft.left, polRight.left);
-          return true;
-        }
-        return false;
-      }
-
-      protected override bool Default(Unit data)
-      {
-        result = default(Polynomial<Variable, Expression>);
-        return false;
-      }
-
-      private static bool TryToPolynomialFormHelperForSubtraction(
-        Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight, out Polynomial<Variable, Expression> result)
-      {
-        Polynomial<Variable, Expression> minusPolRight;
-        if (TryMinus(polRight, out minusPolRight))
-        {
-          result = Concatenate(polLeft, minusPolRight);
-          return true;
-        }
-        else
-        {
-          result = default(Polynomial<Variable, Expression>);
-          return false;
-        }
-      }
-
-      // We consider just the easy cases, when polLeft or polRight are constants
-      private bool TryToPolynomialFormHelperForDivision(Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight,
-        out Polynomial<Variable, Expression> result)
-      {       
-        long leftK, rightK;
-        if (polLeft.IsIntConstant(out leftK) && polRight.IsIntConstant(out rightK))
-        {
-          if (rightK != 0)
-          {
-            var division = leftK / rightK;
-            if (Int32.MinValue <= division && division <= Int32.MaxValue)
+            public override bool VisitAddition_Overflow(Expression left, Expression right, Expression original, Unit data)
             {
-              result = new Polynomial<Variable, Expression>(new Monomial<Variable>((Int32)division));
-              return true;
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                if (Visit(left, out polLeft) && Visit(right, out polRight))
+                {
+                    result = Concatenate(polLeft, polRight);
+                    return true;
+                }
+
+                return false;
             }
-          }
-          result = default(Polynomial<Variable, Expression>);
-          return false;
-        }
 
-        if (polRight.Left.Length == 1) // (n1 + ... + nt) / m
-        {
-          var m = polRight.Left[0];
-          if (m.IsConstant && m.K != 0)    // (n1 + .... + nt) / k
-          {
-            var divided = new Monomial<Variable>[polLeft.Left.Length];
-            var counter = 0;
-            foreach (var n in polLeft.Left)
+            public override bool VisitSubtraction(Expression left, Expression right, Expression original, Unit data)
             {
-              Rational v;
+                Polynomial<Variable, Expression> polLeft, polRight;
 
-              try
-              {
-                v = n.K / m.K;
-              }
-              catch (ArithmeticExceptionRational)
-              { // Division caused an error
+                if (Visit(left, out polLeft) && Visit(right, out polRight))
+                {
+                    Int64 kLeft, kRight;
+                    object vv;
+                    var type = Decoder.TypeOf(original);
+                    if (polLeft.IsIntConstant(out kLeft) && polRight.IsIntConstant(out kRight)
+                      &&
+                      (type != ExpressionType.Int32 || kRight != Int32.MinValue)
+                      &&
+                      (type != ExpressionType.Int64 || kLeft != Int64.MinValue)
+                      &&
+                      EvaluateArithmeticWithOverflow.TryBinary<Int64>(type, ExpressionOperator.Subtraction, kLeft, kRight, out vv))
+                    {
+                        var asLong = vv.ForceInt64();
+                        if (asLong.HasValue)
+                        {
+                            result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Rational.For(asLong.Value)));
+                            return true;
+                        }
+                    }
+
+                    return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
+                }
+
+                return false;
+            }
+
+            public override bool VisitSubtraction_Overflow(Expression left, Expression right, Expression original, Unit data)
+            {
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                if (Visit(left, out polLeft) && Visit(right, out polRight))
+                {
+                    return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
+                }
+                return false;
+            }
+
+            public override bool VisitModulus(Expression left, Expression right, Expression original, Unit data)
+            {
+                result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Decoder.UnderlyingVariable(original)));
+
+                return true;
+            }
+
+            public override bool VisitMultiplication(Expression left, Expression right, Expression original, Unit data)
+            {
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                var isPolLeft = Visit(left, out polLeft);
+                var isPolRight = Visit(right, out polRight);
+
+                if (isPolLeft && isPolRight)
+                {
+                    Int64 kLeft, kRight;
+                    object vv;
+                    if (polLeft.IsIntConstant(out kLeft) && polRight.IsIntConstant(out kRight) &&
+                      EvaluateArithmeticWithOverflow.TryBinary<Int64>(Decoder.TypeOf(original), ExpressionOperator.Multiplication, kLeft, kRight, out vv))
+                    {
+                        var asLong = vv.ForceInt64();
+                        if (asLong.HasValue)
+                        {
+                            result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Rational.For(asLong.Value)));
+                            return true;
+                        }
+                    }
+
+                    return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
+                }
+                // Handle the case exp * m
+                else if (isPolLeft || isPolRight)
+                {
+                    Expression notPolynomial;
+
+                    // Swap so that right is always the non-polynomial
+                    if (isPolRight)
+                    {
+                        polLeft = polRight;
+                        isPolLeft = true;
+
+                        polRight = default(Polynomial<Variable, Expression>);
+                        isPolRight = false;
+
+                        notPolynomial = left;
+                    }
+                    else
+                    {
+                        notPolynomial = right;
+                    }
+
+                    Monomial<Variable> m;
+                    if (polLeft.IsMonomial(out m) && TryMultiplyExpressionByMonomial(notPolynomial, m, out result))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            public override bool VisitMultiplication_Overflow(Expression left, Expression right, Expression original, Unit data)
+            {
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                var isPolLeft = Visit(left, out polLeft);
+                var isPolRight = Visit(right, out polRight);
+
+                if (isPolLeft && isPolRight)
+                {
+                    return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
+                }
+                // Handle the case exp * m
+                else if (isPolLeft || isPolRight)
+                {
+                    Expression notPolynomial;
+
+                    // Swap so that right is always the non-polynomial
+                    if (isPolRight)
+                    {
+                        polLeft = polRight;
+                        isPolLeft = true;
+
+                        polRight = default(Polynomial<Variable, Expression>);
+                        isPolRight = false;
+
+                        notPolynomial = left;
+                    }
+                    else
+                    {
+                        notPolynomial = right;
+                    }
+
+                    Monomial<Variable> m;
+                    if (polLeft.IsMonomial(out m) && TryMultiplyExpressionByMonomial(notPolynomial, m, out result))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            public override bool VisitShiftRight(Expression left, Expression right, Expression original, Unit data)
+            {
+                Polynomial<Variable, Expression> polLeft;
+
+                int k;
+                if (this.Decoder.IsConstantInt(right, out k) && k >= 0)
+                {
+                    if (Visit(left, out polLeft))
+                    {
+                        Rational coeff;
+
+                        try
+                        {
+                            coeff = Rational.ToThePowerOfTwo(k);
+                        }
+                        catch (ArithmeticExceptionRational)
+                        { // If we've got an exception, it means that we cannot convert this polynomial 
+                            return false;
+                        }
+
+                        var mList = new List<Monomial<Variable>>();
+                        foreach (var m in polLeft.Left)
+                        {
+                            Rational newCoeff;
+                            if (Rational.TryDiv(m.K, coeff, out newCoeff) && newCoeff.IsInteger)
+                            {
+                                mList.Add(new Monomial<Variable>(newCoeff, m.Variables));
+                            }
+                            else
+                            {
+                                return false;
+                            }
+                        }
+                        result = new Polynomial<Variable, Expression>(mList.ToArray());
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            public override bool VisitSizeOf(Expression sizeofExp, Unit data)
+            {
+                int size;
+                if (this.Decoder.TrySizeOf(sizeofExp, out size))
+                {
+                    result = new Polynomial<Variable, Expression>(new Monomial<Variable>(size));
+                    return true;
+                }
+
+                return false;
+            }
+
+            public override bool VisitDivision(Expression left, Expression right, Expression original, Unit data)
+            {
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                if (Visit(left, out polLeft) && Visit(right, out polRight))
+                {
+                    return TryToPolynomialFormHelperForDivision(polLeft, polRight, out result);
+                }
+
+                return false;
+            }
+
+            public override bool VisitNot(Expression left, Unit data)
+            {
+                return false;
+            }
+
+            public override bool VisitUnaryMinus(Expression left, Expression original, Unit data)
+            {
+                Polynomial<Variable, Expression> polLeft;
+
+                if (Visit(left, out polLeft))
+                {
+                    return TryMinus(polLeft, out result);
+                }
+
+                return false;
+            }
+
+            public override bool VisitWritableBytes(Expression left, Expression wholeExpression, Unit data)
+            {
+                bool success;
+                var monome = ExtractWritableBytesExpression(left, this.Decoder, out success);
+                if (success)
+                {
+                    result = new Polynomial<Variable, Expression>(monome);
+                    return true;
+                }
+
+                return false;
+            }
+
+            public override bool VisitConvertToInt8(Expression left, Expression original, Unit data)
+            {
+                if (this.Decoder.TypeOf(left) == ExpressionType.Int8)
+                {
+                    return this.Visit(left, data);
+                }
+                else
+                {
+                    var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(Decoder).Visit(
+                      left, new IntervalEnvironment<Variable, Expression>(Decoder, VoidLogger.Log));
+
+                    Rational v;
+                    // Take care of polymorphism of constants
+                    if (constValue.TryGetSingletonValue(out v))
+                    {
+                        var value = (short)v;
+                        result = new Polynomial<Variable, Expression>(new Monomial<Variable>(value));
+                    }
+                    else
+                    {
+                        result = new Polynomial<Variable, Expression>(new Monomial<Variable>(this.Decoder.UnderlyingVariable(original)));
+                    }
+
+                    return true;
+                }
+            }
+
+            public override bool VisitConvertToInt32(Expression left, Expression original, Unit data)
+            {
+                return this.Visit(left, data);
+            }
+
+            public override bool VisitConvertToUInt16(Expression left, Expression original, Unit data)
+            {
+                var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(Decoder).Visit(
+                  left, new IntervalEnvironment<Variable, Expression>(Decoder, VoidLogger.Log));
+
+                Rational v;
+                // Take care of polymorphism of constants
+                if (constValue.TryGetSingletonValue(out v) && v < 0)
+                {
+                    var value = (UInt16)v;
+                    result = new Polynomial<Variable, Expression>(new Monomial<Variable>(value));
+
+                    return true;
+                }
+                else
+                {
+                    return this.Visit(left, data);
+                }
+            }
+
+            public override bool VisitConvertToUInt32(Expression left, Expression original, Unit data)
+            {
+                var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(Decoder).Visit(
+                  left, new IntervalEnvironment<Variable, Expression>(Decoder, VoidLogger.Log));
+
+                Rational v;
+                // We assume polynomials containing Int32 coefficients. If the constant is too large, we give up
+                if (constValue.TryGetSingletonValue(out v) && v < 0)
+                {
+                    return false;
+                }
+                else
+                {
+                    return Visit(left, out result);
+                }
+            }
+
+            public override bool VisitVariable(Variable variable, Expression original, Unit data)
+            {
+                result = new Polynomial<Variable, Expression>(new Monomial<Variable>(Decoder.UnderlyingVariable(original)));
+
+                return true;
+            }
+
+            public override bool VisitEqual(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original);
+            }
+
+            public override bool VisitEqual_Obj(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original);
+            }
+
+            public override bool VisitNotEqual(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            public override bool VisitLessEqualThan(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original);
+            }
+            public override bool VisitLessEqualThan_Un(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            public override bool VisitLessThan(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            public override bool VisitLessThan_Un(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            public override bool VisitGreaterEqualThan(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            public override bool VisitGreaterEqualThan_Un(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            public override bool VisitGreaterThan(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            public override bool VisitGreaterThan_Un(Expression left, Expression right, Expression original, Unit data)
+            {
+                return HelperForRelations(left, right, original); ;
+            }
+
+            private bool HelperForRelations(Expression left, Expression right, Expression original)
+            {
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                if (Visit(left, out polLeft) && Visit(right, out polRight) && !polLeft.Relation.HasValue && !polRight.Relation.HasValue)
+                {
+                    var op = this.Decoder.OperatorFor(original);  // Doing it instead of passing as parameter as I am lazy
+                    result = new Polynomial<Variable, Expression>(op, polLeft.left, polRight.left);
+                    return true;
+                }
+                return false;
+            }
+
+            protected override bool Default(Unit data)
+            {
                 result = default(Polynomial<Variable, Expression>);
                 return false;
-              }
-
-              var dividedMonomial = new Monomial<Variable>(v, n.Variables);
-              divided[counter++] = dividedMonomial;
             }
 
-            result = new Polynomial<Variable, Expression>(divided);
-            return true;
-          }
+            private static bool TryToPolynomialFormHelperForSubtraction(
+              Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight, out Polynomial<Variable, Expression> result)
+            {
+                Polynomial<Variable, Expression> minusPolRight;
+                if (TryMinus(polRight, out minusPolRight))
+                {
+                    result = Concatenate(polLeft, minusPolRight);
+                    return true;
+                }
+                else
+                {
+                    result = default(Polynomial<Variable, Expression>);
+                    return false;
+                }
+            }
+
+            // We consider just the easy cases, when polLeft or polRight are constants
+            private bool TryToPolynomialFormHelperForDivision(Polynomial<Variable, Expression> polLeft, Polynomial<Variable, Expression> polRight,
+              out Polynomial<Variable, Expression> result)
+            {
+                long leftK, rightK;
+                if (polLeft.IsIntConstant(out leftK) && polRight.IsIntConstant(out rightK))
+                {
+                    if (rightK != 0)
+                    {
+                        var division = leftK / rightK;
+                        if (Int32.MinValue <= division && division <= Int32.MaxValue)
+                        {
+                            result = new Polynomial<Variable, Expression>(new Monomial<Variable>((Int32)division));
+                            return true;
+                        }
+                    }
+                    result = default(Polynomial<Variable, Expression>);
+                    return false;
+                }
+
+                if (polRight.Left.Length == 1) // (n1 + ... + nt) / m
+                {
+                    var m = polRight.Left[0];
+                    if (m.IsConstant && m.K != 0)    // (n1 + .... + nt) / k
+                    {
+                        var divided = new Monomial<Variable>[polLeft.Left.Length];
+                        var counter = 0;
+                        foreach (var n in polLeft.Left)
+                        {
+                            Rational v;
+
+                            try
+                            {
+                                v = n.K / m.K;
+                            }
+                            catch (ArithmeticExceptionRational)
+                            { // Division caused an error
+                                result = default(Polynomial<Variable, Expression>);
+                                return false;
+                            }
+
+                            var dividedMonomial = new Monomial<Variable>(v, n.Variables);
+                            divided[counter++] = dividedMonomial;
+                        }
+
+                        result = new Polynomial<Variable, Expression>(divided);
+                        return true;
+                    }
+                }
+
+                result = default(Polynomial<Variable, Expression>);
+                return false;
+            }
+
+            private bool TryMultiplyExpressionByMonomial(Expression exp, Monomial<Variable> m, out Polynomial<Variable, Expression> result)
+            {
+                Contract.Requires(exp != null);
+
+                Polynomial<Variable, Expression> polLeft, polRight;
+
+                switch (this.Decoder.OperatorFor(exp))
+                {
+                    case ExpressionOperator.Addition:
+                        // (e1 + e2) * m = (e1 * m) + (e2 * m)
+                        if (TryMultiplyExpressionByMonomial(this.Decoder.LeftExpressionFor(exp), m, out polLeft) &&
+                          TryMultiplyExpressionByMonomial(this.Decoder.RightExpressionFor(exp), m, out polRight))
+                        {
+                            result = Concatenate(polLeft, polRight);
+                            return result.TryToCanonicalForm(out result);
+                        }
+                        /* else*/
+                        goto default;
+
+                    case ExpressionOperator.Multiplication:
+                        // (e1 * e2) * m = (e1 * m) * (e2 * m)
+                        if (TryMultiplyExpressionByMonomial(Decoder.LeftExpressionFor(exp), m, out polLeft) &&
+                          TryMultiplyExpressionByMonomial(Decoder.RightExpressionFor(exp), m, out polRight))
+                        {
+                            return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
+                        }
+                        /* else*/
+                        goto default;
+
+                    case ExpressionOperator.Subtraction:
+                        // (e1 - e2) * m = (e1 * m) - (e2 * m)
+                        if (TryMultiplyExpressionByMonomial(Decoder.LeftExpressionFor(exp), m, out polLeft) &&
+                          TryMultiplyExpressionByMonomial(Decoder.RightExpressionFor(exp), m, out polRight))
+                        {
+                            return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
+                        }
+                        /* else*/
+                        goto default;
+
+
+                    case ExpressionOperator.Constant:
+                        // k * m = km
+                        var value = new VisitorForEvalConstant(this.Decoder).Visit(exp, Unit.Value);
+
+                        Contract.Assume(!object.ReferenceEquals(value.One, null));
+
+                        if (value.Two && !value.One.IsInfinity)
+                        {
+                            var k = value.One * m.K;
+
+                            result = new Polynomial<Variable, Expression>(new Monomial<Variable>(value.One * m.K, m.Variables));
+
+                            return true;
+                        }
+                        /* else */
+                        goto default;
+
+                    case ExpressionOperator.Division:
+                        // Just the case (e1 / e2) * e2 == e1
+                        if (TryToPolynomialForm(this.Decoder.RightExpressionFor(exp), this.Decoder, out polRight))
+                        {
+                            Monomial<Variable> tmp;
+                            if (polRight.IsMonomial(out tmp) && m.IsEquivalentTo(tmp))
+                            {
+                                return TryToPolynomialForm(this.Decoder.LeftExpressionFor(exp), this.Decoder, out result);
+                            }
+                        }
+                        /* else */
+                        goto default;
+
+                    case ExpressionOperator.UnaryMinus:
+                        // -(e1) * m =  -(e1 * m)
+                        if (TryToPolynomialForm(this.Decoder.LeftExpressionFor(exp), this.Decoder, out polLeft))
+                        {
+                            return TryMinus(polLeft, out result);
+                        }
+                        /* else */
+                        goto default;
+
+                    case ExpressionOperator.Variable:
+                    case ExpressionOperator.Unknown:
+                        // x * (k * xs) = k * [x; xs]
+                        var newvars = new List<Variable>(m.Variables);
+                        newvars.Add(this.Decoder.UnderlyingVariable(exp));
+
+                        result = new Polynomial<Variable, Expression>(new Monomial<Variable>(m.K, newvars));
+                        return true;
+
+                    case ExpressionOperator.WritableBytes:
+                    case ExpressionOperator.ConvertToFloat32:
+                    case ExpressionOperator.ConvertToFloat64:
+                    case ExpressionOperator.ConvertToInt32:
+                    case ExpressionOperator.ConvertToUInt16:
+                    case ExpressionOperator.ConvertToUInt32:
+                    case ExpressionOperator.ConvertToUInt8:
+                    case ExpressionOperator.And:
+                    case ExpressionOperator.Equal:
+                    case ExpressionOperator.Equal_Obj:
+                    case ExpressionOperator.GreaterEqualThan:
+                    case ExpressionOperator.GreaterEqualThan_Un:
+                    case ExpressionOperator.GreaterThan:
+                    case ExpressionOperator.GreaterThan_Un:
+                    case ExpressionOperator.LessEqualThan:
+                    case ExpressionOperator.LessEqualThan_Un:
+                    case ExpressionOperator.LessThan:
+                    case ExpressionOperator.LessThan_Un:
+                    case ExpressionOperator.Not:
+                    case ExpressionOperator.NotEqual:
+                    case ExpressionOperator.Or:
+                    case ExpressionOperator.Xor:
+                    case ExpressionOperator.ShiftLeft:
+                    case ExpressionOperator.ShiftRight:
+                    case ExpressionOperator.SizeOf:
+                    case ExpressionOperator.Modulus:
+                    default:
+                        result = default(Polynomial<Variable, Expression>);
+                        return false;
+                }
+            }
         }
 
-        result = default(Polynomial<Variable, Expression>);
-        return false;
-      }
-
-      private bool TryMultiplyExpressionByMonomial(Expression exp, Monomial<Variable> m, out Polynomial<Variable, Expression> result)
-      {
-        Contract.Requires(exp != null);
-
-        Polynomial<Variable, Expression> polLeft, polRight;
-
-        switch (this.Decoder.OperatorFor(exp))
+        /// <summary>
+        /// Evaluate the constant to a rational
+        /// </summary>
+        private class VisitorForEvalConstant
+          : GenericTypeExpressionVisitor<Variable, Expression, Unit, Pair<Rational, bool>>
         {
-          case ExpressionOperator.Addition:
-            // (e1 + e2) * m = (e1 * m) + (e2 * m)
-            if (TryMultiplyExpressionByMonomial(this.Decoder.LeftExpressionFor(exp), m, out polLeft) &&
-              TryMultiplyExpressionByMonomial(this.Decoder.RightExpressionFor(exp), m, out polRight))
+            readonly private static Pair<Rational, bool> NotSuccessfull = new Pair<Rational, bool>(Rational.PlusInfinity, false);
+
+            public VisitorForEvalConstant(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
             {
-              result = Concatenate(polLeft, polRight);
-              return result.TryToCanonicalForm(out result);
+                Contract.Requires(decoder != null);
             }
-            /* else*/
-            goto default;
 
-          case ExpressionOperator.Multiplication:
-            // (e1 * e2) * m = (e1 * m) * (e2 * m)
-            if (TryMultiplyExpressionByMonomial(Decoder.LeftExpressionFor(exp), m, out polLeft) &&
-              TryMultiplyExpressionByMonomial(Decoder.RightExpressionFor(exp), m, out polRight))
+            public override Pair<Rational, bool> VisitBool(Expression exp, Unit input)
             {
-              return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
+                return NotSuccessfull;
             }
-            /* else*/
-            goto default;
 
-          case ExpressionOperator.Subtraction:
-            // (e1 - e2) * m = (e1 * m) - (e2 * m)
-            if (TryMultiplyExpressionByMonomial(Decoder.LeftExpressionFor(exp), m, out polLeft) &&
-              TryMultiplyExpressionByMonomial(Decoder.RightExpressionFor(exp), m, out polRight))
+            public override Pair<Rational, bool> VisitInt8(Expression exp, Unit input)
             {
-              return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
+                SByte value;
+                if (Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value))
+                {
+                    return Success(Rational.For(value));
+                }
+                else
+                {
+                    return NotSuccessfull;
+                }
             }
-            /* else*/
-            goto default;
 
-
-          case ExpressionOperator.Constant:
-            // k * m = km
-            var value = new VisitorForEvalConstant(this.Decoder).Visit(exp, Unit.Value);
-
-            Contract.Assume(!object.ReferenceEquals(value.One, null));
-
-            if (value.Two && !value.One.IsInfinity)
+            public override Pair<Rational, bool> VisitInt16(Expression exp, Unit input)
             {
-              var k = value.One * m.K;
-
-              result = new Polynomial<Variable, Expression>(new Monomial<Variable>(value.One * m.K, m.Variables));
-
-              return true;
+                Int16 value;
+                if (Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value))
+                    return Success(Rational.For(value));
+                else
+                    return NotSuccessfull;
             }
-            /* else */
-            goto default;
 
-          case ExpressionOperator.Division:
-            // Just the case (e1 / e2) * e2 == e1
-            if (TryToPolynomialForm(this.Decoder.RightExpressionFor(exp), this.Decoder, out polRight))
+            public override Pair<Rational, bool> VisitInt32(Expression exp, Unit input)
             {
-              Monomial<Variable> tmp;
-              if (polRight.IsMonomial(out tmp) && m.IsEquivalentTo(tmp))
-              {
-                return TryToPolynomialForm(this.Decoder.LeftExpressionFor(exp), this.Decoder, out result);
-              }
+                Int32 value;
+                if (Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value))
+                    return Success(Rational.For(value));
+                else
+                    return NotSuccessfull;
             }
-            /* else */
-            goto default;
 
-          case ExpressionOperator.UnaryMinus:
-            // -(e1) * m =  -(e1 * m)
-            if (TryToPolynomialForm(this.Decoder.LeftExpressionFor(exp), this.Decoder, out polLeft))
+            public override Pair<Rational, bool> VisitInt64(Expression exp, Unit input)
             {
-              return TryMinus(polLeft, out result);
+                Int64 value;
+                if (Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value))
+                {
+                    if (Rational.CanRepresentExactly(value))
+                        return Success(Rational.For(value));
+                    else
+                        return value > 0 ? Success(Rational.PlusInfinity) : Success(Rational.MinusInfinity);
+                }
+                else
+                    return NotSuccessfull;
             }
-            /* else */
-            goto default;
 
-          case ExpressionOperator.Variable:
-          case ExpressionOperator.Unknown:
-            // x * (k * xs) = k * [x; xs]
-            var newvars = new List<Variable>(m.Variables);
-            newvars.Add(this.Decoder.UnderlyingVariable(exp));
+            public override Pair<Rational, bool> VisitFloat32(Expression exp, Unit input)
+            {
+                Single value;
+                if (Decoder.TryValueOf<Single>(exp, ExpressionType.Float32, out value))
+                {
+                    var intv = value.ConvertFromDouble();
+                    if (intv.IsSingleton)
+                        return new Pair<Rational, bool>(intv.LowerBound, true);
+                }
 
-            result = new Polynomial<Variable, Expression>(new Monomial<Variable>(m.K, newvars));
+                return NotSuccessfull;
+            }
+
+            public override Pair<Rational, bool> VisitFloat64(Expression exp, Unit input)
+            {
+                Double value;
+                if (Decoder.TryValueOf<Double>(exp, ExpressionType.Float32, out value))
+                {
+                    var intv = value.ConvertFromDouble();
+                    if (intv.IsSingleton)
+                        return new Pair<Rational, bool>(intv.LowerBound, true);
+                }
+
+                return NotSuccessfull;
+            }
+
+            public override Pair<Rational, bool> VisitString(Expression exp, Unit input)
+            {
+                return NotSuccessfull;
+            }
+
+            public override Pair<Rational, bool> VisitUInt8(Expression exp, Unit input)
+            {
+                Byte value;
+                if (Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value))
+                    return Success(Rational.For(value));
+                else
+                    return NotSuccessfull;
+            }
+
+            public override Pair<Rational, bool> VisitUInt16(Expression exp, Unit input)
+            {
+                UInt16 value;
+                if (Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value))
+                    return Success(Rational.For(value));
+                else
+                    return NotSuccessfull;
+            }
+
+            public override Pair<Rational, bool> VisitUInt32(Expression exp, Unit input)
+            {
+                UInt32 value;
+                if (Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value))
+                    return Success(Rational.For(value));
+                else
+                    return NotSuccessfull;
+            }
+
+            public override Pair<Rational, bool> Default(Expression exp)
+            {
+                if (this.Decoder.IsNull(exp))
+                    return Success(Rational.For(0));
+                else
+                    return NotSuccessfull;
+            }
+
+            private Pair<Rational, bool> Success(Rational value)
+            {
+                return new Pair<Rational, bool>(value, true);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (!(obj is Polynomial<Variable, Expression>))
+                return false;
+
+            var other = (Polynomial<Variable, Expression>)obj;
+
+            return FastEqual(this, other);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = 0;
+            foreach (var m in this.Left)
+            {
+                hash += m.GetHashCode();
+            }
+
+            if (this.Right != null)
+            {
+                foreach (var m in this.Right)
+                {
+                    hash += m.GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+
+        public static bool FastEqual(Polynomial<Variable, Expression> p1, Polynomial<Variable, Expression> p2)
+        {
+            if (p1.Relation != p2.Relation)
+                return false;
+            if (!FastEqual(p1.Left, p2.Left))
+                return false;
+            if (!FastEqual(p1.Right, p2.Right))
+                return false;
+
             return true;
+        }
 
-          case ExpressionOperator.WritableBytes:
-          case ExpressionOperator.ConvertToFloat32:
-          case ExpressionOperator.ConvertToFloat64:
-          case ExpressionOperator.ConvertToInt32:
-          case ExpressionOperator.ConvertToUInt16:
-          case ExpressionOperator.ConvertToUInt32:
-          case ExpressionOperator.ConvertToUInt8:
-          case ExpressionOperator.And:
-          case ExpressionOperator.Equal:
-          case ExpressionOperator.Equal_Obj:
-          case ExpressionOperator.GreaterEqualThan:
-          case ExpressionOperator.GreaterEqualThan_Un:
-          case ExpressionOperator.GreaterThan:
-          case ExpressionOperator.GreaterThan_Un:
-          case ExpressionOperator.LessEqualThan:
-          case ExpressionOperator.LessEqualThan_Un:
-          case ExpressionOperator.LessThan:
-          case ExpressionOperator.LessThan_Un:
-          case ExpressionOperator.Not:
-          case ExpressionOperator.NotEqual:
-          case ExpressionOperator.Or:
-          case ExpressionOperator.Xor:
-          case ExpressionOperator.ShiftLeft:
-          case ExpressionOperator.ShiftRight:
-          case ExpressionOperator.SizeOf:
-          case ExpressionOperator.Modulus:
-          default:
-            result = default(Polynomial<Variable, Expression>);
+        [Pure]
+        private static bool FastEqual(Monomial<Variable>[] l1, Monomial<Variable>[] l2)
+        {
+            if (l1 == null && l2 == null)
+                return true;
+            if (l1 == null || l2 == null)
+                return false;
+
+            if (l1.Length != l2.Length)
+                return false;
+
+            var b2 = new bool[l2.Length];
+
+            for (int i = 0; i < l1.Length; i++)
+            {
+                for (int j = 0; j < l2.Length; j++)
+                {
+                    if (b2[j])
+                        continue;
+
+                    if (l1[i].Equals(l2[j]))
+                    {
+                        b2[j] = true;
+
+                        break;
+                    }
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static IComparer<Polynomial<Variable, Expression>> Comparer
+        {
+            get
+            {
+                return new PolynomialComparison();
+            }
+        }
+
+        private class PolynomialComparison : IComparer<Polynomial<Variable, Expression>>
+        {
+            #region IComparer<Polynomial<Variable,Expression>> Members
+
+            // F: HACK HACK using strings to compare polynomials, very inefficient, should rewrite it
+            public int Compare(Polynomial<Variable, Expression> x, Polynomial<Variable, Expression> y)
+            {
+                var xStr = x.ToString();
+                var yStr = y.ToString();
+
+                if (xStr == yStr)
+                    return 0;
+                else
+                    return LexographicOrder(xStr, yStr);
+            }
+
+            static private int LexographicOrder(string x, string y)
+            {
+                Contract.Requires(x != null);
+                Contract.Requires(y != null);
+
+                for (var i = 0; i < Math.Min(x.Length, y.Length); i++)
+                {
+                    if (x[i] < y[i])
+                        return -1;
+                    else if (x[i] > y[i])
+                        return 1;
+                }
+
+                return x.Length < y.Length ? -1 : 1;
+            }
+
+            #endregion
+        }
+    }
+
+    /// <summary>
+    /// A Monomial is a pair <code>(k, x1...xn)</code> where <code>k</code> is a rational number and <code>xi</code> is a variable
+    /// </summary>
+    [ContractVerification(true)]
+    public struct Monomial<Variable>
+    {
+        #region Cached values
+        static readonly private IComparer<Variable> varCompaper = new ExpressionComparer<Variable>();
+        #endregion
+
+        #region Object Invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(!object.ReferenceEquals(k, null));
+            Contract.Invariant(variables != null);
+        }
+        #endregion
+
+        #region Private fields
+        private Rational k;
+        readonly private Variable[] variables;     // The sorted list of the variables in the monomial
+        #endregion
+
+        #region Getters
+        public Rational K
+        {
+            get
+            {
+                Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));
+
+                return k;
+            }
+            set
+            {
+                Contract.Requires(!object.ReferenceEquals(value, null));
+
+                k = value;
+            }
+        }
+
+        public IEnumerable<Variable> Variables
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Variable>>() == variables);
+                Contract.Ensures(Contract.Result<IEnumerable<Variable>>() != null);
+
+                return variables;
+            }
+        }
+
+        [Pure]
+        public Variable VariableAt(int i)
+        {
+            Contract.Requires(i >= 0);
+            Contract.Requires(i < this.Degree);
+
+            return variables[i];
+        }
+
+        public bool IsLinear
+        {
+            get
+            {
+                return this.Degree <= 1;
+            }
+        }
+
+
+        public bool IsConstant
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<bool>() || this.Degree > 0);
+
+                return variables.Length == 0;
+            }
+        }
+
+        [Pure]
+        internal bool IsIntConstant(out long kLeft)
+        {
+            if (variables.Length == 0 && k.IsInteger)
+            {
+                kLeft = (Int64)k.NextInt64;
+                return true;
+            }
+
+            kLeft = default(long);
             return false;
         }
 
-      }
-    }
 
-    /// <summary>
-    /// Evaluate the constant to a rational
-    /// </summary>
-    private class VisitorForEvalConstant
-      : GenericTypeExpressionVisitor<Variable, Expression, Unit, Pair<Rational, bool>>
-    {
-      readonly private static Pair<Rational, bool> NotSuccessfull = new Pair<Rational, bool>(Rational.PlusInfinity, false);
-
-      public VisitorForEvalConstant(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-      }
-
-      public override Pair<Rational, bool> VisitBool(Expression exp, Unit input)
-      {
-        return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitInt8(Expression exp, Unit input)
-      {
-        SByte value;
-        if (Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value))
+        [Pure]
+        public bool ContainsVariable(Variable var)
         {
-          return Success(Rational.For(value));
-        }
-        else
-        {
-          return NotSuccessfull;
-        }
-      }
+            foreach (var x in variables)
+            {
+                if (x.Equals(var))
+                    return true;
+            }
 
-      public override Pair<Rational, bool> VisitInt16(Expression exp, Unit input)
-      {
-        Int16 value;
-        if (Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value))
-          return Success(Rational.For(value));
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitInt32(Expression exp, Unit input)
-      {
-        Int32 value;
-        if (Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value))
-          return Success(Rational.For(value));
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitInt64(Expression exp, Unit input)
-      {
-        Int64 value;
-        if (Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value))
-        {
-          if (Rational.CanRepresentExactly(value))
-            return Success(Rational.For(value));
-          else
-            return value > 0 ? Success(Rational.PlusInfinity) : Success(Rational.MinusInfinity);
-        }
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitFloat32(Expression exp, Unit input)
-      {
-        Single value;
-        if (Decoder.TryValueOf<Single>(exp, ExpressionType.Float32, out value))
-        {
-          var intv = value.ConvertFromDouble();
-          if (intv.IsSingleton)
-            return new Pair<Rational, bool>(intv.LowerBound, true);
-        }
-
-        return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitFloat64(Expression exp, Unit input)
-      {
-        Double value;
-        if (Decoder.TryValueOf<Double>(exp, ExpressionType.Float32, out value))
-        {
-          var intv = value.ConvertFromDouble();
-          if (intv.IsSingleton)
-            return new Pair<Rational, bool>(intv.LowerBound, true);
-        }
-
-        return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitString(Expression exp, Unit input)
-      {
-        return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitUInt8(Expression exp, Unit input)
-      {
-        Byte value;
-        if (Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value))
-          return Success(Rational.For(value));
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitUInt16(Expression exp, Unit input)
-      {
-        UInt16 value;
-        if (Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value))
-          return Success(Rational.For(value));
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> VisitUInt32(Expression exp, Unit input)
-      {
-        UInt32 value;
-        if (Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value))
-          return Success(Rational.For(value));
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<Rational, bool> Default(Expression exp)
-      {
-        if (this.Decoder.IsNull(exp))
-          return Success(Rational.For(0));
-        else
-          return NotSuccessfull;
-      }
-
-      private Pair<Rational, bool> Success(Rational value)
-      {
-        return new Pair<Rational, bool>(value, true);
-      }
-
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj == null)
-        return false;
-
-      if (!(obj is Polynomial<Variable, Expression>))
-        return false;
-
-      var other = (Polynomial<Variable, Expression>)obj;
-
-      return FastEqual(this, other);
-    }
-
-    public override int GetHashCode()
-    {
-      var hash = 0;
-      foreach (var m in this.Left)
-      {
-        hash += m.GetHashCode();
-      }
-
-      if (this.Right != null)
-      {
-        foreach (var m in this.Right)
-        {
-          hash += m.GetHashCode();
-        }
-      }
-
-      return hash;
-    }
-
-    public static bool FastEqual(Polynomial<Variable, Expression> p1, Polynomial<Variable, Expression> p2)
-    {
-      if (p1.Relation != p2.Relation)
-        return false;
-      if (!FastEqual(p1.Left, p2.Left))
-        return false;
-      if (!FastEqual(p1.Right, p2.Right))
-        return false;
-
-      return true;
-    }
-
-    [Pure]
-    private static bool FastEqual(Monomial<Variable>[] l1, Monomial<Variable>[] l2)
-    {
-      if (l1 == null && l2 == null)
-        return true;
-      if (l1 == null || l2 == null)
-        return false;
-
-      if (l1.Length != l2.Length)
-        return false;
-
-      var b2 = new bool[l2.Length];
-
-      for (int i = 0; i < l1.Length; i++)
-      {
-        for (int j = 0; j < l2.Length; j++)
-        {
-          if (b2[j])
-            continue;
-
-          if (l1[i].Equals(l2[j]))
-          {
-            b2[j] = true;
-
-            break;
-          }
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    public static IComparer<Polynomial<Variable, Expression>> Comparer
-    {
-      get
-      {
-        return new PolynomialComparison();
-      }
-    }
-
-    private class PolynomialComparison : IComparer<Polynomial<Variable, Expression>>
-    {
-
-      #region IComparer<Polynomial<Variable,Expression>> Members
-
-      // F: HACK HACK using strings to compare polynomials, very inefficient, should rewrite it
-      public int Compare(Polynomial<Variable, Expression> x, Polynomial<Variable, Expression> y)
-      {
-        var xStr = x.ToString();
-        var yStr = y.ToString();
-
-        if (xStr == yStr)
-          return 0;
-        else
-          return LexographicOrder(xStr, yStr);
-      }
-
-      static private int LexographicOrder(string x, string y)
-      {
-        Contract.Requires(x != null);
-        Contract.Requires(y != null);
-
-        for (var i = 0; i < Math.Min(x.Length, y.Length); i++)
-        {
-          if (x[i] < y[i])
-            return -1;
-          else if (x[i] > y[i])
-            return 1;
-        }
-
-        return x.Length < y.Length ? -1 : 1;
-      }
-
-      #endregion
-    }
-  }
-
-  /// <summary>
-  /// A Monomial is a pair <code>(k, x1...xn)</code> where <code>k</code> is a rational number and <code>xi</code> is a variable
-  /// </summary>
-  [ContractVerification(true)]
-  public struct Monomial<Variable>
-  {
-    #region Cached values
-    static readonly private IComparer<Variable> varCompaper = new ExpressionComparer<Variable>();
-    #endregion
-
-    #region Object Invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(!object.ReferenceEquals(this.k, null));
-      Contract.Invariant(this.variables != null);
-    }
-    #endregion
-
-    #region Private fields
-    private Rational k;
-    readonly private Variable[] variables;     // The sorted list of the variables in the monomial
-    #endregion
-
-    #region Getters
-    public Rational K
-    {
-      get
-      {
-        Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));
-
-        return this.k;
-      }
-      set
-      {
-        Contract.Requires(!object.ReferenceEquals(value, null));
-
-        this.k = value;
-      }
-    }
-
-    public IEnumerable<Variable> Variables
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<Variable>>() == this.variables);
-        Contract.Ensures(Contract.Result<IEnumerable<Variable>>() != null);
-
-        return this.variables;
-      }
-    }
-
-    [Pure]
-    public Variable VariableAt(int i)
-    {
-      Contract.Requires(i >= 0);
-      Contract.Requires(i < this.Degree);
-
-      return this.variables[i];
-    }
-
-    public bool IsLinear
-    {
-      get
-      {
-        return this.Degree <= 1;
-      }
-    }
-
-
-    public bool IsConstant
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<bool>() || this.Degree > 0);
-
-        return this.variables.Length == 0;
-      }
-    }
-
-    [Pure]
-    internal bool IsIntConstant(out long kLeft)
-    {
-      if (this.variables.Length == 0 && this.k.IsInteger)
-      {
-        kLeft = (Int64)this.k.NextInt64;
-        return true;
-      }
-
-      kLeft = default(long);
-      return false;
-    }
-
-
-    [Pure]
-    public bool ContainsVariable(Variable var)
-    {
-      foreach (var x in this.variables)
-      {
-        if (x.Equals(var))
-          return true;
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public bool IsVariable(out Variable var)
-    {
-      if (this.Degree == 1)
-      {
-        var = this.variables[0];
-
-        return true;
-      }
-      else
-      {
-        var = default(Variable);
-
-        return false;
-      }
-    }
-
-    public int Degree
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() == this.variables.Length);
-
-        return this.variables.Length;
-      }
-    }
-
-    #endregion
-
-    #region Constructors
-    /// <summary>
-    /// Constructs a constant from an <code>Int32</code>
-    /// </summary>
-    public Monomial(int k)
-      : this(Rational.For(k))
-    {
-    }
-
-    ///<summary>
-    /// Constructs a constant form a <code>Rational</code>
-    ///</summary>
-    public Monomial(Rational r)
-    {
-      Contract.Requires((object)r != null);
-
-      this.k = r;
-      this.variables = new Variable[0];
-    }
-
-    ///<summary>
-    ///Constructs a monomial made by only a variable
-    ///</summary>
-    public Monomial(Variable x)
-    {
-      this.k = Rational.For(1);
-      this.variables = new Variable[] { x };
-    }
-
-    /// <summary>
-    /// Constructs a monomial with just one variable
-    /// </summary>
-    public Monomial(Rational k, Variable x)
-    {
-      Contract.Requires((object)k != null);
-
-      this.k = k;
-      this.variables = k.IsNotZero ? new Variable[] { x } : new Variable[0];
-    }
-
-    /// <summary>
-    /// Constructs a monomial with just one variable
-    /// </summary>
-    /// <summary>
-    /// Constructs a monomial with just one variable
-    /// </summary>
-    public Monomial(int k, Variable x)
-      : this(Rational.For(k), x)
-    {
-    }
-
-    /// <summary>
-    /// Constructs a monome with several variables (i.e. of a degree > 1)
-    /// </summary>
-    public Monomial(Rational k, IEnumerable<Variable> xs)
-    {
-      Contract.Requires(!object.ReferenceEquals(k, null));
-
-      this.k = k;
-
-      var tobeSorted = new List<Variable>(xs);
-      tobeSorted.Sort(varCompaper);
-
-      this.variables = tobeSorted.ToArray();
-    }
-
-    /// <summary>
-    /// Constructs a monome with several variables (i.e. of a degree > 1)
-    /// </summary>
-    public Monomial(int k, IEnumerable<Variable> xs)
-      : this(Rational.For(k), xs)
-    {
-    }
-    #endregion
-
-    private Monomial(Rational k, Variable[] vars)
-    {
-      Contract.Requires(!object.Equals(k, null));
-      Contract.Requires(vars != null);
-
-      this.k = k;
-      this.variables = vars;
-    }
-
-    public static Monomial<Variable> operator -(Monomial<Variable> m)
-    {
-      Contract.Assume(m.variables != null);
-
-      var copy = new Variable[m.variables.Length];
-      Array.Copy(m.variables, copy, m.variables.Length);
-      return new Monomial<Variable>(-m.K, copy);
-    }
-
-    public Monomial<Variable> Rename(Variable x, Variable xNew)
-    {
-      if (this.ContainsVariable(x))
-      {
-        var newVars = new Set<Variable>(this.Variables);
-        newVars.Remove(x);
-        newVars.Add(xNew);
-
-        return new Monomial<Variable>(this.K, newVars);
-      }
-      else
-      {
-        return this;
-      }
-    }
-
-    #region Overridden
-    public override string ToString()
-    {
-      return this.k + "*" + VarsToString(this.variables) + " ";
-    }
-
-    static private string VarsToString(Variable[] vars)
-    {
-      if (vars == null)
-      {
-        return "";
-      }
-
-      var s = new StringBuilder();
-
-      if (vars.Length == 0)
-      {
-        s.Append("1");
-      }
-      else
-      {
-        foreach (var v in vars)
-        {
-          if (v != null)
-            s.Append(v.ToString() + "* ");
-          else
-            s.Append("null");
-        }
-      }
-
-      var stmp = s.ToString();
-
-      if (stmp.Length > 2)         // Get rid of the last "* ", if any
-        stmp = stmp.Remove(stmp.Length - 2);
-
-      return stmp;
-    }
-    #endregion
-
-    public bool IsEquivalentTo(Monomial<Variable> other)
-    {
-      if (this.K != other.K)
-      {
-        return false;
-      }
-
-      if (this.Degree != other.Degree)
-      {
-        return false;
-      }
-
-      // This case is so common that we want to specialize it
-      if (this.Degree == 1)
-      {
-        var vThis = this.variables[0];
-        var vOther = other.variables[0];
-
-        return vThis.Equals(vOther);
-      }
-      else
-      {
-        foreach (var x in this.Variables)
-        {
-          if (!other.ContainsVariable(x))
             return false;
         }
 
-        return true;
-      }
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj == null)
-        return false;
-
-      if (object.ReferenceEquals(this, obj))
-        return true;
-
-      var other = (Monomial<Variable>)obj;
-
-      return this.IsEquivalentTo(other);
-    }
-
-    public override int GetHashCode()
-    {
-      var hash = 0;
-      // if (this.variables != null)
-      {
-        foreach (var x in this.Variables)
+        [Pure]
+        public bool IsVariable(out Variable var)
         {
-          hash += x.GetHashCode();
+            if (this.Degree == 1)
+            {
+                var = variables[0];
+
+                return true;
+            }
+            else
+            {
+                var = default(Variable);
+
+                return false;
+            }
         }
-      }
 
-      hash += this.K.GetHashCode();
+        public int Degree
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() == variables.Length);
 
-      return hash;
+                return variables.Length;
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Constructs a constant from an <code>Int32</code>
+        /// </summary>
+        public Monomial(int k)
+          : this(Rational.For(k))
+        {
+        }
+
+        ///<summary>
+        /// Constructs a constant form a <code>Rational</code>
+        ///</summary>
+        public Monomial(Rational r)
+        {
+            Contract.Requires((object)r != null);
+
+            k = r;
+            variables = new Variable[0];
+        }
+
+        ///<summary>
+        ///Constructs a monomial made by only a variable
+        ///</summary>
+        public Monomial(Variable x)
+        {
+            k = Rational.For(1);
+            variables = new Variable[] { x };
+        }
+
+        /// <summary>
+        /// Constructs a monomial with just one variable
+        /// </summary>
+        public Monomial(Rational k, Variable x)
+        {
+            Contract.Requires((object)k != null);
+
+            this.k = k;
+            variables = k.IsNotZero ? new Variable[] { x } : new Variable[0];
+        }
+
+        /// <summary>
+        /// Constructs a monomial with just one variable
+        /// </summary>
+        /// <summary>
+        /// Constructs a monomial with just one variable
+        /// </summary>
+        public Monomial(int k, Variable x)
+          : this(Rational.For(k), x)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a monome with several variables (i.e. of a degree > 1)
+        /// </summary>
+        public Monomial(Rational k, IEnumerable<Variable> xs)
+        {
+            Contract.Requires(!object.ReferenceEquals(k, null));
+
+            this.k = k;
+
+            var tobeSorted = new List<Variable>(xs);
+            tobeSorted.Sort(varCompaper);
+
+            variables = tobeSorted.ToArray();
+        }
+
+        /// <summary>
+        /// Constructs a monome with several variables (i.e. of a degree > 1)
+        /// </summary>
+        public Monomial(int k, IEnumerable<Variable> xs)
+          : this(Rational.For(k), xs)
+        {
+        }
+        #endregion
+
+        private Monomial(Rational k, Variable[] vars)
+        {
+            Contract.Requires(!object.Equals(k, null));
+            Contract.Requires(vars != null);
+
+            this.k = k;
+            variables = vars;
+        }
+
+        public static Monomial<Variable> operator -(Monomial<Variable> m)
+        {
+            Contract.Assume(m.variables != null);
+
+            var copy = new Variable[m.variables.Length];
+            Array.Copy(m.variables, copy, m.variables.Length);
+            return new Monomial<Variable>(-m.K, copy);
+        }
+
+        public Monomial<Variable> Rename(Variable x, Variable xNew)
+        {
+            if (this.ContainsVariable(x))
+            {
+                var newVars = new Set<Variable>(this.Variables);
+                newVars.Remove(x);
+                newVars.Add(xNew);
+
+                return new Monomial<Variable>(this.K, newVars);
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        #region Overridden
+        public override string ToString()
+        {
+            return k + "*" + VarsToString(variables) + " ";
+        }
+
+        static private string VarsToString(Variable[] vars)
+        {
+            if (vars == null)
+            {
+                return "";
+            }
+
+            var s = new StringBuilder();
+
+            if (vars.Length == 0)
+            {
+                s.Append("1");
+            }
+            else
+            {
+                foreach (var v in vars)
+                {
+                    if (v != null)
+                        s.Append(v.ToString() + "* ");
+                    else
+                        s.Append("null");
+                }
+            }
+
+            var stmp = s.ToString();
+
+            if (stmp.Length > 2)         // Get rid of the last "* ", if any
+                stmp = stmp.Remove(stmp.Length - 2);
+
+            return stmp;
+        }
+        #endregion
+
+        public bool IsEquivalentTo(Monomial<Variable> other)
+        {
+            if (this.K != other.K)
+            {
+                return false;
+            }
+
+            if (this.Degree != other.Degree)
+            {
+                return false;
+            }
+
+            // This case is so common that we want to specialize it
+            if (this.Degree == 1)
+            {
+                var vThis = variables[0];
+                var vOther = other.variables[0];
+
+                return vThis.Equals(vOther);
+            }
+            else
+            {
+                foreach (var x in this.Variables)
+                {
+                    if (!other.ContainsVariable(x))
+                        return false;
+                }
+
+                return true;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (object.ReferenceEquals(this, obj))
+                return true;
+
+            var other = (Monomial<Variable>)obj;
+
+            return this.IsEquivalentTo(other);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = 0;
+            // if (this.variables != null)
+            {
+                foreach (var x in this.Variables)
+                {
+                    hash += x.GetHashCode();
+                }
+            }
+
+            hash += this.K.GetHashCode();
+
+            return hash;
+        }
     }
-
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/PolynomialsOfInt.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Expressions/PolynomialsOfInt.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Few classes for helping manipulating PolynomialOfInts and MonomialOfInts
 
@@ -23,2904 +12,2897 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Expressions
 {
-  using System.Collections.Generic;
-  using System.Diagnostics.Contracts;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
 
-  /// <summary>
-  /// A PolynomialOfInt is a triple <code>(op, left, right)</code> where <code>op</code> is the binary operator (e.g. <code>==</code>), <code>left</code> the list of monomes on the left and
-  /// <code>right</code> the list of constant monomes on the right.
-  /// The list stands for the "addition"
-  /// </summary>
+    /// <summary>
+    /// A PolynomialOfInt is a triple <code>(op, left, right)</code> where <code>op</code> is the binary operator (e.g. <code>==</code>), <code>left</code> the list of monomes on the left and
+    /// <code>right</code> the list of constant monomes on the right.
+    /// The list stands for the "addition"
+    /// </summary>
 #if SUBPOLY_ONLY
-  internal
+    internal
 #else
-  public
+    public
 #endif
  class PolynomialOfInt<Variable, Expression>
-  {
-    #region Static fields
-
-    // TODO: figure out the statistics
-    //static readonly private FIFOCache<Expression, PolynomialOfInt<Variable, Expression>> cache_PolynomialOfIntForm = new FIFOCache<Expression,PolynomialOfInt<Variable, Expression>>();
-    // static readonly private FIFOCache<PolynomialOfInt<Variable, Expression>, PolynomialOfInt<Variable, Expression>> cache_CanonicalForms = new FIFOCache<PolynomialOfInt<Variable, Expression>, PolynomialOfInt<Variable, Expression>>();
-    #endregion
-
-    #region Private fields
-    private ExpressionOperator? relation;            // ^ invariant ExpressionOperatorHelper.IsBinaryExpression(relation) || relation == null;
-
-    private List<MonomialOfInt<Variable>>/*!*/ left;
-    private List<MonomialOfInt<Variable>>/*?*/ right;                     //^ invariant (this.relation == null) ==> right == null;
-
-    // Cached values
-    private bool? Cached_IsLinear = null;
-    private int? Cached_Degree = null;
-    private bool? Cached_IsTautology = null;
-
-    #endregion
-
-    #region Getters
-    /// <summary>
-    /// The relation of the PolynomialOfInt, or null if it is a spourious PolynomialOfInt
-    /// </summary>
-    public ExpressionOperator? Relation
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<ExpressionOperator?>().HasValue == this.relation.HasValue);
+        #region Static fields
 
-        return this.relation;
-      }
-    }
+        // TODO: figure out the statistics
+        //static readonly private FIFOCache<Expression, PolynomialOfInt<Variable, Expression>> cache_PolynomialOfIntForm = new FIFOCache<Expression,PolynomialOfInt<Variable, Expression>>();
+        // static readonly private FIFOCache<PolynomialOfInt<Variable, Expression>, PolynomialOfInt<Variable, Expression>> cache_CanonicalForms = new FIFOCache<PolynomialOfInt<Variable, Expression>, PolynomialOfInt<Variable, Expression>>();
+        #endregion
 
-    /// <summary>
-    /// The variables defined in this PolynomialOfInt
-    /// </summary>
-    public Set<Variable> Variables
-    {
-      get
-      {
-        Set<Variable> result = new Set<Variable>();
+        #region Private fields
+        private ExpressionOperator? relation;            // ^ invariant ExpressionOperatorHelper.IsBinaryExpression(relation) || relation == null;
 
-        foreach (MonomialOfInt<Variable> m in this.Left)
+        private List<MonomialOfInt<Variable>>/*!*/ left;
+        private List<MonomialOfInt<Variable>>/*?*/ right;                     //^ invariant (this.relation == null) ==> right == null;
+
+        // Cached values
+        private bool? Cached_IsLinear = null;
+        private int? Cached_Degree = null;
+        private bool? Cached_IsTautology = null;
+
+        #endregion
+
+        #region Getters
+        /// <summary>
+        /// The relation of the PolynomialOfInt, or null if it is a spourious PolynomialOfInt
+        /// </summary>
+        public ExpressionOperator? Relation
         {
-          result.AddRange(m.Variables);
-        }
-
-        if (this.Relation != null)
-        {
-          foreach (MonomialOfInt<Variable> m in this.Right)
-          {
-            result.AddRange(m.Variables);
-          }
-        }
-        return result;
-      }
-    }
-
-    /// <summary>
-    /// The list of MonomialOfInts on the Left of the relational operator
-    /// </summary>
-    public IList<MonomialOfInt<Variable>> Left
-    {
-      get
-      {
-#if DEBUG
-        return this.left.AsReadOnly();
-#else
-        return this.left;
-#endif
-      }
-    }
-
-    /// <summary>
-    /// The list of MonomialOfInts on the Right of the relational operator.
-    /// Precondition: <code>this.Relation != null</code>
-    /// </summary>
-    public IList<MonomialOfInt<Variable>> Right
-    {
-      get
-      {
-#if DEBUG
-        return this.right != null ? this.right.AsReadOnly() : null;
-#else
-        return this.right;
-#endif
-      }
-    }
-
-    /// <summary>
-    /// The Left part of this PolynomialOfInt as an instance of <code>PolynomialOfInt</code>
-    /// </summary>
-    public PolynomialOfInt<Variable, Expression> LeftAsPolynomialOfInt
-    {
-      get
-      {
-        PolynomialOfInt<Variable, Expression> result;
-        TryToPolynomialForm(this.left, out result); // We know that it never fails...
-
-        return result;
-      }
-    }
-
-    /// <summary>
-    /// The Right part of this PolynomialOfInt as an instance of <code>PolynomialOfInt</code>
-    /// </summary>
-    public PolynomialOfInt<Variable, Expression> RightAsPolynomialOfInt
-    {
-      get
-      {
-        Contract.Requires(this.Relation.HasValue);
-
-        PolynomialOfInt<Variable, Expression> result;
-        TryToPolynomialForm(this.right, out result); // We know that it never fails...
-
-        return result;
-      }
-    }
-
-
-    /// <summary>
-    /// Is a simple tautology?
-    /// </summary>
-    public bool IsTautology
-    {
-      get
-      {
-        if (this.Relation == null)
-          return false;
-
-        if (Cached_IsTautology.HasValue)
-          return Cached_IsTautology.Value;
-
-        if (this.Left.Count == 1 && this.Right.Count == 1)
-        {
-          if (this.Left[0].Variables.Count == 0 && this.Right[0].Variables.Count == 0)
-          {
-            bool result;
-
-            switch (this.Relation)
+            get
             {
-              case ExpressionOperator.Equal:
-              case ExpressionOperator.Equal_Obj:
-                result = this.Right[0].K == this.Left[0].K;
-                break;
+                Contract.Ensures(Contract.Result<ExpressionOperator?>().HasValue == relation.HasValue);
 
-              case ExpressionOperator.GreaterEqualThan:
-              case ExpressionOperator.GreaterEqualThan_Un:
-                result = this.Left[0].K >= this.Right[0].K;
-                break;
-
-              case ExpressionOperator.GreaterThan:
-              case ExpressionOperator.GreaterThan_Un:
-                result = this.Left[0].K > this.Right[0].K;
-                break;
-
-              case ExpressionOperator.LessEqualThan:
-              case ExpressionOperator.LessEqualThan_Un:
-                result = this.Left[0].K <= this.Right[0].K;
-                break;
-
-              case ExpressionOperator.LessThan:
-              case ExpressionOperator.LessThan_Un:
-                result = this.Left[0].K < this.Right[0].K;
-                break;
-
-              case ExpressionOperator.NotEqual:
-                result = this.Right[0].K != this.Left[0].K;
-                break;
-
-              default:
-                result = false;
-                break;
+                return relation;
             }
-
-            Cached_IsTautology = result;
-            return result;
-          }
         }
 
-        Cached_IsTautology = false;
-        return false;
-      }
-    }
-
-    public bool IsConstant(out int value)
-    {
-      if(this.Relation.HasValue || this.left.Count != 1 || this.Degree != 0)
-      {
-        value = default(int);
-        return false;
-      }
-
-      value = this.left[0].K;
-      return true;
-    }
-
-
-    /// <summary>
-    /// Is a simple inconsistence?
-    /// </summary>
-    public bool IsInconsistent
-    {
-      get
-      {
-        if (this.Relation == null)
-          return false;
-
-        if (this.Left.Count == 1 && this.Right.Count == 1)
+        /// <summary>
+        /// The variables defined in this PolynomialOfInt
+        /// </summary>
+        public Set<Variable> Variables
         {
-          if (this.Left[0].Variables.Count == 0 && this.Right[0].Variables.Count == 0)
-          {
-            switch (this.Relation)
+            get
             {
-              case ExpressionOperator.Equal:
-              case ExpressionOperator.Equal_Obj:
-                return this.Right[0].K != this.Left[0].K;
+                Set<Variable> result = new Set<Variable>();
 
-              case ExpressionOperator.GreaterEqualThan:
-              case ExpressionOperator.GreaterEqualThan_Un:
-                return this.Left[0].K < this.Right[0].K;
+                foreach (MonomialOfInt<Variable> m in this.Left)
+                {
+                    result.AddRange(m.Variables);
+                }
 
-              case ExpressionOperator.GreaterThan:
-              case ExpressionOperator.GreaterThan_Un:
-                return this.Left[0].K <= this.Right[0].K;
+                if (this.Relation != null)
+                {
+                    foreach (MonomialOfInt<Variable> m in this.Right)
+                    {
+                        result.AddRange(m.Variables);
+                    }
+                }
+                return result;
+            }
+        }
 
-              case ExpressionOperator.LessEqualThan:
-              case ExpressionOperator.LessEqualThan_Un:
-                return this.Left[0].K > this.Right[0].K;
+        /// <summary>
+        /// The list of MonomialOfInts on the Left of the relational operator
+        /// </summary>
+        public IList<MonomialOfInt<Variable>> Left
+        {
+            get
+            {
+#if DEBUG
+                return left.AsReadOnly();
+#else
+                return left;
+#endif
+            }
+        }
 
-              case ExpressionOperator.LessThan:
-              case ExpressionOperator.LessThan_Un:
-                return this.Left[0].K >= this.Right[0].K;
+        /// <summary>
+        /// The list of MonomialOfInts on the Right of the relational operator.
+        /// Precondition: <code>this.Relation != null</code>
+        /// </summary>
+        public IList<MonomialOfInt<Variable>> Right
+        {
+            get
+            {
+#if DEBUG
+                return right != null ? right.AsReadOnly() : null;
+#else
+                return right;
+#endif
+            }
+        }
 
-              case ExpressionOperator.NotEqual:
-                return this.Right[0].K == this.Left[0].K;
+        /// <summary>
+        /// The Left part of this PolynomialOfInt as an instance of <code>PolynomialOfInt</code>
+        /// </summary>
+        public PolynomialOfInt<Variable, Expression> LeftAsPolynomialOfInt
+        {
+            get
+            {
+                PolynomialOfInt<Variable, Expression> result;
+                TryToPolynomialForm(left, out result); // We know that it never fails...
 
-              default:
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// The Right part of this PolynomialOfInt as an instance of <code>PolynomialOfInt</code>
+        /// </summary>
+        public PolynomialOfInt<Variable, Expression> RightAsPolynomialOfInt
+        {
+            get
+            {
+                Contract.Requires(this.Relation.HasValue);
+
+                PolynomialOfInt<Variable, Expression> result;
+                TryToPolynomialForm(right, out result); // We know that it never fails...
+
+                return result;
+            }
+        }
+
+
+        /// <summary>
+        /// Is a simple tautology?
+        /// </summary>
+        public bool IsTautology
+        {
+            get
+            {
+                if (this.Relation == null)
+                    return false;
+
+                if (Cached_IsTautology.HasValue)
+                    return Cached_IsTautology.Value;
+
+                if (this.Left.Count == 1 && this.Right.Count == 1)
+                {
+                    if (this.Left[0].Variables.Count == 0 && this.Right[0].Variables.Count == 0)
+                    {
+                        bool result;
+
+                        switch (this.Relation)
+                        {
+                            case ExpressionOperator.Equal:
+                            case ExpressionOperator.Equal_Obj:
+                                result = this.Right[0].K == this.Left[0].K;
+                                break;
+
+                            case ExpressionOperator.GreaterEqualThan:
+                            case ExpressionOperator.GreaterEqualThan_Un:
+                                result = this.Left[0].K >= this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.GreaterThan:
+                            case ExpressionOperator.GreaterThan_Un:
+                                result = this.Left[0].K > this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.LessEqualThan:
+                            case ExpressionOperator.LessEqualThan_Un:
+                                result = this.Left[0].K <= this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.LessThan:
+                            case ExpressionOperator.LessThan_Un:
+                                result = this.Left[0].K < this.Right[0].K;
+                                break;
+
+                            case ExpressionOperator.NotEqual:
+                                result = this.Right[0].K != this.Left[0].K;
+                                break;
+
+                            default:
+                                result = false;
+                                break;
+                        }
+
+                        Cached_IsTautology = result;
+                        return result;
+                    }
+                }
+
+                Cached_IsTautology = false;
                 return false;
             }
-          }
         }
 
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// Is it in the form of <code>a*x + b *y \leq c</code>, with a, b \in  {+1, -1, 0}, and c is an int
-    /// </summary>
-    public bool IsOctagonForm
-    {
-      get
-      {
-        if (this.Relation == null)
+        public bool IsConstant(out int value)
         {
-          return false;
-        }
-        if (!this.IsLinear)
-        {
-          return false;
-        }
-        if (!(this.Left.Count <= 2 && this.Right.Count == 1))   // Something in the form of m1 + m2 <= m3
-        {
-          return false;
-        }
-        if (!(this.Left[0].K == -1 || this.Left[0].K == 1 || this.Left[0].K == 0))     // m1.K must be -1, 0 or +1
-        {
-          return false;
-        }
-        if (this.Left.Count == 2)
-        {
-          if (!(this.Left[1].K == -1 || this.Left[1].K == 1 || this.Left[0].K == 0)) // m2.K must be -1, 0 or +1
-          {
-            return false;
-          }
-        }
-        if (!this.Right[0].IsConstant)                          // m3 must be a constant
-        {
-          return false;
-        }
-
-        return true;                                            // If we reached this point, then it is an octagon
-      }
-    }
-
-
-
-    /// <summary>
-    /// Is it a linear MonomialOfInt?
-    /// </summary>
-    public bool IsLinear
-    {
-      get
-      {
-        if (Cached_IsLinear.HasValue)
-        {
-          return Cached_IsLinear.Value;
-        }
-
-        foreach (var m in this.Left)
-        { // all the MonomialOfInt on the left must be linear
-          if (!m.IsLinear)
-          {
-            Cached_IsLinear = false;
-            return false;
-          }
-        }
-        if (this.Relation != null)
-        {
-          foreach (var m in this.Right)
-          { // all the MonomialOfInt on the right must be linear
-            if (!m.IsLinear)
+            if (this.Relation.HasValue || left.Count != 1 || this.Degree != 0)
             {
-              Cached_IsLinear = false;
-              return false;
+                value = default(int);
+                return false;
             }
-          }
-          Cached_IsLinear = true;
-          return true;
+
+            value = left[0].K;
+            return true;
         }
-        else
+
+
+        /// <summary>
+        /// Is a simple inconsistence?
+        /// </summary>
+        public bool IsInconsistent
         {
-          Cached_IsLinear = true;
-          return true;
-        }
-      }
-    }
-
-    public bool IsLinearOctagon
-    {
-      get
-      {
-        if (!this.IsLinear)
-        {
-          return false;
-        }
-        else if (this.IsOctagonForm)
-        {
-          return true;
-        }
-        else if (!this.Relation.HasValue)
-        {
-          if (this.Left.Count > 2)
-          {
-            return false;
-          }
-          else if (this.Left.Count == 1)
-          {   // is the case that we have <k, 1> or <+/- 1, x> ?
-            return (this.Left[0].IsConstant || this.Left[0].K == 1 || this.Left[0].K == -1);
-          }
-          else
-          {
-            Contract.Assume(this.Left.Count == 2, "Error cannot have an empty left on a PolynomialOfInt");
-
-            return (this.Left[0].IsLinear && (this.Left[0].K == 1 || this.Left[0].K == -1) && this.Left[1].IsConstant);
-          }
-        }
-        else
-        {
-          return false;
-        }
-      }
-    }
-
-    /// <summary>
-    /// The degree of the PolynomialOfInt
-    /// </summary>
-    public int Degree
-    {
-      get
-      {
-        if (this.Cached_Degree.HasValue)
-          return this.Cached_Degree.Value;
-
-        int max = -1;
-        foreach (var m in this.Left)
-        {
-          if (m.Degree > max)
-            max = m.Degree;
-        }
-        if (this.Right != null)
-        {
-          foreach (var m in this.Right)
-          {
-            if (m.Degree > max)
-              max = m.Degree;
-          }
-        }
-
-        this.Cached_Degree = max;
-        return max;
-      }
-    }
-
-    /// <summary>
-    /// Is in the form of k1 * x \leq k2 ?
-    /// </summary>
-    public bool IsIntervalForm
-    {
-      get
-      {
-        if (this.Relation != ExpressionOperator.LessEqualThan) // Must be "<="
-        {
-          return false;
-        }
-        if (!(this.Left.Count == 1 && this.Right.Count == 1))   // Must be "m1 <= m2"
-        {
-          return false;
-        }
-        if (!(this.Left[0].Degree == 1))                 // Must be "m1 == k1 * x"
-        {
-          return false;
-        }
-        if (!this.Right[0].IsConstant)                  // Must be "m2 == k2"
-        {
-          return false;
-        }
-
-        return true;    // It is "k1 * x <= k2 "
-      }
-    }
-
-    private bool IsMonomialOfInt(out MonomialOfInt<Variable> m)
-    {
-      if (!this.relation.HasValue && this.left.Count == 1)
-      {
-        m = this.left[0];
-        return true;
-      }
-      else
-      {
-        m = default(MonomialOfInt<Variable>);
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// Add a constant to the left of the PolynomialOfInt
-    /// </summary>
-    /// <param name="p"></param>
-    public void PlusConstant(int p)
-    {
-      Contract.Requires((object)p != null);
-      Contract.Requires(!this.Relation.HasValue);
-
-      this.Left.Add(new MonomialOfInt<Variable>(p));
-    }
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    /// A PolynomialOfInt made by just one MonomialOfInt...
-    /// </summary>
-    private PolynomialOfInt(MonomialOfInt<Variable> monome)
-    {
-      this.relation = null;
-
-      // To please the Spec# compiler, the lines below have been modified
-      // this.left = new List<MonomialOfInt<Variable>>(1);
-      // this.left.Add(monome);
-
-      List<MonomialOfInt<Variable>> this_left = new List<MonomialOfInt<Variable>>(1);
-      this_left.Add(monome);
-      this.left = this_left;
-      //^ base();
-
-      this.right = null;
-    }
-
-
-    /// <summary>
-    /// If <code>monomes == (k1, xs1) ... (kn, xsn)</code> then it constructs the polynome <code>k1*xs1 +  ... + kn* xsn</code>
-    /// </summary>
-    private PolynomialOfInt(List<MonomialOfInt<Variable>> monomes)
-    {
-      this.relation = null;
-      this.left = monomes;
-      this.right = null;
-    }
-
-    /// <summary>
-    /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
-    /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
-    /// </summary>
-    /// <param name="op">Must be a binary operator</param>
-    private PolynomialOfInt(ExpressionOperator op, List<MonomialOfInt<Variable>> left, List<MonomialOfInt<Variable>> right)
-    {
-      Contract.Requires(op.IsBinary());
-
-      this.relation = op;
-      this.left = left;
-      this.right = right;
-    }
-
-    /// <summary>
-    /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1)</code>, then it constructs the polynome standing for 
-    /// <code> k1*xs1 +  ... + kn* xsn op c1*ys1</code>
-    /// </summary>
-    /// <param name="op">Must be a binary operator</param>
-    private PolynomialOfInt(ExpressionOperator op, List<MonomialOfInt<Variable>> left, MonomialOfInt<Variable> right)
-    {
-      Contract.Requires(op.IsBinary());
-
-      this.relation = op;
-      this.left = left;
-      this.right = new List<MonomialOfInt<Variable>>();
-      this.right.Add(right);
-    }
-
-    /// <summary>
-    /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
-    /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
-    /// </summary>
-    /// <param name="op">Must be a binary operator</param>
-    /// <param name="left">shoukd be such that left.Relation == null</param>
-    /// <param name="right">shoukd be such that right.Relation == null</param>
-    private PolynomialOfInt(ExpressionOperator op, PolynomialOfInt<Variable, Expression> left, PolynomialOfInt<Variable, Expression> right)
-    {
-      Contract.Requires(op.IsBinary());
-      Contract.Requires(!left.Relation.HasValue);
-      Contract.Requires(!right.Relation.HasValue);
-
-      this.relation = op;
-      this.left = left.left;
-      this.right = right.left;
-    }
-
-    private PolynomialOfInt(PolynomialOfInt<Variable, Expression> other)
-    {
-      this.relation = other.relation;
-      this.left = new List<MonomialOfInt<Variable>>(other.left);
-      this.right = other.right != null ? new List<MonomialOfInt<Variable>>(other.right) : null;
-    }
-
-    #endregion
-
-    #region Manipulation of the PolynomialOfInt: Creates a PolynomialOfInt from a PureExpression and puts it into a canonical form
-
-    /// <summary>
-    /// Convert the pure expression <code>exp</code> into a PolynomialOfInt, that is somehow simpler to handle.
-    /// Essentially, it gets rid of all the parentheses, it performs the(simple) multiplications, additions, etc.
-    /// </summary>
-    /// <param name="exp">The expression that will be decoded</param>
-    /// <param name="decoder">The decoder for the expression</param>
-    /// <param name="result">If the result is true, then it returns a PolynomialOfInt into a canonical form</param>
-    static public bool TryToPolynomialForm(Expression/*!*/ exp, IExpressionDecoder<Variable, Expression>/*!*/ decoder,
-      out PolynomialOfInt<Variable, Expression> result)
-    {
-      PolynomialOfInt<Variable, Expression> polLeft, polRight;
-      bool success;
-
-      // We check if it is in the cache
-      // We do not want to do it for variables, as there are some problems if we want to refine them or not
-      //if (!decoder.IsVariable(exp) /*&& cache_PolynomialOfIntForm.TryGetValue(exp, out result)*/)
-      //{
-      //  return true;
-      //}
-
-      if (decoder == null)
-      {
-        result = null;
-        return false;
-      }
-
-      switch (decoder.OperatorFor(exp))   // Depending on the operator of the expression...
-      {
-        #region All the cases to "flat" the expression e to a PolynomialOfInt (there is the exception for division of PolynomialOfInts : not handled yet)
-        case ExpressionOperator.Constant:
-          //Sometimes we do not know the type of the constant, we try to extract the value,             
-
-          var value = new VisitorForEvalConstant(decoder).Visit(exp, Unit.Value);
-
-          if (value.Two && value.One != Int32.MaxValue && value.One != Int32.MinValue)
-          {
-            var constantMonome = new MonomialOfInt<Variable>(value.One);
-
-            success = true;
-            result = new PolynomialOfInt<Variable, Expression>(constantMonome);
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
-
-        case ExpressionOperator.ConvertToInt32:
-        case ExpressionOperator.ConvertToInt8:
-          // We forget about the conversion....
-          success = TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out result);
-          break;
-
-        case ExpressionOperator.ConvertToUInt32:
-          // We specialize this case
-          var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(decoder).Visit(decoder.LeftExpressionFor(exp), new IntervalEnvironment<Variable, Expression>(decoder, VoidLogger.Log));
-
-          Rational v;
-          if (constValue.TryGetSingletonValue(out v) && v.IsInteger && v < 0 )
-          {
-            success = false;
-            result = null;
-          }
-          else
-          {
-            success = TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out result);
-          }
-          break;
-
-        case ExpressionOperator.ConvertToFloat64:
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToUInt8:
-        case ExpressionOperator.ConvertToUInt16:
-        case ExpressionOperator.ConvertToInt64:
-          // Approximation ...
-          success = false;
-          result = null;
-          break;
-
-        case ExpressionOperator.Variable:               // return (1, e)
-          var variableMonome = new MonomialOfInt<Variable>(decoder.UnderlyingVariable(exp));
-
-          success = true;
-          result = new PolynomialOfInt<Variable, Expression>(variableMonome);
-          break;
-
-        case ExpressionOperator.And:
-        case ExpressionOperator.Or:
-        case ExpressionOperator.Xor:
-        case ExpressionOperator.LogicalAnd:
-        case ExpressionOperator.LogicalNot:
-        case ExpressionOperator.LogicalOr:
-          success = false;
-          result = null;
-          break;
-
-        // The cases below are ok
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-        case ExpressionOperator.NotEqual:
-        case ExpressionOperator.LessThan:
-        case ExpressionOperator.LessThan_Un:
-        case ExpressionOperator.LessEqualThan:
-        case ExpressionOperator.LessEqualThan_Un:
-        case ExpressionOperator.GreaterThan:
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.GreaterEqualThan:
-        case ExpressionOperator.GreaterEqualThan_Un:
-          if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft)
-            && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight)
-            && !polLeft.Relation.HasValue
-            && !polRight.Relation.HasValue)
-          {
-            success = true;
-            result = new PolynomialOfInt<Variable, Expression>(decoder.OperatorFor(exp), polLeft.left, polRight.left);
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
-
-        case ExpressionOperator.Addition:   // (m1 + ... + mt) + (n1 + ... + nk) = (m1 + ... + mn + n1  + ... nk)
-          if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out  polLeft)
-            && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
-          {
-            success = true;
-            result = Concatenate(polLeft, polRight);
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
-
-        case ExpressionOperator.Subtraction: // (m1 + ... + mt) - (n1 + ... + nk) = (m1 + ... + mn - n1  - ... - nk)
-          if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft)
-            && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
-          {
-            success = TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
-
-        case ExpressionOperator.Modulus: // We give up for it
-          success = false;
-          result = null;
-          break;
-
-        case ExpressionOperator.Multiplication: // (m1 + ... + mt) * (n1 + ... + nk) = (m1*n1 + m1*n2 + ... + mt*n(k-1)+ mt*nk)
-          var isPolLeft = TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft);
-          var isPolRight = TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight);
-
-          if (isPolLeft && isPolRight)
-          {
-            success = TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
-          }
-          // Handle the case exp * m
-          else if (isPolLeft || isPolRight)
-          {
-            Expression notPolynomialOfInt;
-
-            // Swap so that right is always the non-PolynomialOfInt
-            if (isPolRight)
+            get
             {
-              polLeft = polRight;
-              isPolLeft = true;
+                if (this.Relation == null)
+                    return false;
 
-              polRight = default(PolynomialOfInt<Variable, Expression>);
-              isPolRight = false;
+                if (this.Left.Count == 1 && this.Right.Count == 1)
+                {
+                    if (this.Left[0].Variables.Count == 0 && this.Right[0].Variables.Count == 0)
+                    {
+                        switch (this.Relation)
+                        {
+                            case ExpressionOperator.Equal:
+                            case ExpressionOperator.Equal_Obj:
+                                return this.Right[0].K != this.Left[0].K;
 
-              notPolynomialOfInt = decoder.LeftExpressionFor(exp);
+                            case ExpressionOperator.GreaterEqualThan:
+                            case ExpressionOperator.GreaterEqualThan_Un:
+                                return this.Left[0].K < this.Right[0].K;
+
+                            case ExpressionOperator.GreaterThan:
+                            case ExpressionOperator.GreaterThan_Un:
+                                return this.Left[0].K <= this.Right[0].K;
+
+                            case ExpressionOperator.LessEqualThan:
+                            case ExpressionOperator.LessEqualThan_Un:
+                                return this.Left[0].K > this.Right[0].K;
+
+                            case ExpressionOperator.LessThan:
+                            case ExpressionOperator.LessThan_Un:
+                                return this.Left[0].K >= this.Right[0].K;
+
+                            case ExpressionOperator.NotEqual:
+                                return this.Right[0].K == this.Left[0].K;
+
+                            default:
+                                return false;
+                        }
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Is it in the form of <code>a*x + b *y \leq c</code>, with a, b \in  {+1, -1, 0}, and c is an int
+        /// </summary>
+        public bool IsOctagonForm
+        {
+            get
+            {
+                if (this.Relation == null)
+                {
+                    return false;
+                }
+                if (!this.IsLinear)
+                {
+                    return false;
+                }
+                if (!(this.Left.Count <= 2 && this.Right.Count == 1))   // Something in the form of m1 + m2 <= m3
+                {
+                    return false;
+                }
+                if (!(this.Left[0].K == -1 || this.Left[0].K == 1 || this.Left[0].K == 0))     // m1.K must be -1, 0 or +1
+                {
+                    return false;
+                }
+                if (this.Left.Count == 2)
+                {
+                    if (!(this.Left[1].K == -1 || this.Left[1].K == 1 || this.Left[0].K == 0)) // m2.K must be -1, 0 or +1
+                    {
+                        return false;
+                    }
+                }
+                if (!this.Right[0].IsConstant)                          // m3 must be a constant
+                {
+                    return false;
+                }
+
+                return true;                                            // If we reached this point, then it is an octagon
+            }
+        }
+
+
+
+        /// <summary>
+        /// Is it a linear MonomialOfInt?
+        /// </summary>
+        public bool IsLinear
+        {
+            get
+            {
+                if (Cached_IsLinear.HasValue)
+                {
+                    return Cached_IsLinear.Value;
+                }
+
+                foreach (var m in this.Left)
+                { // all the MonomialOfInt on the left must be linear
+                    if (!m.IsLinear)
+                    {
+                        Cached_IsLinear = false;
+                        return false;
+                    }
+                }
+                if (this.Relation != null)
+                {
+                    foreach (var m in this.Right)
+                    { // all the MonomialOfInt on the right must be linear
+                        if (!m.IsLinear)
+                        {
+                            Cached_IsLinear = false;
+                            return false;
+                        }
+                    }
+                    Cached_IsLinear = true;
+                    return true;
+                }
+                else
+                {
+                    Cached_IsLinear = true;
+                    return true;
+                }
+            }
+        }
+
+        public bool IsLinearOctagon
+        {
+            get
+            {
+                if (!this.IsLinear)
+                {
+                    return false;
+                }
+                else if (this.IsOctagonForm)
+                {
+                    return true;
+                }
+                else if (!this.Relation.HasValue)
+                {
+                    if (this.Left.Count > 2)
+                    {
+                        return false;
+                    }
+                    else if (this.Left.Count == 1)
+                    {   // is the case that we have <k, 1> or <+/- 1, x> ?
+                        return (this.Left[0].IsConstant || this.Left[0].K == 1 || this.Left[0].K == -1);
+                    }
+                    else
+                    {
+                        Contract.Assume(this.Left.Count == 2, "Error cannot have an empty left on a PolynomialOfInt");
+
+                        return (this.Left[0].IsLinear && (this.Left[0].K == 1 || this.Left[0].K == -1) && this.Left[1].IsConstant);
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The degree of the PolynomialOfInt
+        /// </summary>
+        public int Degree
+        {
+            get
+            {
+                if (Cached_Degree.HasValue)
+                    return Cached_Degree.Value;
+
+                int max = -1;
+                foreach (var m in this.Left)
+                {
+                    if (m.Degree > max)
+                        max = m.Degree;
+                }
+                if (this.Right != null)
+                {
+                    foreach (var m in this.Right)
+                    {
+                        if (m.Degree > max)
+                            max = m.Degree;
+                    }
+                }
+
+                Cached_Degree = max;
+                return max;
+            }
+        }
+
+        /// <summary>
+        /// Is in the form of k1 * x \leq k2 ?
+        /// </summary>
+        public bool IsIntervalForm
+        {
+            get
+            {
+                if (this.Relation != ExpressionOperator.LessEqualThan) // Must be "<="
+                {
+                    return false;
+                }
+                if (!(this.Left.Count == 1 && this.Right.Count == 1))   // Must be "m1 <= m2"
+                {
+                    return false;
+                }
+                if (!(this.Left[0].Degree == 1))                 // Must be "m1 == k1 * x"
+                {
+                    return false;
+                }
+                if (!this.Right[0].IsConstant)                  // Must be "m2 == k2"
+                {
+                    return false;
+                }
+
+                return true;    // It is "k1 * x <= k2 "
+            }
+        }
+
+        private bool IsMonomialOfInt(out MonomialOfInt<Variable> m)
+        {
+            if (!relation.HasValue && left.Count == 1)
+            {
+                m = left[0];
+                return true;
             }
             else
             {
-              notPolynomialOfInt = decoder.RightExpressionFor(exp);
+                m = default(MonomialOfInt<Variable>);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Add a constant to the left of the PolynomialOfInt
+        /// </summary>
+        /// <param name="p"></param>
+        public void PlusConstant(int p)
+        {
+            Contract.Requires((object)p != null);
+            Contract.Requires(!this.Relation.HasValue);
+
+            this.Left.Add(new MonomialOfInt<Variable>(p));
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// A PolynomialOfInt made by just one MonomialOfInt...
+        /// </summary>
+        private PolynomialOfInt(MonomialOfInt<Variable> monome)
+        {
+            relation = null;
+
+            // To please the Spec# compiler, the lines below have been modified
+            // this.left = new List<MonomialOfInt<Variable>>(1);
+            // this.left.Add(monome);
+
+            List<MonomialOfInt<Variable>> this_left = new List<MonomialOfInt<Variable>>(1);
+            this_left.Add(monome);
+            left = this_left;
+            //^ base();
+
+            right = null;
+        }
+
+
+        /// <summary>
+        /// If <code>monomes == (k1, xs1) ... (kn, xsn)</code> then it constructs the polynome <code>k1*xs1 +  ... + kn* xsn</code>
+        /// </summary>
+        private PolynomialOfInt(List<MonomialOfInt<Variable>> monomes)
+        {
+            relation = null;
+            left = monomes;
+            right = null;
+        }
+
+        /// <summary>
+        /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
+        /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
+        /// </summary>
+        /// <param name="op">Must be a binary operator</param>
+        private PolynomialOfInt(ExpressionOperator op, List<MonomialOfInt<Variable>> left, List<MonomialOfInt<Variable>> right)
+        {
+            Contract.Requires(op.IsBinary());
+
+            relation = op;
+            this.left = left;
+            this.right = right;
+        }
+
+        /// <summary>
+        /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1)</code>, then it constructs the polynome standing for 
+        /// <code> k1*xs1 +  ... + kn* xsn op c1*ys1</code>
+        /// </summary>
+        /// <param name="op">Must be a binary operator</param>
+        private PolynomialOfInt(ExpressionOperator op, List<MonomialOfInt<Variable>> left, MonomialOfInt<Variable> right)
+        {
+            Contract.Requires(op.IsBinary());
+
+            relation = op;
+            this.left = left;
+            this.right = new List<MonomialOfInt<Variable>>();
+            this.right.Add(right);
+        }
+
+        /// <summary>
+        /// If <code>left == (k1, xs1) ... (kn, xsn)</code> and <code>right == (c1, ys1) ... (cm, ysm)</code>, then it constructs the polynome standing for 
+        /// <code> k1*xs1 +  ... + kn* xsn op c1*cs1 + ...  + cn*csn</code>
+        /// </summary>
+        /// <param name="op">Must be a binary operator</param>
+        /// <param name="left">shoukd be such that left.Relation == null</param>
+        /// <param name="right">shoukd be such that right.Relation == null</param>
+        private PolynomialOfInt(ExpressionOperator op, PolynomialOfInt<Variable, Expression> left, PolynomialOfInt<Variable, Expression> right)
+        {
+            Contract.Requires(op.IsBinary());
+            Contract.Requires(!left.Relation.HasValue);
+            Contract.Requires(!right.Relation.HasValue);
+
+            relation = op;
+            this.left = left.left;
+            this.right = right.left;
+        }
+
+        private PolynomialOfInt(PolynomialOfInt<Variable, Expression> other)
+        {
+            relation = other.relation;
+            left = new List<MonomialOfInt<Variable>>(other.left);
+            right = other.right != null ? new List<MonomialOfInt<Variable>>(other.right) : null;
+        }
+
+        #endregion
+
+        #region Manipulation of the PolynomialOfInt: Creates a PolynomialOfInt from a PureExpression and puts it into a canonical form
+
+        /// <summary>
+        /// Convert the pure expression <code>exp</code> into a PolynomialOfInt, that is somehow simpler to handle.
+        /// Essentially, it gets rid of all the parentheses, it performs the(simple) multiplications, additions, etc.
+        /// </summary>
+        /// <param name="exp">The expression that will be decoded</param>
+        /// <param name="decoder">The decoder for the expression</param>
+        /// <param name="result">If the result is true, then it returns a PolynomialOfInt into a canonical form</param>
+        static public bool TryToPolynomialForm(Expression/*!*/ exp, IExpressionDecoder<Variable, Expression>/*!*/ decoder,
+          out PolynomialOfInt<Variable, Expression> result)
+        {
+            PolynomialOfInt<Variable, Expression> polLeft, polRight;
+            bool success;
+
+            // We check if it is in the cache
+            // We do not want to do it for variables, as there are some problems if we want to refine them or not
+            //if (!decoder.IsVariable(exp) /*&& cache_PolynomialOfIntForm.TryGetValue(exp, out result)*/)
+            //{
+            //  return true;
+            //}
+
+            if (decoder == null)
+            {
+                result = null;
+                return false;
             }
 
-            MonomialOfInt<Variable> m;
-            if (polLeft.IsMonomialOfInt(out m) && TryMultiplyExpressionByMonomialOfInt(notPolynomialOfInt, m, decoder, out result))
+            switch (decoder.OperatorFor(exp))   // Depending on the operator of the expression...
             {
-              success = true;
-            }
-            else
-            {
-              success = false;
-              result = null;
-            }
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
+                #region All the cases to "flat" the expression e to a PolynomialOfInt (there is the exception for division of PolynomialOfInts : not handled yet)
+                case ExpressionOperator.Constant:
+                    //Sometimes we do not know the type of the constant, we try to extract the value,             
 
-        case ExpressionOperator.ShiftLeft: // (m1 + ... + mt) << (n1 + ... + nk) : we give up...
-          success = false;
-          result = null;
-          break;
+                    var value = new VisitorForEvalConstant(decoder).Visit(exp, Unit.Value);
 
-        case ExpressionOperator.ShiftRight: // (m1 + ... + mt) >> (n1 + ... + nk) : we give up...
-          {
-            int k;
-            if (decoder.IsConstantInt(decoder.RightExpressionFor(exp), out k) && k >= 0)
+                    if (value.Two && value.One != Int32.MaxValue && value.One != Int32.MinValue)
+                    {
+                        var constantMonome = new MonomialOfInt<Variable>(value.One);
+
+                        success = true;
+                        result = new PolynomialOfInt<Variable, Expression>(constantMonome);
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                case ExpressionOperator.ConvertToInt32:
+                case ExpressionOperator.ConvertToInt8:
+                    // We forget about the conversion....
+                    success = TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out result);
+                    break;
+
+                case ExpressionOperator.ConvertToUInt32:
+                    // We specialize this case
+                    var constValue = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(decoder).Visit(decoder.LeftExpressionFor(exp), new IntervalEnvironment<Variable, Expression>(decoder, VoidLogger.Log));
+
+                    Rational v;
+                    if (constValue.TryGetSingletonValue(out v) && v.IsInteger && v < 0)
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    else
+                    {
+                        success = TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out result);
+                    }
+                    break;
+
+                case ExpressionOperator.ConvertToFloat64:
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToUInt8:
+                case ExpressionOperator.ConvertToUInt16:
+                case ExpressionOperator.ConvertToInt64:
+                    // Approximation ...
+                    success = false;
+                    result = null;
+                    break;
+
+                case ExpressionOperator.Variable:               // return (1, e)
+                    var variableMonome = new MonomialOfInt<Variable>(decoder.UnderlyingVariable(exp));
+
+                    success = true;
+                    result = new PolynomialOfInt<Variable, Expression>(variableMonome);
+                    break;
+
+                case ExpressionOperator.And:
+                case ExpressionOperator.Or:
+                case ExpressionOperator.Xor:
+                case ExpressionOperator.LogicalAnd:
+                case ExpressionOperator.LogicalNot:
+                case ExpressionOperator.LogicalOr:
+                    success = false;
+                    result = null;
+                    break;
+
+                // The cases below are ok
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                case ExpressionOperator.NotEqual:
+                case ExpressionOperator.LessThan:
+                case ExpressionOperator.LessThan_Un:
+                case ExpressionOperator.LessEqualThan:
+                case ExpressionOperator.LessEqualThan_Un:
+                case ExpressionOperator.GreaterThan:
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.GreaterEqualThan:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft)
+                      && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight)
+                      && !polLeft.Relation.HasValue
+                      && !polRight.Relation.HasValue)
+                    {
+                        success = true;
+                        result = new PolynomialOfInt<Variable, Expression>(decoder.OperatorFor(exp), polLeft.left, polRight.left);
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                case ExpressionOperator.Addition:   // (m1 + ... + mt) + (n1 + ... + nk) = (m1 + ... + mn + n1  + ... nk)
+                    if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft)
+                      && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
+                    {
+                        success = true;
+                        result = Concatenate(polLeft, polRight);
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                case ExpressionOperator.Subtraction: // (m1 + ... + mt) - (n1 + ... + nk) = (m1 + ... + mn - n1  - ... - nk)
+                    if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft)
+                      && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
+                    {
+                        success = TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                case ExpressionOperator.Modulus: // We give up for it
+                    success = false;
+                    result = null;
+                    break;
+
+                case ExpressionOperator.Multiplication: // (m1 + ... + mt) * (n1 + ... + nk) = (m1*n1 + m1*n2 + ... + mt*n(k-1)+ mt*nk)
+                    var isPolLeft = TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft);
+                    var isPolRight = TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight);
+
+                    if (isPolLeft && isPolRight)
+                    {
+                        success = TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
+                    }
+                    // Handle the case exp * m
+                    else if (isPolLeft || isPolRight)
+                    {
+                        Expression notPolynomialOfInt;
+
+                        // Swap so that right is always the non-PolynomialOfInt
+                        if (isPolRight)
+                        {
+                            polLeft = polRight;
+                            isPolLeft = true;
+
+                            polRight = default(PolynomialOfInt<Variable, Expression>);
+                            isPolRight = false;
+
+                            notPolynomialOfInt = decoder.LeftExpressionFor(exp);
+                        }
+                        else
+                        {
+                            notPolynomialOfInt = decoder.RightExpressionFor(exp);
+                        }
+
+                        MonomialOfInt<Variable> m;
+                        if (polLeft.IsMonomialOfInt(out m) && TryMultiplyExpressionByMonomialOfInt(notPolynomialOfInt, m, decoder, out result))
+                        {
+                            success = true;
+                        }
+                        else
+                        {
+                            success = false;
+                            result = null;
+                        }
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                case ExpressionOperator.ShiftLeft: // (m1 + ... + mt) << (n1 + ... + nk) : we give up...
+                    success = false;
+                    result = null;
+                    break;
+
+                case ExpressionOperator.ShiftRight: // (m1 + ... + mt) >> (n1 + ... + nk) : we give up...
+                    {
+                        int k;
+                        if (decoder.IsConstantInt(decoder.RightExpressionFor(exp), out k) && k >= 0)
+                        {
+                            if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft))
+                            {
+                                int coeff;
+
+                                try
+                                {
+                                    coeff = 1 << k;
+                                }
+                                catch (ArithmeticExceptionRational)
+                                { // If we've got an exception, it means that we cannot convert this PolynomialOfInt 
+                                    result = null;
+                                    success = false;
+
+                                    return success;
+                                }
+
+                                var mList = new List<MonomialOfInt<Variable>>();
+                                foreach (MonomialOfInt<Variable> m in polLeft.Left)
+                                {
+                                    int newCoeff;
+
+                                    try
+                                    {
+                                        newCoeff = m.K / coeff;
+                                    }
+                                    catch (ArithmeticExceptionRational)
+                                    {
+                                        success = false;
+                                        result = null;
+
+                                        return success;
+                                    }
+
+                                    var tmp = new MonomialOfInt<Variable>(newCoeff, m.Variables);
+                                    mList.Add(tmp);
+                                }
+                                success = true; // Already true here, but it is to make the code more readable
+                                result = new PolynomialOfInt<Variable, Expression>(mList);
+                            }
+                            else
+                            {
+                                success = false;
+                                result = null;
+                            }
+                        }
+                        else
+                        {
+                            success = false;
+                            result = null;
+                        }
+                    }
+                    break;
+
+                case ExpressionOperator.SizeOf: // We try to extract the sizeof of the expression, if we fail we give up
+                    int size;
+                    if (decoder.TrySizeOf(exp, out size))
+                    {
+                        MonomialOfInt<Variable> constantMonome = new MonomialOfInt<Variable>(size);
+                        result = new PolynomialOfInt<Variable, Expression>(constantMonome);
+                        success = true;
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                case ExpressionOperator.Division: // (m1 + ... + mt) / (n1 + ... + nk) = ? We do just simple cases, and we did not made it a complete PolynomialOfInt division
+
+                    if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft)
+                      && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
+                    {
+                        success = TryToPolynomialFormHelperForDivision(polLeft, polRight, out result);
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                case ExpressionOperator.Not:
+                case ExpressionOperator.UnaryMinus: // -(m1 + ... + mt) = -m1 - ... -mt
+
+                    if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft))
+                    {
+                        success = TryMinus(polLeft, out result);
+                    }
+                    else
+                    {
+                        success = false;
+                        result = null;
+                    }
+                    break;
+
+                // If we do not know it, we treat it as just a symbol
+                case ExpressionOperator.Unknown:
+                    result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(decoder.UnderlyingVariable(exp)));
+                    success = true;
+                    break;
+
+                case ExpressionOperator.WritableBytes:
+                    result = new PolynomialOfInt<Variable, Expression>(ExtractWritableBytesExpression(decoder.LeftExpressionFor(exp), decoder, out success));
+                    break;
+
+
+                default:
+                    Contract.Assert(false, "Unknown case ... ");
+
+                    success = false;
+
+                    throw new AbstractInterpretationException("Error, unknown case : " + exp);
+                    #endregion
+            }
+
+            if (success)
             {
-              if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft))
-              {
-                int coeff;
+                Contract.Assert(result != null); // Invariant success => result != null
 
                 try
                 {
-                    coeff = 1 << k;
+                    result = result.ToCanonicalForm();
+
+                    //if (!decoder.IsVariable(exp))
+                    //{
+                    //  cache_PolynomialOfIntForm.Add(exp, result);
+                    //}
                 }
                 catch (ArithmeticExceptionRational)
-                { // If we've got an exception, it means that we cannot convert this PolynomialOfInt 
-                  result = null;
-                  success = false;
-
-                  return success;
-                }
-
-                var mList = new List<MonomialOfInt<Variable>>();
-                foreach (MonomialOfInt<Variable> m in polLeft.Left)
                 {
-                  int newCoeff;
-
-                  try
-                  {
-                    newCoeff = m.K / coeff;
-                  }
-                  catch (ArithmeticExceptionRational)
-                  {
+                    result = null;
                     success = false;
+                }
+            }
+
+            return success;
+        }
+
+        private static bool TryMultiplyExpressionByMonomialOfInt(Expression exp, MonomialOfInt<Variable> m, IExpressionDecoder<Variable, Expression> decoder, out PolynomialOfInt<Variable, Expression> result)
+        {
+            PolynomialOfInt<Variable, Expression> polLeft, polRight;
+
+            switch (decoder.OperatorFor(exp))
+            {
+                case ExpressionOperator.Addition:
+                    // (e1 + e2) * m = (e1 * m) + (e2 * m)
+                    if (TryMultiplyExpressionByMonomialOfInt(decoder.LeftExpressionFor(exp), m, decoder, out polLeft) &&
+                      TryMultiplyExpressionByMonomialOfInt(decoder.RightExpressionFor(exp), m, decoder, out polRight))
+                    {
+                        result = Concatenate(polLeft, polRight).ToCanonicalForm();
+                        return true;
+                    }
+                    /* else*/
+                    goto default;
+
+                case ExpressionOperator.Multiplication:
+                    // (e1 * e2) * m = (e1 * m) * (e2 * m)
+                    if (TryMultiplyExpressionByMonomialOfInt(decoder.LeftExpressionFor(exp), m, decoder, out polLeft) &&
+                      TryMultiplyExpressionByMonomialOfInt(decoder.RightExpressionFor(exp), m, decoder, out polRight))
+                    {
+                        return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
+                    }
+                    /* else*/
+                    goto default;
+
+                case ExpressionOperator.Subtraction:
+                    // (e1 - e2) * m = (e1 * m) - (e2 * m)
+                    if (TryMultiplyExpressionByMonomialOfInt(decoder.LeftExpressionFor(exp), m, decoder, out polLeft) &&
+                      TryMultiplyExpressionByMonomialOfInt(decoder.RightExpressionFor(exp), m, decoder, out polRight))
+                    {
+                        return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
+                    }
+                    /* else*/
+                    goto default;
+
+
+                case ExpressionOperator.Constant:
+                    // k * m = km
+                    var value = new VisitorForEvalConstant(decoder).Visit(exp, Unit.Value);
+
+                    if (value.Two && value.One != Int32.MinValue && value.One != Int32.MaxValue)
+                    {
+                        var k = value.One * m.K;
+
+                        result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(value.One * m.K, m.Variables));
+
+                        return true;
+                    }
+                    /* else */
+                    goto default;
+
+                case ExpressionOperator.Division:
+                    // Just the case (e1 / e2) * e2 == e1
+                    if (TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
+                    {
+                        MonomialOfInt<Variable> tmp;
+                        if (polRight.IsMonomialOfInt(out tmp) && m.IsEquivalentTo(tmp))
+                        {
+                            return TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out result);
+                        }
+                    }
+                    /* else */
+                    goto default;
+
+                case ExpressionOperator.UnaryMinus:
+                    // -(e1) * m =  -(e1 * m)
+                    if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft))
+                    {
+                        return TryMinus(polLeft, out result);
+                    }
+                    /* else */
+                    goto default;
+
+                case ExpressionOperator.Variable:
+                case ExpressionOperator.Unknown:
+                    // x * (k * xs) = k * [x; xs]
+                    var newvars = new List<Variable>(m.Variables);
+                    newvars.Add(decoder.UnderlyingVariable(exp));
+
+                    result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(m.K, newvars));
+                    return true;
+
+                case ExpressionOperator.WritableBytes:
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToFloat64:
+                case ExpressionOperator.ConvertToInt32:
+                case ExpressionOperator.ConvertToUInt16:
+                case ExpressionOperator.ConvertToUInt32:
+                case ExpressionOperator.ConvertToUInt8:
+                case ExpressionOperator.And:
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                case ExpressionOperator.GreaterEqualThan:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                case ExpressionOperator.GreaterThan:
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.LessEqualThan:
+                case ExpressionOperator.LessEqualThan_Un:
+                case ExpressionOperator.LessThan:
+                case ExpressionOperator.LessThan_Un:
+                case ExpressionOperator.Not:
+                case ExpressionOperator.NotEqual:
+                case ExpressionOperator.Or:
+                case ExpressionOperator.Xor:
+                case ExpressionOperator.ShiftLeft:
+                case ExpressionOperator.ShiftRight:
+                case ExpressionOperator.SizeOf:
+                case ExpressionOperator.Modulus:
+                default:
+                    result = default(PolynomialOfInt<Variable, Expression>);
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Construct the PolynomialOfInt "left == value".
+        /// It handles left in a monolitic fashion
+        /// </summary>
+        static public bool TryToPolynomialForm_Eq(Expression left, int value,
+          out PolynomialOfInt<Variable, Expression> pol,
+          IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires((object)value != null);
+
+            pol = new PolynomialOfInt<Variable, Expression>(ExpressionOperator.Equal,
+              new List<MonomialOfInt<Variable>>(1) { new MonomialOfInt<Variable>(decoder.UnderlyingVariable(left)) },
+              new List<MonomialOfInt<Variable>>(1) { new MonomialOfInt<Variable>(value) });
+
+            return true;
+        }
+
+        /// <summary>
+        /// Convert the pure expression <code>left op right</code> into a PolynomialOfInt, that is somehow simpler to handle.
+        /// Essentially, it gets rid of all the parenthesis, it performs the(simple) multiplications, additions, etc.
+        /// </summary>
+        /// <param name="result">if the result is true, it is a PolynomialOfInt in canonical form</param>
+        static public bool TryToPolynomialForm(ExpressionOperator op, Expression/*!*/ left, Expression/*!*/ right, IExpressionDecoder<Variable, Expression>/*!*/ decoder, out PolynomialOfInt<Variable, Expression> result)
+        {
+            Contract.Requires(op.IsBinary());
+
+            if (decoder.OperatorFor(left).IsRelationalOperator()
+              || decoder.OperatorFor(right).IsRelationalOperator())
+            {
+                result = null;
+                return false;
+            }
+            else
+            {
+                PolynomialOfInt<Variable, Expression> leftAsPol, rightAsPol;
+
+                if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(left, decoder, out leftAsPol)
+                  && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol))
+                {
+                    try
+                    {
+                        Contract.Assume(!leftAsPol.Relation.HasValue);
+                        Contract.Assume(!rightAsPol.Relation.HasValue);
+
+                        var tmp = new PolynomialOfInt<Variable, Expression>(op, leftAsPol, rightAsPol);
+                        result = tmp.ToCanonicalForm();
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        result = null;
+                        return false;
+                    }
+
+                    return true;
+                }
+                else
+                {
                     result = null;
 
-                    return success;
-                  }
-
-                  var tmp = new MonomialOfInt<Variable>(newCoeff, m.Variables);
-                  mList.Add(tmp);
+                    return false;
                 }
-                success = true; // Already true here, but it is to make the code more readable
-                result = new PolynomialOfInt<Variable, Expression>(mList);
-              }
-              else
-              {
-                success = false;
+            }
+        }
+
+        static public bool TryToPolynomialFormNoDiv(ExpressionOperator op, Expression/*!*/ left, Expression/*!*/ right, IExpressionDecoder<Variable, Expression>/*!*/ decoder, out PolynomialOfInt<Variable, Expression> result)
+        {
+            Contract.Requires(op.IsBinary());
+
+            if (decoder.OperatorFor(left).IsRelationalOperator()
+              || decoder.OperatorFor(right).IsRelationalOperator())
+            {
                 result = null;
-              }
+                return false;
+            }
+
+
+            {
+                PolynomialOfInt<Variable, Expression> leftAsPol, rightAsPol;
+
+                if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(left, decoder, out leftAsPol)
+                  && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol))
+                {
+                    if (!leftAsPol.IsLinearOctagon || !rightAsPol.IsLinearOctagon)
+                    {
+                        result = null;
+                        return false;
+                    }
+
+                    try
+                    {
+                        Contract.Assume(!leftAsPol.Relation.HasValue);
+                        Contract.Assume(!rightAsPol.Relation.HasValue);
+
+                        var tmp = new PolynomialOfInt<Variable, Expression>(op, leftAsPol, rightAsPol);
+                        result = tmp.ToCanonicalForm();
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        result = null;
+                        return false;
+                    }
+
+                    return true;
+                }
+                else
+                {
+                    result = null;
+
+                    return false;
+                }
+            }
+        }
+
+
+        /// <param name="result">If the result is true, it is a PolynomialOfInt in canonical form</param>
+        static public bool TryToPolynomialForm(ExpressionOperator op, PolynomialOfInt<Variable, Expression>/*!*/ left, PolynomialOfInt<Variable, Expression>/*!*/ right, out PolynomialOfInt<Variable, Expression> result)
+        {
+            if (!op.IsBinary() || left.Relation != null || right.Relation != null)
+            {
+                result = null;
+                return false;
             }
             else
             {
-              success = false;
-              result = null;
+                try
+                {
+                    Contract.Assert(right.Relation == null);
+
+                    // here we return a new PolynomialOfInt. An alternative is to return a PolynomialOfInt in canonical form
+                    result = new PolynomialOfInt<Variable, Expression>(op, left, right).ToCanonicalForm();
+                    return true;
+                }
+                catch (ArithmeticExceptionRational)
+                {
+                    // If there is an exception in the ints, then we simply fail
+                    result = null;
+                    return false;
+                }
             }
-          }
-          break;
+        }
 
-        case ExpressionOperator.SizeOf: // We try to extract the sizeof of the expression, if we fail we give up
-          int size;
-          if (decoder.TrySizeOf(exp, out size))
-          {
-            MonomialOfInt<Variable> constantMonome = new MonomialOfInt<Variable>(size);
-            result = new PolynomialOfInt<Variable, Expression>(constantMonome);
-            success = true;
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
+        /// <param name="result">The result: a PolynomialOfInt in canonical form</param>
+        /// <returns>Always true</returns>
+        static public bool TryToPolynomialForm(ExpressionOperator expressionOperator, List<MonomialOfInt<Variable>> left, List<MonomialOfInt<Variable>> right, out PolynomialOfInt<Variable, Expression> result)
+        {
+            Contract.Requires(expressionOperator.IsBinary());
 
-        case ExpressionOperator.Division: // (m1 + ... + mt) / (n1 + ... + nk) = ? We do just simple cases, and we did not made it a complete PolynomialOfInt division
+            result = new PolynomialOfInt<Variable, Expression>(expressionOperator, left, right).ToCanonicalForm();
 
-          if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft)
-            && TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
-          {
-            success = TryToPolynomialFormHelperForDivision(polLeft, polRight, out result);
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
+            return true;
+        }
 
-        case ExpressionOperator.Not:
-        case ExpressionOperator.UnaryMinus: // -(m1 + ... + mt) = -m1 - ... -mt
+        static public bool TryToPolynomialForm(bool canonicalByConstruction, ExpressionOperator expressionOperator, List<MonomialOfInt<Variable>> left, List<MonomialOfInt<Variable>> right, out PolynomialOfInt<Variable, Expression> result)
+        {
+            Contract.Requires(expressionOperator.IsBinary());
 
-          if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft))
-          {
-            success = TryMinus(polLeft, out result);
-          }
-          else
-          {
-            success = false;
-            result = null;
-          }
-          break;
+            if (canonicalByConstruction)
+            {
+                result = new PolynomialOfInt<Variable, Expression>(expressionOperator, left, right);
 
-        // If we do not know it, we treat it as just a symbol
-        case ExpressionOperator.Unknown:
-          result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(decoder.UnderlyingVariable(exp)));
-          success = true;
-          break;
-
-        case ExpressionOperator.WritableBytes:
-          result = new PolynomialOfInt<Variable, Expression>(ExtractWritableBytesExpression(decoder.LeftExpressionFor(exp), decoder, out success));
-          break;
+                return true;
+            }
+            else
+            {
+                return TryToPolynomialForm(expressionOperator, left, right, out result);
+            }
+        }
 
 
-        default:
-          Contract.Assert(false, "Unknown case ... ");
+        /// <summary>
+        /// Convert the list of MonomialOfInts <code>MonomialOfInts</code> into a PolynomialOfInt in canonical form
+        /// </summary>
+        /// <param name="pol">The PolynomialOfInt in canonical form</param>
+        /// <returns>Always true</returns>
+        static public bool TryToPolynomialForm(List<MonomialOfInt<Variable>> MonomialOfInts, out PolynomialOfInt<Variable, Expression> pol)
+        {
+            if (MonomialOfInts.Count > 1)
+            {
+                pol = new PolynomialOfInt<Variable, Expression>(MonomialOfInts).ToCanonicalForm();
+            }
+            else
+            {
+                pol = new PolynomialOfInt<Variable, Expression>(MonomialOfInts);
+            }
 
-          success = false;
+            return true;
+        }
 
-          throw new AbstractInterpretationException("Error, unknown case : " + exp);
+        static public bool TryToPolynomialForm(bool canonicalByConstruction, List<MonomialOfInt<Variable>> MonomialOfInts, out PolynomialOfInt<Variable, Expression> pol)
+        {
+            if (canonicalByConstruction)
+            {
+                pol = new PolynomialOfInt<Variable, Expression>(MonomialOfInts);
+                return true;
+            }
+            else
+            {
+                return TryToPolynomialForm(MonomialOfInts, out pol);
+            }
+        }
+
         #endregion
-      }
 
-      if (success)
-      {
-        Contract.Assert(result != null); // Invariant success => result != null
-
-        try
+        #region Manipulation of the PolynomialOfInt : Add a monome
+        public PolynomialOfInt<Variable, Expression> AddMonomialOfIntToTheLeft(MonomialOfInt<Variable> m)
         {
-          result = result.ToCanonicalForm();
+            PolynomialOfInt<Variable, Expression> thisCloned = new PolynomialOfInt<Variable, Expression>(this);
+            thisCloned.left.Add(m);
 
-          //if (!decoder.IsVariable(exp))
-          //{
-          //  cache_PolynomialOfIntForm.Add(exp, result);
-          //}
+            return thisCloned.ToCanonicalForm();
         }
-        catch (ArithmeticExceptionRational)
+
+        public PolynomialOfInt<Variable, Expression> AddMonomialOfIntToTheLeft(List<MonomialOfInt<Variable>> m)
         {
-          result = null;
-          success = false;
+            PolynomialOfInt<Variable, Expression> thisCloned = new PolynomialOfInt<Variable, Expression>(this);
+            thisCloned.left.AddRange(m);
+
+            return thisCloned.ToCanonicalForm();
         }
-      }
 
-      return success;
-    }
+        #endregion
 
-    private static bool TryMultiplyExpressionByMonomialOfInt(Expression exp, MonomialOfInt<Variable> m, IExpressionDecoder<Variable, Expression> decoder, out PolynomialOfInt<Variable, Expression> result)
-    {
-      PolynomialOfInt<Variable, Expression> polLeft, polRight;
+        #region ToCanonicalForm, ToPureExpression, Renaming
+        /// <summary>
+        /// Put this PolynomialOfInt into a canonical form, meaning that all the MonomialOfInt involving variables are on the left, all the constants on the right, and all the easy arithmetic operations are performed
+        /// </summary>
+        /// <returns>The canonical form of this PolynomialOfInt</returns>
+        private PolynomialOfInt<Variable, Expression>/*!*/ ToCanonicalForm()
+        {
+            PolynomialOfInt<Variable, Expression> canonical;
 
-      switch (decoder.OperatorFor(exp))
-      {
-        case ExpressionOperator.Addition:
-          // (e1 + e2) * m = (e1 * m) + (e2 * m)
-          if (TryMultiplyExpressionByMonomialOfInt(decoder.LeftExpressionFor(exp), m, decoder, out polLeft) &&
-            TryMultiplyExpressionByMonomialOfInt(decoder.RightExpressionFor(exp), m, decoder, out polRight))
-          {
-            result = Concatenate(polLeft, polRight).ToCanonicalForm();
-            return true;
-          }
-          /* else*/
-          goto default;
+            //if (cache_CanonicalForms.TryGetValue(this, out canonical))
+            //{
+            //  return canonical;
+            //}
 
-        case ExpressionOperator.Multiplication:
-          // (e1 * e2) * m = (e1 * m) * (e2 * m)
-          if (TryMultiplyExpressionByMonomialOfInt(decoder.LeftExpressionFor(exp), m, decoder, out polLeft) &&
-            TryMultiplyExpressionByMonomialOfInt(decoder.RightExpressionFor(exp), m, decoder, out polRight))
-          {
-            return TryToPolynomialFormHelperForMultiplication(polLeft, polRight, out result);
-          }
-          /* else*/
-          goto default;
-
-        case ExpressionOperator.Subtraction:
-          // (e1 - e2) * m = (e1 * m) - (e2 * m)
-          if (TryMultiplyExpressionByMonomialOfInt(decoder.LeftExpressionFor(exp), m, decoder, out polLeft) &&
-            TryMultiplyExpressionByMonomialOfInt(decoder.RightExpressionFor(exp), m, decoder, out polRight))
-          {
-            return TryToPolynomialFormHelperForSubtraction(polLeft, polRight, out result);
-          }
-          /* else*/
-          goto default;
-
-
-        case ExpressionOperator.Constant:
-          // k * m = km
-          var value = new VisitorForEvalConstant(decoder).Visit(exp, Unit.Value);
-
-          if (value.Two && value.One != Int32.MinValue && value.One != Int32.MaxValue)
-          {
-            var k = value.One * m.K;
-
-            result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(value.One * m.K, m.Variables));
-
-            return true;
-          }
-          /* else */
-          goto default;
-
-        case ExpressionOperator.Division:
-          // Just the case (e1 / e2) * e2 == e1
-          if (TryToPolynomialForm(decoder.RightExpressionFor(exp), decoder, out polRight))
-          {
-            MonomialOfInt<Variable> tmp;
-            if (polRight.IsMonomialOfInt(out tmp) && m.IsEquivalentTo(tmp))
+            // Two main cases: this PolynomialOfInt is binded by a relation, or it is just a sequence of MonomialOfInts
+            if (this.Relation.HasValue)
             {
-              return TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out result);
+                switch (this.Relation.Value)
+                {
+                    case ExpressionOperator.GreaterEqualThan:
+                        SwapOperands(ExpressionOperator.LessEqualThan);
+                        break;
+
+                    case ExpressionOperator.GreaterEqualThan_Un:
+                        SwapOperands(ExpressionOperator.LessEqualThan_Un);
+                        break;
+
+                    case ExpressionOperator.GreaterThan:
+                        SwapOperands(ExpressionOperator.LessThan);
+                        break;
+
+                    case ExpressionOperator.GreaterThan_Un:
+                        SwapOperands(ExpressionOperator.LessThan_Un);
+                        break;
+                }
+
+                var moved = this.MoveConstantsAndMonomes();
+                var simplifiedLeft = Simplify(moved.left);
+                var simplifiedRight = Simplify(moved.right);
+
+                Contract.Assume(simplifiedRight.Count == 1, "At this point we expected just a constant on the right side...");
+
+                canonical = new PolynomialOfInt<Variable, Expression>((ExpressionOperator)this.Relation, simplifiedLeft, simplifiedRight);
             }
-          }
-          /* else */
-          goto default;
-
-        case ExpressionOperator.UnaryMinus:
-          // -(e1) * m =  -(e1 * m)
-          if (TryToPolynomialForm(decoder.LeftExpressionFor(exp), decoder, out polLeft))
-          {
-            return TryMinus(polLeft, out result);
-          }
-          /* else */
-          goto default;
-
-        case ExpressionOperator.Variable:
-        case ExpressionOperator.Unknown:
-          // x * (k * xs) = k * [x; xs]
-          var newvars = new List<Variable>(m.Variables);
-          newvars.Add(decoder.UnderlyingVariable(exp));
-
-          result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(m.K, newvars));
-          return true;
-
-        case ExpressionOperator.WritableBytes:
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToFloat64:
-        case ExpressionOperator.ConvertToInt32:
-        case ExpressionOperator.ConvertToUInt16:
-        case ExpressionOperator.ConvertToUInt32:
-        case ExpressionOperator.ConvertToUInt8:
-        case ExpressionOperator.And:
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-        case ExpressionOperator.GreaterEqualThan:
-        case ExpressionOperator.GreaterEqualThan_Un:
-        case ExpressionOperator.GreaterThan:
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.LessEqualThan:
-        case ExpressionOperator.LessEqualThan_Un:
-        case ExpressionOperator.LessThan:
-        case ExpressionOperator.LessThan_Un:
-        case ExpressionOperator.Not:
-        case ExpressionOperator.NotEqual:
-        case ExpressionOperator.Or:
-        case ExpressionOperator.Xor:
-        case ExpressionOperator.ShiftLeft:
-        case ExpressionOperator.ShiftRight:
-        case ExpressionOperator.SizeOf:
-        case ExpressionOperator.Modulus:
-        default:
-          result = default(PolynomialOfInt<Variable, Expression>);
-          return false;
-      }
-    }
-
-    /// <summary>
-    /// Construct the PolynomialOfInt "left == value".
-    /// It handles left in a monolitic fashion
-    /// </summary>
-    static public bool TryToPolynomialForm_Eq(Expression left, int value, 
-      out PolynomialOfInt<Variable, Expression> pol, 
-      IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires((object)value != null);
-
-      pol = new PolynomialOfInt<Variable, Expression>(ExpressionOperator.Equal,
-        new List<MonomialOfInt<Variable>>(1) { new MonomialOfInt<Variable>(decoder.UnderlyingVariable(left)) },
-        new List<MonomialOfInt<Variable>>(1) { new MonomialOfInt<Variable>(value) });
-
-      return true;
-    }
-
-    /// <summary>
-    /// Convert the pure expression <code>left op right</code> into a PolynomialOfInt, that is somehow simpler to handle.
-    /// Essentially, it gets rid of all the parenthesis, it performs the(simple) multiplications, additions, etc.
-    /// </summary>
-    /// <param name="result">if the result is true, it is a PolynomialOfInt in canonical form</param>
-    static public bool TryToPolynomialForm(ExpressionOperator op, Expression/*!*/ left, Expression/*!*/ right, IExpressionDecoder<Variable, Expression>/*!*/ decoder, out PolynomialOfInt<Variable, Expression> result)
-    {
-      Contract.Requires(op.IsBinary());
-
-      if (decoder.OperatorFor(left).IsRelationalOperator()
-        || decoder.OperatorFor(right).IsRelationalOperator())
-      {
-        result = null;
-        return false;
-      }
-      else
-      {
-        PolynomialOfInt<Variable, Expression> leftAsPol, rightAsPol;
-
-        if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(left, decoder, out leftAsPol)
-          && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol))
-        {
-          try
-          {
-            Contract.Assume(!leftAsPol.Relation.HasValue);
-            Contract.Assume(!rightAsPol.Relation.HasValue);
-
-            var tmp = new PolynomialOfInt<Variable, Expression>(op, leftAsPol, rightAsPol);
-            result = tmp.ToCanonicalForm();
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            result = null;
-            return false;
-          }
-
-          return true;
-        }
-        else
-        {
-          result = null;
-
-          return false;
-        }
-      }
-    }
-
-    static public bool TryToPolynomialFormNoDiv(ExpressionOperator op, Expression/*!*/ left, Expression/*!*/ right, IExpressionDecoder<Variable, Expression>/*!*/ decoder, out PolynomialOfInt<Variable, Expression> result)
-    {
-      Contract.Requires(op.IsBinary());
-
-      if (decoder.OperatorFor(left).IsRelationalOperator()
-        || decoder.OperatorFor(right).IsRelationalOperator())
-      {
-        result = null;
-        return false;
-      }
-
-
-      {
-        PolynomialOfInt<Variable, Expression> leftAsPol, rightAsPol;
-
-        if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(left, decoder, out leftAsPol)
-          && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(right, decoder, out rightAsPol))
-        {
-          if (!leftAsPol.IsLinearOctagon || !rightAsPol.IsLinearOctagon)
-          {
-            result = null;
-            return false;
-          }
-
-          try
-          {
-            Contract.Assume(!leftAsPol.Relation.HasValue);
-            Contract.Assume(!rightAsPol.Relation.HasValue);
-
-            var tmp = new PolynomialOfInt<Variable, Expression>(op, leftAsPol, rightAsPol);
-            result = tmp.ToCanonicalForm();
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            result = null;
-            return false;
-          }
-
-          return true;
-        }
-        else
-        {
-          result = null;
-
-          return false;
-        }
-      }
-    }
-
-
-    /// <param name="result">If the result is true, it is a PolynomialOfInt in canonical form</param>
-    static public bool TryToPolynomialForm(ExpressionOperator op, PolynomialOfInt<Variable, Expression>/*!*/ left, PolynomialOfInt<Variable, Expression>/*!*/ right, out PolynomialOfInt<Variable, Expression> result)
-    {
-      if (!op.IsBinary() || left.Relation != null || right.Relation != null)
-      {
-        result = null;
-        return false;
-      }
-      else
-      {
-        try
-        {
-          Contract.Assert(right.Relation == null);
-
-          // here we return a new PolynomialOfInt. An alternative is to return a PolynomialOfInt in canonical form
-          result = new PolynomialOfInt<Variable, Expression>(op, left, right).ToCanonicalForm();
-          return true;
-        }
-        catch (ArithmeticExceptionRational)
-        {
-          // If there is an exception in the ints, then we simply fail
-          result = null;
-          return false;
-        }
-      }
-    }
-
-    /// <param name="result">The result: a PolynomialOfInt in canonical form</param>
-    /// <returns>Always true</returns>
-    static public bool TryToPolynomialForm(ExpressionOperator expressionOperator, List<MonomialOfInt<Variable>> left, List<MonomialOfInt<Variable>> right, out PolynomialOfInt<Variable, Expression> result)
-    {
-      Contract.Requires(expressionOperator.IsBinary());
-
-      result = new PolynomialOfInt<Variable, Expression>(expressionOperator, left, right).ToCanonicalForm();
-
-      return true;
-    }
-
-    static public bool TryToPolynomialForm(bool canonicalByConstruction, ExpressionOperator expressionOperator, List<MonomialOfInt<Variable>> left, List<MonomialOfInt<Variable>> right, out PolynomialOfInt<Variable, Expression> result)
-    {
-      Contract.Requires(expressionOperator.IsBinary());
-
-      if (canonicalByConstruction)
-      {
-        result = new PolynomialOfInt<Variable, Expression>(expressionOperator, left, right);
-
-        return true;
-      }
-      else
-      {
-        return TryToPolynomialForm(expressionOperator, left, right, out result);
-      }
-    }
-
-
-    /// <summary>
-    /// Convert the list of MonomialOfInts <code>MonomialOfInts</code> into a PolynomialOfInt in canonical form
-    /// </summary>
-    /// <param name="pol">The PolynomialOfInt in canonical form</param>
-    /// <returns>Always true</returns>
-    static public bool TryToPolynomialForm(List<MonomialOfInt<Variable>> MonomialOfInts, out PolynomialOfInt<Variable, Expression> pol)
-    {
-      if (MonomialOfInts.Count > 1)
-      {
-        pol = new PolynomialOfInt<Variable, Expression>(MonomialOfInts).ToCanonicalForm();
-      }
-      else
-      {
-        pol = new PolynomialOfInt<Variable, Expression>(MonomialOfInts);
-      }
-
-      return true;
-    }
-
-    static public bool TryToPolynomialForm(bool canonicalByConstruction, List<MonomialOfInt<Variable>> MonomialOfInts, out PolynomialOfInt<Variable, Expression> pol)
-    {
-      if (canonicalByConstruction)
-      {
-        pol = new PolynomialOfInt<Variable, Expression>(MonomialOfInts);
-        return true;
-      }
-      else
-      {
-        return TryToPolynomialForm(MonomialOfInts, out pol);
-      }
-    }
-
-    #endregion
-
-    #region Manipulation of the PolynomialOfInt : Add a monome
-    public PolynomialOfInt<Variable, Expression> AddMonomialOfIntToTheLeft(MonomialOfInt<Variable> m)
-    {
-      PolynomialOfInt<Variable, Expression> thisCloned = new PolynomialOfInt<Variable, Expression>(this);
-      thisCloned.left.Add(m);
-
-      return thisCloned.ToCanonicalForm();
-    }
-
-    public PolynomialOfInt<Variable, Expression> AddMonomialOfIntToTheLeft(List<MonomialOfInt<Variable>> m)
-    {
-      PolynomialOfInt<Variable, Expression> thisCloned = new PolynomialOfInt<Variable, Expression>(this);
-      thisCloned.left.AddRange(m);
-
-      return thisCloned.ToCanonicalForm();
-    }
-
-    #endregion
-
-    #region ToCanonicalForm, ToPureExpression, Renaming
-    /// <summary>
-    /// Put this PolynomialOfInt into a canonical form, meaning that all the MonomialOfInt involving variables are on the left, all the constants on the right, and all the easy arithmetic operations are performed
-    /// </summary>
-    /// <returns>The canonical form of this PolynomialOfInt</returns>
-    private PolynomialOfInt<Variable, Expression>/*!*/ ToCanonicalForm()
-    {
-      PolynomialOfInt<Variable, Expression> canonical;
-
-      //if (cache_CanonicalForms.TryGetValue(this, out canonical))
-      //{
-      //  return canonical;
-      //}
-
-      // Two main cases: this PolynomialOfInt is binded by a relation, or it is just a sequence of MonomialOfInts
-      if (this.Relation.HasValue)
-      {
-        switch (this.Relation.Value)
-        {
-          case ExpressionOperator.GreaterEqualThan:
-            SwapOperands(ExpressionOperator.LessEqualThan);
-            break;
-
-          case ExpressionOperator.GreaterEqualThan_Un:
-            SwapOperands(ExpressionOperator.LessEqualThan_Un);
-            break;
-
-          case ExpressionOperator.GreaterThan:
-            SwapOperands(ExpressionOperator.LessThan);
-            break;
-
-          case ExpressionOperator.GreaterThan_Un:
-            SwapOperands(ExpressionOperator.LessThan_Un);
-            break;
-        }
-
-        var moved = this.MoveConstantsAndMonomes();
-        var simplifiedLeft = Simplify(moved.left);
-        var simplifiedRight = Simplify(moved.right);
-
-        Contract.Assume(simplifiedRight.Count == 1, "At this point we expected just a constant on the right side...");
-
-        canonical = new PolynomialOfInt<Variable, Expression>((ExpressionOperator)this.Relation, simplifiedLeft, simplifiedRight);
-      }
-      else
-      {
-        List<MonomialOfInt<Variable>> simplified = Simplify(this.left);
-        canonical = new PolynomialOfInt<Variable, Expression>(simplified);
-      }
-
-      //cache_CanonicalForms.Add(this, canonical);
-
-      return canonical;
-    }
-
-    /// <summary>
-    /// Swap in place
-    /// Works with side effects!!!
-    /// </summary>
-    private void SwapOperands(ExpressionOperator newOperator)
-    {
-      Contract.Ensures(this.relation.HasValue);
-      Contract.Ensures(this.left == Contract.OldValue(this.right));
-      Contract.Ensures(this.right == Contract.OldValue(this.left));
-
-      this.relation = newOperator;
-
-      var tmp = this.left;
-      this.left = this.right;
-      this.right = tmp;
-    }
-
-    /// <summary>
-    /// Convert this PolynomialOfInt into a pure expression
-    /// </summary>
-    public Expression/*!*/ ToPureExpression(IExpressionEncoder<Variable, Expression>/*!*/ encoder)
-    {
-      Contract.Requires(encoder != null);
-
-      return ToPureExpressionForm(this, encoder);
-    }
-
-    /// <summary>
-    /// Convert a PolynomialOfInt into a pure expression
-    /// </summary>
-    /// <param name="encoder">The encoder for constructing an expression</param>
-    static public Expression/*!*/ ToPureExpressionForm(PolynomialOfInt<Variable, Expression>/*!*/ p, IExpressionEncoder<Variable, Expression>/*!*/ encoder)
-    {
-      Contract.Requires(p != null);
-      Contract.Requires(encoder != null);
-
-      Expression eLeft = ConvertToPureExpression(p.left, encoder);
-      if (p.Relation.HasValue)
-      {
-        Expression eRight = ConvertToPureExpression(p.right, encoder);
-        return encoder.CompoundExpressionFor(ExpressionType.Bool, p.Relation.Value, eLeft, eRight);
-      }
-      else
-      {
-        return eLeft;
-      }
-    }
-
-    /// <summary>
-    /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
-    /// </summary>
-    public PolynomialOfInt<Variable, Expression>/*!*/ Rename(Variable/*!*/ x, Variable/*!*/ xNew)
-    {
-      return Rename(true, x, xNew);
-    }
-
-    /// <summary>
-    /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
-    /// </summary>
-    public PolynomialOfInt<Variable, Expression>/*!*/ Rename(bool canonical, Variable/*!*/ x, Variable/*!*/ xNew)
-    {
-      // Improve: Use sharing when the renamed PolynomialOfInt is the same
-
-      var leftResult = new List<MonomialOfInt<Variable>>();
-      var rightResult = new List<MonomialOfInt<Variable>>();
-
-      foreach (var m in this.Left)
-      {
-        leftResult.Add(m.Rename(x, xNew));
-      }
-      if (this.Relation.HasValue)
-      {
-        foreach (var m in this.Right)
-        {
-          rightResult.Add(m.Rename(x, xNew));
-        }
-      }
-
-      PolynomialOfInt<Variable, Expression> result = this.Relation.HasValue
-        ? new PolynomialOfInt<Variable, Expression>(this.Relation.Value, leftResult, rightResult)
-        : new PolynomialOfInt<Variable, Expression>(leftResult);
-
-      return canonical ? result.ToCanonicalForm() : result;
-    }
-
-    /// <summary>
-    /// Rename the current PolynomialOfInt according to the translation map.
-    /// </summary>
-    /// <param name="trMap"></param>
-    /// <returns></returns>
-    public PolynomialOfInt<Variable, Expression>/*!*/ Rename(IDictionary<Variable, PolynomialOfInt<Variable, Expression>> trMap)
-    {
-      ///// It is very limited up to now !!!!!!!!!!!!! //////
-      //TODO5: do it more generic (if we really need it...)
-
-      Contract.Requires(this.IsLinear);
-
-      var resultLeft = new List<MonomialOfInt<Variable>>();
-
-      foreach (var m in this.Left)
-      {
-        // we know is linear...
-        if (!m.IsConstant && trMap.ContainsKey(m.Variables[0]))
-        {
-          foreach (var m1 in trMap[m.Variables[0]].Left)
-          {
-            var newMonomialOfInt = new MonomialOfInt<Variable>(m1.K * m.K, m1.Variables);
-            resultLeft.Add(newMonomialOfInt);
-          }
-        }
-        else
-        {
-          resultLeft.Add(m);
-        }
-      }
-
-      if (this.relation != null)
-      {
-        throw new AbstractInterpretationException("Not done yet!!!!!");
-      }
-
-      return new PolynomialOfInt<Variable, Expression>(resultLeft).ToCanonicalForm();
-    }
-
-    #endregion
-
-    #region Equivalence of PolynomialOfInts
-
-    public bool IsEquivalentTo(PolynomialOfInt<Variable, Expression>/*!*/ other)
-    {
-      var left = this.ToCanonicalForm();
-      var right = other.ToCanonicalForm();
-
-      if (!SimpleEquivalence(left, right))
-      {
-        return false;
-      }
-      else
-      { // At this point we know they have the same cardinality
-
-        if (!UniformCoefficents(left, right))
-        {
-          return false;
-        }
-
-        foreach (var m in left.Left)
-        {
-          if (!ContainsMonomialOfIntEquivalentTo(right.left, m))
-            return false;
-        }
-
-        if (left.Relation.HasValue)
-        {
-          Contract.Assert(right.Relation.HasValue);
-
-          foreach (var m in left.Right)
-          {
-            if (!ContainsMonomialOfIntEquivalentTo(right.right, m))
-              return false;
-          }
-        }
-
-        // right contains all the MonomialOfInts in left, and right has the same cardinality of left, so they are equivalent
-        return true;
-      }
-    }
-
-    private static bool SimpleEquivalence(PolynomialOfInt<Variable, Expression> left, PolynomialOfInt<Variable, Expression> right)
-    {
-      if (left.Degree != right.Degree)
-        return false;
-      if (left.Left.Count != right.Left.Count)
-        return false;
-      if (left.Relation != right.Relation)
-        return false;
-      if ((!left.Relation.HasValue && !right.Relation.HasValue) && (left.Right.Count != right.Right.Count))
-        return false;
-
-      return true;
-    }
-
-    private static bool UniformCoefficents(PolynomialOfInt<Variable, Expression> left, PolynomialOfInt<Variable, Expression> right)
-    {
-      var listLeft = left.left;
-      var listRight = right.left;
-
-      if (listLeft.Count == 0)
-      {
-        if (listRight.Count == 0)
-        {
-          return true;
-        }
-        else
-        {
-          listLeft = left.right;
-          listRight = right.right;
-        }
-      }
-
-      var mLeft = listLeft[0];
-      MonomialOfInt<Variable> mRight = null;
-
-      foreach (var m in listRight)
-      {
-        if (mLeft.Variables.Count != m.Variables.Count)
-          continue;
-
-        foreach (var v in mLeft.Variables)
-        {
-          if (!m.Variables.Contains(v))
-            goto nextMonomialOfInt;
-        }
-
-        mRight = m;   // We found a MonomialOfInt with the same variables
-        break;
-
-      nextMonomialOfInt:
-        ;
-      }
-
-      if (mRight != null)
-      {
-        int kLeft = mLeft.K;
-        int kRight = mRight.K;
-
-        if (kLeft != kRight)
-        {
-          if (kRight == 0)
-            return true;
-
-          int k = kLeft / kRight;
-
-          foreach (var m in right.Left)
-          {
-            m.K = m.K * k;
-          }
-
-          if (right.Relation.HasValue)
-          {
-            foreach (var m in right.Right)
-            {
-              m.K = m.K * k;
-            }
-          }
-        }
-
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
-
-    private static bool ContainsMonomialOfIntEquivalentTo(List<MonomialOfInt<Variable>> l, MonomialOfInt<Variable> toFind)
-    {
-      foreach (MonomialOfInt<Variable> m in l)
-      {
-        if (m.K != toFind.K)
-          continue;
-
-        if (m.Variables.Count != toFind.Variables.Count)
-          continue;
-
-        foreach (var v in m.Variables)
-        {
-          if (!toFind.Variables.Contains(v))
-            goto nextMonomialOfInt;
-        }
-
-        // At this point, they have the same coefficent, and the same variables, so they are the same
-        return true;
-
-      nextMonomialOfInt:
-        ;
-      }
-
-      return false;
-    }
-
-    #endregion
-
-    #region Private methods
-    /// <summary>
-    /// Move the constants to the right of the relation operator, and the MonomialOfInt to the left.
-    /// It makes sense just if this.Relation is LessEqualThan, LessThan, Equal or NotEqual
-    /// </summary>
-    private PolynomialOfInt<Variable, Expression> MoveConstantsAndMonomes()
-    {
-      Contract.Requires(this.Relation.HasValue);   // It can be applied just to PolynomialOfInts with a relation operator
-      Contract.Requires(this.right != null);
-
-      var newLeft = new List<MonomialOfInt<Variable>>();
-      var newRight = new List<MonomialOfInt<Variable>>();
-
-      // Move all the constants to the right, and leave the non-constants on the left
-      foreach (var m in this.Left)
-      {
-        if (!m.IsConstant)    // k * xs, k != 0
-        {
-          newLeft.Add(m);
-        }
-        else                                // k * 1
-        {
-          MonomialOfInt<Variable> mToTheRight = new MonomialOfInt<Variable>(-m.K, m.Variables);
-          newRight.Add(mToTheRight);
-        }
-      }
-
-      // Move all the non-constant MonomialOfInts to the left, and leave the constants on the right
-      foreach (MonomialOfInt<Variable> m in this.right)
-      {
-        if (!m.IsConstant)              // k * xs, k != 0
-        {
-          var mToTheLeft = new MonomialOfInt<Variable>(-m.K, m.Variables);
-          newLeft.Add(mToTheLeft);
-        }
-        else
-        {
-          newRight.Add(m);
-        }
-      }
-
-      // If there is nothing on the left or on the right, we add a zero
-      if (newLeft.Count == 0)
-      {
-        newLeft.Add(new MonomialOfInt<Variable>(0));
-      }
-      if (newRight.Count == 0)
-      {
-        newRight.Add(new MonomialOfInt<Variable>(0));
-      }
-
-      return new PolynomialOfInt<Variable, Expression>((ExpressionOperator)this.Relation, newLeft, newRight);
-    }
-
-    /// <summary>
-    /// Simplify the polinomial by performing basic arithmetic operations
-    /// </summary>
-    static private List<MonomialOfInt<Variable>> Simplify(List<MonomialOfInt<Variable>> monomes)
-    {
-      // Shortcuts for common and simple cases
-      if (monomes.Count <= 1)
-        return monomes;
-
-      // keep a cache between the variables of the MonomialOfInts and the actual value. We use this data structure for performances
-      var cache = new Dictionary<SetEqual<Variable>, MonomialOfInt<Variable>>();
-      var cacheMap = new Dictionary<SetEqual<Variable>, Expression>();
-
-      foreach (MonomialOfInt<Variable> m in monomes)
-      {
-        var vars = new SetEqual<Variable>(m.Variables);
-
-        // We assume that m.Variables is ordered
-        if (cache.ContainsKey(vars))
-        {
-          // if the string is in the dictionary, we update the value of the coefficent
-          MonomialOfInt<Variable> oldMonomialOfInt = cache[vars];
-          int newK = oldMonomialOfInt.K + m.K;     // Add the coefficients
-
-          MonomialOfInt<Variable> newMonomialOfInt = new MonomialOfInt<Variable>(newK, oldMonomialOfInt.Variables);
-          cache[vars] = newMonomialOfInt;  // Update the MonomialOfInt
-        }
-        else
-        {   // it is a new MonomialOfInt, so we add it to the cache
-          cache.Add(vars, m);
-        }
-      }
-
-      var result = new List<MonomialOfInt<Variable>>(cache.Count);
-
-      var positive = new List<MonomialOfInt<Variable>>(cache.Count);
-      var negative = new List<MonomialOfInt<Variable>>(cache.Count);
-
-      var constant = (MonomialOfInt<Variable>) null;
-
-      foreach (var s in cache.Keys)
-      {
-        var m = cache[s];
-
-        if (m.K != 0)
-        {
-          if (m.IsConstant)
-          {
-            constant = m;
-          }
-          else if (m.K > 0)
-          {
-            positive.Add(m);
-          }
-          else
-          {
-            negative.Add(m);
-          }
-        }
-      }
-
-      result.InsertRange(0, negative);
-      result.InsertRange(0, positive);
-
-      if (constant != null)
-      {
-        result.Insert(result.Count, constant);
-      }
-
-      // If everything turned out to be zero, we want to keep just one
-      if (result.Count == 0)
-      {
-        result.Add(new MonomialOfInt<Variable>(0));
-      }
-
-      return result;
-    }
-
-    public class ListEqual<Element>
-    {
-      List<Element> list;
-      public ListEqual(List<Element> a)
-      {
-        this.list = a;
-      }
-
-      public override int GetHashCode()
-      {
-        if (list.Count == 0)
-          return 0;
-        else
-          return list[0].GetHashCode();
-      }
-
-      public override bool Equals(object obj)
-      {
-        if (!(obj is ListEqual<Element>))
-        {
-          return false;
-        }
-
-        List<Element> other = ((ListEqual<Element>)obj).list;
-
-        if (list.Count != other.Count)
-        {
-          return false;
-        }
-
-        foreach (Element el in list)
-        {
-          if (!other.Contains(el))
-          {
-            return false;
-          }
-        }
-        return true;
-      }
-    }
-
-    public class SetEqual<Element>
-    {
-      Set<Element> elements;
-
-      public SetEqual(Set<Element> a)
-      {
-        this.elements = a;
-      }
-
-      public SetEqual(List<Element> l)
-      {
-        this.elements = new Set<Element>(l);
-      }
-
-      public override int GetHashCode()
-      {
-        return this.elements.GetHashCode();
-      }
-
-      public override bool Equals(object obj)
-      {
-        SetEqual<Element> asSet = obj as SetEqual<Element>;
-
-        if (asSet == null)
-          return false;
-
-        if (this.elements.Count != asSet.elements.Count)
-          return false;
-
-        return this.elements.IsSubset(asSet.elements);
-
-      }
-    }
-    #endregion
-
-    #region Overridden
-    //^ [Confined]
-    public override string/*!*/ ToString()
-    {
-      if (this.relation == null)
-      {
-        return listToString(this.left);
-      }
-      else
-      {
-        string leftStr = listToString(this.left);
-        string rightStr = listToString(this.right);
-        string retVal = leftStr + " " + this.relation + " " + rightStr;
-
-        return retVal;
-      }
-    }
-
-    static private string listToString(List<MonomialOfInt<Variable>> l)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      StringBuilder s = new StringBuilder();
-      if (l.Count == 0)
-        return "()";
-      else
-      {
-        s.Append("(");
-        foreach (MonomialOfInt<Variable> m in l)
-        {
-          s.Append(m.ToString() + ", ");
-        }
-        s.Append(")");
-
-        string stmp = s.ToString();
-        if (stmp.Length > 4)
-        {
-          stmp = stmp.Remove(stmp.Length - 4, 3);
-        }
-        return stmp;
-      }
-    }
-    #endregion
-
-    #region (almost) Private helper methods
-
-    /// <summary>
-    /// Meaning: let <code>polLeft = (m1 + ... + mt)</code> and <code>polRight = (n1 + ... + nk)</code>, 
-    /// it returns the polynome <code>(m1 + ... + mt + n1 + ... + nk)</code>
-    /// </summary>
-    private static PolynomialOfInt<Variable, Expression> Concatenate(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight)
-    {
-      var concat = new List<MonomialOfInt<Variable>>(polLeft.Left.Count + polRight.Left.Count);
-      concat.AddRange(polLeft.Left);          // Add all the monomes on the left
-      concat.AddRange(polRight.Left);         // Add all the monomes on the right
-
-      return new PolynomialOfInt<Variable, Expression>(concat);
-    }
-
-    private static bool TryToPolynomialFormHelperForSubtraction(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight, out PolynomialOfInt<Variable, Expression> result)
-    {
-      PolynomialOfInt<Variable, Expression> minusPolRight;
-      if (TryMinus(polRight, out minusPolRight))
-      {
-        result = Concatenate(polLeft, minusPolRight);
-        return true;
-      }
-      else
-      {
-        result = null;
-        return false;
-      }
-    }
-
-    private static bool TryToPolynomialFormHelperForMultiplication(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight, out PolynomialOfInt<Variable, Expression> result)
-    {
-      var left = polLeft.left;
-      var right = polRight.left;
-      var multiplicationResult = new List<MonomialOfInt<Variable>>(left.Count * right.Count);
-
-      foreach (var l in left)         // l = (k, xs)
-        foreach (var r in right)   // r  = (c, ys)
-        {
-          int resultCoeff;
-          // result = (k*c, xs... ys)
-          try
-          {
-            resultCoeff = l.K * r.K;
-          }
-          catch (ArithmeticExceptionRational)
-          { // If we get an overflow in the multiplication, we get throw away the multiplication
-            result = null;
-            return false;
-          }
-
-          var concat = new List<Variable>(l.Variables.Count + r.Variables.Count);
-          concat.AddRange(l.Variables);
-          concat.AddRange(r.Variables);
-
-          var resultMonomialOfInt = new MonomialOfInt<Variable>(resultCoeff, concat);
-
-          multiplicationResult.Add(resultMonomialOfInt);
-        }
-
-      result = new PolynomialOfInt<Variable, Expression>(multiplicationResult);
-      return true;
-    }
-
-    // We consider just the easy cases, when polLeft or polRight are constants
-    private static bool TryToPolynomialFormHelperForDivision(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight, out PolynomialOfInt<Variable, Expression> result)
-    {
-      int leftVal, rightVal;
-
-      if(polLeft.IsConstant(out leftVal) && polRight.IsConstant(out rightVal))
-      {
-        result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(leftVal / rightVal));
-        return true;
-      }
-
-      result = null;
-      return false;
-    }
-
-    private static bool TryMinus(PolynomialOfInt<Variable, Expression> p, out PolynomialOfInt<Variable, Expression> result)
-    {
-      var minusP = new List<MonomialOfInt<Variable>>(p.Left.Count);
-      foreach (var m in p.Left)
-      {
-        int v = -m.K;
-        if (v != Int32.MaxValue && v != Int32.MinValue)
-        {
-          var minusM = new MonomialOfInt<Variable>(v, m.Variables);
-          minusP.Add(minusM);
-        }
-        else  // PolynomialOfInt with an infinity component does not make sense, so we fail
-        {
-          result = null;
-          return false;
-        }
-      }
-
-      result = new PolynomialOfInt<Variable, Expression>(minusP);
-      return true;
-    }
-
-    private static Expression/*!*/ ConvertToPureExpression(List<MonomialOfInt<Variable>> p, IExpressionEncoder<Variable, Expression>/*!*/ encoder)
-    {
-      Contract.Requires(encoder != null);
-
-      var result = default(Expression);
-      if (p.Count == 0)
-      {
-        return encoder.ConstantFor(0); //return new Constant<int>(0);
-      }
-      else
-      {
-        foreach (MonomialOfInt<Variable> m in p)
-        {
-          bool neg;
-          Expression newMonomialOfInt = ConvertToPureExpression(m, encoder, out neg);
-
-          if (result == null)
-          {
-            if (neg)
-              result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.UnaryMinus, newMonomialOfInt);
             else
-              result = newMonomialOfInt;
-          }
-          else if (neg)
-            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, result, newMonomialOfInt);  // result = result - m
-          else
-            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, result, newMonomialOfInt);  // result = result + m
-
-        }
-        return result;
-      }
-    }
-
-    private static Expression ConvertToPureExpression(MonomialOfInt<Variable> m, IExpressionEncoder<Variable, Expression>/*!*/ encoder, out bool neg)
-    {
-      Contract.Requires(encoder != null);
-
-      if (m.IsConstant)
-      {
-        neg = m.K < 0;
-        return encoder.ConstantFor(Math.Abs(m.K));
-      }
-      else
-      {
-        var result = default(Expression);
-        bool first = true;
-
-        neg = false;
-
-        if (m.K == -1)
-        {
-          neg = true;
-        }
-        else if (m.K != 1)
-        {
-          result = encoder.ConstantFor(m.K);
-          first = false;
-        }
-
-        foreach (var v in m.Variables)
-        {
-          var vExp = encoder.VariableFor(v);
-          if (first)
-          {
-            result = vExp;
-            first = false;
-          }
-          else
-          {
-            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, result, vExp); // result = result * v      
-          }
-        }
-
-        return result;
-      }
-
-    }
-
-    private static List<MonomialOfInt<Variable>> ExtractWritableBytesExpression(Expression e, IExpressionDecoder<Variable, Expression>/*!*/ decoder, out bool success)
-    {
-      List<MonomialOfInt<Variable>> polLeft, polRight;
-      List<MonomialOfInt<Variable>> result;
-      bool b1, b2;
-      Expression lng;
-
-      switch (decoder.OperatorFor(e))
-      {
-        case ExpressionOperator.Addition:
-          polLeft = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out b1);
-          polRight = ExtractWritableBytesExpression(decoder.RightExpressionFor(e), decoder, out b2);
-          success = b1 || b2;
-
-          if (polRight != null && polLeft != null)
-          {
-            foreach (MonomialOfInt<Variable> mon in polRight)
             {
-              mon.K = -mon.K;
+                List<MonomialOfInt<Variable>> simplified = Simplify(left);
+                canonical = new PolynomialOfInt<Variable, Expression>(simplified);
             }
 
-            result = new List<MonomialOfInt<Variable>>(polLeft);
-            result.AddRange(polRight);
-          }
-          else
-          {
-            result = default(List<MonomialOfInt<Variable>>);
-            success = false;
-          }
-          break;
+            //cache_CanonicalForms.Add(this, canonical);
 
-        //We don't expect other than k*x
-        case ExpressionOperator.Multiplication:
-          PolynomialOfInt<Variable, Expression> temp;
-          success = TryToPolynomialForm(e, decoder, out temp);
-          result = temp.left;
-          break;
+            return canonical;
+        }
 
-        case ExpressionOperator.ConvertToInt32:
-        case ExpressionOperator.ConvertToUInt16:
-        case ExpressionOperator.ConvertToUInt32:
-        case ExpressionOperator.ConvertToUInt8:
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToFloat64:
-          result = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out success);
-          break;
+        /// <summary>
+        /// Swap in place
+        /// Works with side effects!!!
+        /// </summary>
+        private void SwapOperands(ExpressionOperator newOperator)
+        {
+            Contract.Ensures(relation.HasValue);
+            Contract.Ensures(left == Contract.OldValue(right));
+            Contract.Ensures(right == Contract.OldValue(left));
 
-        case ExpressionOperator.Variable:
-#if !SUBPOLY_ONLY
-          if (decoder.TryGetAssociatedExpression(e, AssociatedInfo.WritableBytes, out lng))
-          {
-            MonomialOfInt<Variable> lngMonome = new MonomialOfInt<Variable>(decoder.UnderlyingVariable(lng));
-            success = true;
-            result = new List<MonomialOfInt<Variable>>();
-            result.Add(lngMonome);
-          }
-          else
-#endif
-          {
-            success = false;
-            result = new List<MonomialOfInt<Variable>>();
-            result.Add(new MonomialOfInt<Variable>(decoder.UnderlyingVariable(e)));
-          }
-          break;
+            relation = newOperator;
 
-        default:
+            var tmp = left;
+            left = right;
+            right = tmp;
+        }
 
-          PolynomialOfInt<Variable, Expression> poly;
-          success = TryToPolynomialForm(e, decoder, out poly);
+        /// <summary>
+        /// Convert this PolynomialOfInt into a pure expression
+        /// </summary>
+        public Expression/*!*/ ToPureExpression(IExpressionEncoder<Variable, Expression>/*!*/ encoder)
+        {
+            Contract.Requires(encoder != null);
 
-          if (success && poly.Relation == null)
-            result = poly.left;
-          else
+            return ToPureExpressionForm(this, encoder);
+        }
+
+        /// <summary>
+        /// Convert a PolynomialOfInt into a pure expression
+        /// </summary>
+        /// <param name="encoder">The encoder for constructing an expression</param>
+        static public Expression/*!*/ ToPureExpressionForm(PolynomialOfInt<Variable, Expression>/*!*/ p, IExpressionEncoder<Variable, Expression>/*!*/ encoder)
+        {
+            Contract.Requires(p != null);
+            Contract.Requires(encoder != null);
+
+            Expression eLeft = ConvertToPureExpression(p.left, encoder);
+            if (p.Relation.HasValue)
+            {
+                Expression eRight = ConvertToPureExpression(p.right, encoder);
+                return encoder.CompoundExpressionFor(ExpressionType.Bool, p.Relation.Value, eLeft, eRight);
+            }
+            else
+            {
+                return eLeft;
+            }
+        }
+
+        /// <summary>
+        /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
+        /// </summary>
+        public PolynomialOfInt<Variable, Expression>/*!*/ Rename(Variable/*!*/ x, Variable/*!*/ xNew)
+        {
+            return Rename(true, x, xNew);
+        }
+
+        /// <summary>
+        /// Renames all the occurrences of the variable <code>x</code> to <code>xNew</code>
+        /// </summary>
+        public PolynomialOfInt<Variable, Expression>/*!*/ Rename(bool canonical, Variable/*!*/ x, Variable/*!*/ xNew)
+        {
+            // Improve: Use sharing when the renamed PolynomialOfInt is the same
+
+            var leftResult = new List<MonomialOfInt<Variable>>();
+            var rightResult = new List<MonomialOfInt<Variable>>();
+
+            foreach (var m in this.Left)
+            {
+                leftResult.Add(m.Rename(x, xNew));
+            }
+            if (this.Relation.HasValue)
+            {
+                foreach (var m in this.Right)
+                {
+                    rightResult.Add(m.Rename(x, xNew));
+                }
+            }
+
+            PolynomialOfInt<Variable, Expression> result = this.Relation.HasValue
+              ? new PolynomialOfInt<Variable, Expression>(this.Relation.Value, leftResult, rightResult)
+              : new PolynomialOfInt<Variable, Expression>(leftResult);
+
+            return canonical ? result.ToCanonicalForm() : result;
+        }
+
+        /// <summary>
+        /// Rename the current PolynomialOfInt according to the translation map.
+        /// </summary>
+        /// <param name="trMap"></param>
+        /// <returns></returns>
+        public PolynomialOfInt<Variable, Expression>/*!*/ Rename(IDictionary<Variable, PolynomialOfInt<Variable, Expression>> trMap)
+        {
+            ///// It is very limited up to now !!!!!!!!!!!!! //////
+            //TODO5: do it more generic (if we really need it...)
+
+            Contract.Requires(this.IsLinear);
+
+            var resultLeft = new List<MonomialOfInt<Variable>>();
+
+            foreach (var m in this.Left)
+            {
+                // we know is linear...
+                if (!m.IsConstant && trMap.ContainsKey(m.Variables[0]))
+                {
+                    foreach (var m1 in trMap[m.Variables[0]].Left)
+                    {
+                        var newMonomialOfInt = new MonomialOfInt<Variable>(m1.K * m.K, m1.Variables);
+                        resultLeft.Add(newMonomialOfInt);
+                    }
+                }
+                else
+                {
+                    resultLeft.Add(m);
+                }
+            }
+
+            if (relation != null)
+            {
+                throw new AbstractInterpretationException("Not done yet!!!!!");
+            }
+
+            return new PolynomialOfInt<Variable, Expression>(resultLeft).ToCanonicalForm();
+        }
+
+        #endregion
+
+        #region Equivalence of PolynomialOfInts
+
+        public bool IsEquivalentTo(PolynomialOfInt<Variable, Expression>/*!*/ other)
+        {
+            var left = this.ToCanonicalForm();
+            var right = other.ToCanonicalForm();
+
+            if (!SimpleEquivalence(left, right))
+            {
+                return false;
+            }
+            else
+            { // At this point we know they have the same cardinality
+                if (!UniformCoefficents(left, right))
+                {
+                    return false;
+                }
+
+                foreach (var m in left.Left)
+                {
+                    if (!ContainsMonomialOfIntEquivalentTo(right.left, m))
+                        return false;
+                }
+
+                if (left.Relation.HasValue)
+                {
+                    Contract.Assert(right.Relation.HasValue);
+
+                    foreach (var m in left.Right)
+                    {
+                        if (!ContainsMonomialOfIntEquivalentTo(right.right, m))
+                            return false;
+                    }
+                }
+
+                // right contains all the MonomialOfInts in left, and right has the same cardinality of left, so they are equivalent
+                return true;
+            }
+        }
+
+        private static bool SimpleEquivalence(PolynomialOfInt<Variable, Expression> left, PolynomialOfInt<Variable, Expression> right)
+        {
+            if (left.Degree != right.Degree)
+                return false;
+            if (left.Left.Count != right.Left.Count)
+                return false;
+            if (left.Relation != right.Relation)
+                return false;
+            if ((!left.Relation.HasValue && !right.Relation.HasValue) && (left.Right.Count != right.Right.Count))
+                return false;
+
+            return true;
+        }
+
+        private static bool UniformCoefficents(PolynomialOfInt<Variable, Expression> left, PolynomialOfInt<Variable, Expression> right)
+        {
+            var listLeft = left.left;
+            var listRight = right.left;
+
+            if (listLeft.Count == 0)
+            {
+                if (listRight.Count == 0)
+                {
+                    return true;
+                }
+                else
+                {
+                    listLeft = left.right;
+                    listRight = right.right;
+                }
+            }
+
+            var mLeft = listLeft[0];
+            MonomialOfInt<Variable> mRight = null;
+
+            foreach (var m in listRight)
+            {
+                if (mLeft.Variables.Count != m.Variables.Count)
+                    continue;
+
+                foreach (var v in mLeft.Variables)
+                {
+                    if (!m.Variables.Contains(v))
+                        goto nextMonomialOfInt;
+                }
+
+                mRight = m;   // We found a MonomialOfInt with the same variables
+                break;
+
+            nextMonomialOfInt:
+                ;
+            }
+
+            if (mRight != null)
+            {
+                int kLeft = mLeft.K;
+                int kRight = mRight.K;
+
+                if (kLeft != kRight)
+                {
+                    if (kRight == 0)
+                        return true;
+
+                    int k = kLeft / kRight;
+
+                    foreach (var m in right.Left)
+                    {
+                        m.K = m.K * k;
+                    }
+
+                    if (right.Relation.HasValue)
+                    {
+                        foreach (var m in right.Right)
+                        {
+                            m.K = m.K * k;
+                        }
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private static bool ContainsMonomialOfIntEquivalentTo(List<MonomialOfInt<Variable>> l, MonomialOfInt<Variable> toFind)
+        {
+            foreach (MonomialOfInt<Variable> m in l)
+            {
+                if (m.K != toFind.K)
+                    continue;
+
+                if (m.Variables.Count != toFind.Variables.Count)
+                    continue;
+
+                foreach (var v in m.Variables)
+                {
+                    if (!toFind.Variables.Contains(v))
+                        goto nextMonomialOfInt;
+                }
+
+                // At this point, they have the same coefficent, and the same variables, so they are the same
+                return true;
+
+            nextMonomialOfInt:
+                ;
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region Private methods
+        /// <summary>
+        /// Move the constants to the right of the relation operator, and the MonomialOfInt to the left.
+        /// It makes sense just if this.Relation is LessEqualThan, LessThan, Equal or NotEqual
+        /// </summary>
+        private PolynomialOfInt<Variable, Expression> MoveConstantsAndMonomes()
+        {
+            Contract.Requires(this.Relation.HasValue);   // It can be applied just to PolynomialOfInts with a relation operator
+            Contract.Requires(right != null);
+
+            var newLeft = new List<MonomialOfInt<Variable>>();
+            var newRight = new List<MonomialOfInt<Variable>>();
+
+            // Move all the constants to the right, and leave the non-constants on the left
+            foreach (var m in this.Left)
+            {
+                if (!m.IsConstant)    // k * xs, k != 0
+                {
+                    newLeft.Add(m);
+                }
+                else                                // k * 1
+                {
+                    MonomialOfInt<Variable> mToTheRight = new MonomialOfInt<Variable>(-m.K, m.Variables);
+                    newRight.Add(mToTheRight);
+                }
+            }
+
+            // Move all the non-constant MonomialOfInts to the left, and leave the constants on the right
+            foreach (MonomialOfInt<Variable> m in right)
+            {
+                if (!m.IsConstant)              // k * xs, k != 0
+                {
+                    var mToTheLeft = new MonomialOfInt<Variable>(-m.K, m.Variables);
+                    newLeft.Add(mToTheLeft);
+                }
+                else
+                {
+                    newRight.Add(m);
+                }
+            }
+
+            // If there is nothing on the left or on the right, we add a zero
+            if (newLeft.Count == 0)
+            {
+                newLeft.Add(new MonomialOfInt<Variable>(0));
+            }
+            if (newRight.Count == 0)
+            {
+                newRight.Add(new MonomialOfInt<Variable>(0));
+            }
+
+            return new PolynomialOfInt<Variable, Expression>((ExpressionOperator)this.Relation, newLeft, newRight);
+        }
+
+        /// <summary>
+        /// Simplify the polinomial by performing basic arithmetic operations
+        /// </summary>
+        static private List<MonomialOfInt<Variable>> Simplify(List<MonomialOfInt<Variable>> monomes)
+        {
+            // Shortcuts for common and simple cases
+            if (monomes.Count <= 1)
+                return monomes;
+
+            // keep a cache between the variables of the MonomialOfInts and the actual value. We use this data structure for performances
+            var cache = new Dictionary<SetEqual<Variable>, MonomialOfInt<Variable>>();
+            var cacheMap = new Dictionary<SetEqual<Variable>, Expression>();
+
+            foreach (MonomialOfInt<Variable> m in monomes)
+            {
+                var vars = new SetEqual<Variable>(m.Variables);
+
+                // We assume that m.Variables is ordered
+                if (cache.ContainsKey(vars))
+                {
+                    // if the string is in the dictionary, we update the value of the coefficent
+                    MonomialOfInt<Variable> oldMonomialOfInt = cache[vars];
+                    int newK = oldMonomialOfInt.K + m.K;     // Add the coefficients
+
+                    MonomialOfInt<Variable> newMonomialOfInt = new MonomialOfInt<Variable>(newK, oldMonomialOfInt.Variables);
+                    cache[vars] = newMonomialOfInt;  // Update the MonomialOfInt
+                }
+                else
+                {   // it is a new MonomialOfInt, so we add it to the cache
+                    cache.Add(vars, m);
+                }
+            }
+
+            var result = new List<MonomialOfInt<Variable>>(cache.Count);
+
+            var positive = new List<MonomialOfInt<Variable>>(cache.Count);
+            var negative = new List<MonomialOfInt<Variable>>(cache.Count);
+
+            var constant = (MonomialOfInt<Variable>)null;
+
+            foreach (var s in cache.Keys)
+            {
+                var m = cache[s];
+
+                if (m.K != 0)
+                {
+                    if (m.IsConstant)
+                    {
+                        constant = m;
+                    }
+                    else if (m.K > 0)
+                    {
+                        positive.Add(m);
+                    }
+                    else
+                    {
+                        negative.Add(m);
+                    }
+                }
+            }
+
+            result.InsertRange(0, negative);
+            result.InsertRange(0, positive);
+
+            if (constant != null)
+            {
+                result.Insert(result.Count, constant);
+            }
+
+            // If everything turned out to be zero, we want to keep just one
+            if (result.Count == 0)
+            {
+                result.Add(new MonomialOfInt<Variable>(0));
+            }
+
+            return result;
+        }
+
+        public class ListEqual<Element>
+        {
+            private List<Element> list;
+            public ListEqual(List<Element> a)
+            {
+                list = a;
+            }
+
+            public override int GetHashCode()
+            {
+                if (list.Count == 0)
+                    return 0;
+                else
+                    return list[0].GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is ListEqual<Element>))
+                {
+                    return false;
+                }
+
+                List<Element> other = ((ListEqual<Element>)obj).list;
+
+                if (list.Count != other.Count)
+                {
+                    return false;
+                }
+
+                foreach (Element el in list)
+                {
+                    if (!other.Contains(el))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        public class SetEqual<Element>
+        {
+            private Set<Element> elements;
+
+            public SetEqual(Set<Element> a)
+            {
+                elements = a;
+            }
+
+            public SetEqual(List<Element> l)
+            {
+                elements = new Set<Element>(l);
+            }
+
+            public override int GetHashCode()
+            {
+                return elements.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                SetEqual<Element> asSet = obj as SetEqual<Element>;
+
+                if (asSet == null)
+                    return false;
+
+                if (elements.Count != asSet.elements.Count)
+                    return false;
+
+                return elements.IsSubset(asSet.elements);
+            }
+        }
+        #endregion
+
+        #region Overridden
+        //^ [Confined]
+        public override string/*!*/ ToString()
+        {
+            if (relation == null)
+            {
+                return listToString(left);
+            }
+            else
+            {
+                string leftStr = listToString(left);
+                string rightStr = listToString(right);
+                string retVal = leftStr + " " + relation + " " + rightStr;
+
+                return retVal;
+            }
+        }
+
+        static private string listToString(List<MonomialOfInt<Variable>> l)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            StringBuilder s = new StringBuilder();
+            if (l.Count == 0)
+                return "()";
+            else
+            {
+                s.Append("(");
+                foreach (MonomialOfInt<Variable> m in l)
+                {
+                    s.Append(m.ToString() + ", ");
+                }
+                s.Append(")");
+
+                string stmp = s.ToString();
+                if (stmp.Length > 4)
+                {
+                    stmp = stmp.Remove(stmp.Length - 4, 3);
+                }
+                return stmp;
+            }
+        }
+        #endregion
+
+        #region (almost) Private helper methods
+
+        /// <summary>
+        /// Meaning: let <code>polLeft = (m1 + ... + mt)</code> and <code>polRight = (n1 + ... + nk)</code>, 
+        /// it returns the polynome <code>(m1 + ... + mt + n1 + ... + nk)</code>
+        /// </summary>
+        private static PolynomialOfInt<Variable, Expression> Concatenate(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight)
+        {
+            var concat = new List<MonomialOfInt<Variable>>(polLeft.Left.Count + polRight.Left.Count);
+            concat.AddRange(polLeft.Left);          // Add all the monomes on the left
+            concat.AddRange(polRight.Left);         // Add all the monomes on the right
+
+            return new PolynomialOfInt<Variable, Expression>(concat);
+        }
+
+        private static bool TryToPolynomialFormHelperForSubtraction(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight, out PolynomialOfInt<Variable, Expression> result)
+        {
+            PolynomialOfInt<Variable, Expression> minusPolRight;
+            if (TryMinus(polRight, out minusPolRight))
+            {
+                result = Concatenate(polLeft, minusPolRight);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        private static bool TryToPolynomialFormHelperForMultiplication(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight, out PolynomialOfInt<Variable, Expression> result)
+        {
+            var left = polLeft.left;
+            var right = polRight.left;
+            var multiplicationResult = new List<MonomialOfInt<Variable>>(left.Count * right.Count);
+
+            foreach (var l in left)         // l = (k, xs)
+                foreach (var r in right)   // r  = (c, ys)
+                {
+                    int resultCoeff;
+                    // result = (k*c, xs... ys)
+                    try
+                    {
+                        resultCoeff = l.K * r.K;
+                    }
+                    catch (ArithmeticExceptionRational)
+                    { // If we get an overflow in the multiplication, we get throw away the multiplication
+                        result = null;
+                        return false;
+                    }
+
+                    var concat = new List<Variable>(l.Variables.Count + r.Variables.Count);
+                    concat.AddRange(l.Variables);
+                    concat.AddRange(r.Variables);
+
+                    var resultMonomialOfInt = new MonomialOfInt<Variable>(resultCoeff, concat);
+
+                    multiplicationResult.Add(resultMonomialOfInt);
+                }
+
+            result = new PolynomialOfInt<Variable, Expression>(multiplicationResult);
+            return true;
+        }
+
+        // We consider just the easy cases, when polLeft or polRight are constants
+        private static bool TryToPolynomialFormHelperForDivision(PolynomialOfInt<Variable, Expression> polLeft, PolynomialOfInt<Variable, Expression> polRight, out PolynomialOfInt<Variable, Expression> result)
+        {
+            int leftVal, rightVal;
+
+            if (polLeft.IsConstant(out leftVal) && polRight.IsConstant(out rightVal))
+            {
+                result = new PolynomialOfInt<Variable, Expression>(new MonomialOfInt<Variable>(leftVal / rightVal));
+                return true;
+            }
+
             result = null;
+            return false;
+        }
 
-          break;
-      }
-      return result;
+        private static bool TryMinus(PolynomialOfInt<Variable, Expression> p, out PolynomialOfInt<Variable, Expression> result)
+        {
+            var minusP = new List<MonomialOfInt<Variable>>(p.Left.Count);
+            foreach (var m in p.Left)
+            {
+                int v = -m.K;
+                if (v != Int32.MaxValue && v != Int32.MinValue)
+                {
+                    var minusM = new MonomialOfInt<Variable>(v, m.Variables);
+                    minusP.Add(minusM);
+                }
+                else  // PolynomialOfInt with an infinity component does not make sense, so we fail
+                {
+                    result = null;
+                    return false;
+                }
+            }
+
+            result = new PolynomialOfInt<Variable, Expression>(minusP);
+            return true;
+        }
+
+        private static Expression/*!*/ ConvertToPureExpression(List<MonomialOfInt<Variable>> p, IExpressionEncoder<Variable, Expression>/*!*/ encoder)
+        {
+            Contract.Requires(encoder != null);
+
+            var result = default(Expression);
+            if (p.Count == 0)
+            {
+                return encoder.ConstantFor(0); //return new Constant<int>(0);
+            }
+            else
+            {
+                foreach (MonomialOfInt<Variable> m in p)
+                {
+                    bool neg;
+                    Expression newMonomialOfInt = ConvertToPureExpression(m, encoder, out neg);
+
+                    if (result == null)
+                    {
+                        if (neg)
+                            result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.UnaryMinus, newMonomialOfInt);
+                        else
+                            result = newMonomialOfInt;
+                    }
+                    else if (neg)
+                        result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, result, newMonomialOfInt);  // result = result - m
+                    else
+                        result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, result, newMonomialOfInt);  // result = result + m
+                }
+                return result;
+            }
+        }
+
+        private static Expression ConvertToPureExpression(MonomialOfInt<Variable> m, IExpressionEncoder<Variable, Expression>/*!*/ encoder, out bool neg)
+        {
+            Contract.Requires(encoder != null);
+
+            if (m.IsConstant)
+            {
+                neg = m.K < 0;
+                return encoder.ConstantFor(Math.Abs(m.K));
+            }
+            else
+            {
+                var result = default(Expression);
+                bool first = true;
+
+                neg = false;
+
+                if (m.K == -1)
+                {
+                    neg = true;
+                }
+                else if (m.K != 1)
+                {
+                    result = encoder.ConstantFor(m.K);
+                    first = false;
+                }
+
+                foreach (var v in m.Variables)
+                {
+                    var vExp = encoder.VariableFor(v);
+                    if (first)
+                    {
+                        result = vExp;
+                        first = false;
+                    }
+                    else
+                    {
+                        result = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, result, vExp); // result = result * v      
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        private static List<MonomialOfInt<Variable>> ExtractWritableBytesExpression(Expression e, IExpressionDecoder<Variable, Expression>/*!*/ decoder, out bool success)
+        {
+            List<MonomialOfInt<Variable>> polLeft, polRight;
+            List<MonomialOfInt<Variable>> result;
+            bool b1, b2;
+            Expression lng;
+
+            switch (decoder.OperatorFor(e))
+            {
+                case ExpressionOperator.Addition:
+                    polLeft = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out b1);
+                    polRight = ExtractWritableBytesExpression(decoder.RightExpressionFor(e), decoder, out b2);
+                    success = b1 || b2;
+
+                    if (polRight != null && polLeft != null)
+                    {
+                        foreach (MonomialOfInt<Variable> mon in polRight)
+                        {
+                            mon.K = -mon.K;
+                        }
+
+                        result = new List<MonomialOfInt<Variable>>(polLeft);
+                        result.AddRange(polRight);
+                    }
+                    else
+                    {
+                        result = default(List<MonomialOfInt<Variable>>);
+                        success = false;
+                    }
+                    break;
+
+                //We don't expect other than k*x
+                case ExpressionOperator.Multiplication:
+                    PolynomialOfInt<Variable, Expression> temp;
+                    success = TryToPolynomialForm(e, decoder, out temp);
+                    result = temp.left;
+                    break;
+
+                case ExpressionOperator.ConvertToInt32:
+                case ExpressionOperator.ConvertToUInt16:
+                case ExpressionOperator.ConvertToUInt32:
+                case ExpressionOperator.ConvertToUInt8:
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToFloat64:
+                    result = ExtractWritableBytesExpression(decoder.LeftExpressionFor(e), decoder, out success);
+                    break;
+
+                case ExpressionOperator.Variable:
+#if !SUBPOLY_ONLY
+                    if (decoder.TryGetAssociatedExpression(e, AssociatedInfo.WritableBytes, out lng))
+                    {
+                        MonomialOfInt<Variable> lngMonome = new MonomialOfInt<Variable>(decoder.UnderlyingVariable(lng));
+                        success = true;
+                        result = new List<MonomialOfInt<Variable>>();
+                        result.Add(lngMonome);
+                    }
+                    else
+#endif
+                    {
+                        success = false;
+                        result = new List<MonomialOfInt<Variable>>();
+                        result.Add(new MonomialOfInt<Variable>(decoder.UnderlyingVariable(e)));
+                    }
+                    break;
+
+                default:
+
+                    PolynomialOfInt<Variable, Expression> poly;
+                    success = TryToPolynomialForm(e, decoder, out poly);
+
+                    if (success && poly.Relation == null)
+                        result = poly.left;
+                    else
+                        result = null;
+
+                    break;
+            }
+            return result;
+        }
+
+        #endregion
+
+
+        /// <summary>
+        /// Evaluate the constant to a int
+        /// </summary>
+        private class VisitorForEvalConstant
+          : GenericTypeExpressionVisitor<Variable, Expression, Unit, Pair<int, bool>>
+        {
+            readonly private static Pair<int, bool> NotSuccessfull = new Pair<int, bool>(Int32.MaxValue, false);
+
+            public VisitorForEvalConstant(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
+              : base(decoder)
+            {
+            }
+
+            public override Pair<int, bool> VisitBool(Expression exp, Unit input)
+            {
+                return NotSuccessfull;
+            }
+
+            public override Pair<int, bool> VisitInt8(Expression exp, Unit input)
+            {
+                SByte value;
+                if (Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value))
+                {
+                    return Success(value);
+                }
+                else
+                {
+                    return NotSuccessfull;
+                }
+            }
+
+            public override Pair<int, bool> VisitInt16(Expression exp, Unit input)
+            {
+                Int16 value;
+                if (Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value))
+                    return Success(value);
+                else
+                    return NotSuccessfull;
+            }
+
+            public override Pair<int, bool> VisitInt32(Expression exp, Unit input)
+            {
+                Int32 value;
+                if (Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value))
+                    return Success(value);
+                else
+                    return NotSuccessfull;
+            }
+
+            public override Pair<int, bool> VisitInt64(Expression exp, Unit input)
+            {
+                Int64 value;
+                if (Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value))
+                {
+                    if (CanRepresentExactly(value))
+                        return Success((Int32)value);
+                }
+                return NotSuccessfull;
+            }
+
+            private bool CanRepresentExactly(long value)
+            {
+                return Int32.MinValue < value && value < Int32.MaxValue;
+            }
+
+            private bool CanRepresentExactly(UInt32 value)
+            {
+                return value < Int32.MaxValue;
+            }
+
+            public override Pair<int, bool> VisitString(Expression exp, Unit input)
+            {
+                return NotSuccessfull;
+            }
+
+            public override Pair<int, bool> VisitUInt8(Expression exp, Unit input)
+            {
+                Byte value;
+                if (Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value))
+                    return Success(value);
+                else
+                    return NotSuccessfull;
+            }
+
+            public override Pair<int, bool> VisitUInt16(Expression exp, Unit input)
+            {
+                UInt16 value;
+                if (Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value))
+                    return Success(value);
+                else
+                    return NotSuccessfull;
+            }
+
+            public override Pair<int, bool> VisitUInt32(Expression exp, Unit input)
+            {
+                UInt32 value;
+                if (Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value) && CanRepresentExactly(value))
+                    return Success((Int32)value);
+
+                return NotSuccessfull;
+            }
+
+            public override Pair<int, bool> Default(Expression exp)
+            {
+                return NotSuccessfull;
+            }
+
+            private Pair<int, bool> Success(int value)
+            {
+                return new Pair<int, bool>(value, true);
+            }
+        }
     }
-
-    #endregion
-
 
     /// <summary>
-    /// Evaluate the constant to a int
+    /// A MonomialOfInt is a pair <code>(k, x1...xn)</code> where <code>k</code> is a int number and <code>xi</code> is a variable
     /// </summary>
-    private class VisitorForEvalConstant
-      : GenericTypeExpressionVisitor<Variable, Expression, Unit, Pair<int, bool>>
-    {
-      readonly private static Pair<int, bool> NotSuccessfull = new Pair<int, bool>(Int32.MaxValue, false);
-
-      public VisitorForEvalConstant(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
-        : base(decoder)
-      {
-      }
-
-      public override Pair<int, bool> VisitBool(Expression exp, Unit input)
-      {
-        return NotSuccessfull;
-      }
-
-      public override Pair<int, bool> VisitInt8(Expression exp, Unit input)
-      {
-        SByte value;
-        if (Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value))
-        {
-          return Success(value);
-        }
-        else
-        {
-          return NotSuccessfull;
-        }
-      }
-
-      public override Pair<int, bool> VisitInt16(Expression exp, Unit input)
-      {
-        Int16 value;
-        if (Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value))
-          return Success(value);
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<int, bool> VisitInt32(Expression exp, Unit input)
-      {
-        Int32 value;
-        if (Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value))
-          return Success(value);
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<int, bool> VisitInt64(Expression exp, Unit input)
-      {
-        Int64 value;
-        if (Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value))
-        {
-          if (CanRepresentExactly(value))
-            return Success((Int32)value);
-        }
-        return NotSuccessfull;
-      }
-
-      private bool CanRepresentExactly(long value)
-      {
-        return Int32.MinValue < value && value < Int32.MaxValue;
-      }
-
-      private bool CanRepresentExactly(UInt32 value)
-      {
-        return value < Int32.MaxValue;
-      }
-
-      public override Pair<int, bool> VisitString(Expression exp, Unit input)
-      {
-        return NotSuccessfull;
-      }
-
-      public override Pair<int, bool> VisitUInt8(Expression exp, Unit input)
-      {
-        Byte value;
-        if (Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value))
-          return Success(value);
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<int, bool> VisitUInt16(Expression exp, Unit input)
-      {
-        UInt16 value;
-        if (Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value))
-          return Success(value);
-        else
-          return NotSuccessfull;
-      }
-
-      public override Pair<int, bool> VisitUInt32(Expression exp, Unit input)
-      {
-        UInt32 value;
-        if (Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value) && CanRepresentExactly(value))
-          return Success((Int32) value);
-        
-          return NotSuccessfull;
-      }
-
-      public override Pair<int, bool> Default(Expression exp)
-      {
-        return NotSuccessfull;
-      }
-
-      private Pair<int, bool> Success(int value)
-      {
-        return new Pair<int, bool>(value, true);
-      }
-
-    }
-  }
-
-  /// <summary>
-  /// A MonomialOfInt is a pair <code>(k, x1...xn)</code> where <code>k</code> is a int number and <code>xi</code> is a variable
-  /// </summary>
 #if SUBPOLY_ONLY
-  internal
+    internal
 #else
-  public
+    public
 #endif
  class MonomialOfInt<Variable>
-  {
-    #region Cached values
-    static private IComparer<Variable> varCompaper = new ExpressionComparer<Variable>();
-    #endregion
-
-    #region Private fields
-    private int k;
-    readonly private List<Variable> variables;     // The sorted list of the variables in the MonomialOfInt
-    
-    #endregion
-
-    #region Getters
-    public int K
     {
-      get
-      {
-        return this.k;
-      }
-      set
-      {
-        Contract.Requires((object)value != null);
+        #region Cached values
+        static private IComparer<Variable> varCompaper = new ExpressionComparer<Variable>();
+        #endregion
 
-        this.k = value;
-      }
-    }
+        #region Private fields
+        private int k;
+        readonly private List<Variable> variables;     // The sorted list of the variables in the MonomialOfInt
 
-    public List<Variable> Variables
-    {
-      get
-      {
-        // Here it may be better to return a copy, but we trust the context it is not going to change it?
-        return this.variables;
-      }
-    }
+        #endregion
 
-    public bool IsLinear
-    {
-      get
-      {
-        return this.Degree <= 1;
-      }
-    }
-
-
-    public bool IsConstant
-    {
-      get
-      {
-        return this.variables.Count == 0;
-      }
-    }
-
-    public bool IsVariable(out Variable var)
-    {
-      if (this.Degree == 1)
-      {
-        var = this.variables[0];
-
-        return true;
-      }
-      else
-      {
-        var = default(Variable);
-
-        return false;
-      }
-    }
-
-    public int Degree
-    {
-      get
-      {
-        return this.variables.Count;
-      }
-    }
-
-
-
-    #endregion
-
-    #region Constructors
-
-    ///<summary>
-    /// Constructs a constant form a <code>int</code>
-    ///</summary>
-    public MonomialOfInt(int r)
-    {
-
-      this.k = r;
-      this.variables = new List<Variable>(0);
-    }
-
-    ///<summary>
-    ///Constructs a MonomialOfInt made by only a variable
-    ///</summary>
-    public MonomialOfInt(Variable x)
-    {
-      this.k = 1;
-      this.variables = new List<Variable>(1);
-      this.variables.Add(x);
-    }
-
-    /// <summary>
-    /// Constructs a MonomialOfInt with just one variable
-    /// </summary>
-    public MonomialOfInt(int k, Variable x)
-    {
-      this.k = k;
-      this.variables = new List<Variable>() { x };
-    }
-
-
-    /// <summary>
-    /// Constructs a monome with several variables (i.e. of a degree > 1)
-    /// </summary>
-    //^ [NotDelayed]
-    public MonomialOfInt(int k, IEnumerable<Variable> xs)
-    {
-      this.k = k;
-      this.variables = new List<Variable>(xs);
-      //^ base();
-      this.variables.Sort(varCompaper);
-    }
-
-    #endregion
-
-    /// <summary>
-    /// Return a MonomialOfInt where the variable <code>x</code> is replaced with <code>xNew</code>
-    /// </summary>
-    public MonomialOfInt<Variable>/*!*/ Rename(Variable/*!*/ x, Variable/*!*/ xNew)
-    {
-      if (this.Variables.Contains(x))
-      {
-        var newVars = new Set<Variable>(this.Variables);
-        newVars.Remove(x);
-        newVars.Add(xNew);
-
-        return new MonomialOfInt<Variable>(this.K, newVars);
-      }
-      else
-      {
-        return this;
-      }
-    }
-
-    #region Overridden
-    //^ [Confined]
-    public override string/*!*/ ToString()
-    {
-      return this.k + "*" + VarsToString(this.variables) + " ";
-    }
-
-    static private string VarsToString(List<Variable> vars)
-    {
-      StringBuilder s = new StringBuilder();
-      if (vars.Count == 0)
-        s.Append("1");
-      else
-      {
-        foreach (var v in vars)
+        #region Getters
+        public int K
         {
-          if (v != null)
-            s.Append(v.ToString() + "* ");
-          else
-            s.Append("null");
+            get
+            {
+                return k;
+            }
+            set
+            {
+                Contract.Requires((object)value != null);
+
+                k = value;
+            }
         }
-      }
-      string/*!*/ stmp = s.ToString();
 
-      if (stmp.Length > 2)         // Get rid of the last "* ", if any
-        stmp = stmp.Remove(stmp.Length - 2);
-
-      return stmp;
-    }
-    #endregion
-
-    public bool IsEquivalentTo(MonomialOfInt<Variable> tmp)
-    {
-      if (this.K != tmp.K)
-        return false;
-
-      foreach (var x in this.Variables)
-      {
-        if (!tmp.Variables.Contains(x))
-          return false;
-      }
-
-      foreach (var x in tmp.variables)
-      {
-        if (!tmp.Variables.Contains(x))
-          return false;
-      }
-
-      return true;
-    }
-  }
-
-  public static class PolynomialOfIntHelper
-  {
-    //private PolynomialHelper()
-    //{
-    //}
-
-    public static bool TryMatch_k1XPlusk2YEqualk3<Variable, Expression>(this PolynomialOfInt<Variable, Expression> expAsPolCanonical, out int k1, out Variable x, out int k2, out Variable y, out int k3)
-    {
-      if (expAsPolCanonical.Degree == 1 && expAsPolCanonical.Relation.HasValue && expAsPolCanonical.Relation.Value == ExpressionOperator.Equal
-        && expAsPolCanonical.Left.Count == 2 && expAsPolCanonical.Right.Count == 1)
-      {
-        var m1 = expAsPolCanonical.Left[0];
-        var m2 = expAsPolCanonical.Left[1];
-
-        var m3 = expAsPolCanonical.Right[0];
-
-        if (m3.Variables.Count == 0)
+        public List<Variable> Variables
         {
-          k1 = m1.K;
-          x = m1.Variables[0];
-
-          k2 = m2.K;
-          y = m2.Variables[0];
-
-          k3 = m3.K;
-
-          return true;
+            get
+            {
+                // Here it may be better to return a copy, but we trust the context it is not going to change it?
+                return variables;
+            }
         }
-      }
 
-      k1 = k2 = k3 = default(int);
-      x = y = default(Variable);
-
-      return false;
-    }
-
-    public static bool TryMatch_XMinusYEqualk3<Variable, Expression>(this PolynomialOfInt<Variable, Expression> expAsPolCanonical, out Variable x, out Variable y, out int k)
-    {
-      int k1, k2, k3;
-      if (TryMatch_k1XPlusk2YEqualk3(expAsPolCanonical, out k1, out x, out k2, out y, out k3) && k1 == 1 && k2 == -1)
-      {
-        k = k3;
-
-        return true;
-      }
-
-      k = default(int);
-
-      return false;
-    }
-
-
-
-    /// <summary>
-    ///  Matches the polynomial <code>expAsPolCanonical</code> with the expression <code>y - k</code>
-    /// </summary>
-    /// <param name="expAsPolCanonical">A polynomial what is <b>assumed</b> to be already into a canonical form</param>
-    /// <returns>true iff the matching works</returns>
-    public static bool Match_YMinusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> expAsPolCanonical, out Variable y, out int k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || (object)Contract.ValueAtReturn(out k) != null);
-
-      bool result;
-
-      if (expAsPolCanonical.Relation == null && expAsPolCanonical.Degree == 1)
-      {
-        var monomials = expAsPolCanonical.Left;
-        if (monomials.Count == 2 && monomials[0].IsLinear && monomials[1].IsConstant)
+        public bool IsLinear
         {
-          k = monomials[1].K;
-
-          if (k < 0)
-          {
-            y = monomials[0].Variables[0];
-            result = true;
-          }
-          else
-          {
-            result = HelperForFalse(out y, out k);
-          }
+            get
+            {
+                return this.Degree <= 1;
+            }
         }
-        else
+
+
+        public bool IsConstant
         {
-          result = HelperForFalse(out y, out k);
+            get
+            {
+                return variables.Count == 0;
+            }
         }
-      }
-      else
-      {
-        result = HelperForFalse(out y, out k);
-      }
 
-      return result;
-    }
-
-    /// <summary>
-    ///  Matches the polynomial <code>expAsPolCanonical</code> with the expression <code>y + k</code>
-    /// </summary>
-    /// <param name="expAsPolCanonical">A polynomial what is <b>assumed</b> to be already into a canonical form</param>
-    /// <returns>true iff the matching works</returns>
-    public static bool Match_YPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> expAsPolCanonical, out Variable y, out int k)
-    {
-      Contract.Ensures(Contract.Result<bool>() == false || (object)Contract.ValueAtReturn(out k) != null);
-
-      bool result;
-
-      if (expAsPolCanonical.Relation == null && expAsPolCanonical.Degree == 1)
-      {
-        var monomials = expAsPolCanonical.Left;
-        if (monomials.Count == 2 && monomials[0].IsLinear && monomials[1].IsConstant)
+        public bool IsVariable(out Variable var)
         {
-          k = monomials[1].K;
+            if (this.Degree == 1)
+            {
+                var = variables[0];
 
-          if (k > 0)
-          {
-            y = monomials[0].Variables[0];
-            result = true;
-          }
-          else
-          {
-            result = HelperForFalse(out y, out k);
-          }
-        }
-        else
-        {
-          result = HelperForFalse(out y, out k);
-        }
-      }
-      else
-      {
-        result = HelperForFalse(out y, out k);
-      }
+                return true;
+            }
+            else
+            {
+                var = default(Variable);
 
-      return result;
-    }
-
-    /// <summary>
-    ///  Matches the polynomial <code>pol</code> with the expression <code>y</code>
-    /// </summary>
-    /// <param name="pol">A polynomial what is <b>assumed</b> to be already into a canonical form</param>
-    /// <returns>true iff the matching works</returns>
-    public static bool Match_Y<Variable, Expression>(PolynomialOfInt<Variable, Expression> pol, out Variable y)
-    {
-      if (!(pol.Degree == 1 && pol.Relation == null && pol.Left.Count == 1))
-      {
-        return HelperForFalse(out y);
-      }
-      else
-      {
-        y = pol.Variables.PickAnElement();
-        return true;
-      }
-    }
-
-    /// <summary>
-    /// Matches the polynomial with the expression <code>k1 * x1 + k2 * x2 \leq k</code>
-    /// </summary>
-    /// <returns>true iff it is the case</returns>
-    public static bool Match_k1XPlusk2YLessEqualThanK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out int k1, out Variable x1, out int k2, out Variable x2, out int k)
-    {
-      // ????
-      // Contract.Requires(e1LTe2.Relation.HasValue);
-
-      if (e1LTe2.Left.Count == 2 && e1LTe2.IsOctagonForm && e1LTe2.Relation.Value.IsLessEqualThan())
-      {
-        k1 = e1LTe2.Left[0].K;
-        x1 = e1LTe2.Left[0].Variables[0];
-
-        k2 = e1LTe2.Left[1].K;
-        x2 = e1LTe2.Left[1].Variables[0];
-
-        k = e1LTe2.Right[0].K;
-
-        return true;
-      }
-
-      k1 = k2 = k = default(int);
-      x1 = x2 = default(Variable);
-      return false;
-    }
-
-    /// <summary>
-    /// Matches the polynomial with the expression <code>k1 * x1 + k2 * x2 \lt k</code>
-    /// </summary>
-    /// <returns>true iff it is the case</returns>
-    public static bool Match_k1XPlusk2YLessThanK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out int k1, out Variable x1, out int k2, out Variable x2, out int k)
-    {
-      if (e1LTe2.Left.Count == 2 && e1LTe2.IsOctagonForm)
-      {
-        k1 = e1LTe2.Left[0].K;
-        x1 = e1LTe2.Left[0].Variables[0];
-
-        k2 = e1LTe2.Left[1].K;
-        x2 = e1LTe2.Left[1].Variables[0];
-        if (e1LTe2.Relation.Value.IsLessThan())
-        {
-          k = e1LTe2.Right[0].K;
-
-          return true;
-        }
-        else if (e1LTe2.Relation.Value.IsLessEqualThan()) // == ExpressionOperator.LessEqualThan)
-        {
-          k = e1LTe2.Right[0].K + 1;
-
-          return true;
-        }
-      }
-
-      k1 = k2 = k = default(int);
-      x1 = x2 = default(Variable);
-      return false;
-    }
-
-
-
-    /// <summary>
-    /// Matches the polynomial with the expression <code>x1 + x2 \lt x3 + k</code>
-    /// </summary>
-    /// <returns>true iff it is the case</returns>
-    public static bool Match_XPlusYLess_Equal_ThanZPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out Variable x1, out Variable x2, out Variable x3, out int k)
-    {
-      x1 = x2 = x3 = default(Variable);
-      k = default(int);
-
-      var x = new Variable[3];
-      if (e1LTe2.Left.Count == 3)
-      {
-        bool found = false;
-        for (int i = 0; i < 3; i++)
-        {
-          if (!e1LTe2.Left[i].IsLinear)
-            return false;
-          switch ((int)e1LTe2.Left[i].K)
-          {
-            case 1:
-              x[i - (found ? 1 : 0)] = e1LTe2.Left[i].Variables[0];
-              break;
-            case -1:
-              if (found)
                 return false;
-              found = true;
-              x[2] = e1LTe2.Left[i].Variables[0];
-              break;
-            default:
-              return false;
-          }
+            }
         }
-        if (!found)
-          return false;
-        if (e1LTe2.Right.Count == 1 && e1LTe2.Right[0].IsConstant)
+
+        public int Degree
         {
-          k = e1LTe2.Right[0].K;
-          x1 = x[0];
-          x2 = x[1];
-          x3 = x[2];
-          return true;
+            get
+            {
+                return variables.Count;
+            }
         }
-      }
-      return false;
-    }
 
 
 
-    /// <summary>
-    /// Matches the polynomial with the expression <code>x1 \lt x2 + x3 + k</code>
-    /// </summary>
-    /// <returns>true iff it is the case</returns>
-    public static bool Match_XLess_Equal_ThanYPlusZPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out Variable x1, out Variable x2, out Variable x3, out int k)
-    {
-      x1 = x2 = x3 = default(Variable);
-      k = default(int);
-      var x = new Variable[3];
+        #endregion
 
-      if (e1LTe2.Left.Count == 3)
-      {
-        bool found = false;
-        for (int i = 0; i < 3; i++)
+        #region Constructors
+
+        ///<summary>
+        /// Constructs a constant form a <code>int</code>
+        ///</summary>
+        public MonomialOfInt(int r)
         {
-          if (!e1LTe2.Left[i].IsLinear)
-            return false;
-          switch ((int)e1LTe2.Left[i].K)
-          {
-            case -1:
-              x[i - (found ? 1 : 0)] = e1LTe2.Left[i].Variables[0];
-              break;
-            case 1:
-              if (found)
+            k = r;
+            variables = new List<Variable>(0);
+        }
+
+        ///<summary>
+        ///Constructs a MonomialOfInt made by only a variable
+        ///</summary>
+        public MonomialOfInt(Variable x)
+        {
+            k = 1;
+            variables = new List<Variable>(1);
+            variables.Add(x);
+        }
+
+        /// <summary>
+        /// Constructs a MonomialOfInt with just one variable
+        /// </summary>
+        public MonomialOfInt(int k, Variable x)
+        {
+            this.k = k;
+            variables = new List<Variable>() { x };
+        }
+
+
+        /// <summary>
+        /// Constructs a monome with several variables (i.e. of a degree > 1)
+        /// </summary>
+        //^ [NotDelayed]
+        public MonomialOfInt(int k, IEnumerable<Variable> xs)
+        {
+            this.k = k;
+            variables = new List<Variable>(xs);
+            //^ base();
+            variables.Sort(varCompaper);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Return a MonomialOfInt where the variable <code>x</code> is replaced with <code>xNew</code>
+        /// </summary>
+        public MonomialOfInt<Variable>/*!*/ Rename(Variable/*!*/ x, Variable/*!*/ xNew)
+        {
+            if (this.Variables.Contains(x))
+            {
+                var newVars = new Set<Variable>(this.Variables);
+                newVars.Remove(x);
+                newVars.Add(xNew);
+
+                return new MonomialOfInt<Variable>(this.K, newVars);
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        #region Overridden
+        //^ [Confined]
+        public override string/*!*/ ToString()
+        {
+            return k + "*" + VarsToString(variables) + " ";
+        }
+
+        static private string VarsToString(List<Variable> vars)
+        {
+            StringBuilder s = new StringBuilder();
+            if (vars.Count == 0)
+                s.Append("1");
+            else
+            {
+                foreach (var v in vars)
+                {
+                    if (v != null)
+                        s.Append(v.ToString() + "* ");
+                    else
+                        s.Append("null");
+                }
+            }
+            string/*!*/ stmp = s.ToString();
+
+            if (stmp.Length > 2)         // Get rid of the last "* ", if any
+                stmp = stmp.Remove(stmp.Length - 2);
+
+            return stmp;
+        }
+        #endregion
+
+        public bool IsEquivalentTo(MonomialOfInt<Variable> tmp)
+        {
+            if (this.K != tmp.K)
                 return false;
-              found = true;
-              x[2] = e1LTe2.Left[i].Variables[0];
-              break;
-            default:
-              return false;
-          }
+
+            foreach (var x in this.Variables)
+            {
+                if (!tmp.Variables.Contains(x))
+                    return false;
+            }
+
+            foreach (var x in tmp.variables)
+            {
+                if (!tmp.Variables.Contains(x))
+                    return false;
+            }
+
+            return true;
         }
-        if (!found)
-          return false;
-        if (e1LTe2.Right.Count == 1 && e1LTe2.Right[0].IsConstant)
+    }
+
+    public static class PolynomialOfIntHelper
+    {
+        //private PolynomialHelper()
+        //{
+        //}
+
+        public static bool TryMatch_k1XPlusk2YEqualk3<Variable, Expression>(this PolynomialOfInt<Variable, Expression> expAsPolCanonical, out int k1, out Variable x, out int k2, out Variable y, out int k3)
         {
-          k = e1LTe2.Right[0].K;
-          x1 = x[2];
-          x2 = x[0];
-          x3 = x[1];
-          return true;
+            if (expAsPolCanonical.Degree == 1 && expAsPolCanonical.Relation.HasValue && expAsPolCanonical.Relation.Value == ExpressionOperator.Equal
+              && expAsPolCanonical.Left.Count == 2 && expAsPolCanonical.Right.Count == 1)
+            {
+                var m1 = expAsPolCanonical.Left[0];
+                var m2 = expAsPolCanonical.Left[1];
+
+                var m3 = expAsPolCanonical.Right[0];
+
+                if (m3.Variables.Count == 0)
+                {
+                    k1 = m1.K;
+                    x = m1.Variables[0];
+
+                    k2 = m2.K;
+                    y = m2.Variables[0];
+
+                    k3 = m3.K;
+
+                    return true;
+                }
+            }
+
+            k1 = k2 = k3 = default(int);
+            x = y = default(Variable);
+
+            return false;
         }
-      }
-      return false;
-    }
 
-
-
-    /// <summary>
-    /// Matches the polynomial <code>p</code> with <code>x - y + k</code>, where <code>k</code> can be positive, negative or zero
-    /// </summary>
-    /// <returns></returns>
-    public static bool Match_XMinusYPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> pol, out Variable x, out Variable y, out int k)
-    {
-      bool result;
-      if (!pol.Relation.HasValue && pol.IsLinear)
-      {
-        if (pol.Left.Count == 3)
+        public static bool TryMatch_XMinusYEqualk3<Variable, Expression>(this PolynomialOfInt<Variable, Expression> expAsPolCanonical, out Variable x, out Variable y, out int k)
         {
-          if (pol.Left[0].K == 1 && pol.Left[1].K == -1 && pol.Left[2].Variables.Count == 0)
-          {
-            x = pol.Left[0].Variables[0];
-            y = pol.Left[1].Variables[0];
-            k = pol.Left[2].K;
+            int k1, k2, k3;
+            if (TryMatch_k1XPlusk2YEqualk3(expAsPolCanonical, out k1, out x, out k2, out y, out k3) && k1 == 1 && k2 == -1)
+            {
+                k = k3;
 
-            result = true;
-          }
-          else if (pol.Left[0].K == -1 && pol.Left[1].K == 1 && pol.Left[2].Variables.Count == 0)
-          {
-            y = pol.Left[0].Variables[0];
-            x = pol.Left[1].Variables[0];
-            k = pol.Left[2].K;
+                return true;
+            }
 
-            result = true;
-          }
-          else
-          {
-            result = HelperForFalse(out x, out y, out k);
-          }
+            k = default(int);
+
+            return false;
         }
-        else if (pol.Left.Count == 2 && pol.Left[0].Variables.Count == 1 && pol.Left[1].Variables.Count == 1)
+
+
+
+        /// <summary>
+        ///  Matches the polynomial <code>expAsPolCanonical</code> with the expression <code>y - k</code>
+        /// </summary>
+        /// <param name="expAsPolCanonical">A polynomial what is <b>assumed</b> to be already into a canonical form</param>
+        /// <returns>true iff the matching works</returns>
+        public static bool Match_YMinusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> expAsPolCanonical, out Variable y, out int k)
         {
-          if (pol.Left[0].K == 1 && pol.Left[1].K == -1)
-          {
-            x = pol.Left[0].Variables[0];
-            y = pol.Left[1].Variables[0];
-            k = 0;
-            result = true;
-          }
-          else if (pol.Left[0].K == -1 && pol.Left[1].K == 1)
-          {
-            y = pol.Left[0].Variables[0];
-            x = pol.Left[1].Variables[0];
-            k = 0;
-            result = true;
-          }
-          else
-          {
-            result = HelperForFalse(out x, out y, out k);
-          }
-          // to be refined....
+            Contract.Ensures(!Contract.Result<bool>() || (object)Contract.ValueAtReturn(out k) != null);
+
+            bool result;
+
+            if (expAsPolCanonical.Relation == null && expAsPolCanonical.Degree == 1)
+            {
+                var monomials = expAsPolCanonical.Left;
+                if (monomials.Count == 2 && monomials[0].IsLinear && monomials[1].IsConstant)
+                {
+                    k = monomials[1].K;
+
+                    if (k < 0)
+                    {
+                        y = monomials[0].Variables[0];
+                        result = true;
+                    }
+                    else
+                    {
+                        result = HelperForFalse(out y, out k);
+                    }
+                }
+                else
+                {
+                    result = HelperForFalse(out y, out k);
+                }
+            }
+            else
+            {
+                result = HelperForFalse(out y, out k);
+            }
+
+            return result;
         }
-        else
+
+        /// <summary>
+        ///  Matches the polynomial <code>expAsPolCanonical</code> with the expression <code>y + k</code>
+        /// </summary>
+        /// <param name="expAsPolCanonical">A polynomial what is <b>assumed</b> to be already into a canonical form</param>
+        /// <returns>true iff the matching works</returns>
+        public static bool Match_YPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> expAsPolCanonical, out Variable y, out int k)
         {
-          result = HelperForFalse(out x, out y, out k);
+            Contract.Ensures(Contract.Result<bool>() == false || (object)Contract.ValueAtReturn(out k) != null);
+
+            bool result;
+
+            if (expAsPolCanonical.Relation == null && expAsPolCanonical.Degree == 1)
+            {
+                var monomials = expAsPolCanonical.Left;
+                if (monomials.Count == 2 && monomials[0].IsLinear && monomials[1].IsConstant)
+                {
+                    k = monomials[1].K;
+
+                    if (k > 0)
+                    {
+                        y = monomials[0].Variables[0];
+                        result = true;
+                    }
+                    else
+                    {
+                        result = HelperForFalse(out y, out k);
+                    }
+                }
+                else
+                {
+                    result = HelperForFalse(out y, out k);
+                }
+            }
+            else
+            {
+                result = HelperForFalse(out y, out k);
+            }
+
+            return result;
         }
-      }
-      else
-      {
-        result = HelperForFalse(out x, out y, out k);
-      }
 
-      return result;
+        /// <summary>
+        ///  Matches the polynomial <code>pol</code> with the expression <code>y</code>
+        /// </summary>
+        /// <param name="pol">A polynomial what is <b>assumed</b> to be already into a canonical form</param>
+        /// <returns>true iff the matching works</returns>
+        public static bool Match_Y<Variable, Expression>(PolynomialOfInt<Variable, Expression> pol, out Variable y)
+        {
+            if (!(pol.Degree == 1 && pol.Relation == null && pol.Left.Count == 1))
+            {
+                return HelperForFalse(out y);
+            }
+            else
+            {
+                y = pol.Variables.PickAnElement();
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Matches the polynomial with the expression <code>k1 * x1 + k2 * x2 \leq k</code>
+        /// </summary>
+        /// <returns>true iff it is the case</returns>
+        public static bool Match_k1XPlusk2YLessEqualThanK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out int k1, out Variable x1, out int k2, out Variable x2, out int k)
+        {
+            // ????
+            // Contract.Requires(e1LTe2.Relation.HasValue);
+
+            if (e1LTe2.Left.Count == 2 && e1LTe2.IsOctagonForm && e1LTe2.Relation.Value.IsLessEqualThan())
+            {
+                k1 = e1LTe2.Left[0].K;
+                x1 = e1LTe2.Left[0].Variables[0];
+
+                k2 = e1LTe2.Left[1].K;
+                x2 = e1LTe2.Left[1].Variables[0];
+
+                k = e1LTe2.Right[0].K;
+
+                return true;
+            }
+
+            k1 = k2 = k = default(int);
+            x1 = x2 = default(Variable);
+            return false;
+        }
+
+        /// <summary>
+        /// Matches the polynomial with the expression <code>k1 * x1 + k2 * x2 \lt k</code>
+        /// </summary>
+        /// <returns>true iff it is the case</returns>
+        public static bool Match_k1XPlusk2YLessThanK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out int k1, out Variable x1, out int k2, out Variable x2, out int k)
+        {
+            if (e1LTe2.Left.Count == 2 && e1LTe2.IsOctagonForm)
+            {
+                k1 = e1LTe2.Left[0].K;
+                x1 = e1LTe2.Left[0].Variables[0];
+
+                k2 = e1LTe2.Left[1].K;
+                x2 = e1LTe2.Left[1].Variables[0];
+                if (e1LTe2.Relation.Value.IsLessThan())
+                {
+                    k = e1LTe2.Right[0].K;
+
+                    return true;
+                }
+                else if (e1LTe2.Relation.Value.IsLessEqualThan()) // == ExpressionOperator.LessEqualThan)
+                {
+                    k = e1LTe2.Right[0].K + 1;
+
+                    return true;
+                }
+            }
+
+            k1 = k2 = k = default(int);
+            x1 = x2 = default(Variable);
+            return false;
+        }
+
+
+
+        /// <summary>
+        /// Matches the polynomial with the expression <code>x1 + x2 \lt x3 + k</code>
+        /// </summary>
+        /// <returns>true iff it is the case</returns>
+        public static bool Match_XPlusYLess_Equal_ThanZPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out Variable x1, out Variable x2, out Variable x3, out int k)
+        {
+            x1 = x2 = x3 = default(Variable);
+            k = default(int);
+
+            var x = new Variable[3];
+            if (e1LTe2.Left.Count == 3)
+            {
+                bool found = false;
+                for (int i = 0; i < 3; i++)
+                {
+                    if (!e1LTe2.Left[i].IsLinear)
+                        return false;
+                    switch ((int)e1LTe2.Left[i].K)
+                    {
+                        case 1:
+                            x[i - (found ? 1 : 0)] = e1LTe2.Left[i].Variables[0];
+                            break;
+                        case -1:
+                            if (found)
+                                return false;
+                            found = true;
+                            x[2] = e1LTe2.Left[i].Variables[0];
+                            break;
+                        default:
+                            return false;
+                    }
+                }
+                if (!found)
+                    return false;
+                if (e1LTe2.Right.Count == 1 && e1LTe2.Right[0].IsConstant)
+                {
+                    k = e1LTe2.Right[0].K;
+                    x1 = x[0];
+                    x2 = x[1];
+                    x3 = x[2];
+                    return true;
+                }
+            }
+            return false;
+        }
+
+
+
+        /// <summary>
+        /// Matches the polynomial with the expression <code>x1 \lt x2 + x3 + k</code>
+        /// </summary>
+        /// <returns>true iff it is the case</returns>
+        public static bool Match_XLess_Equal_ThanYPlusZPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> e1LTe2, out Variable x1, out Variable x2, out Variable x3, out int k)
+        {
+            x1 = x2 = x3 = default(Variable);
+            k = default(int);
+            var x = new Variable[3];
+
+            if (e1LTe2.Left.Count == 3)
+            {
+                bool found = false;
+                for (int i = 0; i < 3; i++)
+                {
+                    if (!e1LTe2.Left[i].IsLinear)
+                        return false;
+                    switch ((int)e1LTe2.Left[i].K)
+                    {
+                        case -1:
+                            x[i - (found ? 1 : 0)] = e1LTe2.Left[i].Variables[0];
+                            break;
+                        case 1:
+                            if (found)
+                                return false;
+                            found = true;
+                            x[2] = e1LTe2.Left[i].Variables[0];
+                            break;
+                        default:
+                            return false;
+                    }
+                }
+                if (!found)
+                    return false;
+                if (e1LTe2.Right.Count == 1 && e1LTe2.Right[0].IsConstant)
+                {
+                    k = e1LTe2.Right[0].K;
+                    x1 = x[2];
+                    x2 = x[0];
+                    x3 = x[1];
+                    return true;
+                }
+            }
+            return false;
+        }
+
+
+
+        /// <summary>
+        /// Matches the polynomial <code>p</code> with <code>x - y + k</code>, where <code>k</code> can be positive, negative or zero
+        /// </summary>
+        /// <returns></returns>
+        public static bool Match_XMinusYPlusK<Variable, Expression>(PolynomialOfInt<Variable, Expression> pol, out Variable x, out Variable y, out int k)
+        {
+            bool result;
+            if (!pol.Relation.HasValue && pol.IsLinear)
+            {
+                if (pol.Left.Count == 3)
+                {
+                    if (pol.Left[0].K == 1 && pol.Left[1].K == -1 && pol.Left[2].Variables.Count == 0)
+                    {
+                        x = pol.Left[0].Variables[0];
+                        y = pol.Left[1].Variables[0];
+                        k = pol.Left[2].K;
+
+                        result = true;
+                    }
+                    else if (pol.Left[0].K == -1 && pol.Left[1].K == 1 && pol.Left[2].Variables.Count == 0)
+                    {
+                        y = pol.Left[0].Variables[0];
+                        x = pol.Left[1].Variables[0];
+                        k = pol.Left[2].K;
+
+                        result = true;
+                    }
+                    else
+                    {
+                        result = HelperForFalse(out x, out y, out k);
+                    }
+                }
+                else if (pol.Left.Count == 2 && pol.Left[0].Variables.Count == 1 && pol.Left[1].Variables.Count == 1)
+                {
+                    if (pol.Left[0].K == 1 && pol.Left[1].K == -1)
+                    {
+                        x = pol.Left[0].Variables[0];
+                        y = pol.Left[1].Variables[0];
+                        k = 0;
+                        result = true;
+                    }
+                    else if (pol.Left[0].K == -1 && pol.Left[1].K == 1)
+                    {
+                        y = pol.Left[0].Variables[0];
+                        x = pol.Left[1].Variables[0];
+                        k = 0;
+                        result = true;
+                    }
+                    else
+                    {
+                        result = HelperForFalse(out x, out y, out k);
+                    }
+                    // to be refined....
+                }
+                else
+                {
+                    result = HelperForFalse(out x, out y, out k);
+                }
+            }
+            else
+            {
+                result = HelperForFalse(out x, out y, out k);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Matches the polynomial with 
+        /// </summary>
+        public static bool Match_k1XLessThank2<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out int k1, out Variable x, out int k2)
+        {
+            if (p.Relation.Value.IsLessThan())  // (p.Relation == ExpressionOperator.LessThan)
+            {
+                return HelperForMatch_k1Xopk2(p, out k1, out x, out k2);
+            }
+            else
+            {
+                return HelperForFalse(out x, out k1, out k2);
+            }
+        }
+
+        public static bool Match_k1XLessEqualThank2<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out int k1, out Variable x, out int k2)
+        {
+            if (p.Relation.Value.IsLessEqualThan())
+            {
+                return HelperForMatch_k1Xopk2(p, out k1, out x, out k2);
+            }
+            else
+            {
+                return HelperForFalse(out x, out k1, out k2);
+            }
+        }
+
+        public static bool Match_kY<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out Variable y, out int k)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || (object)Contract.ValueAtReturn(out k) != null);
+
+            if (p.Relation == null && p.Left.Count == 1 && p.Left[0].Degree == 1)
+            {
+                y = p.Left[0].Variables[0];
+                k = p.Left[0].K;
+                return true;
+            }
+            else
+            {
+                return HelperForFalse(out y, out k);
+            }
+        }
+
+        private static bool HelperForMatch_k1Xopk2<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out int k1, out Variable x, out int k2)
+        {
+            bool result;
+            if (p.IsLinear && p.Degree != 0 && p.Left.Count == 1 && p.Right.Count == 1)
+            {
+                k1 = p.Left[0].K;
+                x = p.Left[0].Variables[0];
+                k2 = p.Right[0].K;
+
+                Contract.Assert(p.Right[0].Variables.Count == 0);  // no var
+
+                result = true;
+            }
+            else
+            {
+                result = HelperForFalse(out x, out k1, out k2);
+            }
+
+            return result;
+        }
+
+        private static bool HelperForFalse<Variable>(out Variable x, out int k1, out int k2)
+        {
+            Contract.Ensures(Contract.Result<bool>() == false);
+
+            x = default(Variable);
+            k1 = default(int);
+            k2 = default(int);
+            return false;
+        }
+
+        private static bool HelperForFalse<Variable>(out Variable x, out Variable y, out int k)
+        {
+            Contract.Ensures(Contract.Result<bool>() == false);
+
+            x = y = default(Variable);
+            k = default(int);
+
+            return false;
+        }
+
+        private static bool HelperForFalse<Variable>(out Variable y, out int k)
+        {
+            Contract.Ensures(Contract.Result<bool>() == false);
+
+            y = default(Variable);
+            k = default(int);
+
+            return false;
+        }
+
+        private static bool HelperForFalse<Variable>(out Variable y)
+        {
+            Contract.Ensures(Contract.Result<bool>() == false);
+
+            y = default(Variable);
+
+            return false;
+        }
     }
-
-    /// <summary>
-    /// Matches the polynomial with 
-    /// </summary>
-    public static bool Match_k1XLessThank2<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out int k1, out Variable x, out int k2)
-    {
-      if (p.Relation.Value.IsLessThan())  // (p.Relation == ExpressionOperator.LessThan)
-      {
-        return HelperForMatch_k1Xopk2(p, out k1, out x, out k2);
-      }
-      else
-      {
-        return HelperForFalse(out x, out k1, out k2);
-      }
-    }
-
-    public static bool Match_k1XLessEqualThank2<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out int k1, out Variable x, out int k2)
-    {
-      if (p.Relation.Value.IsLessEqualThan())
-      {
-        return  HelperForMatch_k1Xopk2(p, out k1, out x, out k2);
-      }
-      else
-      {
-        return HelperForFalse(out x, out k1, out k2);
-      }
-    }
-
-    public static bool Match_kY<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out Variable y, out int k)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || (object)Contract.ValueAtReturn(out k) != null);
-
-      if (p.Relation == null && p.Left.Count == 1 && p.Left[0].Degree == 1)
-      {
-        y = p.Left[0].Variables[0];
-        k = p.Left[0].K;
-        return true;
-      }
-      else
-      {
-        return HelperForFalse(out y, out k);
-      }
-    }
-
-    private static bool HelperForMatch_k1Xopk2<Variable, Expression>(PolynomialOfInt<Variable, Expression> p, out int k1, out Variable x, out int k2)
-    {
-      bool result;
-      if (p.IsLinear && p.Degree != 0 && p.Left.Count == 1 && p.Right.Count == 1)
-      {
-        k1 = p.Left[0].K;
-        x = p.Left[0].Variables[0];
-        k2 = p.Right[0].K;
-
-        Contract.Assert(p.Right[0].Variables.Count == 0);  // no var
-
-        result = true;
-      }
-      else
-      {
-        result = HelperForFalse(out x, out k1, out k2);
-      }
-
-      return result;
-    }
-
-    private static bool HelperForFalse<Variable>(out Variable x, out int k1, out int k2)
-    {
-      Contract.Ensures(Contract.Result<bool>() == false);
-
-      x = default(Variable);
-      k1 = default(int);
-      k2 = default(int);
-      return false;
-    }
-
-    private static bool HelperForFalse<Variable>(out Variable x, out Variable y, out int k)
-    {
-      Contract.Ensures(Contract.Result<bool>() == false);
-
-      x = y =default(Variable);
-      k = default(int);
-
-      return false;
-    }
-
-    private static bool HelperForFalse<Variable>(out Variable y, out int k)
-    {
-      Contract.Ensures(Contract.Result<bool>() == false);
-
-      y = default(Variable);
-      k = default(int);
-
-      return false;
-    }
-
-    private static bool HelperForFalse<Variable>(out Variable y)
-    {
-      Contract.Ensures(Contract.Result<bool>() == false);
-
-      y = default(Variable);
-
-      return false;
-    }
-  }
-
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Extensions.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Extensions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using Microsoft.Research.AbstractDomains.Numerical;
@@ -24,1139 +13,1138 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  [ContractVerification(true)]  
-  public static class INumericalAbstractDomainExtensions
-  {
-    public static INumericalAbstractDomain<Variable, Expression> AssumeInInterval<Variable, Expression>(
-      this INumericalAbstractDomain<Variable, Expression> aState, 
-      Expression exp, Interval intv,  IExpressionEncoder<Variable, Expression> encoder)
+    [ContractVerification(true)]
+    public static class INumericalAbstractDomainExtensions
     {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(intv != null);
-      Contract.Requires(encoder != null);
-
-      if (aState.IsBottom || intv.IsTop)
-      {
-        return aState;
-      }
-
-      if (intv.IsBottom)
-      {
-        return aState.Bottom as INumericalAbstractDomain<Variable, Expression>;
-      }
-
-      // a <= exp
-      if(!intv.LowerBound.IsInfinity)
-      {
-        aState = aState.TestTrueLessEqualThan(intv.LowerBound.ToExpression(encoder), exp);
-      }
-      // b <= exp
-      if (!intv.UpperBound.IsInfinity)
-      {
-        aState = aState.TestTrueLessEqualThan(exp, intv.UpperBound.ToExpression(encoder));
-      }
-
-      return aState;
-    }
-
-    public static INumericalAbstractDomain<Variable, Expression> TestTrueEqual<Variable, Expression>(
-     this INumericalAbstractDomain<Variable, Expression> aState,
-     Expression exp, IEnumerable<Expression> uppBounds)
-    {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(uppBounds != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      if (aState.IsBottom)
-      {
-        return aState;
-      }
-
-      var result = aState;
-      foreach (var upp in uppBounds)
-      {
-        Contract.Assume(upp != null);
-        result = result.TestTrueEqual(exp, upp);
-      }
-
-      return result;
-    }
-
-    public static INumericalAbstractDomain<Variable, Expression> TestTrueEqual<Variable, Expression>(
-      this INumericalAbstractDomain<Variable, Expression> aState,
-      Expression exp, SetOfConstraints<Variable> equalities,
-      IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(equalities != null);
-      Contract.Requires(encoder != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      if (equalities.IsNormal())
-      {
-        var newSet = new Set<Expression>();
-        foreach (var v in equalities.Values)
+        public static INumericalAbstractDomain<Variable, Expression> AssumeInInterval<Variable, Expression>(
+          this INumericalAbstractDomain<Variable, Expression> aState,
+          Expression exp, Interval intv, IExpressionEncoder<Variable, Expression> encoder)
         {
-          newSet.Add(encoder.VariableFor(v));
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(intv != null);
+            Contract.Requires(encoder != null);
+
+            if (aState.IsBottom || intv.IsTop)
+            {
+                return aState;
+            }
+
+            if (intv.IsBottom)
+            {
+                return aState.Bottom as INumericalAbstractDomain<Variable, Expression>;
+            }
+
+            // a <= exp
+            if (!intv.LowerBound.IsInfinity)
+            {
+                aState = aState.TestTrueLessEqualThan(intv.LowerBound.ToExpression(encoder), exp);
+            }
+            // b <= exp
+            if (!intv.UpperBound.IsInfinity)
+            {
+                aState = aState.TestTrueLessEqualThan(exp, intv.UpperBound.ToExpression(encoder));
+            }
+
+            return aState;
         }
 
-        return aState.TestTrueEqual(exp, newSet);
-      }
-      else
-      {
-        return aState;
-      }
-    }
+        public static INumericalAbstractDomain<Variable, Expression> TestTrueEqual<Variable, Expression>(
+         this INumericalAbstractDomain<Variable, Expression> aState,
+         Expression exp, IEnumerable<Expression> uppBounds)
+        {
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(uppBounds != null);
 
-    public static INumericalAbstractDomain<Variable, Expression> TestTrueLessThan<Variable, Expression>(
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            if (aState.IsBottom)
+            {
+                return aState;
+            }
+
+            var result = aState;
+            foreach (var upp in uppBounds)
+            {
+                Contract.Assume(upp != null);
+                result = result.TestTrueEqual(exp, upp);
+            }
+
+            return result;
+        }
+
+        public static INumericalAbstractDomain<Variable, Expression> TestTrueEqual<Variable, Expression>(
+          this INumericalAbstractDomain<Variable, Expression> aState,
+          Expression exp, SetOfConstraints<Variable> equalities,
+          IExpressionEncoder<Variable, Expression> encoder)
+        {
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(equalities != null);
+            Contract.Requires(encoder != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            if (equalities.IsNormal())
+            {
+                var newSet = new Set<Expression>();
+                foreach (var v in equalities.Values)
+                {
+                    newSet.Add(encoder.VariableFor(v));
+                }
+
+                return aState.TestTrueEqual(exp, newSet);
+            }
+            else
+            {
+                return aState;
+            }
+        }
+
+        public static INumericalAbstractDomain<Variable, Expression> TestTrueLessThan<Variable, Expression>(
+          this INumericalAbstractDomain<Variable, Expression> aState,
+          Expression exp, IEnumerable<Expression> uppBounds)
+        {
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(uppBounds != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            if (aState.IsBottom)
+            {
+                return aState;
+            }
+
+            var result = aState;
+            foreach (var upp in uppBounds)
+            {
+                Contract.Assume(upp != null);
+                result = result.TestTrueLessThan(exp, upp);
+            }
+
+            return result;
+        }
+
+        public static INumericalAbstractDomain<Variable, Expression> TestTrueLessThan<Variable, Expression>(
+          this INumericalAbstractDomain<Variable, Expression> aState,
+          Expression exp, Set<Variable> uppBounds,
+          IExpressionEncoder<Variable, Expression> encoder)
+        {
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(uppBounds != null);
+            Contract.Requires(encoder != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            return aState.TestTrueLessThan(exp, uppBounds.ConvertAll(v => encoder.VariableFor(v)));
+        }
+
+        public static INumericalAbstractDomain<Variable, Expression> TestTrueLessThan<Variable, Expression>(
+        this INumericalAbstractDomain<Variable, Expression> aState,
+        Expression exp, SetOfConstraints<Variable> uppBounds,
+        IExpressionEncoder<Variable, Expression> encoder)
+        {
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(uppBounds != null);
+            Contract.Requires(encoder != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            if (uppBounds.IsNormal())
+            {
+                var newSet = new Set<Expression>();
+                foreach (var v in uppBounds.Values)
+                {
+                    newSet.Add(encoder.VariableFor(v));
+                }
+
+                return aState.TestTrueLessThan(exp, newSet);
+            }
+            else
+            {
+                return aState;
+            }
+        }
+
+        public static INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan<Variable, Expression>(
       this INumericalAbstractDomain<Variable, Expression> aState,
       Expression exp, IEnumerable<Expression> uppBounds)
-    {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(uppBounds != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      if (aState.IsBottom)
-      {
-        return aState;
-      }
-
-      var result = aState;
-      foreach (var upp in uppBounds)
-      {
-        Contract.Assume(upp != null);
-        result = result.TestTrueLessThan(exp, upp);
-      }
-
-      return result;
-    }
-
-    public static INumericalAbstractDomain<Variable, Expression> TestTrueLessThan<Variable, Expression>(
-      this INumericalAbstractDomain<Variable, Expression> aState,
-      Expression exp, Set<Variable> uppBounds,
-      IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(uppBounds != null);
-      Contract.Requires(encoder != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      return aState.TestTrueLessThan(exp, uppBounds.ConvertAll(v => encoder.VariableFor(v)));
-    }
-
-    public static INumericalAbstractDomain<Variable, Expression> TestTrueLessThan<Variable, Expression>(
-    this INumericalAbstractDomain<Variable, Expression> aState,
-    Expression exp, SetOfConstraints<Variable> uppBounds,
-    IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(uppBounds != null);
-      Contract.Requires(encoder != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      if(uppBounds.IsNormal())
-      {
-        var newSet = new Set<Expression>();
-        foreach (var v in uppBounds.Values)
         {
-          newSet.Add(encoder.VariableFor(v));
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(uppBounds != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            if (aState.IsBottom)
+            {
+                return aState;
+            }
+
+            var result = aState;
+            foreach (var upp in uppBounds)
+            {
+                Contract.Assume(upp != null);
+                result = result.TestTrueLessEqualThan(exp, upp);
+            }
+
+            return result;
         }
 
-        return aState.TestTrueLessThan(exp, newSet);
-      }
-      else
-      {
-        return aState;
-      }
-    }
-
-    public static INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan<Variable, Expression>(
-  this INumericalAbstractDomain<Variable, Expression> aState,
-  Expression exp, IEnumerable<Expression> uppBounds)
-    {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(uppBounds != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      if (aState.IsBottom)
-      {
-        return aState;
-      }
-
-      var result = aState;
-      foreach (var upp in uppBounds)
-      {
-        Contract.Assume(upp != null);
-        result = result.TestTrueLessEqualThan(exp, upp);
-      }
-
-      return result;
-    }
-
-    public static INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan<Variable, Expression>(
-    this INumericalAbstractDomain<Variable, Expression> aState,
-    Expression exp, SetOfConstraints<Variable> uppBounds,
-    IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(aState != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(uppBounds != null);
-      Contract.Requires(encoder != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      if (uppBounds.IsNormal())
-      {
-        var newSet = new Set<Expression>();
-        foreach (var v in uppBounds.Values)
+        public static INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan<Variable, Expression>(
+        this INumericalAbstractDomain<Variable, Expression> aState,
+        Expression exp, SetOfConstraints<Variable> uppBounds,
+        IExpressionEncoder<Variable, Expression> encoder)
         {
-          newSet.Add(encoder.VariableFor(v));
+            Contract.Requires(aState != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(uppBounds != null);
+            Contract.Requires(encoder != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            if (uppBounds.IsNormal())
+            {
+                var newSet = new Set<Expression>();
+                foreach (var v in uppBounds.Values)
+                {
+                    newSet.Add(encoder.VariableFor(v));
+                }
+
+                return aState.TestTrueLessEqualThan(exp, newSet);
+            }
+            else
+            {
+                return aState;
+            }
         }
 
-        return aState.TestTrueLessEqualThan(exp, newSet);
-      }
-      else
-      {
-        return aState;
-      }
-    }
-
-    public static INumericalAbstractDomain<Variable, Expression> TestTrue<Variable, Expression>(
-      this INumericalAbstractDomain<Variable, Expression> aState,
-      Variable v, NonRelationalValueAbstraction<Variable, Expression> nonRelationalValue,
-      IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(v != null);
-      Contract.Requires(aState != null);
-      Contract.Requires(nonRelationalValue != null);
-      Contract.Requires(encoder != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      if (nonRelationalValue.IsBottom)
-      {
-        Contract.Assume(aState.Bottom as INumericalAbstractDomain<Variable, Expression> != null); // F: Adding the assumption as we do not track types
-
-        return aState.Bottom as INumericalAbstractDomain<Variable, Expression>;
-      }
-
-      if (nonRelationalValue.IsTop)
-        return aState;
-
-      var result = aState;
-
-      // Assume the interval
-      if (nonRelationalValue.Interval.IsNormal())
-      {
-        result.AssumeInDisInterval(v, nonRelationalValue.Interval);
-      }
-
-      var vExp = encoder.VariableFor(v);
-
-      // Assume the equalities
-      if (nonRelationalValue.Equalities.IsNormal())
-      {
-        result = result.TestTrueEqual(vExp, nonRelationalValue.Equalities, encoder);
-      }
-
-      // Assume the strict upper bounds
-      if (nonRelationalValue.StrictUpperBounds.IsNormal())
-      {
-        result = result.TestTrueLessThan(vExp, nonRelationalValue.StrictUpperBounds, encoder);
-      }
-
-      // Assume the weak upper bounds
-      if (nonRelationalValue.WeakUpperBounds.IsNormal())      
-      {
-        result = result.TestTrueLessEqualThan(vExp, nonRelationalValue.WeakUpperBounds, encoder);
-      }
-
-      return result;
-    }
-  }
-
-  [ContractVerification(true)]
-  public static class INumericalAbstractDomainQueryExtensions
-  {
-    /// <summary>
-    /// Checks if <code>e1 leq e2</code> using CheckLessThan of <code>dom</code>
-    /// </summary>
-    public static FlatAbstractDomain<bool> HelperForCheckLessEqualThan<Variable, Expression>(
-      this INumericalAbstractDomainQuery<Variable, Expression> dom, Expression  e1, Expression e2)
-    {
-      Contract.Requires(dom != null);
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-      
-      var result = dom.CheckIfLessThan(e1, e2);
-
-      if (!result.IsNormal() || result.BoxedElement)
-      {
-        return result;
-      }
-      else // if (result.BoxedElement == false)
-      {
-        return CheckOutcome.Top;
-      }
-    }
-  }
-
-  [ContractVerification(true)]
-  public static class SetOfConstraintsExtensions
-  {
-    [Pure]
-    [SuppressMessage("Microsoft.Contracts", "Requires-30-36")]
-    public static bool IsSingleton<El>(this SetOfConstraints<El> constraints, out El value)
-    {
-      if (constraints == null || !constraints.IsNormal() || constraints.Count < 1)
-      {
-        value = default(El);
-        return false;
-      }
-
-      value = constraints.Values.First();
-
-      return true;
-    }
-
-  }
-
-  [ContractVerification(true)]
-  public static class ArrayExtension
-  {
-    public static T[] Duplicate<T>(this T[] original)
-    {
-      if (original == null)
-        return original;
-
-      var result = new T[original.Length];
-      Array.Copy(original, result, original.Length);
-
-      return result;
-    }
-
-    public static int CountNotNull<T>(this T[] original)
-      where T : class
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      Contract.Ensures(original == null || Contract.Result<int>() <= original.Length);
-
-      if (original == null)
-      {
-        return 0;
-      }
-      int count = 0;
-      foreach (var x in original)
-      {
-        if (x != null) count++;
-      }
-
-      return count;
-    }
-
-    public static bool TryGetValue<Key, Value>(this Tuple<Key, Value>[] original, Key k, out Value v)
-    {
-      if (original == null)
-      {
-        v = default(Value);
-        return false;
-      }
-
-      foreach (var x in original)
-      {
-        if (x != null)
+        public static INumericalAbstractDomain<Variable, Expression> TestTrue<Variable, Expression>(
+          this INumericalAbstractDomain<Variable, Expression> aState,
+          Variable v, NonRelationalValueAbstraction<Variable, Expression> nonRelationalValue,
+          IExpressionEncoder<Variable, Expression> encoder)
         {
-          if(x.Item1.Equals(k))
-          {
-            v = x.Item2;
+            Contract.Requires(v != null);
+            Contract.Requires(aState != null);
+            Contract.Requires(nonRelationalValue != null);
+            Contract.Requires(encoder != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            if (nonRelationalValue.IsBottom)
+            {
+                Contract.Assume(aState.Bottom as INumericalAbstractDomain<Variable, Expression> != null); // F: Adding the assumption as we do not track types
+
+                return aState.Bottom as INumericalAbstractDomain<Variable, Expression>;
+            }
+
+            if (nonRelationalValue.IsTop)
+                return aState;
+
+            var result = aState;
+
+            // Assume the interval
+            if (nonRelationalValue.Interval.IsNormal())
+            {
+                result.AssumeInDisInterval(v, nonRelationalValue.Interval);
+            }
+
+            var vExp = encoder.VariableFor(v);
+
+            // Assume the equalities
+            if (nonRelationalValue.Equalities.IsNormal())
+            {
+                result = result.TestTrueEqual(vExp, nonRelationalValue.Equalities, encoder);
+            }
+
+            // Assume the strict upper bounds
+            if (nonRelationalValue.StrictUpperBounds.IsNormal())
+            {
+                result = result.TestTrueLessThan(vExp, nonRelationalValue.StrictUpperBounds, encoder);
+            }
+
+            // Assume the weak upper bounds
+            if (nonRelationalValue.WeakUpperBounds.IsNormal())
+            {
+                result = result.TestTrueLessEqualThan(vExp, nonRelationalValue.WeakUpperBounds, encoder);
+            }
+
+            return result;
+        }
+    }
+
+    [ContractVerification(true)]
+    public static class INumericalAbstractDomainQueryExtensions
+    {
+        /// <summary>
+        /// Checks if <code>e1 leq e2</code> using CheckLessThan of <code>dom</code>
+        /// </summary>
+        public static FlatAbstractDomain<bool> HelperForCheckLessEqualThan<Variable, Expression>(
+          this INumericalAbstractDomainQuery<Variable, Expression> dom, Expression e1, Expression e2)
+        {
+            Contract.Requires(dom != null);
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            var result = dom.CheckIfLessThan(e1, e2);
+
+            if (!result.IsNormal() || result.BoxedElement)
+            {
+                return result;
+            }
+            else // if (result.BoxedElement == false)
+            {
+                return CheckOutcome.Top;
+            }
+        }
+    }
+
+    [ContractVerification(true)]
+    public static class SetOfConstraintsExtensions
+    {
+        [Pure]
+        [SuppressMessage("Microsoft.Contracts", "Requires-30-36")]
+        public static bool IsSingleton<El>(this SetOfConstraints<El> constraints, out El value)
+        {
+            if (constraints == null || !constraints.IsNormal() || constraints.Count < 1)
+            {
+                value = default(El);
+                return false;
+            }
+
+            value = constraints.Values.First();
+
             return true;
-          }
         }
-      }
-
-      v = default(Value);
-      return false;
     }
 
-    public static bool ContainsKey<Key, Value>(this Tuple<Key, Value>[] original, Key k)
+    [ContractVerification(true)]
+    public static class ArrayExtension
     {
-      if (original == null)
-        return false;
-      foreach (var x in original)
-      {
-        if (x != null)
+        public static T[] Duplicate<T>(this T[] original)
         {
-          if (x.Item1.Equals(k))
-          {
-            return true;
-          }
+            if (original == null)
+                return original;
+
+            var result = new T[original.Length];
+            Array.Copy(original, result, original.Length);
+
+            return result;
         }
-      }
 
-      return false;
-    }
-
-    public static bool Remove<Key, Value>(this Tuple<Key, Value>[] original, Key k)
-    {
-      if (original == null)
-        return false;
-      for (var i = 0; i < original.Length; i++)
-      {
-        var item = original[i];
-        if (item != null)
+        public static int CountNotNull<T>(this T[] original)
+          where T : class
         {
-          if (item.Item1.Equals(k))
-          {
-            original[i] = null;
-            return true;
-          }
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            Contract.Ensures(original == null || Contract.Result<int>() <= original.Length);
+
+            if (original == null)
+            {
+                return 0;
+            }
+            int count = 0;
+            foreach (var x in original)
+            {
+                if (x != null) count++;
+            }
+
+            return count;
         }
-      }
 
-      return false;
-    }
-
-    public static Tuple<Key, Value>[] Add<Key, Value>(this Tuple<Key, Value>[] original, Key key, Value v)
-    {
-      var newValue = new Tuple<Key, Value>(key, v);
-
-      if (original == null)
-      {
-        return new Tuple<Key, Value>[] { newValue };
-      }
-
-      var firstNullIndex = -1;
-      for (var i = 0; i < original.Length; i++)
-      {
-        var item = original[i];
-        if (item != null)
+        public static bool TryGetValue<Key, Value>(this Tuple<Key, Value>[] original, Key k, out Value v)
         {
-          if (item.Item1.Equals(key))
-          {
-            original[i] = newValue;
+            if (original == null)
+            {
+                v = default(Value);
+                return false;
+            }
+
+            foreach (var x in original)
+            {
+                if (x != null)
+                {
+                    if (x.Item1.Equals(k))
+                    {
+                        v = x.Item2;
+                        return true;
+                    }
+                }
+            }
+
+            v = default(Value);
+            return false;
+        }
+
+        public static bool ContainsKey<Key, Value>(this Tuple<Key, Value>[] original, Key k)
+        {
+            if (original == null)
+                return false;
+            foreach (var x in original)
+            {
+                if (x != null)
+                {
+                    if (x.Item1.Equals(k))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool Remove<Key, Value>(this Tuple<Key, Value>[] original, Key k)
+        {
+            if (original == null)
+                return false;
+            for (var i = 0; i < original.Length; i++)
+            {
+                var item = original[i];
+                if (item != null)
+                {
+                    if (item.Item1.Equals(k))
+                    {
+                        original[i] = null;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static Tuple<Key, Value>[] Add<Key, Value>(this Tuple<Key, Value>[] original, Key key, Value v)
+        {
+            var newValue = new Tuple<Key, Value>(key, v);
+
+            if (original == null)
+            {
+                return new Tuple<Key, Value>[] { newValue };
+            }
+
+            var firstNullIndex = -1;
+            for (var i = 0; i < original.Length; i++)
+            {
+                var item = original[i];
+                if (item != null)
+                {
+                    if (item.Item1.Equals(key))
+                    {
+                        original[i] = newValue;
+
+                        return original;
+                    }
+                }
+                else if (firstNullIndex < 0)
+                {
+                    firstNullIndex = i;
+                }
+            }
+
+            if (firstNullIndex >= 0)
+            {
+                original[firstNullIndex] = newValue;
+                return original;
+            }
+
+            var result = original.Resize(1);
+            result[result.Length - 1] = newValue;
+
+            return result;
+        }
+
+        public static Tuple<Key, Value>[] Resize<Key, Value>(this Tuple<Key, Value>[] original, int length)
+        {
+            Contract.Requires(length >= 0);
+            Contract.Ensures(Contract.Result<Tuple<Key, Value>[]>().Length >= length);
+
+            if (original == null)
+            {
+                return new Tuple<Key, Value>[length];
+            }
+
+            Array.Resize(ref original, original.Length + length);
 
             return original;
-          }
-        }
-        else if (firstNullIndex < 0)
-        {
-          firstNullIndex = i;
-        }
-      }
-
-      if (firstNullIndex >= 0)
-      {
-        original[firstNullIndex] = newValue;
-        return original;
-      }
-
-      var result = original.Resize(1);
-      result[result.Length - 1] = newValue;
-
-      return result;
-    }
-
-    public static Tuple<Key, Value>[] Resize<Key, Value>(this Tuple<Key, Value>[] original, int length)
-    {
-      Contract.Requires(length >= 0);
-      Contract.Ensures(Contract.Result<Tuple<Key, Value>[]>().Length >= length);
-
-      if (original == null)
-      {
-        return new Tuple<Key, Value>[length];
-      }
-
-      Array.Resize(ref original, original.Length + length);
-
-      return original;
-    }
-
-    public static string ToStringInDepth<T>(this T[] arr)
-    {
-      Contract.Requires(arr != null);
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      var result = new StringBuilder();
-
-      result.Append("[");
-      for (var i = 0; i < arr.Length; i++)
-      {
-        var el = arr[i];
-        result.Append((el == null ? "<null>" : el.ToString()) + " ");
-      }
-      result.Append("]");
-
-      return result.ToString();
-    }
-  }
-
-  [ContractVerification(true)]  
-  public static class DictionaryExtensions
-  {
-    public static bool IsIdentityMap<Variable>(this Dictionary<Variable, FList<Variable>> map)
-    {
-      if (map == null || map.Count == 0)
-        return true;
-
-      foreach (var pair in map)
-      {
-        Contract.Assume(pair.Value != null);
-        if (pair.Value.Length() != 1)
-        {
-          return false;
-        }
-        var val = pair.Value.Head;
-        if (!pair.Key.Equals(val))
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    public static void Add<T, V>(this Dictionary<T, List<V>> dictionary, T key, V value)
-    {
-      Contract.Requires(dictionary != null);
-
-      List<V> list;
-      if (!dictionary.TryGetValue(key, out list))
-      {
-        list = new List<V>();
-      }
-      else
-      {
-        Contract.Assume(list != null);
-      }
-      list.Add(value);
-      dictionary[key] = list;
-    }
-  }
-
-  [ContractVerification(true)]
-  public static class ListExtensions
-  {
-    public static List<T> SetUnion<T>(this List<T> me, List<T> other)
-    {
-      Contract.Requires(me != null);
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<List<T>>() != null);
-
-      if (me.Count == 0)
-        return other;
-
-      if (other.Count == 0)
-        return me;
-
-      var tmp = new Set<T>(me);
-      tmp.AddRange(other);
-
-      return tmp.ToList();
-    }
-
-    public static List<T> SetIntersection<T>(this List<T> me, List<T> other)
-    {
-      Contract.Requires(me != null);
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<List<T>>() != null);
-
-      if (me.Count == 0)
-      {
-        return me;
-      }
-
-      if (other.Count == 0)
-      {
-        return other;
-      }
-
-      var tmp = new Set<T>(me);
-      tmp = tmp.Intersection(other);
-
-      return tmp.ToList();
-    }
-
-    public static List<T> SetDifference<T>(this List<T> me, List<T> other)
-    {
-      Contract.Requires(me != null);
-      Contract.Requires(other != null);
-
-      Contract.Ensures(Contract.Result<List<T>>() != null);
-
-      if (me.Count == 0 || other.Count == 0)
-      {
-        return me;
-      }
-
-      var tmp = new Set<T>(me);
-      tmp = tmp.Difference(new Set<T>(other));
-
-      return tmp.ToList();
-    }
-
-    static public void Add<A, B>(this List<Pair<A, B>> list, A a, B b)
-    {
-      Contract.Requires(list != null);
-
-      Contract.Ensures(list.Count == Contract.OldValue(list.Count) + 1);
-
-      list.Add(new Pair<A, B>(a, b));
-    }
-
-    static public void AddIfNotNull<A, B>(this List<PairNonNull<A, B>> list, A a, B b)
-      where A: class
-      where B: class
-    {
-      Contract.Requires(list != null);
-
-      Contract.Ensures(list.Count <= Contract.OldValue(list.Count) + 1);
-      Contract.Ensures(list.Count >= Contract.OldValue(list.Count));
-
-      if (a != null && b != null)
-      {
-        list.Add(new PairNonNull<A, B>(a, b));
-      }
-    }
-
-    static public bool SearchAndRemoveIfFound<A, B>(this List<Pair<A, B>> values, A key, out B value)
-    {
-      Contract.Requires(values != null);
-
-      for (int i = 0; i < values.Count; i++)
-      {
-        var currVal = values[i];
-        if (currVal.One.Equals(key))
-        {
-          value = currVal.Two;
-          values.RemoveAt(i);
-
-          return true;
-        }
-      }
-
-      value = default(B);
-      return false;
-    }
-
-    static public List<List<T>> DeepCopy<T>(this List<List<T>> elements)
-    {
-      Contract.Requires(elements != null);
-
-      var result = new List<List<T>>(elements.Count);
-
-      foreach (var bucket in elements)
-      {
-        result.Add(new List<T>(bucket));
-      }
-
-      return result;
-    }
-  }
-
-  [ContractVerification(true)]
-  public static class IExpressionDecoderExtensions
-  {
-    [Pure]
-    public static bool IsInfinity<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
-    {
-      Contract.Requires(decoder != null);
-      Contract.Requires(exp != null);
-
-      if (decoder.IsConstant(exp))
-      {
-        var value = decoder.Constant(exp);
-        if (value is Double)
-        {
-          return Double.IsInfinity((Double)value);
-        }
-        if (value is Single)
-        {
-          return Single.IsInfinity((Single)value);
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static bool IsPositiveInfinity<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
-    {
-      Contract.Requires(decoder != null);
-      Contract.Requires(exp != null);
-
-      if (decoder.IsConstant(exp))
-      {
-        var value = decoder.Constant(exp);
-        if (value is Double)
-        {
-          return Double.IsPositiveInfinity((Double)value);
-        }
-        if (value is Single)
-        {
-          return Single.IsPositiveInfinity((Single)value);
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static bool IsNegativeInfinity<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
-    {
-      Contract.Requires(decoder != null);
-      Contract.Requires(exp != null);
-
-      if (decoder.IsConstant(exp))
-      {
-        var value = decoder.Constant(exp);
-        if (value is Double)
-        {
-          return Double.IsNegativeInfinity((Double)value);
-        }
-        if (value is Single)
-        {
-          return Single.IsNegativeInfinity((Single)value);
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static bool TryMatchVarPlusConst<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder,
-      Expression exp, out Variable var, out int k)
-    {
-      Contract.Requires(decoder != null);
-
-      if (decoder.IsBinaryExpression(exp) && decoder.OperatorFor(exp) == ExpressionOperator.Addition)
-      {
-        var left = decoder.LeftExpressionFor(exp);
-        var right = decoder.RightExpressionFor(exp);
-
-        if (decoder.IsConstantInt(left, out k) && decoder.IsVariable(right))
-        {
-          var = decoder.UnderlyingVariable(right);
-
-          return true;
         }
 
-        if (decoder.IsConstantInt(right, out k) && decoder.IsVariable(left))
+        public static string ToStringInDepth<T>(this T[] arr)
         {
-          var = decoder.UnderlyingVariable(left);
+            Contract.Requires(arr != null);
+            Contract.Ensures(Contract.Result<string>() != null);
 
-          return true;
+            var result = new StringBuilder();
+
+            result.Append("[");
+            for (var i = 0; i < arr.Length; i++)
+            {
+                var el = arr[i];
+                result.Append((el == null ? "<null>" : el.ToString()) + " ");
+            }
+            result.Append("]");
+
+            return result.ToString();
         }
-      }
-
-      var = default(Variable);
-      k = default(int);
-      return false;
     }
 
-    public static bool IsAtomicExpression<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
+    [ContractVerification(true)]
+    public static class DictionaryExtensions
     {
-      Contract.Requires(decoder != null);
-
-      return decoder.IsConstant(exp) || decoder.IsVariable(exp);
-    }
-
-      /// <summary>
-      /// See if one can match the expression "left == right" with the expression "(e11 op e12) == 0", where op is a relational operator
-      /// </summary>
-      public static bool Match_E1relopE2eq0<Variable, Expression>(
-        this IExpressionDecoder<Variable, Expression> decoder,
-        Expression e1, Expression e2,
-        out ExpressionOperator op, out Expression e11, out Expression e12)
-      {
-        Contract.Requires(decoder != null);
-
-        Int32 value;
-
-        if (decoder.IsConstantInt(e2, out value) && value == 0)
+        public static bool IsIdentityMap<Variable>(this Dictionary<Variable, FList<Variable>> map)
         {
-          op = decoder.OperatorFor(e1);
-          if (op.IsRelationalOperator())
-          {
-            e11 = decoder.LeftExpressionFor(e1);
-            e12 = decoder.RightExpressionFor(e1);
+            if (map == null || map.Count == 0)
+                return true;
+
+            foreach (var pair in map)
+            {
+                Contract.Assume(pair.Value != null);
+                if (pair.Value.Length() != 1)
+                {
+                    return false;
+                }
+                var val = pair.Value.Head;
+                if (!pair.Key.Equals(val))
+                {
+                    return false;
+                }
+            }
+
             return true;
-          }
         }
 
-        op = default(ExpressionOperator);
-        e11 = e12 = default(Expression);
-
-        return false;
-      }
-
-      public static bool Match_E1aritopE2eq0<Variable, Expression>(
-        this IExpressionDecoder<Variable, Expression> decoder,
-        Expression e1, Expression e2,
-        out ExpressionOperator op, out Expression e11, out Expression e12)
-      {
-        Contract.Requires(decoder != null);
-
-        Int32 value;
-        if (decoder.IsConstantInt(e2, out value) && value == 0)
+        public static void Add<T, V>(this Dictionary<T, List<V>> dictionary, T key, V value)
         {
-          op = decoder.OperatorFor(e1);
-          if (op.Equals(ExpressionOperator.Addition) || op.Equals(ExpressionOperator.Subtraction))
-          {
-            e11 = decoder.LeftExpressionFor(e1);
-            e12 = decoder.RightExpressionFor(e1);
-            return true;
-          }
+            Contract.Requires(dictionary != null);
+
+            List<V> list;
+            if (!dictionary.TryGetValue(key, out list))
+            {
+                list = new List<V>();
+            }
+            else
+            {
+                Contract.Assume(list != null);
+            }
+            list.Add(value);
+            dictionary[key] = list;
+        }
+    }
+
+    [ContractVerification(true)]
+    public static class ListExtensions
+    {
+        public static List<T> SetUnion<T>(this List<T> me, List<T> other)
+        {
+            Contract.Requires(me != null);
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<List<T>>() != null);
+
+            if (me.Count == 0)
+                return other;
+
+            if (other.Count == 0)
+                return me;
+
+            var tmp = new Set<T>(me);
+            tmp.AddRange(other);
+
+            return tmp.ToList();
         }
 
-        op = default(ExpressionOperator);
-        e11 = e12 = default(Expression);
+        public static List<T> SetIntersection<T>(this List<T> me, List<T> other)
+        {
+            Contract.Requires(me != null);
+            Contract.Requires(other != null);
 
-        return false;
-      }
-  }
+            Contract.Ensures(Contract.Result<List<T>>() != null);
 
-  [ContractVerification(true)]
-  public static class IExpressionEncoderExtensions
-  {
-    /// <summary>
-    /// Construct left - right, or left iff right == 0
-    /// </summary>
-    public static Expression SmartSubtraction<Variable, Expression>(this IExpressionEncoder<Variable, Expression> encoder,
-      Expression left, Expression right, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(decoder != null);
-      Contract.Requires(encoder != null);
+            if (me.Count == 0)
+            {
+                return me;
+            }
 
-      int value;
-      if (decoder.IsConstantInt(right, out value) && value == 0)
-      {
-        return left;
-      }
+            if (other.Count == 0)
+            {
+                return other;
+            }
 
-      return encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
+            var tmp = new Set<T>(me);
+            tmp = tmp.Intersection(other);
+
+            return tmp.ToList();
+        }
+
+        public static List<T> SetDifference<T>(this List<T> me, List<T> other)
+        {
+            Contract.Requires(me != null);
+            Contract.Requires(other != null);
+
+            Contract.Ensures(Contract.Result<List<T>>() != null);
+
+            if (me.Count == 0 || other.Count == 0)
+            {
+                return me;
+            }
+
+            var tmp = new Set<T>(me);
+            tmp = tmp.Difference(new Set<T>(other));
+
+            return tmp.ToList();
+        }
+
+        static public void Add<A, B>(this List<Pair<A, B>> list, A a, B b)
+        {
+            Contract.Requires(list != null);
+
+            Contract.Ensures(list.Count == Contract.OldValue(list.Count) + 1);
+
+            list.Add(new Pair<A, B>(a, b));
+        }
+
+        static public void AddIfNotNull<A, B>(this List<PairNonNull<A, B>> list, A a, B b)
+          where A : class
+          where B : class
+        {
+            Contract.Requires(list != null);
+
+            Contract.Ensures(list.Count <= Contract.OldValue(list.Count) + 1);
+            Contract.Ensures(list.Count >= Contract.OldValue(list.Count));
+
+            if (a != null && b != null)
+            {
+                list.Add(new PairNonNull<A, B>(a, b));
+            }
+        }
+
+        static public bool SearchAndRemoveIfFound<A, B>(this List<Pair<A, B>> values, A key, out B value)
+        {
+            Contract.Requires(values != null);
+
+            for (int i = 0; i < values.Count; i++)
+            {
+                var currVal = values[i];
+                if (currVal.One.Equals(key))
+                {
+                    value = currVal.Two;
+                    values.RemoveAt(i);
+
+                    return true;
+                }
+            }
+
+            value = default(B);
+            return false;
+        }
+
+        static public List<List<T>> DeepCopy<T>(this List<List<T>> elements)
+        {
+            Contract.Requires(elements != null);
+
+            var result = new List<List<T>>(elements.Count);
+
+            foreach (var bucket in elements)
+            {
+                result.Add(new List<T>(bucket));
+            }
+
+            return result;
+        }
     }
 
-    /// <summary>
-    /// Construct left - right, or left iff right == 0
-    /// </summary>
-    public static Expression SmartSubtraction<Variable, Expression>(this IExpressionEncoder<Variable, Expression> encoder,
-      Variable leftVar, Variable rightVar, IExpressionDecoder<Variable, Expression> decoder)
+    [ContractVerification(true)]
+    public static class IExpressionDecoderExtensions
     {
-      Contract.Requires(decoder != null);
-      Contract.Requires(encoder != null);
+        [Pure]
+        public static bool IsInfinity<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(exp != null);
 
-      var right = encoder.VariableFor(rightVar);
-      var left = encoder.VariableFor(leftVar);
+            if (decoder.IsConstant(exp))
+            {
+                var value = decoder.Constant(exp);
+                if (value is Double)
+                {
+                    return Double.IsInfinity((Double)value);
+                }
+                if (value is Single)
+                {
+                    return Single.IsInfinity((Single)value);
+                }
+            }
 
-      int value;
-      if (decoder.IsConstantInt(right, out value) && value == 0)
-      {
-        return left;
-      }
+            return false;
+        }
 
-      return encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
+        [Pure]
+        public static bool IsPositiveInfinity<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(exp != null);
+
+            if (decoder.IsConstant(exp))
+            {
+                var value = decoder.Constant(exp);
+                if (value is Double)
+                {
+                    return Double.IsPositiveInfinity((Double)value);
+                }
+                if (value is Single)
+                {
+                    return Single.IsPositiveInfinity((Single)value);
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        public static bool IsNegativeInfinity<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(exp != null);
+
+            if (decoder.IsConstant(exp))
+            {
+                var value = decoder.Constant(exp);
+                if (value is Double)
+                {
+                    return Double.IsNegativeInfinity((Double)value);
+                }
+                if (value is Single)
+                {
+                    return Single.IsNegativeInfinity((Single)value);
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        public static bool TryMatchVarPlusConst<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder,
+          Expression exp, out Variable var, out int k)
+        {
+            Contract.Requires(decoder != null);
+
+            if (decoder.IsBinaryExpression(exp) && decoder.OperatorFor(exp) == ExpressionOperator.Addition)
+            {
+                var left = decoder.LeftExpressionFor(exp);
+                var right = decoder.RightExpressionFor(exp);
+
+                if (decoder.IsConstantInt(left, out k) && decoder.IsVariable(right))
+                {
+                    var = decoder.UnderlyingVariable(right);
+
+                    return true;
+                }
+
+                if (decoder.IsConstantInt(right, out k) && decoder.IsVariable(left))
+                {
+                    var = decoder.UnderlyingVariable(left);
+
+                    return true;
+                }
+            }
+
+            var = default(Variable);
+            k = default(int);
+            return false;
+        }
+
+        public static bool IsAtomicExpression<Variable, Expression>(this IExpressionDecoder<Variable, Expression> decoder, Expression exp)
+        {
+            Contract.Requires(decoder != null);
+
+            return decoder.IsConstant(exp) || decoder.IsVariable(exp);
+        }
+
+        /// <summary>
+        /// See if one can match the expression "left == right" with the expression "(e11 op e12) == 0", where op is a relational operator
+        /// </summary>
+        public static bool Match_E1relopE2eq0<Variable, Expression>(
+          this IExpressionDecoder<Variable, Expression> decoder,
+          Expression e1, Expression e2,
+          out ExpressionOperator op, out Expression e11, out Expression e12)
+        {
+            Contract.Requires(decoder != null);
+
+            Int32 value;
+
+            if (decoder.IsConstantInt(e2, out value) && value == 0)
+            {
+                op = decoder.OperatorFor(e1);
+                if (op.IsRelationalOperator())
+                {
+                    e11 = decoder.LeftExpressionFor(e1);
+                    e12 = decoder.RightExpressionFor(e1);
+                    return true;
+                }
+            }
+
+            op = default(ExpressionOperator);
+            e11 = e12 = default(Expression);
+
+            return false;
+        }
+
+        public static bool Match_E1aritopE2eq0<Variable, Expression>(
+          this IExpressionDecoder<Variable, Expression> decoder,
+          Expression e1, Expression e2,
+          out ExpressionOperator op, out Expression e11, out Expression e12)
+        {
+            Contract.Requires(decoder != null);
+
+            Int32 value;
+            if (decoder.IsConstantInt(e2, out value) && value == 0)
+            {
+                op = decoder.OperatorFor(e1);
+                if (op.Equals(ExpressionOperator.Addition) || op.Equals(ExpressionOperator.Subtraction))
+                {
+                    e11 = decoder.LeftExpressionFor(e1);
+                    e12 = decoder.RightExpressionFor(e1);
+                    return true;
+                }
+            }
+
+            op = default(ExpressionOperator);
+            e11 = e12 = default(Expression);
+
+            return false;
+        }
     }
-  }
 
-  [ContractVerification(true)]
-  public static class NormalizedExpressionsExtensions
-  {
-    [Pure]
-    public static string PrettyPrint<Variable>(this NormalizedExpression<Variable> exp, Func<Variable, string> variableNamePrettyPrinter)
+    [ContractVerification(true)]
+    public static class IExpressionEncoderExtensions
     {
-      Contract.Requires(exp != null);
-      Contract.Requires(variableNamePrettyPrinter != null);
+        /// <summary>
+        /// Construct left - right, or left iff right == 0
+        /// </summary>
+        public static Expression SmartSubtraction<Variable, Expression>(this IExpressionEncoder<Variable, Expression> encoder,
+          Expression left, Expression right, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(encoder != null);
 
-      Variable x;
-      int k;
-      if (exp.IsConstant(out k))
-      {
-        return k.ToString();
-      }
-      else if (exp.IsVariable(out x))
-      {
-        return variableNamePrettyPrinter(x);
-      }
-      else if (exp.IsAddition(out x, out k))
-      {
-        return variableNamePrettyPrinter(x) + " + " + k.ToString();
-      }
-      return null;
+            int value;
+            if (decoder.IsConstantInt(right, out value) && value == 0)
+            {
+                return left;
+            }
+
+            return encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
+        }
+
+        /// <summary>
+        /// Construct left - right, or left iff right == 0
+        /// </summary>
+        public static Expression SmartSubtraction<Variable, Expression>(this IExpressionEncoder<Variable, Expression> encoder,
+          Variable leftVar, Variable rightVar, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(encoder != null);
+
+            var right = encoder.VariableFor(rightVar);
+            var left = encoder.VariableFor(leftVar);
+
+            int value;
+            if (decoder.IsConstantInt(right, out value) && value == 0)
+            {
+                return left;
+            }
+
+            return encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
+        }
     }
-  }
 
-  [ContractVerification(true)]
-  public static class ExpressionOperatorExtensions
-  {
-    private readonly static Set<ExpressionOperator> relationalOperators;
-
-    static ExpressionOperatorExtensions()
+    [ContractVerification(true)]
+    public static class NormalizedExpressionsExtensions
     {
-      relationalOperators = new Set<ExpressionOperator>{
-          ExpressionOperator.Equal, 
+        [Pure]
+        public static string PrettyPrint<Variable>(this NormalizedExpression<Variable> exp, Func<Variable, string> variableNamePrettyPrinter)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(variableNamePrettyPrinter != null);
+
+            Variable x;
+            int k;
+            if (exp.IsConstant(out k))
+            {
+                return k.ToString();
+            }
+            else if (exp.IsVariable(out x))
+            {
+                return variableNamePrettyPrinter(x);
+            }
+            else if (exp.IsAddition(out x, out k))
+            {
+                return variableNamePrettyPrinter(x) + " + " + k.ToString();
+            }
+            return null;
+        }
+    }
+
+    [ContractVerification(true)]
+    public static class ExpressionOperatorExtensions
+    {
+        private readonly static Set<ExpressionOperator> relationalOperators;
+
+        static ExpressionOperatorExtensions()
+        {
+            relationalOperators = new Set<ExpressionOperator>{
+          ExpressionOperator.Equal,
           ExpressionOperator.Equal_Obj,
           ExpressionOperator.GreaterEqualThan, ExpressionOperator.GreaterEqualThan_Un,
-          ExpressionOperator.GreaterThan, ExpressionOperator.GreaterThan_Un, 
-          ExpressionOperator.LessEqualThan, ExpressionOperator.LessEqualThan_Un, 
-          ExpressionOperator.LessThan, ExpressionOperator.LessThan_Un, 
+          ExpressionOperator.GreaterThan, ExpressionOperator.GreaterThan_Un,
+          ExpressionOperator.LessEqualThan, ExpressionOperator.LessEqualThan_Un,
+          ExpressionOperator.LessThan, ExpressionOperator.LessThan_Un,
           ExpressionOperator.NotEqual };
-    }
-
-    /// <returns>true iff <code>op</code> is a constant or a variable</returns>
-    [Pure]
-    public static bool IsZerary(this ExpressionOperator op)
-    {
-      Contract.Ensures(Contract.Result<bool>() == ((op == ExpressionOperator.Constant) || (op == ExpressionOperator.Variable)));
-
-      return (op == ExpressionOperator.Constant) || (op == ExpressionOperator.Variable);
-    }
-
-    /// <returns>true iff <code>op</code> is an unary operator</returns>
-    [Pure]
-    public static bool IsUnary(this ExpressionOperator op)
-    {
-      Contract.Ensures(Contract.Result<bool>() == ((op == ExpressionOperator.UnaryMinus) || (op == ExpressionOperator.Not)));
-
-      return (op == ExpressionOperator.UnaryMinus) || (op == ExpressionOperator.Not);
-    }
-
-    /// <returns>true iff op is a Binary operator</returns>
-    [Pure]
-    public static bool IsBinary(this ExpressionOperator op)
-    {
-      Contract.Ensures(Contract.Result<bool>() == (!IsUnary(op) && !IsZerary(op)));
-
-      return !IsUnary(op) && !IsZerary(op);
-    }
-
-    /// <returns>true iff <code>is a relational operator</code></returns>
-    [Pure]
-    public static bool IsRelationalOperator(this ExpressionOperator op)
-    {
-      return relationalOperators.Contains(op);
-    }
-
-    /// <returns>true iff <code>e</code> is the constant true</returns>
-    [Pure]
-    public static bool IsConstantTrue<Variable, Expression>(Expression e, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(decoder != null);
-
-      return IsConstantTrueOrFalse(e, true, decoder);
-    }
-
-    /// <returns>true iff <code>e</code> is the constant true</returns>
-    [Pure]
-    public static bool IsConstantFalse<Variable, Expression>(Expression e, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(decoder != null);
-
-      return IsConstantTrueOrFalse(e, false, decoder);
-    }
-
-    [Pure]
-    public static bool IsConversionOperator(this ExpressionOperator op)
-    {
-      return (op == ExpressionOperator.ConvertToInt32 || op == ExpressionOperator.ConvertToUInt8
-        || op == ExpressionOperator.ConvertToUInt16 || op == ExpressionOperator.ConvertToUInt32
-        || op == ExpressionOperator.ConvertToFloat32 || op == ExpressionOperator.ConvertToFloat64);
-    }
-
-    /// <returns>op == ExpressionOperator.LessThan || op == ExpressionOperator.LessThan_Un</returns>
-    [Pure]
-    public static bool IsLessThan(this ExpressionOperator op)
-    {
-      return op == ExpressionOperator.LessThan || op == ExpressionOperator.LessThan_Un;
-    }
-
-    /// <returns>op == ExpressionOperator.LessEqualThan || op == ExpressionOperator.LessEqualThan_Un</returns>
-    [Pure]
-    public static bool IsLessEqualThan(this ExpressionOperator op)
-    {
-      return op == ExpressionOperator.LessEqualThan || op == ExpressionOperator.LessEqualThan_Un;
-    }
-
-    /// <returns>op == ExpressionOperator.GreaterThan || op == ExpressionOperator.GreaterThan_Un</returns>
-    [Pure]
-    public static bool IsGreaterThan(this ExpressionOperator op)
-    {
-      return op == ExpressionOperator.GreaterThan || op == ExpressionOperator.GreaterThan_Un;
-    }
-
-    /// <returns>op == ExpressionOperator.GreaterEqualThan || op == ExpressionOperator.GreaterEqualThan_Un</returns>
-    [Pure]
-    public static bool IsGreaterEqualThan(this ExpressionOperator op)
-    {
-      return op == ExpressionOperator.GreaterEqualThan || op == ExpressionOperator.GreaterEqualThan_Un;
-    }
-
-    #region Private methods
-
-    private static bool IsConstantTrueOrFalse<Variable, Expression>(
-      Expression e, bool t, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(decoder != null);
-
-      bool boolValue;
-      Int32 intValue;
-
-      if (decoder.IsConstant(e))
-      {
-        if (decoder.TryValueOf<bool>(e, ExpressionType.Bool, out boolValue))
-        {
-          return boolValue == t;
-        }
-        else if (decoder.IsConstantInt(e, out intValue))
-        {
-          return (intValue != 0) == t;
-        }
-        else
-        {
-          return false;
-        }
-      }
-      else
-      {
-        return false;
-      }
-    }
-    #endregion
-  }
-
-  [ContractVerification(true)]
-  public static class SparseRationalArrayExtensions
-  {
-    [Pure]
-    static public bool IsConstantRow(this SparseRationalArray row)
-    {
-      Contract.Requires(row != null);
-
-      int count = row.Count;
-      switch (count)
-      {
-        case 0:
-        case 1:
-          return true;
-
-        case 2:
-          Contract.Assume(row.Length >= 1); // There is an invariant on sparse arrays: Length >= Count
-          return row.IsIndexOfNonDefaultElement(row.Length - 1);
-
-        default:
-          return false;
-      }
-    }
-  }
-
-  [ContractVerification(true)]
-  public static class DoubleExtensions
-  {
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    public static Interval ConvertFromDouble(this Double d)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (d.Equals(Double.NaN) || Double.IsInfinity(d) || d < Int64.MinValue || d > Int64.MaxValue)
-      {
-        return Interval.UnknownInterval;
-      }
-
-           
-      var trunc = Math.Truncate(d);
-                
-      var l = (long)trunc;
-
-      if (d == trunc)
-      {
-        return Interval.For(Rational.For(l, 1));
-      }
-      else
-      {
-        Interval candidate;
-        if (d > 0)
-        {
-          candidate = Interval.For(Rational.For(l, 1), Rational.For(l + 1, 1));
-        }
-        else
-        {
-          candidate = Interval.For(Rational.For(l - 1, 1), Rational.For(l, 1));
         }
 
-        // Check for conversion errors
-        if (candidate.LowerBound.Ceiling > d || candidate.UpperBound.Floor < d)
+        /// <returns>true iff <code>op</code> is a constant or a variable</returns>
+        [Pure]
+        public static bool IsZerary(this ExpressionOperator op)
         {
-          return Interval.UnknownInterval;
+            Contract.Ensures(Contract.Result<bool>() == ((op == ExpressionOperator.Constant) || (op == ExpressionOperator.Variable)));
+
+            return (op == ExpressionOperator.Constant) || (op == ExpressionOperator.Variable);
         }
 
-        return candidate;
-      }
+        /// <returns>true iff <code>op</code> is an unary operator</returns>
+        [Pure]
+        public static bool IsUnary(this ExpressionOperator op)
+        {
+            Contract.Ensures(Contract.Result<bool>() == ((op == ExpressionOperator.UnaryMinus) || (op == ExpressionOperator.Not)));
+
+            return (op == ExpressionOperator.UnaryMinus) || (op == ExpressionOperator.Not);
+        }
+
+        /// <returns>true iff op is a Binary operator</returns>
+        [Pure]
+        public static bool IsBinary(this ExpressionOperator op)
+        {
+            Contract.Ensures(Contract.Result<bool>() == (!IsUnary(op) && !IsZerary(op)));
+
+            return !IsUnary(op) && !IsZerary(op);
+        }
+
+        /// <returns>true iff <code>is a relational operator</code></returns>
+        [Pure]
+        public static bool IsRelationalOperator(this ExpressionOperator op)
+        {
+            return relationalOperators.Contains(op);
+        }
+
+        /// <returns>true iff <code>e</code> is the constant true</returns>
+        [Pure]
+        public static bool IsConstantTrue<Variable, Expression>(Expression e, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+
+            return IsConstantTrueOrFalse(e, true, decoder);
+        }
+
+        /// <returns>true iff <code>e</code> is the constant true</returns>
+        [Pure]
+        public static bool IsConstantFalse<Variable, Expression>(Expression e, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+
+            return IsConstantTrueOrFalse(e, false, decoder);
+        }
+
+        [Pure]
+        public static bool IsConversionOperator(this ExpressionOperator op)
+        {
+            return (op == ExpressionOperator.ConvertToInt32 || op == ExpressionOperator.ConvertToUInt8
+              || op == ExpressionOperator.ConvertToUInt16 || op == ExpressionOperator.ConvertToUInt32
+              || op == ExpressionOperator.ConvertToFloat32 || op == ExpressionOperator.ConvertToFloat64);
+        }
+
+        /// <returns>op == ExpressionOperator.LessThan || op == ExpressionOperator.LessThan_Un</returns>
+        [Pure]
+        public static bool IsLessThan(this ExpressionOperator op)
+        {
+            return op == ExpressionOperator.LessThan || op == ExpressionOperator.LessThan_Un;
+        }
+
+        /// <returns>op == ExpressionOperator.LessEqualThan || op == ExpressionOperator.LessEqualThan_Un</returns>
+        [Pure]
+        public static bool IsLessEqualThan(this ExpressionOperator op)
+        {
+            return op == ExpressionOperator.LessEqualThan || op == ExpressionOperator.LessEqualThan_Un;
+        }
+
+        /// <returns>op == ExpressionOperator.GreaterThan || op == ExpressionOperator.GreaterThan_Un</returns>
+        [Pure]
+        public static bool IsGreaterThan(this ExpressionOperator op)
+        {
+            return op == ExpressionOperator.GreaterThan || op == ExpressionOperator.GreaterThan_Un;
+        }
+
+        /// <returns>op == ExpressionOperator.GreaterEqualThan || op == ExpressionOperator.GreaterEqualThan_Un</returns>
+        [Pure]
+        public static bool IsGreaterEqualThan(this ExpressionOperator op)
+        {
+            return op == ExpressionOperator.GreaterEqualThan || op == ExpressionOperator.GreaterEqualThan_Un;
+        }
+
+        #region Private methods
+
+        private static bool IsConstantTrueOrFalse<Variable, Expression>(
+          Expression e, bool t, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+
+            bool boolValue;
+            Int32 intValue;
+
+            if (decoder.IsConstant(e))
+            {
+                if (decoder.TryValueOf<bool>(e, ExpressionType.Bool, out boolValue))
+                {
+                    return boolValue == t;
+                }
+                else if (decoder.IsConstantInt(e, out intValue))
+                {
+                    return (intValue != 0) == t;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+        #endregion
     }
 
-    public static bool IsNormal(this Double d)
+    [ContractVerification(true)]
+    public static class SparseRationalArrayExtensions
     {
-      return !Double.IsNaN(d) && !Double.IsInfinity(d);
-    }
-  }
+        [Pure]
+        static public bool IsConstantRow(this SparseRationalArray row)
+        {
+            Contract.Requires(row != null);
 
-  [ContractVerification(true)]
-  public static class SingleExtensions
-  {
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    public static Interval ConvertFromDouble(this Single d)
+            int count = row.Count;
+            switch (count)
+            {
+                case 0:
+                case 1:
+                    return true;
+
+                case 2:
+                    Contract.Assume(row.Length >= 1); // There is an invariant on sparse arrays: Length >= Count
+                    return row.IsIndexOfNonDefaultElement(row.Length - 1);
+
+                default:
+                    return false;
+            }
+        }
+    }
+
+    [ContractVerification(true)]
+    public static class DoubleExtensions
     {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (d.Equals(Single.NaN) || d < Int64.MinValue || d > Int64.MaxValue)
-      {
-        return Interval.UnknownInterval;
-      }
-
-      var trunc = Math.Truncate(d);
-      var l = (long)trunc;
-
-      if (d == trunc)
-      {
-        return Interval.For(Rational.For(l, 1));
-      }
-      else
-      {
-        Interval candidate;
-        if (d > 0)
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        public static Interval ConvertFromDouble(this Double d)
         {
-          candidate = Interval.For(Rational.For(l, 1), Rational.For(l + 1, 1));
-        }
-        else
-        {
-          candidate = Interval.For(Rational.For(l - 1, 1), Rational.For(l, 1));
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (d.Equals(Double.NaN) || Double.IsInfinity(d) || d < Int64.MinValue || d > Int64.MaxValue)
+            {
+                return Interval.UnknownInterval;
+            }
+
+
+            var trunc = Math.Truncate(d);
+
+            var l = (long)trunc;
+
+            if (d == trunc)
+            {
+                return Interval.For(Rational.For(l, 1));
+            }
+            else
+            {
+                Interval candidate;
+                if (d > 0)
+                {
+                    candidate = Interval.For(Rational.For(l, 1), Rational.For(l + 1, 1));
+                }
+                else
+                {
+                    candidate = Interval.For(Rational.For(l - 1, 1), Rational.For(l, 1));
+                }
+
+                // Check for conversion errors
+                if (candidate.LowerBound.Ceiling > d || candidate.UpperBound.Floor < d)
+                {
+                    return Interval.UnknownInterval;
+                }
+
+                return candidate;
+            }
         }
 
-        // Check for conversion errors
-        if (candidate.LowerBound.Ceiling > d || candidate.UpperBound.Floor < d)
+        public static bool IsNormal(this Double d)
         {
-          return Interval.UnknownInterval;
+            return !Double.IsNaN(d) && !Double.IsInfinity(d);
         }
-
-        return candidate;
-      }
     }
 
-    public static bool IsNormal(this Single d)
+    [ContractVerification(true)]
+    public static class SingleExtensions
     {
-      return !Single.IsNaN(d) && !Single.IsInfinity(d);
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        public static Interval ConvertFromDouble(this Single d)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (d.Equals(Single.NaN) || d < Int64.MinValue || d > Int64.MaxValue)
+            {
+                return Interval.UnknownInterval;
+            }
+
+            var trunc = Math.Truncate(d);
+            var l = (long)trunc;
+
+            if (d == trunc)
+            {
+                return Interval.For(Rational.For(l, 1));
+            }
+            else
+            {
+                Interval candidate;
+                if (d > 0)
+                {
+                    candidate = Interval.For(Rational.For(l, 1), Rational.For(l + 1, 1));
+                }
+                else
+                {
+                    candidate = Interval.For(Rational.For(l - 1, 1), Rational.For(l, 1));
+                }
+
+                // Check for conversion errors
+                if (candidate.LowerBound.Ceiling > d || candidate.UpperBound.Floor < d)
+                {
+                    return Interval.UnknownInterval;
+                }
+
+                return candidate;
+            }
+        }
+
+        public static bool IsNormal(this Single d)
+        {
+            return !Single.IsNaN(d) && !Single.IsInfinity(d);
+        }
     }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/GenericDomains.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/GenericDomains.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This file contains the interfaces for the abstract domains.
 // It also contain the definition for some generic abstract domains (functional, flat, powerset, etc.)
@@ -27,3126 +16,3119 @@ using System.Linq;
 
 namespace Microsoft.Research.AbstractDomains
 {
-
-  public enum AbstractState { Normal, Top, Bottom };
-
-  /// <summary>
-  /// Just for performances
-  /// </summary>
-  public abstract class FunctionalAbstractDomain
-  {
-    #region Performance counters
-
-#if TRACE_PERFORMANCE
-    [ThreadStatic]
-    static private TimeSpan timeSpentInIntervalEval;
-#endif
-
-    [Conditional("TRACE_PERFORMANCE")]
-    static protected void UpdateTimeSpentInIntervalEval(TimeSpan span)
-    {
-#if TRACE_PERFORMANCE
-      timeSpentInIntervalEval += span;
-#endif
-    }
-
-    static public string Statistics
-    {
-      get
-      {
-#if TRACE_PERFORMANCE
-        var result = new StringBuilder();
-
-        result.AppendFormat("Overall time spent in Eval of Intervals* : {0} {1}", timeSpentInIntervalEval.ToString(), Environment.NewLine);
-
-        return result.ToString();
-#else
-        return "Performance tracing is off";
-#endif
-      }
-    }
-
-    #endregion
-  }
-
-  /// <summary>
-  /// A functional lift for the operations on the abstract domain <code>Codomain</code>.
-  /// Essentially, is a map from <code>Domain</code> elements to <code>Codomain</code>
-  /// </summary>
-  /// <typeparam name="Codomain">Must be an instance of IAbstractDomain</typeparam>
-  [ContractVerification(true)]
-  [ContractClass(typeof(FunctionalAbstractDomainContracts<,,>))]
-  public abstract class FunctionalAbstractDomain<This, Domain, Codomain>
-    : FunctionalAbstractDomain,
-      IAbstractDomain
-    where This : FunctionalAbstractDomain<This, Domain, Codomain>
-    where Codomain : IAbstractDomain
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.elements != null);
-    }
-
-    #region Private variables
-
-    private AbstractState state;
-
-    private Dictionary<Domain, Codomain> elements;
-    private Int32 version;
-
-    #endregion
-
-    public void SetElements(Dictionary<Domain, Codomain> value)
-    {
-      Contract.Requires(value != null);
-
-      this.version++;
-      this.elements = value;
-    }
-
-    public void SetElements(List<Pair<Domain, Codomain>> value)
-    {
-      Contract.Requires(value != null);
-
-      this.version++;
-      this.elements = new Dictionary<Domain, Codomain>(value.Count);
-      foreach (var pair in value)
-      {
-        if(pair.Two.IsNormal())
-          this.elements.Add(pair.One, pair.Two);
-      }
-    }
-
-    public void CopyAndTransferOwnership(FunctionalAbstractDomain<This, Domain, Codomain> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Assume(other.elements != null);
-
-      this.version++;
-      this.elements = other.elements;
-      other.elements = null;
-    }
-
-    public void RemoveElement(Domain key)
-    {
-      this.version++;
-      this.elements.Remove(key);
-    }
-
-    //[SuppressMessage("Microsoft.Contracts", "Ensures-27-45")]
-    virtual public bool TryGetValue(Domain key, out Codomain value)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Codomain>(out value) != null);
-
-      return  this.elements.TryGetValue(key, out value);
-    }
-
-
-    public void ClearElements()
-    {
-      this.version++;
-      this.elements.Clear();
-    }
-
-    public void AddElement(Domain key, Codomain value)
-    {
-      this.version++;
-      this.elements.Add(key, value);
-    }
-
-    public IEnumerable<KeyValuePair<Domain, Codomain>> Elements
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<Domain, Codomain>>>() != null);
-
-        return this.elements;
-      }
-    }
-
-    public IEnumerable<Domain> Keys
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<Domain>>() != null);
-
-        return this.elements.Keys;     
-      }
-    }
-
-    protected AbstractState State
-    {
-      get { return this.state; }
-      set { this.state = value; }
-    }
-
-    protected Int32 Version
-    {
-      get
-      {
-        return this.version;
-      }
-      set
-      {
-        this.version = value;
-      }
-    }
-
-    #region Constructors
-    public FunctionalAbstractDomain()
-    {
-      this.elements = new Dictionary<Domain, Codomain>();
-      this.state = AbstractState.Normal;
-      this.version = 0;
-    }
-
-    protected FunctionalAbstractDomain(FunctionalAbstractDomain<This, Domain, Codomain> fun)
-    {
-      Contract.Requires(fun != null);
-
-      this.elements = new Dictionary<Domain, Codomain>(fun.elements);
-      this.state = fun.state;
-      this.version = fun.version;
-    }
-    #endregion
-
-    #region Implementation for IAbstractDomain
-
-    abstract public object Clone();
+    public enum AbstractState { Normal, Top, Bottom };
 
     /// <summary>
-    /// A functional map is bottom when at least one element is bottom
+    /// Just for performances
     /// </summary>
-    public bool IsBottom
+    public abstract class FunctionalAbstractDomain
     {
-      get
-      {
-        if (this.State == AbstractState.Bottom)
-          return true;
-        if (this.elements.Keys.Count == 0)        // !bottom && no variable => it is not bottom
-          return false;
+        #region Performance counters
 
-        return false;
-      }
-    }
+#if TRACE_PERFORMANCE
+        [ThreadStatic]
+        static private TimeSpan timeSpentInIntervalEval;
+#endif
 
-    /// <summary>
-    /// A functional map is top when all of the values in the codomain are top
-    /// </summary>
-    public bool IsTop
-    {
-      get
-      {
-        foreach (var val in this.elements)
+        [Conditional("TRACE_PERFORMANCE")]
+        static protected void UpdateTimeSpentInIntervalEval(TimeSpan span)
         {
-          if (!val.Value.IsTop)
+#if TRACE_PERFORMANCE
+            timeSpentInIntervalEval += span;
+#endif
+        }
+
+        static public string Statistics
+        {
+            get
+            {
+#if TRACE_PERFORMANCE
+                var result = new StringBuilder();
+
+                result.AppendFormat("Overall time spent in Eval of Intervals* : {0} {1}", timeSpentInIntervalEval.ToString(), Environment.NewLine);
+
+                return result.ToString();
+#else
+                return "Performance tracing is off";
+#endif
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A functional lift for the operations on the abstract domain <code>Codomain</code>.
+    /// Essentially, is a map from <code>Domain</code> elements to <code>Codomain</code>
+    /// </summary>
+    /// <typeparam name="Codomain">Must be an instance of IAbstractDomain</typeparam>
+    [ContractVerification(true)]
+    [ContractClass(typeof(FunctionalAbstractDomainContracts<,,>))]
+    public abstract class FunctionalAbstractDomain<This, Domain, Codomain>
+      : FunctionalAbstractDomain,
+        IAbstractDomain
+      where This : FunctionalAbstractDomain<This, Domain, Codomain>
+      where Codomain : IAbstractDomain
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(elements != null);
+        }
+
+        #region Private variables
+
+        private AbstractState state;
+
+        private Dictionary<Domain, Codomain> elements;
+        private Int32 version;
+
+        #endregion
+
+        public void SetElements(Dictionary<Domain, Codomain> value)
+        {
+            Contract.Requires(value != null);
+
+            version++;
+            elements = value;
+        }
+
+        public void SetElements(List<Pair<Domain, Codomain>> value)
+        {
+            Contract.Requires(value != null);
+
+            version++;
+            elements = new Dictionary<Domain, Codomain>(value.Count);
+            foreach (var pair in value)
+            {
+                if (pair.Two.IsNormal())
+                    elements.Add(pair.One, pair.Two);
+            }
+        }
+
+        public void CopyAndTransferOwnership(FunctionalAbstractDomain<This, Domain, Codomain> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Assume(other.elements != null);
+
+            version++;
+            elements = other.elements;
+            other.elements = null;
+        }
+
+        public void RemoveElement(Domain key)
+        {
+            version++;
+            elements.Remove(key);
+        }
+
+        //[SuppressMessage("Microsoft.Contracts", "Ensures-27-45")]
+        virtual public bool TryGetValue(Domain key, out Codomain value)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Codomain>(out value) != null);
+
+            return elements.TryGetValue(key, out value);
+        }
+
+
+        public void ClearElements()
+        {
+            version++;
+            elements.Clear();
+        }
+
+        public void AddElement(Domain key, Codomain value)
+        {
+            version++;
+            elements.Add(key, value);
+        }
+
+        public IEnumerable<KeyValuePair<Domain, Codomain>> Elements
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<Domain, Codomain>>>() != null);
+
+                return elements;
+            }
+        }
+
+        public IEnumerable<Domain> Keys
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Domain>>() != null);
+
+                return elements.Keys;
+            }
+        }
+
+        protected AbstractState State
+        {
+            get { return state; }
+            set { state = value; }
+        }
+
+        protected Int32 Version
+        {
+            get
+            {
+                return version;
+            }
+            set
+            {
+                version = value;
+            }
+        }
+
+        #region Constructors
+        public FunctionalAbstractDomain()
+        {
+            elements = new Dictionary<Domain, Codomain>();
+            state = AbstractState.Normal;
+            version = 0;
+        }
+
+        protected FunctionalAbstractDomain(FunctionalAbstractDomain<This, Domain, Codomain> fun)
+        {
+            Contract.Requires(fun != null);
+
+            elements = new Dictionary<Domain, Codomain>(fun.elements);
+            state = fun.state;
+            version = fun.version;
+        }
+        #endregion
+
+        #region Implementation for IAbstractDomain
+
+        abstract public object Clone();
+
+        /// <summary>
+        /// A functional map is bottom when at least one element is bottom
+        /// </summary>
+        public bool IsBottom
+        {
+            get
+            {
+                if (this.State == AbstractState.Bottom)
+                    return true;
+                if (elements.Keys.Count == 0)        // !bottom && no variable => it is not bottom
+                    return false;
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// A functional map is top when all of the values in the codomain are top
+        /// </summary>
+        public bool IsTop
+        {
+            get
+            {
+                foreach (var val in elements)
+                {
+                    if (!val.Value.IsTop)
+                        return false;
+                }
+
+                this.State = AbstractState.Top;
+                return true;
+            }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            return this.LessEqual((This)a);
+        }
+
+        /// <summary>
+        /// The pointwise extension of the order on the elements in the codomain
+        /// </summary>
+        virtual public bool LessEqual(This right)
+        {
+            Contract.Requires(right != null);
+
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
+            {
+                return result;
+            }
+
+            foreach (var pair in right.Elements)
+            {
+                var rightVal = pair.Value;
+
+                Contract.Assume(rightVal != null);
+
+                // We do not want to enforce each subclass to have a canonical representation so we explicitely check for it
+                if (rightVal.IsTop)
+                {
+                    continue;
+                }
+
+                Codomain leftVal;
+                if (!elements.TryGetValue(pair.Key, out leftVal))
+                {
+                    return false;
+                }
+
+                if (!leftVal.LessEqual(rightVal))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns an empty function
+        /// </summary>
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get
+            {
+                return this.Bottom;
+            }
+        }
+
+        public This Bottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<This>() != null);
+
+                var bot = this.Factory();
+
+                bot.state = AbstractState.Bottom;
+
+                return bot;
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get
+            {
+                return this.Top;
+            }
+        }
+
+        public This Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<This>() != null);
+
+                var top = this.Factory();
+
+                top.state = AbstractState.Top;
+
+                return top;
+            }
+        }
+
+        /// <summary>
+        /// Join of functional maps
+        /// </summary>
+        /// <returns> A freshly allocated functional map, with the pointwise join</returns>
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            return this.Join((This)a);
+        }
+
+        public virtual This Join(This other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            if (object.ReferenceEquals(this, other))
+            {
+                return other;
+            }
+
+            if (this.IsBottom)
+                return other;
+            if (other.IsBottom)
+                return (This)this;
+
+            Dictionary<Domain, Codomain> left, right;
+
+            Contract.Assume(other.elements != null);
+
+            // Select the smaller one
+            if (elements.Count <= other.elements.Count)
+            {
+                left = elements;
+                right = other.elements;
+            }
+            else
+            {
+                left = other.elements;
+                right = elements;
+            }
+
+            var result = this.Factory();
+
+            foreach (var pair in left)       // For all the elements in the intersection do the point-wise join
+            {
+                Codomain right_x;
+                if (right.TryGetValue(pair.Key, out right_x))
+                {
+                    Contract.Assume(right_x != null);
+
+                    var join = pair.Value.Join(right_x);
+
+                    if (join.IsBottom)
+                    {
+                        return result.Bottom;
+                    }
+
+                    if (!join.IsTop)
+                    { // We keep in the map only the elements that are != top
+                        result[pair.Key] = (Codomain)join;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Meet of functional abstract domains
+        /// </summary>
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            return this.Meet((This)a);
+        }
+
+        public virtual This Meet(This right)
+        {
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            // Here we do not have trivial joins as we want to join maps of different cardinality
+            if (this.IsBottom)
+                return (This)this;
+            if (right.IsBottom)
+                return right;
+
+            var result = this.Factory();
+
+            Contract.Assume(right.elements != null);
+
+            foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
+            {
+                Codomain right_x;
+                if (right.elements.TryGetValue(pair.Key, out right_x))
+                {
+                    Contract.Assume(right_x != null);
+
+                    var meet = pair.Value.Meet(right_x);
+                    result[pair.Key] = (Codomain)meet;
+                }
+            }
+
+            return result;
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            return this.Widening((This)prev);
+        }
+
+        /// <summary>
+        /// Widening of the functional domain.
+        /// If the two functions have the same cardinality, then it is a widening.
+        /// If not, i.e. the cardinality of the domain increases then it may not terminate.
+        /// If you are in this 2nd case, please contact me (logozzo)
+        /// </summary>
+        public virtual This Widening(This right)
+        {
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            // Here we do not have trivial widening as we want to join maps of different cardinality
+            if (this.IsBottom)
+                return right;
+
+            if (right.IsBottom)
+                return (This)this;
+
+            var result = this.Factory();
+
+            Contract.Assume(right.elements != null);
+
+            foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
+            {
+                Codomain right_x;
+                if (right.elements.TryGetValue(pair.Key, out right_x))
+                {
+                    Contract.Assume(right_x != null);
+
+                    var widening = pair.Value.Widening(right_x);
+
+                    if (!widening.IsTop)
+                    {
+                        result[pair.Key] = (Codomain)widening;
+                    }
+                }
+            }
+
+            return result;
+        }
+        #endregion
+
+        #region Redefined indexer
+
+#if TRACEPERFORMANCE
+        public static Dictionary<int, int> MaxSizes
+        {
+            get
+            {
+                return PerformanceCounter.MaxSizes;
+            }
+        }
+
+        [ThreadStatic]
+        private static int MaxSize;
+#endif
+
+        virtual public Codomain this[Domain index]
+        {
+            set
+            {
+                if (value.IsBottom)
+                {
+                    state = AbstractState.Bottom;
+                }
+
+#if TRACEPERFORMANCE
+
+                int oldMaxSize = MaxSize;
+                MaxSize = Math.Max(MaxSize, this.Count);
+
+#if TRACEPERFORMANCE && VERBOSEOUTPUT
+                if (MaxSize > oldMaxSize)
+                {
+                    ConsoleColor oldColor = Console.ForegroundColor;
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+
+                    Console.WriteLine("New MaxSize for an instance of a FunctionalAbstractDomain: {0}", MaxSize);
+
+                    Console.ForegroundColor = oldColor;
+                }
+#endif
+
+                if (MaxSizes.ContainsKey(this.GetHashCode()))
+                {
+                    MaxSizes[this.GetHashCode()] = Math.Max(MaxSizes[this.GetHashCode()], this.Count);
+                }
+                else
+                {
+                    MaxSizes[this.GetHashCode()] = this.Count;
+                }
+
+#if TRACEPERFORMANCE && VERBOSEOUTPUT
+                if (MaxSizes[this.GetHashCode()] >= 50)
+                {
+                    ConsoleColor oldColor = Console.ForegroundColor;
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+
+                    Console.WriteLine(" >50 vars : {0}", MaxSizes[this.GetHashCode()]);
+
+                    Console.ForegroundColor = oldColor;
+                }
+#endif
+#endif
+                version++;
+                elements[index] = value;
+            }
+
+            get
+            {
+                return elements[index];
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return elements.Count;
+            }
+        }
+
+        public bool ContainsKey(Domain d)
+        {
+            return elements.ContainsKey(d);
+        }
+
+        #endregion
+
+        #region TO BE OVERRIDDEN
+
+        abstract protected This Factory();
+
+        abstract protected string ToLogicalFormula(Domain d, Codomain c);
+
+        abstract protected T To<T>(Domain d, Codomain c, IFactory<T> factory);
+
+        #endregion
+
+        #region To<T>
+
+        public T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.Constant(false);
+            if (this.IsTop)
+                return factory.Constant(true);
+
+            T result = factory.IdentityForAnd;
+
+            foreach (Domain d in elements.Keys)
+            {
+                T singleEntry = To(d, this[d], factory);
+
+                result = factory.And(result, singleEntry);
+            }
+
+            return result;
+        }
+        #endregion
+
+        #region Assume Domain specific facts
+        virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+        }
+
+        #endregion
+
+        #region Overriden
+        //^ [Confined]
+        public override string ToString()
+        {
+            if (this.Count == 0)
+                return "empty";
+
+            string result = "";
+            foreach (var x in elements.Keys)
+            {
+                if (x != null)
+                {
+                    result += x.ToString() + " -> " + this[x] + ", ";
+                }
+            }
+            return result;
+        }
+        #endregion
+    }
+
+    [ContractClassFor(typeof(FunctionalAbstractDomain<,,>))]
+    internal abstract class FunctionalAbstractDomainContracts<This, Domain, Codomain>
+      : FunctionalAbstractDomain<This, Domain, Codomain>
+      where This : FunctionalAbstractDomain<This, Domain, Codomain>
+      where Codomain : IAbstractDomain
+    {
+        protected override This Factory()
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        public override object Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override string ToLogicalFormula(Domain d, Codomain c)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override T To<T>(Domain d, Codomain c, IFactory<T> factory)
+        {
+            Contract.Requires(factory != null);
+
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// A simple implementation of the functional abstract domain
+    /// </summary>
+    [ContractVerification(true)]
+    public sealed class SimpleImmutableFunctional<Domain, Codomain>
+      : FunctionalAbstractDomain<SimpleImmutableFunctional<Domain, Codomain>, Domain, Codomain>
+      where Codomain : IAbstractDomain
+    {
+        #region Constuctor
+        public SimpleImmutableFunctional(Dictionary<Domain, Codomain> map)
+          : base()
+        {
+            Contract.Requires(map != null);
+
+            foreach (var pair in map)
+            {
+                base[pair.Key] = pair.Value;
+            }
+        }
+
+        #endregion
+
+        #region Add
+        public SimpleImmutableFunctional<Domain, Codomain> Add(Domain x, Codomain y)
+        {
+            Contract.Ensures(Contract.Result<SimpleImmutableFunctional<Domain, Codomain>>() != null);
+
+            Codomain oldy;
+            if (this.TryGetValue(x, out oldy) && oldy.Equals(x))
+            {
+                return this;
+            }
+            var newMap = new Dictionary<Domain, Codomain>();
+            foreach (var pair in this.Elements)
+            {
+                newMap.Add(pair.Key, pair.Value);
+            }
+
+            newMap[x] = y;
+
+            return new SimpleImmutableFunctional<Domain, Codomain>(newMap);
+        }
+        #endregion
+
+        #region Overridden
+
+        public override Codomain this[Domain index]
+        {
+            get
+            {
+                return base[index];
+            }
+            set
+            {
+                base[index] = value;
+            }
+        }
+
+        public override object Clone()
+        {
+            return this;
+        }
+
+        protected override string ToLogicalFormula(Domain d, Codomain c)
+        {
+            return null;
+        }
+
+        protected override T To<T>(Domain d, Codomain c, IFactory<T> factory)
+        {
+            return factory.Constant(true);
+        }
+
+        protected override SimpleImmutableFunctional<Domain, Codomain> Factory()
+        {
+            return new SimpleImmutableFunctional<Domain, Codomain>(new Dictionary<Domain, Codomain>());
+        }
+        #endregion
+
+        #region Statics
+        static public SimpleImmutableFunctional<Domain, Codomain> Unknown
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SimpleImmutableFunctional<Domain, Codomain>>() != null);
+
+                return new SimpleImmutableFunctional<Domain, Codomain>(new Dictionary<Domain, Codomain>());
+            }
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// The extension of a functional abstract domain to environemnts
+    /// </summary>
+    public abstract class FunctionalAbstractDomainEnvironment<This, Domain, Codomain, Variable, Expression>
+      : FunctionalAbstractDomain<This, Domain, Codomain>,
+      IAbstractDomainForEnvironments<Variable, Expression>
+      where This : FunctionalAbstractDomainEnvironment<This, Domain, Codomain, Variable, Expression>
+      where Codomain : IAbstractDomain
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.ExpressionManager != null);
+        }
+
+        #region State
+
+        protected readonly ExpressionManager<Variable, Expression> ExpressionManager;
+
+        #endregion
+
+        #region Constructors
+
+        protected FunctionalAbstractDomainEnvironment(ExpressionManager<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
+
+            this.ExpressionManager = expManager;
+        }
+
+        protected FunctionalAbstractDomainEnvironment(FunctionalAbstractDomainEnvironment<This, Domain, Codomain, Variable, Expression> other)
+          : base(other)
+        {
+            Contract.Requires(other != null);
+
+            this.ExpressionManager = other.ExpressionManager;
+        }
+
+        #endregion
+
+        #region To be OVERRIDDEN
+
+        abstract override public object Clone();
+
+        abstract override protected This Factory();
+
+        abstract public List<Variable> Variables { get; }
+
+        abstract public void Assign(Expression x, Expression exp);
+
+        abstract public void ProjectVariable(Variable var);
+
+        abstract public void RemoveVariable(Variable var);
+
+        abstract public void RenameVariable(Variable OldName, Variable NewName);
+
+        abstract public This TestTrue(Expression guard);
+
+        abstract public This TestFalse(Expression guard);
+
+        abstract public FlatAbstractDomain<bool> CheckIfHolds(Expression exp);
+
+        abstract public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert);
+
+        #endregion
+
+        #region TestTrue Equal
+
+        virtual public This TestTrueEqual(Domain v1, Domain v2)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            Codomain sl, sr;
+            var inLeft = this.TryGetValue(v1, out sl);
+            var inRight = this.TryGetValue(v2, out sr);
+
+            if (inLeft ^ inRight)
+            {
+                if (inLeft)
+                {
+                    this.AddElement(v2, sl);
+                }
+                else
+                {
+                    this.AddElement(v1, sr);
+                }
+            }
+            else if (inLeft)
+            {
+                Contract.Assert(inRight);
+
+                var meet = sl.Meet(sr);
+
+                if (meet is Codomain)
+                {
+                    this[v1] = (Codomain)meet;
+                    this[v2] = (Codomain)meet;
+                }
+            }
+
+            return (This)this;
+        }
+
+        #endregion
+
+        #region Overridden
+        protected override string ToLogicalFormula(Domain d, Codomain c)
+        {
+            return "true";
+        }
+
+        protected override T To<T>(Domain d, Codomain c, IFactory<T> factory)
+        {
+            return factory.IdentityForAnd;
+        }
+        #endregion
+
+        #region IAbstractDomainForEnvironments<Variable,Expression> Members
+
+        public string ToString(Expression exp)
+        {
+            return ExpressionPrinter.ToString(exp, this.ExpressionManager.Decoder);
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        public virtual void AddVariable(Variable var)
+        {
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            return this.TestTrue(guard);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            return this.TestFalse(guard);
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// The implementation for a cartesian abstract domain with reduction.
+    /// The reduction operation is specific to the domains, so each subclass must implement is
+    /// </summary>
+    [ContractClass(typeof(ReducedCartesianAbstractDomainContracts<,>))]
+    public abstract class ReducedCartesianAbstractDomain<LeftDomain, RightDomain> : IAbstractDomain
+      where LeftDomain : class, IAbstractDomain
+      where RightDomain : class, IAbstractDomain
+    {
+        #region Private fields
+        readonly private LeftDomain left;
+        readonly private RightDomain right;
+        #endregion
+
+        #region Object Invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(left != null);
+            Contract.Invariant(right != null);
+        }
+
+        #endregion
+
+        #region Getters
+
+        public LeftDomain Left
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<LeftDomain>() != null);
+                Contract.Ensures(Contract.Result<LeftDomain>().Equals(left));
+
+                return left;
+            }
+        }
+
+        public RightDomain Right
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<RightDomain>() != null);
+                Contract.Ensures(Contract.Result<RightDomain>().Equals(right));
+
+                return right;
+            }
+        }
+        #endregion
+
+        #region Constructor
+        protected ReducedCartesianAbstractDomain(LeftDomain left, RightDomain right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(this.left.Equals(left));
+            Contract.Ensures(this.right.Equals(right));
+
+            Contract.Ensures(this.left != null);
+            Contract.Ensures(this.right != null);
+
+            this.left = left;
+            this.right = right;
+        }
+        #endregion
+
+        #region TO BE OVERRIDDEN
+
+        /// <summary>
+        /// Perform the reduction of the elements of the two domains.
+        /// The reduction depends by the abstract domains, so each subclass of <code>ReducedCartesianAbstractDomain</code> is responsible for defining and implementing it.
+        /// </summary>
+        abstract public ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Reduce(LeftDomain left, RightDomain right);
+
+        /// <summary>
+        /// The widening is abstract because I want each implementation to think to his widening.
+        /// In particular I want to avoid non termination problems consequence of a bad interaction between closure (or reduction) and naive widenings 
+        /// </summary>
+        abstract public IAbstractDomain Widening(IAbstractDomain prev);
+
+        /// <summary>
+        /// The factory method for creating a particular instance of 
+        /// </summary>
+        abstract protected ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Factory(LeftDomain left, RightDomain right);
+
+        #endregion
+
+        #region Generic assume
+        virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            Contract.Requires(fact != null);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        public virtual bool IsBottom
+        {
+            get
+            {
+                return left.IsBottom || right.IsBottom;       // Please note that we do the reduction here, so the element is bottom if one of the two is
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return left.IsTop && right.IsTop;
+            }
+        }
+
+        /// <summary>
+        /// The pairwise order.
+        /// If first perform the closure of the two arguments, and then checks them pairwisely.
+        /// It is defined virtual so that a class can redefine it so to make it faster
+        /// </summary>
+        virtual public bool LessEqual(IAbstractDomain a)
+        {
+            Contract.Assert(a is ReducedCartesianAbstractDomain<LeftDomain, RightDomain>);
+
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
+            {
+                return result;
+            }
+
+            var r = a as ReducedCartesianAbstractDomain<LeftDomain, RightDomain>;
+            Contract.Assume(r != null);
+
+            var lreduced = this.Reduce(left, right);
+            var rreduced = r.Reduce(r.left, r.right);
+
+            bool b1 = lreduced.Left.LessEqual(rreduced.Left);
+
+            if (!b1)
+                return b1;
+
+            bool b2 = lreduced.Right.LessEqual(rreduced.Right);
+
+            return b2;
+        }
+
+        public IAbstractDomain Bottom
+        {
+            get
+            {
+                return Factory((LeftDomain)this.Left.Bottom, (RightDomain)this.Right.Bottom);
+            }
+        }
+
+        public IAbstractDomain Top
+        {
+            get
+            {
+                return Factory((LeftDomain)this.Left.Top, (RightDomain)this.Right.Top);
+            }
+        }
+
+        /// <summary>
+        /// The pointwise join. The results are then reduced through <code>Reduce</code>
+        /// </summary>
+        virtual public IAbstractDomain Join(IAbstractDomain a)
+        {
+            IAbstractDomain result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out result))
+            {
+                return result;
+            }
+
+            var r = a as ReducedCartesianAbstractDomain<LeftDomain, RightDomain>;
+            Contract.Assume(r != null);
+
+            var joinLeftPart = (LeftDomain)this.Left.Join(r.Left);
+            var joinRightPart = (RightDomain)this.Right.Join(r.Right);
+
+            return this.Reduce(joinLeftPart, joinRightPart);
+        }
+
+        /// <summary>
+        /// The pointwise meet. The results are then reduced through <code>Reduce</code>
+        /// </summary>
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            IAbstractDomain trivialMeet;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
+            {
+                return trivialMeet;
+            }
+
+            var r = a as ReducedCartesianAbstractDomain<LeftDomain, RightDomain>;
+            Contract.Assume(r != null);
+
+            var meetLeftPart = (LeftDomain)this.Left.Meet(r.Left);
+            var meetRightPart = (RightDomain)this.Right.Meet(r.Right);
+
+            return this.Reduce(meetLeftPart, meetRightPart);
+        }
+
+        virtual public T To<T>(IFactory<T> factory)
+        {
+            var left = this.Left.To(factory);
+            var right = this.Right.To(factory);
+
+            return factory.And(left, right);
+        }
+        #endregion
+
+        #region ICloneable Members
+
+        /// <summary>
+        /// Make a deep copy of this abstract element, i.e. it also clones the contained abstract elements
+        /// </summary>
+        virtual public object Clone()
+        {
+            var leftCloned = this.Left.Clone() as LeftDomain;
+            var rightCloned = this.Right.Clone() as RightDomain;
+
+            Contract.Assume(leftCloned != null);
+            Contract.Assume(rightCloned != null);
+
+            return Factory(leftCloned, rightCloned);
+        }
+        #endregion
+
+        #region Overridden
+
+        public override string ToString()
+        {
+            var leftStr = format(this.Left.ToString());
+            var rightStr = format(this.Right.ToString());
+
+            return "<" + Environment.NewLine + "  " + leftStr + ";" + Environment.NewLine + rightStr + Environment.NewLine + ">";
+        }
+
+        #endregion
+
+        #region Pretty printing...
+        /// <summary>
+        /// Format the string <code>input</code>, and replaces all the "\n" with "\n  "
+        /// </summary>
+        static private string format(string input)
+        {
+            Contract.Requires(input != null);
+
+            string s = input.Replace(Environment.NewLine, Environment.NewLine + "  ");
+
+            return s;
+        }
+        #endregion
+    }
+
+    #region Contracts for Reduced Cartesian Abstract Domain
+
+    [ContractClassFor(typeof(ReducedCartesianAbstractDomain<,>))]
+    internal abstract class ReducedCartesianAbstractDomainContracts<LeftDomain, RightDomain>
+      : ReducedCartesianAbstractDomain<LeftDomain, RightDomain>
+      where LeftDomain : class, IAbstractDomain
+      where RightDomain : class, IAbstractDomain
+    {
+        private ReducedCartesianAbstractDomainContracts(LeftDomain left, RightDomain right)
+          : base(left, right)
+        { }
+
+        public override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Reduce(LeftDomain left, RightDomain right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<LeftDomain, RightDomain>>() != null);
+
+            return default(ReducedCartesianAbstractDomain<LeftDomain, RightDomain>);
+        }
+
+        protected override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Factory(LeftDomain left, RightDomain right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<LeftDomain, RightDomain>>() != null);
+
+            return default(ReducedCartesianAbstractDomain<LeftDomain, RightDomain>);
+        }
+
+        public override IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+
+    #endregion
+
+    /// <summary>
+    /// The base class for a cartesian product of two numerical abstract domains
+    /// </summary>
+    public abstract class ReducedNumericalDomains<LeftDomain, RightDomain, Variable, Expression>
+      : ReducedCartesianAbstractDomain<LeftDomain, RightDomain>,
+        INumericalAbstractDomain<Variable, Expression>
+      where LeftDomain : class, INumericalAbstractDomain<Variable, Expression>
+      where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
+    {
+        #region Object invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(expManager != null);
+        }
+
+        #endregion
+
+        #region State
+
+        private readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
+
+        protected readonly INumericalAbstractDomain<Variable, Expression>[] arr;
+
+        #endregion
+
+        #region Getters
+
+        public ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ExpressionManagerWithEncoder<Variable, Expression>>() != null);
+
+                return expManager;
+            }
+        }
+
+        protected Expression Zero
+        {
+            get
+            {
+                return this.ExpressionManager.Encoder.ConstantFor(0);
+            }
+        }
+
+        #endregion
+
+        #region (Protected) constructor
+
+        protected ReducedNumericalDomains(LeftDomain left, RightDomain right, ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(left, right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Requires(expManager != null);
+
+            Contract.Ensures(this.Left.Equals(left));
+            Contract.Ensures(this.Right.Equals(right));
+
+            this.expManager = expManager;
+            this.arr = new INumericalAbstractDomain<Variable, Expression>[] { this.Left, this.Right };
+        }
+
+        #endregion
+
+        #region To be implemented by subclasses
+        abstract public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp);
+
+        abstract public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2);
+
+        abstract public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2);
+
+        virtual public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression> Members
+
+        virtual public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
+        {
+            FlatAbstractDomain<bool> left, right;
+            left = right = null;
+
+            left = this.Left.CheckIfLessThan(v1, v2);
+
+            if (left.IsBottom)
+            {
+                return left;
+            }
+
+            right = this.Right.CheckIfLessThan(v1, v2);
+
+            return left.Meet(right);
+        }
+
+        virtual public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
+        {
+            FlatAbstractDomain<bool> left, right;
+            left = right = null;
+
+            left = this.Left.CheckIfLessEqualThan(v1, v2);
+
+            if (left.IsBottom)
+            {
+                return left;
+            }
+
+            right = this.Right.CheckIfLessEqualThan(v1, v2);
+
+            return left.Meet(right);
+            //return this.Left.CheckIfLessEqualThan(v1, v2).Meet(this.Right.CheckIfLessEqualThan(v1, v2));
+        }
+
+        virtual public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> left, right;
+            left = right = null;
+
+            left = this.Left.CheckIfLessThan_Un(e1, e2);
+
+            if (left.IsBottom)
+            {
+                return left;
+            }
+
+            right = this.Right.CheckIfLessThan_Un(e1, e2);
+
+            return left.Meet(right);
+
+            // return this.Left.CheckIfLessThan_Un(e1, e2).Meet(this.Right.CheckIfLessThan_Un(e1, e2));
+        }
+
+        virtual public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> left, right;
+            left = right = null;
+
+            left = this.Left.CheckIfLessEqualThan_Un(e1, e2);
+
+            if (left.IsBottom)
+            {
+                return left;
+            }
+
+            right = this.Right.CheckIfLessEqualThan_Un(e1, e2);
+
+            return left.Meet(right);
+
+            //return this.Left.CheckIfLessEqualThan_Un(e1, e2).Meet(this.Right.CheckIfLessEqualThan_Un(e1, e2));
+        }
+
+        virtual public DisInterval BoundsFor(Expression exp)
+        {
+            DisInterval left, right;
+            left = right = null;
+
+            left = this.Left.BoundsFor(exp);
+
+            if (left.IsBottom)
+            {
+                return left;
+            }
+
+            right = this.Right.BoundsFor(exp);
+
+            return left.Meet(right);
+
+            //return this.Left.BoundsFor(exp).Meet(this.Right.BoundsFor(exp));
+        }
+
+        virtual public DisInterval BoundsFor(Variable v)
+        {
+            DisInterval left, right;
+            left = right = null;
+
+            left = this.Left.BoundsFor(v);
+
+            if (left.IsBottom)
+            {
+                return left;
+            }
+            right = this.Right.BoundsFor(v);
+
+            return left.Meet(right);
+
+            //return this.Left.BoundsFor(v).Meet(this.Right.BoundsFor(v));
+        }
+
+        virtual public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                var leftConstants = this.Left.IntConstants;
+                var rightConstants = this.Right.IntConstants;
+
+                leftConstants.AddRange(rightConstants);
+
+                return leftConstants;
+            }
+        }
+
+        virtual public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
+        }
+
+        virtual public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
+        }
+
+        virtual public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
+        }
+
+        virtual public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
+        }
+
+        virtual public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            return this.Right.EqualitiesFor(v).Union(this.Left.EqualitiesFor(v));
+        }
+
+        virtual public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            var leftResult = (LeftDomain)this.Left.TestTrueGeqZero(exp);
+            var rightResult = (RightDomain)this.Right.TestTrueGeqZero(exp);
+
+            return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        virtual public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            var leftResult = (LeftDomain)this.Left.TestTrueLessThan(exp1, exp2);
+            var rightResult = (RightDomain)this.Right.TestTrueLessThan(exp1, exp2);
+
+            return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        virtual public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            var leftResult = (LeftDomain)this.Left.TestTrueLessEqualThan(exp1, exp2);
+            var rightResult = (RightDomain)this.Right.TestTrueLessEqualThan(exp1, exp2);
+
+            return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        virtual public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            var leftResult = (LeftDomain)this.Left.TestTrueEqual(exp1, exp2);
+            var rightResult = (RightDomain)this.Right.TestTrueEqual(exp1, exp2);
+
+            return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        virtual public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            var leftReduced = (LeftDomain)this.Left.RemoveRedundanciesWith(this.Right);
+            var rightReduced = (RightDomain)this.Right.RemoveRedundanciesWith(oracle);
+
+            return this.Factory(leftReduced, rightReduced) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        public List<Variable> Variables
+        {
+            get
+            {
+                return this.Left.Variables.SetUnion(this.Right.Variables);
+            }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            this.Left.AddVariable(var);
+            this.Right.AddVariable(var);
+        }
+
+        virtual public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            //this.Left.AssumeInDisInterval(x, value);
+            this.Right.AssumeInDisInterval(x, value);
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        override public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.Left.AssumeDomainSpecificFact(fact);
+            this.Right.AssumeDomainSpecificFact(fact);
+        }
+
+        virtual public void Assign(Expression x, Expression exp)
+        {
+            this.Left.Assign(x, exp);
+            this.Right.Assign(x, exp);
+        }
+
+        virtual public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            this.Left.Assign(x, exp, preState);
+            this.Right.Assign(x, exp, preState);
+        }
+
+        virtual public void ProjectVariable(Variable var)
+        {
+            this.Left.ProjectVariable(var);
+            this.Right.ProjectVariable(var);
+        }
+
+        virtual public void RemoveVariable(Variable var)
+        {
+            this.Left.RemoveVariable(var);
+            this.Right.RemoveVariable(var);
+        }
+
+        virtual public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            this.Left.RenameVariable(OldName, NewName);
+            this.Right.RenameVariable(OldName, NewName);
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+        public virtual IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            var results = new IAbstractDomain[this.arr.Length];
+
+            for (var i = 0; i < this.arr.Length; i++)
+            {
+                results[i] = this.arr[i].TestTrue(guard);
+            }
+
+            return this.Factory((LeftDomain)results[0], (RightDomain)results[1]) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        virtual public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            var results = new IAbstractDomain[this.arr.Length];
+
+            for (var i = 0; i < this.arr.Length; i++)
+            {
+                results[i] = this.arr[i].TestFalse(guard);
+            }
+
+            return this.Factory((LeftDomain)results[0], (RightDomain)results[1]) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        virtual public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            if (CommonChecks.CheckTrivialEquality(exp, expManager.Decoder))
+            {
+                return CheckOutcome.True;
+            }
+
+            var results = new FlatAbstractDomain<bool>[this.arr.Length];
+
+            for (var i = 0; i < arr.Length; i++)
+            {
+                results[i] = this.arr[i].CheckIfHolds(exp);
+            }
+
+            return results[0].Meet(results[1]);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> outcome;
+            if (CommonChecks.CheckTrivialEquality(e1, e2, expManager.Decoder, out outcome))
+            {
+                return outcome;
+            }
+
+            var leftOutcome = this.Left.CheckIfEqual(e1, e2);
+            if (leftOutcome.IsNormal())
+            {
+                return leftOutcome;
+            }
+
+            return this.Right.CheckIfEqual(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfEqual(e1, e2);
+        }
+
+        /// <summary>
+        /// Check if <code>e != 0</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
+        {
+            var checks = new FlatAbstractDomain<bool>[this.arr.Length];
+            //MyParallel.For(0, 2, i => checks[i] = this.arr[i].CheckIfNonZero(exp));
+
+            for (var i = 0; i < arr.Length; i++)
+            {
+                checks[i] = this.arr[i].CheckIfNonZero(exp);
+            }
+
+            var result = checks[0].Meet(checks[1]);
+
+            if (result.IsTop)
+            {
+                // We give a try by checking if exp > 0 or exp < 0
+                var isGTzero = this.CheckIfLessThan(this.Zero, exp);  // zero < exp ?
+
+                if (isGTzero.IsTrue())
+                {
+                    return isGTzero;
+                }
+
+                var isLTzero = this.CheckIfLessThan(exp, this.Zero);  // exp < zero ?
+
+                if (isLTzero.IsTrue())
+                {
+                    return isLTzero;
+                }
+            }
+
+            return result;
+        }
+
+        public override IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            if (this.IsBottom)
+                return prev;
+            if (prev.IsBottom)
+                return this;
+
+            var castedPrev = prev as ReducedNumericalDomains<LeftDomain, RightDomain, Variable, Expression>;
+
+            Contract.Assert(prev != null);
+
+            var widened = new IAbstractDomain[this.arr.Length];
+
+            for (var i = 0; i < arr.Length; i++)
+            {
+                widened[i] = this.arr[i].Widening(castedPrev.arr[i]);
+            }
+
+            return this.Factory((LeftDomain)widened[0], (RightDomain)widened[1]);
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Expression> Members
+
+        virtual public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            this.Left.AssignInParallel(sourcesToTargets, convert);
+            this.Right.AssignInParallel(sourcesToTargets, convert);
+        }
+
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            this.Left.SetFloatType(v, f);
+            this.Right.SetFloatType(v, f);
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return this.Left.GetFloatType(v).Meet(this.Right.GetFloatType(v));
+        }
+
+        #endregion
+
+        #region ToString
+        public string ToString(Expression exp)
+        {
+            if (expManager.Decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, expManager.Decoder);
+            }
+            else
+            {
+                return "< missing expression decoder >";
+            }
+        }
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        public Variable ToVariable(Expression exp)
+        {
+            return expManager.Decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// A flat abstract domain, to be used for instance for constant propagation
+    /// </summary>
+    /// <typeparam name="Elements">The elements in the flat lattice. We perform the comparison of elements through <code>Equals</code></typeparam>
+    [ContractVerification(true)]
+    public class FlatAbstractDomain<Elements>
+      : IAbstractDomain
+    {
+        public enum State { Top, Bottom, Normal }
+
+        #region Cached values
+        static private readonly FlatAbstractDomain<Elements> cachedBottom; // Thread-safe
+        static private readonly FlatAbstractDomain<Elements> cachedTop; // Thread-safe
+
+        static FlatAbstractDomain()
+        {
+            cachedBottom = new FlatAbstractDomain<Elements>(State.Bottom);
+            cachedTop = new FlatAbstractDomain<Elements>(State.Top);
+        }
+
+        #endregion
+
+        #region Private fields
+        protected readonly State state;              // The state of the abstract element
+        private readonly Elements val;               // If the state is top or bottom, this value is meaningless
+        private readonly string name;                // An optional string, for pretty printing
+
+        #endregion
+
+        #region Getter
+        /// <summary>
+        /// The element encapsulated inside this element.
+        /// It makes sense only if <code>!this.IsBottom</code> and <code>!this.IsTop</code>
+        /// </summary>
+        public Elements BoxedElement
+        {
+            get
+            {
+                Contract.Requires(this.IsNormal(), "BoxedElement makes sense just on non extreme cases");
+
+                return val;
+            }
+        }
+        #endregion
+
+        #region Constructors
+        public FlatAbstractDomain(Elements val, string name = "")
+        {
+            this.state = State.Normal;
+            this.val = val;
+            this.name = name;
+        }
+
+        protected FlatAbstractDomain()
+        {
+            this.state = State.Normal;
+            val = default(Elements);
+        }
+
+        protected FlatAbstractDomain(State state)
+        {
+            this.state = state;
+            val = default(Elements);
+        }
+
+        #endregion
+
+        #region Implementation of IAbstractDomain
+
+        public virtual object Clone()
+        {
+            return this;
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                return this.state == State.Bottom;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return this.state == State.Top;
+            }
+        }
+
+        public bool LessEqual(IAbstractDomain a)
+        {
+            var other = a as FlatAbstractDomain<Elements>;
+
+            Contract.Assume(other != null);
+
+            return this.LessEqual(other);
+        }
+
+        public bool LessEqual(FlatAbstractDomain<Elements> right)
+        {
+            Contract.Requires(right != null);
+
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
+            {
+                return result;
+            }
+
+            return AreEqual(val, right.val);
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get
+            {
+                return BottomFactory();
+            }
+        }
+
+        public FlatAbstractDomain<Elements> Bottom
+        {
+            get
+            {
+                return BottomFactory();
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get
+            {
+                return TopFactory();
+            }
+        }
+
+        public FlatAbstractDomain<Elements> Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
+
+                return TopFactory();
+            }
+        }
+
+        public IAbstractDomain Join(IAbstractDomain a)
+        {
+            var other = a as FlatAbstractDomain<Elements>;
+
+            Contract.Assume(other != null);
+
+            return this.Join(other);
+        }
+
+        public FlatAbstractDomain<Elements> Join(FlatAbstractDomain<Elements> right)
+        {
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
+
+            FlatAbstractDomain<Elements> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
+            {
+                return result;
+            }
+
+            Contract.Assume(val != null);
+            Contract.Assume(right.val != null);
+
+            return AreEqual(val, right.val) ? this : Top;
+        }
+
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            var other = a as FlatAbstractDomain<Elements>;
+
+            Contract.Assume(other != null);
+
+            return this.Meet(other);
+        }
+
+        public FlatAbstractDomain<Elements> Meet(FlatAbstractDomain<Elements> right)
+        {
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
+
+            FlatAbstractDomain<Elements> trivialMeet;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, right, out trivialMeet))
+            {
+                return trivialMeet;
+            }
+
+            if (AreEqual(val, right.val))
+                return this;
+            else
+                return Bottom;
+        }
+
+        public IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            return this.Join(prev);
+        }
+        #endregion
+
+        #region Protected, to be Overridden
+        /// <summary>
+        /// A Factory method
+        /// </summary>
+        virtual protected FlatAbstractDomain<Elements> Factory()
+        {
+            return new FlatAbstractDomain<Elements>();
+        }
+
+        /// <summary>
+        /// To be overridden if we want to change the meaning of equality.
+        /// The default is to use the object.Equals() method
+        /// </summary>
+        /// <returns>
+        /// true iff <code>left</code> and <code>right</code> are the same elements. False otherwise
+        /// </returns>
+        virtual protected bool AreEqual(Elements left, Elements right)
+        {
+            if (object.ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            return left.Equals(right);
+        }
+
+        virtual protected FlatAbstractDomain<Elements> BottomFactory()
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
+
+            Contract.Assert(cachedBottom != null);
+
+            return cachedBottom;
+        }
+
+        virtual protected FlatAbstractDomain<Elements> TopFactory()
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
+
+            Contract.Assert(cachedTop != null);
+
+            return cachedTop;
+        }
+
+        #endregion
+
+        #region Overridden
+
+        virtual public T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.Constant(false);
+            else
+                return factory.Constant(true);
+        }
+
+        public override string ToString()
+        {
+            if (this.IsBottom)
+                return "_|_";
+            else if (this.IsTop)
+                return "Top";
+            else
+            {
+                Contract.Assume(val != null);
+
+                return name != null && name.Length > 0 ? name : val.ToString();
+            }
+        }
+        #endregion
+
+        #region Implicit conversion
+        public static implicit operator FlatAbstractDomain<Elements>(Elements el)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
+
+            return new FlatAbstractDomain<Elements>(el);
+        }
+        #endregion
+    }
+
+    public class FlatAbstractDomainWithRenaming<Elements>
+      : FlatAbstractDomain<Elements>,
+      IAbstractDomainWithRenaming<FlatAbstractDomainWithRenaming<Elements>, Elements>
+    {
+        public FlatAbstractDomainWithRenaming(Elements el)
+          : base(el)
+        {
+        }
+
+        public FlatAbstractDomainWithRenaming(State state = State.Top)
+          : base(state)
+        {
+        }
+
+        #region IAbstractDomainWithRenaming<FlatAbstractDomainWithRenaming<Elements>,Elements> Members
+
+        public FlatAbstractDomainWithRenaming<Elements> Rename(Dictionary<Elements, FList<Elements>> renaming)
+        {
+            if (this.IsNormal())
+            {
+                FList<Elements> newNames;
+                if (renaming.TryGetValue(this.BoxedElement, out newNames) && newNames.Length() == 1)
+                {
+                    return new FlatAbstractDomainWithRenaming<Elements>(newNames.Head);
+                }
+                return new FlatAbstractDomainWithRenaming<Elements>();
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        #endregion
+
+        #region Implicit conversion
+        static public implicit operator FlatAbstractDomainWithRenaming<Elements>(Elements el)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomainWithRenaming<Elements>>() != null);
+
+            return new FlatAbstractDomainWithRenaming<Elements>(el);
+        }
+        #endregion
+
+        #region Override
+
+        protected override FlatAbstractDomain<Elements> BottomFactory()
+        {
+            return new FlatAbstractDomainWithRenaming<Elements>(State.Bottom);
+        }
+
+        protected override FlatAbstractDomain<Elements> TopFactory()
+        {
+            return new FlatAbstractDomainWithRenaming<Elements>(State.Top);
+        }
+
+        #endregion
+
+        #region ToString
+
+        public override string ToString()
+        {
+            if (this.IsBottom)
+                return "_|_";
+            if (this.IsTop)
+                return "Top";
+            return this.BoxedElement.ToString();
+        }
+        #endregion
+    }
+
+    [ContractVerification(true)]
+    public class FlatAbstractDomainOfBoolsWithRenaming<Variable>
+      : FlatAbstractDomain<bool>,
+      IAbstractDomainForArraySegmentationAbstraction<FlatAbstractDomainOfBoolsWithRenaming<Variable>, Variable>
+    {
+        public FlatAbstractDomainOfBoolsWithRenaming(bool value, string msg = "")
+          : base(value, msg)
+        {
+        }
+
+        public FlatAbstractDomainOfBoolsWithRenaming(State state)
+          : base(state)
+        {
+        }
+
+        #region IAbstractDomainWithRenaming<FlatAbstractDomainWithRenaming<Elements,Variable>,Variable> Members
+
+        public FlatAbstractDomainOfBoolsWithRenaming<Variable> Rename(Dictionary<Variable, FList<Variable>> renaming)
+        {
+            return this;
+        }
+
+        #endregion
+
+        #region overridden
+
+        protected override FlatAbstractDomain<bool> BottomFactory()
+        {
+            return new FlatAbstractDomainOfBoolsWithRenaming<Variable>(State.Bottom);
+        }
+
+        protected override FlatAbstractDomain<bool> TopFactory()
+        {
+            return new FlatAbstractDomainOfBoolsWithRenaming<Variable>(State.Top);
+        }
+
+        #endregion
+
+        #region To
+
+        public override T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.IdentityForOr;
+
+            if (this.IsTop)
+                return factory.IdentityForAnd;
+
+            T name;
+            if (this.BoxedElement && factory.TryGetName(out name))
+            {
+                // name != null
+                return factory.NotEqualTo(name, factory.Null);
+            }
+
+            return factory.IdentityForAnd;
+        }
+
+        #endregion
+
+        #region IAbstractDomainForArraySegmentationAbstraction<FlatAbstractDomainOfBoolsWithRenaming<Variable>,Variable> Members
+
+        public FlatAbstractDomainOfBoolsWithRenaming<Variable> AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            return this;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// One day this should be merged with ProofOutcome
+    /// </summary>
+    static public class CheckOutcome
+    {
+        readonly public static FlatAbstractDomain<bool> True;   // Thread-safe
+        readonly public static FlatAbstractDomain<bool> False;  // Thread-safe
+        readonly public static FlatAbstractDomain<bool> Bottom; // Thread-safe
+        readonly public static FlatAbstractDomain<bool> Top;    // Thread-safe
+
+        static CheckOutcome()
+        {
+            True = new FlatAbstractDomain<bool>(true);
+            False = new FlatAbstractDomain<bool>(false);
+            Bottom = True.Bottom;
+            Top = True.Top;
+        }
+
+        [Pure]
+        static public bool IsNormal(this IAbstractDomain receiver)
+        {
+            Contract.Ensures(Contract.Result<bool>() == (!receiver.IsBottom && !receiver.IsTop));
+
+            return !receiver.IsBottom && !receiver.IsTop;
+        }
+
+        [Pure]
+        static public bool IsTrue(this FlatAbstractDomain<bool> receiver)
+        {
+            return receiver.IsNormal() && receiver.BoxedElement;
+        }
+
+        [Pure]
+        static public bool IsFalse(this FlatAbstractDomain<bool> receiver)
+        {
+            return receiver.IsNormal() && !receiver.BoxedElement;
+        }
+    }
+
+    /// <summary>
+    /// A flat abstract domain which uses a Comparer to test if two elements are the same.
+    /// A first application is in the symbolic abstract domain.
+    /// </summary>
+    public class FlatAbstractDomainWithComparer<Elements>
+      : FlatAbstractDomain<Elements>
+    {
+        #region Static constructor
+
+        static private readonly FlatAbstractDomainWithComparer<Elements> cachedBottom; // Thread-safe
+        static private readonly FlatAbstractDomainWithComparer<Elements> cachedTop;    // Thread-safe
+
+        static FlatAbstractDomainWithComparer()
+        {
+            cachedBottom = new FlatAbstractDomainWithComparer<Elements>(State.Bottom);
+            cachedTop = new FlatAbstractDomainWithComparer<Elements>(State.Top);
+        }
+        #endregion
+
+        #region The comparer used to test if two elements are the same
+        private readonly IComparer<Elements> comparer;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Construct an abstract element of the flat lattice and the ability of comparing elements
+        /// </summary>
+        /// <param name="value">The element embedded in this abstract value</param>
+        /// <param name="comparer">The comparer for the elements</param>
+        public FlatAbstractDomainWithComparer(Elements value, IComparer<Elements> comparer)
+          : base(value)
+        {
+            this.comparer = comparer;
+        }
+
+        protected FlatAbstractDomainWithComparer(IComparer<Elements> comparer)
+          : base()
+        {
+            this.comparer = comparer;
+        }
+
+        protected FlatAbstractDomainWithComparer(State state)
+          : base(state)
+        {
+            comparer = null;
+        }
+
+        #endregion
+
+        #region Overridden methods
+        /// <summary>
+        /// We use the comparer passed at object creation time for comparing the elements
+        /// </summary>
+        protected override bool AreEqual(Elements left, Elements right)
+        {
+            return comparer.Compare(left, right) == 0;
+        }
+
+        /// <returns>A new instance of <code>FlatAbstractDomainWithComparer</code> that has the same comparer than this object </returns>
+        protected override FlatAbstractDomain<Elements> Factory()
+        {
+            var freshValue = new FlatAbstractDomainWithComparer<Elements>(comparer);
+
+            return freshValue;
+        }
+
+        protected override FlatAbstractDomain<Elements> BottomFactory()
+        {
+            return cachedBottom;
+        }
+
+        protected override FlatAbstractDomain<Elements> TopFactory()
+        {
+            return cachedTop;
+        }
+        #endregion
+    }
+
+    ///<summary>
+    /// A powerset abstract domain
+    ///</summary>
+    ///<typeparam name="Elements">The elements of the set</typeparam>
+    public class PowerSetAbstractDomain<Elements>
+      : IAbstractDomain
+    {
+        // Improve: Add subclass to handle exactly enums, for precision and speed
+
+        #region Cached values
+        static protected readonly PowerSetAbstractDomain<Elements> cachedBottom = new PowerSetAbstractDomain<Elements>(State.Bottom); // Thread-safe
+        static protected readonly PowerSetAbstractDomain<Elements> cachedTop = new PowerSetAbstractDomain<Elements>(State.Top);       // Thread-safe
+        #endregion
+
+        protected enum State { Top, Bottom, Normal };
+
+        #region Private fields
+        private readonly State state;                            // The state of the abstract element
+        private readonly IReadonlySet<Elements> elements;        // The elements in the abstract element. This field is not significative if state == Top or state == Bottom
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Constructs the singleton {<code>element</code>}
+        /// </summary>
+        //^ [NotDelayed]
+        public PowerSetAbstractDomain(Elements element)
+        {
+            // To make happy the Spec# compiler, we rewrite the two lines below by adding  a temp
+            //  
+            //  elements = new Set<Elements>();
+            //  elements.Add(element);
+            //
+            var tmpElements = new Set<Elements>();
+
+            tmpElements.Add(element);
+            elements = tmpElements;
+            //^ base();
+            state = State.Normal;
+        }
+
+        /// <summary>
+        /// Constructs the PowerSet containing all and only <code>elements</code>
+        /// </summary>
+        //^ [NotDelayed]
+        public PowerSetAbstractDomain(IReadonlySet<Elements> elements)
+        {
+            //  To make happy the Spec# compiler, we rewrite the line below by adding a temp
+            //      this.elements = new Set<Elements>(elements);
+
+            var tmpElements = elements;
+            this.elements = tmpElements;
+            state = tmpElements.Count != 0 ? State.Normal : State.Bottom;
+            //^ base();
+        }
+
+        private PowerSetAbstractDomain(State state)
+        {
+            this.state = state;
+            elements = new Set<Elements>();
+        }
+
+        private PowerSetAbstractDomain(PowerSetAbstractDomain<Elements> psAD)
+        {
+            state = psAD.state;
+            elements = new Set<Elements>(psAD.elements);
+        }
+        #endregion
+
+        #region Implementation of IAbstractDomain
+
+        public object Clone()
+        {
+            return new PowerSetAbstractDomain<Elements>(this);
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                if (elements != null && elements.Count == 0 && state != State.Top)
+                    return true;
+                else
+                    return state == State.Bottom;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return state == State.Top;
+            }
+        }
+
+        /// <summary>
+        /// The partial order on the abstract domain
+        ///</summary>
+        public bool LessEqual(IAbstractDomain a)
+        {
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
+            {
+                return result;
+            }
+
+            Contract.Assume(a is PowerSetAbstractDomain<Elements>, "Error: expecting a PowerSetAbstractDomain<Elements> " + a);
+            PowerSetAbstractDomain<Elements> right = (PowerSetAbstractDomain<Elements>)a;
+
+            //^ assert this.state == State.Normal && right.state == State.Normal;
+
+            return elements.IsSubset(right.elements);
+        }
+
+        /// <summary>
+        /// Get the bottom element of the abstract domain
+        ///</summary>
+        public IAbstractDomain Bottom
+        {
+            get
+            {
+                return cachedBottom;
+            }
+        }
+
+        /// <summary>
+        /// Get the top element of the abstract doman
+        ///</summary>
+        public IAbstractDomain Top
+        {
+            get
+            {
+                return cachedTop;
+            }
+        }
+
+        /// <summary>
+        /// The join is roughly the set union
+        ///</summary>
+        public IAbstractDomain Join(IAbstractDomain a)
+        {
+            IAbstractDomain trivialresult;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivialresult))
+            {
+                return trivialresult;
+            }
+
+            var right = a as PowerSetAbstractDomain<Elements>;
+            Contract.Assume(right != null);
+
+            return new PowerSetAbstractDomain<Elements>(elements.Union(right.elements));
+        }
+
+        /// <summary>
+        /// The meet is roughly the set intersection
+        ///</summary>
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            IAbstractDomain trivialMeet;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
+            {
+                return trivialMeet;
+            }
+
+            var right = a as PowerSetAbstractDomain<Elements>;
+            Contract.Assume(right != null);
+
+            var result = elements.Intersection(right.elements);
+
+            return new PowerSetAbstractDomain<Elements>(result);
+        }
+
+        /// <summary>
+        /// The widening is quite rough, in that it approximate the set with top
+        /// Convention: <code>this</code> is the value of the new iteration. <code>prev</code> is the value of the previous one
+        ///</summary>
+        public IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            if (this.IsTop)
+                return this;
+            else if (this.IsBottom)
+                return prev;
+            else if (prev.IsBottom)
+                return this;
+            else if (prev.IsTop)
+                return prev;
+            else
+                return Top;
+        }
+        #endregion
+
+        public bool IsSigleton
+        {
+            get
+            {
+                if (this.IsBottom || this.IsTop)
+                {
+                    return true;
+                }
+                else
+                {
+                    return elements.Count == 1;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The set of elements contained an an element of this domain.
+        /// If this element is top, then an exception is thrown
+        /// </summary>
+        public Set<Elements> EmbeddedValues
+        {
+            get
+            {
+                if (!this.IsTop)
+                {
+                    return new Set<Elements>(elements);
+                }
+                else
+                {
+                    throw new AbstractInterpretationException("Cannot have the elements of a top powerset");
+                }
+            }
+        }
+
+        #region Overridden
+
+        public T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.Constant(false);
+            else
+                return factory.Constant(true);
+        }
+
+        //^ [Confined]
+        public override string ToString()
+        {
+            string result;
+            if (this.IsBottom)
+            {
+                result = "{}";
+            }
+            else if (this.IsTop)
+            {
+                result = "Top";
+            }
+            else
+            {
+                result = "{ ";
+                foreach (Elements e in elements)
+                {
+                    result += (e != null ? e.ToString() : "null") + ",";
+                }
+
+                int indexOfLastComma = result.LastIndexOf(",");
+                if (indexOfLastComma > 0)
+                {
+                    result = result.Remove(indexOfLastComma);
+                }
+
+                result += " }";
+            }
+
+            return result;
+        }
+        #endregion
+
+    }
+
+    /// <summary>
+    /// The generic class for set of constraints.
+    /// Please note that it is different from <code>PowerSetAbstractDomain</code>
+    /// </summary>
+    [ContractVerification(true)]
+    public class SetOfConstraints<Elements>
+      : IAbstractDomainWithRenaming<SetOfConstraints<Elements>, Elements>
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(elements != null);
+        }
+
+        #region Cached values
+        static private readonly SetOfConstraints<Elements> cachedBottom = new SetOfConstraints<Elements>(State.Bottom); // Thread-safe
+        static private readonly SetOfConstraints<Elements> cachedTop = new SetOfConstraints<Elements>(State.Top);       // Thread-safe
+        #endregion
+
+        private enum State { Top, Bottom, Normal };
+
+        #region Private fields
+        private readonly State state;                      // The state of the abstract element
+        private readonly Set<Elements> elements;           // The elements in the abstract element. This field is not significative if state == Top or state == Bottom
+
+        #endregion
+
+        #region Constructors
+
+        public SetOfConstraints(Elements element)
+        {
+            elements = new Set<Elements>() { element };
+
+            state = State.Normal;
+        }
+
+        public SetOfConstraints(IEnumerable<Elements> elements)
+          : this(new Set<Elements>(elements))
+        {
+            Contract.Requires(elements != null);
+        }
+
+        public SetOfConstraints(Set<Elements> elements, bool makeCopy)
+          : this(makeCopy ? new Set<Elements>(elements) : elements)
+        {
+            Contract.Requires(elements != null);
+        }
+
+        private SetOfConstraints(Set<Elements> elements)
+        {
+            Contract.Requires(elements != null);
+
+            this.elements = elements;
+            state = this.elements.Count != 0 ? State.Normal : State.Top;
+        }
+
+        private SetOfConstraints(State state)
+        {
+            this.state = state;
+            elements = new Set<Elements>();
+        }
+
+        private SetOfConstraints(SetOfConstraints<Elements> psAD)
+        {
+            Contract.Requires(psAD != null);
+
+            Contract.Assume(psAD.elements != null);
+
+            state = psAD.state;
+            elements = new Set<Elements>(psAD.elements);
+        }
+        #endregion
+
+        #region Static Properties
+        static public SetOfConstraints<Elements> Unknown
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
+
+                return cachedTop;
+            }
+        }
+
+        static public SetOfConstraints<Elements> Unreached
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
+
+                return cachedBottom;
+            }
+        }
+
+        #endregion
+
+        #region Implementation of IAbstractDomain
+
+        public object Clone()
+        {
+            return this; // It's functional
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                if (/*this.elements != null && */elements.Count == 0 && state != State.Top)
+                    return true;
+                else
+                    return state == State.Bottom;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return state == State.Top;
+            }
+        }
+
+        /// <summary>
+        /// Order is superset inclusion
+        /// </summary>
+        public bool LessEqual(IAbstractDomain a)
+        {
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
+            {
+                return result;
+            }
+
+            var right = a as SetOfConstraints<Elements>;
+
+            Contract.Assume(right != null);
+            Contract.Assume(right.elements != null);
+
+            return right.elements.IsSubset(elements);
+        }
+
+        public IAbstractDomain Bottom
+        {
+            get
+            {
+                return cachedBottom;
+            }
+        }
+
+        /// <summary>
+        /// Get the top element of the abstract doman
+        ///</summary>
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get
+            {
+                return cachedTop;
+            }
+        }
+
+        public SetOfConstraints<Elements> Top
+        {
+            get
+            {
+                return cachedTop;
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var other = a as SetOfConstraints<Elements>;
+
+            Contract.Assume(other != null);
+
+            return this.Join(other);
+        }
+
+        /// <summary>
+        /// The join is set intersection
+        ///</summary>
+        [Pure]
+        public SetOfConstraints<Elements> Join(SetOfConstraints<Elements> right)
+        {
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
+
+            SetOfConstraints<Elements> trivialresult;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, right, out trivialresult))
+            {
+                return trivialresult;
+            }
+            Contract.Assume(right.elements != null);
+
+            var result = elements.Intersection(right.elements);
+
+            return new SetOfConstraints<Elements>(result, false);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            var other = a as SetOfConstraints<Elements>;
+
+            Contract.Assume(other != null);
+
+            return this.Meet(other);
+        }
+
+        /// <summary>
+        /// The meet is set union
+        ///</summary>
+        [Pure]
+        public SetOfConstraints<Elements> Meet(SetOfConstraints<Elements> right)
+        {
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
+
+            SetOfConstraints<Elements> trivialMeet;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, right, out trivialMeet))
+            {
+                return trivialMeet;
+            }
+
+            Contract.Assume(right.elements != null);
+
+            var result = elements.Union(right.elements);
+
+            return new SetOfConstraints<Elements>(result, false);
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain a)
+        {
+            var other = a as SetOfConstraints<Elements>;
+
+            Contract.Assume(other != null);
+
+            return this.Widening(other);
+        }
+
+        /// <summary>
+        /// The widening is quite rough, in that it approximate the set with top
+        /// Convention: <code>this</code> is the value of the new iteration. <code>prev</code> is the value of the previous one
+        ///</summary>
+        [Pure]
+        public SetOfConstraints<Elements> Widening(SetOfConstraints<Elements> prev)
+        {
+            Contract.Requires(prev != null);
+
+            Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
+
+            if (this.IsTop)
+                return this;
+            if (this.IsBottom)
+                return prev;
+
+            if (prev.IsBottom)
+                return this;
+            if (prev.IsTop)
+                return prev;
+
+            return this.Join(prev as SetOfConstraints<Elements>);
+        }
+        #endregion
+
+        public int Count
+        {
+            get
+            {
+                if (!this.IsNormal())
+                {
+                    return 0;
+                }
+                return elements.Count;
+            }
+        }
+
+        public IEnumerable<Elements> Values
+        {
+            get
+            {
+                if (this.IsNormal())
+                {
+                    foreach (var x in elements)
+                    {
+                        yield return x;
+                    }
+                }
+                else
+                {
+                    yield break;
+                }
+            }
+        }
+
+        [Pure]
+        public SetOfConstraints<Elements> Add(Elements el)
+        {
+            Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
+
+            if (this.IsBottom)
+            {
+                return this;
+            }
+            if (this.IsTop)
+            {
+                return new SetOfConstraints<Elements>(el);
+            }
+            else
+            {
+                var newSet = new Set<Elements>(elements);
+                newSet.Add(el);
+
+                return new SetOfConstraints<Elements>(newSet, false);
+            }
+        }
+
+        [Pure]
+        public bool Contains(Elements what)
+        {
+            if (!this.IsNormal())
+                return false;
+
+            return elements.Contains(what);
+        }
+
+        public T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.Constant(false);
+            else
+                return factory.Constant(true);
+        }
+
+        #region Overridden
+
+        private Optional<int> hash;
+        public override int GetHashCode()
+        {
+            if (!hash.IsValid)
+            {
+                hash = elements.GetHashCode();
+            }
+
+            return hash.Value;
+        }
+
+        public override string ToString()
+        {
+            if (this.IsBottom)
+                return "{}";
+            else if (this.IsTop)
+                return "Top";
+            else
+            {
+                return elements.ToString();
+            }
+        }
+        #endregion
+
+        #region IAbstractDomainWithRenaming<SetOfConstraints<Elements>,Elements> Members
+
+        public SetOfConstraints<Elements> Rename(Dictionary<Elements, FList<Elements>> renaming)
+        {
+            if (this.IsNormal())
+            {
+                var newSet = new Set<Elements>(elements.Count);
+                foreach (var el in elements)
+                {
+                    FList<Elements> renamed;
+                    if (renaming.TryGetValue(el, out renamed))
+                    {
+                        newSet.AddRange(renamed.GetEnumerable());
+                    }
+                }
+
+                return new SetOfConstraints<Elements>(newSet, false);
+            }
+
+            return this;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// An abstract element with just two elements, top and bottom
+    /// This is mainly for creating dummy top and bottom values and for debugging purposes
+    /// </summary>
+    [ContractVerification(true)]
+    public class Reachability :
+      IAbstractDomain
+    {
+        public enum State { Top, Bottom }
+
+        #region Cached values
+        static private readonly Reachability bottomReachbility = new Reachability(State.Bottom); // Thread-safe
+        static private readonly Reachability topReachbility = new Reachability(State.Top);       // Thread-safe
+        #endregion
+
+        #region Private fields
+        readonly private State val;
+        #endregion
+
+        #region Getters
+
+        static public Reachability aTopElement
+        {
+            get
+            {
+                return topReachbility;
+            }
+        }
+
+        static public Reachability aBottomElement
+        {
+            get
+            {
+                return bottomReachbility;
+            }
+        }
+        #endregion
+
+        #region Constructors
+
+        protected Reachability(State r)
+        {
+            val = r;
+        }
+
+        #endregion
+
+        #region Implementation of IAbstractDomain
+
+        public object Clone()
+        {
+            return this;
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                return val == State.Bottom;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return val == State.Top;
+            }
+        }
+
+        public bool LessEqual(IAbstractDomain a)
+        {
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
+            {
+                return result;
+            }
+
             return false;
         }
 
-        this.State = AbstractState.Top;
-        return true;
-      }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      return this.LessEqual((This)a);
-    }
-
-    /// <summary>
-    /// The pointwise extension of the order on the elements in the codomain
-    /// </summary>
-    virtual public bool LessEqual(This right)
-    {
-      Contract.Requires(right != null);
-
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
-      {
-        return result;
-      }
-
-      foreach (var pair in right.Elements)
-      {
-        var rightVal = pair.Value;
-
-        Contract.Assume(rightVal != null);
-
-        // We do not want to enforce each subclass to have a canonical representation so we explicitely check for it
-        if (rightVal.IsTop)
+        virtual public IAbstractDomain Bottom
         {
-          continue;
+            get
+            {
+                return bottomReachbility;
+            }
         }
 
-        Codomain leftVal;
-        if (!this.elements.TryGetValue(pair.Key, out leftVal))
+        virtual public IAbstractDomain Top
         {
-          return false;
+            get
+            {
+                return topReachbility;
+            }
         }
 
-        if (!leftVal.LessEqual(rightVal))
-          return false;
-      }
-
-      return true;
-    }
-
-    /// <summary>
-    /// Returns an empty function
-    /// </summary>
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get
-      {
-        return this.Bottom;
-      }
-    }
-
-    public This Bottom
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<This>() != null);
-
-        var bot = this.Factory();
-
-        bot.state = AbstractState.Bottom;
-
-        return bot;
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get
-      {
-        return this.Top;
-      }
-    }
-
-    public This Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<This>() != null);
-
-        var top = this.Factory();
-
-        top.state = AbstractState.Top;
-
-        return top;
-      }
-    }
-
-    /// <summary>
-    /// Join of functional maps
-    /// </summary>
-    /// <returns> A freshly allocated functional map, with the pointwise join</returns>
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      return this.Join((This)a);
-    }
-
-    public virtual This Join(This other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      if (object.ReferenceEquals(this, other))
-      {
-        return other;
-      }
-
-      if (this.IsBottom)
-        return other;
-      if (other.IsBottom)
-        return (This)this;
-
-      Dictionary<Domain, Codomain> left, right;
-
-      Contract.Assume(other.elements != null);
-
-      // Select the smaller one
-      if (this.elements.Count <= other.elements.Count)
-      {
-        left = this.elements;
-        right = other.elements;
-      }
-      else
-      {
-        left = other.elements;
-        right = this.elements;
-      }
-
-      var result = this.Factory();
-
-      foreach (var pair in left)       // For all the elements in the intersection do the point-wise join
-      {
-        Codomain right_x;
-        if (right.TryGetValue(pair.Key, out right_x))
+        public IAbstractDomain Join(IAbstractDomain a)
         {
-          Contract.Assume(right_x != null);
+            IAbstractDomain result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out result))
+            {
+                return result;
+            }
 
-          var join = pair.Value.Join(right_x);
+            Contract.Assume(false, "you were not supposed to be there.... " + a);
 
-          if (join.IsBottom)
-          {
-            return result.Bottom;
-          }
-
-          if (!join.IsTop)
-          { // We keep in the map only the elements that are != top
-            result[pair.Key] = (Codomain)join;
-          }
+            return this.Top;
         }
-      }
 
-      return result;
-    }
-
-    /// <summary>
-    /// Meet of functional abstract domains
-    /// </summary>
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      return this.Meet((This)a);
-    }
-
-    public virtual This Meet(This right)
-    {
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      // Here we do not have trivial joins as we want to join maps of different cardinality
-      if (this.IsBottom)
-        return (This)this;
-      if (right.IsBottom)
-        return right;
-
-      var result = this.Factory();
-
-      Contract.Assume(right.elements != null);
-
-      foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
-      {
-              Codomain right_x;
-        if (right.elements.TryGetValue(pair.Key, out right_x))
+        public IAbstractDomain Meet(IAbstractDomain a)
         {
-          Contract.Assume(right_x != null);
+            IAbstractDomain trivialMeet;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
+            {
+                return trivialMeet;
+            }
 
-          var meet = pair.Value.Meet(right_x);
-          result[pair.Key] = (Codomain)meet;
+            Contract.Assume(false, "you were not supposed to be there.... " + a);
+
+            return this.Bottom;
         }
-      }
 
-      return result;
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      return this.Widening((This)prev);
-    }
-
-    /// <summary>
-    /// Widening of the functional domain.
-    /// If the two functions have the same cardinality, then it is a widening.
-    /// If not, i.e. the cardinality of the domain increases then it may not terminate.
-    /// If you are in this 2nd case, please contact me (logozzo)
-    /// </summary>
-    public virtual This Widening(This right)
-    {
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      // Here we do not have trivial widening as we want to join maps of different cardinality
-      if (this.IsBottom)
-        return right;
-
-      if (right.IsBottom)
-        return (This)this;
-
-      var result = this.Factory();
-
-      Contract.Assume(right.elements != null);
- 
-      foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
-      {
-        Codomain right_x;
-        if (right.elements.TryGetValue(pair.Key, out right_x))
+        public IAbstractDomain Widening(IAbstractDomain prev)
         {
-          Contract.Assume(right_x != null);
-
-          var widening = pair.Value.Widening(right_x);
-
-          if (!widening.IsTop)
-          {
-            result[pair.Key] = (Codomain)widening;
-          }
+            return this.Join(prev);
         }
-      }
 
-      return result;
-    }
-    #endregion
-
-    #region Redefined indexer
-
-#if TRACEPERFORMANCE
-    public static Dictionary<int, int> MaxSizes
-    {
-      get
-      {
-        return PerformanceCounter.MaxSizes;
-      }
-    }
-
-    [ThreadStatic]
-    private static int MaxSize;
-#endif
-
-    virtual public Codomain this[Domain index]
-    {
-      set
-      {
-        if (value.IsBottom)
+        public T To<T>(IFactory<T> factory)
         {
-          this.state = AbstractState.Bottom;
+            if (this.IsBottom)
+                return factory.Constant(false);
+            else
+                return factory.Constant(true);
         }
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            return val == State.Bottom ? "bottom" : "top";
+        }
+        #endregion
+    }
+
+    [ContractVerification(true)]
+    public class TwoValuesLattice<Variable>
+      : Reachability, IAbstractDomainForArraySegmentationAbstraction<TwoValuesLattice<Variable>, Variable>
+    {
+        private readonly string message;
+
+        public TwoValuesLattice(Reachability.State state, string msg = null)
+          : base(state)
+        {
+            message = msg;
+        }
+
+        override public IAbstractDomain Bottom
+        {
+            get
+            {
+                return new TwoValuesLattice<Variable>(State.Bottom, (this.IsBottom && message != null) ? message : "");
+            }
+        }
+
+        override public IAbstractDomain Top
+        {
+            get
+            {
+                return new TwoValuesLattice<Variable>(State.Top);
+            }
+        }
+
+        #region IAbstractDomainWithRenaming<Reachability<Variable>,Variable> Members
+
+        public TwoValuesLattice<Variable> Rename(Dictionary<Variable, FList<Variable>> renaming)
+        {
+            return this;
+        }
+
+        #endregion
+
+        #region ToString
+
+        public override string ToString()
+        {
+            if (message != null)
+            {
+                return message;
+            }
+
+            return base.ToString();
+        }
+
+        #endregion
+
+        #region IAbstractDomainForArraySegmentationAbstraction<TwoValuesLattice<Variable>,Variable> Members
+
+        public TwoValuesLattice<Variable> AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            return this;
+        }
+
+        #endregion
+    }
 
 #if TRACEPERFORMANCE
 
-        int oldMaxSize = MaxSize;
-        MaxSize = Math.Max(MaxSize, this.Count);
+    internal static class PerformanceCounter
+    {
+        // For performance counting...
+        [ThreadStatic]
+        static internal Dictionary<int, int> maxSizes;
 
-#if TRACEPERFORMANCE && VERBOSEOUTPUT
-        if (MaxSize > oldMaxSize)
+        static internal Dictionary<int, int> MaxSizes
         {
-          ConsoleColor oldColor = Console.ForegroundColor;
-          Console.ForegroundColor = ConsoleColor.Yellow;
-
-          Console.WriteLine("New MaxSize for an instance of a FunctionalAbstractDomain: {0}", MaxSize);
-
-          Console.ForegroundColor = oldColor;
+            get
+            {
+                if (maxSizes == null)
+                    maxSizes = new Dictionary<int, int>();
+                return maxSizes;
+            }
         }
-#endif
-
-        if (MaxSizes.ContainsKey(this.GetHashCode()))
-        {
-          MaxSizes[this.GetHashCode()] = Math.Max(MaxSizes[this.GetHashCode()], this.Count);
-        }
-        else
-        {
-          MaxSizes[this.GetHashCode()] = this.Count;
-        }
-
-#if TRACEPERFORMANCE && VERBOSEOUTPUT
-        if (MaxSizes[this.GetHashCode()] >= 50)
-        {
-          ConsoleColor oldColor = Console.ForegroundColor;
-          Console.ForegroundColor = ConsoleColor.Yellow;
-
-          Console.WriteLine(" >50 vars : {0}", MaxSizes[this.GetHashCode()]);
-
-          Console.ForegroundColor = oldColor;
-        }
-#endif
-#endif
-        this.version++;
-        this.elements[index] = value;
-      }
-
-      get
-      {
-        return this.elements[index];
-      }
     }
-
-    public int Count
-    {
-      get
-      {
-        return this.elements.Count;
-      }
-    }
-
-    public bool ContainsKey(Domain d)
-    {
-      return this.elements.ContainsKey(d);
-    }
-
-    #endregion
-
-    #region TO BE OVERRIDDEN
-
-    abstract protected This Factory();
-
-    abstract protected string ToLogicalFormula(Domain d, Codomain c);
-
-    abstract protected T To<T>(Domain d, Codomain c, IFactory<T> factory);
-
-    #endregion
-
-    #region To<T>
-
-    public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.Constant(false);
-      if (this.IsTop)
-        return factory.Constant(true);
-
-      T result = factory.IdentityForAnd;
-
-      foreach (Domain d in this.elements.Keys)
-      {
-        T singleEntry = To(d, this[d], factory);
-
-        result = factory.And(result, singleEntry);
-      }
-
-      return result;
-    }
-    #endregion
-
-    #region Assume Domain specific facts
-    virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-    }
-
-    #endregion
-
-    #region Overriden
-    //^ [Confined]
-    public override string ToString()
-    {
-      if (this.Count == 0)
-        return "empty";
-
-      string result = "";
-      foreach (var x in this.elements.Keys)
-      {
-        if (x != null)
-        {
-          result += x.ToString() + " -> " + this[x] + ", ";
-        }
-      }
-      return result;
-    }
-    #endregion
-  }
-
-  [ContractClassFor(typeof(FunctionalAbstractDomain<,,>))]
-  abstract class FunctionalAbstractDomainContracts<This, Domain, Codomain>
-    : FunctionalAbstractDomain<This, Domain, Codomain>
-    where This : FunctionalAbstractDomain<This, Domain, Codomain>
-    where Codomain : IAbstractDomain
-  {
-
-    protected override This Factory()
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      return default(This);
-    }
-
-    public override object Clone()
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override string ToLogicalFormula(Domain d, Codomain c)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override T To<T>(Domain d, Codomain c, IFactory<T> factory)
-    {
-      Contract.Requires(factory != null);
-
-      throw new NotImplementedException();
-    }
-  }
-
-  /// <summary>
-  /// A simple implementation of the functional abstract domain
-  /// </summary>
-  [ContractVerification(true)]
-  public sealed class SimpleImmutableFunctional<Domain, Codomain>
-    :  FunctionalAbstractDomain<SimpleImmutableFunctional<Domain, Codomain>, Domain, Codomain>
-    where Codomain : IAbstractDomain 
-  {
-    #region Constuctor
-    public SimpleImmutableFunctional(Dictionary<Domain, Codomain> map)
-      : base()
-    {
-      Contract.Requires(map != null);
-
-      foreach (var pair in map)
-      {
-        base[pair.Key] = pair.Value;
-      }
-    }
-
-    #endregion
-
-    #region Add
-    public SimpleImmutableFunctional<Domain, Codomain> Add(Domain x, Codomain y)
-    {
-      Contract.Ensures(Contract.Result<SimpleImmutableFunctional<Domain, Codomain>>() != null);
-
-      Codomain oldy;
-      if (this.TryGetValue(x, out oldy) && oldy.Equals(x))
-      {
-        return this;
-      }
-      var newMap = new Dictionary<Domain, Codomain>();
-      foreach (var pair in this.Elements)
-      {
-        newMap.Add(pair.Key, pair.Value);
-      }
-
-      newMap[x] = y;
-
-      return new SimpleImmutableFunctional<Domain, Codomain>(newMap);
-    }
-    #endregion
-
-    #region Overridden
-
-    public override Codomain this[Domain index]
-    {
-      get
-      {
-        return base[index];
-      }
-      set
-      {
-        base[index] = value;
-      }
-    }
-
-    public override object Clone()
-    {
-      return this;
-    }
-
-    protected override string ToLogicalFormula(Domain d, Codomain c)
-    {
-      return null;
-    }
-
-    protected override T To<T>(Domain d, Codomain c, IFactory<T> factory)
-    {
-      return factory.Constant(true);
-    }
-
-    protected override SimpleImmutableFunctional<Domain, Codomain> Factory()
-    {
-      return new SimpleImmutableFunctional<Domain, Codomain>(new Dictionary<Domain, Codomain>());
-    }
-    #endregion
-
-    #region Statics
-    static public SimpleImmutableFunctional<Domain, Codomain> Unknown
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SimpleImmutableFunctional<Domain, Codomain>>() != null);
-
-        return new SimpleImmutableFunctional<Domain, Codomain>(new Dictionary<Domain, Codomain>());
-      }
-    }
-    #endregion
-  }
-
-  /// <summary>
-  /// The extension of a functional abstract domain to environemnts
-  /// </summary>
-  public abstract class FunctionalAbstractDomainEnvironment<This, Domain, Codomain, Variable, Expression>
-    : FunctionalAbstractDomain<This, Domain, Codomain>,
-    IAbstractDomainForEnvironments<Variable, Expression>
-    where This : FunctionalAbstractDomainEnvironment<This, Domain, Codomain, Variable, Expression>
-    where Codomain : IAbstractDomain
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.ExpressionManager != null);
-    }
-
-    #region State
-
-    protected readonly ExpressionManager<Variable, Expression> ExpressionManager;
-    
-    #endregion
-
-    #region Constructors
-
-    protected FunctionalAbstractDomainEnvironment(ExpressionManager<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
-
-      this.ExpressionManager = expManager;
-    }
-
-    protected FunctionalAbstractDomainEnvironment(FunctionalAbstractDomainEnvironment<This, Domain, Codomain, Variable, Expression> other)
-      : base(other)
-    {
-      Contract.Requires(other != null);
-
-      this.ExpressionManager = other.ExpressionManager;
-    }
-
-    #endregion
-
-    #region To be OVERRIDDEN
-
-    abstract override public object Clone();
-
-    abstract override protected This Factory();
-
-    abstract public List<Variable> Variables { get; }
-
-    abstract public void Assign(Expression x, Expression exp);
-
-    abstract public void ProjectVariable(Variable var);
-
-    abstract public void RemoveVariable(Variable var);
-
-    abstract public void RenameVariable(Variable OldName, Variable NewName);
-
-    abstract public This TestTrue(Expression guard);
-
-    abstract public This TestFalse(Expression guard);
-
-    abstract public FlatAbstractDomain<bool> CheckIfHolds(Expression exp);
-
-    abstract public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert);
-
-    #endregion
-
-    #region TestTrue Equal
-
-    virtual public This TestTrueEqual(Domain v1, Domain v2)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      Codomain sl, sr;
-      var inLeft = this.TryGetValue(v1, out sl);
-      var inRight = this.TryGetValue(v2, out sr);
-
-      if (inLeft ^ inRight)
-      {
-        if (inLeft)
-        {
-          this.AddElement(v2, sl);
-        }
-        else
-        {
-          this.AddElement(v1, sr);
-        }
-      }
-      else if (inLeft)
-      {
-        Contract.Assert(inRight);
-
-        var meet = sl.Meet(sr);
-
-        if (meet is Codomain)
-        {
-          this[v1] = (Codomain)meet;
-          this[v2] = (Codomain)meet;
-        }
-      }
-
-      return (This)this;
-    }
-
-    #endregion
-
-    #region Overridden
-    protected override string ToLogicalFormula(Domain d, Codomain c)
-    {
-      return "true";
-    }
-
-    protected override T To<T>(Domain d, Codomain c, IFactory<T> factory)
-    {
-      return factory.IdentityForAnd;
-    }
-    #endregion
-
-    #region IAbstractDomainForEnvironments<Variable,Expression> Members
-
-    public string ToString(Expression exp)
-    {
-      return ExpressionPrinter.ToString(exp, this.ExpressionManager.Decoder);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    public virtual void AddVariable(Variable var)
-    {
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-      return this.TestTrue(guard);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      return this.TestFalse(guard);
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-    
-    #endregion
-  }
-
-  /// <summary>
-  /// The implementation for a cartesian abstract domain with reduction.
-  /// The reduction operation is specific to the domains, so each subclass must implement is
-  /// </summary>
-  [ContractClass(typeof(ReducedCartesianAbstractDomainContracts<,>))]
-  public abstract class ReducedCartesianAbstractDomain<LeftDomain, RightDomain> : IAbstractDomain
-    where LeftDomain : class, IAbstractDomain
-    where RightDomain : class,  IAbstractDomain
-  {
-    #region Private fields
-    readonly private LeftDomain left;
-    readonly private RightDomain right;
-    #endregion
-
-    #region Object Invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.left != null);
-      Contract.Invariant(this.right != null);
-    }
-
-    #endregion
-
-    #region Getters
-
-    public LeftDomain Left
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<LeftDomain>() != null);
-        Contract.Ensures(Contract.Result<LeftDomain>().Equals(this.left));
-
-        return this.left;
-      }
-    }
-
-    public RightDomain Right
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<RightDomain>() != null);
-        Contract.Ensures(Contract.Result<RightDomain>().Equals(this.right));
-
-        return this.right;
-      }
-    }
-    #endregion
-
-    #region Constructor
-    protected ReducedCartesianAbstractDomain(LeftDomain left, RightDomain right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(this.left.Equals(left));
-      Contract.Ensures(this.right.Equals(right));
-
-      Contract.Ensures(this.left != null);
-      Contract.Ensures(this.right != null);
-
-      this.left = left;
-      this.right = right;
-    }
-    #endregion
-
-    #region TO BE OVERRIDDEN
-
-    /// <summary>
-    /// Perform the reduction of the elements of the two domains.
-    /// The reduction depends by the abstract domains, so each subclass of <code>ReducedCartesianAbstractDomain</code> is responsible for defining and implementing it.
-    /// </summary>
-    abstract public ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Reduce(LeftDomain left, RightDomain right);
-
-    /// <summary>
-    /// The widening is abstract because I want each implementation to think to his widening.
-    /// In particular I want to avoid non termination problems consequence of a bad interaction between closure (or reduction) and naive widenings 
-    /// </summary>
-    abstract public IAbstractDomain Widening(IAbstractDomain prev);
-
-    /// <summary>
-    /// The factory method for creating a particular instance of 
-    /// </summary>
-    abstract protected ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Factory(LeftDomain left, RightDomain right);
-
-    #endregion
-
-    #region Generic assume
-    virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      Contract.Requires(fact != null);
-    }
-    
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public virtual bool IsBottom
-    {
-      get
-      {
-        return this.left.IsBottom || this.right.IsBottom;       // Please note that we do the reduction here, so the element is bottom if one of the two is
-      }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.left.IsTop && this.right.IsTop;
-      }
-    }
-
-    /// <summary>
-    /// The pairwise order.
-    /// If first perform the closure of the two arguments, and then checks them pairwisely.
-    /// It is defined virtual so that a class can redefine it so to make it faster
-    /// </summary>
-    virtual public bool LessEqual(IAbstractDomain a)
-    {
-      Contract.Assert(a is ReducedCartesianAbstractDomain<LeftDomain, RightDomain>);
-
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
-      {
-        return result;
-      }
-
-      var r = a as ReducedCartesianAbstractDomain<LeftDomain, RightDomain>;
-      Contract.Assume(r != null);
-
-      var lreduced = this.Reduce(this.left, this.right);
-      var rreduced = r.Reduce(r.left, r.right);
-
-      bool b1 = lreduced.Left.LessEqual(rreduced.Left);
-
-      if (!b1)
-        return b1;
-
-      bool b2 = lreduced.Right.LessEqual(rreduced.Right);
-
-      return b2;
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get
-      {
-        return Factory((LeftDomain)this.Left.Bottom, (RightDomain)this.Right.Bottom);
-      }
-    }
-
-    public IAbstractDomain Top
-    {
-      get
-      {
-        return Factory((LeftDomain)this.Left.Top, (RightDomain)this.Right.Top);
-      }
-    }
-
-    /// <summary>
-    /// The pointwise join. The results are then reduced through <code>Reduce</code>
-    /// </summary>
-    virtual public IAbstractDomain Join(IAbstractDomain a)
-    {
-      IAbstractDomain result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, a, out result))
-      {
-        return result;
-      }
-
-      var r = a as ReducedCartesianAbstractDomain<LeftDomain, RightDomain>;
-      Contract.Assume(r != null);
-
-      var joinLeftPart = (LeftDomain)this.Left.Join(r.Left);
-      var joinRightPart = (RightDomain)this.Right.Join(r.Right);
-
-      return this.Reduce(joinLeftPart, joinRightPart);
-    }
-
-    /// <summary>
-    /// The pointwise meet. The results are then reduced through <code>Reduce</code>
-    /// </summary>
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      IAbstractDomain trivialMeet;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
-      {
-        return trivialMeet;
-      }
-
-      var r = a as ReducedCartesianAbstractDomain<LeftDomain, RightDomain>;
-      Contract.Assume(r != null);
-
-      var meetLeftPart = (LeftDomain)this.Left.Meet(r.Left);
-      var meetRightPart = (RightDomain)this.Right.Meet(r.Right);
-
-      return this.Reduce(meetLeftPart, meetRightPart);
-    }
-
-    virtual public T To<T>(IFactory<T> factory)
-    {
-      var left = this.Left.To(factory);
-      var right = this.Right.To(factory);
-
-      return factory.And(left, right);
-    }
-    #endregion
-
-    #region ICloneable Members
-
-    /// <summary>
-    /// Make a deep copy of this abstract element, i.e. it also clones the contained abstract elements
-    /// </summary>
-    virtual public object Clone()
-    {
-      var leftCloned = this.Left.Clone() as LeftDomain;
-      var rightCloned = this.Right.Clone() as RightDomain;
-
-      Contract.Assume(leftCloned != null);
-      Contract.Assume(rightCloned != null);
-
-      return Factory(leftCloned, rightCloned);
-    }
-    #endregion
-
-    #region Overridden
-
-    public override string ToString()
-    {
-      var leftStr = format(this.Left.ToString());
-      var rightStr = format(this.Right.ToString());
-
-      return "<" + Environment.NewLine + "  " + leftStr + ";" + Environment.NewLine + rightStr + Environment.NewLine + ">";
-    }
-
-    #endregion
-
-    #region Pretty printing...
-    /// <summary>
-    /// Format the string <code>input</code>, and replaces all the "\n" with "\n  "
-    /// </summary>
-    static private string format(string input)
-    {
-      Contract.Requires(input != null);
-
-      string s = input.Replace(Environment.NewLine, Environment.NewLine + "  ");
-
-      return s;
-    }
-    #endregion
-  }
-
-  #region Contracts for Reduced Cartesian Abstract Domain
-
-  [ContractClassFor(typeof(ReducedCartesianAbstractDomain<,>))]
-  abstract class ReducedCartesianAbstractDomainContracts<LeftDomain, RightDomain>
-    : ReducedCartesianAbstractDomain<LeftDomain, RightDomain>
-    where LeftDomain : class, IAbstractDomain
-    where RightDomain : class, IAbstractDomain
-  {
-
-    private ReducedCartesianAbstractDomainContracts(LeftDomain left, RightDomain right)
-      : base(left, right)
-    { }
-
-    public override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Reduce(LeftDomain left, RightDomain right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<LeftDomain, RightDomain>>() != null);
-
-      return default(ReducedCartesianAbstractDomain<LeftDomain, RightDomain>);
-    }
-
-    protected override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Factory(LeftDomain left, RightDomain right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<LeftDomain, RightDomain>>() != null);
-
-      return default(ReducedCartesianAbstractDomain<LeftDomain, RightDomain>);
-    }
-
-    public override IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      throw new NotImplementedException();
-    }
-  }
-
-
-  #endregion
-
-  /// <summary>
-  /// The base class for a cartesian product of two numerical abstract domains
-  /// </summary>
-  public abstract class ReducedNumericalDomains<LeftDomain, RightDomain, Variable, Expression>
-    : ReducedCartesianAbstractDomain<LeftDomain, RightDomain>,
-      INumericalAbstractDomain<Variable, Expression>
-    where LeftDomain : class, INumericalAbstractDomain<Variable, Expression>
-    where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Object invariant
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.expManager != null);
-    }
-
-    #endregion
-
-    #region State
-
-    private readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
-
-    protected readonly INumericalAbstractDomain<Variable, Expression>[] arr;
-
-    #endregion
-
-    #region Getters
-
-    public ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ExpressionManagerWithEncoder<Variable, Expression>>() != null);
-
-        return this.expManager;
-      }
-    }
-
-    protected Expression Zero 
-    {
-      get
-      {
-        return this.ExpressionManager.Encoder.ConstantFor(0);
-      }
-    }
-
-    #endregion
-
-    #region (Protected) constructor
-
-    protected ReducedNumericalDomains(LeftDomain left, RightDomain right, ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(left, right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Requires(expManager!= null);
-
-      Contract.Ensures(this.Left.Equals(left));
-      Contract.Ensures(this.Right.Equals(right));
-
-      this.expManager = expManager;
-      this.arr = new INumericalAbstractDomain<Variable, Expression>[] { this.Left, this.Right };
-    }
-
-    #endregion
-
-    #region To be implemented by subclasses
-    abstract public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp);
-
-    abstract public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2);
-
-    abstract public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2);
-
-    virtual public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression> Members
-
-    virtual public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
-    {
-      FlatAbstractDomain<bool> left, right;
-      left = right = null;
-
-      left = this.Left.CheckIfLessThan(v1, v2);
-
-      if (left.IsBottom)
-      {
-        return left;
-      }
-
-      right = this.Right.CheckIfLessThan(v1, v2);
-
-      return left.Meet(right);
-    }
-
-    virtual public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
-    {
-      FlatAbstractDomain<bool> left, right;
-      left = right = null;
-
-      left = this.Left.CheckIfLessEqualThan(v1, v2);
-
-      if (left.IsBottom)
-      {
-        return left;
-      }
-      
-      right = this.Right.CheckIfLessEqualThan(v1, v2);
-
-      return left.Meet(right);
-      //return this.Left.CheckIfLessEqualThan(v1, v2).Meet(this.Right.CheckIfLessEqualThan(v1, v2));
-    }
-
-    virtual public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> left, right;
-      left = right = null;
-
-      left = this.Left.CheckIfLessThan_Un(e1, e2);
-
-      if (left.IsBottom)
-      {
-        return left;
-      }
-
-      right = this.Right.CheckIfLessThan_Un(e1, e2);
-
-      return left.Meet(right);
-
-      // return this.Left.CheckIfLessThan_Un(e1, e2).Meet(this.Right.CheckIfLessThan_Un(e1, e2));
-    }
-
-    virtual public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> left, right;
-      left = right = null;
-
-      left = this.Left.CheckIfLessEqualThan_Un(e1, e2);
-
-      if (left.IsBottom)
-      {
-        return left;
-      }
-
-      right = this.Right.CheckIfLessEqualThan_Un(e1, e2);
-
-      return left.Meet(right);
-
-      //return this.Left.CheckIfLessEqualThan_Un(e1, e2).Meet(this.Right.CheckIfLessEqualThan_Un(e1, e2));
-    }
-
-    virtual public DisInterval BoundsFor(Expression exp)
-    {
-      DisInterval left, right;
-      left = right = null;
-
-      left = this.Left.BoundsFor(exp);
-       
-      if (left.IsBottom)
-      {
-        return left;
-      }
-
-      right = this.Right.BoundsFor(exp);
-
-      return left.Meet(right);
-
-      //return this.Left.BoundsFor(exp).Meet(this.Right.BoundsFor(exp));
-    }
-
-    virtual public DisInterval BoundsFor(Variable v)
-    {
-      DisInterval left, right;
-      left = right = null;
-
-      left = this.Left.BoundsFor(v);
-
-      if (left.IsBottom)
-      {
-        return left;
-      }
-      right = this.Right.BoundsFor(v);
-
-      return left.Meet(right);
-
-      //return this.Left.BoundsFor(v).Meet(this.Right.BoundsFor(v));
-    }
-
-    virtual public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        var leftConstants = this.Left.IntConstants;
-        var rightConstants = this.Right.IntConstants;
-
-        leftConstants.AddRange(rightConstants);
-
-        return leftConstants;
-      }
-    }
-
-    virtual public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
-    }
-
-    virtual public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
-    }
-
-    virtual public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
-    }
-
-    virtual public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
-    }
-
-    virtual public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      return this.Right.EqualitiesFor(v).Union(this.Left.EqualitiesFor(v));
-    }
-
-    virtual public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      var leftResult = (LeftDomain)this.Left.TestTrueGeqZero(exp);      
-      var rightResult = (RightDomain)this.Right.TestTrueGeqZero(exp);
-
-      return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    virtual public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      var leftResult = (LeftDomain)this.Left.TestTrueLessThan(exp1, exp2);
-      var rightResult = (RightDomain)this.Right.TestTrueLessThan(exp1, exp2);
-
-      return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    virtual public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      var leftResult = (LeftDomain)this.Left.TestTrueLessEqualThan(exp1, exp2);
-      var rightResult = (RightDomain)this.Right.TestTrueLessEqualThan(exp1, exp2);
-
-      return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    virtual public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      var leftResult = (LeftDomain)this.Left.TestTrueEqual(exp1, exp2);
-      var rightResult = (RightDomain)this.Right.TestTrueEqual(exp1, exp2);
-
-      return this.Factory(leftResult, rightResult) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    virtual public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      var leftReduced = (LeftDomain)this.Left.RemoveRedundanciesWith(this.Right);
-      var rightReduced = (RightDomain)this.Right.RemoveRedundanciesWith(oracle);
-
-      return this.Factory(leftReduced, rightReduced) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get
-      {
-        return this.Left.Variables.SetUnion(this.Right.Variables);
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      this.Left.AddVariable(var);
-      this.Right.AddVariable(var);
-    }
-
-    virtual public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      //this.Left.AssumeInDisInterval(x, value);
-      this.Right.AssumeInDisInterval(x, value);
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    override public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.Left.AssumeDomainSpecificFact(fact);
-      this.Right.AssumeDomainSpecificFact(fact);
-    }
-
-    virtual public void Assign(Expression x, Expression exp)
-    {
-      this.Left.Assign(x, exp);
-      this.Right.Assign(x, exp);
-    }
-
-    virtual public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      this.Left.Assign(x, exp, preState);
-      this.Right.Assign(x, exp, preState);
-    }
-
-    virtual public void ProjectVariable(Variable var)
-    {
-      this.Left.ProjectVariable(var);
-      this.Right.ProjectVariable(var);
-    }
-
-    virtual public void RemoveVariable(Variable var)
-    {
-      this.Left.RemoveVariable(var);
-      this.Right.RemoveVariable(var);
-    }
-
-    virtual public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      this.Left.RenameVariable(OldName, NewName);
-      this.Right.RenameVariable(OldName, NewName);
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-    public virtual IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      var results = new IAbstractDomain[this.arr.Length];
-
-      for (var i = 0; i < this.arr.Length; i++)
-      {
-        results[i] = this.arr[i].TestTrue(guard);
-      }
-
-      return this.Factory((LeftDomain)results[0], (RightDomain)results[1]) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    virtual public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-       var results = new IAbstractDomain[this.arr.Length];
-
-      for (var i = 0; i < this.arr.Length; i++)
-      {
-        results[i] = this.arr[i].TestFalse(guard);
-      }
-
-      return this.Factory((LeftDomain)results[0], (RightDomain)results[1]) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    virtual public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      if (CommonChecks.CheckTrivialEquality(exp, this.expManager.Decoder))
-      {
-        return CheckOutcome.True;
-      }
-
-      var results = new FlatAbstractDomain<bool>[this.arr.Length];
-
-      for (var i = 0; i < arr.Length; i++)
-      {
-        results[i] = this.arr[i].CheckIfHolds(exp);
-      }
-
-      return results[0].Meet(results[1]);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> outcome;
-      if (CommonChecks.CheckTrivialEquality(e1, e2, this.expManager.Decoder, out outcome))
-      {
-        return outcome;
-      }
-
-      var leftOutcome = this.Left.CheckIfEqual(e1, e2);
-      if (leftOutcome.IsNormal())
-      {
-        return leftOutcome;
-      }
-
-      return this.Right.CheckIfEqual(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfEqual(e1, e2);
-    }
-
-    /// <summary>
-    /// Check if <code>e != 0</code>
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
-    {
-      var checks = new FlatAbstractDomain<bool>[this.arr.Length];
-      //MyParallel.For(0, 2, i => checks[i] = this.arr[i].CheckIfNonZero(exp));
-
-      for (var i = 0; i < arr.Length; i++)
-      {
-        checks[i] = this.arr[i].CheckIfNonZero(exp);
-      }
-
-      var result = checks[0].Meet(checks[1]);
-
-      if (result.IsTop)
-      {
-        // We give a try by checking if exp > 0 or exp < 0
-        var isGTzero = this.CheckIfLessThan(this.Zero, exp);  // zero < exp ?
-
-        if (isGTzero.IsTrue())
-        {
-          return isGTzero;
-        }
-
-        var isLTzero = this.CheckIfLessThan(exp, this.Zero);  // exp < zero ?
-
-        if (isLTzero.IsTrue())
-        {
-          return isLTzero;
-        }
-      }
-
-      return result;
-    }
-
-    public override IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      if (this.IsBottom)
-        return prev;
-      if (prev.IsBottom)
-        return this;
-
-      var castedPrev = prev as ReducedNumericalDomains<LeftDomain, RightDomain, Variable, Expression>;
-
-      Contract.Assert(prev != null);
-
-      var widened = new IAbstractDomain[this.arr.Length];
-
-      for (var i = 0; i < arr.Length; i++)
-      {
-        widened[i] = this.arr[i].Widening(castedPrev.arr[i]);
-      }
-
-      return this.Factory((LeftDomain)widened[0], (RightDomain)widened[1]);
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Expression> Members
-
-    virtual public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      this.Left.AssignInParallel(sourcesToTargets, convert);
-      this.Right.AssignInParallel(sourcesToTargets, convert);
-    }
-
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      this.Left.SetFloatType(v, f);
-      this.Right.SetFloatType(v, f);
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return this.Left.GetFloatType(v).Meet(this.Right.GetFloatType(v));
-    }
-
-    #endregion
-
-    #region ToString
-    public string ToString(Expression exp)
-    {
-      if (this.expManager.Decoder!= null)
-      {
-        return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
-      }
-      else
-      {
-        return "< missing expression decoder >";
-      }
-    }
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.expManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-  }
-
-  /// <summary>
-  /// A flat abstract domain, to be used for instance for constant propagation
-  /// </summary>
-  /// <typeparam name="Elements">The elements in the flat lattice. We perform the comparison of elements through <code>Equals</code></typeparam>
-  [ContractVerification(true)]
-  public class FlatAbstractDomain<Elements>
-    : IAbstractDomain
-  {
-    public enum State { Top, Bottom, Normal }
-
-    #region Cached values
-    static private readonly FlatAbstractDomain<Elements> cachedBottom; // Thread-safe
-    static private readonly FlatAbstractDomain<Elements> cachedTop; // Thread-safe
-
-    static FlatAbstractDomain()
-    {
-      cachedBottom = new FlatAbstractDomain<Elements>(State.Bottom);
-      cachedTop = new FlatAbstractDomain<Elements>(State.Top);
-    }
-
-    #endregion
-
-    #region Private fields
-    protected readonly State state;              // The state of the abstract element
-    private readonly Elements val;               // If the state is top or bottom, this value is meaningless
-    private readonly string name;                // An optional string, for pretty printing
-    
-    #endregion
-
-    #region Getter
-    /// <summary>
-    /// The element encapsulated inside this element.
-    /// It makes sense only if <code>!this.IsBottom</code> and <code>!this.IsTop</code>
-    /// </summary>
-    public Elements BoxedElement
-    {
-      get
-      {
-        Contract.Requires(this.IsNormal(), "BoxedElement makes sense just on non extreme cases");
-
-        return this.val;
-      }
-    }
-    #endregion
-
-    #region Constructors
-    public FlatAbstractDomain(Elements val, string name="")
-    {
-      this.state = State.Normal;
-      this.val = val;
-      this.name = name;
-    }
-
-    protected FlatAbstractDomain()
-    {
-      this.state = State.Normal;
-      this.val = default(Elements);
-    }
-
-    protected FlatAbstractDomain(State state)
-    {
-      this.state = state;
-      this.val = default(Elements);
-    }
-
-    #endregion
-
-    #region Implementation of IAbstractDomain
-
-    public virtual object Clone()
-    {
-      return this;
-    }
-
-    public bool IsBottom
-    {
-      get
-      {
-        return this.state == State.Bottom;
-      }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.state == State.Top;
-      }
-    }
-
-    public bool LessEqual(IAbstractDomain a)
-    {
-      var other = a as FlatAbstractDomain<Elements>;
-
-      Contract.Assume(other != null);
-
-      return this.LessEqual(other);
-    }
-
-    public bool LessEqual(FlatAbstractDomain<Elements> right)
-    {
-      Contract.Requires(right != null);
-
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
-      {
-        return result;
-      }
-
-      return AreEqual(this.val, right.val);
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get
-      {
-        return BottomFactory();
-      }
-    }
-
-    public FlatAbstractDomain<Elements> Bottom
-    {
-      get
-      {
-        return BottomFactory();
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get
-      {
-        return TopFactory();
-      }
-    }
-
-    public FlatAbstractDomain<Elements> Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
-
-        return TopFactory();
-      }
-    }
-
-    public IAbstractDomain Join(IAbstractDomain a)
-    {
-      var other = a as FlatAbstractDomain<Elements>;
-
-      Contract.Assume(other != null);
-
-      return this.Join(other);
-    }
-
-    public FlatAbstractDomain<Elements> Join(FlatAbstractDomain<Elements> right)
-    {
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
-
-      FlatAbstractDomain<Elements> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
-      {
-        return result;
-      }
-
-      Contract.Assume(this.val != null);
-      Contract.Assume(right.val != null);
-
-      return AreEqual(this.val, right.val) ? this : Top;
-    }
-
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      var other = a as FlatAbstractDomain<Elements>;
-
-      Contract.Assume(other != null);
-
-      return this.Meet(other);
-    }
-
-    public FlatAbstractDomain<Elements> Meet(FlatAbstractDomain<Elements> right)
-    {
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
-
-      FlatAbstractDomain<Elements> trivialMeet;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, right, out trivialMeet))
-      {
-        return trivialMeet;
-      }
-
-      if (AreEqual(this.val, right.val))
-        return this;
-      else
-        return Bottom;
-    }
-
-    public IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      return this.Join(prev);
-    }
-    #endregion
-
-    #region Protected, to be Overridden
-    /// <summary>
-    /// A Factory method
-    /// </summary>
-    virtual protected FlatAbstractDomain<Elements> Factory()
-    {
-      return new FlatAbstractDomain<Elements>();
-    }
-
-    /// <summary>
-    /// To be overridden if we want to change the meaning of equality.
-    /// The default is to use the object.Equals() method
-    /// </summary>
-    /// <returns>
-    /// true iff <code>left</code> and <code>right</code> are the same elements. False otherwise
-    /// </returns>
-    virtual protected bool AreEqual(Elements left, Elements right)
-    {
-      if (object.ReferenceEquals(left, right))
-      {
-        return true;
-      }
-
-      return left.Equals(right);
-    }
-
-    virtual protected FlatAbstractDomain<Elements> BottomFactory()
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
-
-      Contract.Assert(cachedBottom != null);
-
-      return cachedBottom;
-    }
-
-    virtual protected FlatAbstractDomain<Elements> TopFactory()
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
-
-      Contract.Assert(cachedTop != null);
-
-      return cachedTop;
-    }
-
-    #endregion
-
-    #region Overridden
-
-    virtual public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.Constant(false);
-      else
-        return factory.Constant(true);
-    }
-
-    public override string ToString()
-    {
-      if (this.IsBottom)
-        return "_|_";
-      else if (this.IsTop)
-        return "Top";
-      else
-      {
-        Contract.Assume(this.val != null);
-
-        return this.name != null && this.name.Length > 0? this.name : this.val.ToString();
-      }
-    }
-    #endregion
-
-    #region Implicit conversion
-    public static implicit operator FlatAbstractDomain<Elements>(Elements el)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<Elements>>() != null);
-
-      return new FlatAbstractDomain<Elements>(el);
-    }
-    #endregion
-  }
-
-  public class FlatAbstractDomainWithRenaming<Elements>
-    : FlatAbstractDomain<Elements>,
-    IAbstractDomainWithRenaming<FlatAbstractDomainWithRenaming<Elements>, Elements>
-  {
-    public FlatAbstractDomainWithRenaming(Elements el)
-      : base(el)
-    {      
-    }
-
-    public FlatAbstractDomainWithRenaming(State state = State.Top) 
-      : base(state)
-    {
-    }
-
-    #region IAbstractDomainWithRenaming<FlatAbstractDomainWithRenaming<Elements>,Elements> Members
-
-    public FlatAbstractDomainWithRenaming<Elements> Rename(Dictionary<Elements, FList<Elements>> renaming)
-    {
-      if (this.IsNormal())
-      {
-        FList<Elements> newNames;
-        if (renaming.TryGetValue(this.BoxedElement, out newNames) && newNames.Length() == 1)
-        {
-          return new FlatAbstractDomainWithRenaming<Elements>(newNames.Head);
-        }
-        return new FlatAbstractDomainWithRenaming<Elements>();
-      }
-      else
-      {
-        return this;
-      }
-    }
-
-    #endregion
-
-    #region Implicit conversion
-    static public implicit operator FlatAbstractDomainWithRenaming<Elements>(Elements el)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomainWithRenaming<Elements>>() != null);
-
-      return new FlatAbstractDomainWithRenaming<Elements>(el);
-    }
-    #endregion
-
-    #region Override
-
-    protected override FlatAbstractDomain<Elements> BottomFactory()
-    {
-      return new FlatAbstractDomainWithRenaming<Elements>(State.Bottom);
-    }
-
-    protected override FlatAbstractDomain<Elements> TopFactory()
-    {
-      return new FlatAbstractDomainWithRenaming<Elements>(State.Top);
-    }
-    
-    #endregion
-
-    #region ToString
-
-    public override string ToString()
-    {
-      if (this.IsBottom)
-        return "_|_";
-      if (this.IsTop)
-        return "Top";
-      return this.BoxedElement.ToString();
-    }
-    #endregion
-  }
-
-  [ContractVerification(true)]
-  public class FlatAbstractDomainOfBoolsWithRenaming<Variable>
-    : FlatAbstractDomain<bool>,
-    IAbstractDomainForArraySegmentationAbstraction<FlatAbstractDomainOfBoolsWithRenaming<Variable>, Variable>
-  {
-
-    public FlatAbstractDomainOfBoolsWithRenaming(bool value, string msg = "")
-      : base(value, msg)
-    {
-    }
-
-    public FlatAbstractDomainOfBoolsWithRenaming(State state)
-      : base(state)
-    {
-    }
-
-    #region IAbstractDomainWithRenaming<FlatAbstractDomainWithRenaming<Elements,Variable>,Variable> Members
-
-    public FlatAbstractDomainOfBoolsWithRenaming<Variable> Rename(Dictionary<Variable, FList<Variable>> renaming)
-    {
-      return this;
-    }
-
-    #endregion
-
-    #region overridden
-
-    protected override FlatAbstractDomain<bool> BottomFactory()
-    {
-      return new FlatAbstractDomainOfBoolsWithRenaming<Variable>(State.Bottom);
-    }
-
-    protected override FlatAbstractDomain<bool> TopFactory()
-    {
-      return new FlatAbstractDomainOfBoolsWithRenaming<Variable>(State.Top);
-    }
-
-    #endregion
-
-    #region To
-
-    public override T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.IdentityForOr;
-
-      if (this.IsTop)
-        return factory.IdentityForAnd;
-
-      T name;
-      if (this.BoxedElement && factory.TryGetName(out name))
-      {
-        // name != null
-        return factory.NotEqualTo(name, factory.Null);
-      }
-      
-      return factory.IdentityForAnd;
-      }
-    
-    #endregion
-
-    #region IAbstractDomainForArraySegmentationAbstraction<FlatAbstractDomainOfBoolsWithRenaming<Variable>,Variable> Members
-
-    public FlatAbstractDomainOfBoolsWithRenaming<Variable> AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      return this;
-    }
-
-    #endregion
-  }
-
-  /// <summary>
-  /// One day this should be merged with ProofOutcome
-  /// </summary>
-  static public class CheckOutcome
-  {
-    readonly public static FlatAbstractDomain<bool> True;   // Thread-safe
-    readonly public static FlatAbstractDomain<bool> False;  // Thread-safe
-    readonly public static FlatAbstractDomain<bool> Bottom; // Thread-safe
-    readonly public static FlatAbstractDomain<bool> Top;    // Thread-safe
-
-    static CheckOutcome()
-    {
-      True = new FlatAbstractDomain<bool>(true);
-      False = new FlatAbstractDomain<bool>(false);
-      Bottom = True.Bottom;
-      Top = True.Top;
-    }
-
-    [Pure]
-    static public bool IsNormal(this IAbstractDomain receiver)
-    {
-      Contract.Ensures(Contract.Result<bool>() == (!receiver.IsBottom && !receiver.IsTop));
-
-      return !receiver.IsBottom && !receiver.IsTop;
-    }
-
-    [Pure]
-    static public bool IsTrue(this FlatAbstractDomain<bool> receiver)
-    {
-      return receiver.IsNormal() && receiver.BoxedElement;
-    }
-
-    [Pure]
-    static public bool IsFalse(this FlatAbstractDomain<bool> receiver)
-    {
-      return receiver.IsNormal() && !receiver.BoxedElement;
-    }
-  }
-
-  /// <summary>
-  /// A flat abstract domain which uses a Comparer to test if two elements are the same.
-  /// A first application is in the symbolic abstract domain.
-  /// </summary>
-  public class FlatAbstractDomainWithComparer<Elements>
-    : FlatAbstractDomain<Elements>
-  {
-    #region Static constructor
-
-    static private readonly FlatAbstractDomainWithComparer<Elements> cachedBottom; // Thread-safe
-    static private readonly FlatAbstractDomainWithComparer<Elements> cachedTop;    // Thread-safe
-
-    static FlatAbstractDomainWithComparer()
-    {
-      cachedBottom = new FlatAbstractDomainWithComparer<Elements>(State.Bottom);
-      cachedTop = new FlatAbstractDomainWithComparer<Elements>(State.Top);
-    }
-    #endregion
-
-    #region The comparer used to test if two elements are the same
-    private readonly IComparer<Elements> comparer;
-    #endregion
-
-    #region Constructors
-    /// <summary>
-    /// Construct an abstract element of the flat lattice and the ability of comparing elements
-    /// </summary>
-    /// <param name="value">The element embedded in this abstract value</param>
-    /// <param name="comparer">The comparer for the elements</param>
-    public FlatAbstractDomainWithComparer(Elements value, IComparer<Elements> comparer)
-      : base(value)
-    {
-      this.comparer = comparer;
-    }
-
-    protected FlatAbstractDomainWithComparer(IComparer<Elements> comparer)
-      : base()
-    {
-      this.comparer = comparer;
-    }
-
-    protected FlatAbstractDomainWithComparer(State state)
-      : base(state)
-    {
-      this.comparer = null;
-    }
-
-    #endregion
-
-    #region Overridden methods
-    /// <summary>
-    /// We use the comparer passed at object creation time for comparing the elements
-    /// </summary>
-    protected override bool AreEqual(Elements left, Elements right)
-    {
-      return this.comparer.Compare(left, right) == 0;
-    }
-
-    /// <returns>A new instance of <code>FlatAbstractDomainWithComparer</code> that has the same comparer than this object </returns>
-    protected override FlatAbstractDomain<Elements> Factory()
-    {
-      var freshValue = new FlatAbstractDomainWithComparer<Elements>(this.comparer);
-
-      return freshValue;
-    }
-
-    protected override FlatAbstractDomain<Elements> BottomFactory()
-    {
-      return cachedBottom;
-    }
-
-    protected override FlatAbstractDomain<Elements> TopFactory()
-    {
-      return cachedTop;
-    }
-    #endregion
-  }
-
-  ///<summary>
-  /// A powerset abstract domain
-  ///</summary>
-  ///<typeparam name="Elements">The elements of the set</typeparam>
-  public class PowerSetAbstractDomain<Elements>
-    : IAbstractDomain
-  {
-    // Improve: Add subclass to handle exactly enums, for precision and speed
-
-    #region Cached values
-    static protected readonly PowerSetAbstractDomain<Elements> cachedBottom = new PowerSetAbstractDomain<Elements>(State.Bottom); // Thread-safe
-    static protected readonly PowerSetAbstractDomain<Elements> cachedTop = new PowerSetAbstractDomain<Elements>(State.Top);       // Thread-safe
-    #endregion
-
-    protected enum State { Top, Bottom, Normal };
-
-    #region Private fields
-    private readonly State state;                            // The state of the abstract element
-    private readonly IReadonlySet<Elements> elements;        // The elements in the abstract element. This field is not significative if state == Top or state == Bottom
-    #endregion
-
-    #region Constructors
-    /// <summary>
-    /// Constructs the singleton {<code>element</code>}
-    /// </summary>
-    //^ [NotDelayed]
-    public PowerSetAbstractDomain(Elements element)
-    {
-      // To make happy the Spec# compiler, we rewrite the two lines below by adding  a temp
-      //  
-      //  elements = new Set<Elements>();
-      //  elements.Add(element);
-      //
-      var tmpElements = new Set<Elements>();
-
-      tmpElements.Add(element);
-      this.elements = tmpElements;
-      //^ base();
-      this.state = State.Normal;
-    }
-
-    /// <summary>
-    /// Constructs the PowerSet containing all and only <code>elements</code>
-    /// </summary>
-    //^ [NotDelayed]
-    public PowerSetAbstractDomain(IReadonlySet<Elements> elements)
-    {
-      //  To make happy the Spec# compiler, we rewrite the line below by adding a temp
-      //      this.elements = new Set<Elements>(elements);
-
-      var tmpElements = elements;
-      this.elements = tmpElements;
-      this.state = tmpElements.Count != 0 ? State.Normal : State.Bottom;
-      //^ base();
-    }
-
-    private PowerSetAbstractDomain(State state)
-    {
-      this.state = state;
-      this.elements = new Set<Elements>();
-    }
-
-    private PowerSetAbstractDomain(PowerSetAbstractDomain<Elements> psAD)
-    {
-      this.state = psAD.state;
-      this.elements = new Set<Elements>(psAD.elements);
-    }
-    #endregion
-
-    #region Implementation of IAbstractDomain
-
-    public object Clone()
-    {
-      return new PowerSetAbstractDomain<Elements>(this);
-    }
-
-    public bool IsBottom
-    {
-      get
-      {
-        if (this.elements != null && this.elements.Count == 0 && this.state != State.Top)
-          return true;
-        else
-          return this.state == State.Bottom;
-      }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.state == State.Top;
-      }
-    }
-
-    /// <summary>
-    /// The partial order on the abstract domain
-    ///</summary>
-    public bool LessEqual(IAbstractDomain a)
-    {
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
-      {
-        return result;
-      }
-
-      Contract.Assume(a is PowerSetAbstractDomain<Elements>, "Error: expecting a PowerSetAbstractDomain<Elements> " + a);
-      PowerSetAbstractDomain<Elements> right = (PowerSetAbstractDomain<Elements>)a;
-
-      //^ assert this.state == State.Normal && right.state == State.Normal;
-
-      return this.elements.IsSubset(right.elements);
-    }
-
-    /// <summary>
-    /// Get the bottom element of the abstract domain
-    ///</summary>
-    public IAbstractDomain Bottom
-    {
-      get
-      {
-        return cachedBottom;
-      }
-    }
-
-    /// <summary>
-    /// Get the top element of the abstract doman
-    ///</summary>
-    public IAbstractDomain Top
-    {
-      get
-      {
-        return cachedTop;
-      }
-    }
-
-    /// <summary>
-    /// The join is roughly the set union
-    ///</summary>
-    public IAbstractDomain Join(IAbstractDomain a)
-    {
-      IAbstractDomain trivialresult;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivialresult))
-      {
-        return trivialresult;
-      }
-
-      var right = a as PowerSetAbstractDomain<Elements>;
-      Contract.Assume(right != null);
-
-      return new PowerSetAbstractDomain<Elements>(this.elements.Union(right.elements));
-    }
-
-    /// <summary>
-    /// The meet is roughly the set intersection
-    ///</summary>
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      IAbstractDomain trivialMeet;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
-      {
-        return trivialMeet;
-      }
-
-      var right = a as PowerSetAbstractDomain<Elements>;
-      Contract.Assume(right != null);
-
-      var result = this.elements.Intersection(right.elements);
-
-      return new PowerSetAbstractDomain<Elements>(result);
-
-    }
-
-    /// <summary>
-    /// The widening is quite rough, in that it approximate the set with top
-    /// Convention: <code>this</code> is the value of the new iteration. <code>prev</code> is the value of the previous one
-    ///</summary>
-    public IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      if (this.IsTop)
-        return this;
-      else if (this.IsBottom)
-        return prev;
-      else if (prev.IsBottom)
-        return this;
-      else if (prev.IsTop)
-        return prev;
-      else
-        return Top;
-    }
-    #endregion
-
-    public bool IsSigleton
-    {
-      get
-      {
-        if (this.IsBottom || this.IsTop)
-        {
-          return true;
-        }
-        else
-        {
-          return this.elements.Count == 1;
-        }
-      }
-    }
-
-    /// <summary>
-    /// The set of elements contained an an element of this domain.
-    /// If this element is top, then an exception is thrown
-    /// </summary>
-    public Set<Elements> EmbeddedValues
-    {
-      get
-      {
-        if (!this.IsTop)
-        {
-          return new Set<Elements>(this.elements);
-        }
-        else
-        {
-          throw new AbstractInterpretationException("Cannot have the elements of a top powerset");
-        }
-      }
-    }
-
-    #region Overridden
-
-    public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.Constant(false);
-      else
-        return factory.Constant(true);
-    }
-
-    //^ [Confined]
-    public override string ToString()
-    {
-      string result;
-      if (this.IsBottom)
-      {
-        result = "{}";
-      }
-      else if (this.IsTop)
-      {
-        result = "Top";
-      }
-      else
-      {
-        result = "{ ";
-        foreach (Elements e in this.elements)
-        {
-          result += (e != null ? e.ToString() : "null") + ",";
-        }
-
-        int indexOfLastComma = result.LastIndexOf(",");
-        if (indexOfLastComma > 0)
-        {
-          result = result.Remove(indexOfLastComma);
-        }
-
-        result += " }";
-
-      }
-
-      return result;
-    }
-    #endregion
-
-  }
-
-  /// <summary>
-  /// The generic class for set of constraints.
-  /// Please note that it is different from <code>PowerSetAbstractDomain</code>
-  /// </summary>
-  [ContractVerification(true)]
-  public class SetOfConstraints<Elements>
-    : IAbstractDomainWithRenaming<SetOfConstraints<Elements>, Elements>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.elements != null);
-    }
-
-    #region Cached values
-    static private readonly SetOfConstraints<Elements> cachedBottom = new SetOfConstraints<Elements>(State.Bottom); // Thread-safe
-    static private readonly SetOfConstraints<Elements> cachedTop = new SetOfConstraints<Elements>(State.Top);       // Thread-safe
-    #endregion
-
-    private enum State { Top, Bottom, Normal };
-
-    #region Private fields
-    private readonly State state;                      // The state of the abstract element
-    private readonly Set<Elements> elements;           // The elements in the abstract element. This field is not significative if state == Top or state == Bottom
-
-    #endregion
-
-    #region Constructors
-
-    public SetOfConstraints(Elements element)
-    {
-      this.elements = new Set<Elements>() { element };
-
-      this.state = State.Normal;
-    }
-
-    public SetOfConstraints(IEnumerable<Elements> elements)
-      : this(new Set<Elements>(elements))
-    {
-      Contract.Requires(elements != null);
-    }
-
-    public SetOfConstraints(Set<Elements> elements, bool makeCopy)
-      : this(makeCopy ? new Set<Elements>(elements) : elements)
-    {
-      Contract.Requires(elements != null);
-    }
-
-    private SetOfConstraints(Set<Elements> elements)
-    {
-      Contract.Requires(elements != null);
-
-      this.elements = elements;
-      this.state = this.elements.Count != 0 ? State.Normal : State.Top;
-    }
-
-    private SetOfConstraints(State state)
-    {
-      this.state = state;
-      this.elements = new Set<Elements>();
-    }
-
-    private SetOfConstraints(SetOfConstraints<Elements> psAD)
-    {
-      Contract.Requires(psAD != null);
-
-      Contract.Assume(psAD.elements != null);
-
-      this.state = psAD.state;
-      this.elements = new Set<Elements>(psAD.elements);
-    }
-    #endregion
-
-    #region Static Properties
-    static public SetOfConstraints<Elements> Unknown
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
-
-        return cachedTop;
-      }
-    }
-
-    static public SetOfConstraints<Elements> Unreached
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
-        
-        return cachedBottom;
-      }
-    }
-
-    #endregion
-
-    #region Implementation of IAbstractDomain
-
-    public object Clone()
-    {
-      return this; // It's functional
-    }
-
-    public bool IsBottom
-    {
-      get
-      {
-        if (/*this.elements != null && */this.elements.Count == 0 && this.state != State.Top)
-          return true;
-        else
-          return this.state == State.Bottom;
-      }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.state == State.Top;
-      }
-    }
-
-    /// <summary>
-    /// Order is superset inclusion
-    /// </summary>
-    public bool LessEqual(IAbstractDomain a)
-    {
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
-      {
-        return result;
-      }
-
-      var right = a as SetOfConstraints<Elements>;
-
-      Contract.Assume(right != null);
-      Contract.Assume(right.elements != null);
-
-      return right.elements.IsSubset(this.elements);
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get
-      {
-        return cachedBottom;
-      }
-    }
-
-    /// <summary>
-    /// Get the top element of the abstract doman
-    ///</summary>
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get
-      {
-        return cachedTop;
-      }
-    }
-
-    public SetOfConstraints<Elements> Top
-    {
-      get
-      {
-        return cachedTop;
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var other = a as SetOfConstraints<Elements>;
-
-      Contract.Assume(other != null);
-
-      return this.Join(other);
-    }
-
-    /// <summary>
-    /// The join is set intersection
-    ///</summary>
-    [Pure]
-    public SetOfConstraints<Elements> Join(SetOfConstraints<Elements> right)
-    {
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
-
-      SetOfConstraints<Elements> trivialresult;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, right, out trivialresult))
-      {
-        return trivialresult;
-      }
-      Contract.Assume(right.elements != null);
-
-      var result = this.elements.Intersection(right.elements);
-
-      return new SetOfConstraints<Elements>(result, false);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      var other = a as SetOfConstraints<Elements>;
-
-      Contract.Assume(other != null);
-
-      return this.Meet(other);
-    }
-
-    /// <summary>
-    /// The meet is set union
-    ///</summary>
-    [Pure]
-    public SetOfConstraints<Elements> Meet(SetOfConstraints<Elements> right)
-    {
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
-
-      SetOfConstraints<Elements> trivialMeet;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, right, out trivialMeet))
-      {
-        return trivialMeet;
-      }
-
-      Contract.Assume(right.elements != null);
-
-      var result = this.elements.Union(right.elements);
-
-      return new SetOfConstraints<Elements>(result, false);
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain a)
-    {
-      var other = a as SetOfConstraints<Elements>;
-
-      Contract.Assume(other != null);
-
-      return this.Widening(other);
-    }
-
-    /// <summary>
-    /// The widening is quite rough, in that it approximate the set with top
-    /// Convention: <code>this</code> is the value of the new iteration. <code>prev</code> is the value of the previous one
-    ///</summary>
-    [Pure]
-    public SetOfConstraints<Elements> Widening(SetOfConstraints<Elements> prev)
-    {
-      Contract.Requires(prev != null);
-
-      Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
-
-      if (this.IsTop)
-        return this;
-      if (this.IsBottom)
-        return prev;
-
-      if (prev.IsBottom)
-        return this;
-      if (prev.IsTop)
-        return prev;
-
-      return this.Join(prev as SetOfConstraints<Elements>);
-    }
-    #endregion
-
-    public int Count
-    {
-      get
-      {
-        if (!this.IsNormal())
-        {
-          return 0;
-        }
-        return this.elements.Count;
-      }
-    }
-
-    public IEnumerable<Elements> Values
-    {
-      get
-      {
-        if (this.IsNormal())
-        {
-          foreach (var x in this.elements)
-          {
-            yield return x;
-          }
-        }
-        else
-        {
-          yield break;
-        }
-      }
-    }
-
-    [Pure]
-    public SetOfConstraints<Elements> Add(Elements el)
-    {
-      Contract.Ensures(Contract.Result<SetOfConstraints<Elements>>() != null);
-
-      if (this.IsBottom)
-      {
-        return this;
-      }
-      if (this.IsTop)
-      {
-        return new SetOfConstraints<Elements>(el);
-      }
-      else
-      {
-        var newSet = new Set<Elements>(this.elements);
-        newSet.Add(el);
-
-        return new SetOfConstraints<Elements>(newSet, false);
-      }
-    }
-
-    [Pure]
-    public bool Contains(Elements what)
-    {
-      if (!this.IsNormal())
-        return false;
-
-      return this.elements.Contains(what);
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.Constant(false);
-      else
-        return factory.Constant(true);
-    }
-
-    #region Overridden
-
-    private Optional<int> hash;
-    public override int GetHashCode()
-    {
-      if (!this.hash.IsValid)
-      {
-        this.hash = this.elements.GetHashCode();
-      }
-
-      return this.hash.Value;
-    }
-
-    public override string ToString()
-    {
-      if (this.IsBottom)
-        return "{}";
-      else if (this.IsTop)
-        return "Top";
-      else
-      {
-        return this.elements.ToString();
-      }
-    }
-    #endregion
-
-    #region IAbstractDomainWithRenaming<SetOfConstraints<Elements>,Elements> Members
-
-    public SetOfConstraints<Elements> Rename(Dictionary<Elements, FList<Elements>> renaming)
-    {
-      if (this.IsNormal())
-      {
-        var newSet = new Set<Elements>(this.elements.Count);
-        foreach (var el in this.elements)
-        {
-          FList<Elements> renamed;
-          if (renaming.TryGetValue(el, out renamed))
-          {
-            newSet.AddRange(renamed.GetEnumerable());
-          }
-        }
-
-        return new SetOfConstraints<Elements>(newSet, false);
-      }
-
-      return this;
-    }
-
-    #endregion
-  }
-
-  /// <summary>
-  /// An abstract element with just two elements, top and bottom
-  /// This is mainly for creating dummy top and bottom values and for debugging purposes
-  /// </summary>
-  [ContractVerification(true)]
-  public class Reachability : 
-    IAbstractDomain
-  {
-    public enum State { Top, Bottom }
-
-    #region Cached values
-    static private readonly Reachability bottomReachbility = new Reachability(State.Bottom); // Thread-safe
-    static private readonly Reachability topReachbility = new Reachability(State.Top);       // Thread-safe
-    #endregion
-
-    #region Private fields
-    readonly private State val;
-    #endregion
-
-    #region Getters
-
-    static public Reachability aTopElement
-    {
-      get
-      {
-        return topReachbility;
-      }
-    }
-
-    static public Reachability aBottomElement
-    {
-      get
-      {
-        return bottomReachbility;
-      }
-    }
-    #endregion
-
-    #region Constructors
-    
-    protected Reachability(State r)
-    {
-      this.val = r;
-    }
-
-    #endregion
-
-    #region Implementation of IAbstractDomain
-
-    public object Clone()
-    {
-      return this;
-    }
-
-    public bool IsBottom
-    {
-      get
-      {
-        return this.val == State.Bottom;
-      }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.val == State.Top;
-      }
-    }
-
-    public bool LessEqual(IAbstractDomain a)
-    {
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
-      {
-        return result;
-      }
-
-      return false;
-    }
-
-    virtual public IAbstractDomain Bottom
-    {
-      get
-      {
-        return bottomReachbility;
-      }
-    }
-
-    virtual public IAbstractDomain Top
-    {
-      get
-      {
-        return topReachbility;
-      }
-    }
-
-    public IAbstractDomain Join(IAbstractDomain a)
-    {
-      IAbstractDomain result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, a, out result))
-      {
-        return result;
-      }
-
-      Contract.Assume(false, "you were not supposed to be there.... " + a);
-
-      return this.Top;
-    }
-
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      IAbstractDomain trivialMeet;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
-      {
-        return trivialMeet;
-      }
-
-      Contract.Assume(false, "you were not supposed to be there.... " + a);
-
-      return this.Bottom;
-    }
-
-    public IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      return this.Join(prev);
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.Constant(false);
-      else
-        return factory.Constant(true);
-    }
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      return this.val == State.Bottom ? "bottom" : "top"; 
-    }
-    #endregion
-  }
-
-  [ContractVerification(true)]
-  public class TwoValuesLattice<Variable>
-    : Reachability, IAbstractDomainForArraySegmentationAbstraction<TwoValuesLattice<Variable>, Variable>
-  {
-    private readonly string message;
-
-    public TwoValuesLattice(Reachability.State state, string msg = null)
-      : base(state)
-    {
-      this.message = msg;
-    }
-
-    override public IAbstractDomain Bottom
-    {
-      get
-      {
-        return new TwoValuesLattice<Variable>(State.Bottom, (this.IsBottom && this.message != null)? this.message : "");
-      }
-    }
-
-    override public IAbstractDomain Top
-    {
-      get
-      {
-        return new TwoValuesLattice<Variable>(State.Top);
-      }
-    }
-
-    #region IAbstractDomainWithRenaming<Reachability<Variable>,Variable> Members
-
-    public TwoValuesLattice<Variable> Rename(Dictionary<Variable, FList<Variable>> renaming)
-    {
-      return this;
-    }
-    
-    #endregion
-
-    #region ToString
-
-    public override string ToString()
-    {
-      if (this.message != null)
-      {
-        return this.message;
-      }
-
-      return base.ToString();
-    }
-
-    #endregion
-
-    #region IAbstractDomainForArraySegmentationAbstraction<TwoValuesLattice<Variable>,Variable> Members
-
-    public TwoValuesLattice<Variable> AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      return this;
-    }
-
-    #endregion
-  }
-
-  
-#if TRACEPERFORMANCE
-
-  internal static class PerformanceCounter
-  {
-    // For performance counting...
-    [ThreadStatic]
-    static internal Dictionary<int, int> maxSizes;
-
-    static internal Dictionary<int, int> MaxSizes
-    {
-      get
-      {
-        if (maxSizes == null)
-          maxSizes = new Dictionary<int, int>();
-        return maxSizes;
-      }
-    }
-  }
 
 #endif
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/IAIOptions.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/IAIOptions.cs
@@ -1,17 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,25 +10,25 @@ using Microsoft.Research.DataStructures;
 namespace Microsoft.Research.CodeAnalysis
 {
 #if SUBPOLY_ONLY
-  public enum Precision { Light, Normal, Strong }
-  public enum ProofOutcome { Top, False, True, Bottom }
+    public enum Precision { Light, Normal, Strong }
+    public enum ProofOutcome { Top, False, True, Bottom }
 #endif
 
-  public enum ReductionAlgorithm { Fast, Complete, Simplex, SimplexFast, SimplexOptima, None }
+    public enum ReductionAlgorithm { Fast, Complete, Simplex, SimplexFast, SimplexOptima, None }
 
-  public interface IAIOptions
-  {
-    ReductionAlgorithm Algorithm { get; }
-    
-    bool Use2DConvexHull { get; }
-    bool InferOctagonConstraints { get; }
+    public interface IAIOptions
+    {
+        ReductionAlgorithm Algorithm { get; }
 
-    bool UseMorePreciseWidening { get; }
-    bool UseTracePartitioning { get; }
-    bool TrackDisequalities { get; }
+        bool Use2DConvexHull { get; }
+        bool InferOctagonConstraints { get; }
 
-    bool TracePartitionAnalysis { get; }
+        bool UseMorePreciseWidening { get; }
+        bool UseTracePartitioning { get; }
+        bool TrackDisequalities { get; }
 
-    bool TraceNumericalAnalysis { get; }
-  }
+        bool TracePartitionAnalysis { get; }
+
+        bool TraceNumericalAnalysis { get; }
+    }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/InterfacesForAbstractDomains.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/InterfacesForAbstractDomains.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This file contains the interfaces and the hierarchies for the abstract domains
 
@@ -26,1931 +15,1921 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  #region Interfaces for the domains
-
-  /// <summary>
-  /// The interface for a basic abstract domain (bottom, top, join, meet, widening)
-  /// </summary>
-  [ContractClass(typeof(IAbstractDomainContracts))]
-  public interface IAbstractDomain 
-    : ICloneable
-  {
-    bool IsBottom { get; }
-    bool IsTop { get; }
+    #region Interfaces for the domains
 
     /// <summary>
-    /// The partial order on the abstract domain
+    /// The interface for a basic abstract domain (bottom, top, join, meet, widening)
     /// </summary>
-    bool LessEqual(IAbstractDomain a);
-
-    /// <summary>
-    /// Get the bottom element of the abstract domain
-    /// </summary>
-    IAbstractDomain Bottom { get; }
-
-    /// <summary>
-    /// Get the top element of the abstract doman
-    /// </summary>
-    IAbstractDomain Top { get; }
-
-    /// <summary>
-    /// Join of the abstract domain
-    /// </summary>
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-a != null")]
-    IAbstractDomain Join(IAbstractDomain a);
-
-    /// <summary>
-    /// Meet of the abstract domain
-    /// </summary>
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-a != null")]
-    IAbstractDomain Meet(IAbstractDomain a);
-
-    /// <summary>
-    /// Widening of the abstract domain.
-    /// Convention: <code>this</code> is the value of the new iteration. <code>prev</code> is the value of the previous one
-    /// </summary>
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-prev != null")]
-    IAbstractDomain Widening(IAbstractDomain prev);
-
-    /// <summary>
-    /// Give a <code>T</code> view of the elements using <code>factory</code>
-    /// </summary>
-    [Pure]
-    T To<T>(IFactory<T> factory);
-  }
-
-  #region Contracts for a IAbstractDomain
-  [ContractClassFor(typeof(IAbstractDomain))]
-  abstract class IAbstractDomainContracts
-    : IAbstractDomain
-  {
-    #region IAbstractDomain Members
-
-    bool IAbstractDomain.IsBottom
-    {
-      get
-      {
-        return default(bool);
-      }
-    }
-
-    bool IAbstractDomain.IsTop
-    {
-      get
-      {
-        return default(bool);
-      }
-    }
-
-    [Pure]
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      Contract.Requires(a != null);
-
-      return default(bool);
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
-
-        return default(IAbstractDomain);
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
-
-        return default(IAbstractDomain);
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      Contract.Requires(a != null);
-
-      Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
-
-      return default(IAbstractDomain);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      Contract.Requires(a != null);
-
-      Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
-
-      return default(IAbstractDomain);
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      Contract.Requires(prev != null);
-
-      Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
-
-      return default(IAbstractDomain);
-    }
-
-    T IAbstractDomain.To<T>(IFactory<T> factory)
-    {
-      Contract.Requires(factory != null);
-
-      return default(T);
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    object ICloneable.Clone()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  #endregion
-
-  ///<summary>
-  /// The capability of handling assignments
-  ///</summary>
-  ///<typeparam name="Variable">The type of the variables handled by this abstract domain</typeparam>
-  ///<typeparam name="Expression">The type of the expressions handled by this abstract domain</typeparam>
-
-  [ContractClass(typeof(IAbstractDomainWithRenamingContracts<,>))]
-  public interface IAbstractDomainWithRenaming<T, Variable>
-    : IAbstractDomain
-    where T: IAbstractDomainWithRenaming<T, Variable>
-  {
-    T Rename(Dictionary<Variable, FList<Variable>> renaming);
-  }
-
-  #region Contracts for IAbstractDomainWithRenaming
-  [ContractClassFor(typeof(IAbstractDomainWithRenaming<,>))]
-  abstract class IAbstractDomainWithRenamingContracts<T, Variable>
-    : IAbstractDomainWithRenaming<T, Variable>
-    where T : IAbstractDomainWithRenaming<T, Variable>
-  {
-    #region IAbstractDomainWithRenaming<Variable,T> Members
-
-    T IAbstractDomainWithRenaming<T, Variable>.Rename(Dictionary<Variable, FList<Variable>> renaming)
-    {
-      Contract.Requires(renaming != null);
-
-      Contract.Ensures(Contract.Result<T>() != null);
-
-      return default(T);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members - not used
-
-    bool IAbstractDomain.IsBottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IAbstractDomain.IsTop
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      throw new NotImplementedException();
-    }
-
-    TT IAbstractDomain.To<TT>(IFactory<TT> factory)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    object ICloneable.Clone()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  #endregion
-
-  /// <summary>
-  ///  The interface for the elements abstracting an array segmentation
-  /// </summary>
-  [ContractClass(typeof(IAbstractDomainForArraySegmentationAbstractionContracts<,>))]
-  public interface IAbstractDomainForArraySegmentationAbstraction<T, Variable>
-  : IAbstractDomainWithRenaming<T, Variable>
-    where T : IAbstractDomainForArraySegmentationAbstraction<T, Variable>
-  {
-    T AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle);
-  }
-
-  #region Contracts for IAbstractDomainForArraySegmentationAbstraction
-  [ContractClassFor(typeof(IAbstractDomainForArraySegmentationAbstraction<,>))]
-  abstract class IAbstractDomainForArraySegmentationAbstractionContracts<T, Variable>
-    : IAbstractDomainForArraySegmentationAbstraction<T, Variable>
-      where T : IAbstractDomainForArraySegmentationAbstraction<T, Variable>
-  {
-    public T AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Requires(oracle != null);
-      Contract.Ensures(Contract.Result<T>() != null);
-
-      return default(T);
-    }
-
-    #region Dummy
-    #region IAbstractDomainWithRenaming<T,Variable> Members
-
-    public T Rename(Dictionary<Variable, FList<Variable>> renaming)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool IsTop
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool LessEqual(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IAbstractDomain Top
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IAbstractDomain Join(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Tp To<Tp>(IFactory<Tp> factory)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-    #endregion
-  }
-  #endregion
-
-  [ContractClass(typeof(IPureExpressionAssignmentsContracts<,>))]
-  public interface IPureExpressionAssignments<Variable, Expression>
-  {
-    /// <summary>
-    /// The set of variables defined in this environment
-    /// </summary>
-    List<Variable> Variables { get; }
-
-    /// <summary>
-    /// Add a new variable to the environment.
-    /// </summary>
-    /// <param name="var">must be a variable</param>
-    void AddVariable(Variable var);
-
-    /// <summary>
-    /// The transfer function corresponding to the assignment <code>x := exp</code>.
-    /// </summary>
-    /// <param name="x">Must be a variable</param>
-    void Assign(Expression x, Expression exp);
-
-    /// <summary>
-    /// Project the value of the variable <code>var</code>.
-    /// It is as setting its value to top
-    /// </summary>
-    /// <param name="var">Must be a variable</param>
-    void ProjectVariable(Variable var);
-
-    /// <summary>
-    /// Remove the variable from the current environment.
-    /// Its values is projected, so that the relations are kept.
-    /// The variable is removed from the octagon
-    /// </summary>
-    /// <param name="var">Must be a variable</param>
-    void RemoveVariable(Variable var);
-
-    /// <summary>
-    /// Rename the variable <code>OldName</code> with <code>NewName</code>
-    /// </summary>
-    /// <param name="OldName">The old of the variable</param>
-    /// <param name="NewName">The new name</param>
-    void RenameVariable(Variable OldName, Variable NewName);
-  }
-
-  #region Contracts for IPureExpressionAssigments
-  [ContractClassFor(typeof(IPureExpressionAssignments<,>))]
-  abstract class IPureExpressionAssignmentsContracts<Variable, Expression>
-    : IPureExpressionAssignments<Variable, Expression>
-  {
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    List<Variable> IPureExpressionAssignments<Variable, Expression>.Variables
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<List<Variable>>() != null);
-
-        return default(List<Variable>);
-      }
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.AddVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.Assign(Expression x, Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.ProjectVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.RemoveVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.RenameVariable(Variable OldName, Variable NewName)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  #endregion
-
-  /// <summary>
-  /// The capability of handling tests
-  /// </summary>    
-  public partial interface IPureExpressionTest<Variable, Expression>
-  {
-    /// <summary>
-    /// The boolean guard for positive tests.
-    /// </summary>
-    /// <returns>
-    /// An over approximation of { s | s \in \gamma(this) and [[guard]](s) == true }
-    /// </returns>
-    IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard);
-
-    /// <summary>
-    /// The boolean guard for negative tests.
-    /// </summary>
-    /// <returns>
-    /// An over approximation of { s | s \in \gamma(this) and [[! guard]](s) == true }
-    /// </returns>
-    IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard);
-
-    /// <summary>
-    /// Checks whether the expression <code>exp</code> holds or not
-    /// </summary>
-    /// <param name="exp">The expression to check</param>
-    /// <returns>Bottom if the expression is unreached, true if it holds, false it does not hold, Top if it is unknown</returns>
-    FlatAbstractDomain<bool> CheckIfHolds(Expression exp);
-
-    /// <summary>
-    /// Pushes some abstract domain specific Fact. 
-    /// Abstract domains are free to ignore it
-    /// </summary>
-    void AssumeDomainSpecificFact(DomainSpecificFact fact);
-
-  }
-
-  #region IPureExpressionTest<Variable,Expression> contract binding
-  [ContractClass(typeof(IPureExpressionTestContract<,>))]
-  public partial interface IPureExpressionTest<Variable,Expression>
-  {
-  }
-
-  [ContractClassFor(typeof(IPureExpressionTest<,>))]
-  abstract class IPureExpressionTestContract<Variable,Expression> : IPureExpressionTest<Variable,Expression>
-  {
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-      Contract.Requires(guard != null);
-      Contract.Ensures(Contract.Result<IAbstractDomainForEnvironments<Variable, Expression>>() != null);
-
-      return default(IAbstractDomainForEnvironments<Variable, Expression>);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      Contract.Requires(guard != null);
-      Contract.Ensures(Contract.Result<IAbstractDomainForEnvironments<Variable, Expression>>() != null);
-
-      return default(IAbstractDomainForEnvironments<Variable, Expression>);
-    }
-
-    FlatAbstractDomain<bool> IPureExpressionTest<Variable, Expression>.CheckIfHolds(Expression exp)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      return default(FlatAbstractDomain<bool>);
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      Contract.Requires(fact != null);
-
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  #endregion
-
-  [ContractClass(typeof(IAssignInParallelContracts<,>))]
-  public interface IAssignInParallel<Variable, Expression>
-  {
-    /// <summary>
-    /// The parallel assigment
-    /// </summary>
-    /// <param name="sourcesToTargets">The map from sources to their targets</param>
-    void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert);
-  }
-
-
-  #region Contracts for IAssignInParallel<Variable, Expression>
-  [ContractClassFor(typeof(IAssignInParallel<,>))]
-  abstract class IAssignInParallelContracts<Variable, Expression>
-    : IAssignInParallel<Variable, Expression>
-  {
-    #region IAssignInParallel<Variable,Expression> Members
-
-    void IAssignInParallel<Variable, Expression>.AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      Contract.Requires(sourcesToTargets != null);
-      Contract.Requires(convert != null);
-    }
-
-    #endregion
-  }
-  #endregion
-
-  public interface IAbstractDomainForEnvironments<Variable, Expression> :
-    IAbstractDomain,
-    IPureExpressionAssignments<Variable, Expression>,
-    IPureExpressionTest<Variable, Expression>,
-    IAssignInParallel<Variable, Expression>
-  {
-    /// <returns>
-    /// A textual representation for the expression <code>exp</code>
-    /// </returns>
-    string ToString(Expression exp);
-  }
-
-  public partial interface INumericalAbstractDomainQuery<Variable, Expression>
-  {
-    #region Queries
-    [Pure]
-    DisInterval BoundsFor(Expression v);
-
-    [Pure]
-    DisInterval BoundsFor(Variable v);
-
-    [Pure]
-    IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict);
-    
-    [Pure]
-    IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict);
-
-    [Pure]
-    IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict);
-
-    [Pure]
-    IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict);
-
-    [Pure]
-    IEnumerable<Variable> EqualitiesFor(Variable v);
-
-    #endregion
-
-    #region Checks
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2);
-    
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2);
-
-    [Pure]
-    FlatAbstractDomain<bool> CheckIfNonZero(Expression e);
-
-    #endregion
-
-    #region Conversion Exp -> Variable
-
-    [Pure]
-    Variable ToVariable(Expression exp);
-
-    #endregion
-  }
-
-  #region INumericalAbstractDomainQuery<Variable,Expression> contract binding
-  [ContractClass(typeof(INumericalAbstractDomainQueryContract<,>))]
-  public partial interface INumericalAbstractDomainQuery<Variable,Expression>
-  {
-
-  }
-
-  [ContractClassFor(typeof(INumericalAbstractDomainQuery<,>))]
-  abstract class INumericalAbstractDomainQueryContract<Variable,Expression> : INumericalAbstractDomainQuery<Variable, Expression>
-  {
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Expression v)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return default(DisInterval);
-    }
-
-    DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Variable v)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return default(DisInterval);
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Expression v, bool strict)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);      
-
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Expression v, bool strict)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);  
-
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Variable v, bool strict)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);  
-     
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Variable v, bool strict)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);  
-
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Variable> INumericalAbstractDomainQuery<Variable, Expression>.EqualitiesFor(Variable v)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Variable>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      Contract.Requires(exp != null);
-
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);  
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Variable v1, Variable v2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan_Un(Expression v1, Expression v2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqual(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      return null;
-    }
-
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfNonZero(Expression e)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    // ok to return default(Variable)
-    Variable INumericalAbstractDomainQuery<Variable, Expression>.ToVariable(Expression exp)
-    {
-      return default(Variable);
-    }
-
-    #endregion
-
-
-
-  }
-  #endregion
-
-  /// <summary>
-  ///  Abstractions over the numerical type
-  /// </summary>
-  public interface INumericalTypeQuery<NType>
-  {
-    bool IsGreaterEqualThanZero(NType val);
-    bool IsGreaterThanZero(NType val);
-    bool IsLessThanZero(NType val);
-    bool IsLessEqualThanZero(NType val);
-    bool IsLessThan(NType val1, NType val2);
-    bool IsLessEqualThan(NType val1, NType val2);
-    bool IsZero(NType val);
-    bool IsNotZero(NType val);
-    bool IsPlusInfinity(NType val);
-    bool IsMinusInfinity(NType val);
-
-    
-    NType PlusInfinity { get; }
-    NType MinusInfinty { get; }
-    bool TryAdd(NType left, NType right, out NType result);
-  }
-
-  public interface ISetOfNumbersAbstraction<Variable, Expression, NType, IType>
-    : INumericalTypeQuery<NType>
-  {
-    bool TryGetValue(Variable var, bool isSigned, out IType intv);
-
-    IType Eval(Expression exp);
-    IType Eval(Variable var);
-
-    // Abstractions over the intervals 
-    FlatAbstractDomain<bool> IsNotZero(IType intv);
-    bool IsGreaterEqualThanZero(IType intv);
-    bool IsLessEqualThanZero(IType intv);
-    bool AreEqual(IType left, IType right);
-    
-    IType IntervalUnknown { get; }
-    IType IntervalZero { get; }
-    IType IntervalOne { get; }
-    IType Interval_Positive { get; }
-    IType IntervalSingleton(NType val);
-    IType IntervalRightOpen(NType inf);
-    IType IntervalLeftOpen(NType sup);
-
-    IType Interval_Add(IType left, IType right);
-    IType Interval_Div(IType left, IType right);
-    IType Interval_Sub(IType left, IType right);
-    IType Interval_Mul(IType left, IType right);
-    IType Interval_UnaryMinus(IType left);
-    IType Interval_Rem(IType left, IType right);
-
-    IType Interval_BitwiseAnd(IType left, IType right);
-    IType Interval_BitwiseOr(IType left, IType right);
-
-    IType Interval_ShiftLeft(IType left, IType right);
-    IType Interval_ShiftRight(IType left, IType right);
-
-    IType For(Byte v);
-
-    IType For(Double d);
-    IType For(Int16 v);
-    IType For(Int32 v);
-    IType For(Int64 v);
-    IType For(SByte s);
-    IType For(UInt16 u);
-    IType For(UInt32 u);
-    IType For(Rational r);
-    IType For(NType inf, NType sup);
-  }
-
-  [ContractClass(typeof(IIntervalAbstractionContracts<,>))] 
-  public interface IIntervalAbstraction<Variable, Expression>
-    : 
-    IAbstractDomain,
-    INumericalAbstractDomainQuery<Variable, Expression>,
-    IPureExpressionAssignments<Variable, Expression>,
-    IPureExpressionTest<Variable, Expression>,
-    IAssignInParallel<Variable, Expression>
-  {
-    bool LessEqual(IIntervalAbstraction<Variable, Expression> other);
-    IIntervalAbstraction<Variable, Expression> Join(IIntervalAbstraction<Variable, Expression> other);
-    IIntervalAbstraction<Variable, Expression> Widening(IIntervalAbstraction<Variable, Expression> other);
-
-    List<Pair<Variable, Int32>> IntConstants { get; }
-
-    void AssumeInDisInterval(Variable x, DisInterval value);
-    void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState);
-
-    IIntervalAbstraction<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle);
-
-    new IIntervalAbstraction<Variable, Expression> TestTrue(Expression exp);
-    new IIntervalAbstraction<Variable, Expression> TestFalse(Expression exp);
-
-    IIntervalAbstraction<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2);
-    IIntervalAbstraction<Variable, Expression> TestTrueLessThan(Variable v1, Variable v2);
-    IIntervalAbstraction<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2);
-    IIntervalAbstraction<Variable, Expression> TestTrueLessEqualThan(Variable v1, Variable v2);
-    IIntervalAbstraction<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2);
-    IIntervalAbstraction<Variable, Expression> TestTrueGeqZero(Expression exp);
-  }
-
-  #region Contracts for IIntervalAbstraction<Variable, Expression>
-  [ContractClassFor(typeof(IIntervalAbstraction<,>))]
-  abstract class IIntervalAbstractionContracts<Variable, Expression> : IIntervalAbstraction<Variable, Expression>
-  {
-    #region IIntervalAbstraction<Variable,Expression> Members
-
-    bool IIntervalAbstraction<Variable, Expression>.LessEqual(IIntervalAbstraction<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      return default(bool);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Join(IIntervalAbstraction<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Widening(IIntervalAbstraction<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    List<Pair<Variable, int>> IIntervalAbstraction<Variable, Expression>.IntConstants
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<List<Pair<Variable, int>>>() != null);
-
-        return default(List<Pair<Variable, int>>);
-      }
-    }
-
-    void IIntervalAbstraction<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      Contract.Requires(x != null);
-      Contract.Requires(value != null);
-    }
-
-    void IIntervalAbstraction<Variable, Expression>.Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      Contract.Requires(x != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(preState != null);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      Contract.Requires(oracle != null);
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrue(Expression exp)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-      
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestFalse(Expression exp)
-    {
-      Contract.Requires(exp != null);
-
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-      
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Variable v1, Variable v2)
-    {
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-      
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Variable v1, Variable v2)
-    {
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueGeqZero(Expression exp)
-    {
-      Contract.Requires(exp != null);
-
-      Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
-
-      return default(IIntervalAbstraction<Variable, Expression>);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    bool IAbstractDomain.IsBottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IAbstractDomain.IsTop
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      throw new NotImplementedException();
-    }
-
-    T IAbstractDomain.To<T>(IFactory<T> factory)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    object ICloneable.Clone()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Expression v)
-    {
-      throw new NotImplementedException();
-    }
-
-    DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Variable v)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Expression v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Expression v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Variable v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Variable v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Variable v1, Variable v2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqual(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfNonZero(Expression e)
-    {
-      throw new NotImplementedException();
-    }
-
-    Variable INumericalAbstractDomainQuery<Variable, Expression>.ToVariable(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-    #endregion
-
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    List<Variable> IPureExpressionAssignments<Variable, Expression>.Variables
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.AddVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.Assign(Expression x, Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.ProjectVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.RemoveVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.RenameVariable(Variable OldName, Variable NewName)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> IPureExpressionTest<Variable, Expression>.CheckIfHolds(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Variable,Expression> Members
-
-    void IAssignInParallel<Variable, Expression>.AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-    IEnumerable<Variable> INumericalAbstractDomainQuery<Variable, Expression>.EqualitiesFor(Variable v)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-
-  }
-  #endregion
-
-  /// <summary>
-  /// A numerical abstract domain
-  /// </summary>
-  /// <typeparam name="Expression">The language of the expression understood by the domain</typeparam>
-  [ContractClass(typeof(INumericalAbstractDomainContracts<,>))]
-  public interface INumericalAbstractDomain<Variable, Expression> :
-      IAbstractDomainForEnvironments<Variable, Expression>,
-      INumericalAbstractDomainQuery<Variable, Expression>
-  {
-    void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState);
-
-    /// <summary>
-    /// The variable <code>x</code> ranges in the interval <code>intv</code>
-    /// </summary>
-    void AssumeInDisInterval(Variable x, DisInterval intv);
-
-    /// <summary>
-    /// The variables which have a definite <code>Int32</code> value 
-    /// </summary>
-    List<Pair<Variable, Int32>> IntConstants { get; }
-
-    /// <summary>
-    /// Removes the relations in this domain that are also implied by the oracle
-    /// </summary>
-    /// <param name="oracle"></param>
-    /// <returns>A Fresh domain where the relations implied by <code>oracle</code> have been removed</returns>
-    INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle);
-
-    /// <summary>
-    /// Add the constraint <code> 0 \leq exp </code> to the abstract domain
-    /// </summary>
-    INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp);
-
-    /// <summary>
-    /// Add the constraint <code> exp1 \lt exp2 </code>
-    /// </summary>
-    INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2);
-
-    /// <summary>
-    /// Add the constraint <code> exp1 \leq exp2 </code>
-    /// </summary>
-    INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2);
-
-    /// <summary>
-    ///  Add the constraint <code>exp1 == exp2</code>
-    /// </summary>
-    INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2);
-
-    /// <summary>
-    /// Set the floating point type for the expression exp
-    /// </summary>
-    void SetFloatType(Variable v, ConcreteFloat f);
-    
-    /// <summary>
-    /// Get the floating type for exp, if any
-    /// </summary>
-    FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v);
-
-  }
-
-  #region Contracts for INumericalAbstractDomain
-  [ContractClassFor(typeof(INumericalAbstractDomain<,>))]
-  abstract partial class INumericalAbstractDomainContracts<Variable, Expression>
-    : INumericalAbstractDomain<Variable, Expression>
-  {
-    #region INumericalAbstractDomain<Variable,Expression> Members
-
-    void INumericalAbstractDomain<Variable, Expression>.Assign(Expression x, Expression exp, 
-      INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      Contract.Requires(x != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(preState != null);
-    }
-
-    void INumericalAbstractDomain<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      Contract.Requires(x != null);
-      Contract.Requires(value != null) ;
-    }
-
-    List<Pair<Variable, int>> INumericalAbstractDomain<Variable, Expression>.IntConstants
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<List<Pair<Variable, int>>>() != null);
-        return default(List<Pair<Variable, int>>);
-      }
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      Contract.Requires(oracle != null);
-
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      return default(INumericalAbstractDomain<Variable, Expression>);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression exp)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      return default(INumericalAbstractDomain<Variable, Expression>);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      return default(INumericalAbstractDomain<Variable, Expression>);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      return default(INumericalAbstractDomain<Variable, Expression>);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-      Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
-
-      return default(INumericalAbstractDomain<Variable, Expression>);
-    }
-
-    void INumericalAbstractDomain<Variable, Expression>.SetFloatType(Variable v, ConcreteFloat f)
-    {
-      Contract.Requires(v != null);
-    }
-
-    FlatAbstractDomain<ConcreteFloat> INumericalAbstractDomain<Variable, Expression>.GetFloatType(Variable v)
-    {
-      Contract.Requires(v != null);
-
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<ConcreteFloat>>() != null);
-
-
-      return default(FlatAbstractDomain<ConcreteFloat>);
-    }
-
-    Variable INumericalAbstractDomainQuery<Variable, Expression>.ToVariable(Expression exp)
-    {
-      return default(Variable);
-    }
-    #endregion
-
-
-    #region IAbstractDomainForEnvironments<Variable,Expression> Members
-
-    public string ToString(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool IsTop
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool LessEqual(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IAbstractDomain Top
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IAbstractDomain Join(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      throw new NotImplementedException();
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    public List<Variable> Variables
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Variable,Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public DisInterval BoundsFor(Expression v)
-    {
-      throw new NotImplementedException();
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return null;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IAbstractDomainForEnvironments<Variable,Expression> Members
-
-    string IAbstractDomainForEnvironments<Variable, Expression>.ToString(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    bool IAbstractDomain.IsBottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IAbstractDomain.IsTop
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      throw new NotImplementedException();
-    }
-
-    T IAbstractDomain.To<T>(IFactory<T> factory)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    object ICloneable.Clone()
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Variable,Expression> Members
-
-    List<Variable> IPureExpressionAssignments<Variable, Expression>.Variables
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.AddVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.Assign(Expression x, Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.ProjectVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.RemoveVariable(Variable var)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionAssignments<Variable, Expression>.RenameVariable(Variable OldName, Variable NewName)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Variable,Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-      throw new NotImplementedException();
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> IPureExpressionTest<Variable, Expression>.CheckIfHolds(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Variable,Expression> Members
-
-    void IAssignInParallel<Variable, Expression>.AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Expression v)
-    {
-      throw new NotImplementedException();
-    }
-
-    DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Variable v)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Expression v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Expression v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Variable v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Variable v, bool strict)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Variable v1, Variable v2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqual(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfNonZero(Expression e)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-
-    IEnumerable<Variable> INumericalAbstractDomainQuery<Variable, Expression>.EqualitiesFor(Variable v)
-    {
-      throw new NotImplementedException();
-    }
-    FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      throw new NotImplementedException();
-    }
-    #endregion
-
-
-  }
-
-
-  #endregion
-
-  interface IStringAbstractDomain<Elements, Variable, Expression> :
-    IAbstractDomainForEnvironments<Variable, Expression>
-    where Elements : IStringAbstraction
-  {
-    /// <summary>
-    /// The abstract concatenation
-    /// </summary>
-    void Concat(Expression/*!*/ target, Expression/*!*/ left, Expression/*!*/ right);
-  
-    /// <summary>
-    /// Insert <code>what</code> at the position <code>where</code> in <code>target</code>
-    /// </summary>
-    void Insert(Expression/*!*/ target, Expression/*!*/ which, Expression/*!*/ where, Expression/*!*/ what);
-
-    /// <summary>
-    /// Remove all the spaces from <code>who</code>
-    /// </summary>
-    void Trim(Expression/*!*/ who, Expression/*!*/ what);
-
-    FlatAbstractDomain<int> CompareTo(Expression/*!*/ left, Expression/*!*/ right);
-    FlatAbstractDomain<bool> Contains(Expression/*!*/ who, Expression/*!*/ what);
-    FlatAbstractDomain<bool> StartsWith(Expression/*!*/ who, Expression/*!*/ what);
-  }
-  #endregion
-
-  #region Abstract Domain-specific facts
-  public class DomainSpecificFact
-  {
-    virtual public bool IsAssumeInFloatInterval<Variable>(out Variable var, out Interval_IEEE754 intv)
-    {
-      var = default(Variable);
-      intv = default(Interval_IEEE754);
-
-      return false;
-    }
-
-    public class AssumeInFloatInterval : DomainSpecificFact
-    {
-      private readonly object var;
-      private readonly Interval_IEEE754 intv;
-
-      public AssumeInFloatInterval(object var, Interval_IEEE754 intv)
-      {
-        this.var = var;
-        this.intv = intv;
-      }
-
-      public override bool IsAssumeInFloatInterval<Variable>(out Variable v, out Interval_IEEE754 intv)
-      {
-        if (this.var is Variable)
+    [ContractClass(typeof(IAbstractDomainContracts))]
+    public interface IAbstractDomain
+      : ICloneable
+    {
+        bool IsBottom { get; }
+        bool IsTop { get; }
+
+        /// <summary>
+        /// The partial order on the abstract domain
+        /// </summary>
+        bool LessEqual(IAbstractDomain a);
+
+        /// <summary>
+        /// Get the bottom element of the abstract domain
+        /// </summary>
+        IAbstractDomain Bottom { get; }
+
+        /// <summary>
+        /// Get the top element of the abstract doman
+        /// </summary>
+        IAbstractDomain Top { get; }
+
+        /// <summary>
+        /// Join of the abstract domain
+        /// </summary>
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-a != null")]
+        IAbstractDomain Join(IAbstractDomain a);
+
+        /// <summary>
+        /// Meet of the abstract domain
+        /// </summary>
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-a != null")]
+        IAbstractDomain Meet(IAbstractDomain a);
+
+        /// <summary>
+        /// Widening of the abstract domain.
+        /// Convention: <code>this</code> is the value of the new iteration. <code>prev</code> is the value of the previous one
+        /// </summary>
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-prev != null")]
+        IAbstractDomain Widening(IAbstractDomain prev);
+
+        /// <summary>
+        /// Give a <code>T</code> view of the elements using <code>factory</code>
+        /// </summary>
+        [Pure]
+        T To<T>(IFactory<T> factory);
+    }
+
+    #region Contracts for a IAbstractDomain
+    [ContractClassFor(typeof(IAbstractDomain))]
+    internal abstract class IAbstractDomainContracts
+      : IAbstractDomain
+    {
+        #region IAbstractDomain Members
+
+        bool IAbstractDomain.IsBottom
         {
-          v = (Variable)this.var;
-          intv = this.intv;
-
-          return true;
+            get
+            {
+                return default(bool);
+            }
         }
-        
-        return base.IsAssumeInFloatInterval(out v, out intv);
-      }
 
+        bool IAbstractDomain.IsTop
+        {
+            get
+            {
+                return default(bool);
+            }
+        }
+
+        [Pure]
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            Contract.Requires(a != null);
+
+            return default(bool);
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
+
+                return default(IAbstractDomain);
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
+
+                return default(IAbstractDomain);
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            Contract.Requires(a != null);
+
+            Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
+
+            return default(IAbstractDomain);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            Contract.Requires(a != null);
+
+            Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
+
+            return default(IAbstractDomain);
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            Contract.Requires(prev != null);
+
+            Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
+
+            return default(IAbstractDomain);
+        }
+
+        T IAbstractDomain.To<T>(IFactory<T> factory)
+        {
+            Contract.Requires(factory != null);
+
+            return default(T);
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        object ICloneable.Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
     }
+    #endregion
 
-  }
+    ///<summary>
+    /// The capability of handling assignments
+    ///</summary>
+    ///<typeparam name="Variable">The type of the variables handled by this abstract domain</typeparam>
+    ///<typeparam name="Expression">The type of the expressions handled by this abstract domain</typeparam>
 
-
-  #endregion
-
-  #region Logging
-  public delegate string StringClosure();
-
-  public delegate void Logger(string format, params StringClosure[] args);
-
-  public static class VoidLogger
-  {
-    public static void Log(string format, params StringClosure[] args)
+    [ContractClass(typeof(IAbstractDomainWithRenamingContracts<,>))]
+    public interface IAbstractDomainWithRenaming<T, Variable>
+      : IAbstractDomain
+      where T : IAbstractDomainWithRenaming<T, Variable>
     {
-      // It does nothing
+        T Rename(Dictionary<Variable, FList<Variable>> renaming);
     }
-  }
 
-  #endregion
+    #region Contracts for IAbstractDomainWithRenaming
+    [ContractClassFor(typeof(IAbstractDomainWithRenaming<,>))]
+    internal abstract class IAbstractDomainWithRenamingContracts<T, Variable>
+      : IAbstractDomainWithRenaming<T, Variable>
+      where T : IAbstractDomainWithRenaming<T, Variable>
+    {
+        #region IAbstractDomainWithRenaming<Variable,T> Members
+
+        T IAbstractDomainWithRenaming<T, Variable>.Rename(Dictionary<Variable, FList<Variable>> renaming)
+        {
+            Contract.Requires(renaming != null);
+
+            Contract.Ensures(Contract.Result<T>() != null);
+
+            return default(T);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members - not used
+
+        bool IAbstractDomain.IsBottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IAbstractDomain.IsTop
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            throw new NotImplementedException();
+        }
+
+        TT IAbstractDomain.To<TT>(IFactory<TT> factory)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        object ICloneable.Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+    #endregion
+
+    /// <summary>
+    ///  The interface for the elements abstracting an array segmentation
+    /// </summary>
+    [ContractClass(typeof(IAbstractDomainForArraySegmentationAbstractionContracts<,>))]
+    public interface IAbstractDomainForArraySegmentationAbstraction<T, Variable>
+    : IAbstractDomainWithRenaming<T, Variable>
+      where T : IAbstractDomainForArraySegmentationAbstraction<T, Variable>
+    {
+        T AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle);
+    }
+
+    #region Contracts for IAbstractDomainForArraySegmentationAbstraction
+    [ContractClassFor(typeof(IAbstractDomainForArraySegmentationAbstraction<,>))]
+    internal abstract class IAbstractDomainForArraySegmentationAbstractionContracts<T, Variable>
+      : IAbstractDomainForArraySegmentationAbstraction<T, Variable>
+        where T : IAbstractDomainForArraySegmentationAbstraction<T, Variable>
+    {
+        public T AssumeInformationFrom<Expression>(INumericalAbstractDomainQuery<Variable, Expression> oracle)
+        {
+            Contract.Requires(oracle != null);
+            Contract.Ensures(Contract.Result<T>() != null);
+
+            return default(T);
+        }
+
+        #region Dummy
+        #region IAbstractDomainWithRenaming<T,Variable> Members
+
+        public T Rename(Dictionary<Variable, FList<Variable>> renaming)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        public bool IsBottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool IsTop
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool LessEqual(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAbstractDomain Bottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IAbstractDomain Top
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IAbstractDomain Join(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Tp To<Tp>(IFactory<Tp> factory)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+        #endregion
+    }
+    #endregion
+
+    [ContractClass(typeof(IPureExpressionAssignmentsContracts<,>))]
+    public interface IPureExpressionAssignments<Variable, Expression>
+    {
+        /// <summary>
+        /// The set of variables defined in this environment
+        /// </summary>
+        List<Variable> Variables { get; }
+
+        /// <summary>
+        /// Add a new variable to the environment.
+        /// </summary>
+        /// <param name="var">must be a variable</param>
+        void AddVariable(Variable var);
+
+        /// <summary>
+        /// The transfer function corresponding to the assignment <code>x := exp</code>.
+        /// </summary>
+        /// <param name="x">Must be a variable</param>
+        void Assign(Expression x, Expression exp);
+
+        /// <summary>
+        /// Project the value of the variable <code>var</code>.
+        /// It is as setting its value to top
+        /// </summary>
+        /// <param name="var">Must be a variable</param>
+        void ProjectVariable(Variable var);
+
+        /// <summary>
+        /// Remove the variable from the current environment.
+        /// Its values is projected, so that the relations are kept.
+        /// The variable is removed from the octagon
+        /// </summary>
+        /// <param name="var">Must be a variable</param>
+        void RemoveVariable(Variable var);
+
+        /// <summary>
+        /// Rename the variable <code>OldName</code> with <code>NewName</code>
+        /// </summary>
+        /// <param name="OldName">The old of the variable</param>
+        /// <param name="NewName">The new name</param>
+        void RenameVariable(Variable OldName, Variable NewName);
+    }
+
+    #region Contracts for IPureExpressionAssigments
+    [ContractClassFor(typeof(IPureExpressionAssignments<,>))]
+    internal abstract class IPureExpressionAssignmentsContracts<Variable, Expression>
+      : IPureExpressionAssignments<Variable, Expression>
+    {
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        List<Variable> IPureExpressionAssignments<Variable, Expression>.Variables
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<List<Variable>>() != null);
+
+                return default(List<Variable>);
+            }
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.AddVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.Assign(Expression x, Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.ProjectVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.RemoveVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.RenameVariable(Variable OldName, Variable NewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+    #endregion
+
+    /// <summary>
+    /// The capability of handling tests
+    /// </summary>    
+    public partial interface IPureExpressionTest<Variable, Expression>
+    {
+        /// <summary>
+        /// The boolean guard for positive tests.
+        /// </summary>
+        /// <returns>
+        /// An over approximation of { s | s \in \gamma(this) and [[guard]](s) == true }
+        /// </returns>
+        IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard);
+
+        /// <summary>
+        /// The boolean guard for negative tests.
+        /// </summary>
+        /// <returns>
+        /// An over approximation of { s | s \in \gamma(this) and [[! guard]](s) == true }
+        /// </returns>
+        IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard);
+
+        /// <summary>
+        /// Checks whether the expression <code>exp</code> holds or not
+        /// </summary>
+        /// <param name="exp">The expression to check</param>
+        /// <returns>Bottom if the expression is unreached, true if it holds, false it does not hold, Top if it is unknown</returns>
+        FlatAbstractDomain<bool> CheckIfHolds(Expression exp);
+
+        /// <summary>
+        /// Pushes some abstract domain specific Fact. 
+        /// Abstract domains are free to ignore it
+        /// </summary>
+        void AssumeDomainSpecificFact(DomainSpecificFact fact);
+    }
+
+    #region IPureExpressionTest<Variable,Expression> contract binding
+    [ContractClass(typeof(IPureExpressionTestContract<,>))]
+    public partial interface IPureExpressionTest<Variable, Expression>
+    {
+    }
+
+    [ContractClassFor(typeof(IPureExpressionTest<,>))]
+    internal abstract class IPureExpressionTestContract<Variable, Expression> : IPureExpressionTest<Variable, Expression>
+    {
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            Contract.Requires(guard != null);
+            Contract.Ensures(Contract.Result<IAbstractDomainForEnvironments<Variable, Expression>>() != null);
+
+            return default(IAbstractDomainForEnvironments<Variable, Expression>);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            Contract.Requires(guard != null);
+            Contract.Ensures(Contract.Result<IAbstractDomainForEnvironments<Variable, Expression>>() != null);
+
+            return default(IAbstractDomainForEnvironments<Variable, Expression>);
+        }
+
+        FlatAbstractDomain<bool> IPureExpressionTest<Variable, Expression>.CheckIfHolds(Expression exp)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            return default(FlatAbstractDomain<bool>);
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            Contract.Requires(fact != null);
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+    #endregion
+
+    [ContractClass(typeof(IAssignInParallelContracts<,>))]
+    public interface IAssignInParallel<Variable, Expression>
+    {
+        /// <summary>
+        /// The parallel assigment
+        /// </summary>
+        /// <param name="sourcesToTargets">The map from sources to their targets</param>
+        void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert);
+    }
+
+
+    #region Contracts for IAssignInParallel<Variable, Expression>
+    [ContractClassFor(typeof(IAssignInParallel<,>))]
+    internal abstract class IAssignInParallelContracts<Variable, Expression>
+      : IAssignInParallel<Variable, Expression>
+    {
+        #region IAssignInParallel<Variable,Expression> Members
+
+        void IAssignInParallel<Variable, Expression>.AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            Contract.Requires(sourcesToTargets != null);
+            Contract.Requires(convert != null);
+        }
+
+        #endregion
+    }
+    #endregion
+
+    public interface IAbstractDomainForEnvironments<Variable, Expression> :
+      IAbstractDomain,
+      IPureExpressionAssignments<Variable, Expression>,
+      IPureExpressionTest<Variable, Expression>,
+      IAssignInParallel<Variable, Expression>
+    {
+        /// <returns>
+        /// A textual representation for the expression <code>exp</code>
+        /// </returns>
+        string ToString(Expression exp);
+    }
+
+    public partial interface INumericalAbstractDomainQuery<Variable, Expression>
+    {
+        #region Queries
+        [Pure]
+        DisInterval BoundsFor(Expression v);
+
+        [Pure]
+        DisInterval BoundsFor(Variable v);
+
+        [Pure]
+        IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict);
+
+        [Pure]
+        IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict);
+
+        [Pure]
+        IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict);
+
+        [Pure]
+        IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict);
+
+        [Pure]
+        IEnumerable<Variable> EqualitiesFor(Variable v);
+
+        #endregion
+
+        #region Checks
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2);
+
+        [Pure]
+        FlatAbstractDomain<bool> CheckIfNonZero(Expression e);
+
+        #endregion
+
+        #region Conversion Exp -> Variable
+
+        [Pure]
+        Variable ToVariable(Expression exp);
+
+        #endregion
+    }
+
+    #region INumericalAbstractDomainQuery<Variable,Expression> contract binding
+    [ContractClass(typeof(INumericalAbstractDomainQueryContract<,>))]
+    public partial interface INumericalAbstractDomainQuery<Variable, Expression>
+    {
+    }
+
+    [ContractClassFor(typeof(INumericalAbstractDomainQuery<,>))]
+    internal abstract class INumericalAbstractDomainQueryContract<Variable, Expression> : INumericalAbstractDomainQuery<Variable, Expression>
+    {
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Expression v)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return default(DisInterval);
+        }
+
+        DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Variable v)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return default(DisInterval);
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Expression v, bool strict)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Expression v, bool strict)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Variable v, bool strict)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Variable v, bool strict)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Expression>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Variable> INumericalAbstractDomainQuery<Variable, Expression>.EqualitiesFor(Variable v)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Variable>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            Contract.Requires(exp != null);
+
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Variable v1, Variable v2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan_Un(Expression v1, Expression v2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqual(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            return null;
+        }
+
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfNonZero(Expression e)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        // ok to return default(Variable)
+        Variable INumericalAbstractDomainQuery<Variable, Expression>.ToVariable(Expression exp)
+        {
+            return default(Variable);
+        }
+
+        #endregion
+    }
+    #endregion
+
+    /// <summary>
+    ///  Abstractions over the numerical type
+    /// </summary>
+    public interface INumericalTypeQuery<NType>
+    {
+        bool IsGreaterEqualThanZero(NType val);
+        bool IsGreaterThanZero(NType val);
+        bool IsLessThanZero(NType val);
+        bool IsLessEqualThanZero(NType val);
+        bool IsLessThan(NType val1, NType val2);
+        bool IsLessEqualThan(NType val1, NType val2);
+        bool IsZero(NType val);
+        bool IsNotZero(NType val);
+        bool IsPlusInfinity(NType val);
+        bool IsMinusInfinity(NType val);
+
+
+        NType PlusInfinity { get; }
+        NType MinusInfinty { get; }
+        bool TryAdd(NType left, NType right, out NType result);
+    }
+
+    public interface ISetOfNumbersAbstraction<Variable, Expression, NType, IType>
+      : INumericalTypeQuery<NType>
+    {
+        bool TryGetValue(Variable var, bool isSigned, out IType intv);
+
+        IType Eval(Expression exp);
+        IType Eval(Variable var);
+
+        // Abstractions over the intervals 
+        FlatAbstractDomain<bool> IsNotZero(IType intv);
+        bool IsGreaterEqualThanZero(IType intv);
+        bool IsLessEqualThanZero(IType intv);
+        bool AreEqual(IType left, IType right);
+
+        IType IntervalUnknown { get; }
+        IType IntervalZero { get; }
+        IType IntervalOne { get; }
+        IType Interval_Positive { get; }
+        IType IntervalSingleton(NType val);
+        IType IntervalRightOpen(NType inf);
+        IType IntervalLeftOpen(NType sup);
+
+        IType Interval_Add(IType left, IType right);
+        IType Interval_Div(IType left, IType right);
+        IType Interval_Sub(IType left, IType right);
+        IType Interval_Mul(IType left, IType right);
+        IType Interval_UnaryMinus(IType left);
+        IType Interval_Rem(IType left, IType right);
+
+        IType Interval_BitwiseAnd(IType left, IType right);
+        IType Interval_BitwiseOr(IType left, IType right);
+
+        IType Interval_ShiftLeft(IType left, IType right);
+        IType Interval_ShiftRight(IType left, IType right);
+
+        IType For(Byte v);
+
+        IType For(Double d);
+        IType For(Int16 v);
+        IType For(Int32 v);
+        IType For(Int64 v);
+        IType For(SByte s);
+        IType For(UInt16 u);
+        IType For(UInt32 u);
+        IType For(Rational r);
+        IType For(NType inf, NType sup);
+    }
+
+    [ContractClass(typeof(IIntervalAbstractionContracts<,>))]
+    public interface IIntervalAbstraction<Variable, Expression>
+      :
+      IAbstractDomain,
+      INumericalAbstractDomainQuery<Variable, Expression>,
+      IPureExpressionAssignments<Variable, Expression>,
+      IPureExpressionTest<Variable, Expression>,
+      IAssignInParallel<Variable, Expression>
+    {
+        bool LessEqual(IIntervalAbstraction<Variable, Expression> other);
+        IIntervalAbstraction<Variable, Expression> Join(IIntervalAbstraction<Variable, Expression> other);
+        IIntervalAbstraction<Variable, Expression> Widening(IIntervalAbstraction<Variable, Expression> other);
+
+        List<Pair<Variable, Int32>> IntConstants { get; }
+
+        void AssumeInDisInterval(Variable x, DisInterval value);
+        void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState);
+
+        IIntervalAbstraction<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle);
+
+        new IIntervalAbstraction<Variable, Expression> TestTrue(Expression exp);
+        new IIntervalAbstraction<Variable, Expression> TestFalse(Expression exp);
+
+        IIntervalAbstraction<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2);
+        IIntervalAbstraction<Variable, Expression> TestTrueLessThan(Variable v1, Variable v2);
+        IIntervalAbstraction<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2);
+        IIntervalAbstraction<Variable, Expression> TestTrueLessEqualThan(Variable v1, Variable v2);
+        IIntervalAbstraction<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2);
+        IIntervalAbstraction<Variable, Expression> TestTrueGeqZero(Expression exp);
+    }
+
+    #region Contracts for IIntervalAbstraction<Variable, Expression>
+    [ContractClassFor(typeof(IIntervalAbstraction<,>))]
+    internal abstract class IIntervalAbstractionContracts<Variable, Expression> : IIntervalAbstraction<Variable, Expression>
+    {
+        #region IIntervalAbstraction<Variable,Expression> Members
+
+        bool IIntervalAbstraction<Variable, Expression>.LessEqual(IIntervalAbstraction<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            return default(bool);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Join(IIntervalAbstraction<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Widening(IIntervalAbstraction<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        List<Pair<Variable, int>> IIntervalAbstraction<Variable, Expression>.IntConstants
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<List<Pair<Variable, int>>>() != null);
+
+                return default(List<Pair<Variable, int>>);
+            }
+        }
+
+        void IIntervalAbstraction<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            Contract.Requires(x != null);
+            Contract.Requires(value != null);
+        }
+
+        void IIntervalAbstraction<Variable, Expression>.Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            Contract.Requires(x != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(preState != null);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            Contract.Requires(oracle != null);
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrue(Expression exp)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestFalse(Expression exp)
+        {
+            Contract.Requires(exp != null);
+
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Variable v1, Variable v2)
+        {
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Variable v1, Variable v2)
+        {
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueGeqZero(Expression exp)
+        {
+            Contract.Requires(exp != null);
+
+            Contract.Ensures(Contract.Result<IIntervalAbstraction<Variable, Expression>>() != null);
+
+            return default(IIntervalAbstraction<Variable, Expression>);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        bool IAbstractDomain.IsBottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IAbstractDomain.IsTop
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            throw new NotImplementedException();
+        }
+
+        T IAbstractDomain.To<T>(IFactory<T> factory)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        object ICloneable.Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Expression v)
+        {
+            throw new NotImplementedException();
+        }
+
+        DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Variable v)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Expression v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Expression v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Variable v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Variable v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Variable v1, Variable v2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqual(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfNonZero(Expression e)
+        {
+            throw new NotImplementedException();
+        }
+
+        Variable INumericalAbstractDomainQuery<Variable, Expression>.ToVariable(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        List<Variable> IPureExpressionAssignments<Variable, Expression>.Variables
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.AddVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.Assign(Expression x, Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.ProjectVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.RemoveVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.RenameVariable(Variable OldName, Variable NewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> IPureExpressionTest<Variable, Expression>.CheckIfHolds(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Variable,Expression> Members
+
+        void IAssignInParallel<Variable, Expression>.AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerable<Variable> INumericalAbstractDomainQuery<Variable, Expression>.EqualitiesFor(Variable v)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+    #endregion
+
+    /// <summary>
+    /// A numerical abstract domain
+    /// </summary>
+    /// <typeparam name="Expression">The language of the expression understood by the domain</typeparam>
+    [ContractClass(typeof(INumericalAbstractDomainContracts<,>))]
+    public interface INumericalAbstractDomain<Variable, Expression> :
+        IAbstractDomainForEnvironments<Variable, Expression>,
+        INumericalAbstractDomainQuery<Variable, Expression>
+    {
+        void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState);
+
+        /// <summary>
+        /// The variable <code>x</code> ranges in the interval <code>intv</code>
+        /// </summary>
+        void AssumeInDisInterval(Variable x, DisInterval intv);
+
+        /// <summary>
+        /// The variables which have a definite <code>Int32</code> value 
+        /// </summary>
+        List<Pair<Variable, Int32>> IntConstants { get; }
+
+        /// <summary>
+        /// Removes the relations in this domain that are also implied by the oracle
+        /// </summary>
+        /// <param name="oracle"></param>
+        /// <returns>A Fresh domain where the relations implied by <code>oracle</code> have been removed</returns>
+        INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle);
+
+        /// <summary>
+        /// Add the constraint <code> 0 \leq exp </code> to the abstract domain
+        /// </summary>
+        INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp);
+
+        /// <summary>
+        /// Add the constraint <code> exp1 \lt exp2 </code>
+        /// </summary>
+        INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2);
+
+        /// <summary>
+        /// Add the constraint <code> exp1 \leq exp2 </code>
+        /// </summary>
+        INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2);
+
+        /// <summary>
+        ///  Add the constraint <code>exp1 == exp2</code>
+        /// </summary>
+        INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2);
+
+        /// <summary>
+        /// Set the floating point type for the expression exp
+        /// </summary>
+        void SetFloatType(Variable v, ConcreteFloat f);
+
+        /// <summary>
+        /// Get the floating type for exp, if any
+        /// </summary>
+        FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v);
+    }
+
+    #region Contracts for INumericalAbstractDomain
+    [ContractClassFor(typeof(INumericalAbstractDomain<,>))]
+    internal abstract partial class INumericalAbstractDomainContracts<Variable, Expression>
+      : INumericalAbstractDomain<Variable, Expression>
+    {
+        #region INumericalAbstractDomain<Variable,Expression> Members
+
+        void INumericalAbstractDomain<Variable, Expression>.Assign(Expression x, Expression exp,
+          INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            Contract.Requires(x != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(preState != null);
+        }
+
+        void INumericalAbstractDomain<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            Contract.Requires(x != null);
+            Contract.Requires(value != null);
+        }
+
+        List<Pair<Variable, int>> INumericalAbstractDomain<Variable, Expression>.IntConstants
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<List<Pair<Variable, int>>>() != null);
+                return default(List<Pair<Variable, int>>);
+            }
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            Contract.Requires(oracle != null);
+
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            return default(INumericalAbstractDomain<Variable, Expression>);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression exp)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            return default(INumericalAbstractDomain<Variable, Expression>);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            return default(INumericalAbstractDomain<Variable, Expression>);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            return default(INumericalAbstractDomain<Variable, Expression>);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+            Contract.Ensures(Contract.Result<INumericalAbstractDomain<Variable, Expression>>() != null);
+
+            return default(INumericalAbstractDomain<Variable, Expression>);
+        }
+
+        void INumericalAbstractDomain<Variable, Expression>.SetFloatType(Variable v, ConcreteFloat f)
+        {
+            Contract.Requires(v != null);
+        }
+
+        FlatAbstractDomain<ConcreteFloat> INumericalAbstractDomain<Variable, Expression>.GetFloatType(Variable v)
+        {
+            Contract.Requires(v != null);
+
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<ConcreteFloat>>() != null);
+
+
+            return default(FlatAbstractDomain<ConcreteFloat>);
+        }
+
+        Variable INumericalAbstractDomainQuery<Variable, Expression>.ToVariable(Expression exp)
+        {
+            return default(Variable);
+        }
+        #endregion
+
+
+        #region IAbstractDomainForEnvironments<Variable,Expression> Members
+
+        public string ToString(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        public bool IsBottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool IsTop
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool LessEqual(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAbstractDomain Bottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IAbstractDomain Top
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IAbstractDomain Join(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            throw new NotImplementedException();
+        }
+
+        public T To<T>(IFactory<T> factory)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        public List<Variable> Variables
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Variable,Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        public DisInterval BoundsFor(Expression v)
+        {
+            throw new NotImplementedException();
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return null;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IAbstractDomainForEnvironments<Variable,Expression> Members
+
+        string IAbstractDomainForEnvironments<Variable, Expression>.ToString(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        bool IAbstractDomain.IsBottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IAbstractDomain.IsTop
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            throw new NotImplementedException();
+        }
+
+        T IAbstractDomain.To<T>(IFactory<T> factory)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        object ICloneable.Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Variable,Expression> Members
+
+        List<Variable> IPureExpressionAssignments<Variable, Expression>.Variables
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.AddVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.Assign(Expression x, Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.ProjectVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.RemoveVariable(Variable var)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionAssignments<Variable, Expression>.RenameVariable(Variable OldName, Variable NewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Variable,Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            throw new NotImplementedException();
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> IPureExpressionTest<Variable, Expression>.CheckIfHolds(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Variable,Expression> Members
+
+        void IAssignInParallel<Variable, Expression>.AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Expression v)
+        {
+            throw new NotImplementedException();
+        }
+
+        DisInterval INumericalAbstractDomainQuery<Variable, Expression>.BoundsFor(Variable v)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Expression v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Expression v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.LowerBoundsFor(Variable v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Expression> INumericalAbstractDomainQuery<Variable, Expression>.UpperBoundsFor(Variable v, bool strict)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan(Variable v1, Variable v2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfEqual(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfNonZero(Expression e)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+
+        IEnumerable<Variable> INumericalAbstractDomainQuery<Variable, Expression>.EqualitiesFor(Variable v)
+        {
+            throw new NotImplementedException();
+        }
+        FlatAbstractDomain<bool> INumericalAbstractDomainQuery<Variable, Expression>.CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
+
+    }
+
+
+    #endregion
+
+    internal interface IStringAbstractDomain<Elements, Variable, Expression> :
+      IAbstractDomainForEnvironments<Variable, Expression>
+      where Elements : IStringAbstraction
+    {
+        /// <summary>
+        /// The abstract concatenation
+        /// </summary>
+        void Concat(Expression/*!*/ target, Expression/*!*/ left, Expression/*!*/ right);
+
+        /// <summary>
+        /// Insert <code>what</code> at the position <code>where</code> in <code>target</code>
+        /// </summary>
+        void Insert(Expression/*!*/ target, Expression/*!*/ which, Expression/*!*/ where, Expression/*!*/ what);
+
+        /// <summary>
+        /// Remove all the spaces from <code>who</code>
+        /// </summary>
+        void Trim(Expression/*!*/ who, Expression/*!*/ what);
+
+        FlatAbstractDomain<int> CompareTo(Expression/*!*/ left, Expression/*!*/ right);
+        FlatAbstractDomain<bool> Contains(Expression/*!*/ who, Expression/*!*/ what);
+        FlatAbstractDomain<bool> StartsWith(Expression/*!*/ who, Expression/*!*/ what);
+    }
+    #endregion
+
+    #region Abstract Domain-specific facts
+    public class DomainSpecificFact
+    {
+        virtual public bool IsAssumeInFloatInterval<Variable>(out Variable var, out Interval_IEEE754 intv)
+        {
+            var = default(Variable);
+            intv = default(Interval_IEEE754);
+
+            return false;
+        }
+
+        public class AssumeInFloatInterval : DomainSpecificFact
+        {
+            private readonly object var;
+            private readonly Interval_IEEE754 intv;
+
+            public AssumeInFloatInterval(object var, Interval_IEEE754 intv)
+            {
+                this.var = var;
+                this.intv = intv;
+            }
+
+            public override bool IsAssumeInFloatInterval<Variable>(out Variable v, out Interval_IEEE754 intv)
+            {
+                if (var is Variable)
+                {
+                    v = (Variable)var;
+                    intv = this.intv;
+
+                    return true;
+                }
+
+                return base.IsAssumeInFloatInterval(out v, out intv);
+            }
+        }
+    }
+
+
+    #endregion
+
+    #region Logging
+    public delegate string StringClosure();
+
+    public delegate void Logger(string format, params StringClosure[] args);
+
+    public static class VoidLogger
+    {
+        public static void Log(string format, params StringClosure[] args)
+        {
+            // It does nothing
+        }
+    }
+
+    #endregion
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Assignments.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Assignments.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Helpers for inferring constraints from assignments
 
@@ -26,678 +15,674 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// The interface for the assignment crawler
-  /// </summary>
-  [ContractClass(typeof(IConstraintsForAssignmentContracts<,,>))]
-  public interface IConstraintsForAssignment<Variable, Expression, AbstractDomain>
-    where AbstractDomain : INumericalAbstractDomainQuery<Variable, Expression>
-  {
-    /// <returns>
-    /// A set of constraints corresponding to the assignment <code>x := exp</code>, using the abstract domain <code>adom</code>
-    /// </returns>
-    List<Expression> InferConstraints(Expression x, Expression exp, AbstractDomain adom);  
-  }
-
-  [ContractClassFor(typeof(IConstraintsForAssignment<,,>))]
-  abstract class IConstraintsForAssignmentContracts<Variable, Expression, AbstractDomain>
-    : IConstraintsForAssignment<Variable, Expression, AbstractDomain>
-    where AbstractDomain : INumericalAbstractDomainQuery<Variable, Expression>
-  {
-
-    List<Expression> IConstraintsForAssignment<Variable, Expression, AbstractDomain>.InferConstraints(Expression x, Expression exp, AbstractDomain adom)
+    /// <summary>
+    /// The interface for the assignment crawler
+    /// </summary>
+    [ContractClass(typeof(IConstraintsForAssignmentContracts<,,>))]
+    public interface IConstraintsForAssignment<Variable, Expression, AbstractDomain>
+      where AbstractDomain : INumericalAbstractDomainQuery<Variable, Expression>
     {
-      Contract.Requires(x != null);
-      Contract.Requires(exp != null);
-      Contract.Requires(adom != null);
-
-      Contract.Ensures(Contract.Result<List<Expression>>() != null);
-      Contract.Ensures(Contract.ForAll(Contract.Result<List<Expression>>(), e => e != null));
-      
-      throw new NotImplementedException();
-    }
-  }
-
-  [ContractVerification(true)]
-  internal class LessEqualThanConstraints<Variable, Expression>
-    : IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.expManager != null);
+        /// <returns>
+        /// A set of constraints corresponding to the assignment <code>x := exp</code>, using the abstract domain <code>adom</code>
+        /// </returns>
+        List<Expression> InferConstraints(Expression x, Expression exp, AbstractDomain adom);
     }
 
-    readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
-
-    public LessEqualThanConstraints(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+    [ContractClassFor(typeof(IConstraintsForAssignment<,,>))]
+    internal abstract class IConstraintsForAssignmentContracts<Variable, Expression, AbstractDomain>
+      : IConstraintsForAssignment<Variable, Expression, AbstractDomain>
+      where AbstractDomain : INumericalAbstractDomainQuery<Variable, Expression>
     {
-      Contract.Requires(expManager != null);
-
-      this.expManager = expManager;
-    }
-
-    #region IConstraintsForAssignment<Expression, AbstractDomain> Members
-
-    //[SuppressMessage("Microsoft.Contracts", "Ensures-106-407")]
-    public List<Expression> InferConstraints(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> adom)
-    {
-      Contract.Assert(adom != null);
-
-      var xExp = new Pair<Expression, Expression>(x, exp);
-      var result = new List<Expression>();
-
-      Polynomial<Variable, Expression> expAsPol;
-
-      var decoder = this.expManager.Decoder;
-      var encoder = this.expManager.Encoder;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, decoder, out expAsPol))
-      {
-        if (expAsPol.IsLinear)
+        List<Expression> IConstraintsForAssignment<Variable, Expression, AbstractDomain>.InferConstraints(Expression x, Expression exp, AbstractDomain adom)
         {
-          #region The cases
-          Expression leqExp;
-          Variable y;
-          Rational k;
+            Contract.Requires(x != null);
+            Contract.Requires(exp != null);
+            Contract.Requires(adom != null);
 
-          // If it is in the form y - k, with k constant, then we add the constraint " x <= y "
-          if (expAsPol.TryMatch_YMinusK(out y, out k))
-          {
-            var yExp = encoder.VariableFor(y);
+            Contract.Ensures(Contract.Result<List<Expression>>() != null);
+            Contract.Ensures(Contract.ForAll(Contract.Result<List<Expression>>(), e => e != null));
 
-            leqExp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, yExp);
+            throw new NotImplementedException();
+        }
+    }
 
-            Contract.Assert(leqExp != null);
+    [ContractVerification(true)]
+    internal class LessEqualThanConstraints<Variable, Expression>
+      : IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(expManager != null);
+        }
 
-            result.Add(leqExp);  // add the constraint x <= y
-          }
-          // If it is in the form y + k, with k constant, we add the constraint "y <= x" 
-          else if (expAsPol.TryMatch_YPlusK(out y, out k))
-          {
-            var yExp = encoder.VariableFor(y);
+        readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
 
-            leqExp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, yExp, x);
+        public LessEqualThanConstraints(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
 
-            Contract.Assert(leqExp != null);
+            this.expManager = expManager;
+        }
 
-            result.Add(leqExp); // As we know x, this is a clever encoding for the constraint y <= x
+        #region IConstraintsForAssignment<Expression, AbstractDomain> Members
 
-            // x = y + 1 then if y < z => x <= z
-            if (k == 1)
+        //[SuppressMessage("Microsoft.Contracts", "Ensures-106-407")]
+        public List<Expression> InferConstraints(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> adom)
+        {
+            Contract.Assert(adom != null);
+
+            var xExp = new Pair<Expression, Expression>(x, exp);
+            var result = new List<Expression>();
+
+            Polynomial<Variable, Expression> expAsPol;
+
+            var decoder = expManager.Decoder;
+            var encoder = expManager.Encoder;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, decoder, out expAsPol))
             {
-              result.AddRange(UpperBoundsNonStrict(x, adom.UpperBoundsFor(y, true)));
+                if (expAsPol.IsLinear)
+                {
+                    #region The cases
+                    Expression leqExp;
+                    Variable y;
+                    Rational k;
+
+                    // If it is in the form y - k, with k constant, then we add the constraint " x <= y "
+                    if (expAsPol.TryMatch_YMinusK(out y, out k))
+                    {
+                        var yExp = encoder.VariableFor(y);
+
+                        leqExp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, yExp);
+
+                        Contract.Assert(leqExp != null);
+
+                        result.Add(leqExp);  // add the constraint x <= y
+                    }
+                    // If it is in the form y + k, with k constant, we add the constraint "y <= x" 
+                    else if (expAsPol.TryMatch_YPlusK(out y, out k))
+                    {
+                        var yExp = encoder.VariableFor(y);
+
+                        leqExp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, yExp, x);
+
+                        Contract.Assert(leqExp != null);
+
+                        result.Add(leqExp); // As we know x, this is a clever encoding for the constraint y <= x
+
+                        // x = y + 1 then if y < z => x <= z
+                        if (k == 1)
+                        {
+                            result.AddRange(UpperBoundsNonStrict(x, adom.UpperBoundsFor(y, true)));
+                        }
+                    }
+                    // If it is in the form k * y then it add the constaints "y <= x" or "x <= y"
+                    else if (expAsPol.TryMatch_kY(out y, out k))
+                    {
+                        var yExp = encoder.VariableFor(y);
+
+                        Contract.Assert(yExp != null);
+
+                        if (TryHelperFor_MatchkY(x, adom, yExp, k, out leqExp))
+                        {
+                            // F: this should be some bug, it is not taking into account the postcondition
+                            Contract.Assume(leqExp != null);
+
+                            result.Add(leqExp);
+                        }
+                    }
+                    #endregion
+                }
             }
-          }
-          // If it is in the form k * y then it add the constaints "y <= x" or "x <= y"
-          else if (expAsPol.TryMatch_kY(out y, out k))
-          {
-            var yExp = encoder.VariableFor(y);
 
-            Contract.Assert(yExp != null);
+            var nonPolynomial = new TreatNonPolynomialCases(x, expManager).Visit(exp, adom);
 
-            if (TryHelperFor_MatchkY(x, adom, yExp, k, out leqExp))
+            Contract.Assert(nonPolynomial != null);
+
+            result.AddRange(nonPolynomial);
+
+            Contract.Assume(Contract.ForAll(result, e => e != null));
+
+            return result;
+        }
+
+        private IEnumerable<Expression> UpperBoundsNonStrict(Expression x, IEnumerable<Expression> iSet)
+        {
+            Contract.Requires(iSet != null);
+
+            foreach (var upp in iSet)
             {
-              // F: this should be some bug, it is not taking into account the postcondition
-              Contract.Assume(leqExp != null);
-
-              result.Add(leqExp);
+                yield return expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, upp);
             }
-          }
-          #endregion
-        }
-      }
-
-      var nonPolynomial = new TreatNonPolynomialCases(x, this.expManager).Visit(exp, adom);
-
-      Contract.Assert(nonPolynomial != null);
-
-      result.AddRange(nonPolynomial);
-
-      Contract.Assume(Contract.ForAll(result, e => e != null));
-
-      return result;
-    }
-
-    private IEnumerable<Expression> UpperBoundsNonStrict(Expression x, IEnumerable<Expression> iSet)
-    {
-      Contract.Requires(iSet != null);
-
-      foreach (var upp in iSet)
-      {
-        yield return this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, upp);
-      }
-    }
-
-    private bool TryHelperFor_MatchkY(Expression x, INumericalAbstractDomainQuery<Variable, Expression> adom, 
-      Expression y, Rational k, out Expression leqExp)
-    {
-      Contract.Requires(adom != null);
-      Contract.Requires(y != null);
-      Contract.Requires(!object.ReferenceEquals(k, null));
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leqExp) != null);
-
-      var yPositive = adom.CheckIfGreaterEqualThanZero(y);
-
-      if (k >= 1 && yPositive.IsNormal())
-      {
-        if (yPositive.BoxedElement)
-        {
-          leqExp = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, y, x);
-          return true;
-        }
-        else
-        {
-          leqExp = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, y);
-          return true;
-        }
-      }
-
-      leqExp = default(Expression);
-      return false;
-    }
-
-    private class TreatNonPolynomialCases
-     : GenericExpressionVisitor<INumericalAbstractDomainQuery<Variable, Expression>, Set<Expression>, Variable, Expression>
-    {
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.expManager != null);
-      }
-
-      readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
-
-      private Expression x;
-
-      public TreatNonPolynomialCases(Expression x, ExpressionManagerWithEncoder<Variable, Expression> expManager)
-        : base(expManager.Decoder)
-      {
-        Contract.Requires(expManager != null);
-
-        this.x = x;
-        this.expManager = expManager;
-      }
-
-      public override Set<Expression> VisitModulus(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)           
-      {
-        var result = new Set<Expression>();
-
-        if (data == null)
-          return result;
-
-        if (data.BoundsFor(right).LowerBound >= 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, right));     // Then assume x < e2
-         }
-
-        return result;
-      }
-
-      public override Set<Expression> VisitSubtraction(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        var result = new Set<Expression>();
-
-        if (data == null)
-          return result;
-
-        if (data.BoundsFor(right).LowerBound >= 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, left));     // Then assume x < left
         }
 
-        return result;
-      }
-
-      public override Set<Expression> VisitAddition(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        var result = new Set<Expression>();
-
-        if (data == null)
-          return result;
-
-        // x := left + right
-        if (data.BoundsFor(right).LowerBound >= 0)
+        private bool TryHelperFor_MatchkY(Expression x, INumericalAbstractDomainQuery<Variable, Expression> adom,
+          Expression y, Rational k, out Expression leqExp)
         {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, left, x));     // Then assume left <= x
-        }
+            Contract.Requires(adom != null);
+            Contract.Requires(y != null);
+            Contract.Requires(!object.ReferenceEquals(k, null));
 
-        if (data.BoundsFor(left).LowerBound >= 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, right, x));     // Then assume right <= x
-        }
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out leqExp) != null);
 
-        return result; 
-      }
+            var yPositive = adom.CheckIfGreaterEqualThanZero(y);
 
-      public override Set<Expression> VisitOr(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        var result = new Set<Expression>();
-
-        if (data == null || left == null || right == null)
-          return result;
-
-        if (data.CheckIfGreaterEqualThanZero(left).IsTrue() && data.CheckIfGreaterEqualThanZero(right).IsTrue())
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, left, x));
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, right, x));
-        }
-
-        return result;
-      }
-
-      protected override Set<Expression> Default(INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        return new Set<Expression>();
-      }
-    }
-
-
-    #endregion
-  }
-
-  internal class LessThanConstraints<Variable, Expression>
-    : IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(expManager != null);
-    }
-
-    readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
-    readonly private FIFOCache<Pair<Expression, Expression>, Cache_Entry<Expression>> cache;
-
-    public LessThanConstraints(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
-
-      this.expManager = expManager;
-      this.cache = new FIFOCache<Pair<Expression, Expression>, Cache_Entry<Expression>>(16);
-    }
-
-    #region IConstraintsForAssignment<Expression,AbstractDomain> Members
-
-    public List<Expression> InferConstraints(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain)
-    {
-      Polynomial<Variable, Expression> expAsPol;
-      Expression ltExp;
-
-      var result = new List<Expression>();
-      var xExp = new Pair<Expression, Expression>(x, exp);
-
-      #region 0. Fetch the cache
-      Cache_Entry<Expression> cached;
-      if (cache.TryGetValue(xExp, out cached))
-      {
-        switch (cached.Match_case)
-        {
-          case Cache_Entry.MatchCase.YMinusK:
-            result.Add(cached.ResultExpression);
-            result.AddRange(UpperBounds(cached.X, oracleDomain.UpperBoundsFor(cached.Y, false)));
-            break;
-
-          case Cache_Entry.MatchCase.YPlusK:
-            result.Add(cached.ResultExpression);
-            result.AddRange(UpperBounds(cached.Y, oracleDomain.UpperBoundsFor(cached.X, false)));
-            break;
-
-          case Cache_Entry.MatchCase.kY:
-            Helper_Match_kY(cached.X, oracleDomain, result, cached.Y);
-            break;
-
-          case Cache_Entry.MatchCase.NotLinear:
-            // do nothing: this case essentially avoids the computation in the other branchs that we know to be unfruitfull
-            break;
-
-          default:
-            // error?
-            break;
-        }
-      }
-      #endregion
-
-      #region 1. If failed, Try to put the r-exp in a polynomial (with simplifications, etc.)
-      else if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.expManager.Decoder, out expAsPol))
-      {
-        if (expAsPol.IsLinear)
-        {
-          // If it is in the form y - k, with k constant, then we add the constraint
-          Variable y;
-          Rational k;
-          if (expAsPol.TryMatch_YMinusK(out y, out k) && !x.Equals(y))
-          {
-            var yExp = this.expManager.Encoder.VariableFor(y);
-
-            ltExp = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, yExp);
-            result.Add(ltExp);
-
-            result.AddRange(UpperBounds(x, oracleDomain.UpperBoundsFor(y, false)));
-
-            // update the cache 
-            cache.Add(xExp, Cache_Entry.For(Cache_Entry.MatchCase.YMinusK, x, yExp, k, ltExp));
-          }
-          // If it is in the form y + k, with k constant, we add the constraint "y < x" to the back constraits
-          else if (expAsPol.TryMatch_YPlusK(out y, out k) && !x.Equals(y))
-          {
-            var yExp = this.expManager.Encoder.VariableFor(y);
-
-            ltExp = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, yExp, x);
-
-            result.Add(ltExp);
-            result.AddRange(UpperBounds(yExp, oracleDomain.UpperBoundsFor(x, false)));
-
-            // update the cache
-            cache.Add(xExp, Cache_Entry.For(Cache_Entry.MatchCase.YPlusK, x, yExp, k, ltExp));
-          }
-          // If it is in the form k*y, with k constant, if k > 1 we add the constraint "x > y"
-          else if (expAsPol.TryMatch_kY(out y, out k) && !x.Equals(y))
-          {
-            var yExp = this.expManager.Encoder.VariableFor(y);
-            if (k > 1)
+            if (k >= 1 && yPositive.IsNormal())
             {
-              Helper_Match_kY(x, oracleDomain, result, yExp);
-              cache.Add(xExp, Cache_Entry.For(Cache_Entry.MatchCase.kY, x, yExp, k, default(Expression)));
+                if (yPositive.BoxedElement)
+                {
+                    leqExp = expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, y, x);
+                    return true;
+                }
+                else
+                {
+                    leqExp = expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, y);
+                    return true;
+                }
             }
-            else
+
+            leqExp = default(Expression);
+            return false;
+        }
+
+        private class TreatNonPolynomialCases
+         : GenericExpressionVisitor<INumericalAbstractDomainQuery<Variable, Expression>, Set<Expression>, Variable, Expression>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
             {
-              cache.Add(xExp, Cache_Entry.ForNonLinear<Expression>());
+                Contract.Invariant(expManager != null);
             }
-          }
-        }
-      }
-      #endregion
 
-      #region 2. Special treatment for reminder and non polynomial expressions
+            private readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
 
-      result.AddRange(new TreatNonPolynomialCases(x, this.expManager).Visit(exp, oracleDomain));
+            private Expression x;
 
-      #endregion
-
-      return result;
-    }
-
-    private void Helper_Match_kY(
-      Expression x, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain, List<Expression> result, Expression y)
-    {
-      Contract.Requires(result != null);
-
-      Expression ltExp;
-      if (oracleDomain.BoundsFor(y).LowerBound >= 1)
-      {
-        ltExp = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, y, x);
-        result.Add(ltExp);
-
-        result.AddRange(UpperBounds(y, oracleDomain.UpperBoundsFor(x, false)));
-      }
-    }
-
-    private IEnumerable<Expression> UpperBounds(Expression x, IEnumerable<Expression> iSet)
-    {
-      foreach (Expression upp in iSet)
-      {
-        yield return this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, upp);
-      }
-    }
-
-    #endregion
-
-    private class TreatNonPolynomialCases
-      : GenericExpressionVisitor<INumericalAbstractDomainQuery<Variable, Expression>, Set<Expression>, Variable, Expression>
-    {
-
-      readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
-
-      private Expression x;
-
-      public TreatNonPolynomialCases(Expression x, ExpressionManagerWithEncoder<Variable, Expression> expManager)
-        : base(expManager.Decoder)
-      {
-        Contract.Requires(expManager != null);
-
-        this.x = x;
-        this.expManager = expManager;
-      }
-
-      public override Set<Expression> VisitModulus(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        var result = new Set<Expression>();
-
-        if (this.AreInfinities(left, right))
-        {
-          return result;
-        }
-
-        if (data.BoundsFor(right).LowerBound >= 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, right));     // Then assume x < right
-        }
-
-        return result;
-      }
-
-      public override Set<Expression> VisitShiftRight(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        if (this.AreInfinities(left, right))
-        {
-          return new Set<Expression>();
-        }
-
-        var bounds = data.BoundsFor(right).AsInterval;
-        int val;
-        Polynomial<Variable, Expression> pol;
-        if (bounds.IsFiniteAndInt32Singleton(out val) && val > 0 &&
-          Polynomial<Variable, Expression>.TryToPolynomialForm(left, this.Decoder, out pol) 
-          && pol.IsLinear && !pol.Relation.HasValue && pol.Left.Length <= (1 << val))
-        {
-          var ub = null as IEnumerable<Expression>;
-
-          foreach (var m in pol.Left)
-          {
-            Variable v;
-            if (m.IsVariable(out v) && data.BoundsFor(v).LowerBound >= 0)
+            public TreatNonPolynomialCases(Expression x, ExpressionManagerWithEncoder<Variable, Expression> expManager)
+              : base(expManager.Decoder)
             {
-              var upperbounds = data.UpperBoundsFor(v, true);
-              ub = ub == null ? upperbounds : ub.Intersect(upperbounds);
+                Contract.Requires(expManager != null);
 
-              if (ub.Any())
-              {
-                continue;
-              }
+                this.x = x;
+                this.expManager = expManager;
             }
-            return new Set<Expression>();
-          }
 
-          // If we reach this point, we have meaningful constraints
+            public override Set<Expression> VisitModulus(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                var result = new Set<Expression>();
 
-          return new Set<Expression>(ub.ApplyToAll(exp => this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, exp)));
+                if (data == null)
+                    return result;
+
+                if (data.BoundsFor(right).LowerBound >= 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, right));     // Then assume x < e2
+                }
+
+                return result;
+            }
+
+            public override Set<Expression> VisitSubtraction(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                var result = new Set<Expression>();
+
+                if (data == null)
+                    return result;
+
+                if (data.BoundsFor(right).LowerBound >= 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, x, left));     // Then assume x < left
+                }
+
+                return result;
+            }
+
+            public override Set<Expression> VisitAddition(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                var result = new Set<Expression>();
+
+                if (data == null)
+                    return result;
+
+                // x := left + right
+                if (data.BoundsFor(right).LowerBound >= 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, left, x));     // Then assume left <= x
+                }
+
+                if (data.BoundsFor(left).LowerBound >= 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, right, x));     // Then assume right <= x
+                }
+
+                return result;
+            }
+
+            public override Set<Expression> VisitOr(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                var result = new Set<Expression>();
+
+                if (data == null || left == null || right == null)
+                    return result;
+
+                if (data.CheckIfGreaterEqualThanZero(left).IsTrue() && data.CheckIfGreaterEqualThanZero(right).IsTrue())
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, left, x));
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, right, x));
+                }
+
+                return result;
+            }
+
+            protected override Set<Expression> Default(INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                return new Set<Expression>();
+            }
         }
 
-        return new Set<Expression>();
-      }
-
-      public override Set<Expression> VisitSubtraction(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        var result = new Set<Expression>();
-
-        if (this.AreInfinities(left, right))
-        {
-          return result;
-        }
-
-        // It is x = left - right, 
-        if (data.BoundsFor(right).LowerBound > 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, left));     // Then assume x < left
-        }
-        // It is x = left - (- Abs(right))
-        else if (data.BoundsFor(right).UpperBound < 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, left, x));   // Then assume left < x
-        }
-
-        return result;
-      }
-
-      public override Set<Expression> VisitAddition(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        var result = new Set<Expression>();
-
-        if (this.AreInfinities(left, right))
-        {
-          return result;
-        }
-
-        // It is x = left + right, 
-        if (data.BoundsFor(right).LowerBound > 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, left, x));     // Then assume left < x 
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, this.Decoder.Stripped(left), x));
-        }
-        // It is x = left + (- Abs(right))
-        else if (data.BoundsFor(right).UpperBound < 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, left));   // The assume x < left
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, this.Decoder.Stripped(left)));
-        }
-
-        if (data.BoundsFor(left).LowerBound > 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, right, x));     // Then assume right < x 
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, this.Decoder.Stripped(right), x));
-        }
-        // It is x = -(Abs(left)) + right
-        else if (data.BoundsFor(left).UpperBound < 0)
-        {
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, right));   // The assume x < right
-          result.Add(this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, this.Decoder.Stripped(right)));
-        }
-
-        return result;
-      }
-
-      protected override Set<Expression> Default(INumericalAbstractDomainQuery<Variable, Expression> data)
-      {
-        return new Set<Expression>();
-      }
-
-      private bool AreInfinities(Expression e1, Expression e2)
-      {
-        return this.Decoder.IsInfinity(e1) || this.Decoder.IsInfinity(e2);
-      }
+        #endregion
     }
-  }
 
-  internal class GreaterEqualThanZeroConstraints<Variable, Expression>
-    : IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>
-  {
-    private readonly ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
-
-    public GreaterEqualThanZeroConstraints(ExpressionManagerWithEncoder<Variable, Expression> expressionManager)
+    internal class LessThanConstraints<Variable, Expression>
+      : IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>
     {
-      Contract.Requires(expressionManager != null);
-
-      this.ExpressionManager = expressionManager;
-    }
-
-    #region IConstraintsForAssignment<Expression,Rational,AbstractDomain> Members
-
-    public List<Expression> InferConstraints(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> adom)
-    {
-      Contract.Ensures(Contract.Result<List<Expression>>() != null);      
-
-      var result = new List<Expression>();
-
-      if (adom == null)
-      {
-        return result;
-      }
-
-      // This may appear straightforward and repeatitive, but sometimes the CheckIfxxx are more precise than what the abstract domain can track 
-      // (because of the refinement of the expressions, and the fact that they are "goal directed")
-      // As a consequence, we add explicitely this information to the abstract domain
-      var isGeqZero = adom.CheckIfGreaterEqualThanZero(exp);
-
-      if (isGeqZero.IsNormal())
-      {
-        var zero = this.ExpressionManager.Encoder.ConstantFor(0);
-        if (isGeqZero.IsTrue())
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          // Discovered the disequality : 0 <= x 
-
-          var newConstraint = this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.GreaterEqualThan, x, zero);
-          result.Add(newConstraint);
+            Contract.Invariant(expManager != null);
         }
-        else
+
+        readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
+        readonly private FIFOCache<Pair<Expression, Expression>, Cache_Entry<Expression>> cache;
+
+        public LessThanConstraints(ExpressionManagerWithEncoder<Variable, Expression> expManager)
         {
-          // Discovered the disequality : x < 0" 
+            Contract.Requires(expManager != null);
 
-          var newConstraint = this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, zero);
-          result.Add(newConstraint);
+            this.expManager = expManager;
+            cache = new FIFOCache<Pair<Expression, Expression>, Cache_Entry<Expression>>(16);
         }
-      }
 
-      return result;
+        #region IConstraintsForAssignment<Expression,AbstractDomain> Members
 
+        public List<Expression> InferConstraints(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain)
+        {
+            Polynomial<Variable, Expression> expAsPol;
+            Expression ltExp;
+
+            var result = new List<Expression>();
+            var xExp = new Pair<Expression, Expression>(x, exp);
+
+            #region 0. Fetch the cache
+            Cache_Entry<Expression> cached;
+            if (cache.TryGetValue(xExp, out cached))
+            {
+                switch (cached.Match_case)
+                {
+                    case Cache_Entry.MatchCase.YMinusK:
+                        result.Add(cached.ResultExpression);
+                        result.AddRange(UpperBounds(cached.X, oracleDomain.UpperBoundsFor(cached.Y, false)));
+                        break;
+
+                    case Cache_Entry.MatchCase.YPlusK:
+                        result.Add(cached.ResultExpression);
+                        result.AddRange(UpperBounds(cached.Y, oracleDomain.UpperBoundsFor(cached.X, false)));
+                        break;
+
+                    case Cache_Entry.MatchCase.kY:
+                        Helper_Match_kY(cached.X, oracleDomain, result, cached.Y);
+                        break;
+
+                    case Cache_Entry.MatchCase.NotLinear:
+                        // do nothing: this case essentially avoids the computation in the other branchs that we know to be unfruitfull
+                        break;
+
+                    default:
+                        // error?
+                        break;
+                }
+            }
+            #endregion
+
+            #region 1. If failed, Try to put the r-exp in a polynomial (with simplifications, etc.)
+            else if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, expManager.Decoder, out expAsPol))
+            {
+                if (expAsPol.IsLinear)
+                {
+                    // If it is in the form y - k, with k constant, then we add the constraint
+                    Variable y;
+                    Rational k;
+                    if (expAsPol.TryMatch_YMinusK(out y, out k) && !x.Equals(y))
+                    {
+                        var yExp = expManager.Encoder.VariableFor(y);
+
+                        ltExp = expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, yExp);
+                        result.Add(ltExp);
+
+                        result.AddRange(UpperBounds(x, oracleDomain.UpperBoundsFor(y, false)));
+
+                        // update the cache 
+                        cache.Add(xExp, Cache_Entry.For(Cache_Entry.MatchCase.YMinusK, x, yExp, k, ltExp));
+                    }
+                    // If it is in the form y + k, with k constant, we add the constraint "y < x" to the back constraits
+                    else if (expAsPol.TryMatch_YPlusK(out y, out k) && !x.Equals(y))
+                    {
+                        var yExp = expManager.Encoder.VariableFor(y);
+
+                        ltExp = expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, yExp, x);
+
+                        result.Add(ltExp);
+                        result.AddRange(UpperBounds(yExp, oracleDomain.UpperBoundsFor(x, false)));
+
+                        // update the cache
+                        cache.Add(xExp, Cache_Entry.For(Cache_Entry.MatchCase.YPlusK, x, yExp, k, ltExp));
+                    }
+                    // If it is in the form k*y, with k constant, if k > 1 we add the constraint "x > y"
+                    else if (expAsPol.TryMatch_kY(out y, out k) && !x.Equals(y))
+                    {
+                        var yExp = expManager.Encoder.VariableFor(y);
+                        if (k > 1)
+                        {
+                            Helper_Match_kY(x, oracleDomain, result, yExp);
+                            cache.Add(xExp, Cache_Entry.For(Cache_Entry.MatchCase.kY, x, yExp, k, default(Expression)));
+                        }
+                        else
+                        {
+                            cache.Add(xExp, Cache_Entry.ForNonLinear<Expression>());
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region 2. Special treatment for reminder and non polynomial expressions
+
+            result.AddRange(new TreatNonPolynomialCases(x, expManager).Visit(exp, oracleDomain));
+
+            #endregion
+
+            return result;
+        }
+
+        private void Helper_Match_kY(
+          Expression x, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain, List<Expression> result, Expression y)
+        {
+            Contract.Requires(result != null);
+
+            Expression ltExp;
+            if (oracleDomain.BoundsFor(y).LowerBound >= 1)
+            {
+                ltExp = expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, y, x);
+                result.Add(ltExp);
+
+                result.AddRange(UpperBounds(y, oracleDomain.UpperBoundsFor(x, false)));
+            }
+        }
+
+        private IEnumerable<Expression> UpperBounds(Expression x, IEnumerable<Expression> iSet)
+        {
+            foreach (Expression upp in iSet)
+            {
+                yield return expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, upp);
+            }
+        }
+
+        #endregion
+
+        private class TreatNonPolynomialCases
+          : GenericExpressionVisitor<INumericalAbstractDomainQuery<Variable, Expression>, Set<Expression>, Variable, Expression>
+        {
+            readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
+
+            private Expression x;
+
+            public TreatNonPolynomialCases(Expression x, ExpressionManagerWithEncoder<Variable, Expression> expManager)
+              : base(expManager.Decoder)
+            {
+                Contract.Requires(expManager != null);
+
+                this.x = x;
+                this.expManager = expManager;
+            }
+
+            public override Set<Expression> VisitModulus(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                var result = new Set<Expression>();
+
+                if (this.AreInfinities(left, right))
+                {
+                    return result;
+                }
+
+                if (data.BoundsFor(right).LowerBound >= 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, right));     // Then assume x < right
+                }
+
+                return result;
+            }
+
+            public override Set<Expression> VisitShiftRight(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                if (this.AreInfinities(left, right))
+                {
+                    return new Set<Expression>();
+                }
+
+                var bounds = data.BoundsFor(right).AsInterval;
+                int val;
+                Polynomial<Variable, Expression> pol;
+                if (bounds.IsFiniteAndInt32Singleton(out val) && val > 0 &&
+                  Polynomial<Variable, Expression>.TryToPolynomialForm(left, this.Decoder, out pol)
+                  && pol.IsLinear && !pol.Relation.HasValue && pol.Left.Length <= (1 << val))
+                {
+                    var ub = null as IEnumerable<Expression>;
+
+                    foreach (var m in pol.Left)
+                    {
+                        Variable v;
+                        if (m.IsVariable(out v) && data.BoundsFor(v).LowerBound >= 0)
+                        {
+                            var upperbounds = data.UpperBoundsFor(v, true);
+                            ub = ub == null ? upperbounds : ub.Intersect(upperbounds);
+
+                            if (ub.Any())
+                            {
+                                continue;
+                            }
+                        }
+                        return new Set<Expression>();
+                    }
+
+                    // If we reach this point, we have meaningful constraints
+
+                    return new Set<Expression>(ub.ApplyToAll(exp => expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, exp)));
+                }
+
+                return new Set<Expression>();
+            }
+
+            public override Set<Expression> VisitSubtraction(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                var result = new Set<Expression>();
+
+                if (this.AreInfinities(left, right))
+                {
+                    return result;
+                }
+
+                // It is x = left - right, 
+                if (data.BoundsFor(right).LowerBound > 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, left));     // Then assume x < left
+                }
+                // It is x = left - (- Abs(right))
+                else if (data.BoundsFor(right).UpperBound < 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, left, x));   // Then assume left < x
+                }
+
+                return result;
+            }
+
+            public override Set<Expression> VisitAddition(Expression left, Expression right, Expression original, INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                var result = new Set<Expression>();
+
+                if (this.AreInfinities(left, right))
+                {
+                    return result;
+                }
+
+                // It is x = left + right, 
+                if (data.BoundsFor(right).LowerBound > 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, left, x));     // Then assume left < x 
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, this.Decoder.Stripped(left), x));
+                }
+                // It is x = left + (- Abs(right))
+                else if (data.BoundsFor(right).UpperBound < 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, left));   // The assume x < left
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, this.Decoder.Stripped(left)));
+                }
+
+                if (data.BoundsFor(left).LowerBound > 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, right, x));     // Then assume right < x 
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, this.Decoder.Stripped(right), x));
+                }
+                // It is x = -(Abs(left)) + right
+                else if (data.BoundsFor(left).UpperBound < 0)
+                {
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, right));   // The assume x < right
+                    result.Add(expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, this.Decoder.Stripped(right)));
+                }
+
+                return result;
+            }
+
+            protected override Set<Expression> Default(INumericalAbstractDomainQuery<Variable, Expression> data)
+            {
+                return new Set<Expression>();
+            }
+
+            private bool AreInfinities(Expression e1, Expression e2)
+            {
+                return this.Decoder.IsInfinity(e1) || this.Decoder.IsInfinity(e2);
+            }
+        }
     }
-    #endregion
 
-  }
-
-  internal abstract class Cache_Entry
-  {
-    public enum MatchCase { NotLinear, YMinusK, YPlusK, kY }
-
-    static public Cache_Entry<Expression> For<Expression>(MatchCase match_case, Expression x, Expression y, Rational k, Expression result)
+    internal class GreaterEqualThanZeroConstraints<Variable, Expression>
+      : IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>
     {
-      Contract.Requires((object)k != null);
-      Contract.Requires(match_case != MatchCase.NotLinear);
+        private readonly ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
 
-      return new Cache_Entry<Expression>(match_case, x, y, k, result);
+        public GreaterEqualThanZeroConstraints(ExpressionManagerWithEncoder<Variable, Expression> expressionManager)
+        {
+            Contract.Requires(expressionManager != null);
+
+            ExpressionManager = expressionManager;
+        }
+
+        #region IConstraintsForAssignment<Expression,Rational,AbstractDomain> Members
+
+        public List<Expression> InferConstraints(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> adom)
+        {
+            Contract.Ensures(Contract.Result<List<Expression>>() != null);
+
+            var result = new List<Expression>();
+
+            if (adom == null)
+            {
+                return result;
+            }
+
+            // This may appear straightforward and repeatitive, but sometimes the CheckIfxxx are more precise than what the abstract domain can track 
+            // (because of the refinement of the expressions, and the fact that they are "goal directed")
+            // As a consequence, we add explicitely this information to the abstract domain
+            var isGeqZero = adom.CheckIfGreaterEqualThanZero(exp);
+
+            if (isGeqZero.IsNormal())
+            {
+                var zero = ExpressionManager.Encoder.ConstantFor(0);
+                if (isGeqZero.IsTrue())
+                {
+                    // Discovered the disequality : 0 <= x 
+
+                    var newConstraint = ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.GreaterEqualThan, x, zero);
+                    result.Add(newConstraint);
+                }
+                else
+                {
+                    // Discovered the disequality : x < 0" 
+
+                    var newConstraint = ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, x, zero);
+                    result.Add(newConstraint);
+                }
+            }
+
+            return result;
+        }
+        #endregion
+
     }
 
-    static public Cache_Entry<Expression> ForNonLinear<Expression>()
+    internal abstract class Cache_Entry
     {
-      return new Cache_Entry<Expression>(MatchCase.NotLinear, default(Expression), default(Expression), default(Rational), default(Expression));
+        public enum MatchCase { NotLinear, YMinusK, YPlusK, kY }
+
+        static public Cache_Entry<Expression> For<Expression>(MatchCase match_case, Expression x, Expression y, Rational k, Expression result)
+        {
+            Contract.Requires((object)k != null);
+            Contract.Requires(match_case != MatchCase.NotLinear);
+
+            return new Cache_Entry<Expression>(match_case, x, y, k, result);
+        }
+
+        static public Cache_Entry<Expression> ForNonLinear<Expression>()
+        {
+            return new Cache_Entry<Expression>(MatchCase.NotLinear, default(Expression), default(Expression), default(Rational), default(Expression));
+        }
     }
-  }
 
-  internal class Cache_Entry<Expression> : Cache_Entry
-  {
-    public readonly MatchCase Match_case;
-    public readonly Expression X;
-    public readonly Expression Y;
-    public readonly Rational k;
-
-    public readonly Expression ResultExpression;
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    internal class Cache_Entry<Expression> : Cache_Entry
     {
-      Contract.Invariant(Match_case == MatchCase.NotLinear || !object.ReferenceEquals(k, null));
+        public readonly MatchCase Match_case;
+        public readonly Expression X;
+        public readonly Expression Y;
+        public readonly Rational k;
+
+        public readonly Expression ResultExpression;
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(Match_case == MatchCase.NotLinear || !object.ReferenceEquals(k, null));
+        }
+
+        public Rational K
+        {
+            get
+            {
+                Contract.Requires(Match_case != MatchCase.NotLinear);
+                Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+                return this.k;
+            }
+        }
+
+        internal Cache_Entry(MatchCase match_case, Expression x, Expression y, Rational k, Expression resultExpression)
+        {
+            Contract.Requires(match_case == MatchCase.NotLinear || !object.ReferenceEquals(k, null));
+
+            this.Match_case = match_case;
+            this.X = x;
+            this.Y = y;
+            this.k = k;
+            this.ResultExpression = resultExpression;
+        }
     }
-
-    public Rational K
-    {
-      get
-      {
-        Contract.Requires(Match_case != MatchCase.NotLinear);
-        Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-        return this.k;
-      }
-    }
-
-    internal Cache_Entry(MatchCase match_case, Expression x, Expression y, Rational k, Expression resultExpression)
-    {
-      Contract.Requires(match_case == MatchCase.NotLinear || !object.ReferenceEquals(k, null));
-
-      this.Match_case = match_case;
-      this.X = x;
-      this.Y = y;
-      this.k = k;
-      this.ResultExpression = resultExpression;
-    }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Disequalities.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Disequalities.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // An implementation for simple disequalities
 
@@ -24,1256 +13,1256 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  // We keep constraints in the form x != a, b, ... , with x a variable and a, b, ... being a finite set of rationals
-  public class SimpleDisequalities<Variable, Expression>
-    : FunctionalAbstractDomain<SimpleDisequalities<Variable, Expression>, Variable, SetOfConstraints<Rational>>,
-      INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Private state
-
-    private readonly SimpleDisequalitiesCheckIfHoldsVisitor /*!*/ checkIfHoldsVisitor;
-    private readonly IExpressionDecoder<Variable, Expression> /*!*/ decoder;
-    private readonly IExpressionEncoder<Variable, Expression> /*!*/ encoder;
-
-    private readonly ConstantVisitor /*!*/ evalConstant;
-
-    private readonly SimpleDisequalitiesTestFalseVisitor /*!*/ testFalseVisitor;
-    private readonly SimpleDisequalitiesTestTrueVisitor /*!*/ testTrueVisitor;
-
-    #endregion
-
-    #region Constructors
-
-    /// <summary>
-    ///   Construct a new domain
-    /// </summary>
-    public SimpleDisequalities(IExpressionDecoder<Variable, Expression> /*!*/ decoder,
-                               IExpressionEncoder<Variable, Expression> /*!*/ encoder)
+    // We keep constraints in the form x != a, b, ... , with x a variable and a, b, ... being a finite set of rationals
+    public class SimpleDisequalities<Variable, Expression>
+      : FunctionalAbstractDomain<SimpleDisequalities<Variable, Expression>, Variable, SetOfConstraints<Rational>>,
+        INumericalAbstractDomain<Variable, Expression>
     {
-      this.decoder = decoder;
-      this.encoder = encoder;
+        #region Private state
 
-      evalConstant = new ConstantVisitor(decoder);
+        private readonly SimpleDisequalitiesCheckIfHoldsVisitor /*!*/ checkIfHoldsVisitor;
+        private readonly IExpressionDecoder<Variable, Expression> /*!*/ decoder;
+        private readonly IExpressionEncoder<Variable, Expression> /*!*/ encoder;
 
-      testTrueVisitor = new SimpleDisequalitiesTestTrueVisitor(this.decoder, evalConstant);
-      testFalseVisitor = new SimpleDisequalitiesTestFalseVisitor(this.decoder);
+        private readonly ConstantVisitor /*!*/ evalConstant;
 
-      testTrueVisitor.FalseVisitor = testFalseVisitor;
-      testFalseVisitor.TrueVisitor = testTrueVisitor;
+        private readonly SimpleDisequalitiesTestFalseVisitor /*!*/ testFalseVisitor;
+        private readonly SimpleDisequalitiesTestTrueVisitor /*!*/ testTrueVisitor;
 
-      checkIfHoldsVisitor = new SimpleDisequalitiesCheckIfHoldsVisitor(this.decoder, evalConstant);
-    }
+        #endregion
 
-    private SimpleDisequalities(SimpleDisequalities<Variable, Expression> original)
-      : base(original)
-    {
-      decoder = original.decoder;
-      encoder = original.encoder;
+        #region Constructors
 
-      evalConstant = original.evalConstant;
-
-      testTrueVisitor = original.testTrueVisitor;
-      testFalseVisitor = original.testFalseVisitor;
-
-      checkIfHoldsVisitor = original.checkIfHoldsVisitor;
-    }
-
-    #endregion
-
-    #region Overriding the accessors
-
-    public override SetOfConstraints<Rational> this[Variable index]
-    {
-      get
-      {
-        if (ContainsKey(index))
+        /// <summary>
+        ///   Construct a new domain
+        /// </summary>
+        public SimpleDisequalities(IExpressionDecoder<Variable, Expression> /*!*/ decoder,
+                                   IExpressionEncoder<Variable, Expression> /*!*/ encoder)
         {
-          return base[index];
-        }
-        else
-        {
-          return new SetOfConstraints<Rational>(Rational.For(-30)).Top; // Top
-        }
-      }
-      set
-      {
-        if (decoder.IsSlackOrFrameworkVariable(index))
-        {
-          base[index] = value;
-        }
-      }
-    }
+            this.decoder = decoder;
+            this.encoder = encoder;
 
-    #endregion
+            evalConstant = new ConstantVisitor(decoder);
 
-    #region Implementation of abstract methods
+            testTrueVisitor = new SimpleDisequalitiesTestTrueVisitor(this.decoder, evalConstant);
+            testFalseVisitor = new SimpleDisequalitiesTestFalseVisitor(this.decoder);
 
-    public override object Clone()
-    {
-      return new SimpleDisequalities<Variable, Expression>(this);
-    }
+            testTrueVisitor.FalseVisitor = testFalseVisitor;
+            testFalseVisitor.TrueVisitor = testTrueVisitor;
 
-    protected override SimpleDisequalities<Variable, Expression> Factory()
-    {
-      return new SimpleDisequalities<Variable, Expression>(decoder, encoder);
-    }
-
-    // To be implemented
-    protected override string ToLogicalFormula(Variable d, SetOfConstraints<Rational> c)
-    {
-      return "1";
-    }
-
-    protected override T To<T>(Variable d, SetOfConstraints<Rational> c, IFactory<T> factory)
-    {
-      if (c.IsBottom)
-        return factory.Constant(false);
-
-      if (c.IsTop)
-        return factory.Constant(true);
-
-      T result = factory.IdentityForAnd;
-      T x = factory.Variable(d);
-
-      foreach (Rational r in c.Values)
-      {
-        result = factory.And(result, factory.NotEqualTo(x, factory.Constant(r)));
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression> Members
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      Interval intvForExp = preState.BoundsFor(exp).AsInterval;
-
-      Variable xVar = decoder.UnderlyingVariable(x);
-
-      AssumeInInterval(xVar, intvForExp);
-    }
-
-    public void AssumeInDisInterval(Variable x, DisInterval values)
-    {
-      AssumeInInterval(x, values.AsInterval);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(
-      Expression left, Expression right)
-    {
-      return TestTrueEqual(left, right);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(
-      Expression exp)
-    {
-      return TestTrueGeqZero(exp);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(
-      Expression left, Expression right)
-    {
-      return TestTrueLessThan(left, right);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(
-      Expression left, Expression right)
-    {
-      return TestTrueLessEqualThan(left, right);
-    }
-
-    /// <summary>
-    ///   Adds the constraints x != value.LowerBound-1 and x != value.UpperBound+1
-    /// </summary>
-    public void AssumeInInterval(Variable x, Interval value)
-    {
-      if (value.IsNormal)
-      {
-        var strictBounds = new Set<Rational>(2);
-        if (!value.LowerBound.IsInfinity)
-        {
-          try
-          {
-            strictBounds.Add(value.LowerBound - 1);
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            // It may be the case that value.UpperBound is too large, so we catch it
-            // and do nothing (i.e. we abstract)
-          }
+            checkIfHoldsVisitor = new SimpleDisequalitiesCheckIfHoldsVisitor(this.decoder, evalConstant);
         }
 
-        if (!value.UpperBound.IsInfinity)
+        private SimpleDisequalities(SimpleDisequalities<Variable, Expression> original)
+          : base(original)
         {
-          try
-          {
-            strictBounds.Add(value.UpperBound + 1);
-          }
+            decoder = original.decoder;
+            encoder = original.encoder;
 
-          catch (ArithmeticExceptionRational)
-          {
-            // It may be the case that value.UpperBound is too large, so we catch it
-            // and do nothing (i.e. we abstract)
-          }
+            evalConstant = original.evalConstant;
+
+            testTrueVisitor = original.testTrueVisitor;
+            testFalseVisitor = original.testFalseVisitor;
+
+            checkIfHoldsVisitor = original.checkIfHoldsVisitor;
         }
 
-        // Check if zero is not included. In the case, we want to add the constraint x != 0
-        if (value.DoesNotInclude(0))
+        #endregion
+
+        #region Overriding the accessors
+
+        public override SetOfConstraints<Rational> this[Variable index]
         {
-          strictBounds.Add(Rational.For(0));
-        }
-
-        // It may be the case that the interval is e.g. [+oo, +oo], so we cannot blindly add the matrixes
-        if (strictBounds.Count > 0)
-        {
-          this[x] = new SetOfConstraints<Rational>(strictBounds);
-        }
-      }
-    }
-
-    public SimpleDisequalities<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      // exp >= 0 => exp != -1  (and also -2, ... but we ignore it)
-
-      Variable expVar = decoder.UnderlyingVariable(exp);
-
-      this[expVar] = this[expVar].Meet(new SetOfConstraints<Rational>(Rational.For(-1)));
-
-      return this;
-    }
-
-
-    public SimpleDisequalities<Variable, Expression> TestTrueLessThan(Expression left, Expression right)
-    {
-      SimpleDisequalities<Variable, Expression> result = this;
-
-      evalConstant.Visit(right);
-
-      if (evalConstant.HasValue)
-      {
-        Rational v = evalConstant.Result;
-
-        Variable leftVar = decoder.UnderlyingVariable(left);
-
-        // left < k => left != k (also k+1, k+2, k+3, etc. but we do not care ...) 
-
-        SetOfConstraints<Rational> newConstraintsForLeft = this[leftVar].Meet(new SetOfConstraints<Rational>(v));
-        result[leftVar] = newConstraintsForLeft;
-      }
-
-      evalConstant.Visit(left);
-
-      if (evalConstant.HasValue)
-      {
-        Rational v = evalConstant.Result;
-
-        Variable rightVar = decoder.UnderlyingVariable(right);
-
-        // k < right => right != k (also k-1, k-2, etc. but we do not care ...)
-        SetOfConstraints<Rational> newConstraintsForRight = this[rightVar].Meet(new SetOfConstraints<Rational>(v));
-        result[rightVar] = newConstraintsForRight;
-      }
-
-      return result;
-    }
-
-    public SimpleDisequalities<Variable, Expression> TestTrueLessEqualThan(Expression left, Expression right)
-    {
-      SimpleDisequalities<Variable, Expression> result = this;
-
-      evalConstant.Visit(right);
-
-      if (evalConstant.HasValue)
-      {
-        Rational v = evalConstant.Result;
-
-        Variable leftVar = decoder.UnderlyingVariable(left);
-
-        // left <= k => left != k + 1 (also k+2, k+3, etc. but we do not care ...) 
-        SetOfConstraints<Rational> newConstraintsForLeft = this[leftVar].Meet(new SetOfConstraints<Rational>(v + 1));
-        result[leftVar] = newConstraintsForLeft;
-      }
-
-      evalConstant.Visit(left);
-
-      if (evalConstant.HasValue)
-      {
-        Rational v = evalConstant.Result;
-
-        Variable rightVar = decoder.UnderlyingVariable(right);
-
-        // k <= right => right != k - 1 (also k - 2, k - 3, etc. but we do not care ...)
-        SetOfConstraints<Rational> newConstraintsForRight = this[rightVar].Meet(new SetOfConstraints<Rational>(v - 1));
-        result[rightVar] = newConstraintsForRight;
-      }
-
-      return result;
-    }
-
-    public SimpleDisequalities<Variable, Expression> TestTrueEqual(Expression left, Expression right)
-    {
-      return testTrueVisitor.VisitEqual(left, right, default(Expression), this);
-    }
-
-    #endregion
-
-    #region IAbstractDomainForEnvironments<Variable, Expression> Members
-
-    /// <summary>
-    ///   Pretty print the expression
-    /// </summary>
-    public string ToString(Expression exp)
-    {
-      return ExpressionPrinter.ToString(exp, decoder);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get { return new List<Variable>(Keys); }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      // Does nothing ...
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      RemoveVariable(var);
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      if (ContainsKey(var))
-        RemoveElement(var);
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      if (ContainsKey(OldName))
-      {
-        this[NewName] = this[OldName];
-        RemoveVariable(OldName);
-      }
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(
-      Expression guard)
-    {
-      return TestTrue(guard);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(
-      Expression guard)
-    {
-      return TestFalse(guard);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      return checkIfHoldsVisitor.Visit(exp, this);
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      AssumeDomainSpecificFact(fact);
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(
-      INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      var result = new SimpleDisequalities<Variable, Expression>(decoder, encoder);
-
-      if (encoder != null)
-      {
-        foreach (var x_pair in Elements)
-        {
-          SetOfConstraints<Rational> k = x_pair.Value;
-
-          if (k.IsBottom || k.IsTop)
-          {
-            result[x_pair.Key] = k;
-          }
-          else
-          {
-            Expression xExp = encoder.VariableFor(x_pair.Key);
-            foreach (Rational exp in k.Values)
+            get
             {
-              Expression notEq = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, xExp,
-                                                               exp.ToExpression(encoder));
-
-              FlatAbstractDomain<bool> check = oracle.CheckIfHolds(notEq);
-
-              if (check.IsBottom || check.IsTop || !check.BoxedElement)
-              {
-                // If it is not implied by the oracle, we give up
-                result = result.TestTrue(notEq);
-              }
+                if (ContainsKey(index))
+                {
+                    return base[index];
+                }
+                else
+                {
+                    return new SetOfConstraints<Rational>(Rational.For(-30)).Top; // Top
+                }
             }
-          }
-        }
-      }
-
-      return result;
-    }
-
-    public SimpleDisequalities<Variable, Expression> TestTrue(Expression guard)
-    {
-      return testTrueVisitor.Visit(guard, this);
-    }
-
-    public SimpleDisequalities<Variable, Expression> TestFalse(Expression guard)
-    {
-      return testFalseVisitor.Visit(guard, this);
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets,
-                                 Converter<Variable, Expression> convert)
-    {
-      var result = new SimpleDisequalities<Variable, Expression>(decoder, encoder);
-
-      foreach (Variable e in Keys)
-      {
-        if (decoder.IsSlackVariable(e))
-        {
-          result[e] = this[e];
-        }
-      }
-
-      State = AbstractState.Normal;
-
-      if (sourcesToTargets.Count == 0)
-      {
-        // do nothing...
-      }
-      else
-      {
-        // Update the values
-        foreach (Variable exp in sourcesToTargets.Keys)
-        {
-          SetOfConstraints<Rational> value = this[exp];
-
-          foreach (Variable target in sourcesToTargets[exp].GetEnumerable())
-          {
-            if (!value.IsTop)
+            set
             {
-              result[target] = value;
+                if (decoder.IsSlackOrFrameworkVariable(index))
+                {
+                    base[index] = value;
+                }
             }
-          }
         }
-      }
 
-      ClearElements();
-      foreach (Variable e in result.Keys)
-      {
-        this[e] = result[e];
-      }
-    }
+        #endregion
 
-    #endregion
+        #region Implementation of abstract methods
 
-    #region INumericalAbstractDomainQuery<Variable, Expression> Members
-
-    public DisInterval BoundsFor(Expression v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get { return new List<Pair<Variable, Int32>>(); }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      yield break;
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      yield break;
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      yield break;
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      yield break;
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      return new Set<Variable>();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return CheckIfLessThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return CheckIfLessEqualThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    /// <returns>True iff 0 \in this[e]</returns>
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
-    {
-      Variable eVar = decoder.UnderlyingVariable(e);
-      if (ContainsKey(eVar) && this[eVar].IsNormal())
-      {
-        return this[eVar].Contains(Rational.For(0)) ? CheckOutcome.True : CheckOutcome.Top;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public Variable ToVariable(Expression exp)
-    {
-      return decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-
-    #region Tostring
-
-    public override string ToString()
-    {
-      if (IsBottom)
-        return "_|_";
-
-      if (IsTop)
-        return "Top (disequalities)";
-
-      var result = new StringBuilder();
-
-      foreach (Variable x in Keys)
-      {
-        SetOfConstraints<Rational> value = this[x];
-        string toAppend = x + " ";
-
-        if (value.IsBottom)
+        public override object Clone()
         {
-          toAppend += ": _|_,";
+            return new SimpleDisequalities<Variable, Expression>(this);
         }
-        else if (value.IsTop)
+
+        protected override SimpleDisequalities<Variable, Expression> Factory()
         {
-          toAppend += ": {},";
+            return new SimpleDisequalities<Variable, Expression>(decoder, encoder);
         }
-        else
+
+        // To be implemented
+        protected override string ToLogicalFormula(Variable d, SetOfConstraints<Rational> c)
         {
-          toAppend += "!= ";
-          foreach (Rational r in value.Values)
-            toAppend += r + ", ";
+            return "1";
         }
 
-        result.AppendLine(toAppend);
-      }
-
-      return result.ToString();
-    }
-
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-
-    #region Visitors
-
-    private class ConstantVisitor
-      : GenericTypeExpressionVisitor<Variable, Expression, Unit, bool>
-    {
-      private bool hasValue;
-      private Rational result;
-
-      public ConstantVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        hasValue = false;
-        result = default(Rational);
-      }
-
-      public Rational Result
-      {
-        get
+        protected override T To<T>(Variable d, SetOfConstraints<Rational> c, IFactory<T> factory)
         {
-          Contract.Requires(HasValue);
-          return result;
+            if (c.IsBottom)
+                return factory.Constant(false);
+
+            if (c.IsTop)
+                return factory.Constant(true);
+
+            T result = factory.IdentityForAnd;
+            T x = factory.Variable(d);
+
+            foreach (Rational r in c.Values)
+            {
+                result = factory.And(result, factory.NotEqualTo(x, factory.Constant(r)));
+            }
+
+            return result;
         }
-      }
 
-      public bool HasValue
-      {
-        get { return hasValue; }
-      }
+        #endregion
 
-      public bool Visit(Expression exp)
-      {
-        hasValue = false;
-        result = default(Rational);
+        #region INumericalAbstractDomain<Variable, Expression> Members
 
-        if (Decoder.IsConstant(exp))
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
         {
-          return base.Visit(exp, Unit.Value);
+            Interval intvForExp = preState.BoundsFor(exp).AsInterval;
+
+            Variable xVar = decoder.UnderlyingVariable(x);
+
+            AssumeInInterval(xVar, intvForExp);
         }
 
-        return Default(exp);
-      }
-
-      public override bool VisitFloat32(Expression exp, Unit input)
-      {
-        Single value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.Float32, out value) && Rational.CanRepresentExactly(value))
+        public void AssumeInDisInterval(Variable x, DisInterval values)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            AssumeInInterval(x, values.AsInterval);
         }
 
-        return hasValue;
-      }
-
-      public override bool VisitFloat64(Expression exp, Unit input)
-      {
-        Double value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.Float64, out value) && Rational.CanRepresentExactly(value))
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(
+          Expression left, Expression right)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            return TestTrueEqual(left, right);
         }
 
-        return hasValue;
-      }
-
-      public override bool VisitInt8(Expression exp, Unit input)
-      {
-        SByte value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.Int8, out value))
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(
+          Expression exp)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            return TestTrueGeqZero(exp);
         }
 
-        return hasValue;
-      }
-
-      public override bool VisitInt16(Expression exp, Unit input)
-      {
-        Int16 value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.Int16, out value))
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(
+          Expression left, Expression right)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            return TestTrueLessThan(left, right);
         }
 
-        return hasValue;
-      }
-
-      public override bool VisitInt32(Expression exp, Unit input)
-      {
-        Int32 value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.Int32, out value))
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(
+          Expression left, Expression right)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            return TestTrueLessEqualThan(left, right);
         }
 
-        return hasValue;
-      }
-
-      public override bool VisitInt64(Expression exp, Unit input)
-      {
-        Int64 value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.Int64, out value) && Rational.CanRepresentExactly(value))
+        /// <summary>
+        ///   Adds the constraints x != value.LowerBound-1 and x != value.UpperBound+1
+        /// </summary>
+        public void AssumeInInterval(Variable x, Interval value)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            if (value.IsNormal)
+            {
+                var strictBounds = new Set<Rational>(2);
+                if (!value.LowerBound.IsInfinity)
+                {
+                    try
+                    {
+                        strictBounds.Add(value.LowerBound - 1);
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        // It may be the case that value.UpperBound is too large, so we catch it
+                        // and do nothing (i.e. we abstract)
+                    }
+                }
+
+                if (!value.UpperBound.IsInfinity)
+                {
+                    try
+                    {
+                        strictBounds.Add(value.UpperBound + 1);
+                    }
+
+                    catch (ArithmeticExceptionRational)
+                    {
+                        // It may be the case that value.UpperBound is too large, so we catch it
+                        // and do nothing (i.e. we abstract)
+                    }
+                }
+
+                // Check if zero is not included. In the case, we want to add the constraint x != 0
+                if (value.DoesNotInclude(0))
+                {
+                    strictBounds.Add(Rational.For(0));
+                }
+
+                // It may be the case that the interval is e.g. [+oo, +oo], so we cannot blindly add the matrixes
+                if (strictBounds.Count > 0)
+                {
+                    this[x] = new SetOfConstraints<Rational>(strictBounds);
+                }
+            }
         }
 
-        return hasValue;
-      }
-
-      public override bool VisitUInt8(Expression exp, Unit input)
-      {
-        Byte value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.UInt8, out value))
+        public SimpleDisequalities<Variable, Expression> TestTrueGeqZero(Expression exp)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            // exp >= 0 => exp != -1  (and also -2, ... but we ignore it)
+
+            Variable expVar = decoder.UnderlyingVariable(exp);
+
+            this[expVar] = this[expVar].Meet(new SetOfConstraints<Rational>(Rational.For(-1)));
+
+            return this;
         }
 
-        return hasValue;
-      }
 
-      public override bool VisitUInt16(Expression exp, Unit input)
-      {
-        UInt16 value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.UInt16, out value))
+        public SimpleDisequalities<Variable, Expression> TestTrueLessThan(Expression left, Expression right)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            SimpleDisequalities<Variable, Expression> result = this;
+
+            evalConstant.Visit(right);
+
+            if (evalConstant.HasValue)
+            {
+                Rational v = evalConstant.Result;
+
+                Variable leftVar = decoder.UnderlyingVariable(left);
+
+                // left < k => left != k (also k+1, k+2, k+3, etc. but we do not care ...) 
+
+                SetOfConstraints<Rational> newConstraintsForLeft = this[leftVar].Meet(new SetOfConstraints<Rational>(v));
+                result[leftVar] = newConstraintsForLeft;
+            }
+
+            evalConstant.Visit(left);
+
+            if (evalConstant.HasValue)
+            {
+                Rational v = evalConstant.Result;
+
+                Variable rightVar = decoder.UnderlyingVariable(right);
+
+                // k < right => right != k (also k-1, k-2, etc. but we do not care ...)
+                SetOfConstraints<Rational> newConstraintsForRight = this[rightVar].Meet(new SetOfConstraints<Rational>(v));
+                result[rightVar] = newConstraintsForRight;
+            }
+
+            return result;
         }
-        return hasValue;
-      }
 
-      public override bool VisitUInt32(Expression exp, Unit input)
-      {
-        UInt32 value;
-
-        if (Decoder.TryValueOf(exp, ExpressionType.UInt32, out value))
+        public SimpleDisequalities<Variable, Expression> TestTrueLessEqualThan(Expression left, Expression right)
         {
-          result = Rational.For(value);
-          hasValue = true;
+            SimpleDisequalities<Variable, Expression> result = this;
+
+            evalConstant.Visit(right);
+
+            if (evalConstant.HasValue)
+            {
+                Rational v = evalConstant.Result;
+
+                Variable leftVar = decoder.UnderlyingVariable(left);
+
+                // left <= k => left != k + 1 (also k+2, k+3, etc. but we do not care ...) 
+                SetOfConstraints<Rational> newConstraintsForLeft = this[leftVar].Meet(new SetOfConstraints<Rational>(v + 1));
+                result[leftVar] = newConstraintsForLeft;
+            }
+
+            evalConstant.Visit(left);
+
+            if (evalConstant.HasValue)
+            {
+                Rational v = evalConstant.Result;
+
+                Variable rightVar = decoder.UnderlyingVariable(right);
+
+                // k <= right => right != k - 1 (also k - 2, k - 3, etc. but we do not care ...)
+                SetOfConstraints<Rational> newConstraintsForRight = this[rightVar].Meet(new SetOfConstraints<Rational>(v - 1));
+                result[rightVar] = newConstraintsForRight;
+            }
+
+            return result;
         }
-        return hasValue;
-      }
 
-      public override bool Default(Expression exp)
-      {
-        result = default(Rational);
-        hasValue = false;
-
-        return false;
-      }
-    }
-
-    private class SimpleDisequalitiesCheckIfHoldsVisitor :
-      CheckIfHoldsVisitor<SimpleDisequalities<Variable, Expression>, Variable, Expression>
-    {
-      #region Private
-
-      private readonly ConstantVisitor evalConstant;
-
-      #endregion
-
-      #region Constructor
-
-      public SimpleDisequalitiesCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder,
-                                                    ConstantVisitor evalConstant)
-        : base(decoder)
-      {
-        this.evalConstant = evalConstant;
-      }
-
-      #endregion
-
-      public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original,
-                                                             FlatAbstractDomain<bool> data)
-      {
-        if (left.Equals(right) && !Decoder.IsNaN(left) && !Decoder.IsNaN(right))
+        public SimpleDisequalities<Variable, Expression> TestTrueEqual(Expression left, Expression right)
         {
-          return CheckOutcome.False;
+            return testTrueVisitor.VisitEqual(left, right, default(Expression), this);
         }
 
-        evalConstant.Visit(left);
+        #endregion
 
-        bool leftIsConstZero = evalConstant.HasValue && evalConstant.Result.IsZero;
+        #region IAbstractDomainForEnvironments<Variable, Expression> Members
 
-        Variable rightVar = Decoder.UnderlyingVariable(right);
-
-        if (evalConstant.HasValue && Domain.ContainsKey(rightVar) && Domain[rightVar].IsNormal())
+        /// <summary>
+        ///   Pretty print the expression
+        /// </summary>
+        public string ToString(Expression exp)
         {
-          if (Domain[rightVar].Contains(evalConstant.Result))
-          {
-            return CheckOutcome.True;
-          }
+            return ExpressionPrinter.ToString(exp, decoder);
         }
 
-        evalConstant.Visit(right);
+        #endregion
 
-        bool rightIsConstZero = evalConstant.HasValue && evalConstant.Result.IsZero;
+        #region IPureExpressionAssignments<Expression> Members
 
-        Variable leftVar = Decoder.UnderlyingVariable(left);
-
-        if (evalConstant.HasValue && Domain.ContainsKey(leftVar) && Domain[leftVar].IsNormal())
+        public List<Variable> Variables
         {
-          rightIsConstZero = evalConstant.Result.IsZero;
-
-          if (Domain[leftVar].Contains(evalConstant.Result))
-          {
-            return CheckOutcome.True;
-          }
+            get { return new List<Variable>(Keys); }
         }
 
-        if (leftIsConstZero)
+        public void AddVariable(Variable var)
         {
-          return Visit(right, data);
+            // Does nothing ...
         }
-        if (rightIsConstZero)
+
+        public void Assign(Expression x, Expression exp)
         {
-          return Visit(left, data);
+            Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
         }
 
-        return CheckOutcome.Top;
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original,
-                                                          FlatAbstractDomain<bool> data)
-      {
-        ExpressionType leftType = Decoder.TypeOf(left);
-        ExpressionType rightType = Decoder.TypeOf(right);
-
-        if (!leftType.IsFloatingPointType() && !rightType.IsFloatingPointType())
+        public void ProjectVariable(Variable var)
         {
-          if (left.Equals(right) && !Decoder.IsNaN(left) && !Decoder.IsNaN(right))
-          {
-            return CheckOutcome.True;
-          }
+            RemoveVariable(var);
         }
 
-        evalConstant.Visit(left);
-
-        Variable rightVar = Decoder.UnderlyingVariable(right);
-
-        if (evalConstant.HasValue && Domain.ContainsKey(rightVar) && Domain[rightVar].IsNormal())
+        public void RemoveVariable(Variable var)
         {
-          if (Domain[rightVar].Contains(evalConstant.Result))
-          {
-            return CheckOutcome.False;
-          }
+            if (ContainsKey(var))
+                RemoveElement(var);
         }
 
-        evalConstant.Visit(right);
-
-        Variable leftVar = Decoder.UnderlyingVariable(right);
-
-        if (evalConstant.HasValue && Domain.ContainsKey(leftVar) && Domain[leftVar].IsNormal())
+        public void RenameVariable(Variable OldName, Variable NewName)
         {
-          if (Domain[leftVar].Contains(evalConstant.Result))
-          {
-            return CheckOutcome.False;
-          }
+            if (ContainsKey(OldName))
+            {
+                this[NewName] = this[OldName];
+                RemoveVariable(OldName);
+            }
         }
 
-        return CheckOutcome.Top;
-      }
+        #endregion
 
-      public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original,
-                                                              FlatAbstractDomain<bool> data)
-      {
-        return VisitEqual(left, right, original, data);
-      }
+        #region IPureExpressionTest<Expression> Members
 
-      public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original,
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(
+          Expression guard)
+        {
+            return TestTrue(guard);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(
+          Expression guard)
+        {
+            return TestFalse(guard);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return checkIfHoldsVisitor.Visit(exp, this);
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            AssumeDomainSpecificFact(fact);
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(
+          INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            var result = new SimpleDisequalities<Variable, Expression>(decoder, encoder);
+
+            if (encoder != null)
+            {
+                foreach (var x_pair in Elements)
+                {
+                    SetOfConstraints<Rational> k = x_pair.Value;
+
+                    if (k.IsBottom || k.IsTop)
+                    {
+                        result[x_pair.Key] = k;
+                    }
+                    else
+                    {
+                        Expression xExp = encoder.VariableFor(x_pair.Key);
+                        foreach (Rational exp in k.Values)
+                        {
+                            Expression notEq = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, xExp,
+                                                                             exp.ToExpression(encoder));
+
+                            FlatAbstractDomain<bool> check = oracle.CheckIfHolds(notEq);
+
+                            if (check.IsBottom || check.IsTop || !check.BoxedElement)
+                            {
+                                // If it is not implied by the oracle, we give up
+                                result = result.TestTrue(notEq);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public SimpleDisequalities<Variable, Expression> TestTrue(Expression guard)
+        {
+            return testTrueVisitor.Visit(guard, this);
+        }
+
+        public SimpleDisequalities<Variable, Expression> TestFalse(Expression guard)
+        {
+            return testFalseVisitor.Visit(guard, this);
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets,
+                                     Converter<Variable, Expression> convert)
+        {
+            var result = new SimpleDisequalities<Variable, Expression>(decoder, encoder);
+
+            foreach (Variable e in Keys)
+            {
+                if (decoder.IsSlackVariable(e))
+                {
+                    result[e] = this[e];
+                }
+            }
+
+            State = AbstractState.Normal;
+
+            if (sourcesToTargets.Count == 0)
+            {
+                // do nothing...
+            }
+            else
+            {
+                // Update the values
+                foreach (Variable exp in sourcesToTargets.Keys)
+                {
+                    SetOfConstraints<Rational> value = this[exp];
+
+                    foreach (Variable target in sourcesToTargets[exp].GetEnumerable())
+                    {
+                        if (!value.IsTop)
+                        {
+                            result[target] = value;
+                        }
+                    }
+                }
+            }
+
+            ClearElements();
+            foreach (Variable e in result.Keys)
+            {
+                this[e] = result[e];
+            }
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable, Expression> Members
+
+        public DisInterval BoundsFor(Expression v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get { return new List<Pair<Variable, Int32>>(); }
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            yield break;
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            yield break;
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            yield break;
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            yield break;
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            return new Set<Variable>();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return CheckIfLessThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return CheckIfLessEqualThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        /// <returns>True iff 0 \in this[e]</returns>
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
+        {
+            Variable eVar = decoder.UnderlyingVariable(e);
+            if (ContainsKey(eVar) && this[eVar].IsNormal())
+            {
+                return this[eVar].Contains(Rational.For(0)) ? CheckOutcome.True : CheckOutcome.Top;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public Variable ToVariable(Expression exp)
+        {
+            return decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
+
+        #region Tostring
+
+        public override string ToString()
+        {
+            if (IsBottom)
+                return "_|_";
+
+            if (IsTop)
+                return "Top (disequalities)";
+
+            var result = new StringBuilder();
+
+            foreach (Variable x in Keys)
+            {
+                SetOfConstraints<Rational> value = this[x];
+                string toAppend = x + " ";
+
+                if (value.IsBottom)
+                {
+                    toAppend += ": _|_,";
+                }
+                else if (value.IsTop)
+                {
+                    toAppend += ": {},";
+                }
+                else
+                {
+                    toAppend += "!= ";
+                    foreach (Rational r in value.Values)
+                        toAppend += r + ", ";
+                }
+
+                result.AppendLine(toAppend);
+            }
+
+            return result.ToString();
+        }
+
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
+
+        #region Visitors
+
+        private class ConstantVisitor
+          : GenericTypeExpressionVisitor<Variable, Expression, Unit, bool>
+        {
+            private bool hasValue;
+            private Rational result;
+
+            public ConstantVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                hasValue = false;
+                result = default(Rational);
+            }
+
+            public Rational Result
+            {
+                get
+                {
+                    Contract.Requires(HasValue);
+                    return result;
+                }
+            }
+
+            public bool HasValue
+            {
+                get { return hasValue; }
+            }
+
+            public bool Visit(Expression exp)
+            {
+                hasValue = false;
+                result = default(Rational);
+
+                if (Decoder.IsConstant(exp))
+                {
+                    return base.Visit(exp, Unit.Value);
+                }
+
+                return Default(exp);
+            }
+
+            public override bool VisitFloat32(Expression exp, Unit input)
+            {
+                Single value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.Float32, out value) && Rational.CanRepresentExactly(value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+
+                return hasValue;
+            }
+
+            public override bool VisitFloat64(Expression exp, Unit input)
+            {
+                Double value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.Float64, out value) && Rational.CanRepresentExactly(value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+
+                return hasValue;
+            }
+
+            public override bool VisitInt8(Expression exp, Unit input)
+            {
+                SByte value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.Int8, out value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+
+                return hasValue;
+            }
+
+            public override bool VisitInt16(Expression exp, Unit input)
+            {
+                Int16 value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.Int16, out value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+
+                return hasValue;
+            }
+
+            public override bool VisitInt32(Expression exp, Unit input)
+            {
+                Int32 value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.Int32, out value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+
+                return hasValue;
+            }
+
+            public override bool VisitInt64(Expression exp, Unit input)
+            {
+                Int64 value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.Int64, out value) && Rational.CanRepresentExactly(value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+
+                return hasValue;
+            }
+
+            public override bool VisitUInt8(Expression exp, Unit input)
+            {
+                Byte value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.UInt8, out value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+
+                return hasValue;
+            }
+
+            public override bool VisitUInt16(Expression exp, Unit input)
+            {
+                UInt16 value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.UInt16, out value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+                return hasValue;
+            }
+
+            public override bool VisitUInt32(Expression exp, Unit input)
+            {
+                UInt32 value;
+
+                if (Decoder.TryValueOf(exp, ExpressionType.UInt32, out value))
+                {
+                    result = Rational.For(value);
+                    hasValue = true;
+                }
+                return hasValue;
+            }
+
+            public override bool Default(Expression exp)
+            {
+                result = default(Rational);
+                hasValue = false;
+
+                return false;
+            }
+        }
+
+        private class SimpleDisequalitiesCheckIfHoldsVisitor :
+          CheckIfHoldsVisitor<SimpleDisequalities<Variable, Expression>, Variable, Expression>
+        {
+            #region Private
+
+            private readonly ConstantVisitor evalConstant;
+
+            #endregion
+
+            #region Constructor
+
+            public SimpleDisequalitiesCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder,
+                                                          ConstantVisitor evalConstant)
+              : base(decoder)
+            {
+                this.evalConstant = evalConstant;
+            }
+
+            #endregion
+
+            public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original,
+                                                                   FlatAbstractDomain<bool> data)
+            {
+                if (left.Equals(right) && !Decoder.IsNaN(left) && !Decoder.IsNaN(right))
+                {
+                    return CheckOutcome.False;
+                }
+
+                evalConstant.Visit(left);
+
+                bool leftIsConstZero = evalConstant.HasValue && evalConstant.Result.IsZero;
+
+                Variable rightVar = Decoder.UnderlyingVariable(right);
+
+                if (evalConstant.HasValue && Domain.ContainsKey(rightVar) && Domain[rightVar].IsNormal())
+                {
+                    if (Domain[rightVar].Contains(evalConstant.Result))
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
+
+                evalConstant.Visit(right);
+
+                bool rightIsConstZero = evalConstant.HasValue && evalConstant.Result.IsZero;
+
+                Variable leftVar = Decoder.UnderlyingVariable(left);
+
+                if (evalConstant.HasValue && Domain.ContainsKey(leftVar) && Domain[leftVar].IsNormal())
+                {
+                    rightIsConstZero = evalConstant.Result.IsZero;
+
+                    if (Domain[leftVar].Contains(evalConstant.Result))
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
+
+                if (leftIsConstZero)
+                {
+                    return Visit(right, data);
+                }
+                if (rightIsConstZero)
+                {
+                    return Visit(left, data);
+                }
+
+                return CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original,
+                                                                FlatAbstractDomain<bool> data)
+            {
+                ExpressionType leftType = Decoder.TypeOf(left);
+                ExpressionType rightType = Decoder.TypeOf(right);
+
+                if (!leftType.IsFloatingPointType() && !rightType.IsFloatingPointType())
+                {
+                    if (left.Equals(right) && !Decoder.IsNaN(left) && !Decoder.IsNaN(right))
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
+
+                evalConstant.Visit(left);
+
+                Variable rightVar = Decoder.UnderlyingVariable(right);
+
+                if (evalConstant.HasValue && Domain.ContainsKey(rightVar) && Domain[rightVar].IsNormal())
+                {
+                    if (Domain[rightVar].Contains(evalConstant.Result))
+                    {
+                        return CheckOutcome.False;
+                    }
+                }
+
+                evalConstant.Visit(right);
+
+                Variable leftVar = Decoder.UnderlyingVariable(right);
+
+                if (evalConstant.HasValue && Domain.ContainsKey(leftVar) && Domain[leftVar].IsNormal())
+                {
+                    if (Domain[leftVar].Contains(evalConstant.Result))
+                    {
+                        return CheckOutcome.False;
+                    }
+                }
+
+                return CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original,
+                                                                    FlatAbstractDomain<bool> data)
+            {
+                return VisitEqual(left, right, original, data);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original,
+                                                                        FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessEqualThan(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original,
+                                                                   FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessThan(left, right);
+            }
+
+
+            /// <summary>
+            ///   left * right != 0 ??
+            /// </summary>
+            public override FlatAbstractDomain<bool> VisitMultiplication(Expression left, Expression right,
+                                                                         Expression original, FlatAbstractDomain<bool> data)
+            {
+                FlatAbstractDomain<bool> leftIsZero = IsNotZero(left);
+                FlatAbstractDomain<bool> rightIsZero = IsNotZero(right);
+
+                if (leftIsZero.IsNormal() && rightIsZero.IsNormal())
+                {
+                    // One of the two is zero ...
+                    if (leftIsZero.IsFalse() || rightIsZero.IsFalse())
+                    {
+                        return CheckOutcome.False;
+                    }
+                    // Both are non zero
+                    if (leftIsZero.IsTrue() && rightIsZero.IsTrue())
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
+
+                if (leftIsZero.IsBottom || rightIsZero.IsBottom)
+                {
+                    return CheckOutcome.Bottom;
+                }
+
+
+                return CheckOutcome.Top;
+            }
+
+            /// <summary>
+            ///   left / right != 0 ??
+            /// </summary>
+            public override FlatAbstractDomain<bool> VisitDivision(Expression left, Expression right, Expression original,
+                                                                   FlatAbstractDomain<bool> data)
+            {
+                return IsNotZero(left);
+            }
+
+            /// <summary>
+            ///   left % right != 0 ??
+            /// </summary>
+            public override FlatAbstractDomain<bool> VisitModulus(Expression left, Expression right, Expression original,
                                                                   FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessEqualThan(left, right);
-      }
+            {
+                // We do not check if left == k * right, for some k
+                return IsNotZero(left);
+            }
 
-      public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original,
-                                                             FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessThan(left, right);
-      }
+            public override FlatAbstractDomain<bool> VisitUnaryMinus(Expression left, Expression original,
+                                                                     FlatAbstractDomain<bool> data)
+            {
+                return IsNotZero(left);
+            }
 
+            private FlatAbstractDomain<bool> IsNotZero(Expression x)
+            {
+                // First try: Is it a constant?
+                evalConstant.Visit(x);
+                if (evalConstant.HasValue)
+                {
+                    if (evalConstant.Result.IsZero)
+                    {
+                        return CheckOutcome.False;
+                    }
+                    else
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
 
-      /// <summary>
-      ///   left * right != 0 ??
-      /// </summary>
-      public override FlatAbstractDomain<bool> VisitMultiplication(Expression left, Expression right,
-                                                                   Expression original, FlatAbstractDomain<bool> data)
-      {
-        FlatAbstractDomain<bool> leftIsZero = IsNotZero(left);
-        FlatAbstractDomain<bool> rightIsZero = IsNotZero(right);
+                // Second try: Do we have some propagated information
 
-        if (leftIsZero.IsNormal() && rightIsZero.IsNormal())
-        {
-          // One of the two is zero ...
-          if (leftIsZero.IsFalse() || rightIsZero.IsFalse())
-          {
-            return CheckOutcome.False;
-          }
-          // Both are non zero
-          if (leftIsZero.IsTrue() && rightIsZero.IsTrue())
-          {
-            return CheckOutcome.True;
-          }
+                Variable xVar = Decoder.UnderlyingVariable(x);
+
+                SetOfConstraints<Rational> constraints;
+
+                if (Domain.TryGetValue(xVar, out constraints))
+                {
+                    // We know it is != 0 for sure?
+                    if (constraints.IsNormal() && constraints.Contains(Rational.For(0)))
+                    {
+                        return CheckOutcome.True;
+                    }
+                    if (constraints.IsBottom)
+                    {
+                        return CheckOutcome.Bottom;
+                    }
+                }
+
+                // we do not know...
+                return CheckOutcome.Top;
+            }
         }
 
-        if (leftIsZero.IsBottom || rightIsZero.IsBottom)
+        private class SimpleDisequalitiesTestFalseVisitor :
+          TestFalseVisitor<SimpleDisequalities<Variable, Expression>, Variable, Expression>
         {
-          return CheckOutcome.Bottom;
+            #region Constructor
+
+            public SimpleDisequalitiesTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            #endregion
+
+            #region Implementation of abstract methods
+
+            public override SimpleDisequalities<Variable, Expression> VisitVariable(Variable variable, Expression original,
+                                                                                    SimpleDisequalities<Variable, Expression>
+                                                                                      data)
+            {
+                return data;
+            }
+
+            public override SimpleDisequalities<Variable, Expression> VisitEqual_Obj(Expression left, Expression right,
+                                                                                     Expression original,
+                                                                                     SimpleDisequalities<Variable, Expression>
+                                                                                       data)
+            {
+                return VisitEqual(left, right, original, data);
+            }
+
+            #endregion
         }
 
-
-        return CheckOutcome.Top;
-      }
-
-      /// <summary>
-      ///   left / right != 0 ??
-      /// </summary>
-      public override FlatAbstractDomain<bool> VisitDivision(Expression left, Expression right, Expression original,
-                                                             FlatAbstractDomain<bool> data)
-      {
-        return IsNotZero(left);
-      }
-
-      /// <summary>
-      ///   left % right != 0 ??
-      /// </summary>
-      public override FlatAbstractDomain<bool> VisitModulus(Expression left, Expression right, Expression original,
-                                                            FlatAbstractDomain<bool> data)
-      {
-        // We do not check if left == k * right, for some k
-        return IsNotZero(left);
-      }
-
-      public override FlatAbstractDomain<bool> VisitUnaryMinus(Expression left, Expression original,
-                                                               FlatAbstractDomain<bool> data)
-      {
-        return IsNotZero(left);
-      }
-
-      private FlatAbstractDomain<bool> IsNotZero(Expression x)
-      {
-        // First try: Is it a constant?
-        evalConstant.Visit(x);
-        if (evalConstant.HasValue)
+        private class SimpleDisequalitiesTestTrueVisitor :
+          TestTrueVisitor<SimpleDisequalities<Variable, Expression>, Variable, Expression>
         {
-          if (evalConstant.Result.IsZero)
-          {
-            return CheckOutcome.False;
-          }
-          else
-          {
-            return CheckOutcome.True;
-          }
+            #region Private state
+
+            private readonly ConstantVisitor evalConstant;
+
+            #endregion
+
+            #region Constructors
+
+            public SimpleDisequalitiesTestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder,
+                                                      ConstantVisitor evalConstant)
+              : base(decoder)
+            {
+                this.evalConstant = evalConstant;
+            }
+
+            #endregion
+
+            #region Overridden
+
+            public override SimpleDisequalities<Variable, Expression> Visit(Expression exp,
+                                                                            SimpleDisequalities<Variable, Expression> data)
+            {
+                SimpleDisequalities<Variable, Expression> result = base.Visit(exp, data);
+
+                // We also know that exp != 0
+                var expNotZero = new SetOfConstraints<Rational>(Rational.For(0));
+                SetOfConstraints<Rational> prev;
+
+                Variable expVar = Decoder.UnderlyingVariable(exp);
+
+                if (result.TryGetValue(expVar, out prev))
+                {
+                    result[expVar] = prev.Meet(expNotZero);
+                }
+                else
+                {
+                    result[expVar] = expNotZero;
+                }
+
+                return result;
+            }
+
+            #endregion
+
+            #region Implementation of abstract mehtods
+
+            public override SimpleDisequalities<Variable, Expression> VisitEqual(Expression left, Expression right,
+                                                                                 Expression original,
+                                                                                 SimpleDisequalities<Variable, Expression>
+                                                                                   data)
+            {
+                evalConstant.Visit(right);
+
+                Variable leftVar = Decoder.UnderlyingVariable(left);
+
+                if (data.ContainsKey(leftVar) && data[leftVar].IsNormal() && evalConstant.HasValue)
+                {
+                    foreach (Rational r in data[leftVar].Values)
+                    {
+                        // we know left != r, so we want that intvForRight != r
+                        if (r == evalConstant.Result)
+                            return data.Bottom;
+                    }
+                }
+
+                evalConstant.Visit(left);
+
+                Variable rightVar = Decoder.UnderlyingVariable(right);
+
+                if (data.ContainsKey(rightVar) && data[rightVar].IsNormal() && evalConstant.HasValue)
+                {
+                    foreach (Rational r in data[rightVar].Values)
+                    {
+                        // we know right != r, so we want that intvForLeft != r
+                        if (r == evalConstant.Result)
+                            return data.Bottom;
+                    }
+                }
+
+                // At this point we know that we do not have simple contraddictions. 
+                // Now we can say that left and right have the same inequalities
+                SetOfConstraints<Rational> unionOfConstraints = data[leftVar].Meet(data[rightVar]);
+
+                if (!unionOfConstraints.IsTop)
+                {
+                    data[leftVar] = unionOfConstraints;
+                    data[rightVar] = unionOfConstraints;
+                }
+
+                return data;
+            }
+
+            public override SimpleDisequalities<Variable, Expression> VisitEqual_Obj(Expression left, Expression right,
+                                                                                     Expression original,
+                                                                                     SimpleDisequalities<Variable, Expression>
+                                                                                       data)
+            {
+                return VisitEqual(left, right, original, data);
+            }
+
+            public override SimpleDisequalities<Variable, Expression> VisitLessEqualThan(Expression left, Expression right,
+                                                                                         Expression original,
+                                                                                         SimpleDisequalities
+                                                                                           <Variable, Expression> data)
+            {
+                return data.TestTrueLessEqualThan(left, right);
+            }
+
+            public override SimpleDisequalities<Variable, Expression> VisitLessThan(Expression left, Expression right,
+                                                                                    Expression original,
+                                                                                    SimpleDisequalities<Variable, Expression>
+                                                                                      data)
+            {
+                return data.TestTrueLessThan(left, right);
+            }
+
+            public override SimpleDisequalities<Variable, Expression> VisitNotEqual(Expression left, Expression right,
+                                                                                    Expression original,
+                                                                                    SimpleDisequalities<Variable, Expression>
+                                                                                      data)
+            {
+                SimpleDisequalities<Variable, Expression> result = data;
+
+                evalConstant.Visit(Decoder.Stripped(right));
+
+                if (evalConstant.HasValue)
+                {
+                    // left != k 
+
+                    data = Update(left, evalConstant.Result, data);
+                    data = Update(Decoder.Stripped(left), evalConstant.Result, data);
+                }
+
+                evalConstant.Visit(Decoder.Stripped(left));
+                if (evalConstant.HasValue)
+                {
+                    // right != k
+                    var newConstraintsForRight = new SetOfConstraints<Rational>(evalConstant.Result);
+
+                    // check if k != 0. If so we add the constraint right != 0
+                    if (!evalConstant.Result.IsZero)
+                    {
+                        newConstraintsForRight = newConstraintsForRight.Meet(new SetOfConstraints<Rational>(Rational.For(0)));
+                    }
+
+                    Variable rightVar = Decoder.UnderlyingVariable(right);
+                    SetOfConstraints<Rational> prev;
+
+                    if (result.TryGetValue(rightVar, out prev))
+                        newConstraintsForRight = newConstraintsForRight.Meet(prev);
+
+                    result[rightVar] = newConstraintsForRight;
+                }
+
+                return result;
+            }
+
+            public override SimpleDisequalities<Variable, Expression> VisitVariable(Variable var, Expression original,
+                                                                                    SimpleDisequalities<Variable, Expression>
+                                                                                      data)
+            {
+                return data;
+            }
+
+            #endregion
+
+            #region Utils
+
+            private SimpleDisequalities<Variable, Expression> Update(Expression exp, Rational k,
+                                                                     SimpleDisequalities<Variable, Expression> data)
+            {
+                var newConstraints = new SetOfConstraints<Rational>(k);
+
+                SetOfConstraints<Rational> prev;
+                Variable var = Decoder.UnderlyingVariable(exp);
+
+                if (data.TryGetValue(var, out prev))
+                {
+                    newConstraints = newConstraints.Meet(prev);
+                }
+
+                data[var] = newConstraints;
+
+                return data;
+            }
+
+            #endregion
         }
 
-        // Second try: Do we have some propagated information
-
-        Variable xVar = Decoder.UnderlyingVariable(x);
-
-        SetOfConstraints<Rational> constraints;
-
-        if (Domain.TryGetValue(xVar, out constraints))
-        {
-          // We know it is != 0 for sure?
-          if (constraints.IsNormal() && constraints.Contains(Rational.For(0)))
-          {
-            return CheckOutcome.True;
-          }
-          if (constraints.IsBottom)
-          {
-            return CheckOutcome.Bottom;
-          }
-        }
-
-        // we do not know...
-        return CheckOutcome.Top;
-      }
+        #endregion
     }
-
-    private class SimpleDisequalitiesTestFalseVisitor :
-      TestFalseVisitor<SimpleDisequalities<Variable, Expression>, Variable, Expression>
-    {
-      #region Constructor
-
-      public SimpleDisequalitiesTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      #endregion
-
-      #region Implementation of abstract methods
-
-      public override SimpleDisequalities<Variable, Expression> VisitVariable(Variable variable, Expression original,
-                                                                              SimpleDisequalities<Variable, Expression>
-                                                                                data)
-      {
-        return data;
-      }
-
-      public override SimpleDisequalities<Variable, Expression> VisitEqual_Obj(Expression left, Expression right,
-                                                                               Expression original,
-                                                                               SimpleDisequalities<Variable, Expression>
-                                                                                 data)
-      {
-        return VisitEqual(left, right, original, data);
-      }
-
-      #endregion
-    }
-
-    private class SimpleDisequalitiesTestTrueVisitor :
-      TestTrueVisitor<SimpleDisequalities<Variable, Expression>, Variable, Expression>
-    {
-      #region Private state
-
-      private readonly ConstantVisitor evalConstant;
-
-      #endregion
-
-      #region Constructors
-
-      public SimpleDisequalitiesTestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder,
-                                                ConstantVisitor evalConstant)
-        : base(decoder)
-      {
-        this.evalConstant = evalConstant;
-      }
-
-      #endregion
-
-      #region Overridden
-
-      public override SimpleDisequalities<Variable, Expression> Visit(Expression exp,
-                                                                      SimpleDisequalities<Variable, Expression> data)
-      {
-        SimpleDisequalities<Variable, Expression> result = base.Visit(exp, data);
-
-        // We also know that exp != 0
-        var expNotZero = new SetOfConstraints<Rational>(Rational.For(0));
-        SetOfConstraints<Rational> prev;
-
-        Variable expVar = Decoder.UnderlyingVariable(exp);
-
-        if (result.TryGetValue(expVar, out prev))
-        {
-          result[expVar] = prev.Meet(expNotZero);
-        }
-        else
-        {
-          result[expVar] = expNotZero;
-        }
-
-        return result;
-      }
-
-      #endregion
-
-      #region Implementation of abstract mehtods
-
-      public override SimpleDisequalities<Variable, Expression> VisitEqual(Expression left, Expression right,
-                                                                           Expression original,
-                                                                           SimpleDisequalities<Variable, Expression>
-                                                                             data)
-      {
-        evalConstant.Visit(right);
-
-        Variable leftVar = Decoder.UnderlyingVariable(left);
-
-        if (data.ContainsKey(leftVar) && data[leftVar].IsNormal() && evalConstant.HasValue)
-        {
-          foreach (Rational r in data[leftVar].Values)
-          {
-            // we know left != r, so we want that intvForRight != r
-            if (r == evalConstant.Result)
-              return data.Bottom;
-          }
-        }
-
-        evalConstant.Visit(left);
-
-        Variable rightVar = Decoder.UnderlyingVariable(right);
-
-        if (data.ContainsKey(rightVar) && data[rightVar].IsNormal() && evalConstant.HasValue)
-        {
-          foreach (Rational r in data[rightVar].Values)
-          {
-            // we know right != r, so we want that intvForLeft != r
-            if (r == evalConstant.Result)
-              return data.Bottom;
-          }
-        }
-
-        // At this point we know that we do not have simple contraddictions. 
-        // Now we can say that left and right have the same inequalities
-        SetOfConstraints<Rational> unionOfConstraints = data[leftVar].Meet(data[rightVar]);
-
-        if (!unionOfConstraints.IsTop)
-        {
-          data[leftVar] = unionOfConstraints;
-          data[rightVar] = unionOfConstraints;
-        }
-
-        return data;
-      }
-
-      public override SimpleDisequalities<Variable, Expression> VisitEqual_Obj(Expression left, Expression right,
-                                                                               Expression original,
-                                                                               SimpleDisequalities<Variable, Expression>
-                                                                                 data)
-      {
-        return VisitEqual(left, right, original, data);
-      }
-
-      public override SimpleDisequalities<Variable, Expression> VisitLessEqualThan(Expression left, Expression right,
-                                                                                   Expression original,
-                                                                                   SimpleDisequalities
-                                                                                     <Variable, Expression> data)
-      {
-        return data.TestTrueLessEqualThan(left, right);
-      }
-
-      public override SimpleDisequalities<Variable, Expression> VisitLessThan(Expression left, Expression right,
-                                                                              Expression original,
-                                                                              SimpleDisequalities<Variable, Expression>
-                                                                                data)
-      {
-        return data.TestTrueLessThan(left, right);
-      }
-
-      public override SimpleDisequalities<Variable, Expression> VisitNotEqual(Expression left, Expression right,
-                                                                              Expression original,
-                                                                              SimpleDisequalities<Variable, Expression>
-                                                                                data)
-      {
-        SimpleDisequalities<Variable, Expression> result = data;
-
-        evalConstant.Visit(Decoder.Stripped(right));
-
-        if (evalConstant.HasValue)
-        {
-          // left != k 
-
-          data = Update(left, evalConstant.Result, data);
-          data = Update(Decoder.Stripped(left), evalConstant.Result, data);
-        }
-
-        evalConstant.Visit(Decoder.Stripped(left));
-        if (evalConstant.HasValue)
-        {
-          // right != k
-          var newConstraintsForRight = new SetOfConstraints<Rational>(evalConstant.Result);
-
-          // check if k != 0. If so we add the constraint right != 0
-          if (!evalConstant.Result.IsZero)
-          {
-            newConstraintsForRight = newConstraintsForRight.Meet(new SetOfConstraints<Rational>(Rational.For(0)));
-          }
-
-          Variable rightVar = Decoder.UnderlyingVariable(right);
-          SetOfConstraints<Rational> prev;
-
-          if (result.TryGetValue(rightVar, out prev))
-            newConstraintsForRight = newConstraintsForRight.Meet(prev);
-
-          result[rightVar] = newConstraintsForRight;
-        }
-
-        return result;
-      }
-
-      public override SimpleDisequalities<Variable, Expression> VisitVariable(Variable var, Expression original,
-                                                                              SimpleDisequalities<Variable, Expression>
-                                                                                data)
-      {
-        return data;
-      }
-
-      #endregion
-
-      #region Utils
-
-      private SimpleDisequalities<Variable, Expression> Update(Expression exp, Rational k,
-                                                               SimpleDisequalities<Variable, Expression> data)
-      {
-        var newConstraints = new SetOfConstraints<Rational>(k);
-
-        SetOfConstraints<Rational> prev;
-        Variable var = Decoder.UnderlyingVariable(exp);
-
-        if (data.TryGetValue(var, out prev))
-        {
-          newConstraints = newConstraints.Meet(prev);
-        }
-
-        data[var] = newConstraints;
-
-        return data;
-      }
-
-      #endregion
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/FloatsTypes.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/FloatsTypes.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,326 +11,325 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-
-  public class FloatTypes<Variable, Expression>
-    : FunctionalAbstractDomain<FloatTypes<Variable, Expression>, Variable, FlatAbstractDomain<ConcreteFloat>>,
-      INumericalAbstractDomain<Variable, Expression>
-  {
-    public readonly static FlatAbstractDomain<ConcreteFloat> Unknown = new FlatAbstractDomain<ConcreteFloat>(ConcreteFloat.Float32).Top;
-
-    private readonly ExpressionManager<Variable, Expression> expManager;
-
-    public FloatTypes(ExpressionManager<Variable, Expression> expManager)
-      : base()
+    public class FloatTypes<Variable, Expression>
+      : FunctionalAbstractDomain<FloatTypes<Variable, Expression>, Variable, FlatAbstractDomain<ConcreteFloat>>,
+        INumericalAbstractDomain<Variable, Expression>
     {
-      this.expManager = expManager;
-    }
+        public readonly static FlatAbstractDomain<ConcreteFloat> Unknown = new FlatAbstractDomain<ConcreteFloat>(ConcreteFloat.Float32).Top;
 
-    private FloatTypes(FloatTypes<Variable, Expression> other)
-      : base(other)
-    {
-      this.expManager = other.expManager;
-    }
+        private readonly ExpressionManager<Variable, Expression> expManager;
 
-    public override object Clone()
-    {
-      return new FloatTypes<Variable, Expression>(this);
-    }
-
-    protected override FloatTypes<Variable, Expression> Factory()
-    {
-      return new FloatTypes<Variable, Expression>(this.expManager);
-    }
-
-    protected override string ToLogicalFormula(Variable d, FlatAbstractDomain<ConcreteFloat> c)
-    {
-      return "";
-    }
-
-    protected override T To<T>(Variable d, FlatAbstractDomain<ConcreteFloat> c, IFactory<T> factory)
-    {
-      if (c.IsBottom)
-        return factory.Constant(false);
-      else
-        return factory.IdentityForAnd;
-    }
-
-    #region INumericalAbstractDomain<Variable, Expression> Members
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      // does nothing
-    }
-
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      // does nothing
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      return this;
-    }
-
-    #endregion
-
-    #region IAbstractDomainForEnvironments<Variable, Expression> Members
-
-    public string ToString(Expression exp)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get { return new List<Variable>(this.Keys); }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      // does nothing
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      // does nothing
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      if (this.ContainsKey(var))
-        this.RemoveElement(var);
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      if (this.ContainsKey(var))
-        this.RemoveElement(var);
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      if (this.ContainsKey(OldName))
-      {
-        this[NewName] = this[OldName];
-        this.RemoveElement(OldName);
-      }
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      return this;
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      return this;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      var tmp = this.Factory();
-
-      this.State = AbstractState.Normal;
-
-      if (sourcesToTargets.Count != 0)
-      {
-        foreach (var exp in sourcesToTargets.Keys)
+        public FloatTypes(ExpressionManager<Variable, Expression> expManager)
+          : base()
         {
-          FlatAbstractDomain<ConcreteFloat> value;
-          if(this.TryGetValue(exp, out value) && !value.IsTop)
-          {
-            foreach (var target in sourcesToTargets[exp].GetEnumerable())
-            {
-              tmp[target] = value;
-            }
-          }
+            this.expManager = expManager;
         }
 
-        this.CopyAndTransferOwnership(tmp);
-      }
+        private FloatTypes(FloatTypes<Variable, Expression> other)
+          : base(other)
+        {
+            expManager = other.expManager;
+        }
+
+        public override object Clone()
+        {
+            return new FloatTypes<Variable, Expression>(this);
+        }
+
+        protected override FloatTypes<Variable, Expression> Factory()
+        {
+            return new FloatTypes<Variable, Expression>(expManager);
+        }
+
+        protected override string ToLogicalFormula(Variable d, FlatAbstractDomain<ConcreteFloat> c)
+        {
+            return "";
+        }
+
+        protected override T To<T>(Variable d, FlatAbstractDomain<ConcreteFloat> c, IFactory<T> factory)
+        {
+            if (c.IsBottom)
+                return factory.Constant(false);
+            else
+                return factory.IdentityForAnd;
+        }
+
+        #region INumericalAbstractDomain<Variable, Expression> Members
+
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            // does nothing
+        }
+
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            // does nothing
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return this;
+        }
+
+        #endregion
+
+        #region IAbstractDomainForEnvironments<Variable, Expression> Members
+
+        public string ToString(Expression exp)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        public List<Variable> Variables
+        {
+            get { return new List<Variable>(this.Keys); }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            // does nothing
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+            // does nothing
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            if (this.ContainsKey(var))
+                this.RemoveElement(var);
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            if (this.ContainsKey(var))
+                this.RemoveElement(var);
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            if (this.ContainsKey(OldName))
+            {
+                this[NewName] = this[OldName];
+                this.RemoveElement(OldName);
+            }
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            return this;
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            return this;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return CheckOutcome.Top;
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            var tmp = this.Factory();
+
+            this.State = AbstractState.Normal;
+
+            if (sourcesToTargets.Count != 0)
+            {
+                foreach (var exp in sourcesToTargets.Keys)
+                {
+                    FlatAbstractDomain<ConcreteFloat> value;
+                    if (this.TryGetValue(exp, out value) && !value.IsTop)
+                    {
+                        foreach (var target in sourcesToTargets[exp].GetEnumerable())
+                        {
+                            tmp[target] = value;
+                        }
+                    }
+                }
+
+                this.CopyAndTransferOwnership(tmp);
+            }
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable, Expression> Members
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            return new Set<Expression>();
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            return new Set<Expression>();
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            return new Set<Variable>();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Variable exp)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Variable e)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public DisInterval BoundsFor(Expression v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                return new List<Pair<Variable, Int32>>();
+            }
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            yield break;
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            yield break;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public Variable ToVariable(Expression exp)
+        {
+            return expManager.Decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression> Members
+
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            this[v] = new FlatAbstractDomain<ConcreteFloat>(f);
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            FlatAbstractDomain<ConcreteFloat> value;
+            if (this.TryGetValue(v, out value))
+            {
+                return value;
+            }
+
+            return Unknown;
+        }
+
+        #endregion
     }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable, Expression> Members
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      return new Set<Expression>();
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      return new Set<Expression>();
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      return new Set<Variable>();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Variable exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Variable e)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public DisInterval BoundsFor(Expression v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return new List<Pair<Variable, Int32>>();
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      yield break;
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      yield break;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.expManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression> Members
-
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      this[v] = new FlatAbstractDomain<ConcreteFloat>(f);
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      FlatAbstractDomain<ConcreteFloat> value;
-      if (this.TryGetValue(v, out value))
-      {
-        return value;
-      }
-
-      return Unknown;
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/DisIntervalEnvironment.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/DisIntervalEnvironment.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation of the environment of intervals
 
@@ -24,647 +13,646 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  [ContractVerification(true)]
-  sealed public class DisIntervalEnvironment<Variable, Expression>
-   : IntervalEnvironment_Base<DisIntervalEnvironment<Variable, Expression>, Variable, Expression, DisInterval, Rational>
-  {
-    #region Constructors
-
-    public DisIntervalEnvironment(ExpressionManager<Variable, Expression> expManager)
-      : base(expManager, new DisintervalsCheckIfHoldsVisitor(expManager.Decoder))
+    [ContractVerification(true)]
+    sealed public class DisIntervalEnvironment<Variable, Expression>
+     : IntervalEnvironment_Base<DisIntervalEnvironment<Variable, Expression>, Variable, Expression, DisInterval, Rational>
     {
-      Contract.Requires(expManager != null);
-    }
+        #region Constructors
 
-    private DisIntervalEnvironment(DisIntervalEnvironment<Variable, Expression> original)
-      : base(original)
-    {
-      Contract.Requires(original != null);
-    }
-
-    #endregion
-
-    #region TestTrue*
-    
-    public override DisIntervalEnvironment<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      var newConstraints = IntervalInference.InferConstraints_GeqZero(exp, this.ExpressionManager.Decoder, this);
-
-      foreach (var pair in newConstraints)
-      {
-        this[pair.One] = pair.Two;
-      }
-
-      return this;
-    }
-
-    public override DisIntervalEnvironment<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      return HelperForTestTrueLessThanSignedOrUnsigned(true, exp1, exp2);
-    }
-
-    public override DisIntervalEnvironment<Variable, Expression> TestTrueLessThan_Un(Expression exp1, Expression exp2)
-    {
-      return HelperForTestTrueLessThanSignedOrUnsigned(false, exp1, exp2);
-    }
-
-    private DisIntervalEnvironment<Variable, Expression> HelperForTestTrueLessThanSignedOrUnsigned(bool isSigned, Expression exp1, Expression exp2)
-    {
-      bool isBottom;
-      var newConstraints = IntervalInference.InferConstraints_LT(isSigned, exp1, exp2, this.ExpressionManager.Decoder, this, out isBottom);
-
-      if (isBottom)
-      {
-        return this.Bottom;
-      }
-
-      Assume(newConstraints);
-
-      return this;
-    }
-
-    public override DisIntervalEnvironment<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      return HelperForTestTrueLessEqualThanSignedOrUnsigned(true, exp1, exp2);
-    }
-
-    public override DisIntervalEnvironment<Variable, Expression> TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
-    {
-      return HelperForTestTrueLessEqualThanSignedOrUnsigned(false, exp1, exp2);
-    }
-
-    private DisIntervalEnvironment<Variable, Expression> HelperForTestTrueLessEqualThanSignedOrUnsigned(bool isSigned, Expression exp1, Expression exp2)
-    {
-      bool isBottom;
-      var newConstraints = IntervalInference.InferConstraints_Leq(isSigned, exp1, exp2, this.ExpressionManager.Decoder, this, out isBottom);
-
-      if (isBottom)
-      {
-        return this.Bottom;
-      }
-
-      Assume(newConstraints);
-
-      return this;
- 
-    }
-
-    protected override DisIntervalEnvironment<Variable, Expression> TestNotEqualToZero(Expression guard)
-    {
-      var val = Eval(guard).Meet(DisInterval.NotZero);
-
-      var guardVar = this.ExpressionManager.Decoder.UnderlyingVariable(guard);
-
-      this.RefineWith(guardVar, val);
-
-      return this;
-    }
-
-    protected override DisIntervalEnvironment<Variable, Expression> TestNotEqualToZero(Variable v)
-    {
-      return TestTrueEqualToDisinterval(v, DisInterval.NotZero);
-    }
-
-    protected override DisIntervalEnvironment<Variable, Expression> TestEqualToZero(Variable v)
-    {
-      return TestTrueEqualToDisinterval(v, DisInterval.For(0));
-    }
-
-    private DisIntervalEnvironment<Variable, Expression> TestTrueEqualToDisinterval(Variable v, DisInterval dis)
-    {
-      Contract.Requires(dis != null);
-      Contract.Ensures(Contract.Result<DisIntervalEnvironment<Variable, Expression>>() != null);
-
-      DisInterval prevVal;
-      if (this.TryGetValue(v, out prevVal))
-      {
-        dis = prevVal.Meet(dis);
-      }
-
-      this[v] = dis;
-
-      return this;
-    }
-
-    public override DisIntervalEnvironment<Variable, Expression> TestNotEqual(Expression e1, Expression e2)
-    {
-      var v2 = this.Eval(e2);
-      if (v2.IsSingleton)
-      {
-        var notV2 = DisInterval.NotInThisInterval(v2);
-
-        var e1Var = this.ExpressionManager.Decoder.UnderlyingVariable(this.ExpressionManager.Decoder.Stripped(e1));
-
-        this.RefineWith(e1Var, notV2);
-      }
-
-      bool isBottomLT, isBottomGT;
-
-      var constraintsLT = IntervalInference.InferConstraints_LT(true, e1, e2, this.ExpressionManager.Decoder, this, out isBottomLT);
-      var constraintsGT = IntervalInference.InferConstraints_LT(true, e2, e1, this.ExpressionManager.Decoder, this, out isBottomGT);
-
-      if (isBottomLT)
-      {
-        // Bottom join Bottom = Bottom
-        if (isBottomGT)
+        public DisIntervalEnvironment(ExpressionManager<Variable, Expression> expManager)
+          : base(expManager, new DisintervalsCheckIfHoldsVisitor(expManager.Decoder))
         {
-          return this.Bottom;
-        }
-        this.TestTrueListOfFacts(constraintsGT);
-      }
-      else if (isBottomGT)
-      {
-        this.TestTrueListOfFacts(constraintsLT);
-      }
-      else
-      {
-        var join = JoinConstraints(constraintsLT, constraintsGT);
-
-        this.TestTrueListOfFacts(join);
-      }
-
-      return this;
-    }
-
-    protected override void AssumeKLessThanRight(DisInterval k, Variable right)
-    {
-      DisInterval refined;
-      if (IntervalInference.TryRefine_KLessThanRight(true, k, right, Rational.For(1), this, out refined))
-      {
-        this[right] = refined;
-      }
-    }
-
-    protected override void AssumeLeftLessThanK(Variable left, DisInterval k)
-    {
-      DisInterval refined;
-      if (IntervalInference.TryRefine_LeftLessThanK(true, left, k, this, out refined))
-      {
-        this[left] = refined;
-      }
-    }
-
-    /// <summary>
-    /// Assume the constraints <code>newConstraints</code>.
-    /// It works with side effects
-    /// </summary>
-    private void Assume(List<Pair<Variable, DisInterval>> newConstraints)
-    {
-      Contract.Requires(newConstraints != null);
-
-      foreach (var pair in newConstraints)
-      {
-        Contract.Assume(pair.Two != null);
-        this.RefineWith(pair.One, pair.Two);
-      }
-    }
-
-    #endregion
-
-    #region Bounds 
-
-    public override DisInterval BoundsFor(Expression exp)
-    {
-      return this.Eval(exp);
-    }
-
-    public override DisInterval BoundsFor(Variable v)
-    {
-      DisInterval d;
-      if (this.TryGetValue(v, out d))
-      {
-        return d;
-      }
-
-      return DisInterval.UnknownInterval;
-    }
-
-    protected override void AssumeInDisInterval_Internal(Variable x, DisInterval value)
-    {
-      if (value.IsTop)
-      {
-        return;
-      }
-      DisInterval prev, next;
-      if (this.TryGetValue(x, out prev))
-      {
-        next = prev.Meet(value);
-      }
-      else
-      {
-        next = value;
-      }
-
-      if (next.IsBottom)
-      {
-        this.State = AbstractState.Bottom;
-      }
-      else
-      {
-        this[x] = next;
-      }
-    }
-
-    #endregion
-
-    #region Arithmetics
-
-    public override bool IsGreaterEqualThanZero(Rational val)
-    {
-      return val >= 0;
-    }
-
-    public override bool IsGreaterThanZero(Rational val)
-    {
-      return val > 0;
-    }
-
-    public override bool IsLessThanZero(Rational val)
-    {
-      return val < 0;
-    }
-
-    public override bool IsLessEqualThanZero(Rational val)
-    {
-      return val <= 0;
-    }
-
-    public override bool IsLessThan(Rational val1, Rational val2)
-    {
-      return val1 < val2;
-    }
-
-    public override bool IsLessEqualThan(Rational val1, Rational val2)
-    {
-      return val1 <= val2;
-    }
-
-    public override bool IsZero(Rational val)
-    {
-      return val.IsZero;
-    }
-
-    public override bool IsNotZero(Rational val)
-    {
-      return val.IsNotZero;
-    }
-
-    public override bool IsPlusInfinity(Rational val)
-    {
-      return val.IsPlusInfinity;
-    }
-
-    public override bool IsMinusInfinity(Rational val)
-    {
-      return val.IsMinusInfinity;
-    }
-
-    public override bool AreEqual(DisInterval left, DisInterval right)
-    {
-      return left.IsNormal && right.IsNormal && left.LessEqual(right) && right.LessEqual(left);
-    }
-
-    public override Rational PlusInfinity
-    {
-      get
-      {
-        return Rational.PlusInfinity;
-      }
-    }
-
-    public override Rational MinusInfinty
-    {
-      get
-      {
-        return Rational.MinusInfinity;
-      }
-    }
-
-    public override bool TryAdd(Rational left, Rational right, out Rational result)
-    {
-      if (Rational.TryAdd(left, right, out result))
-      {
-        return true;
-      }
-      else
-      {
-        result = default(Rational);
-        return false;
-      }
-    }
-
-    public override FlatAbstractDomain<bool> IsNotZero(DisInterval intv)
-    {
-      Contract.Assume(intv != null); // F: just lazy
-
-      if(intv.IsSingleton && intv.LowerBound.IsZero)
-      {
-        return CheckOutcome.False;
-      }
-
-      if (intv.Meet(this.IntervalZero).IsBottom)
-      {
-        return CheckOutcome.True;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public override bool IsMaxInt32(DisInterval intv)
-    {
-      return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MaxValue;
-    }
-
-    public override bool IsMinInt32(DisInterval intv)
-    {
-      return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MinValue;
-    }
-
-    public override DisInterval IntervalUnknown
-    {
-      get
-      {
-        return DisInterval.UnknownInterval;
-      }
-    }
-
-    public override DisInterval IntervalZero
-    {
-      get
-      {
-        return DisInterval.For(0);
-      }
-    }
-
-    public override DisInterval IntervalOne
-    {
-      get
-      {
-        return DisInterval.For(1);
-      }
-    }
-
-    public override DisInterval Interval_Positive
-    {
-      get { return DisInterval.For(Interval.PositiveInterval); }
-    }
-
-    public override DisInterval Interval_StrictlyPositive
-    {
-      get { return this.IntervalRightOpen(Rational.For(1)); }
-    }
-
-    public override DisInterval IntervalGreaterEqualThanMinusOne
-    {
-      get { return DisInterval.For(Interval.For(-1, Rational.PlusInfinity)); }
-    }
-
-    public override DisInterval IntervalSingleton(Rational val)
-    {
-      return DisInterval.For(val);
-    }
-
-    public override DisInterval IntervalRightOpen(Rational inf)
-    {
-      return DisInterval.For(inf, Rational.PlusInfinity);
-    }
-
-    public override DisInterval IntervalLeftOpen(Rational sup)
-    {
-      return DisInterval.For(Rational.MinusInfinity, sup);
-    }
-
-    public override DisInterval Interval_Add(DisInterval left, DisInterval right)
-    {
-      return left + right;
-    }
-
-    public override DisInterval Interval_Div(DisInterval left, DisInterval right)
-    {
-      return left / right;
-    }
-
-    public override DisInterval Interval_Sub(DisInterval left, DisInterval right)
-    {
-      return left - right;
-    }
-
-    public override DisInterval Interval_Mul(DisInterval left, DisInterval right)
-    {
-      return left * right;
-    }
-
-    public override DisInterval Interval_UnaryMinus(DisInterval left)
-    {
-      return -left;
-    }
-
-    public override DisInterval Interval_Not(DisInterval left)
-    {
-      if (!left.IsNormal)
-      {
-        return left;
-      }
-      // !(!0) is 0
-      if (left.IsNotZero)
-      {
-        return DisInterval.For(0);
-      }
-      // !(0) is !=0
-      if (left.IsZero)
-      {
-        return DisInterval.NotZero;
-      }
-      // !([0, +oo]) is [-oo, -1]
-      if (left.IsPositiveOrZero)
-      {
-        return DisInterval.Negative;
-      }
-
-      return left;
-    }
-
-    public override DisInterval Interval_Rem(DisInterval left, DisInterval right)
-    {
-      return left % right;
-    }
-
-    public override DisInterval Interval_BitwiseAnd(DisInterval left, DisInterval right)
-    {
-      return left & right;
-    }
-
-    public override DisInterval Interval_BitwiseXor(DisInterval left, DisInterval right)
-    {
-      return left ^ right;
-    }
-
-    public override DisInterval Interval_BitwiseOr(DisInterval left, DisInterval right)
-    {
-      return left | right;
-    }
-
-    public override DisInterval Interval_ShiftLeft(DisInterval left, DisInterval right)
-    {
-      return DisInterval.ShiftLeft(left, right);
-    }
-
-    public override DisInterval Interval_ShiftRight(DisInterval left, DisInterval right)
-    {
-      return DisInterval.ShiftRight(left, right);
-    }
-
-    protected override DisInterval ApplyConversion(ExpressionOperator conversionType, DisInterval val)
-    {
-      return val.Map(intv => Interval.ApplyConversion(conversionType, intv));
-    }
-
-    #endregion
-
-    #region For*
-
-    public override DisInterval For(byte v)
-    {
-      return DisInterval.For(v);
-    }
-
-    public override DisInterval For(double d)
-    {
-      return DisInterval.For(d);
-    }
-
-    public override DisInterval For(short v)
-    {
-      return DisInterval.For(v);
-    }
-
-    public override DisInterval For(int v)
-    {
-      return DisInterval.For(v);
-    }
-
-    public override DisInterval For(long v)
-    {
-      return DisInterval.For(v);
-    }
-
-    public override DisInterval For(sbyte s)
-    {
-      return DisInterval.For(s);
-    }
-
-    public override DisInterval For(ushort u)
-    {
-      return DisInterval.For(u);
-    }
-
-    public override DisInterval For(uint u)
-    {
-      return DisInterval.For(u);
-    }
-
-    public override DisInterval For(Rational r)
-    {
-      return DisInterval.For(r);
-    }
-
-    public override DisInterval For(Rational inf, Rational sup)
-    {
-      return DisInterval.For(inf, sup);
-    }
-
-    #endregion
-
-    #region Overridden
-
-    public override List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        if(this.IsBottom || this.IsTop)
-        {
-          return new List<Pair<Variable, Int32>>();
+            Contract.Requires(expManager != null);
         }
 
-        var result = new List<Pair<Variable, Int32>>();
-        foreach (var pair in this.Elements)
+        private DisIntervalEnvironment(DisIntervalEnvironment<Variable, Expression> original)
+          : base(original)
         {
-          Contract.Assume(pair.Value != null);
-
-          if (pair.Value.IsInt32 && pair.Value.IsSingleton)
-          {
-            result.Add(pair.Key, (Int32) pair.Value.LowerBound);
-          }
+            Contract.Requires(original != null);
         }
 
-        return result;
-      }
-    }
+        #endregion
 
-    protected override T To<T>(Rational n, IFactory<T> factory)
-    {
-      return factory.Constant(n);
-    }
+        #region TestTrue*
 
-    protected override DisIntervalEnvironment<Variable, Expression> Factory()
-    {
-      return new DisIntervalEnvironment<Variable, Expression>(this.ExpressionManager);
-    }
-
-    protected override DisIntervalEnvironment<Variable, Expression> DuplicateMe()
-    {
-      return new DisIntervalEnvironment<Variable, Expression>(this);
-    }
-
-    protected override DisIntervalEnvironment<Variable, Expression> NewInstance(
-      ExpressionManager<Variable, Expression> expManager)
-    {
-      return new DisIntervalEnvironment<Variable, Expression>(this.ExpressionManager);
-    }
-
-    protected override DisInterval ConvertInterval(Interval intv)
-    {
-      return DisInterval.For(intv);
-    }
-    #endregion
-
-    #region Specialized CheckIfHolds Visitor
-
-    class DisintervalsCheckIfHoldsVisitor
-      : IntervalsCheckIfHoldsVisitor
-    {
-      public DisintervalsCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-      }
-
-      public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        // Special case for the special semantics of NaN
-        if (left.Equals(right) && !this.Decoder.IsNaN(left) && !this.Decoder.IsNaN(right))
+        public override DisIntervalEnvironment<Variable, Expression> TestTrueGeqZero(Expression exp)
         {
-          return CheckOutcome.False;
+            var newConstraints = IntervalInference.InferConstraints_GeqZero(exp, this.ExpressionManager.Decoder, this);
+
+            foreach (var pair in newConstraints)
+            {
+                this[pair.One] = pair.Two;
+            }
+
+            return this;
         }
 
-        var direct = base.VisitNotEqual(left, right, original, data);
-
-        if (direct.IsNormal())
+        public override DisIntervalEnvironment<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
         {
-          return direct;
+            return HelperForTestTrueLessThanSignedOrUnsigned(true, exp1, exp2);
         }
 
-        var leftDis = Domain.Eval(left);
-        var rightDis = Domain.Eval(right);
-
-        if (leftDis.Meet(rightDis).IsBottom)
+        public override DisIntervalEnvironment<Variable, Expression> TestTrueLessThan_Un(Expression exp1, Expression exp2)
         {
-          return CheckOutcome.True;
+            return HelperForTestTrueLessThanSignedOrUnsigned(false, exp1, exp2);
         }
 
-        return CheckOutcome.Top;
-      }
+        private DisIntervalEnvironment<Variable, Expression> HelperForTestTrueLessThanSignedOrUnsigned(bool isSigned, Expression exp1, Expression exp2)
+        {
+            bool isBottom;
+            var newConstraints = IntervalInference.InferConstraints_LT(isSigned, exp1, exp2, this.ExpressionManager.Decoder, this, out isBottom);
+
+            if (isBottom)
+            {
+                return this.Bottom;
+            }
+
+            Assume(newConstraints);
+
+            return this;
+        }
+
+        public override DisIntervalEnvironment<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return HelperForTestTrueLessEqualThanSignedOrUnsigned(true, exp1, exp2);
+        }
+
+        public override DisIntervalEnvironment<Variable, Expression> TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
+        {
+            return HelperForTestTrueLessEqualThanSignedOrUnsigned(false, exp1, exp2);
+        }
+
+        private DisIntervalEnvironment<Variable, Expression> HelperForTestTrueLessEqualThanSignedOrUnsigned(bool isSigned, Expression exp1, Expression exp2)
+        {
+            bool isBottom;
+            var newConstraints = IntervalInference.InferConstraints_Leq(isSigned, exp1, exp2, this.ExpressionManager.Decoder, this, out isBottom);
+
+            if (isBottom)
+            {
+                return this.Bottom;
+            }
+
+            Assume(newConstraints);
+
+            return this;
+        }
+
+        protected override DisIntervalEnvironment<Variable, Expression> TestNotEqualToZero(Expression guard)
+        {
+            var val = Eval(guard).Meet(DisInterval.NotZero);
+
+            var guardVar = this.ExpressionManager.Decoder.UnderlyingVariable(guard);
+
+            this.RefineWith(guardVar, val);
+
+            return this;
+        }
+
+        protected override DisIntervalEnvironment<Variable, Expression> TestNotEqualToZero(Variable v)
+        {
+            return TestTrueEqualToDisinterval(v, DisInterval.NotZero);
+        }
+
+        protected override DisIntervalEnvironment<Variable, Expression> TestEqualToZero(Variable v)
+        {
+            return TestTrueEqualToDisinterval(v, DisInterval.For(0));
+        }
+
+        private DisIntervalEnvironment<Variable, Expression> TestTrueEqualToDisinterval(Variable v, DisInterval dis)
+        {
+            Contract.Requires(dis != null);
+            Contract.Ensures(Contract.Result<DisIntervalEnvironment<Variable, Expression>>() != null);
+
+            DisInterval prevVal;
+            if (this.TryGetValue(v, out prevVal))
+            {
+                dis = prevVal.Meet(dis);
+            }
+
+            this[v] = dis;
+
+            return this;
+        }
+
+        public override DisIntervalEnvironment<Variable, Expression> TestNotEqual(Expression e1, Expression e2)
+        {
+            var v2 = this.Eval(e2);
+            if (v2.IsSingleton)
+            {
+                var notV2 = DisInterval.NotInThisInterval(v2);
+
+                var e1Var = this.ExpressionManager.Decoder.UnderlyingVariable(this.ExpressionManager.Decoder.Stripped(e1));
+
+                this.RefineWith(e1Var, notV2);
+            }
+
+            bool isBottomLT, isBottomGT;
+
+            var constraintsLT = IntervalInference.InferConstraints_LT(true, e1, e2, this.ExpressionManager.Decoder, this, out isBottomLT);
+            var constraintsGT = IntervalInference.InferConstraints_LT(true, e2, e1, this.ExpressionManager.Decoder, this, out isBottomGT);
+
+            if (isBottomLT)
+            {
+                // Bottom join Bottom = Bottom
+                if (isBottomGT)
+                {
+                    return this.Bottom;
+                }
+                this.TestTrueListOfFacts(constraintsGT);
+            }
+            else if (isBottomGT)
+            {
+                this.TestTrueListOfFacts(constraintsLT);
+            }
+            else
+            {
+                var join = JoinConstraints(constraintsLT, constraintsGT);
+
+                this.TestTrueListOfFacts(join);
+            }
+
+            return this;
+        }
+
+        protected override void AssumeKLessThanRight(DisInterval k, Variable right)
+        {
+            DisInterval refined;
+            if (IntervalInference.TryRefine_KLessThanRight(true, k, right, Rational.For(1), this, out refined))
+            {
+                this[right] = refined;
+            }
+        }
+
+        protected override void AssumeLeftLessThanK(Variable left, DisInterval k)
+        {
+            DisInterval refined;
+            if (IntervalInference.TryRefine_LeftLessThanK(true, left, k, this, out refined))
+            {
+                this[left] = refined;
+            }
+        }
+
+        /// <summary>
+        /// Assume the constraints <code>newConstraints</code>.
+        /// It works with side effects
+        /// </summary>
+        private void Assume(List<Pair<Variable, DisInterval>> newConstraints)
+        {
+            Contract.Requires(newConstraints != null);
+
+            foreach (var pair in newConstraints)
+            {
+                Contract.Assume(pair.Two != null);
+                this.RefineWith(pair.One, pair.Two);
+            }
+        }
+
+        #endregion
+
+        #region Bounds 
+
+        public override DisInterval BoundsFor(Expression exp)
+        {
+            return this.Eval(exp);
+        }
+
+        public override DisInterval BoundsFor(Variable v)
+        {
+            DisInterval d;
+            if (this.TryGetValue(v, out d))
+            {
+                return d;
+            }
+
+            return DisInterval.UnknownInterval;
+        }
+
+        protected override void AssumeInDisInterval_Internal(Variable x, DisInterval value)
+        {
+            if (value.IsTop)
+            {
+                return;
+            }
+            DisInterval prev, next;
+            if (this.TryGetValue(x, out prev))
+            {
+                next = prev.Meet(value);
+            }
+            else
+            {
+                next = value;
+            }
+
+            if (next.IsBottom)
+            {
+                this.State = AbstractState.Bottom;
+            }
+            else
+            {
+                this[x] = next;
+            }
+        }
+
+        #endregion
+
+        #region Arithmetics
+
+        public override bool IsGreaterEqualThanZero(Rational val)
+        {
+            return val >= 0;
+        }
+
+        public override bool IsGreaterThanZero(Rational val)
+        {
+            return val > 0;
+        }
+
+        public override bool IsLessThanZero(Rational val)
+        {
+            return val < 0;
+        }
+
+        public override bool IsLessEqualThanZero(Rational val)
+        {
+            return val <= 0;
+        }
+
+        public override bool IsLessThan(Rational val1, Rational val2)
+        {
+            return val1 < val2;
+        }
+
+        public override bool IsLessEqualThan(Rational val1, Rational val2)
+        {
+            return val1 <= val2;
+        }
+
+        public override bool IsZero(Rational val)
+        {
+            return val.IsZero;
+        }
+
+        public override bool IsNotZero(Rational val)
+        {
+            return val.IsNotZero;
+        }
+
+        public override bool IsPlusInfinity(Rational val)
+        {
+            return val.IsPlusInfinity;
+        }
+
+        public override bool IsMinusInfinity(Rational val)
+        {
+            return val.IsMinusInfinity;
+        }
+
+        public override bool AreEqual(DisInterval left, DisInterval right)
+        {
+            return left.IsNormal && right.IsNormal && left.LessEqual(right) && right.LessEqual(left);
+        }
+
+        public override Rational PlusInfinity
+        {
+            get
+            {
+                return Rational.PlusInfinity;
+            }
+        }
+
+        public override Rational MinusInfinty
+        {
+            get
+            {
+                return Rational.MinusInfinity;
+            }
+        }
+
+        public override bool TryAdd(Rational left, Rational right, out Rational result)
+        {
+            if (Rational.TryAdd(left, right, out result))
+            {
+                return true;
+            }
+            else
+            {
+                result = default(Rational);
+                return false;
+            }
+        }
+
+        public override FlatAbstractDomain<bool> IsNotZero(DisInterval intv)
+        {
+            Contract.Assume(intv != null); // F: just lazy
+
+            if (intv.IsSingleton && intv.LowerBound.IsZero)
+            {
+                return CheckOutcome.False;
+            }
+
+            if (intv.Meet(this.IntervalZero).IsBottom)
+            {
+                return CheckOutcome.True;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public override bool IsMaxInt32(DisInterval intv)
+        {
+            return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MaxValue;
+        }
+
+        public override bool IsMinInt32(DisInterval intv)
+        {
+            return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MinValue;
+        }
+
+        public override DisInterval IntervalUnknown
+        {
+            get
+            {
+                return DisInterval.UnknownInterval;
+            }
+        }
+
+        public override DisInterval IntervalZero
+        {
+            get
+            {
+                return DisInterval.For(0);
+            }
+        }
+
+        public override DisInterval IntervalOne
+        {
+            get
+            {
+                return DisInterval.For(1);
+            }
+        }
+
+        public override DisInterval Interval_Positive
+        {
+            get { return DisInterval.For(Interval.PositiveInterval); }
+        }
+
+        public override DisInterval Interval_StrictlyPositive
+        {
+            get { return this.IntervalRightOpen(Rational.For(1)); }
+        }
+
+        public override DisInterval IntervalGreaterEqualThanMinusOne
+        {
+            get { return DisInterval.For(Interval.For(-1, Rational.PlusInfinity)); }
+        }
+
+        public override DisInterval IntervalSingleton(Rational val)
+        {
+            return DisInterval.For(val);
+        }
+
+        public override DisInterval IntervalRightOpen(Rational inf)
+        {
+            return DisInterval.For(inf, Rational.PlusInfinity);
+        }
+
+        public override DisInterval IntervalLeftOpen(Rational sup)
+        {
+            return DisInterval.For(Rational.MinusInfinity, sup);
+        }
+
+        public override DisInterval Interval_Add(DisInterval left, DisInterval right)
+        {
+            return left + right;
+        }
+
+        public override DisInterval Interval_Div(DisInterval left, DisInterval right)
+        {
+            return left / right;
+        }
+
+        public override DisInterval Interval_Sub(DisInterval left, DisInterval right)
+        {
+            return left - right;
+        }
+
+        public override DisInterval Interval_Mul(DisInterval left, DisInterval right)
+        {
+            return left * right;
+        }
+
+        public override DisInterval Interval_UnaryMinus(DisInterval left)
+        {
+            return -left;
+        }
+
+        public override DisInterval Interval_Not(DisInterval left)
+        {
+            if (!left.IsNormal)
+            {
+                return left;
+            }
+            // !(!0) is 0
+            if (left.IsNotZero)
+            {
+                return DisInterval.For(0);
+            }
+            // !(0) is !=0
+            if (left.IsZero)
+            {
+                return DisInterval.NotZero;
+            }
+            // !([0, +oo]) is [-oo, -1]
+            if (left.IsPositiveOrZero)
+            {
+                return DisInterval.Negative;
+            }
+
+            return left;
+        }
+
+        public override DisInterval Interval_Rem(DisInterval left, DisInterval right)
+        {
+            return left % right;
+        }
+
+        public override DisInterval Interval_BitwiseAnd(DisInterval left, DisInterval right)
+        {
+            return left & right;
+        }
+
+        public override DisInterval Interval_BitwiseXor(DisInterval left, DisInterval right)
+        {
+            return left ^ right;
+        }
+
+        public override DisInterval Interval_BitwiseOr(DisInterval left, DisInterval right)
+        {
+            return left | right;
+        }
+
+        public override DisInterval Interval_ShiftLeft(DisInterval left, DisInterval right)
+        {
+            return DisInterval.ShiftLeft(left, right);
+        }
+
+        public override DisInterval Interval_ShiftRight(DisInterval left, DisInterval right)
+        {
+            return DisInterval.ShiftRight(left, right);
+        }
+
+        protected override DisInterval ApplyConversion(ExpressionOperator conversionType, DisInterval val)
+        {
+            return val.Map(intv => Interval.ApplyConversion(conversionType, intv));
+        }
+
+        #endregion
+
+        #region For*
+
+        public override DisInterval For(byte v)
+        {
+            return DisInterval.For(v);
+        }
+
+        public override DisInterval For(double d)
+        {
+            return DisInterval.For(d);
+        }
+
+        public override DisInterval For(short v)
+        {
+            return DisInterval.For(v);
+        }
+
+        public override DisInterval For(int v)
+        {
+            return DisInterval.For(v);
+        }
+
+        public override DisInterval For(long v)
+        {
+            return DisInterval.For(v);
+        }
+
+        public override DisInterval For(sbyte s)
+        {
+            return DisInterval.For(s);
+        }
+
+        public override DisInterval For(ushort u)
+        {
+            return DisInterval.For(u);
+        }
+
+        public override DisInterval For(uint u)
+        {
+            return DisInterval.For(u);
+        }
+
+        public override DisInterval For(Rational r)
+        {
+            return DisInterval.For(r);
+        }
+
+        public override DisInterval For(Rational inf, Rational sup)
+        {
+            return DisInterval.For(inf, sup);
+        }
+
+        #endregion
+
+        #region Overridden
+
+        public override List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                if (this.IsBottom || this.IsTop)
+                {
+                    return new List<Pair<Variable, Int32>>();
+                }
+
+                var result = new List<Pair<Variable, Int32>>();
+                foreach (var pair in this.Elements)
+                {
+                    Contract.Assume(pair.Value != null);
+
+                    if (pair.Value.IsInt32 && pair.Value.IsSingleton)
+                    {
+                        result.Add(pair.Key, (Int32)pair.Value.LowerBound);
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        protected override T To<T>(Rational n, IFactory<T> factory)
+        {
+            return factory.Constant(n);
+        }
+
+        protected override DisIntervalEnvironment<Variable, Expression> Factory()
+        {
+            return new DisIntervalEnvironment<Variable, Expression>(this.ExpressionManager);
+        }
+
+        protected override DisIntervalEnvironment<Variable, Expression> DuplicateMe()
+        {
+            return new DisIntervalEnvironment<Variable, Expression>(this);
+        }
+
+        protected override DisIntervalEnvironment<Variable, Expression> NewInstance(
+          ExpressionManager<Variable, Expression> expManager)
+        {
+            return new DisIntervalEnvironment<Variable, Expression>(this.ExpressionManager);
+        }
+
+        protected override DisInterval ConvertInterval(Interval intv)
+        {
+            return DisInterval.For(intv);
+        }
+        #endregion
+
+        #region Specialized CheckIfHolds Visitor
+
+        private class DisintervalsCheckIfHoldsVisitor
+          : IntervalsCheckIfHoldsVisitor
+        {
+            public DisintervalsCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+            }
+
+            public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                // Special case for the special semantics of NaN
+                if (left.Equals(right) && !this.Decoder.IsNaN(left) && !this.Decoder.IsNaN(right))
+                {
+                    return CheckOutcome.False;
+                }
+
+                var direct = base.VisitNotEqual(left, right, original, data);
+
+                if (direct.IsNormal())
+                {
+                    return direct;
+                }
+
+                var leftDis = Domain.Eval(left);
+                var rightDis = Domain.Eval(right);
+
+                if (leftDis.Meet(rightDis).IsBottom)
+                {
+                    return CheckOutcome.True;
+                }
+
+                return CheckOutcome.Top;
+            }
+        }
+        #endregion
     }
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/DisIntervals.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/DisIntervals.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation of the disjunction of intervals
 
@@ -27,1456 +16,1455 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
 #if DEBUG
-  using ReadOnlyIntervalList = ReadOnlyCollection<Interval>;
+    using ReadOnlyIntervalList = ReadOnlyCollection<Interval>;
 #else
-  using ReadOnlyIntervalList = List<Interval>;
+    using ReadOnlyIntervalList = List<Interval>;
 #endif
-  [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-this.CheckInvariant()", Justification="Out of reach of the static checker")]
-  [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-Contract.ForAll(this.intervals, x => x != null)", Justification = "At the moment, the array analysis does not understand Lists")]
-  public sealed class DisInterval
-    : IntervalBase<DisInterval, Rational>
-  {
-    #region ObjectInvariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-this.CheckInvariant()", Justification = "Out of reach of the static checker")]
+    [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-Contract.ForAll(this.intervals, x => x != null)", Justification = "At the moment, the array analysis does not understand Lists")]
+    public sealed class DisInterval
+      : IntervalBase<DisInterval, Rational>
     {
-      Contract.Invariant(this.joinInterval != null);
-      Contract.Invariant(this.intervals != null);
-      Contract.Invariant(Contract.ForAll(this.intervals, x => x != null));
-      Contract.Invariant(this.CheckInvariant());
-    }
+        #region ObjectInvariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(joinInterval != null);
+            Contract.Invariant(intervals != null);
+            Contract.Invariant(Contract.ForAll(intervals, x => x != null));
+            Contract.Invariant(this.CheckInvariant());
+        }
 
-    #endregion
+        #endregion
 
-    #region Private statics
+        #region Private statics
 
-    private static readonly DisInterval cachedTop;
-    private static readonly DisInterval cachedBottom;
-    private static readonly DisInterval cachedZero;
-    private static readonly DisInterval cachedNotZero;
-    private static readonly DisInterval cachedPositive;
-    private static readonly DisInterval cachedNegative;
+        private static readonly DisInterval cachedTop;
+        private static readonly DisInterval cachedBottom;
+        private static readonly DisInterval cachedZero;
+        private static readonly DisInterval cachedNotZero;
+        private static readonly DisInterval cachedPositive;
+        private static readonly DisInterval cachedNegative;
 
-    static DisInterval()
-    {
-      cachedTop = new DisInterval(State.Top);
-      cachedBottom = new DisInterval(State.Bottom);
-      cachedZero = new DisInterval(Interval.For(0));
-      cachedNotZero = new DisInterval(new List<Interval>() { 
-            Interval.For(Rational.MinusInfinity, Rational.For(-1)), 
+        static DisInterval()
+        {
+            cachedTop = new DisInterval(State.Top);
+            cachedBottom = new DisInterval(State.Bottom);
+            cachedZero = new DisInterval(Interval.For(0));
+            cachedNotZero = new DisInterval(new List<Interval>() {
+            Interval.For(Rational.MinusInfinity, Rational.For(-1)),
             Interval.For(Rational.For(1), Rational.PlusInfinity)
           });
-      cachedPositive = Interval.PositiveInterval.AsDisInterval;
-      cachedNegative = Interval.NegativeInterval.AsDisInterval;
-    }
-
-    #endregion
-
-    #region Private state
-
-    private enum State { Bottom, Normal, Top }
-
-    private readonly ReadOnlyIntervalList intervals;
-    private readonly Interval joinInterval;
-    private readonly State state;
-
-    #endregion
-
-    #region For
-
-    static public DisInterval For(Rational lower, Rational upper)
-    {
-      Contract.Requires(!object.Equals(lower, null));
-      Contract.Requires(!object.Equals(upper, null));
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      var intv = Interval.For(lower, upper);
-
-      return new DisInterval(intv);
-    }
-
-    static public DisInterval For(Rational r)
-    {
-      Contract.Requires(!object.Equals(r, null));
-      
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return For(r, r);
-    }
-
-    static public DisInterval For(Rational lower, Int64 upper)
-    {
-      Contract.Requires(!object.Equals(lower, null));
-      
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return For(lower, Rational.For(upper));
-    }
-
-    static public DisInterval For(Int64 lower, Rational upper)
-    {
-      Contract.Requires(!object.Equals(upper, null));
-      
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return For(Rational.For(lower), upper);
-    }
-
-    static public DisInterval For(Int64 lower, Int64 upper)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return For(Rational.For(lower), Rational.For(upper));
-    }
-
-    static public DisInterval For(UInt32 lower, UInt32 upper)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return For(Rational.For(lower), Rational.For(upper));
-    }
-
-    static public DisInterval For(Int64 i)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      var r = Rational.For(i);
-      return For(r, r);
-    }
-
-    static public DisInterval For(Byte i)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      var r = Rational.For(i);
-      return For(r, r);
-    }
-
-    static public DisInterval For(UInt32 i)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      var r = Rational.For(i);
-      return For(r, r);
-    }
-
-    static public DisInterval For(UInt64 i)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      var r = Rational.For(i);
-      return For(r, r);
-    }
-
-    static public DisInterval For(Double d)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return DisInterval.For(d.ConvertFromDouble());
-    }
-
-    static public DisInterval For(Interval intv)
-    {
-      Contract.Requires(intv != null);
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return new DisInterval(intv);
-    }
-
-    static public DisInterval For(List<Interval> intervals)
-    {
-      Contract.Requires(intervals != null);
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return new DisInterval(intervals);
-    }
-
-    static public DisInterval For(List<int> values)
-    {
-      Contract.Requires(values != null);
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return new DisInterval(values.ConvertAll(x => Interval.For(x)));
-    }
-
-    public static DisInterval NotInThisInterval(DisInterval intv)
-    {
-      Contract.Requires(intv != null);
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      var low = Interval.For(Rational.MinusInfinity, intv.lowerBound - 1);
-      var upp = Interval.For(intv.UpperBound + 1, Rational.PlusInfinity);
-
-      var bLow = low.IsNormal;
-      var bUpp = upp.IsNormal;
-
-      if (bLow && bUpp)
-      {
-        return For(new List<Interval>() { low, upp });
-      }
-
-      if (bLow)
-      {
-        return For(low);
-      }
-
-      if (bUpp)
-      {
-        return For(upp);
-      }
-
-      return DisInterval.UnknownInterval;
-    }
-
-    #endregion
-
-    #region Constructors
-
-    private DisInterval(Interval intv)
-      : base(intv.LowerBound, intv.UpperBound)
-    {
-      Contract.Requires(intv != null);
-
-      var list = new List<Interval>();
-
-      if (intv.IsTop)
-      {
-        this.state = State.Top;
-      }
-      else if (intv.IsBottom)
-      {
-        this.state = State.Bottom;
-      }
-      else
-      {
-        this.state = State.Normal;
-
-        list.Add(intv);
-      }
-      this.intervals = AsReadOnly(list);
-      this.joinInterval = intv;
-    }
-
-    private static readonly ReadOnlyIntervalList EmptyReadOnlyList = AsReadOnly(new List<Interval>(0));
-
-    private static ReadOnlyIntervalList AsReadOnly(List<Interval> list)
-    {
-      Contract.Requires(list != null);
-
-#if DEBUG
-      return list.AsReadOnly();
-#else
-      return list;
-#endif
-    }
-
-    private DisInterval(List<Interval> intervals)
-      : base(Rational.MinusInfinity, Rational.PlusInfinity)
-    {
-      Contract.Requires(intervals != null);
-
-      bool isBottom;
-      this.intervals = Normalize(intervals, out isBottom);
-
-      if (isBottom)
-      {
-        this.joinInterval = Interval.UnreachedInterval;
-        this.state = State.Bottom;
-      }
-      else
-      {
-        this.joinInterval = JoinAll(intervals);
-
-        if (this.joinInterval.IsBottom)
-        {
-          this.state = State.Bottom;
-        }
-        else if (this.joinInterval.IsTop)
-        {
-          this.state = this.intervals.Count <= 1 ? State.Top : State.Normal;
-        }
-        else
-        {
-          this.lowerBound = this.joinInterval.LowerBound;
-          this.upperBound = this.joinInterval.UpperBound;
-
-          this.state = State.Normal;
-        }
-      }
-    }
-
-    private DisInterval(DisInterval original)
-      : base(original.lowerBound, original.upperBound)
-    {
-      Contract.Requires(original != null);
-
-      this.intervals = original.intervals;
-      this.joinInterval = original.joinInterval.DuplicateMe();
-      this.state = original.state;
-    }
-
-    private DisInterval(State state)
-      : base(Rational.MinusInfinity, Rational.PlusInfinity)
-    {
-      Contract.Requires(state != State.Normal);
-
-      this.state = state;
-      this.joinInterval = this.state == State.Bottom ? Interval.UnreachedInterval : Interval.UnknownInterval;
-      this.intervals = EmptyReadOnlyList;
-    }
-
-    #endregion
-
-    #region Implementation of the abstract methods
-    public override bool IsInt32
-    {
-      get
-      {
-        if (!this.IsNormal)
-        {
-          return false;
+            cachedPositive = Interval.PositiveInterval.AsDisInterval;
+            cachedNegative = Interval.NegativeInterval.AsDisInterval;
         }
 
-        var blow = this.IsLowerBoundMinusInfinity || this.lowerBound >= Int32.MinValue;
-        var bupp = this.IsUpperBoundPlusInfinity || this.upperBound <= Int32.MaxValue;
+        #endregion
 
-        return blow && bupp;
-      }
-    }
+        #region Private state
 
-    public override bool IsInt64
-    {
-      get
-      {
-        if (!this.IsNormal)
+        private enum State { Bottom, Normal, Top }
+
+        private readonly ReadOnlyIntervalList intervals;
+        private readonly Interval joinInterval;
+        private readonly State state;
+
+        #endregion
+
+        #region For
+
+        static public DisInterval For(Rational lower, Rational upper)
         {
-          return false;
+            Contract.Requires(!object.Equals(lower, null));
+            Contract.Requires(!object.Equals(upper, null));
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            var intv = Interval.For(lower, upper);
+
+            return new DisInterval(intv);
         }
 
-        var blow = this.IsLowerBoundMinusInfinity || this.lowerBound >= Int64.MinValue;
-        var bupp = this.IsUpperBoundPlusInfinity || this.upperBound <= Int64.MaxValue;
-
-        return blow && bupp;
-      }
-    }
-
-    public override bool IsLowerBoundMinusInfinity
-    {
-      get
-      {
-        return this.lowerBound.IsMinusInfinity;
-      }
-    }
-
-    public override bool IsUpperBoundPlusInfinity
-    {
-      get
-      {
-        return this.upperBound.IsPlusInfinity;
-      }
-    }
-
-    public override DisInterval Bottom
-    {
-      get
-      {
-        return DisInterval.UnreachedInterval;
-      }
-    }
-
-    static public DisInterval IntervalUnknown
-    {
-      get
-      {
-        return DisInterval.UnknownInterval;
-      }
-    }
-
-    public override DisInterval Top
-    {
-      get
-      {
-        return DisInterval.UnknownInterval;
-      }
-    }
-
-    public override bool IsNormal
-    {
-      get
-      {
-        return this.state == State.Normal;
-      }
-    }
-
-    public bool IsNotZero
-    {
-      get
-      {
-        if (!this.IsNormal)
+        static public DisInterval For(Rational r)
         {
-          return false;
+            Contract.Requires(!object.Equals(r, null));
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return For(r, r);
         }
 
-        foreach(var intv in this.intervals)
+        static public DisInterval For(Rational lower, Int64 upper)
         {
-          if (intv.DoesInclude(0))
-            return false;
+            Contract.Requires(!object.Equals(lower, null));
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return For(lower, Rational.For(upper));
         }
 
-        return true;
-      }
-    }
+        static public DisInterval For(Int64 lower, Rational upper)
+        {
+            Contract.Requires(!object.Equals(upper, null));
 
-    public bool IsZero
-    {
-      get
-      {
-        if (!this.IsNormal)
-        {
-          return false;
-        }
-        Rational value;
-        if (this.TryGetSingletonValue(out value) && value.IsZero)
-        {
-          return true;
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return For(Rational.For(lower), upper);
         }
 
-        return false;
-      }
-    }
-
-    public bool IsPositiveOrZero
-    {
-      get
-      {
-        if (this.IsNormal)
+        static public DisInterval For(Int64 lower, Int64 upper)
         {
-          Int64 lower;
-          return this.LowerBound.TryInt64(out lower) && lower >= 0;
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return For(Rational.For(lower), Rational.For(upper));
         }
 
-        return false;
-      }
-    }
-
-    public bool IsNegativeOrZero
-    {
-      get
-      {
-        if (this.IsNormal)
+        static public DisInterval For(UInt32 lower, UInt32 upper)
         {
-          Int64 upper;
-          return this.UpperBound.TryInt64(out upper) && upper <= 0;
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return For(Rational.For(lower), Rational.For(upper));
         }
 
-        return false;
-      }
-    }
-
-
-    public override bool IsBottom
-    {
-      get
-      {
-        return this.state == State.Bottom;
-      }
-    }
-
-    public override bool IsTop
-    {
-      get
-      {
-        return this.state == State.Top;
-      }
-    }   
-
-    #endregion
-
-    #region Abstract domain operators
-    public override bool LessEqual(DisInterval a)
-    {
-      bool trivial;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out trivial))
-      {
-        return trivial;
-      }
-
-      if (!this.joinInterval.LessEqual(a.joinInterval))
-      {
-        return false;
-      }
-
-      var lastRight = 0;
-
-      for (var i = 0; i < this.intervals.Count; i++)
-      {
-        for (; lastRight < a.intervals.Count; lastRight++)
+        static public DisInterval For(Int64 i)
         {
-          if (this.intervals[i].LessEqual(a.intervals[lastRight]))
-          {
-            goto next;
-          }
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            var r = Rational.For(i);
+            return For(r, r);
         }
 
-        return false; // If we reach this point, we were unable to find un upper interval in right, so we return false
-
-      next:
-        ;
-      }
-
-      return true;
-    }
-
-    public override DisInterval Join(DisInterval a)
-    {
-      DisInterval trivial;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivial))
-      {
-        return trivial;
-      }
-
-      var joinIntervals = Join(this.intervals, a.intervals);
-
-      if (joinIntervals.Count == 0)
-      {
-        return Top;
-      }
-
-      return new DisInterval(joinIntervals);
-    }
-
-    public override DisInterval Meet(DisInterval a)
-    {
-      DisInterval trivial;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivial))
-      {
-        return trivial;
-      }
-
-      bool isBottom;
-      var meetIntervals = Meet(this.intervals, a.intervals, out isBottom);
-
-      if (isBottom)
-      {
-        return Bottom;
-      }
-      if (meetIntervals.Count == 0)
-      {
-        return Top;
-      }
-
-      return new DisInterval(meetIntervals);
-    }
-
-    public override DisInterval Widening(DisInterval prev)
-    {
-      if (this.IsTop || prev.IsTop)
-      {
-        return Top;
-      }
-
-      var widenIntervals = Widening(this.intervals, prev.intervals);
-
-      return new DisInterval(widenIntervals);
-    }
-
-    public override DisInterval DuplicateMe()
-    {
-      return new DisInterval(this);
-    }
-    #endregion
-
-    #region Arithmetic operations on DisIntervals
-
-    private delegate Interval IntervalBinOp(Interval left, Interval right);
-
-    static private DisInterval OperatorLifting(DisInterval left, DisInterval right, IntervalBinOp binop, bool propagateTop)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Requires(binop != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      if (left.IsBottom || right.IsBottom)    // Propagate bottom
-      {
-        return UnreachedInterval;
-      }
-
-      if (propagateTop && (left.IsTop || right.IsTop))          // Propagate top
-      {
-        return UnknownInterval;
-      }
-
-      if(left.IsTop && right.IsTop)
-      {
-        return UnknownInterval;
-      }
-
-      Contract.Assume(left.intervals != null);
-      Contract.Assume(right.intervals != null);
-
-      var result = new List<Interval>(left.intervals.Count + right.intervals.Count);
-
-      bool isBottom = true;
-
-      if (propagateTop || (left.IsNormal && right.IsNormal))
-      {
-        for (var i = 0; i < left.intervals.Count; i++)
+        static public DisInterval For(Byte i)
         {
-          var intvLeft = left.intervals[i];
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
 
-          for (var j = 0; j < right.intervals.Count; j++)
-          {
-            var opResult = binop(intvLeft, right.intervals[j]);
-            if (opResult.IsTop)
+            var r = Rational.For(i);
+            return For(r, r);
+        }
+
+        static public DisInterval For(UInt32 i)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            var r = Rational.For(i);
+            return For(r, r);
+        }
+
+        static public DisInterval For(UInt64 i)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            var r = Rational.For(i);
+            return For(r, r);
+        }
+
+        static public DisInterval For(Double d)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return DisInterval.For(d.ConvertFromDouble());
+        }
+
+        static public DisInterval For(Interval intv)
+        {
+            Contract.Requires(intv != null);
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return new DisInterval(intv);
+        }
+
+        static public DisInterval For(List<Interval> intervals)
+        {
+            Contract.Requires(intervals != null);
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return new DisInterval(intervals);
+        }
+
+        static public DisInterval For(List<int> values)
+        {
+            Contract.Requires(values != null);
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return new DisInterval(values.ConvertAll(x => Interval.For(x)));
+        }
+
+        public static DisInterval NotInThisInterval(DisInterval intv)
+        {
+            Contract.Requires(intv != null);
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            var low = Interval.For(Rational.MinusInfinity, intv.lowerBound - 1);
+            var upp = Interval.For(intv.UpperBound + 1, Rational.PlusInfinity);
+
+            var bLow = low.IsNormal;
+            var bUpp = upp.IsNormal;
+
+            if (bLow && bUpp)
             {
-              return left.Top;
+                return For(new List<Interval>() { low, upp });
             }
 
-            if (opResult.IsBottom)
+            if (bLow)
             {
-              continue;
+                return For(low);
             }
 
-            isBottom = false;
-            result.Add(opResult);
-          }
-        }
-      }
-      else
-      {
-        var nonTopArgument = left.IsTop ? right : left;
-        var nonTopIsLeft = !left.IsTop;
-
-        for (var i = 0; i < nonTopArgument.intervals.Count; i++)
-        {
-          var opResult = nonTopIsLeft ?
-            binop(nonTopArgument.intervals[i], Interval.UnknownInterval) :
-            binop(Interval.UnknownInterval, nonTopArgument.intervals[i]);
-
-          if(opResult.IsTop)
-          {
-            return UnknownInterval;
-          }
-          if(opResult.IsBottom)
-          {
-            continue;
-          }
-
-          isBottom = false;
-          result.Add(opResult);
-        }
-      }
-
-      return isBottom? DisInterval.UnreachedInterval : new DisInterval(result);
-    }
-
-    static public DisInterval operator +(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a+b, true);
-    }
-
-    static public DisInterval operator -(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a - b, true);
-    }
-
-    static public DisInterval operator -(DisInterval left)
-    {
-      Contract.Requires(left != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      if (left.IsBottom || left.IsTop)
-      {
-        return left;
-      }
-
-      var result = new List<Interval>();
-      for (var i = 0; i < left.intervals.Count; i++)
-      {
-        result.Add(-left.intervals[i]);
-      }
-
-      result.Reverse();
-      return new DisInterval(result);
-    }
-
-    static public DisInterval operator *(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a * b, true);
-    }
-
-    static public DisInterval operator /(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a / b, true);
-    }
-
-    static public DisInterval operator %(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a % b, false);
-    }
-
-    static public DisInterval operator &(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a & b, false); 
-    }
-
-    static public DisInterval operator |(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a | b, true); 
-    }
-
-    static public DisInterval operator ^(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, (a, b) => a ^ b, true); 
-    }
-
-    static public DisInterval ShiftLeft(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, Interval.ShiftLeft, true); 
-    }
-
-    static public DisInterval ShiftRight(DisInterval left, DisInterval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return OperatorLifting(left, right, Interval.ShiftRight, true);
-    }
-
-    #endregion
-
-    #region Conversion
-
-    public override DisInterval ToUnsigned()
-    {
-      if (this.IsNormal)
-      {
-        var result = new List<Interval>(this.intervals.Count);
-
-        foreach (var x in this.intervals)
-        {
-          result.Add(x.ToUnsigned());
-        }
-
-        return new DisInterval(result);
-      }
-
-      return this;
-    }
-
-    public Interval AsInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval>() != null);
-
-        return this.joinInterval;
-      }
-    }
-    #endregion
-
-    #region Map
-
-    public DisInterval Map(Func<Interval, Interval> f)
-    {
-      Contract.Requires(f != null);
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      if (this.IsBottom) 
-      {
-        return this;
-      }
-
-      if (this.IsTop)
-      {
-        return new DisInterval(f(Interval.UnknownInterval));
-      }
-
-      var result = new List<Interval>();
-      for (var i = 0; i < this.intervals.Count; i++)
-      {
-        var res = f(this.intervals[i]);
-
-        if (res.IsBottom)
-        {
-          return this.Bottom;
-        }
-        if (res.IsTop)
-        {
-          return this.Top;
-        }
-        result.Add(res);
-      }
-
-      return new DisInterval(result);
-    }
-
-    #endregion
-
-    #region Utils
-
-    static private ReadOnlyIntervalList Normalize(List<Interval> intervals, out bool isBottom)
-    {
-      Contract.Requires(intervals != null);
-
-      Contract.Ensures(Contract.Result<ReadOnlyIntervalList>() != null);
-
-      if (intervals.Count <= 1 )
-      {
-        isBottom = false;
-        return AsReadOnly(intervals);
-      }
-
-      intervals.Sort((a, b) =>
-        a.Equals(b) ?
-        0 :
-       (a.UpperBound <= b.LowerBound ? -1 : 1));
-
-      var result = new List<Interval>(intervals.Count);
-      var bottoms = 0;
-
-      var prev = null as Interval;
-
-      for (var i = 0; i < intervals.Count; i++)
-      {
-        var intv = intervals[i];
-
-        // Skip repetitions
-        if (prev == intv)
-        {
-          continue;
-        }
-        
-        if (intv.IsBottom)
-        {
-          bottoms++;
-
-          continue;
-        }
-        
-        if (intv.IsTop)
-        {
-          isBottom = false;
-
-          return EmptyReadOnlyList;
-        }
-
-        if (prev != null)
-        {
-          var refined = true;
-          while (refined && result.Count > 0)
-          {
-            prev = result[result.Count - 1];
-
-            if (Interval.AreConsecutiveIntegers(prev, intv))         // The intervals are consecutive, so we join them together
+            if (bUpp)
             {
-              result.RemoveAt(result.Count - 1);  // remove the last element
-              intv = prev.Join(intv);             
+                return For(upp);
             }
-            else if (prev.LessEqual(intv))        // The last element we added is subsumed by the next one
+
+            return DisInterval.UnknownInterval;
+        }
+
+        #endregion
+
+        #region Constructors
+
+        private DisInterval(Interval intv)
+          : base(intv.LowerBound, intv.UpperBound)
+        {
+            Contract.Requires(intv != null);
+
+            var list = new List<Interval>();
+
+            if (intv.IsTop)
             {
-              result.RemoveAt(result.Count - 1); // remove the last element
+                state = State.Top;
             }
-            else if (intv.LessEqual(prev))        // The last element we added subsumes the next one
+            else if (intv.IsBottom)
             {
-              goto nextIteration;
-            }
-            else if (prev.OverlapsWith(intv))    // If they are not included by they overlap, we take the join
-            {
-              result.RemoveAt(result.Count - 1);  // remove the last element
-              intv = prev.Join(intv);              
+                state = State.Bottom;
             }
             else
             {
-              refined = false;                    // Done, we cannot do better
+                state = State.Normal;
+
+                list.Add(intv);
             }
-          }
+            intervals = AsReadOnly(list);
+            joinInterval = intv;
         }
-        prev = intv;
-        result.Add(intv);
 
-      nextIteration:
-        ;
-      }
+        private static readonly ReadOnlyIntervalList EmptyReadOnlyList = AsReadOnly(new List<Interval>(0));
 
-      isBottom = bottoms == intervals.Count;
+        private static ReadOnlyIntervalList AsReadOnly(List<Interval> list)
+        {
+            Contract.Requires(list != null);
 
-      return AsReadOnly(result);
+#if DEBUG
+            return list.AsReadOnly();
+#else
+            return list;
+#endif
+        }
+
+        private DisInterval(List<Interval> intervals)
+          : base(Rational.MinusInfinity, Rational.PlusInfinity)
+        {
+            Contract.Requires(intervals != null);
+
+            bool isBottom;
+            this.intervals = Normalize(intervals, out isBottom);
+
+            if (isBottom)
+            {
+                joinInterval = Interval.UnreachedInterval;
+                state = State.Bottom;
+            }
+            else
+            {
+                joinInterval = JoinAll(intervals);
+
+                if (joinInterval.IsBottom)
+                {
+                    state = State.Bottom;
+                }
+                else if (joinInterval.IsTop)
+                {
+                    state = this.intervals.Count <= 1 ? State.Top : State.Normal;
+                }
+                else
+                {
+                    this.lowerBound = joinInterval.LowerBound;
+                    this.upperBound = joinInterval.UpperBound;
+
+                    state = State.Normal;
+                }
+            }
+        }
+
+        private DisInterval(DisInterval original)
+          : base(original.lowerBound, original.upperBound)
+        {
+            Contract.Requires(original != null);
+
+            intervals = original.intervals;
+            joinInterval = original.joinInterval.DuplicateMe();
+            state = original.state;
+        }
+
+        private DisInterval(State state)
+          : base(Rational.MinusInfinity, Rational.PlusInfinity)
+        {
+            Contract.Requires(state != State.Normal);
+
+            this.state = state;
+            joinInterval = this.state == State.Bottom ? Interval.UnreachedInterval : Interval.UnknownInterval;
+            intervals = EmptyReadOnlyList;
+        }
+
+        #endregion
+
+        #region Implementation of the abstract methods
+        public override bool IsInt32
+        {
+            get
+            {
+                if (!this.IsNormal)
+                {
+                    return false;
+                }
+
+                var blow = this.IsLowerBoundMinusInfinity || this.lowerBound >= Int32.MinValue;
+                var bupp = this.IsUpperBoundPlusInfinity || this.upperBound <= Int32.MaxValue;
+
+                return blow && bupp;
+            }
+        }
+
+        public override bool IsInt64
+        {
+            get
+            {
+                if (!this.IsNormal)
+                {
+                    return false;
+                }
+
+                var blow = this.IsLowerBoundMinusInfinity || this.lowerBound >= Int64.MinValue;
+                var bupp = this.IsUpperBoundPlusInfinity || this.upperBound <= Int64.MaxValue;
+
+                return blow && bupp;
+            }
+        }
+
+        public override bool IsLowerBoundMinusInfinity
+        {
+            get
+            {
+                return this.lowerBound.IsMinusInfinity;
+            }
+        }
+
+        public override bool IsUpperBoundPlusInfinity
+        {
+            get
+            {
+                return this.upperBound.IsPlusInfinity;
+            }
+        }
+
+        public override DisInterval Bottom
+        {
+            get
+            {
+                return DisInterval.UnreachedInterval;
+            }
+        }
+
+        static public DisInterval IntervalUnknown
+        {
+            get
+            {
+                return DisInterval.UnknownInterval;
+            }
+        }
+
+        public override DisInterval Top
+        {
+            get
+            {
+                return DisInterval.UnknownInterval;
+            }
+        }
+
+        public override bool IsNormal
+        {
+            get
+            {
+                return state == State.Normal;
+            }
+        }
+
+        public bool IsNotZero
+        {
+            get
+            {
+                if (!this.IsNormal)
+                {
+                    return false;
+                }
+
+                foreach (var intv in intervals)
+                {
+                    if (intv.DoesInclude(0))
+                        return false;
+                }
+
+                return true;
+            }
+        }
+
+        public bool IsZero
+        {
+            get
+            {
+                if (!this.IsNormal)
+                {
+                    return false;
+                }
+                Rational value;
+                if (this.TryGetSingletonValue(out value) && value.IsZero)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public bool IsPositiveOrZero
+        {
+            get
+            {
+                if (this.IsNormal)
+                {
+                    Int64 lower;
+                    return this.LowerBound.TryInt64(out lower) && lower >= 0;
+                }
+
+                return false;
+            }
+        }
+
+        public bool IsNegativeOrZero
+        {
+            get
+            {
+                if (this.IsNormal)
+                {
+                    Int64 upper;
+                    return this.UpperBound.TryInt64(out upper) && upper <= 0;
+                }
+
+                return false;
+            }
+        }
+
+
+        public override bool IsBottom
+        {
+            get
+            {
+                return state == State.Bottom;
+            }
+        }
+
+        public override bool IsTop
+        {
+            get
+            {
+                return state == State.Top;
+            }
+        }
+
+        #endregion
+
+        #region Abstract domain operators
+        public override bool LessEqual(DisInterval a)
+        {
+            bool trivial;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out trivial))
+            {
+                return trivial;
+            }
+
+            if (!joinInterval.LessEqual(a.joinInterval))
+            {
+                return false;
+            }
+
+            var lastRight = 0;
+
+            for (var i = 0; i < intervals.Count; i++)
+            {
+                for (; lastRight < a.intervals.Count; lastRight++)
+                {
+                    if (intervals[i].LessEqual(a.intervals[lastRight]))
+                    {
+                        goto next;
+                    }
+                }
+
+                return false; // If we reach this point, we were unable to find un upper interval in right, so we return false
+
+            next:
+                ;
+            }
+
+            return true;
+        }
+
+        public override DisInterval Join(DisInterval a)
+        {
+            DisInterval trivial;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivial))
+            {
+                return trivial;
+            }
+
+            var joinIntervals = Join(intervals, a.intervals);
+
+            if (joinIntervals.Count == 0)
+            {
+                return Top;
+            }
+
+            return new DisInterval(joinIntervals);
+        }
+
+        public override DisInterval Meet(DisInterval a)
+        {
+            DisInterval trivial;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivial))
+            {
+                return trivial;
+            }
+
+            bool isBottom;
+            var meetIntervals = Meet(intervals, a.intervals, out isBottom);
+
+            if (isBottom)
+            {
+                return Bottom;
+            }
+            if (meetIntervals.Count == 0)
+            {
+                return Top;
+            }
+
+            return new DisInterval(meetIntervals);
+        }
+
+        public override DisInterval Widening(DisInterval prev)
+        {
+            if (this.IsTop || prev.IsTop)
+            {
+                return Top;
+            }
+
+            var widenIntervals = Widening(intervals, prev.intervals);
+
+            return new DisInterval(widenIntervals);
+        }
+
+        public override DisInterval DuplicateMe()
+        {
+            return new DisInterval(this);
+        }
+        #endregion
+
+        #region Arithmetic operations on DisIntervals
+
+        private delegate Interval IntervalBinOp(Interval left, Interval right);
+
+        static private DisInterval OperatorLifting(DisInterval left, DisInterval right, IntervalBinOp binop, bool propagateTop)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Requires(binop != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            if (left.IsBottom || right.IsBottom)    // Propagate bottom
+            {
+                return UnreachedInterval;
+            }
+
+            if (propagateTop && (left.IsTop || right.IsTop))          // Propagate top
+            {
+                return UnknownInterval;
+            }
+
+            if (left.IsTop && right.IsTop)
+            {
+                return UnknownInterval;
+            }
+
+            Contract.Assume(left.intervals != null);
+            Contract.Assume(right.intervals != null);
+
+            var result = new List<Interval>(left.intervals.Count + right.intervals.Count);
+
+            bool isBottom = true;
+
+            if (propagateTop || (left.IsNormal && right.IsNormal))
+            {
+                for (var i = 0; i < left.intervals.Count; i++)
+                {
+                    var intvLeft = left.intervals[i];
+
+                    for (var j = 0; j < right.intervals.Count; j++)
+                    {
+                        var opResult = binop(intvLeft, right.intervals[j]);
+                        if (opResult.IsTop)
+                        {
+                            return left.Top;
+                        }
+
+                        if (opResult.IsBottom)
+                        {
+                            continue;
+                        }
+
+                        isBottom = false;
+                        result.Add(opResult);
+                    }
+                }
+            }
+            else
+            {
+                var nonTopArgument = left.IsTop ? right : left;
+                var nonTopIsLeft = !left.IsTop;
+
+                for (var i = 0; i < nonTopArgument.intervals.Count; i++)
+                {
+                    var opResult = nonTopIsLeft ?
+                      binop(nonTopArgument.intervals[i], Interval.UnknownInterval) :
+                      binop(Interval.UnknownInterval, nonTopArgument.intervals[i]);
+
+                    if (opResult.IsTop)
+                    {
+                        return UnknownInterval;
+                    }
+                    if (opResult.IsBottom)
+                    {
+                        continue;
+                    }
+
+                    isBottom = false;
+                    result.Add(opResult);
+                }
+            }
+
+            return isBottom ? DisInterval.UnreachedInterval : new DisInterval(result);
+        }
+
+        static public DisInterval operator +(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a + b, true);
+        }
+
+        static public DisInterval operator -(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a - b, true);
+        }
+
+        static public DisInterval operator -(DisInterval left)
+        {
+            Contract.Requires(left != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            if (left.IsBottom || left.IsTop)
+            {
+                return left;
+            }
+
+            var result = new List<Interval>();
+            for (var i = 0; i < left.intervals.Count; i++)
+            {
+                result.Add(-left.intervals[i]);
+            }
+
+            result.Reverse();
+            return new DisInterval(result);
+        }
+
+        static public DisInterval operator *(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a * b, true);
+        }
+
+        static public DisInterval operator /(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a / b, true);
+        }
+
+        static public DisInterval operator %(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a % b, false);
+        }
+
+        static public DisInterval operator &(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a & b, false);
+        }
+
+        static public DisInterval operator |(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a | b, true);
+        }
+
+        static public DisInterval operator ^(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, (a, b) => a ^ b, true);
+        }
+
+        static public DisInterval ShiftLeft(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, Interval.ShiftLeft, true);
+        }
+
+        static public DisInterval ShiftRight(DisInterval left, DisInterval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return OperatorLifting(left, right, Interval.ShiftRight, true);
+        }
+
+        #endregion
+
+        #region Conversion
+
+        public override DisInterval ToUnsigned()
+        {
+            if (this.IsNormal)
+            {
+                var result = new List<Interval>(intervals.Count);
+
+                foreach (var x in intervals)
+                {
+                    result.Add(x.ToUnsigned());
+                }
+
+                return new DisInterval(result);
+            }
+
+            return this;
+        }
+
+        public Interval AsInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval>() != null);
+
+                return joinInterval;
+            }
+        }
+        #endregion
+
+        #region Map
+
+        public DisInterval Map(Func<Interval, Interval> f)
+        {
+            Contract.Requires(f != null);
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            if (this.IsBottom)
+            {
+                return this;
+            }
+
+            if (this.IsTop)
+            {
+                return new DisInterval(f(Interval.UnknownInterval));
+            }
+
+            var result = new List<Interval>();
+            for (var i = 0; i < intervals.Count; i++)
+            {
+                var res = f(intervals[i]);
+
+                if (res.IsBottom)
+                {
+                    return this.Bottom;
+                }
+                if (res.IsTop)
+                {
+                    return this.Top;
+                }
+                result.Add(res);
+            }
+
+            return new DisInterval(result);
+        }
+
+        #endregion
+
+        #region Utils
+
+        static private ReadOnlyIntervalList Normalize(List<Interval> intervals, out bool isBottom)
+        {
+            Contract.Requires(intervals != null);
+
+            Contract.Ensures(Contract.Result<ReadOnlyIntervalList>() != null);
+
+            if (intervals.Count <= 1)
+            {
+                isBottom = false;
+                return AsReadOnly(intervals);
+            }
+
+            intervals.Sort((a, b) =>
+              a.Equals(b) ?
+              0 :
+             (a.UpperBound <= b.LowerBound ? -1 : 1));
+
+            var result = new List<Interval>(intervals.Count);
+            var bottoms = 0;
+
+            var prev = null as Interval;
+
+            for (var i = 0; i < intervals.Count; i++)
+            {
+                var intv = intervals[i];
+
+                // Skip repetitions
+                if (prev == intv)
+                {
+                    continue;
+                }
+
+                if (intv.IsBottom)
+                {
+                    bottoms++;
+
+                    continue;
+                }
+
+                if (intv.IsTop)
+                {
+                    isBottom = false;
+
+                    return EmptyReadOnlyList;
+                }
+
+                if (prev != null)
+                {
+                    var refined = true;
+                    while (refined && result.Count > 0)
+                    {
+                        prev = result[result.Count - 1];
+
+                        if (Interval.AreConsecutiveIntegers(prev, intv))         // The intervals are consecutive, so we join them together
+                        {
+                            result.RemoveAt(result.Count - 1);  // remove the last element
+                            intv = prev.Join(intv);
+                        }
+                        else if (prev.LessEqual(intv))        // The last element we added is subsumed by the next one
+                        {
+                            result.RemoveAt(result.Count - 1); // remove the last element
+                        }
+                        else if (intv.LessEqual(prev))        // The last element we added subsumes the next one
+                        {
+                            goto nextIteration;
+                        }
+                        else if (prev.OverlapsWith(intv))    // If they are not included by they overlap, we take the join
+                        {
+                            result.RemoveAt(result.Count - 1);  // remove the last element
+                            intv = prev.Join(intv);
+                        }
+                        else
+                        {
+                            refined = false;                    // Done, we cannot do better
+                        }
+                    }
+                }
+                prev = intv;
+                result.Add(intv);
+
+            nextIteration:
+                ;
+            }
+
+            isBottom = bottoms == intervals.Count;
+
+            return AsReadOnly(result);
+        }
+
+        static private Interval JoinAll(List<Interval> list)
+        {
+            Contract.Requires(list != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (list.Count == 0)
+            {
+                return Interval.UnknownInterval;
+            }
+
+            var result = list[0];
+
+            for (var i = 1; i < list.Count; i++)
+            {
+                result = result.Join(list[i]);
+            }
+
+            return result;
+        }
+
+        static private List<Interval> Join(ReadOnlyIntervalList left, ReadOnlyIntervalList right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<List<Interval>>() != null);
+
+            var result = new List<Interval>(left.Count + right.Count);
+
+            var i = 0;
+            var j = 0;
+
+            while (i < left.Count && j < right.Count)
+            {
+                var leftIntv = left[i];
+                var rigthIntv = right[j];
+
+                if (leftIntv.IsTop || rigthIntv.IsTop)
+                {
+                    return new List<Interval>();  // Top
+                }
+
+                // Consume bottoms
+                if (leftIntv.IsBottom)
+                {
+                    i++;
+
+                    continue;
+                }
+
+                if (rigthIntv.IsBottom)
+                {
+                    j++;
+
+                    continue;
+                }
+
+                // Check for inclusion
+                if (leftIntv.LessEqual(rigthIntv))
+                {
+                    result.Add(rigthIntv);
+                    i++; j++;
+
+                    continue;
+                }
+
+                if (rigthIntv.LessEqual(leftIntv))
+                {
+                    result.Add(leftIntv);
+                    i++; j++;
+
+                    continue;
+                }
+
+                // Check if the intervals overlap or touch
+                if (rigthIntv.OverlapsWith(leftIntv))
+                {
+                    result.Add(rigthIntv.Join(leftIntv));
+                    i++; j++;
+
+                    continue;
+                }
+
+                // Add the leftmost interval
+                if (leftIntv.OnTheLeftOf(rigthIntv))
+                {
+                    result.Add(leftIntv);
+                    i++;
+
+                    continue;
+                }
+
+                if (rigthIntv.OnTheLeftOf(leftIntv)) // F: should always be the case at this point
+                {
+                    result.Add(rigthIntv);
+                    j++;
+
+                    continue;
+                }
+            }
+
+            while (i < left.Count)
+            {
+                result.Add(left[i]);
+                i++;
+            }
+
+            while (j < right.Count)
+            {
+                result.Add(right[j]);
+                j++;
+            }
+
+            return result;
+        }
+
+        static private List<Interval> Meet(ReadOnlyIntervalList left, ReadOnlyIntervalList right, out bool isBottom)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<List<Interval>>() != null);
+
+            isBottom = true;
+
+            var result = new List<Interval>();
+
+            for (var i = 0; i < left.Count; i++)
+            {
+                var leftIntv = left[i];
+                for (var j = 0; j < right.Count; j++)
+                {
+                    var meet = leftIntv.Meet(right[j]);
+                    if (meet.IsNormal)
+                    {
+                        isBottom = false;
+                        result.Add(meet);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        static private List<Interval> Widening(ReadOnlyIntervalList next, ReadOnlyIntervalList prev)
+        {
+            Contract.Requires(next != null);
+            Contract.Requires(prev != null);
+
+            Contract.Ensures(Contract.Result<List<Interval>>() != null);
+
+            // One of the two is top
+            if (next.Count == 0 || prev.Count == 0)
+            {
+                return new List<Interval>();
+            }
+
+            // Boths are one interval
+            if (next.Count == 1 && prev.Count == 1)
+            {
+                var intv = next[0].Widening(prev[0]);
+
+                return new List<Interval>() { intv };
+            }
+
+            // One of the two contains just one interval
+            if (next.Count == 1 && prev.Count > 1)
+            {
+                if (next[0].LessEqual(prev))
+                {
+                    return new List<Interval>(prev);
+                }
+
+                var intv = next[0].Widening(prev[0].Join(prev[prev.Count - 1]));
+
+                return new List<Interval>() { intv };
+            }
+
+            if (next.Count > 1 && prev.Count == 1)
+            {
+                var intv = (next[0].Join(next[next.Count - 1]).Widening(prev[0]));
+
+                return new List<Interval>() { intv };
+            }
+
+            Contract.Assert(next.Count >= 2);
+            Contract.Assert(prev.Count >= 2);
+
+            // We widen the extremes, and keep the internal intervals which are stable among two iterations           
+            var leftMostInterval = next[0].Widening(prev[0]);
+            var rightMostInterval = next[next.Count - 1].Widening(prev[prev.Count - 1]);
+
+            var result = new List<Interval>();
+
+            result.Add(leftMostInterval);
+
+            for (var j = 1; j < prev.Count - 1; j++)
+            {
+                for (var i = 1; i < next.Count - 1; i++)
+                {
+                    if (next[i].LessEqual(prev[j]))
+                    {
+                        result.Add(prev[j]);
+
+                        break;
+                    }
+                }
+            }
+
+            result.Add(rightMostInterval);
+
+            return result;
+        }
+
+        [Pure]
+        [ContractVerification(false)] // This method is only for checking
+        private bool CheckInvariant()
+        {
+            if (this.IsBottom || this.IsTop)
+            {
+                return true;
+            }
+
+            for (var i = 0; i < intervals.Count - 1; i++)
+            {
+                if (intervals[i].UpperBound > intervals[i + 1].LowerBound)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        #endregion
+
+        #region Statics
+
+        public static DisInterval UnknownInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+                return cachedTop;
+            }
+        }
+
+        public static DisInterval UnreachedInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+                return cachedBottom;
+            }
+        }
+
+        public static DisInterval Zero
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+                return cachedZero;
+            }
+        }
+
+        public static DisInterval NotZero
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+                return cachedNotZero;
+            }
+        }
+
+        public static DisInterval Positive
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+                return cachedPositive;
+            }
+        }
+
+        public static DisInterval Negative
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+                return cachedNegative;
+            }
+        }
+
+
+        #endregion
+
+        #region To
+
+        public override T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.IdentityForOr; // false
+            if (this.IsTop)
+                return factory.IdentityForAnd; // true
+            T name;
+            if (factory.TryGetName(out name))
+            {
+                // special cases for 0 and !=0 , as they are so common
+                if (this.IsNotZero)
+                {
+                    return factory.NotEqualTo(name, factory.Constant(0));
+                }
+                else if (this.IsZero)
+                {
+                    return factory.EqualTo(name, factory.Constant(0));
+                }
+                else
+                {
+                    if (this.AsInterval.IsNormal)
+                    {
+                        return this.AsInterval.To(factory);
+                    }
+                }
+            }
+
+            return factory.IdentityForAnd;
+        }
+
+        #endregion
+
+        #region ToSting, Equals, GetHashCode
+
+        public override string ToString()
+        {
+            if (this.IsTop)
+                return "Top";
+
+            if (this.IsBottom)
+                return "_|_";
+
+            if (intervals.Count == 1)
+            {
+                return intervals[0].ToString();
+            }
+
+            return string.Format("({0})", ToString(intervals));
+        }
+
+        private string ToString(ReadOnlyIntervalList roCollection)
+        {
+            if (roCollection == null)
+            {
+                return "null";
+            }
+            var result = new StringBuilder();
+            var count = 0;
+
+            foreach (var itv in roCollection)
+            {
+                if (count != roCollection.Count - 1)
+                {
+                    result.Append(itv + " ");
+                }
+                else
+                {
+                    result.Append(itv.ToString());
+                }
+
+                count++;
+            }
+
+            return result.ToString();
+        }
+
+        [ContractVerification(true)]
+        public override bool Equals(object obj)
+        {
+            if (Object.ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            var other = obj as DisInterval;
+            if (other == null)
+            {
+                // it can be an interval
+                var otherAsIntv = obj as Interval;
+                if (otherAsIntv != null)
+                {
+                    return this.Equals(DisInterval.For(otherAsIntv));
+                }
+
+                return false;
+            }
+
+
+            Contract.Assume(other.intervals != null, "Assuming the object invariant of the other");
+
+            return state == other.state && joinInterval.Equals(other.joinInterval) && HaveSameIntervals(intervals, other.intervals);
+        }
+
+        [Pure]
+        private static bool HaveSameIntervals(ReadOnlyIntervalList left, ReadOnlyIntervalList right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            if (left.Count != right.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < left.Count; i++)
+            {
+                if (!left[i].Equals(right[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return state.GetHashCode() + joinInterval.GetHashCode();
+        }
+        #endregion
+
+        static public class Ranges
+        {
+            private static readonly DisInterval uint8Range = DisInterval.For(Interval.Ranges.UInt8Range);
+            private static readonly DisInterval uint16Range = DisInterval.For(Interval.Ranges.UInt16Range);
+            private static readonly DisInterval uint32Range = DisInterval.For(Interval.Ranges.UInt32Range);
+            private static readonly DisInterval uint64Range = DisInterval.For(Interval.Ranges.UInt64Range);
+
+            private static readonly DisInterval int8Range = DisInterval.For(Interval.Ranges.Int8Range);
+            private static readonly DisInterval int16Range = DisInterval.For(Interval.Ranges.Int16Range);
+            private static readonly DisInterval int32Range = DisInterval.For(Interval.Ranges.Int32Range);
+            private static readonly DisInterval int64Range = DisInterval.For(Interval.Ranges.Int64Range);
+
+            public static DisInterval UInt8Range
+            {
+                get
+                {
+                    return uint8Range;
+                }
+            }
+
+            public static DisInterval UInt16Range
+            {
+                get
+                {
+                    return uint16Range;
+                }
+            }
+
+            public static DisInterval UInt32Range
+            {
+                get
+                {
+                    return uint32Range;
+                }
+            }
+
+            public static DisInterval UInt64Range
+            {
+                get
+                {
+                    return uint64Range;
+                }
+            }
+
+            public static DisInterval Int8Range
+            {
+                get
+                {
+                    return int8Range;
+                }
+            }
+
+            public static DisInterval Int16Range
+            {
+                get
+                {
+                    return int16Range;
+                }
+            }
+
+            public static DisInterval Int32Range
+            {
+                get
+                {
+                    return int32Range;
+                }
+            }
+
+            public static DisInterval Int64Range
+            {
+                get
+                {
+                    return int64Range;
+                }
+            }
+
+            public static DisInterval EnumValues<Type>(Type t, Func<Type, List<int>> enumranges)
+            {
+                var ranges = enumranges(t);
+                if (ranges != null)
+                {
+                    return DisInterval.For(ranges.ConvertAll<Interval>(x => Interval.For(x)));
+                }
+
+                return Ranges.Int32Range;
+            }
+        }
     }
-
-    static private Interval JoinAll(List<Interval> list)
-    {
-      Contract.Requires(list != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (list.Count == 0)
-      {
-        return Interval.UnknownInterval;
-      }
-
-      var result = list[0];
-
-      for (var i = 1; i < list.Count; i++)
-      {
-        result = result.Join(list[i]);
-      }
-
-      return result;
-    }
-
-    static private List<Interval> Join(ReadOnlyIntervalList left, ReadOnlyIntervalList right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<List<Interval>>() != null);
-
-      var result = new List<Interval>(left.Count + right.Count);
-
-      var i = 0;
-      var j = 0;
-
-      while (i < left.Count && j < right.Count)
-      {
-        var leftIntv = left[i];
-        var rigthIntv = right[j];
-
-        if (leftIntv.IsTop || rigthIntv.IsTop)
-        {
-          return new List<Interval>();  // Top
-        }
-
-        // Consume bottoms
-        if (leftIntv.IsBottom)
-        {
-          i++;
-
-          continue;
-        }
-
-        if (rigthIntv.IsBottom)
-        {
-          j++;
-
-          continue;
-        }
-
-        // Check for inclusion
-        if (leftIntv.LessEqual(rigthIntv))
-        {
-          result.Add(rigthIntv);
-          i++; j++; 
-
-          continue;
-        }
-
-        if (rigthIntv.LessEqual(leftIntv))
-        {
-          result.Add(leftIntv);
-          i++; j++; 
-
-          continue;
-        }
-
-        // Check if the intervals overlap or touch
-        if (rigthIntv.OverlapsWith(leftIntv))
-        {
-          result.Add(rigthIntv.Join(leftIntv));
-          i++; j++; 
-
-          continue;
-        }
-
-        // Add the leftmost interval
-        if (leftIntv.OnTheLeftOf(rigthIntv))
-        {
-          result.Add(leftIntv);
-          i++;
-
-          continue;
-        }
-
-        if (rigthIntv.OnTheLeftOf(leftIntv)) // F: should always be the case at this point
-        {
-          result.Add(rigthIntv);
-          j++; 
-
-          continue;
-        }
-      }
-
-      while (i < left.Count)
-      {
-        result.Add(left[i]);
-        i++; 
-      }
-
-      while (j < right.Count)
-      {
-        result.Add(right[j]);
-        j++; 
-      }
-
-      return result;
-    }
-
-    static private List<Interval> Meet(ReadOnlyIntervalList left, ReadOnlyIntervalList right, out bool isBottom)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<List<Interval>>() != null);
-
-      isBottom = true;
-
-      var result = new List<Interval>();
-
-      for (var i = 0; i < left.Count; i++)
-      {
-        var leftIntv = left[i];
-        for (var j = 0; j < right.Count; j++)
-        {
-          var meet = leftIntv.Meet(right[j]);
-          if (meet.IsNormal)
-          {
-            isBottom = false;
-            result.Add(meet);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    static private List<Interval> Widening(ReadOnlyIntervalList next, ReadOnlyIntervalList prev)
-    {
-      Contract.Requires(next != null);
-      Contract.Requires(prev != null);
-
-      Contract.Ensures(Contract.Result<List<Interval>>() != null);
-
-      // One of the two is top
-      if (next.Count == 0 || prev.Count == 0)
-      {
-        return new List<Interval>();
-      }
-
-      // Boths are one interval
-      if (next.Count == 1 && prev.Count == 1)
-      {
-        var intv = next[0].Widening(prev[0]);
-
-        return new List<Interval>() { intv };
-      }
-
-      // One of the two contains just one interval
-      if (next.Count == 1 && prev.Count > 1)
-      {
-        if (next[0].LessEqual(prev))
-        {
-          return new List<Interval>(prev);
-        }
-
-        var intv = next[0].Widening(prev[0].Join(prev[prev.Count - 1]));
-
-        return new List<Interval>() { intv };
-      }
-
-      if (next.Count > 1 && prev.Count == 1)
-      {
-        var intv = (next[0].Join(next[next.Count - 1]).Widening(prev[0]));
-
-        return new List<Interval>() { intv };
-      }
-
-      Contract.Assert(next.Count >= 2);
-      Contract.Assert(prev.Count >= 2);
-
-      // We widen the extremes, and keep the internal intervals which are stable among two iterations           
-      var leftMostInterval = next[0].Widening(prev[0]);
-      var rightMostInterval = next[next.Count - 1].Widening(prev[prev.Count - 1]);
-
-      var result = new List<Interval>();
-      
-      result.Add(leftMostInterval);
-
-      for (var j = 1; j < prev.Count-1; j++)
-      {
-        for (var i = 1; i < next.Count-1; i++)
-        {
-          if (next[i].LessEqual(prev[j]))
-          {
-            result.Add(prev[j]);
-
-            break;
-          }
-        }
-      }
-
-      result.Add(rightMostInterval);
-
-      return result;
-    }
-
-    [Pure]
-    [ContractVerification(false)] // This method is only for checking
-    private bool CheckInvariant()
-    {
-      if (this.IsBottom || this.IsTop)
-      {
-        return true;
-      }
-
-      for (var i = 0; i < intervals.Count - 1; i++)
-      {
-        if (intervals[i].UpperBound > intervals[i + 1].LowerBound)
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    #endregion
-
-    #region Statics
-
-    public static DisInterval UnknownInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return cachedTop;
-      }
-    }
-
-    public static DisInterval UnreachedInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return cachedBottom;
-      }
-    }
-
-    public static DisInterval Zero
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return cachedZero;
-      }
-    }
-
-    public static DisInterval NotZero
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return cachedNotZero;
-      }
-    }
-
-    public static DisInterval Positive
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return cachedPositive;
-      }
-    }
-
-    public static DisInterval Negative
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return cachedNegative;
-      }
-    }
-
-
-    #endregion
-
-    #region To
-
-    public override T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.IdentityForOr; // false
-      if (this.IsTop)
-        return factory.IdentityForAnd; // true
-      T name;
-      if (factory.TryGetName(out name))
-      {
-        // special cases for 0 and !=0 , as they are so common
-        if (this.IsNotZero) 
-        {
-          return factory.NotEqualTo(name, factory.Constant(0));
-        }
-        else if(this.IsZero)
-        {
-          return factory.EqualTo(name, factory.Constant(0));
-        }
-        else 
-        {
-          if (this.AsInterval.IsNormal)
-          {
-            return this.AsInterval.To(factory);
-          }
-        }
-      }
-
-      return factory.IdentityForAnd;
-    }
-    
-    #endregion
-
-    #region ToSting, Equals, GetHashCode
-
-    public override string ToString()
-    {
-      if(this.IsTop)
-        return "Top";
-
-      if(this.IsBottom)
-        return "_|_";
-
-      if (this.intervals.Count == 1)
-      {
-        return this.intervals[0].ToString();
-      }
-
-      return string.Format("({0})", ToString(this.intervals));      
-    }
-
-    private string ToString(ReadOnlyIntervalList roCollection)
-    {
-      if (roCollection == null)
-      {
-        return "null";
-      }
-      var result = new StringBuilder();
-      var count = 0;
-
-      foreach(var itv in roCollection)
-      {
-        if (count != roCollection.Count - 1)
-        {
-          result.Append(itv + " ");
-        }
-        else
-        {
-          result.Append(itv.ToString());
-        }
-
-        count++;
-      }
-
-      return result.ToString();
-    }
-
-    [ContractVerification(true)]
-    public override bool Equals(object obj)
-    {
-      if (Object.ReferenceEquals(this, obj))
-      {
-        return true;
-      }
-
-      var other = obj as DisInterval;
-      if (other == null)
-      {
-        // it can be an interval
-        var otherAsIntv = obj as Interval;
-        if (otherAsIntv != null)
-        {
-          return this.Equals(DisInterval.For(otherAsIntv));
-        }
-
-        return false;
-      }
-
-
-      Contract.Assume(other.intervals != null, "Assuming the object invariant of the other");
-
-      return this.state == other.state && this.joinInterval.Equals(other.joinInterval) && HaveSameIntervals(this.intervals, other.intervals);
-    }
-
-    [Pure]
-    private static bool HaveSameIntervals(ReadOnlyIntervalList left, ReadOnlyIntervalList right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      if (left.Count != right.Count)
-      {
-        return false;
-      }
-
-      for (var i = 0; i < left.Count; i++)
-      {
-        if (!left[i].Equals(right[i]))
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    public override int GetHashCode()
-    {
-      return this.state.GetHashCode() + this.joinInterval.GetHashCode();
-    }
-    #endregion
-
-    static public class Ranges
-    {
-      private static readonly DisInterval uint8Range = DisInterval.For(Interval.Ranges.UInt8Range);
-      private static readonly DisInterval uint16Range = DisInterval.For(Interval.Ranges.UInt16Range);
-      private static readonly DisInterval uint32Range = DisInterval.For(Interval.Ranges.UInt32Range);
-      private static readonly DisInterval uint64Range = DisInterval.For(Interval.Ranges.UInt64Range);
-
-      private static readonly DisInterval int8Range = DisInterval.For(Interval.Ranges.Int8Range);
-      private static readonly DisInterval int16Range = DisInterval.For(Interval.Ranges.Int16Range);
-      private static readonly DisInterval int32Range = DisInterval.For(Interval.Ranges.Int32Range);
-      private static readonly DisInterval int64Range = DisInterval.For(Interval.Ranges.Int64Range);
-
-      public static DisInterval UInt8Range
-      {
-        get
-        {
-          return uint8Range;
-        }
-      }
-
-      public static DisInterval UInt16Range
-      {
-        get
-        {
-          return uint16Range;
-        }
-      }
-
-      public static DisInterval UInt32Range
-      {
-        get
-        {
-          return uint32Range;
-        }
-      }
-
-      public static DisInterval UInt64Range
-      {
-        get
-        {
-          return uint64Range;
-        }
-      }
-
-      public static DisInterval Int8Range
-      {
-        get
-        {
-          return int8Range;
-        }
-      }
-
-      public static DisInterval Int16Range
-      {
-        get
-        {
-          return int16Range;
-        }
-      }
-
-      public static DisInterval Int32Range
-      {
-        get
-        {
-          return int32Range;
-        }
-      }
-
-      public static DisInterval Int64Range
-      {
-        get
-        {
-          return int64Range;
-        }
-      }
-
-      public static DisInterval EnumValues<Type>(Type t, Func<Type, List<int>> enumranges)
-      {
-        var ranges = enumranges(t);
-        if (ranges != null)
-        {
-          return DisInterval.For(ranges.ConvertAll<Interval>(x => Interval.For(x)));
-        }
-
-        return Ranges.Int32Range;
-      }
-    }
-
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalConstraintsInference.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalConstraintsInference.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,914 +10,911 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  public static class IntervalInference
-  {
-    /// <summary>
-    /// left \lt k
-    /// </summary>
-    static public bool TryRefine_LeftLessThanK<Variable, Expression, IType>(
-      bool isSigned, Variable left, IType k,
-      ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery, out IType refinedIntv)
-      where IType : IntervalBase<IType, Rational>
+    public static class IntervalInference
     {
-      var result = new List<Pair<Variable, IType>>();
-
-      if (k.IsNormal)
-      {
-        var upperBound = k.UpperBound.IsInteger ? k.UpperBound - 1 : k.UpperBound;
-        var LessEquanThanK = iquery.IntervalLeftOpen(upperBound);
-
-        IType oldValueForLeft;
-        if (iquery.TryGetValue(left, isSigned, out oldValueForLeft))
+        /// <summary>
+        /// left \lt k
+        /// </summary>
+        static public bool TryRefine_LeftLessThanK<Variable, Expression, IType>(
+          bool isSigned, Variable left, IType k,
+          ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery, out IType refinedIntv)
+          where IType : IntervalBase<IType, Rational>
         {
-          refinedIntv = oldValueForLeft.Meet(LessEquanThanK);
-        }
-        else
-        {
-          refinedIntv = LessEquanThanK;
-        }
+            var result = new List<Pair<Variable, IType>>();
 
-        return true;
-      }
-
-      refinedIntv = default(IType);
-      return false;
-    }
-
-    static public bool TryRefine_KLessThanRight<Variable, Expression, IType>(
-      bool isSigned, IType k, Variable right,
-      Rational succ,
-      ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery, out IType refinedIntv)
-      where IType : IntervalBase<IType, Rational>
-    {
-      if (k.IsNormal)
-      {
-        var lowerBound = k.LowerBound.IsInteger ? k.LowerBound.NextInt32 + succ : k.LowerBound;
-        var GreaterThanK = iquery.IntervalRightOpen(lowerBound);
-
-        IType oldValueForRight;
-        if (iquery.TryGetValue(right, isSigned, out oldValueForRight))
-        {
-          refinedIntv = oldValueForRight.Meet(GreaterThanK);
-        }
-        else
-        {
-          refinedIntv = GreaterThanK;
-        }
-
-        return true;
-      }
-
-      refinedIntv = default(IType);
-      return false;
-    }
-
-    static public bool TryRefine_KLessEqualThanRight<Variable, Expression, NType, IType>(
-      bool isSigned, IType k, Variable right,
-      ISetOfNumbersAbstraction<Variable, Expression, NType, IType> iquery, out IType refinedIntv)
-      where IType : IntervalBase<IType, NType>
-    {
-      if (k.IsNormal)
-      {
-        var GreaterThanK = iquery.IntervalRightOpen(k.LowerBound);
-
-        IType oldValueForRight;
-        if (iquery.TryGetValue(right, isSigned, out oldValueForRight))
-        {
-          refinedIntv = oldValueForRight.Meet(GreaterThanK);
-        }
-        else
-        {
-          refinedIntv = GreaterThanK;
-        }
-
-        return true;
-      }
-
-      refinedIntv = default(IType);
-      return false;
-    }
-
-    static public bool TryRefine_LeftLessEqualThanK<Variable, Expression, NType, IType>(
-      bool isSigned, Variable left, IType k,
-      ISetOfNumbersAbstraction<Variable, Expression, NType, IType> iquery, out IType refinedIntv)
-      where IType : IntervalBase<IType, NType>
-    {
-      if (k.IsNormal)
-      {
-        var LessEquanThanK = iquery.IntervalLeftOpen(k.UpperBound);
-
-        IType oldValueForLeft;
-        if (iquery.TryGetValue(left, isSigned, out oldValueForLeft))
-        {
-          refinedIntv = oldValueForLeft.Meet(LessEquanThanK);
-        }
-        else
-        {
-          refinedIntv = LessEquanThanK;
-        }
-
-        return true;
-      }
-
-      refinedIntv = default(IType);
-      return false;
-    }
-
-    /// <summary>
-    /// Infer exp \in [0, +oo], and if exp is a compound expression also some other constraints
-    /// </summary>
-    static public List<Pair<Variable, IType>> InferConstraints_GeqZero<Variable, Expression, IType>(
-      Expression exp, IExpressionDecoder<Variable, Expression> decoder,
-      ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery)
-      where IType : IntervalBase<IType, Rational>
-    {
-      Contract.Requires(decoder != null);
-      Contract.Requires(iquery != null);
-
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
-
-      var result = new List<Pair<Variable, IType>>();
-
-      var expVar = decoder.UnderlyingVariable(exp);
-
-      result.Add(expVar, iquery.Eval(exp).Meet(iquery.Interval_Positive));
-
-      if (!decoder.IsVariable(exp))
-      {
-        Polynomial<Variable, Expression> zero; // = 0
-
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[] { new Monomial<Variable>(0) }, out zero))
-        {
-          throw new AbstractInterpretationException("It can never be the case that the conversion of a list of monomials into a polynomial fails");
-        }
-
-        Polynomial<Variable, Expression> expAsPolynomial, newPolynomial;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, decoder, out expAsPolynomial)
-          && Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, zero, expAsPolynomial, out newPolynomial)) // 0 <= exp
-        {
-          if (newPolynomial.IsIntervalForm)
-          {  // if it is in the form of k1 * x <= k2 
-            var k1 = newPolynomial.Left[0].K;
-            var x = newPolynomial.Left[0].VariableAt(0);
-
-            var k2 = newPolynomial.Right[0].K;
-
-            Rational bound;
-            if (Rational.TryDiv(k2, k1, out bound)) //var bound = k2 / k1;
+            if (k.IsNormal)
             {
-              if (k1 > 0)
-              {
-                var intv = iquery.Eval(x).Meet(iquery.IntervalLeftOpen(bound));
-                result.Add(x, intv);
-              }
-              else if (k1 < 0)
-              {
-                var intv = iquery.Eval(x).Meet(iquery.IntervalRightOpen(bound));
-                result.Add(x, intv);
-              }
-              else
-              {
-                throw new AbstractInterpretationException("Impossible case");
-              }
-            }
-          }
+                var upperBound = k.UpperBound.IsInteger ? k.UpperBound - 1 : k.UpperBound;
+                var LessEquanThanK = iquery.IntervalLeftOpen(upperBound);
 
-        }
-      }
-
-      return result;
-    }
-
-    static public List<Pair<Variable, IType>> InferConstraints_Leq<Variable, Expression, IType>(
-      bool isSignedComparison,
-      Expression left, Expression right,
-       IExpressionDecoder<Variable, Expression> decoder,
-       ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
-      out bool isBottom)
-    where IType : IntervalBase<IType, Rational>
-    {
-      Contract.Requires(iquery != null);
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
-
-      isBottom = false;   // false, unless someine proves the contrary
-
-      var result = new List<Pair<Variable, IType>>();
-
-      if (IsFloat(left, decoder) || IsFloat(right, decoder))
-      {
-        return result;
-      }
-
-      var kLeft = iquery.Eval(left);
-      var kRight = iquery.Eval(right);
-
-      // We have to take into account the polymorphism of constants
-      if (!isSignedComparison)
-      {
-        kLeft = kLeft.ToUnsigned();
-        kRight = kRight.ToUnsigned();
-      }
-
-      //AssumeKLessEqualThanRight(kLeft, this.Decoder.UnderlyingVariable(right))
-
-      IType refinedIntv;
-      var rightVar = decoder.UnderlyingVariable(right);
-      if (IntervalInference.TryRefine_KLessEqualThanRight(isSignedComparison, kLeft, rightVar, iquery, out refinedIntv))
-      {
-        // If it is an unsigned comparison, and it is a constant, then we should avoid generating the constraint
-        // Example: left <={un} right, with right == -1 then we do not want to generate the constraint right == 2^{32}-1 which is wrong!
-        
-        // unsigned ==> right is not a constant
-        if (isSignedComparison || !kRight.IsSingleton)
-        {
-          result.Add(rightVar, refinedIntv);
-        }
-      }
-
-      //AssumeLeftLessEqualThanK(this.Decoder.UnderlyingVariable(left), kRight);
-      var leftVar = decoder.UnderlyingVariable(left);
-      if (IntervalInference.TryRefine_LeftLessEqualThanK(isSignedComparison, leftVar, kRight, iquery, out refinedIntv))
-      {
-        // unsigned ==> left is not a constant
-        if (isSignedComparison || !kLeft.IsSingleton)
-        {
-          result.Add(leftVar, refinedIntv);
-        }
-      }
-
-      if (isSignedComparison)
-      {
-        Polynomial<Variable, Expression> guardInCanonicalForm;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, left, right, decoder, out guardInCanonicalForm)
-          && guardInCanonicalForm.IsLinear)
-        {
-          // We consider only the case when there is at MOST one variable on the left, i.e. a * x \leq b, or TWO, i.e. a*x +b*y <= c        
-          if (guardInCanonicalForm.Left.Length == 1)
-          {
-            return HelperFortestTrueLessEqualThan_AxLeqK(guardInCanonicalForm, iquery, result, out isBottom);
-          }
-          else if (guardInCanonicalForm.Left.Length == 2)
-          {
-            return HelperFortestTrueLessEqualThan_AxByLtK(guardInCanonicalForm, iquery, result, out isBottom);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    static public List<Pair<Variable, IType>> InferConstraints_LT<Variable, Expression, IType>(
-      bool isSignedComparison,
-      Expression left, Expression right,
-      IExpressionDecoder<Variable, Expression> decoder,
-      ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
-      out bool isBottom)
-      where IType : IntervalBase<IType, Rational>
-    {
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
-
-      isBottom = false; // False untils someone proves the contrary
-
-      var result = new List<Pair<Variable, IType>>();
-
-      var kLeft = iquery.Eval(left);
-      var kRight = iquery.Eval(right);
-
-      if (!isSignedComparison && !IsFloat(left, decoder) && !IsFloat(right, decoder))
-      {
-        kLeft = kLeft.ToUnsigned();
-        kRight = kRight.ToUnsigned();
-      }
-
-      IType refinedIntv;
-      var rightVar = decoder.UnderlyingVariable(right);
-
-      var succ = IsFloat(left, decoder) || IsFloat(right, decoder) ? Rational.For(0) : Rational.For(1);
-
-      if (TryRefine_KLessThanRight(isSignedComparison, kLeft, rightVar, succ, iquery, out refinedIntv))
-      {
-        // If it is an unsigned comparison, and it is a constant, then we should avoid generating the constraint
-        // Example: left <{un} right, with right == -1 then we do not want to generate the constraint right == 2^{32}-1 which is wrong!
-
-        // unsigned ==> right is not a constant
-        if (isSignedComparison || !kRight.IsSingleton)
-        {
-          result.Add(rightVar, refinedIntv);
-        }
-      }
-
-      if (IsFloat(left, decoder) || IsFloat(right, decoder))
-      {
-        return result;
-      }
-
-      var leftVar = decoder.UnderlyingVariable(left);
-      if (TryRefine_LeftLessThanK(isSignedComparison, leftVar, kRight, iquery, out refinedIntv))
-      {
-        // As above
-        // unsigned ==> right is not a constant
-        if (isSignedComparison || !kLeft.IsSingleton)
-        {
-
-          result.Add(leftVar, refinedIntv);
-        }
-      }
-
-      if (isSignedComparison)
-      {
-        // Try to infer some more fact
-        Polynomial<Variable, Expression> guardInCanonicalForm;
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, left, right, decoder, out guardInCanonicalForm)
-          && guardInCanonicalForm.IsLinear)
-        {
-          // First, we consider only the case when there is at MOST one variable on the left, i.e. a * x < b
-          {
-            if (guardInCanonicalForm.Left.Length == 1)
-            {
-              result = HelperFortestTrueLessThan_AxLtK(guardInCanonicalForm, iquery, result, out isBottom);
-            }
-            // Then, we consider the case when it is in the form a*x + b*y < k 
-            else if (guardInCanonicalForm.Left.Length == 2)
-            {
-              return HelperFortestTrueLessThan_AxByLtK(guardInCanonicalForm, iquery, result, out isBottom);
-            }
-          }
-        }
-        else
-        {
-          #region Try to infer something else...
-          switch (decoder.OperatorFor(left))
-          {
-            case ExpressionOperator.And:  // case "(leftLeft && leftRight) < right
-              var leftRight = decoder.RightExpressionFor(left);
-
-              Int32 valueLeft;
-              if (decoder.IsConstantInt(leftRight, out valueLeft))
-              {
-                if (IsPowerOfTwoMinusOne(valueLeft))
-                {   // add the constraint " 0 <= right < valueLeft "
-                  var oldVal = iquery.Eval(right);
-                  var evalVal = iquery.Eval(left);
-                  var newVal = iquery.For(Rational.For(0), Rational.For(valueLeft - 1));   //  [0, valueLeft-1], "-1" as we know it is an integer
-
-                  result.Add(rightVar, oldVal.Meet(newVal).Meet(evalVal));
+                IType oldValueForLeft;
+                if (iquery.TryGetValue(left, isSigned, out oldValueForLeft))
+                {
+                    refinedIntv = oldValueForLeft.Meet(LessEquanThanK);
+                }
+                else
+                {
+                    refinedIntv = LessEquanThanK;
                 }
 
-              }
-              break;
+                return true;
+            }
 
-            default:
-              // do nothing...
-              break;
-          }
-
-          #endregion
+            refinedIntv = default(IType);
+            return false;
         }
-      }
-      return result;
+
+        static public bool TryRefine_KLessThanRight<Variable, Expression, IType>(
+          bool isSigned, IType k, Variable right,
+          Rational succ,
+          ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery, out IType refinedIntv)
+          where IType : IntervalBase<IType, Rational>
+        {
+            if (k.IsNormal)
+            {
+                var lowerBound = k.LowerBound.IsInteger ? k.LowerBound.NextInt32 + succ : k.LowerBound;
+                var GreaterThanK = iquery.IntervalRightOpen(lowerBound);
+
+                IType oldValueForRight;
+                if (iquery.TryGetValue(right, isSigned, out oldValueForRight))
+                {
+                    refinedIntv = oldValueForRight.Meet(GreaterThanK);
+                }
+                else
+                {
+                    refinedIntv = GreaterThanK;
+                }
+
+                return true;
+            }
+
+            refinedIntv = default(IType);
+            return false;
+        }
+
+        static public bool TryRefine_KLessEqualThanRight<Variable, Expression, NType, IType>(
+          bool isSigned, IType k, Variable right,
+          ISetOfNumbersAbstraction<Variable, Expression, NType, IType> iquery, out IType refinedIntv)
+          where IType : IntervalBase<IType, NType>
+        {
+            if (k.IsNormal)
+            {
+                var GreaterThanK = iquery.IntervalRightOpen(k.LowerBound);
+
+                IType oldValueForRight;
+                if (iquery.TryGetValue(right, isSigned, out oldValueForRight))
+                {
+                    refinedIntv = oldValueForRight.Meet(GreaterThanK);
+                }
+                else
+                {
+                    refinedIntv = GreaterThanK;
+                }
+
+                return true;
+            }
+
+            refinedIntv = default(IType);
+            return false;
+        }
+
+        static public bool TryRefine_LeftLessEqualThanK<Variable, Expression, NType, IType>(
+          bool isSigned, Variable left, IType k,
+          ISetOfNumbersAbstraction<Variable, Expression, NType, IType> iquery, out IType refinedIntv)
+          where IType : IntervalBase<IType, NType>
+        {
+            if (k.IsNormal)
+            {
+                var LessEquanThanK = iquery.IntervalLeftOpen(k.UpperBound);
+
+                IType oldValueForLeft;
+                if (iquery.TryGetValue(left, isSigned, out oldValueForLeft))
+                {
+                    refinedIntv = oldValueForLeft.Meet(LessEquanThanK);
+                }
+                else
+                {
+                    refinedIntv = LessEquanThanK;
+                }
+
+                return true;
+            }
+
+            refinedIntv = default(IType);
+            return false;
+        }
+
+        /// <summary>
+        /// Infer exp \in [0, +oo], and if exp is a compound expression also some other constraints
+        /// </summary>
+        static public List<Pair<Variable, IType>> InferConstraints_GeqZero<Variable, Expression, IType>(
+          Expression exp, IExpressionDecoder<Variable, Expression> decoder,
+          ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery)
+          where IType : IntervalBase<IType, Rational>
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(iquery != null);
+
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            var result = new List<Pair<Variable, IType>>();
+
+            var expVar = decoder.UnderlyingVariable(exp);
+
+            result.Add(expVar, iquery.Eval(exp).Meet(iquery.Interval_Positive));
+
+            if (!decoder.IsVariable(exp))
+            {
+                Polynomial<Variable, Expression> zero; // = 0
+
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[] { new Monomial<Variable>(0) }, out zero))
+                {
+                    throw new AbstractInterpretationException("It can never be the case that the conversion of a list of monomials into a polynomial fails");
+                }
+
+                Polynomial<Variable, Expression> expAsPolynomial, newPolynomial;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, decoder, out expAsPolynomial)
+                  && Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, zero, expAsPolynomial, out newPolynomial)) // 0 <= exp
+                {
+                    if (newPolynomial.IsIntervalForm)
+                    {  // if it is in the form of k1 * x <= k2 
+                        var k1 = newPolynomial.Left[0].K;
+                        var x = newPolynomial.Left[0].VariableAt(0);
+
+                        var k2 = newPolynomial.Right[0].K;
+
+                        Rational bound;
+                        if (Rational.TryDiv(k2, k1, out bound)) //var bound = k2 / k1;
+                        {
+                            if (k1 > 0)
+                            {
+                                var intv = iquery.Eval(x).Meet(iquery.IntervalLeftOpen(bound));
+                                result.Add(x, intv);
+                            }
+                            else if (k1 < 0)
+                            {
+                                var intv = iquery.Eval(x).Meet(iquery.IntervalRightOpen(bound));
+                                result.Add(x, intv);
+                            }
+                            else
+                            {
+                                throw new AbstractInterpretationException("Impossible case");
+                            }
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        static public List<Pair<Variable, IType>> InferConstraints_Leq<Variable, Expression, IType>(
+          bool isSignedComparison,
+          Expression left, Expression right,
+           IExpressionDecoder<Variable, Expression> decoder,
+           ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          out bool isBottom)
+        where IType : IntervalBase<IType, Rational>
+        {
+            Contract.Requires(iquery != null);
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            isBottom = false;   // false, unless someine proves the contrary
+
+            var result = new List<Pair<Variable, IType>>();
+
+            if (IsFloat(left, decoder) || IsFloat(right, decoder))
+            {
+                return result;
+            }
+
+            var kLeft = iquery.Eval(left);
+            var kRight = iquery.Eval(right);
+
+            // We have to take into account the polymorphism of constants
+            if (!isSignedComparison)
+            {
+                kLeft = kLeft.ToUnsigned();
+                kRight = kRight.ToUnsigned();
+            }
+
+            //AssumeKLessEqualThanRight(kLeft, this.Decoder.UnderlyingVariable(right))
+
+            IType refinedIntv;
+            var rightVar = decoder.UnderlyingVariable(right);
+            if (IntervalInference.TryRefine_KLessEqualThanRight(isSignedComparison, kLeft, rightVar, iquery, out refinedIntv))
+            {
+                // If it is an unsigned comparison, and it is a constant, then we should avoid generating the constraint
+                // Example: left <={un} right, with right == -1 then we do not want to generate the constraint right == 2^{32}-1 which is wrong!
+
+                // unsigned ==> right is not a constant
+                if (isSignedComparison || !kRight.IsSingleton)
+                {
+                    result.Add(rightVar, refinedIntv);
+                }
+            }
+
+            //AssumeLeftLessEqualThanK(this.Decoder.UnderlyingVariable(left), kRight);
+            var leftVar = decoder.UnderlyingVariable(left);
+            if (IntervalInference.TryRefine_LeftLessEqualThanK(isSignedComparison, leftVar, kRight, iquery, out refinedIntv))
+            {
+                // unsigned ==> left is not a constant
+                if (isSignedComparison || !kLeft.IsSingleton)
+                {
+                    result.Add(leftVar, refinedIntv);
+                }
+            }
+
+            if (isSignedComparison)
+            {
+                Polynomial<Variable, Expression> guardInCanonicalForm;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, left, right, decoder, out guardInCanonicalForm)
+                  && guardInCanonicalForm.IsLinear)
+                {
+                    // We consider only the case when there is at MOST one variable on the left, i.e. a * x \leq b, or TWO, i.e. a*x +b*y <= c        
+                    if (guardInCanonicalForm.Left.Length == 1)
+                    {
+                        return HelperFortestTrueLessEqualThan_AxLeqK(guardInCanonicalForm, iquery, result, out isBottom);
+                    }
+                    else if (guardInCanonicalForm.Left.Length == 2)
+                    {
+                        return HelperFortestTrueLessEqualThan_AxByLtK(guardInCanonicalForm, iquery, result, out isBottom);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        static public List<Pair<Variable, IType>> InferConstraints_LT<Variable, Expression, IType>(
+          bool isSignedComparison,
+          Expression left, Expression right,
+          IExpressionDecoder<Variable, Expression> decoder,
+          ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          out bool isBottom)
+          where IType : IntervalBase<IType, Rational>
+        {
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            isBottom = false; // False untils someone proves the contrary
+
+            var result = new List<Pair<Variable, IType>>();
+
+            var kLeft = iquery.Eval(left);
+            var kRight = iquery.Eval(right);
+
+            if (!isSignedComparison && !IsFloat(left, decoder) && !IsFloat(right, decoder))
+            {
+                kLeft = kLeft.ToUnsigned();
+                kRight = kRight.ToUnsigned();
+            }
+
+            IType refinedIntv;
+            var rightVar = decoder.UnderlyingVariable(right);
+
+            var succ = IsFloat(left, decoder) || IsFloat(right, decoder) ? Rational.For(0) : Rational.For(1);
+
+            if (TryRefine_KLessThanRight(isSignedComparison, kLeft, rightVar, succ, iquery, out refinedIntv))
+            {
+                // If it is an unsigned comparison, and it is a constant, then we should avoid generating the constraint
+                // Example: left <{un} right, with right == -1 then we do not want to generate the constraint right == 2^{32}-1 which is wrong!
+
+                // unsigned ==> right is not a constant
+                if (isSignedComparison || !kRight.IsSingleton)
+                {
+                    result.Add(rightVar, refinedIntv);
+                }
+            }
+
+            if (IsFloat(left, decoder) || IsFloat(right, decoder))
+            {
+                return result;
+            }
+
+            var leftVar = decoder.UnderlyingVariable(left);
+            if (TryRefine_LeftLessThanK(isSignedComparison, leftVar, kRight, iquery, out refinedIntv))
+            {
+                // As above
+                // unsigned ==> right is not a constant
+                if (isSignedComparison || !kLeft.IsSingleton)
+                {
+                    result.Add(leftVar, refinedIntv);
+                }
+            }
+
+            if (isSignedComparison)
+            {
+                // Try to infer some more fact
+                Polynomial<Variable, Expression> guardInCanonicalForm;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, left, right, decoder, out guardInCanonicalForm)
+                  && guardInCanonicalForm.IsLinear)
+                {
+                    // First, we consider only the case when there is at MOST one variable on the left, i.e. a * x < b
+                    {
+                        if (guardInCanonicalForm.Left.Length == 1)
+                        {
+                            result = HelperFortestTrueLessThan_AxLtK(guardInCanonicalForm, iquery, result, out isBottom);
+                        }
+                        // Then, we consider the case when it is in the form a*x + b*y < k 
+                        else if (guardInCanonicalForm.Left.Length == 2)
+                        {
+                            return HelperFortestTrueLessThan_AxByLtK(guardInCanonicalForm, iquery, result, out isBottom);
+                        }
+                    }
+                }
+                else
+                {
+                    #region Try to infer something else...
+                    switch (decoder.OperatorFor(left))
+                    {
+                        case ExpressionOperator.And:  // case "(leftLeft && leftRight) < right
+                            var leftRight = decoder.RightExpressionFor(left);
+
+                            Int32 valueLeft;
+                            if (decoder.IsConstantInt(leftRight, out valueLeft))
+                            {
+                                if (IsPowerOfTwoMinusOne(valueLeft))
+                                {   // add the constraint " 0 <= right < valueLeft "
+                                    var oldVal = iquery.Eval(right);
+                                    var evalVal = iquery.Eval(left);
+                                    var newVal = iquery.For(Rational.For(0), Rational.For(valueLeft - 1));   //  [0, valueLeft-1], "-1" as we know it is an integer
+
+                                    result.Add(rightVar, oldVal.Meet(newVal).Meet(evalVal));
+                                }
+                            }
+                            break;
+
+                        default:
+                            // do nothing...
+                            break;
+                    }
+
+                    #endregion
+                }
+            }
+            return result;
+        }
+
+        static public void InferConstraints_NotEq<Variable, Expression, IType>(
+        Expression left, Expression right,
+        IExpressionDecoder<Variable, Expression> decoder,
+        ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          out List<Pair<Variable, IType>> resultLeft,
+          out List<Pair<Variable, IType>> resultRight,
+          out bool isBottomLeft,
+          out bool isBottomRight)
+        where IType : IntervalBase<IType, Rational>
+        {
+            isBottomLeft = false; // False untils someone proves the contrary
+            isBottomRight = false;
+
+            resultLeft = new List<Pair<Variable, IType>>();
+            resultRight = new List<Pair<Variable, IType>>();
+
+            var kLeft = iquery.Eval(left);
+            var kRight = iquery.Eval(right);
+
+            var rightVar = decoder.UnderlyingVariable(right);
+            var leftVar = decoder.UnderlyingVariable(left);
+
+            var succ = IsFloat(left, decoder) || IsFloat(right, decoder) ? Rational.For(0) : Rational.For(1);
+
+            NewMethod<Variable, Expression, IType>(succ, iquery, kLeft, kRight, rightVar, leftVar, resultLeft);
+            NewMethod<Variable, Expression, IType>(succ, iquery, kRight, kLeft, leftVar, rightVar, resultRight);
+
+            // Try to infer some more fact
+            Polynomial<Variable, Expression> tmpLeftPoly, tmpRightPoly;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(left, decoder, out tmpLeftPoly)
+              && Polynomial<Variable, Expression>.TryToPolynomialForm(right, decoder, out tmpRightPoly))
+            {
+                NewMethod2<Variable, Expression, IType>(tmpLeftPoly, tmpRightPoly, iquery, ref isBottomLeft, resultLeft);
+                NewMethod2<Variable, Expression, IType>(tmpRightPoly, tmpLeftPoly, iquery, ref isBottomRight, resultRight);
+            }
+        }
+
+        private static void NewMethod2<Variable, Expression, IType>(
+          Polynomial<Variable, Expression> tmpLeftPoly, Polynomial<Variable, Expression> tmpRightPoly,
+          ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          ref bool isBottom,
+          List<Pair<Variable, IType>> resultLeft)
+          where IType : IntervalBase<IType, Rational>
+        {
+            Polynomial<Variable, Expression> guardInCanonicalForm;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, tmpLeftPoly, tmpRightPoly, out guardInCanonicalForm))
+            {
+                // First, we consider only the case when there is at MOST one variable on the left, i.e. a * x < b
+                if (guardInCanonicalForm.IsLinear)
+                {
+                    if (guardInCanonicalForm.Left.Length == 1)
+                    {
+                        resultLeft = HelperFortestTrueLessThan_AxLtK(guardInCanonicalForm, iquery, resultLeft, out isBottom);
+                    }
+                    // Then, we consider the case when it is in the form a*x + b*y < k 
+                    else if (guardInCanonicalForm.Left.Length == 2)
+                    {
+                        resultLeft = HelperFortestTrueLessThan_AxByLtK(guardInCanonicalForm, iquery, resultLeft, out isBottom);
+                    }
+                }
+            }
+        }
+
+        private static void NewMethod<Variable, Expression, IType>(
+          Rational succ,
+          ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+           IType kLeft, IType kRight, Variable rightVar, Variable leftVar,
+          List<Pair<Variable, IType>> result)
+          where IType : IntervalBase<IType, Rational>
+        {
+            IType refinedIntv;
+            if (TryRefine_KLessThanRight(true, kLeft, rightVar, succ, iquery, out refinedIntv))
+            {
+                result.Add(rightVar, refinedIntv);
+            }
+
+            if (TryRefine_LeftLessThanK(true, leftVar, kRight, iquery, out refinedIntv))
+            {
+                result.Add(leftVar, refinedIntv);
+            }
+        }
+
+
+        #region Private helpers
+
+        static private List<Pair<Variable, IType>> HelperFortestTrueLessEqualThan_AxLeqK<Variable, Expression, IType>(
+          Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          List<Pair<Variable, IType>> result,
+          out bool isBottom)
+          where IType : IntervalBase<IType, Rational>
+        {
+            Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
+            Contract.Requires(result != null);
+            Contract.Requires(guardInCanonicalForm.Right.Length == 1);
+
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            var MonomialForX = guardInCanonicalForm.Left[0];
+            var MonomilaForB = guardInCanonicalForm.Right[0];
+
+            Contract.Assert(MonomilaForB.IsConstant);
+
+            isBottom = false;
+
+            // 1. We have a case a <= b
+            if (MonomialForX.IsConstant)
+            {
+                var a = MonomialForX.K;
+                var b = MonomilaForB.K;
+
+                if (a > b)
+                {
+                    isBottom = true;
+                }
+            }
+            else // 2. We have the case a * x \leq b
+            {
+                var x = MonomialForX.VariableAt(0);
+
+                Rational k;
+                if (
+                  MonomialForX.K.IsInteger &&
+                  Rational.TryDiv(MonomilaForB.K, MonomialForX.K, out k))
+                {
+                    var oldValueForX = iquery.Eval(x);
+
+                    IType newValueForX;
+
+                    if (MonomialForX.K.Sign == 1)
+                    {   // The constraint is x \leq k
+                        newValueForX = oldValueForX.Meet(iquery.IntervalLeftOpen(k));
+                    }
+                    else
+                    {   // The constraint is x \geq k
+                        newValueForX = oldValueForX.Meet(iquery.IntervalRightOpen(k));
+                    }
+
+                    if (newValueForX.IsBottom)
+                    {
+                        isBottom = true;
+                    }
+                    else
+                    {
+                        Contract.Assert(isBottom == false);
+
+                        result.Add(x, newValueForX);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Handles the case when the guard is in the form of "A*x + B*y &lt;= k"
+        /// </summary>
+        static private List<Pair<Variable, IType>> HelperFortestTrueLessEqualThan_AxByLtK<Variable, Expression, IType>(
+          Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          List<Pair<Variable, IType>> result,
+          out bool isBottom)
+          where IType : IntervalBase<IType, Rational>
+        {
+            Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
+            Contract.Requires(iquery != null);
+            Contract.Requires(result != null);
+
+            Contract.Requires(guardInCanonicalForm.Right.Length == 1);
+            Contract.Requires(guardInCanonicalForm.Left.Length == 2);
+
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            isBottom = false;   // false, unless someone proves not
+
+            var monomialForX = guardInCanonicalForm.Left[0];
+            var monomialForY = guardInCanonicalForm.Left[1];
+
+            var X = monomialForX.VariableAt(0);
+            var Y = monomialForY.VariableAt(0);
+
+            var K = guardInCanonicalForm.Right[0].K;
+
+            var A = monomialForX.K;
+            var B = monomialForY.K;
+
+            var intervalForA = iquery.For(A);
+            var intervalForB = iquery.For(B);
+            var intervalForK = iquery.For(K);
+
+            var intervalForX = iquery.Eval(X);
+            var intervalForY = iquery.Eval(Y);
+
+            // 1. Handle the case for x
+
+            // evalForX =(k - b * y) / a
+            var evalForX = iquery.Interval_Div(iquery.Interval_Sub(intervalForK, (iquery.Interval_Mul(intervalForB, intervalForY))), intervalForA);
+
+            if (A > 0)
+            { // x <= (k - b * y) / a
+                var upperBound = evalForX.UpperBound;
+                var geq = iquery.IntervalLeftOpen(upperBound);
+
+                var newIntv = intervalForX.Meet(geq);
+
+                if (newIntv.IsBottom)
+                {
+                    isBottom = true;
+
+                    return result;
+                }
+
+                result.Add(X, newIntv);
+            }
+            else if (A < 0)
+            { // x >= (k - b * y) / a
+                var lowerBound = evalForX.LowerBound;
+                var leq = iquery.IntervalRightOpen(lowerBound);
+
+                var newIntv = intervalForX.Meet(leq);
+
+                if (newIntv.IsBottom)
+                {
+                    isBottom = true;
+
+                    return result;
+                }
+
+                result.Add(X, newIntv);
+            }
+            else
+            {
+                Contract.Assert(false, "Cannot have a == 0");
+            }
+
+            // 2. Handle the case for y
+
+            // evalForY =(k - a * x) / b
+            //var evalForY = (intervalForK - (intervalForA * intervalForX)) / (intervalForB);
+
+            var evalForY = iquery.Interval_Div(iquery.Interval_Sub(intervalForK, (iquery.Interval_Mul(intervalForA, intervalForX))), intervalForB);
+
+            if (B > 0)
+            { // y <= (k - a * x) / b
+                var upperBound = evalForY.UpperBound;
+                var geq = iquery.IntervalLeftOpen(upperBound);
+
+                var newIntv = intervalForY.Meet(geq);
+
+                if (newIntv.IsBottom)
+                {
+                    isBottom = true;
+                    return result;
+                }
+
+                result.Add(Y, newIntv);
+            }
+            else if (B < 0)
+            { // x >= (k - a * x) / b
+                var lowerBound = evalForY.LowerBound;
+                var leq = iquery.IntervalRightOpen(lowerBound);
+
+                var newIntv = intervalForY.Meet(leq);
+
+                if (newIntv.IsBottom)
+                {
+                    isBottom = true;
+                    return result;
+                }
+
+                result.Add(Y, newIntv);
+            }
+            else
+            {
+                Contract.Assert(false, "Cannot have b == 0");
+            }
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Handles the case when the guard is in the form of "A*x &lt; k"
+        /// </summary>
+        /// <param name="guardInCanonicalForm">A polynomial that must have been already put into canonical form</param>
+        static private List<Pair<Variable, IType>> HelperFortestTrueLessThan_AxLtK<Variable, Expression, IType>(
+          Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          List<Pair<Variable, IType>> result,
+          out bool isBottom)
+          where IType : IntervalBase<IType, Rational>
+        {
+            Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
+            Contract.Requires(guardInCanonicalForm.Right.Length == 1);
+            Contract.Requires(iquery != null);
+            Contract.Requires(result != null);
+
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            isBottom = false;
+
+            var MonomialForX = guardInCanonicalForm.Left[0];
+            var MonomilaForB = guardInCanonicalForm.Right[0];
+
+            Contract.Assert(MonomilaForB.IsConstant);
+
+            // 1. We have a case a < b
+            if (MonomialForX.IsConstant)
+            {
+                var a = MonomialForX.K;
+                var b = MonomilaForB.K;
+
+                if (a >= b)
+                {
+                    isBottom = true;
+                }
+            }
+            else // 2. We have the case a * x < b
+            {
+                var x = MonomialForX.VariableAt(0);
+
+                Rational k;
+                if (!Rational.TryDiv(MonomilaForB.K, MonomialForX.K, out k)) //var k = MonomilaForB.K / MonomialForX.K;
+                {
+                    return result;
+                }
+
+                var oldValueForX = iquery.Eval(x);
+
+                IType newConstraint;
+                if (MonomialForX.K.Sign == 1)
+                {   // The constraint is x < k, but if k is a rational, we approximate it with x \leq k
+                    if (k.IsInteger)
+                    {
+                        newConstraint = iquery.IntervalLeftOpen(k - 1);
+                    }
+                    else
+                    {
+                        newConstraint = iquery.IntervalLeftOpen(k.PreviousInt32);
+                    }
+                }
+                else
+                {   // The constraint is x > k, but if k is a rational, we approximate it with k \leq x
+                    if (k.IsInteger)
+                    {
+                        newConstraint = iquery.IntervalRightOpen(k + 1);
+                    }
+                    else
+                    {
+                        newConstraint = iquery.IntervalRightOpen(k.NextInt32);
+                    }
+                }
+
+                var newValueForX = oldValueForX.Meet(newConstraint);
+
+                if (newValueForX.IsBottom)
+                {
+                    isBottom = true;
+                }
+                else
+                {
+                    result.Add(x, newValueForX);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Handles the case when the guard is in the form of "A*x + B*y &lt; k"
+        /// </summary>
+        /// <param name="guardInCanonicalForm">A polynomial that must have been already put into canonical form</param>
+        static private List<Pair<Variable, IType>> HelperFortestTrueLessThan_AxByLtK<Variable, Expression, IType>(
+          Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
+          List<Pair<Variable, IType>> result,
+          out bool isBottom)
+          where IType : IntervalBase<IType, Rational>
+        {
+            Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
+            Contract.Requires(iquery != null);
+            Contract.Requires(result != null);
+            Contract.Requires(guardInCanonicalForm.Left.Length == 2);
+            Contract.Requires(guardInCanonicalForm.Right.Length == 1);
+
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            isBottom = false; // False, unless another proof
+
+            var monomialForX = guardInCanonicalForm.Left[0];
+            var monomialForY = guardInCanonicalForm.Left[1];
+
+            var X = monomialForX.VariableAt(0);
+            var Y = monomialForY.VariableAt(0);
+
+            var K = guardInCanonicalForm.Right[0].K;
+
+            var A = monomialForX.K;
+            var B = monomialForY.K;
+
+            var intervalForA = iquery.For(A);
+            var intervalForB = iquery.For(B);
+            var intervalForK = iquery.For(K);
+
+            var intervalForX = iquery.Eval(X);
+            var intervalForY = iquery.Eval(Y);
+
+            // 1. Handle the case for x
+
+            // evalForX =(k - b * y) / a
+            var evalForX = iquery.Interval_Div((iquery.Interval_Sub(intervalForK, (iquery.Interval_Mul(intervalForB, intervalForY)))), intervalForA);
+
+            if (A > 0)
+            { // x < (k - b * y) / a
+                var upperBound = evalForX.UpperBound;
+                IType gt;
+                if (upperBound.IsInteger)
+                {
+                    gt = iquery.IntervalLeftOpen(upperBound - 1);
+                }
+                else
+                {
+                    gt = iquery.IntervalLeftOpen(upperBound.PreviousInt32);
+                }
+
+                var intv = intervalForX.Meet(gt);
+
+                if (intv.IsBottom)
+                {
+                    isBottom = true;
+                    return result;
+                }
+                result.Add(X, intv);
+            }
+            else if (A < 0)
+            { // x > (k - b * y) / a
+                var lowerBound = evalForX.LowerBound;
+
+                IType lt;
+
+                if (lowerBound.IsInteger)
+                {
+                    lt = iquery.IntervalRightOpen(lowerBound + 1);
+                }
+                else
+                {
+                    lt = iquery.IntervalRightOpen(lowerBound.NextInt32);
+                }
+
+                var intv = intervalForX.Meet(lt);
+
+                if (intv.IsBottom)
+                {
+                    isBottom = true;
+                    return result;
+                }
+                result.Add(X, intv);
+            }
+            else
+            {
+                Contract.Assert(false, "Cannot have a == 0");
+            }
+
+            // 2. Handle the case for y
+
+            // evalForY =(k - a * x) / b
+            var evalForY = iquery.Interval_Div((iquery.Interval_Sub(intervalForK, (iquery.Interval_Mul(intervalForA, intervalForX)))), intervalForB);
+
+            if (B > 0)
+            { // y < (k - a * x) / b
+                var upperBound = evalForY.UpperBound;
+                IType gt;
+
+                if (upperBound.IsInteger)
+                {
+                    gt = iquery.IntervalLeftOpen(upperBound - 1);
+                }
+                else
+                {
+                    gt = iquery.IntervalLeftOpen(upperBound.PreviousInt32);
+                }
+
+                var intv = intervalForY.Meet(gt);
+                if (intv.IsBottom)
+                {
+                    isBottom = true;
+                    return result;
+                }
+
+                result.Add(Y, intv);
+            }
+            else if (B < 0)
+            { // x > (k - a * x) / b
+                var lowerBound = evalForY.LowerBound;
+                IType lt;
+
+                if (lowerBound.IsInteger)
+                {
+                    lt = iquery.IntervalRightOpen(lowerBound + 1);
+                }
+                else
+                {
+                    lt = iquery.IntervalRightOpen(lowerBound.NextInt32);
+                }
+
+                var intv = intervalForY.Meet(lt);
+
+                if (intv.IsBottom)
+                {
+                    isBottom = true;
+                    return result;
+                }
+
+                result.Add(Y, intv);
+            }
+            else
+            {
+                Contract.Assert(false, "Cannot have b == 0");
+            }
+
+            return result;
+        }
+
+        private static bool IsPowerOfTwoMinusOne(int r)
+        {
+            return r == 15 || r == 31 || r == 63 || r == 127 || r == 255 || r == 511 || r == 1023 || r == 2047 || r == 4095 || r == 8191 || r == 16385 || r == 32767
+            || r == 65535 || r == 131071 || r == 262143 || r == 524287 || r == 1048575 || r == 2097151 || r == 4194303 || r == 8388607 || r == 16777215;
+        }
+
+        private static bool IsFloat<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            if (decoder == null)
+            {
+                return false;
+            }
+
+            var type = decoder.TypeOf(exp);
+
+            return type == ExpressionType.Float32 || type == ExpressionType.Float64;
+        }
+        #endregion
     }
-
-    static public void InferConstraints_NotEq<Variable, Expression, IType>(
-    Expression left, Expression right,
-    IExpressionDecoder<Variable, Expression> decoder,
-    ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
-      out List<Pair<Variable, IType>> resultLeft, 
-      out List<Pair<Variable, IType>> resultRight,
-      out bool isBottomLeft,
-      out bool isBottomRight)
-    where IType : IntervalBase<IType, Rational>
-    {
-      isBottomLeft = false; // False untils someone proves the contrary
-      isBottomRight = false;
-
-      resultLeft = new List<Pair<Variable, IType>>();
-      resultRight = new List<Pair<Variable, IType>>();
-
-      var kLeft = iquery.Eval(left);
-      var kRight = iquery.Eval(right);
-
-      var rightVar = decoder.UnderlyingVariable(right);
-      var leftVar = decoder.UnderlyingVariable(left);
-
-      var succ = IsFloat(left, decoder) || IsFloat(right, decoder) ? Rational.For(0) : Rational.For(1);
-
-      NewMethod<Variable, Expression, IType>(succ, iquery, kLeft, kRight, rightVar, leftVar, resultLeft);
-      NewMethod<Variable, Expression, IType>(succ, iquery, kRight, kLeft, leftVar, rightVar, resultRight);
-
-      // Try to infer some more fact
-      Polynomial<Variable, Expression> tmpLeftPoly, tmpRightPoly;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(left, decoder, out tmpLeftPoly)
-        && Polynomial<Variable, Expression>.TryToPolynomialForm(right, decoder, out tmpRightPoly))
-      {
-        NewMethod2<Variable, Expression, IType>(tmpLeftPoly, tmpRightPoly, iquery, ref isBottomLeft, resultLeft);
-        NewMethod2<Variable, Expression, IType>(tmpRightPoly, tmpLeftPoly, iquery, ref isBottomRight, resultRight);
-      }
-
-    }
-
-    private static void NewMethod2<Variable, Expression, IType>(
-      Polynomial<Variable, Expression> tmpLeftPoly, Polynomial<Variable, Expression> tmpRightPoly, 
-      ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery, 
-      ref bool isBottom, 
-      List<Pair<Variable, IType>> resultLeft) 
-      where IType : IntervalBase<IType, Rational>
-    {
-      Polynomial<Variable, Expression> guardInCanonicalForm;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, tmpLeftPoly, tmpRightPoly, out guardInCanonicalForm))
-      {
-        // First, we consider only the case when there is at MOST one variable on the left, i.e. a * x < b
-        if (guardInCanonicalForm.IsLinear)
-        {
-          if (guardInCanonicalForm.Left.Length == 1)
-          {
-            resultLeft = HelperFortestTrueLessThan_AxLtK(guardInCanonicalForm, iquery, resultLeft, out isBottom);
-          }
-          // Then, we consider the case when it is in the form a*x + b*y < k 
-          else if (guardInCanonicalForm.Left.Length == 2)
-          {
-            resultLeft = HelperFortestTrueLessThan_AxByLtK(guardInCanonicalForm, iquery, resultLeft, out isBottom);
-          }
-        }
-      }
-    }
-
-    private static void NewMethod<Variable, Expression, IType>(
-      Rational succ, 
-      ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery, 
-       IType kLeft, IType kRight, Variable rightVar, Variable leftVar, 
-      List<Pair<Variable, IType>> result) 
-      where IType : IntervalBase<IType, Rational>
-    {
-      IType refinedIntv;
-      if (TryRefine_KLessThanRight(true, kLeft, rightVar, succ, iquery, out refinedIntv))
-      {
-        result.Add(rightVar, refinedIntv);
-      }
-
-      if (TryRefine_LeftLessThanK(true, leftVar, kRight, iquery, out refinedIntv))
-      {
-        result.Add(leftVar, refinedIntv);
-      }
-    }
-
-   
-    #region Private helpers
-
-    static private List<Pair<Variable, IType>> HelperFortestTrueLessEqualThan_AxLeqK<Variable, Expression, IType>(
-      Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
-      List<Pair<Variable, IType>> result,
-      out bool isBottom)
-      where IType : IntervalBase<IType, Rational>
-    {
-      Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
-      Contract.Requires(result != null);
-      Contract.Requires(guardInCanonicalForm.Right.Length == 1);
-
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
-
-      var MonomialForX = guardInCanonicalForm.Left[0];
-      var MonomilaForB = guardInCanonicalForm.Right[0];
-
-      Contract.Assert(MonomilaForB.IsConstant);
-
-      isBottom = false;
-
-      // 1. We have a case a <= b
-      if (MonomialForX.IsConstant)
-      {
-        var a = MonomialForX.K;
-        var b = MonomilaForB.K;
-
-        if (a > b)
-        {
-          isBottom = true;
-        }
-      }
-      else // 2. We have the case a * x \leq b
-      {
-        var x = MonomialForX.VariableAt(0);
-
-        Rational k;
-        if ( 
-          MonomialForX.K.IsInteger &&
-          Rational.TryDiv(MonomilaForB.K, MonomialForX.K, out k))
-        {
-          var oldValueForX = iquery.Eval(x);
-
-          IType newValueForX;
-
-          if (MonomialForX.K.Sign == 1)
-          {   // The constraint is x \leq k
-            newValueForX = oldValueForX.Meet(iquery.IntervalLeftOpen(k));
-          }
-          else
-          {   // The constraint is x \geq k
-            newValueForX = oldValueForX.Meet(iquery.IntervalRightOpen(k));
-          }
-
-          if (newValueForX.IsBottom)
-          {
-            isBottom = true;
-          }
-          else
-          {
-            Contract.Assert(isBottom == false);
-
-            result.Add(x, newValueForX);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Handles the case when the guard is in the form of "A*x + B*y &lt;= k"
-    /// </summary>
-    static private List<Pair<Variable, IType>> HelperFortestTrueLessEqualThan_AxByLtK<Variable, Expression, IType>(
-      Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
-      List<Pair<Variable, IType>> result,
-      out bool isBottom)
-      where IType : IntervalBase<IType, Rational>
-    {
-      Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
-      Contract.Requires(iquery != null);
-      Contract.Requires(result != null);
-
-      Contract.Requires(guardInCanonicalForm.Right.Length == 1);
-      Contract.Requires(guardInCanonicalForm.Left.Length == 2);
-
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
-
-      isBottom = false;   // false, unless someone proves not
-
-      var monomialForX = guardInCanonicalForm.Left[0];
-      var monomialForY = guardInCanonicalForm.Left[1];
-
-      var X = monomialForX.VariableAt(0);
-      var Y = monomialForY.VariableAt(0);
-
-      var K = guardInCanonicalForm.Right[0].K;
-
-      var A = monomialForX.K;
-      var B = monomialForY.K;
-
-      var intervalForA = iquery.For(A);
-      var intervalForB = iquery.For(B);
-      var intervalForK = iquery.For(K);
-
-      var intervalForX = iquery.Eval(X);
-      var intervalForY = iquery.Eval(Y);
-
-      // 1. Handle the case for x
-
-      // evalForX =(k - b * y) / a
-      var evalForX = iquery.Interval_Div(iquery.Interval_Sub(intervalForK, (iquery.Interval_Mul(intervalForB, intervalForY))), intervalForA);
-
-      if (A > 0)
-      { // x <= (k - b * y) / a
-        var upperBound = evalForX.UpperBound;
-        var geq = iquery.IntervalLeftOpen(upperBound);
-
-        var newIntv = intervalForX.Meet(geq);
-
-        if (newIntv.IsBottom)
-        {
-          isBottom = true;
-
-          return result;
-        }
-
-        result.Add(X, newIntv);
-      }
-      else if (A < 0)
-      { // x >= (k - b * y) / a
-        var lowerBound = evalForX.LowerBound;
-        var leq = iquery.IntervalRightOpen(lowerBound);
-
-        var newIntv = intervalForX.Meet(leq);
-
-        if(newIntv.IsBottom)
-        {
-          isBottom = true;
-
-          return result;
-        }
-
-        result.Add(X, newIntv);
-      }
-      else
-      {
-        Contract.Assert(false, "Cannot have a == 0");
-      }
-
-      // 2. Handle the case for y
-
-      // evalForY =(k - a * x) / b
-      //var evalForY = (intervalForK - (intervalForA * intervalForX)) / (intervalForB);
-
-      var evalForY = iquery.Interval_Div(iquery.Interval_Sub(intervalForK, (iquery.Interval_Mul(intervalForA, intervalForX))), intervalForB);
-
-      if (B > 0)
-      { // y <= (k - a * x) / b
-        var upperBound = evalForY.UpperBound;
-        var geq = iquery.IntervalLeftOpen(upperBound);
-
-        var newIntv = intervalForY.Meet(geq);
-
-        if(newIntv.IsBottom)
-        {
-          isBottom = true;
-          return result;
-        }
-
-        result.Add(Y, newIntv);
-      }
-      else if (B < 0)
-      { // x >= (k - a * x) / b
-        var lowerBound = evalForY.LowerBound;
-        var leq = iquery.IntervalRightOpen(lowerBound);
-
-        var newIntv = intervalForY.Meet(leq);
-
-        if (newIntv.IsBottom)
-        {
-          isBottom = true;
-          return result;
-        }
-
-        result.Add(Y, newIntv);
-      }
-      else
-      {
-        Contract.Assert(false, "Cannot have b == 0");
-      }
-
-      return result;
-    }
-
-
-    /// <summary>
-    /// Handles the case when the guard is in the form of "A*x &lt; k"
-    /// </summary>
-    /// <param name="guardInCanonicalForm">A polynomial that must have been already put into canonical form</param>
-    static private List<Pair<Variable, IType>> HelperFortestTrueLessThan_AxLtK<Variable, Expression, IType>(
-      Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
-      List<Pair<Variable, IType>> result,
-      out bool isBottom)
-      where IType : IntervalBase<IType, Rational>
-    {
-      Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
-      Contract.Requires(guardInCanonicalForm.Right.Length == 1);
-      Contract.Requires(iquery  != null);
-      Contract.Requires(result != null);
-
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>> >() != null);
-
-      isBottom = false;
-
-      var MonomialForX = guardInCanonicalForm.Left[0];
-      var MonomilaForB = guardInCanonicalForm.Right[0];
-
-      Contract.Assert(MonomilaForB.IsConstant);
-
-      // 1. We have a case a < b
-      if (MonomialForX.IsConstant)
-      {
-        var a = MonomialForX.K;
-        var b = MonomilaForB.K;
-
-        if (a >=  b)
-        {
-          isBottom = true;
-        }
-      }
-      else // 2. We have the case a * x < b
-      {
-        var x = MonomialForX.VariableAt(0);
-
-        Rational k;
-        if (!Rational.TryDiv(MonomilaForB.K, MonomialForX.K, out k)) //var k = MonomilaForB.K / MonomialForX.K;
-        {
-          return result;
-        }
-
-        var oldValueForX = iquery.Eval(x);
-        
-        IType newConstraint;
-        if (MonomialForX.K.Sign == 1)
-        {   // The constraint is x < k, but if k is a rational, we approximate it with x \leq k
-          if (k.IsInteger)
-          {
-            newConstraint = iquery.IntervalLeftOpen(k - 1);
-          }
-          else
-          {
-            newConstraint = iquery.IntervalLeftOpen(k.PreviousInt32);
-          }
-        }
-        else
-        {   // The constraint is x > k, but if k is a rational, we approximate it with k \leq x
-          if (k.IsInteger)
-          {
-            newConstraint = iquery.IntervalRightOpen(k + 1);
-          }
-          else
-          {
-            newConstraint = iquery.IntervalRightOpen(k.NextInt32);
-          }
-        }
-
-        var newValueForX = oldValueForX.Meet(newConstraint);
-
-        if (newValueForX.IsBottom)
-        {
-          isBottom = true;
-        }
-        else
-        {
-          result.Add(x, newValueForX);          
-        }
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Handles the case when the guard is in the form of "A*x + B*y &lt; k"
-    /// </summary>
-    /// <param name="guardInCanonicalForm">A polynomial that must have been already put into canonical form</param>
-    static private List<Pair<Variable, IType>> HelperFortestTrueLessThan_AxByLtK<Variable, Expression, IType>(
-      Polynomial<Variable, Expression> guardInCanonicalForm, ISetOfNumbersAbstraction<Variable, Expression, Rational, IType> iquery,
-      List<Pair<Variable, IType>> result,
-      out bool isBottom)
-      where IType : IntervalBase<IType, Rational>
-    {
-      Contract.Requires(!object.ReferenceEquals(guardInCanonicalForm, null));
-      Contract.Requires(iquery != null);
-      Contract.Requires(result != null);
-      Contract.Requires(guardInCanonicalForm.Left.Length == 2);
-      Contract.Requires(guardInCanonicalForm.Right.Length == 1);
-
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
-
-      isBottom = false; // False, unless another proof
-
-      var monomialForX = guardInCanonicalForm.Left[0];
-      var monomialForY = guardInCanonicalForm.Left[1];
-
-      var X = monomialForX.VariableAt(0);
-      var Y = monomialForY.VariableAt(0);
-
-      var K = guardInCanonicalForm.Right[0].K;
-
-      var A = monomialForX.K;
-      var B = monomialForY.K;
-
-      var intervalForA = iquery.For(A);
-      var intervalForB = iquery.For(B);
-      var intervalForK = iquery.For(K);
-
-      var intervalForX = iquery.Eval(X);
-      var intervalForY = iquery.Eval(Y);
-
-      // 1. Handle the case for x
-
-      // evalForX =(k - b * y) / a
-      var evalForX = iquery.Interval_Div((iquery.Interval_Sub(intervalForK,(iquery.Interval_Mul(intervalForB, intervalForY)))), intervalForA);
-
-      if (A > 0)
-      { // x < (k - b * y) / a
-        var upperBound = evalForX.UpperBound;
-        IType gt;
-        if (upperBound.IsInteger)
-        {
-          gt = iquery.IntervalLeftOpen(upperBound - 1);
-        }
-        else
-        {
-          gt = iquery.IntervalLeftOpen(upperBound.PreviousInt32);
-        }
-
-        var intv = intervalForX.Meet(gt);
-
-        if(intv.IsBottom)
-        {
-          isBottom = true;
-          return result;
-        }
-        result.Add(X, intv);
-      }
-      else if (A < 0)
-      { // x > (k - b * y) / a
-        var lowerBound = evalForX.LowerBound;
-        
-        IType lt;
-
-        if (lowerBound.IsInteger)
-        {
-          lt = iquery.IntervalRightOpen(lowerBound + 1);
-        }
-        else
-        {
-          lt = iquery.IntervalRightOpen(lowerBound.NextInt32);
-        }
-
-        var intv= intervalForX.Meet(lt);
-
-        if(intv.IsBottom)
-        {
-          isBottom = true;
-          return result;
-        }
-        result.Add(X, intv);
-      }
-      else
-      {
-        Contract.Assert(false, "Cannot have a == 0");
-      }
-
-      // 2. Handle the case for y
-
-      // evalForY =(k - a * x) / b
-      var evalForY = iquery.Interval_Div((iquery.Interval_Sub(intervalForK, (iquery.Interval_Mul(intervalForA, intervalForX)))), intervalForB);
-
-      if (B > 0)
-      { // y < (k - a * x) / b
-        var upperBound = evalForY.UpperBound;
-        IType gt;
-
-        if (upperBound.IsInteger)
-        {
-          gt = iquery.IntervalLeftOpen(upperBound - 1);
-        }
-        else
-        {
-          gt = iquery.IntervalLeftOpen(upperBound.PreviousInt32);
-        }
-
-        var intv = intervalForY.Meet(gt);
-        if(intv.IsBottom)
-        {
-          isBottom = true;
-          return result;
-        }
-
-        result.Add(Y, intv);
-      }
-      else if (B < 0)
-      { // x > (k - a * x) / b
-        var lowerBound = evalForY.LowerBound;
-        IType lt;
-
-        if (lowerBound.IsInteger)
-        {
-          lt = iquery.IntervalRightOpen(lowerBound + 1);
-        }
-        else
-        {
-          lt = iquery.IntervalRightOpen(lowerBound.NextInt32);
-        }
-
-        var intv = intervalForY.Meet(lt);
-
-        if(intv.IsBottom)
-        {
-          isBottom = true;
-          return result;
-        }
-
-        result.Add(Y, intv);      }
-      else
-      {
-        Contract.Assert(false, "Cannot have b == 0");
-      }
-
-      return result;
-    }
-
-    private static bool IsPowerOfTwoMinusOne(int r)
-    {
-      return r == 15 || r == 31 || r == 63 || r == 127 || r == 255 || r == 511 || r == 1023 || r == 2047 || r == 4095 || r == 8191 || r == 16385 || r == 32767
-      || r == 65535 || r == 131071 || r == 262143 || r == 524287 || r == 1048575 || r == 2097151 || r == 4194303 || r == 8388607 || r == 16777215;
-    }
-
-    private static bool IsFloat<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      if (decoder == null)
-      {
-        return false;
-      }
-
-      var type = decoder.TypeOf(exp);
-
-      return type == ExpressionType.Float32 || type == ExpressionType.Float64;
-    }
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalEnvironment.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalEnvironment.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation of the environment of intervals
 
@@ -24,488 +13,488 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// An interval environment is a map from Variables to intervals
-  /// </summary>
-
-  public sealed class IntervalEnvironment<Variable, Expression> :
-      IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>,
-    INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Constructors
-
-    internal IntervalEnvironment(IExpressionDecoder<Variable, Expression> Decoder, Logger Log)
-      : this(new ExpressionManager<Variable, Expression>(null, Decoder, null), true)
-    {
-    }
-
-    public IntervalEnvironment(ExpressionManager<Variable, Expression> expManager)
-      : this(expManager, false)
-    {
-      Contract.Requires(expManager != null);
-    }
-
-    private IntervalEnvironment(IntervalEnvironment<Variable, Expression> original)
-      : base(original)
-    {
-    }
-
-    private IntervalEnvironment(ExpressionManager<Variable, Expression> expManager, bool internalInvocation)
-      : base(expManager)
-    {
-    }
-
-    #endregion
-    
-    #region IPureExpressionAssignmentsWithBackward<Expression> Members
-
     /// <summary>
-    /// The backward assignment for the intervals.
-    /// It modifies the state "in loco", hence with side effects
+    /// An interval environment is a map from Variables to intervals
     /// </summary>
-    /// <param name="x">The variable to be backward assigned</param>
-    /// <param name="exp">The expression</param>
-    public void AssignBackward(Variable/*!*/ x, Expression/*!*/ exp)
+
+    public sealed class IntervalEnvironment<Variable, Expression> :
+        IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>,
+      INumericalAbstractDomain<Variable, Expression>
     {
-      //var postState = this.DuplicateMe();
+        #region Constructors
 
-      //// For all the variables "y" in the expression "exp", we try to revert the assignment, so to find the previous value for "y"
-      //foreach (var y in this.ExpressionManager.Decoder.UnderlyingVariablesIn(exp))
-      //{
-      //  Debug.Assert(y != null);
-      //  Expression backexpression;
-
-      //  // If it can invert the expression
-      //  if (ExpressionInverter<Expression>.TryInvertAssignment(x, exp, y, this.ExpressionManager.Decoder, this.Encoder, out backexpression))
-      //  {
-      //    Polynomial<Variable, Expression> tmpPoly;
-      //    if (!Polynomial<Variable, Expression>.TryToPolynomialForm(backexpression, this.ExpressionManager.Decoder, out tmpPoly))
-      //    {
-      //      break;
-      //    }
-
-      //    Expression normalizedBackExpression = tmpPoly.ToPureExpression(this.Encoder);
-
-      //    var previousValueForY = postState.Eval(normalizedBackExpression);
-
-      //    if (y.Equals(x))
-      //    {
-      //      this[y] = previousValueForY;            // We srongly update the value of "x", as its previous values is meaningless
-      //    }
-      //    else
-      //    {
-      //      this[y] = previousValueForY.Meet(this[y]);             // the previous value for y is the one in the poststate intersect the one "inverted"              
-      //    }
-      //  }
-      //  else
-      //  {   // It cannot invert the expression, so we skip it
-      //    this.ProjectVariable(y);
-      //  }
-      //}
-
-      //if (!this.ExpressionManager.Decoder.UnderlyingVariablesIn(exp).Contains(x))
-      //{   // The previous value for x is lost
-      //  this.ProjectVariable(x);
-      //}
-    }
-
-    #endregion
-
-    #region Code for handling the guards
-
-    /// <summary>
-    /// Assume exp \geq 0
-    /// </summary>
-    override public IntervalEnvironment<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      var newConstraints = IntervalInference.InferConstraints_GeqZero(exp, this.ExpressionManager.Decoder, this);
-
-      foreach (var pair in newConstraints)
-      {
-        this[pair.One] = pair.Two;
-      }
-
-      return this;
-    }
-
-    public override IntervalEnvironment<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      var isSignedComparison = true;
-      var decoder = this.ExpressionManager.Decoder;
-
-      var type1 = decoder.TypeOf(exp1); 
-      var type2 = decoder.TypeOf(exp2);
-      if ((type1 != ExpressionType.Unknown && type2 != ExpressionType.Unknown) && 
-        (type1.IsUnsignedType() || type2.IsUnsignedType()))
-      {
-        isSignedComparison = false;
-      }
-
-      return HelperForTestTrueLessEqualThanSignedOrUnsigned(isSignedComparison, exp1, exp2);
-    }
-
-    public override IntervalEnvironment<Variable, Expression> TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
-    {
-      return HelperForTestTrueLessEqualThanSignedOrUnsigned(false, exp1, exp2);
-    }
-
-    /// <summary>
-    /// We handle just expressions (that after being normalized) become 
-    ///     "a * x \leq b ", or "a * x + b* y \leq c" 
-    /// where {a, b, c} are constants and {x, y} are variables
-    /// </summary>
-    private IntervalEnvironment<Variable, Expression> HelperForTestTrueLessEqualThanSignedOrUnsigned(bool isSigned, Expression left, Expression right)
-    {
-      bool isBottom;
-      var result = IntervalInference.InferConstraints_Leq(isSigned, left, right, this.ExpressionManager.Decoder, this, out isBottom);
-
-      if (isBottom)
-      {
-        return this.Bottom;
-      }
-
-      foreach (var pair in result)
-      {
-        this.RefineWith(pair.One, pair.Two);
-      }
-
-      return this;
-    }
-
-    public override IntervalEnvironment<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      return HelperForTestTrueLessThanSignedOrUnsigned(true, exp1, exp2);
-    }
-
-    public override IntervalEnvironment<Variable, Expression> TestTrueLessThan_Un(Expression exp1, Expression exp2)
-    {
-      return HelperForTestTrueLessThanSignedOrUnsigned(false, exp1, exp2);
-    }
-
-    /// <summary>
-    /// We handle just expressions (that after being normalized) become "  a * x \lt b ", where {a, b} are constants and "x" is a variable
-    /// </summary>
-    private IntervalEnvironment<Variable, Expression> HelperForTestTrueLessThanSignedOrUnsigned(bool isSigned, Expression left, Expression right)
-    {
-      bool isBottom;
-      var constraints = IntervalInference.InferConstraints_LT(isSigned, left, right, this.ExpressionManager.Decoder, this, out isBottom);
-
-      if (isBottom)
-      {
-        return this.Bottom;
-      }
-
-      foreach (var pair in constraints)
-      {
-        this.RefineWith(pair.One, pair.Two);
-      }
-      return this;
-    }
-
-    public override IntervalEnvironment<Variable, Expression> TestNotEqual(Expression e1, Expression e2)
-    {
-      bool isBottomLT, isBottomGT;
-      List<Pair<Variable, Interval>> constraintsLT, constraintsGT;
-
-      IntervalInference.InferConstraints_NotEq(e1, e2, this.ExpressionManager.Decoder, this, 
-        out constraintsLT, out constraintsGT, out isBottomLT, out isBottomGT);
-      
-      if (isBottomLT)
-      {
-        // Bottom join Bottom = Bottom
-        if (isBottomGT)
+        internal IntervalEnvironment(IExpressionDecoder<Variable, Expression> Decoder, Logger Log)
+          : this(new ExpressionManager<Variable, Expression>(null, Decoder, null), true)
         {
-          return this.Bottom;
-        }
-        this.TestTrueListOfFacts(constraintsGT);
-      }
-      else if (isBottomGT)
-      {
-        this.TestTrueListOfFacts(constraintsLT);
-      }
-      else
-      {
-        var join = JoinConstraints(constraintsLT, constraintsGT);
-
-        this.TestTrueListOfFacts(join);
-      }
-
-      return this;
-    }
-
-
-    /// <summary>
-    /// Special case for <code>guard != 0</code>
-    /// Note: It works with side-effects on <code>this</code>!!!
-    /// </summary>
-    override protected IntervalEnvironment<Variable, Expression> TestNotEqualToZero(Expression guard)
-    {
-      var v = Eval(guard);
-      Interval newConstraint;
-
-      if (v.LowerBound.IsZero)
-      {
-        newConstraint = Interval.For(1, v.UpperBound);
-      }
-      else if (v.UpperBound.IsZero)
-      {
-        newConstraint = Interval.For(v.LowerBound, -1);
-      }
-      else
-      {
-        newConstraint = Interval.UnknownInterval;
-      }
-
-      var tmp = v.Meet(newConstraint);
-      var guardVar = this.ExpressionManager.Decoder.UnderlyingVariable(guard);
-
-      if (tmp.IsTop)
-      {  
-        this.RemoveElement(guardVar);
-      }
-      else
-      {
-        this[guardVar] = tmp;
-      }
-
-      return this;
-    }
-
-    protected override IntervalEnvironment<Variable, Expression> TestNotEqualToZero(Variable v)
-    {
-      // cannot capture v != 0
-      return this;
-    }
-
-    protected override IntervalEnvironment<Variable, Expression> TestEqualToZero(Variable v)
-    {
-      var intv = Interval.For(0);
-      Interval prevVal;
-      if (this.TryGetValue(v, out prevVal))
-      {
-        intv = prevVal.Meet(intv);
-      }
-
-      this[v] = intv;
-
-      return this;
-    }
-
-    /// <summary>
-    /// Assume that <code>k \lt right</code>
-    /// </summary>
-    protected override void AssumeKLessThanRight(Interval k, Variable right)
-    {
-      Interval refined;
-      if(IntervalInference.TryRefine_KLessThanRight(true, k, right, Rational.For(1), this, out refined))
-      {
-        this[right] = refined;
-      }
-    }
-
-    /// <summary>
-    /// Assume that <code>left \t k</code>
-    /// </summary>
-    protected override void AssumeLeftLessThanK(Variable left, Interval k)
-    {
-      Interval refined;
-      if (IntervalInference.TryRefine_LeftLessThanK(true, left, k, this, out refined))
-      {
-        this[left] = refined;
-      }
-    }
-
-    #endregion
-
-    #region Private, Helper Methods, and Uninteresting code
-
-    protected override IntervalEnvironment<Variable, Expression> Factory()
-    {
-      return new IntervalEnvironment<Variable, Expression>(this.ExpressionManager);
-    }
-
-    protected override IntervalEnvironment<Variable, Expression> NewInstance(ExpressionManager<Variable, Expression> expManager)
-    {
-      return new IntervalEnvironment<Variable, Expression>(expManager);
-    }
-
-    override protected IntervalEnvironment<Variable, Expression> DuplicateMe()
-    {
-      return new IntervalEnvironment<Variable, Expression>(this);
-    }
-
-    #endregion
-
-    #region Internal methods for SubPolyhedra
-
-    internal Interval EvalArray(SparseRationalArray array, Dictionary<int, Variable> dimsToVar, int keyForConstant)
-    {
-      Interval i;
-      int j, k;
-      return EvalArray(array, dimsToVar, keyForConstant, out i, out j, out k);
-    }
-
-    /// <summary>
-    /// Evaluating a row from Karr with the map <paramref name="varsToDimensions"/>. Given a row a1*x1 + ... + an*xn = b, it evaluates a1*x1 + ... + an*xn - b
-    /// </summary>
-    /// <param name="array">The row to evaluate</param>
-    /// <param name="varsToDimensions">The bijective map from variables to positions</param>
-    /// <param name="keyForConstant">The last index of the row</param>
-    internal Interval EvalArray(SparseRationalArray array, Dictionary<int, Variable> dimsToVar,
-      int keyForConstant, out Interval finiteBounds, out int infLower, out int infUpper)
-    {
-      infLower = 0;
-      infUpper = 0;
-      finiteBounds = Interval.For(0);
-      var tmpValue = Interval.For(0);
-
-      foreach (var pair in array.GetElements())
-      {
-        Interval tmpInt;
-        if (pair.Key == keyForConstant)
-        {
-          tmpInt = Interval.For(-pair.Value); // take the opposite as we want to evaluate f(x) = 0
-        }
-        else if (!this.TryGetValue(dimsToVar[pair.Key], out tmpInt))
-        {
-          tmpInt = Interval.UnknownInterval;
-        }
-        else
-        {
-          tmpInt = pair.Value * tmpInt;
-        }
-        tmpValue = tmpValue + tmpInt;
-
-        var newLower = finiteBounds.LowerBound;
-        var newUpper = finiteBounds.UpperBound;
-
-        if (tmpInt.UpperBound.IsPlusInfinity)
-        {
-          infUpper++;
-        }
-        else
-        {
-          if (!Rational.TryAdd(newUpper, tmpInt.UpperBound, out newUpper))
-          {
-            newUpper = Rational.PlusInfinity;
-          }
-        }
-        if (tmpInt.LowerBound.IsMinusInfinity)
-        {
-          infLower++;
-        }
-        else
-        {
-          if (!Rational.TryAdd(newLower, tmpInt.LowerBound, out newLower))
-          {
-            newLower = Rational.MinusInfinity;
-          }
-        }
-        finiteBounds = Interval.For(newLower, newUpper);
-      }
-
-      return tmpValue;
-    }
-
-
-    /// <summary>
-    /// This method returns a set of polynomials which contains constraints in the convex hull of the projections of the two elements on two-dimensional planes
-    /// </summary>
-    /// <param name="other">The other element with which we want to join</param>
-    /// <param name="slack">A slack variable to insert in the polynomials</param>
-    [ContractVerification(false)] // The analysis of this method takes forever. Should consider refactoring
-    internal Set<Polynomial<Variable, Expression>> ConvexHullHelper(
-      IntervalEnvironment<Variable, Expression> other, Variable slack, SubPolyhedra.JoinConstraintInference inference)
-    {
-      Contract.Requires(other != null);
-
-      var result = new Set<Polynomial<Variable, Expression>>();
-
-      var commonVariables = this.VariablesNonSlack.SetIntersection(other.VariablesNonSlack);
-
-      var oct = false;
-
-      if (commonVariables.Count <= SubPolyhedra.MaxVariablesInOctagonsConstraintInference)
-      {
-        oct = true;
-      }
-      else if (inference == SubPolyhedra.JoinConstraintInference.Standard)
-      {
-        return result;
-      }
-
-      bool CH = 
-        inference == SubPolyhedra.JoinConstraintInference.CHOct 
-        || inference == SubPolyhedra.JoinConstraintInference.ConvexHull2D;
-
-      oct = 
-        oct 
-        || inference == SubPolyhedra.JoinConstraintInference.CHOct 
-        || inference == SubPolyhedra.JoinConstraintInference.Octagons;
-      
-      int i = 0, j = 0;
-
-      var this_Bounds = new Dictionary<Variable, Interval>();
-      var other_Bounds = new Dictionary<Variable, Interval>();
-
-      foreach (var e1 in commonVariables)
-      {
-        i++;
-
-        Interval e1Left, e1Right;
-
-        if(
-          !TryEvalWithCache(this, e1, this_Bounds, out e1Left) 
-          || !TryEvalWithCache(other, e1, other_Bounds, out e1Right))
-        {
-          continue;
         }
 
-        j = 0;
-        foreach (var e2 in commonVariables)
+        public IntervalEnvironment(ExpressionManager<Variable, Expression> expManager)
+          : this(expManager, false)
         {
-          j++;
+            Contract.Requires(expManager != null);
+        }
 
-          // either e1 == e2 or we already have relations between e1 and e2
-          if (e1.Equals(e2) || j <= i)
-          {
-            continue;
-          }
+        private IntervalEnvironment(IntervalEnvironment<Variable, Expression> original)
+          : base(original)
+        {
+        }
 
-          Interval e2Left, e2Right;
-          if (
-            !TryEvalWithCache(this, e2, this_Bounds, out e2Left) 
-            || !TryEvalWithCache(other, e2, other_Bounds, out e2Right))
-          {
-            continue;
-          }
+        private IntervalEnvironment(ExpressionManager<Variable, Expression> expManager, bool internalInvocation)
+          : base(expManager)
+        {
+        }
 
-          if (oct)
-          {
-            #region Adding octogonal constraints to get at least as much precision as octagons
+        #endregion
 
-            var monomials = new Monomial<Variable>[] { new Monomial<Variable>(e1), new Monomial<Variable>(-1, e2), new Monomial<Variable>(slack) };
+        #region IPureExpressionAssignmentsWithBackward<Expression> Members
 
-            Polynomial<Variable, Expression> pol;
-            if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, monomials, out pol))
+        /// <summary>
+        /// The backward assignment for the intervals.
+        /// It modifies the state "in loco", hence with side effects
+        /// </summary>
+        /// <param name="x">The variable to be backward assigned</param>
+        /// <param name="exp">The expression</param>
+        public void AssignBackward(Variable/*!*/ x, Expression/*!*/ exp)
+        {
+            //var postState = this.DuplicateMe();
+
+            //// For all the variables "y" in the expression "exp", we try to revert the assignment, so to find the previous value for "y"
+            //foreach (var y in this.ExpressionManager.Decoder.UnderlyingVariablesIn(exp))
+            //{
+            //  Debug.Assert(y != null);
+            //  Expression backexpression;
+
+            //  // If it can invert the expression
+            //  if (ExpressionInverter<Expression>.TryInvertAssignment(x, exp, y, this.ExpressionManager.Decoder, this.Encoder, out backexpression))
+            //  {
+            //    Polynomial<Variable, Expression> tmpPoly;
+            //    if (!Polynomial<Variable, Expression>.TryToPolynomialForm(backexpression, this.ExpressionManager.Decoder, out tmpPoly))
+            //    {
+            //      break;
+            //    }
+
+            //    Expression normalizedBackExpression = tmpPoly.ToPureExpression(this.Encoder);
+
+            //    var previousValueForY = postState.Eval(normalizedBackExpression);
+
+            //    if (y.Equals(x))
+            //    {
+            //      this[y] = previousValueForY;            // We srongly update the value of "x", as its previous values is meaningless
+            //    }
+            //    else
+            //    {
+            //      this[y] = previousValueForY.Meet(this[y]);             // the previous value for y is the one in the poststate intersect the one "inverted"              
+            //    }
+            //  }
+            //  else
+            //  {   // It cannot invert the expression, so we skip it
+            //    this.ProjectVariable(y);
+            //  }
+            //}
+
+            //if (!this.ExpressionManager.Decoder.UnderlyingVariablesIn(exp).Contains(x))
+            //{   // The previous value for x is lost
+            //  this.ProjectVariable(x);
+            //}
+        }
+
+        #endregion
+
+        #region Code for handling the guards
+
+        /// <summary>
+        /// Assume exp \geq 0
+        /// </summary>
+        override public IntervalEnvironment<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            var newConstraints = IntervalInference.InferConstraints_GeqZero(exp, this.ExpressionManager.Decoder, this);
+
+            foreach (var pair in newConstraints)
             {
-              throw new AbstractInterpretationException("Impossible case");
+                this[pair.One] = pair.Two;
             }
 
-            result.Add(pol);
+            return this;
+        }
 
-            #endregion
-          }
+        public override IntervalEnvironment<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            var isSignedComparison = true;
+            var decoder = this.ExpressionManager.Decoder;
+
+            var type1 = decoder.TypeOf(exp1);
+            var type2 = decoder.TypeOf(exp2);
+            if ((type1 != ExpressionType.Unknown && type2 != ExpressionType.Unknown) &&
+              (type1.IsUnsignedType() || type2.IsUnsignedType()))
+            {
+                isSignedComparison = false;
+            }
+
+            return HelperForTestTrueLessEqualThanSignedOrUnsigned(isSignedComparison, exp1, exp2);
+        }
+
+        public override IntervalEnvironment<Variable, Expression> TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
+        {
+            return HelperForTestTrueLessEqualThanSignedOrUnsigned(false, exp1, exp2);
+        }
+
+        /// <summary>
+        /// We handle just expressions (that after being normalized) become 
+        ///     "a * x \leq b ", or "a * x + b* y \leq c" 
+        /// where {a, b, c} are constants and {x, y} are variables
+        /// </summary>
+        private IntervalEnvironment<Variable, Expression> HelperForTestTrueLessEqualThanSignedOrUnsigned(bool isSigned, Expression left, Expression right)
+        {
+            bool isBottom;
+            var result = IntervalInference.InferConstraints_Leq(isSigned, left, right, this.ExpressionManager.Decoder, this, out isBottom);
+
+            if (isBottom)
+            {
+                return this.Bottom;
+            }
+
+            foreach (var pair in result)
+            {
+                this.RefineWith(pair.One, pair.Two);
+            }
+
+            return this;
+        }
+
+        public override IntervalEnvironment<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return HelperForTestTrueLessThanSignedOrUnsigned(true, exp1, exp2);
+        }
+
+        public override IntervalEnvironment<Variable, Expression> TestTrueLessThan_Un(Expression exp1, Expression exp2)
+        {
+            return HelperForTestTrueLessThanSignedOrUnsigned(false, exp1, exp2);
+        }
+
+        /// <summary>
+        /// We handle just expressions (that after being normalized) become "  a * x \lt b ", where {a, b} are constants and "x" is a variable
+        /// </summary>
+        private IntervalEnvironment<Variable, Expression> HelperForTestTrueLessThanSignedOrUnsigned(bool isSigned, Expression left, Expression right)
+        {
+            bool isBottom;
+            var constraints = IntervalInference.InferConstraints_LT(isSigned, left, right, this.ExpressionManager.Decoder, this, out isBottom);
+
+            if (isBottom)
+            {
+                return this.Bottom;
+            }
+
+            foreach (var pair in constraints)
+            {
+                this.RefineWith(pair.One, pair.Two);
+            }
+            return this;
+        }
+
+        public override IntervalEnvironment<Variable, Expression> TestNotEqual(Expression e1, Expression e2)
+        {
+            bool isBottomLT, isBottomGT;
+            List<Pair<Variable, Interval>> constraintsLT, constraintsGT;
+
+            IntervalInference.InferConstraints_NotEq(e1, e2, this.ExpressionManager.Decoder, this,
+              out constraintsLT, out constraintsGT, out isBottomLT, out isBottomGT);
+
+            if (isBottomLT)
+            {
+                // Bottom join Bottom = Bottom
+                if (isBottomGT)
+                {
+                    return this.Bottom;
+                }
+                this.TestTrueListOfFacts(constraintsGT);
+            }
+            else if (isBottomGT)
+            {
+                this.TestTrueListOfFacts(constraintsLT);
+            }
+            else
+            {
+                var join = JoinConstraints(constraintsLT, constraintsGT);
+
+                this.TestTrueListOfFacts(join);
+            }
+
+            return this;
+        }
 
 
-          if (CH)
-          {
-            #region Convex Hull
+        /// <summary>
+        /// Special case for <code>guard != 0</code>
+        /// Note: It works with side-effects on <code>this</code>!!!
+        /// </summary>
+        override protected IntervalEnvironment<Variable, Expression> TestNotEqualToZero(Expression guard)
+        {
+            var v = Eval(guard);
+            Interval newConstraint;
 
-            // adaptation of the Monotone Chain algorithm
+            if (v.LowerBound.IsZero)
+            {
+                newConstraint = Interval.For(1, v.UpperBound);
+            }
+            else if (v.UpperBound.IsZero)
+            {
+                newConstraint = Interval.For(v.LowerBound, -1);
+            }
+            else
+            {
+                newConstraint = Interval.UnknownInterval;
+            }
 
-            var vertices = new PairNonNull<Rational, Rational>[8] 
-          { new PairNonNull<Rational, Rational>(e1Left.LowerBound, e2Left.LowerBound),
+            var tmp = v.Meet(newConstraint);
+            var guardVar = this.ExpressionManager.Decoder.UnderlyingVariable(guard);
+
+            if (tmp.IsTop)
+            {
+                this.RemoveElement(guardVar);
+            }
+            else
+            {
+                this[guardVar] = tmp;
+            }
+
+            return this;
+        }
+
+        protected override IntervalEnvironment<Variable, Expression> TestNotEqualToZero(Variable v)
+        {
+            // cannot capture v != 0
+            return this;
+        }
+
+        protected override IntervalEnvironment<Variable, Expression> TestEqualToZero(Variable v)
+        {
+            var intv = Interval.For(0);
+            Interval prevVal;
+            if (this.TryGetValue(v, out prevVal))
+            {
+                intv = prevVal.Meet(intv);
+            }
+
+            this[v] = intv;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Assume that <code>k \lt right</code>
+        /// </summary>
+        protected override void AssumeKLessThanRight(Interval k, Variable right)
+        {
+            Interval refined;
+            if (IntervalInference.TryRefine_KLessThanRight(true, k, right, Rational.For(1), this, out refined))
+            {
+                this[right] = refined;
+            }
+        }
+
+        /// <summary>
+        /// Assume that <code>left \t k</code>
+        /// </summary>
+        protected override void AssumeLeftLessThanK(Variable left, Interval k)
+        {
+            Interval refined;
+            if (IntervalInference.TryRefine_LeftLessThanK(true, left, k, this, out refined))
+            {
+                this[left] = refined;
+            }
+        }
+
+        #endregion
+
+        #region Private, Helper Methods, and Uninteresting code
+
+        protected override IntervalEnvironment<Variable, Expression> Factory()
+        {
+            return new IntervalEnvironment<Variable, Expression>(this.ExpressionManager);
+        }
+
+        protected override IntervalEnvironment<Variable, Expression> NewInstance(ExpressionManager<Variable, Expression> expManager)
+        {
+            return new IntervalEnvironment<Variable, Expression>(expManager);
+        }
+
+        override protected IntervalEnvironment<Variable, Expression> DuplicateMe()
+        {
+            return new IntervalEnvironment<Variable, Expression>(this);
+        }
+
+        #endregion
+
+        #region Internal methods for SubPolyhedra
+
+        internal Interval EvalArray(SparseRationalArray array, Dictionary<int, Variable> dimsToVar, int keyForConstant)
+        {
+            Interval i;
+            int j, k;
+            return EvalArray(array, dimsToVar, keyForConstant, out i, out j, out k);
+        }
+
+        /// <summary>
+        /// Evaluating a row from Karr with the map <paramref name="varsToDimensions"/>. Given a row a1*x1 + ... + an*xn = b, it evaluates a1*x1 + ... + an*xn - b
+        /// </summary>
+        /// <param name="array">The row to evaluate</param>
+        /// <param name="varsToDimensions">The bijective map from variables to positions</param>
+        /// <param name="keyForConstant">The last index of the row</param>
+        internal Interval EvalArray(SparseRationalArray array, Dictionary<int, Variable> dimsToVar,
+          int keyForConstant, out Interval finiteBounds, out int infLower, out int infUpper)
+        {
+            infLower = 0;
+            infUpper = 0;
+            finiteBounds = Interval.For(0);
+            var tmpValue = Interval.For(0);
+
+            foreach (var pair in array.GetElements())
+            {
+                Interval tmpInt;
+                if (pair.Key == keyForConstant)
+                {
+                    tmpInt = Interval.For(-pair.Value); // take the opposite as we want to evaluate f(x) = 0
+                }
+                else if (!this.TryGetValue(dimsToVar[pair.Key], out tmpInt))
+                {
+                    tmpInt = Interval.UnknownInterval;
+                }
+                else
+                {
+                    tmpInt = pair.Value * tmpInt;
+                }
+                tmpValue = tmpValue + tmpInt;
+
+                var newLower = finiteBounds.LowerBound;
+                var newUpper = finiteBounds.UpperBound;
+
+                if (tmpInt.UpperBound.IsPlusInfinity)
+                {
+                    infUpper++;
+                }
+                else
+                {
+                    if (!Rational.TryAdd(newUpper, tmpInt.UpperBound, out newUpper))
+                    {
+                        newUpper = Rational.PlusInfinity;
+                    }
+                }
+                if (tmpInt.LowerBound.IsMinusInfinity)
+                {
+                    infLower++;
+                }
+                else
+                {
+                    if (!Rational.TryAdd(newLower, tmpInt.LowerBound, out newLower))
+                    {
+                        newLower = Rational.MinusInfinity;
+                    }
+                }
+                finiteBounds = Interval.For(newLower, newUpper);
+            }
+
+            return tmpValue;
+        }
+
+
+        /// <summary>
+        /// This method returns a set of polynomials which contains constraints in the convex hull of the projections of the two elements on two-dimensional planes
+        /// </summary>
+        /// <param name="other">The other element with which we want to join</param>
+        /// <param name="slack">A slack variable to insert in the polynomials</param>
+        [ContractVerification(false)] // The analysis of this method takes forever. Should consider refactoring
+        internal Set<Polynomial<Variable, Expression>> ConvexHullHelper(
+          IntervalEnvironment<Variable, Expression> other, Variable slack, SubPolyhedra.JoinConstraintInference inference)
+        {
+            Contract.Requires(other != null);
+
+            var result = new Set<Polynomial<Variable, Expression>>();
+
+            var commonVariables = this.VariablesNonSlack.SetIntersection(other.VariablesNonSlack);
+
+            var oct = false;
+
+            if (commonVariables.Count <= SubPolyhedra.MaxVariablesInOctagonsConstraintInference)
+            {
+                oct = true;
+            }
+            else if (inference == SubPolyhedra.JoinConstraintInference.Standard)
+            {
+                return result;
+            }
+
+            bool CH =
+              inference == SubPolyhedra.JoinConstraintInference.CHOct
+              || inference == SubPolyhedra.JoinConstraintInference.ConvexHull2D;
+
+            oct =
+              oct
+              || inference == SubPolyhedra.JoinConstraintInference.CHOct
+              || inference == SubPolyhedra.JoinConstraintInference.Octagons;
+
+            int i = 0, j = 0;
+
+            var this_Bounds = new Dictionary<Variable, Interval>();
+            var other_Bounds = new Dictionary<Variable, Interval>();
+
+            foreach (var e1 in commonVariables)
+            {
+                i++;
+
+                Interval e1Left, e1Right;
+
+                if (
+                  !TryEvalWithCache(this, e1, this_Bounds, out e1Left)
+                  || !TryEvalWithCache(other, e1, other_Bounds, out e1Right))
+                {
+                    continue;
+                }
+
+                j = 0;
+                foreach (var e2 in commonVariables)
+                {
+                    j++;
+
+                    // either e1 == e2 or we already have relations between e1 and e2
+                    if (e1.Equals(e2) || j <= i)
+                    {
+                        continue;
+                    }
+
+                    Interval e2Left, e2Right;
+                    if (
+                      !TryEvalWithCache(this, e2, this_Bounds, out e2Left)
+                      || !TryEvalWithCache(other, e2, other_Bounds, out e2Right))
+                    {
+                        continue;
+                    }
+
+                    if (oct)
+                    {
+                        #region Adding octogonal constraints to get at least as much precision as octagons
+
+                        var monomials = new Monomial<Variable>[] { new Monomial<Variable>(e1), new Monomial<Variable>(-1, e2), new Monomial<Variable>(slack) };
+
+                        Polynomial<Variable, Expression> pol;
+                        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, monomials, out pol))
+                        {
+                            throw new AbstractInterpretationException("Impossible case");
+                        }
+
+                        result.Add(pol);
+
+                        #endregion
+                    }
+
+
+                    if (CH)
+                    {
+                        #region Convex Hull
+
+                        // adaptation of the Monotone Chain algorithm
+
+                        var vertices = new PairNonNull<Rational, Rational>[8]
+                      { new PairNonNull<Rational, Rational>(e1Left.LowerBound, e2Left.LowerBound),
             new PairNonNull<Rational, Rational>(e1Left.LowerBound, e2Left.UpperBound),
             new PairNonNull<Rational, Rational>(e1Left.UpperBound, e2Left.LowerBound),
             new PairNonNull<Rational, Rational>(e1Left.UpperBound, e2Left.UpperBound),
@@ -513,658 +502,657 @@ namespace Microsoft.Research.AbstractDomains.Numerical
             new PairNonNull<Rational, Rational>(e1Right.LowerBound, e2Right.UpperBound),
             new PairNonNull<Rational, Rational>(e1Right.UpperBound, e2Right.LowerBound),
             new PairNonNull<Rational, Rational>(e1Right.UpperBound, e2Right.UpperBound)
-          };
+                      };
 
-            try
-            {
-              Array.Sort(vertices,
-                delegate(PairNonNull<Rational, Rational> x, PairNonNull<Rational, Rational> y)
-                {
-                  if ((x.One - y.One).Sign == 0)
-                    return (x.Two - y.Two).Sign;
-                  else
-                    return (x.One - y.One).Sign;
-                });
+                        try
+                        {
+                            Array.Sort(vertices,
+                              delegate (PairNonNull<Rational, Rational> x, PairNonNull<Rational, Rational> y)
+                              {
+                                  if ((x.One - y.One).Sign == 0)
+                                      return (x.Two - y.Two).Sign;
+                                  else
+                                      return (x.One - y.One).Sign;
+                              });
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            return result;
+                        }
 
+                        var IsInHull = new bool[8];
+                        try
+                        {
+                            Polynomial<Variable, Expression> pol;
+                            #region Computation of the Lower Hull
+                            IsInHull[0] = IsFinite(vertices[0]);
+                            IsInHull[2] = IsFinite(vertices[2]);
+                            IsInHull[4] = IsFinite(vertices[4]);
+
+                            if (IsInHull[0] && IsInHull[2] && IsInHull[4]
+                              && (vertices[2].One - vertices[0].One) * (vertices[4].Two - vertices[0].Two) <= (vertices[4].One - vertices[0].One) * (vertices[2].Two - vertices[0].Two))
+                            {
+                                IsInHull[2] = false;
+                            }
+
+                            IsInHull[6] = IsFinite(vertices[6]);
+
+                            if (IsInHull[2] && IsInHull[4] && IsInHull[6]
+                              && (vertices[4].One - vertices[2].One) * (vertices[6].Two - vertices[2].Two) <= (vertices[6].One - vertices[2].One) * (vertices[4].Two - vertices[2].Two))
+                            {
+                                IsInHull[4] = false;
+                            }
+
+                            if (IsInHull[0] && IsInHull[4] && IsInHull[6]
+                              && (vertices[4].One - vertices[0].One) * (vertices[6].Two - vertices[0].Two) <= (vertices[6].One - vertices[0].One) * (vertices[4].Two - vertices[0].Two))
+                            {
+                                IsInHull[4] = false;
+                            }
+
+                            if (IsInHull[0] && IsInHull[2] && IsInHull[6]
+                              && (vertices[2].One - vertices[0].One) * (vertices[6].Two - vertices[0].Two) <= (vertices[6].One - vertices[0].One) * (vertices[2].Two - vertices[0].Two))
+                            {
+                                IsInHull[2] = false;
+                            }
+                            #endregion
+
+                            #region Computation of the Upper Hull
+                            IsInHull[1] = IsFinite(vertices[1]);
+
+                            IsInHull[3] = IsFinite(vertices[3]);
+
+                            IsInHull[5] = IsFinite(vertices[5]);
+
+                            if (IsInHull[1] && IsInHull[3] && IsInHull[5]
+                              && (vertices[3].One - vertices[1].One) * (vertices[5].Two - vertices[1].Two) >= (vertices[5].One - vertices[1].One) * (vertices[3].Two - vertices[1].Two))
+                            {
+                                IsInHull[3] = false;
+                            }
+
+                            IsInHull[7] = IsFinite(vertices[7]);
+
+                            if (IsInHull[3] && IsInHull[5] && IsInHull[7]
+                              && (vertices[5].One - vertices[3].One) * (vertices[7].Two - vertices[3].Two) >= (vertices[7].One - vertices[3].One) * (vertices[5].Two - vertices[3].Two))
+                            {
+                                IsInHull[5] = false;
+                            }
+
+                            if (IsInHull[1] && IsInHull[5] && IsInHull[7]
+                              && (vertices[5].One - vertices[1].One) * (vertices[7].Two - vertices[1].Two) >= (vertices[7].One - vertices[1].One) * (vertices[5].Two - vertices[1].Two))
+                            {
+                                IsInHull[5] = false;
+                            }
+
+                            if (IsInHull[1] && IsInHull[3] && IsInHull[7]
+                              && (vertices[3].One - vertices[1].One) * (vertices[7].Two - vertices[1].Two) >= (vertices[7].One - vertices[1].One) * (vertices[3].Two - vertices[1].Two))
+                            {
+                                IsInHull[3] = false;
+                            }
+                            #endregion
+
+                            #region Removing points that are in the hull of the subset of finite points but not in the hull due to infinite extreme points
+                            int index = 0;
+                            var value = Rational.For(0);
+
+                            if (vertices[0].One.IsInfinity)
+                            {
+                                index = 2;
+                                value = vertices[2].Two;
+                                for (int n = 4; n < 8; n += 2)
+                                {
+                                    if (vertices[n].Two <= value)
+                                    {
+                                        for (int m = index; m < n; m += 2)
+                                        {
+                                            IsInHull[m] = false;
+                                        }
+                                        index = n;
+                                        value = vertices[n].Two;
+                                    }
+                                }
+                            }
+
+                            if (vertices[6].One.IsInfinity)
+                            {
+                                index = 4;
+                                value = vertices[4].Two;
+                                for (int n = 2; n >= 0; n -= 2)
+                                {
+                                    if (vertices[n].Two <= value)
+                                    {
+                                        for (int m = index; m > n; m -= 2)
+                                        {
+                                            IsInHull[m] = false;
+                                        }
+                                        index = n;
+                                        value = vertices[n].Two;
+                                    }
+                                }
+                            }
+
+                            if (vertices[1].One.IsInfinity)
+                            {
+                                index = 3;
+                                value = vertices[3].Two;
+                                for (int n = 5; n < 8; n += 2)
+                                {
+                                    if (vertices[n].Two >= value)
+                                    {
+                                        for (int m = index; m < n; m += 2)
+                                        {
+                                            IsInHull[m] = false;
+                                        }
+                                        index = n;
+                                        value = vertices[n].Two;
+                                    }
+                                }
+                            }
+
+                            if (vertices[7].One.IsInfinity)
+                            {
+                                index = 5;
+                                value = vertices[5].Two;
+                                for (int n = 3; n >= 0; n -= 2)
+                                {
+                                    if (vertices[n].Two >= value)
+                                    {
+                                        for (int m = index; m > n; m -= 2)
+                                        {
+                                            IsInHull[m] = false;
+                                        }
+                                        index = n;
+                                        value = vertices[n].Two;
+                                    }
+                                }
+                            }
+                            #endregion
+
+                            #region Adding to the result the Polynomials for the edges that are in the hull and neither horizontal nor vertical
+                            var point = new PairNonNull<Rational, Rational>();
+                            Rational c;
+                            int numberOfPointsInHull = 0;
+
+                            for (int k = 0; k < 8; k += 2)
+                            {
+                                if (IsInHull[k])
+                                {
+                                    if (numberOfPointsInHull > 0 && point.One != vertices[k].One && point.Two != vertices[k].Two)
+                                    {
+                                        try
+                                        {
+                                            c = (vertices[k].One - point.One) / (point.Two - vertices[k].Two);
+                                        }
+                                        catch (ArithmeticExceptionRational)
+                                        {
+                                            continue;
+                                        }
+
+                                        var list = new Monomial<Variable>[] { new Monomial<Variable>(e1), new Monomial<Variable>(c, e2), new Monomial<Variable>(slack) };
+
+                                        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, list, out pol))
+                                        {
+                                            throw new AbstractInterpretationException("Impossible case");
+                                        }
+                                        result.Add(pol);
+                                    }
+                                    point = vertices[k];
+                                    numberOfPointsInHull++;
+                                }
+                            }
+                            for (int k = 1; k < 8; k += 2)
+                            {
+                                if (IsInHull[k])
+                                {
+                                    if (numberOfPointsInHull > 0 && point.One != vertices[k].One && point.Two != vertices[k].Two)
+                                    {
+                                        try
+                                        {
+                                            c = (vertices[k].One - point.One) / (point.Two - vertices[k].Two);
+                                        }
+                                        catch (ArithmeticExceptionRational)
+                                        {
+                                            continue;
+                                        }
+
+                                        var list = new Monomial<Variable>[] { new Monomial<Variable>(e1), new Monomial<Variable>(c, e2), new Monomial<Variable>(slack) };
+
+                                        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, list, out pol))
+                                        {
+                                            throw new AbstractInterpretationException("Impossible case");
+                                        }
+
+                                        result.Add(pol);
+                                    }
+                                    point = vertices[k];
+                                    numberOfPointsInHull++;
+                                }
+                            }
+                            #endregion
+                        }
+                        catch (ArithmeticExceptionRational)
+                        {
+                            // Ignore the constraint
+                        }
+                        #endregion
+                    }
+                }
             }
-            catch (InvalidOperationException)
-            {
-              return result;
-            }
-
-            var IsInHull = new bool[8];
-            try
-            {
-              Polynomial<Variable, Expression> pol;
-              #region Computation of the Lower Hull
-              IsInHull[0] = IsFinite(vertices[0]);
-              IsInHull[2] = IsFinite(vertices[2]);
-              IsInHull[4] = IsFinite(vertices[4]);
-
-              if (IsInHull[0] && IsInHull[2] && IsInHull[4]
-                && (vertices[2].One - vertices[0].One) * (vertices[4].Two - vertices[0].Two) <= (vertices[4].One - vertices[0].One) * (vertices[2].Two - vertices[0].Two))
-              {
-                IsInHull[2] = false;
-              }
-
-              IsInHull[6] = IsFinite(vertices[6]);
-
-              if (IsInHull[2] && IsInHull[4] && IsInHull[6]
-                && (vertices[4].One - vertices[2].One) * (vertices[6].Two - vertices[2].Two) <= (vertices[6].One - vertices[2].One) * (vertices[4].Two - vertices[2].Two))
-              {
-                IsInHull[4] = false;
-              }
-
-              if (IsInHull[0] && IsInHull[4] && IsInHull[6]
-                && (vertices[4].One - vertices[0].One) * (vertices[6].Two - vertices[0].Two) <= (vertices[6].One - vertices[0].One) * (vertices[4].Two - vertices[0].Two))
-              {
-                IsInHull[4] = false;
-              }
-
-              if (IsInHull[0] && IsInHull[2] && IsInHull[6]
-                && (vertices[2].One - vertices[0].One) * (vertices[6].Two - vertices[0].Two) <= (vertices[6].One - vertices[0].One) * (vertices[2].Two - vertices[0].Two))
-              {
-                IsInHull[2] = false;
-              }
-              #endregion
-
-              #region Computation of the Upper Hull
-              IsInHull[1] = IsFinite(vertices[1]);
-
-              IsInHull[3] = IsFinite(vertices[3]);
-
-              IsInHull[5] = IsFinite(vertices[5]);
-
-              if (IsInHull[1] && IsInHull[3] && IsInHull[5]
-                && (vertices[3].One - vertices[1].One) * (vertices[5].Two - vertices[1].Two) >= (vertices[5].One - vertices[1].One) * (vertices[3].Two - vertices[1].Two))
-              {
-                IsInHull[3] = false;
-              }
-
-              IsInHull[7] = IsFinite(vertices[7]);
-
-              if (IsInHull[3] && IsInHull[5] && IsInHull[7]
-                && (vertices[5].One - vertices[3].One) * (vertices[7].Two - vertices[3].Two) >= (vertices[7].One - vertices[3].One) * (vertices[5].Two - vertices[3].Two))
-              {
-                IsInHull[5] = false;
-              }
-
-              if (IsInHull[1] && IsInHull[5] && IsInHull[7]
-                && (vertices[5].One - vertices[1].One) * (vertices[7].Two - vertices[1].Two) >= (vertices[7].One - vertices[1].One) * (vertices[5].Two - vertices[1].Two))
-              {
-                IsInHull[5] = false;
-              }
-
-              if (IsInHull[1] && IsInHull[3] && IsInHull[7]
-                && (vertices[3].One - vertices[1].One) * (vertices[7].Two - vertices[1].Two) >= (vertices[7].One - vertices[1].One) * (vertices[3].Two - vertices[1].Two))
-              {
-                IsInHull[3] = false;
-              }
-              #endregion
-
-              #region Removing points that are in the hull of the subset of finite points but not in the hull due to infinite extreme points
-              int index = 0;
-              var value = Rational.For(0);
-
-              if (vertices[0].One.IsInfinity)
-              {
-                index = 2;
-                value = vertices[2].Two;
-                for (int n = 4; n < 8; n += 2)
-                {
-                  if (vertices[n].Two <= value)
-                  {
-                    for (int m = index; m < n; m += 2)
-                    {
-                      IsInHull[m] = false;
-                    }
-                    index = n;
-                    value = vertices[n].Two;
-                  }
-                }
-              }
-
-              if (vertices[6].One.IsInfinity)
-              {
-                index = 4;
-                value = vertices[4].Two;
-                for (int n = 2; n >= 0; n -= 2)
-                {
-                  if (vertices[n].Two <= value)
-                  {
-                    for (int m = index; m > n; m -= 2)
-                    {
-                      IsInHull[m] = false;
-                    }
-                    index = n;
-                    value = vertices[n].Two;
-                  }
-                }
-              }
-
-              if (vertices[1].One.IsInfinity)
-              {
-                index = 3;
-                value = vertices[3].Two;
-                for (int n = 5; n < 8; n += 2)
-                {
-                  if (vertices[n].Two >= value)
-                  {
-                    for (int m = index; m < n; m += 2)
-                    {
-                      IsInHull[m] = false;
-                    }
-                    index = n;
-                    value = vertices[n].Two;
-                  }
-                }
-              }
-
-              if (vertices[7].One.IsInfinity)
-              {
-                index = 5;
-                value = vertices[5].Two;
-                for (int n = 3; n >= 0; n -= 2)
-                {
-                  if (vertices[n].Two >= value)
-                  {
-                    for (int m = index; m > n; m -= 2)
-                    {
-                      IsInHull[m] = false;
-                    }
-                    index = n;
-                    value = vertices[n].Two;
-                  }
-                }
-              }
-              #endregion
-
-              #region Adding to the result the Polynomials for the edges that are in the hull and neither horizontal nor vertical
-              var point = new PairNonNull<Rational, Rational>();
-              Rational c;
-              int numberOfPointsInHull = 0;
-
-              for (int k = 0; k < 8; k += 2)
-              {
-                if (IsInHull[k])
-                {
-                  if (numberOfPointsInHull > 0 && point.One != vertices[k].One && point.Two != vertices[k].Two)
-                  {
-                    try
-                    {
-                      c = (vertices[k].One - point.One) / (point.Two - vertices[k].Two);
-                    }
-                    catch (ArithmeticExceptionRational)
-                    {
-                      continue;
-                    }
-
-                    var list = new Monomial<Variable>[] { new Monomial<Variable>(e1), new Monomial<Variable>(c, e2), new Monomial<Variable>(slack) };
-
-                    if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, list, out pol))
-                    {
-                      throw new AbstractInterpretationException("Impossible case");
-                    }
-                    result.Add(pol);
-                  }
-                  point = vertices[k];
-                  numberOfPointsInHull++;
-                }
-              }
-              for (int k = 1; k < 8; k += 2)
-              {
-                if (IsInHull[k])
-                {
-                  if (numberOfPointsInHull > 0 && point.One != vertices[k].One && point.Two != vertices[k].Two)
-                  {
-                    try
-                    {
-                      c = (vertices[k].One - point.One) / (point.Two - vertices[k].Two);
-                    }
-                    catch (ArithmeticExceptionRational)
-                    {
-                      continue;
-                    }
-
-                    var list = new Monomial<Variable>[] { new Monomial<Variable>(e1), new Monomial<Variable>(c, e2), new Monomial<Variable>(slack) };
-
-                    if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, list, out pol))
-                    {
-                      throw new AbstractInterpretationException("Impossible case");
-                    }
-
-                    result.Add(pol);
-                  }
-                  point = vertices[k];
-                  numberOfPointsInHull++;
-                }
-              }
-              #endregion
-            }
-            catch (ArithmeticExceptionRational)
-            {
-              // Ignore the constraint
-            }
-#endregion
-          }
+            return result;
         }
-      }
-      return result;
-    }
 
-    public static bool TryEvalWithCache(
-      IntervalEnvironment<Variable, Expression> env, Variable exp, Dictionary<Variable, Interval> cache, out Interval valueIfNormal)
-    {
-      Contract.Requires(env != null);
-      Contract.Requires(cache != null);
+        public static bool TryEvalWithCache(
+          IntervalEnvironment<Variable, Expression> env, Variable exp, Dictionary<Variable, Interval> cache, out Interval valueIfNormal)
+        {
+            Contract.Requires(env != null);
+            Contract.Requires(cache != null);
 
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out valueIfNormal) != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out valueIfNormal) != null);
 
-      if (!cache.TryGetValue(exp, out valueIfNormal))
-      {
-        valueIfNormal = env.Eval(exp);
-        cache[exp] = valueIfNormal;
-      }
-      else
-      {
-        Contract.Assume(valueIfNormal != null);
-      }
+            if (!cache.TryGetValue(exp, out valueIfNormal))
+            {
+                valueIfNormal = env.Eval(exp);
+                cache[exp] = valueIfNormal;
+            }
+            else
+            {
+                Contract.Assume(valueIfNormal != null);
+            }
 
-      return valueIfNormal.IsNormal;
-    }
+            return valueIfNormal.IsNormal;
+        }
 
-    private static bool IsFinite(PairNonNull<Rational, Rational> point)
-    {
-      return !point.One.IsInfinity && !point.Two.IsInfinity;
-    }
+        private static bool IsFinite(PairNonNull<Rational, Rational> point)
+        {
+            return !point.One.IsInfinity && !point.Two.IsInfinity;
+        }
 
-    #endregion
+        #endregion
 
-    #region Redefinition for the stand-alone version of subpolyhedra
+        #region Redefinition for the stand-alone version of subpolyhedra
 #if SUBPOLY_ONLY
-    new Interval this[Expression index]
-    {
-      get
-      {
-        return base[index];
-      }
-      set
-      {
-        if (this.ExpressionManager.Decoder.IsVariable(index))
+        new Interval this[Expression index]
         {
-          base[index] = value;
+            get
+            {
+                return base[index];
+            }
+            set
+            {
+                if (this.ExpressionManager.Decoder.IsVariable(index))
+                {
+                    base[index] = value;
+                }
+            }
         }
-      }
-    }
 #endif
-    #endregion
+        #endregion
 
-    #region Abstraction over Intervals
-    /// <summary>
-    /// Tighten the interval <code>val</code> using the range of values
-    /// </summary>
-    protected override Interval ApplyConversion(ExpressionOperator conversionType, Interval val)
-    {
-      return Interval.ApplyConversion(conversionType, val);
-    }
-
-    protected override Interval ConvertInterval(Interval intv)
-    {
-      return intv;
-    }
-
-    public override DisInterval BoundsFor(Expression exp)
-    {
-      return this.Eval(exp).AsDisInterval;
-    }
-
-    public override DisInterval BoundsFor(Variable var)
-    {
-      Interval result;
-      if (this.TryGetValue(var, out result))
-      {
-        return result.AsDisInterval;
-      }
-
-      return DisInterval.UnknownInterval;
-    }
-
-    override public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        var result = new List<Pair<Variable, Int32>>();
-
-        foreach (var pair in this.Elements)
+        #region Abstraction over Intervals
+        /// <summary>
+        /// Tighten the interval <code>val</code> using the range of values
+        /// </summary>
+        protected override Interval ApplyConversion(ExpressionOperator conversionType, Interval val)
         {
-          Rational r;
-          if (pair.Value.TryGetSingletonValue(out r) && r.IsInteger)
-          {
-            var intValue = (Int32) r; // Cast is safe, as r is an Int32
-            result.Add(pair.Key, intValue);
-          }
+            return Interval.ApplyConversion(conversionType, val);
         }
 
-        return result;
-      }
-    }
-
-    public override bool IsGreaterEqualThanZero(Rational val) { return val >= 0; }
-    public override bool IsGreaterThanZero(Rational val) { return val > 0; }
-    public override bool IsLessThanZero(Rational val) { return val < 0; }
-    public override bool IsLessEqualThanZero(Rational val) { return val <= 0; }
-    public override bool IsLessThan(Rational val1, Rational val2) { return val1 < val2; }
-    public override bool IsLessEqualThan(Rational val1, Rational val2) { return val1 <= val2; }
-    public override bool IsZero(Rational val) { return val.IsZero; }
-    public override bool IsNotZero(Rational val) { return val.IsNotZero; }
-    public override Interval IntervalUnknown { get { return Interval.UnknownInterval; } }
-    public override Interval IntervalZero { get { return Interval.For(0); } }
-    public override Interval IntervalOne
-    {
-      get { return Interval.For(1); }
-    }
-
-    public override Interval IntervalGreaterEqualThanMinusOne
-    {
-      get { return Interval.For(-1, Rational.PlusInfinity); }
-    }
-
-    public override Interval Interval_Positive
-    {
-      get { return Interval.PositiveInterval; }
-    }
-
-    public override Interval Interval_StrictlyPositive
-    {
-      get { return this.IntervalRightOpen(Rational.For(1)); }
-    }
-
-    public override Interval IntervalSingleton(Rational val)
-    {
-      return Interval.For(val);
-    }
-
-    public override Interval IntervalLeftOpen(Rational sup) 
-    { 
-      return Interval.For(Rational.MinusInfinity, sup); 
-    }
-
-    public sealed override Interval IntervalRightOpen(Rational inf)
-    {
-      return Interval.For(inf, Rational.PlusInfinity);
-    }
-    
-    public override Interval For(long value)
-    {
-      if (Rational.CanRepresentExactly(value))
-        return Interval.For(Rational.For(value));
-      else if (value >= 0) // of course it will never be zero, it is just to shut up the compiler
-        return Interval.For(1, Rational.PlusInfinity);
-      else
-        return Interval.For(Rational.MinusInfinity, -1);
-    }
-
-    public override Interval For(byte v)
-    {
-      return Interval.For(v);
-    }
-
-    public override Interval For(double d)
-    {
-      return Interval.For(d, d, true);
-    }
-
-    public override Interval For(int v)
-    {
-      return Interval.For((int)v);
-    }
-
-    public override Interval For(sbyte s)
-    {
-      return Interval.For(s);
-    }
-
-    public override Interval For(short v)
-    {
-      return Interval.For(v);
-    }
-
-    public override Interval For(uint u)
-    {
-      return Interval.For(u);
-    }
-
-    public override Interval For(ushort u)
-    {
-      return Interval.For(u);
-    }
-
-    public override Interval For(Rational r)
-    {
-      return Interval.For(r);
-    }
-
-    public override Interval For(Rational inf, Rational sup)
-    {
-      return Interval.For(inf, sup);
-    }
-
-    public override bool AreEqual(Interval left, Interval right)
-    {
-      return left.IsNormal() && right.IsNormal() && left.LessEqual(right) && right.LessEqual(left);
-    }
-
-    public override Interval Interval_Add(Interval left, Interval right)
-    {
-      return left + right;
-    }
-
-    public override Interval Interval_BitwiseAnd(Interval left, Interval right)
-    {
-      return left & right;
-    }
-
-    public override Interval Interval_BitwiseOr(Interval left, Interval right)
-    {
-      return left | right;
-    }
-
-    public override Interval Interval_BitwiseXor(Interval left, Interval right)
-    {
-      return left ^ right;
-    }
-
-    public override Interval Interval_Div(Interval left, Interval right)
-    {
-      return left / right;
-    }
-
-    public override Interval Interval_Mul(Interval left, Interval right)
-    {
-      return left * right;
-    }
-
-    public override Interval Interval_Rem(Interval left, Interval right)
-    {
-      return left % right;
-    }
-
-    public override Interval Interval_ShiftLeft(Interval left, Interval right)
-    {
-      return Interval.ShiftLeft(left, right);
-    }
-
-    public override Interval Interval_ShiftRight(Interval left, Interval right)
-    {
-      return Interval.ShiftRight(left, right);
-    }
-
-    public override Interval Interval_Sub(Interval left, Interval right)
-    {
-      return left - right;
-    }
-
-    public override Interval Interval_UnaryMinus(Interval left)
-    {
-      return -left;
-    }
-
-    public override Interval Interval_Not(Interval left)
-    {
-      if (!left.IsNormal)
-        return left;
-
-      int val;
-      if (left.IsFiniteAndInt32Singleton(out val))
-      {
-        return val == 0 ? Interval.For(1) : Interval.For(0);
-      }
-
-      return Interval.UnknownInterval;
-    }
-
-    public override bool IsMaxInt32(Interval intv)
-    {
-      return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MaxValue;
-    }
-
-    public override bool IsMinInt32(Interval intv)
-    {
-      return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MinValue;
-    }
-
-    public override bool IsMinusInfinity(Rational val)
-    {
-      return val.IsMinusInfinity;
-    }
-
-    public override bool IsPlusInfinity(Rational val)
-    {
-      return val.IsPlusInfinity;
-    }
-
-    public override Rational MinusInfinty
-    {
-      get { return Rational.MinusInfinity;  }
-    }
-
-    public override Rational PlusInfinity
-    {
-      get { return Rational.PlusInfinity; }
-    }
-
-    public override bool TryAdd(Rational left, Rational right, out Rational result)
-    {
-      if (Rational.TryAdd(left, right, out result))
-      {
-        return true;
-      }
-      else
-      {
-        result = default(Rational);
-        return true;
-      }
-    }
-
-    protected override void AssumeInDisInterval_Internal(Variable x, DisInterval value)
-    {
-      AssumeInInterval_Internal(x, value.AsInterval);
-    }
-
-    void AssumeInInterval_Internal(Variable x, Interval value)
-    {
-      Contract.Requires(value != null);
-
-      if (value.IsTop)
-      {
-        return;
-      }
-
-      Interval prev;
-      if (this.TryGetValue(x, out prev))
-      {
-        value = prev.Meet(value);
-      }
-
-      if (value.IsBottom)
-      {
-        this.State = AbstractState.Bottom;
-      }
-      else
-      {
-        this[x] = value;
-      }
-    }
-
-    protected override T To<T>(Rational n, IFactory<T> factory)
-    {
-      return factory.Constant(n);
-    }
-    #endregion
-
-    public IntervalEnvironment<Variable, Expression> AbstractsAwayTooLargeBounds(long min, long max)
-    {
-      Contract.Requires(min <= max);
-      Contract.Ensures(Contract.Result<IntervalEnvironment<Variable, Expression>>() != null);
-
-      if(this.IsBottom || this.IsTop)
-      {
-        return this;
-      }
-
-      var buff = new IntervalEnvironment<Variable, Expression>(this.ExpressionManager);
-
-      foreach(var pair in this.Elements)
-      {
-        // Is lower bound small enough?
-        if (min <= pair.Value.LowerBound)
+        protected override Interval ConvertInterval(Interval intv)
         {
-          // Is upper bound small enough?
-          if (pair.Value.UpperBound <= max)
-          {
-            buff[pair.Key] = pair.Value;
-          }
-          else
-          { // Abstract upper bound
-            buff[pair.Key] = Interval.For(pair.Value.LowerBound, Rational.PlusInfinity);
-          }
+            return intv;
         }
-        else
-        { // We know lower bound is too large
-          if (pair.Value.UpperBound <= max)
-          {
-            buff[pair.Key] = Interval.For(Rational.MinusInfinity, pair.Value.UpperBound);
-          }
-          else
-          { 
-            // Interval too large, let's forget it!
-          }
+
+        public override DisInterval BoundsFor(Expression exp)
+        {
+            return this.Eval(exp).AsDisInterval;
         }
-      }
 
-      return buff;
+        public override DisInterval BoundsFor(Variable var)
+        {
+            Interval result;
+            if (this.TryGetValue(var, out result))
+            {
+                return result.AsDisInterval;
+            }
+
+            return DisInterval.UnknownInterval;
+        }
+
+        override public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                var result = new List<Pair<Variable, Int32>>();
+
+                foreach (var pair in this.Elements)
+                {
+                    Rational r;
+                    if (pair.Value.TryGetSingletonValue(out r) && r.IsInteger)
+                    {
+                        var intValue = (Int32)r; // Cast is safe, as r is an Int32
+                        result.Add(pair.Key, intValue);
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        public override bool IsGreaterEqualThanZero(Rational val) { return val >= 0; }
+        public override bool IsGreaterThanZero(Rational val) { return val > 0; }
+        public override bool IsLessThanZero(Rational val) { return val < 0; }
+        public override bool IsLessEqualThanZero(Rational val) { return val <= 0; }
+        public override bool IsLessThan(Rational val1, Rational val2) { return val1 < val2; }
+        public override bool IsLessEqualThan(Rational val1, Rational val2) { return val1 <= val2; }
+        public override bool IsZero(Rational val) { return val.IsZero; }
+        public override bool IsNotZero(Rational val) { return val.IsNotZero; }
+        public override Interval IntervalUnknown { get { return Interval.UnknownInterval; } }
+        public override Interval IntervalZero { get { return Interval.For(0); } }
+        public override Interval IntervalOne
+        {
+            get { return Interval.For(1); }
+        }
+
+        public override Interval IntervalGreaterEqualThanMinusOne
+        {
+            get { return Interval.For(-1, Rational.PlusInfinity); }
+        }
+
+        public override Interval Interval_Positive
+        {
+            get { return Interval.PositiveInterval; }
+        }
+
+        public override Interval Interval_StrictlyPositive
+        {
+            get { return this.IntervalRightOpen(Rational.For(1)); }
+        }
+
+        public override Interval IntervalSingleton(Rational val)
+        {
+            return Interval.For(val);
+        }
+
+        public override Interval IntervalLeftOpen(Rational sup)
+        {
+            return Interval.For(Rational.MinusInfinity, sup);
+        }
+
+        public sealed override Interval IntervalRightOpen(Rational inf)
+        {
+            return Interval.For(inf, Rational.PlusInfinity);
+        }
+
+        public override Interval For(long value)
+        {
+            if (Rational.CanRepresentExactly(value))
+                return Interval.For(Rational.For(value));
+            else if (value >= 0) // of course it will never be zero, it is just to shut up the compiler
+                return Interval.For(1, Rational.PlusInfinity);
+            else
+                return Interval.For(Rational.MinusInfinity, -1);
+        }
+
+        public override Interval For(byte v)
+        {
+            return Interval.For(v);
+        }
+
+        public override Interval For(double d)
+        {
+            return Interval.For(d, d, true);
+        }
+
+        public override Interval For(int v)
+        {
+            return Interval.For((int)v);
+        }
+
+        public override Interval For(sbyte s)
+        {
+            return Interval.For(s);
+        }
+
+        public override Interval For(short v)
+        {
+            return Interval.For(v);
+        }
+
+        public override Interval For(uint u)
+        {
+            return Interval.For(u);
+        }
+
+        public override Interval For(ushort u)
+        {
+            return Interval.For(u);
+        }
+
+        public override Interval For(Rational r)
+        {
+            return Interval.For(r);
+        }
+
+        public override Interval For(Rational inf, Rational sup)
+        {
+            return Interval.For(inf, sup);
+        }
+
+        public override bool AreEqual(Interval left, Interval right)
+        {
+            return left.IsNormal() && right.IsNormal() && left.LessEqual(right) && right.LessEqual(left);
+        }
+
+        public override Interval Interval_Add(Interval left, Interval right)
+        {
+            return left + right;
+        }
+
+        public override Interval Interval_BitwiseAnd(Interval left, Interval right)
+        {
+            return left & right;
+        }
+
+        public override Interval Interval_BitwiseOr(Interval left, Interval right)
+        {
+            return left | right;
+        }
+
+        public override Interval Interval_BitwiseXor(Interval left, Interval right)
+        {
+            return left ^ right;
+        }
+
+        public override Interval Interval_Div(Interval left, Interval right)
+        {
+            return left / right;
+        }
+
+        public override Interval Interval_Mul(Interval left, Interval right)
+        {
+            return left * right;
+        }
+
+        public override Interval Interval_Rem(Interval left, Interval right)
+        {
+            return left % right;
+        }
+
+        public override Interval Interval_ShiftLeft(Interval left, Interval right)
+        {
+            return Interval.ShiftLeft(left, right);
+        }
+
+        public override Interval Interval_ShiftRight(Interval left, Interval right)
+        {
+            return Interval.ShiftRight(left, right);
+        }
+
+        public override Interval Interval_Sub(Interval left, Interval right)
+        {
+            return left - right;
+        }
+
+        public override Interval Interval_UnaryMinus(Interval left)
+        {
+            return -left;
+        }
+
+        public override Interval Interval_Not(Interval left)
+        {
+            if (!left.IsNormal)
+                return left;
+
+            int val;
+            if (left.IsFiniteAndInt32Singleton(out val))
+            {
+                return val == 0 ? Interval.For(1) : Interval.For(0);
+            }
+
+            return Interval.UnknownInterval;
+        }
+
+        public override bool IsMaxInt32(Interval intv)
+        {
+            return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MaxValue;
+        }
+
+        public override bool IsMinInt32(Interval intv)
+        {
+            return intv.IsSingleton && intv.LowerBound.IsInteger && ((Int32)(intv.LowerBound.NextInt32)) == Int32.MinValue;
+        }
+
+        public override bool IsMinusInfinity(Rational val)
+        {
+            return val.IsMinusInfinity;
+        }
+
+        public override bool IsPlusInfinity(Rational val)
+        {
+            return val.IsPlusInfinity;
+        }
+
+        public override Rational MinusInfinty
+        {
+            get { return Rational.MinusInfinity; }
+        }
+
+        public override Rational PlusInfinity
+        {
+            get { return Rational.PlusInfinity; }
+        }
+
+        public override bool TryAdd(Rational left, Rational right, out Rational result)
+        {
+            if (Rational.TryAdd(left, right, out result))
+            {
+                return true;
+            }
+            else
+            {
+                result = default(Rational);
+                return true;
+            }
+        }
+
+        protected override void AssumeInDisInterval_Internal(Variable x, DisInterval value)
+        {
+            AssumeInInterval_Internal(x, value.AsInterval);
+        }
+
+        private void AssumeInInterval_Internal(Variable x, Interval value)
+        {
+            Contract.Requires(value != null);
+
+            if (value.IsTop)
+            {
+                return;
+            }
+
+            Interval prev;
+            if (this.TryGetValue(x, out prev))
+            {
+                value = prev.Meet(value);
+            }
+
+            if (value.IsBottom)
+            {
+                this.State = AbstractState.Bottom;
+            }
+            else
+            {
+                this[x] = value;
+            }
+        }
+
+        protected override T To<T>(Rational n, IFactory<T> factory)
+        {
+            return factory.Constant(n);
+        }
+        #endregion
+
+        public IntervalEnvironment<Variable, Expression> AbstractsAwayTooLargeBounds(long min, long max)
+        {
+            Contract.Requires(min <= max);
+            Contract.Ensures(Contract.Result<IntervalEnvironment<Variable, Expression>>() != null);
+
+            if (this.IsBottom || this.IsTop)
+            {
+                return this;
+            }
+
+            var buff = new IntervalEnvironment<Variable, Expression>(this.ExpressionManager);
+
+            foreach (var pair in this.Elements)
+            {
+                // Is lower bound small enough?
+                if (min <= pair.Value.LowerBound)
+                {
+                    // Is upper bound small enough?
+                    if (pair.Value.UpperBound <= max)
+                    {
+                        buff[pair.Key] = pair.Value;
+                    }
+                    else
+                    { // Abstract upper bound
+                        buff[pair.Key] = Interval.For(pair.Value.LowerBound, Rational.PlusInfinity);
+                    }
+                }
+                else
+                { // We know lower bound is too large
+                    if (pair.Value.UpperBound <= max)
+                    {
+                        buff[pair.Key] = Interval.For(Rational.MinusInfinity, pair.Value.UpperBound);
+                    }
+                    else
+                    {
+                        // Interval too large, let's forget it!
+                    }
+                }
+            }
+
+            return buff;
+        }
+
+        #region Statistics
+
+        new public string Statistics()
+        {
+            switch (this.State)
+            {
+                case AbstractState.Normal:
+                    return string.Format("Vars: {0}", this.Count);
+                case AbstractState.Bottom:
+                    return "bottom";
+                case AbstractState.Top:
+                    return "top";
+                default:
+                    {
+                        Contract.Assume(false);
+                        return "";
+                    }
+            }
+        }
+
+        #endregion
     }
-
-    #region Statistics
-
-    new public string Statistics()
-    {
-      switch(this.State)
-      {
-        case AbstractState.Normal:
-          return string.Format("Vars: {0}", this.Count);
-        case AbstractState.Bottom:
-          return "bottom";
-        case AbstractState.Top:
-          return "top";
-        default:
-          {
-            Contract.Assume(false);
-          return "";
-          }
-      }
-    }
-    
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalEnvironment_Common.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalEnvironment_Common.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Research.AbstractDomains.Expressions;
 using Microsoft.Research.DataStructures;
@@ -24,371 +13,371 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  [ContractVerification(true)]
-  [ContractClass(typeof(IntervalEnvironment_BaseContracts<,,,,>))]
-  abstract public class IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
-    : FunctionalAbstractDomain<This, Variable, IType>,
-        INumericalAbstractDomain<Variable, Expression>, 
-        ISetOfNumbersAbstraction<Variable, Expression, NType, IType>,
-        IIntervalAbstraction<Variable, Expression>
-    where IType : IntervalBase<IType, NType>
-    where This : IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
-  {
-    #region Constants and statics
-
-    static protected int NEXT_ID = 0;          // The ID for the domains
-    protected const int MAXDEPTH = 10;     // The max depth for evaluating the expressions
-        
-    private static int NextID
+    [ContractVerification(true)]
+    [ContractClass(typeof(IntervalEnvironment_BaseContracts<,,,,>))]
+    abstract public class IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
+      : FunctionalAbstractDomain<This, Variable, IType>,
+          INumericalAbstractDomain<Variable, Expression>,
+          ISetOfNumbersAbstraction<Variable, Expression, NType, IType>,
+          IIntervalAbstraction<Variable, Expression>
+      where IType : IntervalBase<IType, NType>
+      where This : IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
     {
-      get
-      {
-        return NEXT_ID++;
-      }
-    }
+        #region Constants and statics
 
-    #endregion
+        static protected int NEXT_ID = 0;          // The ID for the domains
+        protected const int MAXDEPTH = 10;     // The max depth for evaluating the expressions
 
-    #region Object invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.expManager != null);
-      Contract.Invariant(this.checkIfHoldsVisitor != null);
-    }
-    #endregion
-
-    #region Protected and Private fields (the encoder and decoder, the visitors, the domain id, ...)
-
-    private readonly ExpressionManager<Variable, Expression> expManager;
-    private readonly IntervalsCheckIfHoldsVisitor checkIfHoldsVisitor;
-
-    private int id = -1;   // to be estabilished after the constructor...
-    private int parent_id = -1;
-
-    protected readonly Logger Log;
-
-    #endregion
-
-    #region Constructor
-
-    protected IntervalEnvironment_Base(IntervalEnvironment_Base<This, Variable, Expression, IType, NType> original)
-      : base(original)
-    {
-      Contract.Requires(original != null);
-
-      Contract.Assume(original.expManager != null);
-      this.expManager = original.expManager;
-
-      this.id = NextID;
-      this.parent_id = original.id;
-
-      Contract.Assume(original.checkIfHoldsVisitor != null);
-
-      this.checkIfHoldsVisitor = original.checkIfHoldsVisitor;
-
-      this.Log = original.Log;
-    }
-
-    protected IntervalEnvironment_Base(ExpressionManager<Variable, Expression> expManager)
-      : this(expManager, new IntervalsCheckIfHoldsVisitor(expManager.Decoder))
-    {
-      Contract.Requires(expManager!= null);
-    }
-
-    protected IntervalEnvironment_Base(ExpressionManager<Variable, Expression> expManager, IntervalsCheckIfHoldsVisitor checker)
-      : base()
-    {
-      Contract.Requires(expManager != null);
-      Contract.Requires(checker != null);
-
-      this.expManager = expManager;
-
-      this.id = NextID;
-      this.parent_id = -1;
-
-      this.checkIfHoldsVisitor = checker;
-    }
-  #endregion
-
-    #region Getters and setters
-
-    public ExpressionManager<Variable, Expression> ExpressionManager
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ExpressionManager<Variable, Expression>>() != null);
-
-        return this.expManager;
-      }
-    }
-
-    sealed public override IType this[Variable index]
-    {
-      get
-      {
-        return base[index];
-      }
-      set
-      {
-        // Avoid keeping dummy variables
-        if (this.ExpressionManager.Decoder.IsSlackOrFrameworkVariable(index))
+        private static int NextID
         {
-          base[index] = value;
-        }
-      }
-    }
-
-    #endregion
-
-    #region To be overridden
-
-    abstract protected This DuplicateMe();
-    abstract protected This NewInstance(ExpressionManager<Variable, Expression> expManager);
-    abstract protected IType ConvertInterval(Interval intv);
-
-    // Assumptions
-    abstract public This TestTrueGeqZero(Expression exp);
-    abstract public This TestTrueLessThan(Expression exp1, Expression exp2);
-    abstract public This TestTrueLessEqualThan(Expression exp1, Expression exp2);
-
-    abstract public This TestTrueLessThan_Un(Expression exp1, Expression exp2);
-    abstract public This TestTrueLessEqualThan_Un(Expression exp1, Expression exp2);
-
-    abstract protected This TestNotEqualToZero(Expression guard);
-    abstract protected This TestNotEqualToZero(Variable v);
-
-    abstract protected This TestEqualToZero(Variable v);
-
-    abstract protected void AssumeKLessThanRight(IType k, Variable right);
-    abstract protected void AssumeLeftLessThanK(Variable left, IType k);
-
-    // BoundsFor
-    abstract public DisInterval BoundsFor(Expression exp);
-    abstract public DisInterval BoundsFor(Variable v);
-
-    // Assign
-    abstract protected void AssumeInDisInterval_Internal(Variable x, DisInterval value);
-
-    // Arithmetics
-    abstract public bool IsGreaterEqualThanZero(NType val);
-    abstract public bool IsGreaterThanZero(NType val);
-    abstract public bool IsLessThanZero(NType val);
-    abstract public bool IsLessEqualThanZero(NType val);
-
-    abstract public bool IsLessThan(NType val1, NType val2);
-    abstract public bool IsLessEqualThan(NType val1, NType val2);
-    abstract public bool IsZero(NType val);
-    abstract public bool IsNotZero(NType val);
-    abstract public bool IsPlusInfinity(NType val);
-    abstract public bool IsMinusInfinity(NType val);
-
-    abstract public bool AreEqual(IType left, IType right);
-
-    abstract public NType PlusInfinity { get; }
-    abstract public NType MinusInfinty { get; }
-    abstract public bool TryAdd(NType left, NType right, out NType result);
-
-    abstract public IType IntervalUnknown { get; }
-    abstract public IType IntervalZero { get; }
-    abstract public IType IntervalOne { get; }
-    abstract public IType IntervalGreaterEqualThanMinusOne { get; }
-    abstract public IType Interval_Positive { get; }
-    abstract public IType Interval_StrictlyPositive { get; }
-    abstract public IType IntervalSingleton(NType val);
-    abstract public IType IntervalRightOpen(NType inf);
-    abstract public IType IntervalLeftOpen(NType sup);
-
-    abstract public bool IsMaxInt32(IType intv);
-    abstract public bool IsMinInt32(IType intv);
-
-    abstract public IType Interval_Add(IType left, IType right);
-    abstract public IType Interval_Div(IType left, IType right);
-    abstract public IType Interval_Sub(IType left, IType right);
-    abstract public IType Interval_Mul(IType left, IType right);
-    abstract public IType Interval_Not(IType left);
-    abstract public IType Interval_UnaryMinus(IType left);
-    abstract public IType Interval_Rem(IType left, IType right);
-
-    abstract public IType Interval_BitwiseAnd(IType left, IType right);
-    abstract public IType Interval_BitwiseOr(IType left, IType right);
-    abstract public IType Interval_BitwiseXor(IType left, IType right);
-
-    abstract public IType Interval_ShiftLeft(IType left, IType right);
-    abstract public IType Interval_ShiftRight(IType left, IType right);
-
-    abstract public IType For(Byte v);
-
-    abstract public IType For(Double d);
-    abstract public IType For(Int16 v);
-    abstract public IType For(Int32 v);
-    abstract public IType For(Int64 v);
-    abstract public IType For(SByte s);
-    abstract public IType For(UInt16 u);
-    abstract public IType For(UInt32 u);
-    abstract public IType For(Rational r);
-    abstract public IType For(NType inf, NType sup);
-
-    abstract protected IType ApplyConversion(ExpressionOperator conversionType, IType val);
-
-    abstract protected T To<T>(NType n, IFactory<T> factory);
-
-    #endregion
-
-    #region Helpers
-    
-    virtual public FlatAbstractDomain<bool> IsNotZero(IType intv)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      if (intv.IsNormal)
-      {
-        if (this.IsGreaterThanZero(intv.LowerBound) || this.IsLessThanZero(intv.UpperBound))
-        {
-          return CheckOutcome.True;
-        }
-        if (this.IsZero(intv.LowerBound) && this.IsZero(intv.UpperBound))
-        {
-          return CheckOutcome.False;
-        }
-      }
-      
-        return CheckOutcome.Top;
-    }
-
-    public bool IsGreaterEqualThanZero(IType intv)
-    {
-      return intv.IsNormal && this.IsGreaterEqualThanZero(intv.LowerBound);
-    }
-
-    public bool IsLessEqualThanZero(IType intv)
-    {
-      return intv.IsNormal && this.IsLessEqualThanZero(intv.UpperBound);
-    }
-    #endregion
-
-    #region Common Assumptions
-    /// <summary>
-    /// Assume that <code>k \leq right</code>
-    /// </summary>
-    protected void AssumeKLessEqualThanRight(IType k, Variable right)
-    {
-      IType refinedIntv;
-      if (IntervalInference.TryRefine_KLessEqualThanRight(true, k, right, this, out refinedIntv))
-      {
-        this[right] = refinedIntv;
-      }
-    }
-
-    /// <summary>
-    /// Assume that <code>left \leq k</code>
-    /// </summary>
-    protected void AssumeLeftLessEqualThanK(Variable left, IType k)
-    {
-      IType refinedIntv;
-      if (IntervalInference.TryRefine_LeftLessEqualThanK(true, left, k, this, out refinedIntv))
-      {
-        this[left] = refinedIntv;
-      }
-    }
-    #endregion
-
-    #region IPureAssignment
-
-    /// <summary>
-    /// Evaluates the expression on the left (that must be an arithmetic expression) and assigns it to the variable <code>x</code>
-    /// </summary>
-    public void Assign(Expression x, Expression exp)
-    {
-      State = AbstractState.Normal;
-
-      var val = Eval(exp);
-
-      var xVar = this.expManager.Decoder.UnderlyingVariable(x);
-
-      if (val.IsBottom)
-      {
-        this.State = AbstractState.Bottom;
-        this.ClearElements();
-      }
-      else if (val.IsTop)
-      {
-        return;
-      }
-      else
-      {
-        IType prev;
-        if(this.TryGetValue(xVar, out prev))
-        {
-          val = prev.Meet(val);
-        }
-          
-        this[xVar] = val;
-      }
-    }
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      this.Assign(x, exp);
-
-      this.RefineWithPrestate(x, exp, preState);
-    }
-
-    /// <summary>
-    /// Assign the expression 
-    /// </summary>
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      if (value.IsTop)
-      {
-        return;
-      }
-
-      AssumeInDisInterval_Internal(x, value);
-    }
-
-    /// <summary>
-    /// Perform the parallel assignment.
-    /// First, it evaluates all the expressions in the current state (evaluation is side effect free).
-    /// Then, it updates the values
-    /// </summary>
-    public virtual void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      var result = NewInstance(this.expManager);
-
-      Contract.Assert(result != null);
-
-      foreach (var e_pair in this.Elements)
-      {
-        if (this.expManager.Decoder.IsSlackVariable(e_pair.Key))
-        {
-          result.AddElement(e_pair.Key, e_pair.Value);
-        }
-        Contract.Assert(result != null); // F: It was a bug in Clousot that Manuel fixed. I keep the assertion for regression purposes
-      }
-
-      Contract.Assert(result != null);
-
-      this.State = AbstractState.Normal;
-
-      if (sourcesToTargets.Count == 0)
-      {
-        // do nothing...
-      }
-      else
-      {
-#if true
-        foreach (var pair in this.Elements)
-        {
-          FList<Variable> values;
-          if (sourcesToTargets.TryGetValue(pair.Key, out values))
-          {
-            foreach (var target in values.GetEnumerable())
+            get
             {
-              result[target] = pair.Value;
+                return NEXT_ID++;
             }
-          }
         }
+
+        #endregion
+
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(expManager != null);
+            Contract.Invariant(checkIfHoldsVisitor != null);
+        }
+        #endregion
+
+        #region Protected and Private fields (the encoder and decoder, the visitors, the domain id, ...)
+
+        private readonly ExpressionManager<Variable, Expression> expManager;
+        private readonly IntervalsCheckIfHoldsVisitor checkIfHoldsVisitor;
+
+        private int id = -1;   // to be estabilished after the constructor...
+        private int parent_id = -1;
+
+        protected readonly Logger Log;
+
+        #endregion
+
+        #region Constructor
+
+        protected IntervalEnvironment_Base(IntervalEnvironment_Base<This, Variable, Expression, IType, NType> original)
+          : base(original)
+        {
+            Contract.Requires(original != null);
+
+            Contract.Assume(original.expManager != null);
+            expManager = original.expManager;
+
+            id = NextID;
+            parent_id = original.id;
+
+            Contract.Assume(original.checkIfHoldsVisitor != null);
+
+            checkIfHoldsVisitor = original.checkIfHoldsVisitor;
+
+            this.Log = original.Log;
+        }
+
+        protected IntervalEnvironment_Base(ExpressionManager<Variable, Expression> expManager)
+          : this(expManager, new IntervalsCheckIfHoldsVisitor(expManager.Decoder))
+        {
+            Contract.Requires(expManager != null);
+        }
+
+        protected IntervalEnvironment_Base(ExpressionManager<Variable, Expression> expManager, IntervalsCheckIfHoldsVisitor checker)
+          : base()
+        {
+            Contract.Requires(expManager != null);
+            Contract.Requires(checker != null);
+
+            this.expManager = expManager;
+
+            id = NextID;
+            parent_id = -1;
+
+            checkIfHoldsVisitor = checker;
+        }
+        #endregion
+
+        #region Getters and setters
+
+        public ExpressionManager<Variable, Expression> ExpressionManager
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ExpressionManager<Variable, Expression>>() != null);
+
+                return expManager;
+            }
+        }
+
+        sealed public override IType this[Variable index]
+        {
+            get
+            {
+                return base[index];
+            }
+            set
+            {
+                // Avoid keeping dummy variables
+                if (this.ExpressionManager.Decoder.IsSlackOrFrameworkVariable(index))
+                {
+                    base[index] = value;
+                }
+            }
+        }
+
+        #endregion
+
+        #region To be overridden
+
+        abstract protected This DuplicateMe();
+        abstract protected This NewInstance(ExpressionManager<Variable, Expression> expManager);
+        abstract protected IType ConvertInterval(Interval intv);
+
+        // Assumptions
+        abstract public This TestTrueGeqZero(Expression exp);
+        abstract public This TestTrueLessThan(Expression exp1, Expression exp2);
+        abstract public This TestTrueLessEqualThan(Expression exp1, Expression exp2);
+
+        abstract public This TestTrueLessThan_Un(Expression exp1, Expression exp2);
+        abstract public This TestTrueLessEqualThan_Un(Expression exp1, Expression exp2);
+
+        abstract protected This TestNotEqualToZero(Expression guard);
+        abstract protected This TestNotEqualToZero(Variable v);
+
+        abstract protected This TestEqualToZero(Variable v);
+
+        abstract protected void AssumeKLessThanRight(IType k, Variable right);
+        abstract protected void AssumeLeftLessThanK(Variable left, IType k);
+
+        // BoundsFor
+        abstract public DisInterval BoundsFor(Expression exp);
+        abstract public DisInterval BoundsFor(Variable v);
+
+        // Assign
+        abstract protected void AssumeInDisInterval_Internal(Variable x, DisInterval value);
+
+        // Arithmetics
+        abstract public bool IsGreaterEqualThanZero(NType val);
+        abstract public bool IsGreaterThanZero(NType val);
+        abstract public bool IsLessThanZero(NType val);
+        abstract public bool IsLessEqualThanZero(NType val);
+
+        abstract public bool IsLessThan(NType val1, NType val2);
+        abstract public bool IsLessEqualThan(NType val1, NType val2);
+        abstract public bool IsZero(NType val);
+        abstract public bool IsNotZero(NType val);
+        abstract public bool IsPlusInfinity(NType val);
+        abstract public bool IsMinusInfinity(NType val);
+
+        abstract public bool AreEqual(IType left, IType right);
+
+        abstract public NType PlusInfinity { get; }
+        abstract public NType MinusInfinty { get; }
+        abstract public bool TryAdd(NType left, NType right, out NType result);
+
+        abstract public IType IntervalUnknown { get; }
+        abstract public IType IntervalZero { get; }
+        abstract public IType IntervalOne { get; }
+        abstract public IType IntervalGreaterEqualThanMinusOne { get; }
+        abstract public IType Interval_Positive { get; }
+        abstract public IType Interval_StrictlyPositive { get; }
+        abstract public IType IntervalSingleton(NType val);
+        abstract public IType IntervalRightOpen(NType inf);
+        abstract public IType IntervalLeftOpen(NType sup);
+
+        abstract public bool IsMaxInt32(IType intv);
+        abstract public bool IsMinInt32(IType intv);
+
+        abstract public IType Interval_Add(IType left, IType right);
+        abstract public IType Interval_Div(IType left, IType right);
+        abstract public IType Interval_Sub(IType left, IType right);
+        abstract public IType Interval_Mul(IType left, IType right);
+        abstract public IType Interval_Not(IType left);
+        abstract public IType Interval_UnaryMinus(IType left);
+        abstract public IType Interval_Rem(IType left, IType right);
+
+        abstract public IType Interval_BitwiseAnd(IType left, IType right);
+        abstract public IType Interval_BitwiseOr(IType left, IType right);
+        abstract public IType Interval_BitwiseXor(IType left, IType right);
+
+        abstract public IType Interval_ShiftLeft(IType left, IType right);
+        abstract public IType Interval_ShiftRight(IType left, IType right);
+
+        abstract public IType For(Byte v);
+
+        abstract public IType For(Double d);
+        abstract public IType For(Int16 v);
+        abstract public IType For(Int32 v);
+        abstract public IType For(Int64 v);
+        abstract public IType For(SByte s);
+        abstract public IType For(UInt16 u);
+        abstract public IType For(UInt32 u);
+        abstract public IType For(Rational r);
+        abstract public IType For(NType inf, NType sup);
+
+        abstract protected IType ApplyConversion(ExpressionOperator conversionType, IType val);
+
+        abstract protected T To<T>(NType n, IFactory<T> factory);
+
+        #endregion
+
+        #region Helpers
+
+        virtual public FlatAbstractDomain<bool> IsNotZero(IType intv)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            if (intv.IsNormal)
+            {
+                if (this.IsGreaterThanZero(intv.LowerBound) || this.IsLessThanZero(intv.UpperBound))
+                {
+                    return CheckOutcome.True;
+                }
+                if (this.IsZero(intv.LowerBound) && this.IsZero(intv.UpperBound))
+                {
+                    return CheckOutcome.False;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public bool IsGreaterEqualThanZero(IType intv)
+        {
+            return intv.IsNormal && this.IsGreaterEqualThanZero(intv.LowerBound);
+        }
+
+        public bool IsLessEqualThanZero(IType intv)
+        {
+            return intv.IsNormal && this.IsLessEqualThanZero(intv.UpperBound);
+        }
+        #endregion
+
+        #region Common Assumptions
+        /// <summary>
+        /// Assume that <code>k \leq right</code>
+        /// </summary>
+        protected void AssumeKLessEqualThanRight(IType k, Variable right)
+        {
+            IType refinedIntv;
+            if (IntervalInference.TryRefine_KLessEqualThanRight(true, k, right, this, out refinedIntv))
+            {
+                this[right] = refinedIntv;
+            }
+        }
+
+        /// <summary>
+        /// Assume that <code>left \leq k</code>
+        /// </summary>
+        protected void AssumeLeftLessEqualThanK(Variable left, IType k)
+        {
+            IType refinedIntv;
+            if (IntervalInference.TryRefine_LeftLessEqualThanK(true, left, k, this, out refinedIntv))
+            {
+                this[left] = refinedIntv;
+            }
+        }
+        #endregion
+
+        #region IPureAssignment
+
+        /// <summary>
+        /// Evaluates the expression on the left (that must be an arithmetic expression) and assigns it to the variable <code>x</code>
+        /// </summary>
+        public void Assign(Expression x, Expression exp)
+        {
+            State = AbstractState.Normal;
+
+            var val = Eval(exp);
+
+            var xVar = expManager.Decoder.UnderlyingVariable(x);
+
+            if (val.IsBottom)
+            {
+                this.State = AbstractState.Bottom;
+                this.ClearElements();
+            }
+            else if (val.IsTop)
+            {
+                return;
+            }
+            else
+            {
+                IType prev;
+                if (this.TryGetValue(xVar, out prev))
+                {
+                    val = prev.Meet(val);
+                }
+
+                this[xVar] = val;
+            }
+        }
+
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            this.Assign(x, exp);
+
+            this.RefineWithPrestate(x, exp, preState);
+        }
+
+        /// <summary>
+        /// Assign the expression 
+        /// </summary>
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            if (value.IsTop)
+            {
+                return;
+            }
+
+            AssumeInDisInterval_Internal(x, value);
+        }
+
+        /// <summary>
+        /// Perform the parallel assignment.
+        /// First, it evaluates all the expressions in the current state (evaluation is side effect free).
+        /// Then, it updates the values
+        /// </summary>
+        public virtual void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            var result = NewInstance(expManager);
+
+            Contract.Assert(result != null);
+
+            foreach (var e_pair in this.Elements)
+            {
+                if (expManager.Decoder.IsSlackVariable(e_pair.Key))
+                {
+                    result.AddElement(e_pair.Key, e_pair.Value);
+                }
+                Contract.Assert(result != null); // F: It was a bug in Clousot that Manuel fixed. I keep the assertion for regression purposes
+            }
+
+            Contract.Assert(result != null);
+
+            this.State = AbstractState.Normal;
+
+            if (sourcesToTargets.Count == 0)
+            {
+                // do nothing...
+            }
+            else
+            {
+#if true
+                foreach (var pair in this.Elements)
+                {
+                    FList<Variable> values;
+                    if (sourcesToTargets.TryGetValue(pair.Key, out values))
+                    {
+                        foreach (var target in values.GetEnumerable())
+                        {
+                            result[target] = pair.Value;
+                        }
+                    }
+                }
 #else
         // Update the values
         foreach (var pair in sourcesToTargets)
@@ -409,3057 +398,3052 @@ namespace Microsoft.Research.AbstractDomains.Numerical
 
         }
 #endif
-      }
+            }
 
-      // Update the state
-      this.CopyAndTransferOwnership(result);
-    }
-
-    protected void RefineWith(Variable var, IType intv)
-    {
-      Contract.Requires(intv != null);
-
-      if (intv.IsTop)
-      {
-        return;
-      }
-
-      IType prev;
-      if (this.TryGetValue(var, out prev))
-      {
-        this[var] = prev.Meet(intv);
-      }
-      else
-      {
-        this[var] = intv;
-      }
-    }
-
-    protected void TestTrueListOfFacts(List<Pair<Variable, IType>> list)
-    {
-      Contract.Requires(list != null);
-
-      foreach (var pair in list)
-      {
-        Contract.Assume(pair.Two != null);
-
-        this.RefineWith(pair.One, pair.Two);
-      }
-    }
-
-    protected List<Pair<Variable, IType>> JoinConstraints(
-      List<Pair<Variable, IType>> constraintsLT, 
-      List<Pair<Variable, IType>> constraintsGT)
-    {
-      Contract.Requires(constraintsLT != null);
-      Contract.Requires(constraintsGT != null);
-      Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
-
-      var result = new List<Pair<Variable, IType>>();
-
-      if (constraintsGT.Count == 0 || constraintsLT.Count == 0)
-      {
-        return result;
-      }
-
-      foreach (var pair in constraintsLT)
-      {
-        IType intv;
-        if (constraintsGT.SearchAndRemoveIfFound(pair.One, out intv))
-        {
-          Contract.Assume(intv != null);
-          intv = pair.Two.Join(intv);
-          if (!intv.IsTop)
-          {
-            result.Add(pair.One, intv);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// The variables defined in this environment
-    /// </summary>
-    public List<Variable> Variables
-    {
-      get
-      {
-        return new List<Variable>(this.Keys);
-      }
-    }
-
-    public List<Variable> VariablesNonSlack
-    {
-      get
-      {
-        var result = new List<Variable>();
-        foreach (var k in this.Keys)
-        {
-          if (!this.expManager.Decoder.IsSlackVariable(k))
-          {
-            result.Add(k);
-          }
+            // Update the state
+            this.CopyAndTransferOwnership(result);
         }
 
-        return result;
-      }
-    }
-
-    /// <summary>
-    /// Add the variable <code>var</code> to the environment
-    /// </summary>
-    /// <param name="var">Must not be already there</param>
-    public void AddVariable(Variable var)
-    {
-      this.State = AbstractState.Normal;
-
-      this.ProjectVariable(var);
-    }
-
-    /// <summary>
-    /// Projects out the variable <code>var</code>.
-    /// Its value is set to top.
-    /// </summary>
-    public void ProjectVariable(Variable var)
-    {
-      if (this.ContainsKey(var))
-      {
-        this.RemoveElement(var);
-      }
-    }
-
-    /// <summary>
-    /// Removes the variable <code>var</code>
-    /// </summary>
-    /// <param name="var"></param>
-    public void RemoveVariable(Variable var)
-    {
-      this.RemoveElement(var);
-    }
-
-    /// <summary>
-    /// Renames the variable <code>oldName</code> to <code>newName</code>
-    /// </summary>
-    public void RenameVariable(Variable oldName, Variable newName)
-    {
-      if (this.ContainsKey(oldName))
-      {
-        this[newName] = this[oldName];
-        this.RemoveVariable(oldName);
-      }
-    }
-
-    #endregion
-
-    #region Eval
-    protected internal IType EvalPolynomial(Polynomial<Variable, Expression> pol)
-    {
-      Contract.Requires(pol.Relation == null);
-
-      IType i;
-      int l, u;
-      return this.EvalPolynomial(pol, out i, out l, out u);
-    }
-
-    protected internal IType EvalPolynomial(Polynomial<Variable, Expression> pol, out IType finiteBounds, out int infLower, out int infUpper)
-    {
-      Contract.Requires(pol.Relation == null);
-
-      infLower = 0;
-      infUpper = 0;
-
-      var tmpValue = this.IntervalZero;
-      finiteBounds = this.IntervalZero;
-
-      foreach (var m in pol.Left)
-      {
-        var tmpInt = EvalMonomial(m);
-        tmpValue = Interval_Add(tmpValue, tmpInt);
-
-        var newLower = finiteBounds.LowerBound;
-        var newUpper = finiteBounds.UpperBound;
-        
-        if (this.IsPlusInfinity(tmpInt.UpperBound))
+        protected void RefineWith(Variable var, IType intv)
         {
-          infUpper++;
-        }
-        else
-        {
-          if (!TryAdd(newUpper, tmpInt.UpperBound, out newUpper))
-          {
-            newUpper = this.PlusInfinity;
-          }
-          Contract.Assume(!object.Equals(newUpper, null));
-        }
-        if (this.IsMinusInfinity(tmpInt.LowerBound))
-        {
-          infLower++;
-        }
-        else
-        {
-          if (!TryAdd(newLower, tmpInt.LowerBound, out newLower))
-          {
-            newLower = this.MinusInfinty;
-          }
-          Contract.Assume(!object.Equals(newLower, null));
-        }
-        finiteBounds = For(newLower, newUpper);
-      }
+            Contract.Requires(intv != null);
 
-      return tmpValue;
-    }
-
-    protected IType EvalMonomial(Monomial<Variable> m)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      var tmpValue = For(m.K);
-      IType valueForX;
-
-      foreach (var x in m.Variables)
-      {
-        if (this.TryGetValue(x, out valueForX))
-        {
-          tmpValue = Interval_Mul(tmpValue, valueForX);
-        }
-        else
-        {
-          return IntervalUnknown;
-        }
-      }
-
-      return tmpValue;
-    }
-
-    public IType Eval(Variable v)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      IType val;
-      if (this.TryGetValue(v, out val))
-      {
-        return val;
-      }
-
-      return this.IntervalUnknown;
-    }
-
-    /// <summary>
-    /// The difference with BoundsFor is in the return type, which is more specific for Eval 
-    /// </summary>
-    public IType Eval(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      Contract.Assume(exp != null);
-
-#if TRACE_PERFORMANCE
-      var watch = new Stopwatch();
-      watch.Start();
-#endif
-      // Such a common situation that we want to short cut it
-      int value;
-      if (this.expManager.Decoder.IsConstantInt(exp, out value))
-      {
-        return For(value);
-      }
-
-      // F: funny enough, making evalVisitor a field makes the analysis slower!
-      var evalVisitor = new EvalExpressionVisitor(this.expManager.Decoder);
-
-      var result = evalVisitor.Visit(exp, new Pair<This, int>((This)this, 0));
-
-      Contract.Assert(result != null);
-
-      if (evalVisitor.DuplicatedOccurrences.Count >= 1)
-      {
-        var intv = default(IType);
-        var isFirst = true;
-
-        foreach (var v in evalVisitor.DuplicatedOccurrences)
-        {
-          IType intvForV;
-          if (this.TryGetValue(v, out intvForV) 
-            && intvForV.IsFinite 
-            && this.IsGreaterEqualThanZero(intvForV.LowerBound) // the precision improvement below holds when the interval is non-negative
-            ) 
-          {
-            var r = EvalWithExtremes(exp, v, intvForV);
-            if (isFirst)
+            if (intv.IsTop)
             {
-              intv = r; 
-              isFirst = false;
+                return;
+            }
+
+            IType prev;
+            if (this.TryGetValue(var, out prev))
+            {
+                this[var] = prev.Meet(intv);
             }
             else
             {
-              Contract.Assert(intv != null); 
-              intv = r.Join(intv);
+                this[var] = intv;
             }
-          }
-          Contract.Assert(isFirst || intv != null);
         }
 
-        result = isFirst ? result : result.Meet(intv);
-        Contract.Assert(result != null);
-      }
-
- #if TRACE_PERFORMANCE
-      UpdateTimeSpentInIntervalEval(watch.Elapsed);
-#endif
-      return result;
-    }
-
-    private IType EvalWithExtremes(Expression exp, Variable v, IType intv)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      var evalVisitor = new EvalExpressionVisitor(this.expManager.Decoder);
-
-      this[v] = IntervalSingleton(intv.LowerBound);
-
-      var low = evalVisitor.Visit(exp, new Pair<This, int>((This)this, 0));
-
-      this[v] = IntervalSingleton(intv.UpperBound);
-
-      var upp = evalVisitor.Visit(exp, new Pair<This, int>((This)this, 0));
-
-      Contract.Assert(upp != null);
-
-      this[v] = intv;
-
-      return low.Join(upp);
-    }
-    
-    protected IType EvalConstant(Expression exp)
-    {
-      Contract.Requires(exp != null);
-
-      return new EvalConstantVisitor(this.ExpressionManager.Decoder).Visit(exp, (This) this);
-    }
-    #endregion
-
-    #region Checks
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      var result = this.checkIfHoldsVisitor.Visit(exp, (This) this);
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      var boundsForIndex = this.Eval(exp);
-
-      if (boundsForIndex.IsBottom)
-      {
-        return CheckOutcome.Bottom;
-      }
-      else if (boundsForIndex.IsNormal)
-      {
-        if (this.IsGreaterEqualThanZero(boundsForIndex.LowerBound))
+        protected void TestTrueListOfFacts(List<Pair<Variable, IType>> list)
         {
-          return CheckOutcome.True;
+            Contract.Requires(list != null);
+
+            foreach (var pair in list)
+            {
+                Contract.Assume(pair.Two != null);
+
+                this.RefineWith(pair.One, pair.Two);
+            }
         }
-        else if (this.IsLessThanZero(boundsForIndex.UpperBound))
+
+        protected List<Pair<Variable, IType>> JoinConstraints(
+          List<Pair<Variable, IType>> constraintsLT,
+          List<Pair<Variable, IType>> constraintsGT)
         {
-          return CheckOutcome.False;
+            Contract.Requires(constraintsLT != null);
+            Contract.Requires(constraintsGT != null);
+            Contract.Ensures(Contract.Result<List<Pair<Variable, IType>>>() != null);
+
+            var result = new List<Pair<Variable, IType>>();
+
+            if (constraintsGT.Count == 0 || constraintsLT.Count == 0)
+            {
+                return result;
+            }
+
+            foreach (var pair in constraintsLT)
+            {
+                IType intv;
+                if (constraintsGT.SearchAndRemoveIfFound(pair.One, out intv))
+                {
+                    Contract.Assume(intv != null);
+                    intv = pair.Two.Join(intv);
+                    if (!intv.IsTop)
+                    {
+                        result.Add(pair.One, intv);
+                    }
+                }
+            }
+
+            return result;
         }
-        else
-        {
-          return CheckOutcome.Top;
-        }
-      }
-
-      // It may be the case that the naive evaluation of the expression may cause a lose of precision (we had this case in mscorlib)
-      // As a consequence, we want to simplify the expression to a polynomial, and reasoning on it
-      Polynomial<Variable, Expression> pol;
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.expManager.Decoder, out pol))
-      {
-        return this.CheckIfGreaterEqualThanZero(pol);
-      }
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      var v1 = Eval(e1);
-      var v2 = Eval(e2);
-
-      return this.CheckIfLessThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
-    {
-      var v1 = EvalFast(e1);
-      var v2 = EvalFast(e2);
-
-      return this.CheckIfLessThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      var v1 = Eval(e1);
-      var v2 = Eval(e2);
-
-      if (!this.expManager.Decoder.TypeOf(e1).IsFloatingPointType() && !this.expManager.Decoder.TypeOf(e2).IsFloatingPointType())
-      {
-        ToUInt(ref v1, ref v2);
-      }
-      return this.CheckIfLessThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Variable e1, Variable e2)
-    {
-      var v1 = EvalFast(e1);
-      var v2 = EvalFast(e2);
-
-      ToUInt(ref v1, ref v2);
-
-      return this.CheckIfLessThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      var v1 = Eval(e1);
-      var v2 = Eval(e2);
-
-      return CheckIfLessEqualThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      var v1 = EvalFast(e1);
-      var v2 = EvalFast(e2);
-
-      return this.CheckIfLessEqualThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      var v1 = Eval(e1);
-      var v2 = Eval(e2);
-
-      if (!this.expManager.Decoder.TypeOf(e1).IsFloatingPointType() && !this.expManager.Decoder.TypeOf(e2).IsFloatingPointType())
-      {
-        ToUInt(ref v1, ref v2);
-      }
-
-      return CheckIfLessEqualThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Variable e1, Variable e2)
-    {
-      var v1 = EvalFast(e1);
-      var v2 = EvalFast(e2);
-
-      ToUInt(ref v1, ref v2);
-
-      return this.CheckIfLessEqualThan(v1, v2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      IType v1, v2;
-
-      if ((v1 = Eval(e1)).IsSingleton && (v2 = Eval(e2)).IsSingleton)
-      {
-        return CheckIfEqual(v1, v2);
-      }
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfEqual(e1, e2);
-    }
-
-    virtual public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
-    {
-      var r = this.Eval(e);
-
-      return this.IsNotZero(r);
-    }
-
-    /// <summary>
-    /// Checks if all the elements of the interval <code>v1</code> are smaller than those in <code>v2</code>
-    /// </summary>
-    protected FlatAbstractDomain<bool> CheckIfLessThan(IType v1, IType v2)
-    {
-      Contract.Requires(v1 != null);
-      Contract.Requires(v2 != null);
-
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      if (!v1.IsNormal || !v2.IsNormal)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var lowerBoundForV1 = v1.LowerBound;
-      var upperBoundForV1 = v1.UpperBound;
-      var lowerBoundForV2 = v2.LowerBound;
-      var upperBoundForV2 = v2.UpperBound;
-
-      if (IsLessThan(upperBoundForV1, lowerBoundForV2))
-      {
-        return CheckOutcome.True;
-      }
-      else if (IsLessEqualThan(upperBoundForV2,lowerBoundForV1))
-      {
-        return CheckOutcome.False;
-      }
-      else
-      {
-        return CheckOutcome.Top;
-      }
-    }
-
-    /// <summary>
-    /// Checks if all the elements of the interval <code>v1</code> are smaller or equal of those in <code>v2</code>
-    /// </summary>
-    protected FlatAbstractDomain<bool> CheckIfLessEqualThan(IType v1, IType v2)
-    {
-      Contract.Requires(v1 != null);
-      Contract.Requires(v2 != null);
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      if (!v1.IsNormal || !v2.IsNormal)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var lowerBoundForV1 = v1.LowerBound;
-      var upperBoundForV1 = v1.UpperBound;
-      var lowerBoundForV2 = v2.LowerBound;
-      var upperBoundForV2 = v2.UpperBound;
-
-      if (IsLessEqualThan(upperBoundForV1,lowerBoundForV2))
-      {
-        return CheckOutcome.True;
-      }
-      else if (IsLessThan(upperBoundForV2,lowerBoundForV1))
-      {
-        return CheckOutcome.False;
-      }
-      else
-      {
-        return CheckOutcome.Top;
-      }
-    }
-
-    protected FlatAbstractDomain<bool> CheckIfEqual(IType v1, IType v2)
-    {
-      Contract.Requires(v1 != null);
-      Contract.Requires(v2 != null);
-      Contract.Requires(v1.IsSingleton);
-      Contract.Requires(v2.IsSingleton);
-
-      //if (v1.IsSingleton && v2.IsSingleton)
-      {
-        return v1.LowerBound.Equals(v2.LowerBound) ? CheckOutcome.True : CheckOutcome.False;
-      }
-
-      // return CheckOutcome.Top;
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain
-    public This RemoveRedundanciesWith(INumericalAbstractDomainQuery<Variable, Expression> oracle)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      return this.DuplicateMe();
-    }
-
-    protected IType EvalFast(Variable  v)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      IType result;
-      if (this.TryGetValue(v, out result))
-      {
-        return result;
-      }
-      else
-      {
-        return IntervalUnknown;
-      }
-    }
-
-    public virtual List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return new List<Pair<Variable, int>>();
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      var res = new Set<Expression>();
-      var val = this.BoundsFor(v);
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.LowerBound.IsInfinity)
-      {
-        if (strict)
-        {
-          Rational bound; // = strict ? val.LowerBound - 1 : val.LowerBound;
-          if (Rational.TrySub(val.LowerBound, Rational.For(1), out bound))
-          {
-            res.Add(bound.ToExpression(encoder));
-          }
-        }
-        else
-        {
-          res.Add(val.LowerBound.ToExpression(encoder));
-        }
-      }
-
-      return res;
-    }
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      var res = new Set<Expression>();
-      var val = this.BoundsFor(v);
-      
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.LowerBound.IsInfinity)
-      {
-        if (strict)
-        {
-          Rational bound; // = strict ? val.LowerBound - 1 : val.LowerBound;
-          if (Rational.TrySub(val.LowerBound, Rational.For(1), out bound))
-          {
-            res.Add(bound.ToExpression(encoder));
-          }
-        }
-        else
-        {
-          res.Add(val.LowerBound.ToExpression(encoder));
-        }
-      }
-
-      return res;
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      var val = this.BoundsFor(v);
-      
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.UpperBound.IsInfinity)
-      {
-        Rational bound; // = strict ? val.UpperBound + 1 : val.UpperBound;
-        if (strict)
-        {
-          if (Rational.TryAdd(1, val.UpperBound, out bound))
-          {
-             yield return bound.ToExpression(encoder);
-          }
-        }
-        else
-        {
-          yield return val.UpperBound.ToExpression(encoder);
-        }        
-      }
-
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      var val = this.BoundsFor(v);
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.UpperBound.IsInfinity)
-      {
-        Rational bound; // = strict ? val.UpperBound + 1 : val.UpperBound;
-        if (strict)
-        {
-          if (Rational.TryAdd(1, val.UpperBound, out bound))
-          {
-            yield return bound.ToExpression(encoder);
-          }
-        }
-        else
-        {
-          yield return  val.UpperBound.ToExpression(encoder);
-        }
-      }
-
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      return new Set<Variable>();
-    }
-
-    virtual public This TestTrue(Expression guard)
-    {
-      Contract.Requires(guard != null);
-
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      var res = this.TestNotEqualToZero(this.expManager.Decoder.UnderlyingVariable(guard));
-      var visitor = new IntervalTestVisitor(this.expManager.Decoder);
-
-      return visitor.VisitTrue(guard, (This)this);
-    }
-
-    virtual public This TestFalse(Expression guard)
-    {
-      Contract.Requires(guard != null);
-
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      var res = this.TestEqualToZero(this.expManager.Decoder.UnderlyingVariable(guard));
-      var visitor = new IntervalTestVisitor(this.expManager.Decoder);
-
-      return visitor.VisitFalse(guard, (This)this);
-    }
-
-    public This TestTrueLessThan(Variable left, Variable right)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      var kLeft = EvalFast(left);
-      var kRight = EvalFast(right);
-
-      this.AssumeKLessThanRight(kLeft, right);
-      this.AssumeLeftLessThanK(left, kRight);
-
-      return (This) this;
-    }
-
-    /// <summary>
-    /// The handler for the expressions in the form of <code>e1 == e2</code>.
-    /// The default is built invoking by transforming the code into <code>e1 &lt;= e2 &amp;&amp; e2 &lt;= e1</code>
-    /// However, if no encoder is provided, then it evaluates e1, and e2, and then it tests that they are the same interval...
-    /// </summary>
-    public This TestTrueEqual(Expression e1, Expression e2)
-    {
-      Contract.Requires(e1 != null);
-      Contract.Requires(e2 != null);
-
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      var result = (This) this;
-
-      #region 1. Try to see if it is a relational expression
-      // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant
-      // Then it is a boolean expression, so we handle it as it deserves
-      Int32 value;
-      if (this.ExpressionManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.ExpressionManager.Decoder.IsConstantInt(e2, out value))
-      {
-        if (value == 0)
-        { // that is !(e1)
-          result = this.TestFalse(e1);
-        }
-        else
-        { // that is e1
-          result = this.TestTrue(e1);
-        }
-      }
-      #endregion
-
-      #region 2. Otherwise, handle the equality
-
-      IExpressionEncoder<Variable, Expression> encoder;
-
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        // assume e1 <= e2; assume e2 <= e1
-        return result.TestTrueLessEqualThan(e1, e2).TestTrueLessEqualThan(e2, e1);       
-      }
-      else
-      {
-        var varFore1 = this.expManager.Decoder.UnderlyingVariable(e1);
-        var varFore2 = this.expManager.Decoder.UnderlyingVariable(e2);
-
-        if (this.ContainsKey(varFore1))
-        {
-          var resultTmp = this.DuplicateMe();
-
-          var newVal = Eval(e1).Meet(Eval(e2));
-          resultTmp[varFore1] = newVal;
-          resultTmp[varFore2] = newVal;
-
-          result = resultTmp;
-        }
-        else if (this.ExpressionManager.Decoder.IsVariable(e1) || this.ExpressionManager.Decoder.IsWritableBytes(e1)) // it is in the form of "x == exp"
-        {
-          var intervalForE2 = Eval(e2);
-
-          if (!intervalForE2.IsTop)
-          { // Avoid putting top in the environment
-            this[varFore1] = intervalForE2;
-          }
-        }
-        else if (this.ExpressionManager.Decoder.OperatorFor(e1).IsConversionOperator())
-        { // if it is in the form of "(cast) e1 == e2"
-          result = TestTrueEqual(this.ExpressionManager.Decoder.LeftExpressionFor(e1), e2);
-        }
-        else if (this.ExpressionManager.Decoder.IsConstant(e1) && this.ExpressionManager.Decoder.IsConstant(e2))
-        {
-          var tmpRes = Eval(e1).Meet(Eval(e2));
-          if (tmpRes.IsBottom)
-          {
-            return Bottom;
-          }
-        }
-
-        return result;
-
-      }
-      #endregion
-    }
-
-    /// <summary>
-    /// Handler for expression in the form of <code>e1 != e2</code>
-    /// </summary>
-    /// <returns>by default, it does <code>e1 &lt; e2 ||  e2 &lt; e1</code></returns>
-    virtual public This TestNotEqual(Expression e1, Expression e2)
-    {
-      Contract.Requires(e1 != null);
-      Contract.Requires(e2 != null);
-
-      #region 1. Try to see if it is a relational operator
-      int value;
-      // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant 
-      if (this.ExpressionManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.ExpressionManager.Decoder.IsConstantInt(e2, out value))
-      {
-        if (value == 0)
-        { // that is !!(e1)
-          return this.TestTrue(e1);
-        }
-        else
-        { // that is !e1
-          return this.TestFalse(e1);
-        }
-      }
-      #endregion
-
-      #region 2. Otherwise handle the inequality by two LT operations
-      var adom1 = this.DuplicateMe();
-      var adom2 = this.DuplicateMe();
-
-      var l1 = adom1.TestTrueLessThan(e1, e2);
-      var l2 = adom2.TestTrueLessThan(e2, e1);
-
-      return l1.Join(l2);
-      #endregion
-    }
-
-    [ContractVerification(false)]
-    protected override string ToLogicalFormula(Variable d, IType c)
-    {
-      if (!c.IsNormal())
-      {
-        return null;
-      }
-
-      var result = new List<string>();
-
-      if (c.IsSingleton)
-      {
-        result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.Equal, ExpressionPrinter.ToString(d, this.expManager.Decoder), c.LowerBound.ToString()));
-      }
-      else if (!c.IsLowerBoundMinusInfinity)
-      {
-        result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessEqualThan, c.LowerBound.ToString(), ExpressionPrinter.ToString(d, this.expManager.Decoder)));
-      }
-      else if (!c.IsUpperBoundPlusInfinity)
-      {
-        result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessEqualThan, ExpressionPrinter.ToString(d, this.expManager.Decoder), c.UpperBound.ToString()));
-      }
-
-      return ExpressionPrinter.ToLogicalFormula(ExpressionOperator.LogicalAnd, result);
-    }
-
-    protected override T To<T>(Variable d, IType c, IFactory<T> factory)
-    {
-      if (c.IsTop)
-        return factory.IdentityForAnd;
-      if (c.IsBottom)
-        return factory.Constant(false);
-
-      NType r;
-      if (c.TryGetSingletonValue(out r))
-      {
-        return factory.EqualTo(factory.Variable(d), To(r, factory));
-      }
-
-      T left = c.IsLowerBoundMinusInfinity
-          ? factory.IdentityForAnd
-          : factory.LessEqualThan(To(c.LowerBound, factory), factory.Variable(d));
-
-
-      T right = c.IsUpperBoundPlusInfinity
-          ? factory.IdentityForAnd
-          : factory.LessEqualThan(factory.Variable(d), To(c.UpperBound, factory));
-
-      return factory.And(left, right);
-
-    }
-    #endregion
-    
-    #region Proxies to please the compiler
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return this.RemoveRedundanciesWith(oracle);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-      return this.TestTrue(guard);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression exp)
-    {
-      return this.TestTrueGeqZero(exp);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueLessThan(exp1, exp2);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueLessEqualThan(exp1, exp2);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueEqual(exp1, exp2);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      return this.TestFalse(guard);
-    }
-
-    public override object Clone()
-    {
-      return this.DuplicateMe();
-    }
-
-    #endregion
-
-    #region TryGetValue
-    public bool TryGetValue(Variable var, bool isSigned, out IType intv)
-    {
-      if (this.TryGetValue(var, out intv))
-      {
-        Contract.Assert(intv != null);
-        intv = isSigned ? intv : intv.ToUnsigned();
-
-        return true;
-      }
-
-      return false;
-    }
-
-    #endregion
-
-    #region Privates
-
-    private void RefineWithPrestate(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      Contract.Requires(preState != null);
-
-      var refinedInterval = ConvertInterval(preState.BoundsFor(exp).AsInterval);
-
-      if (refinedInterval.IsNormal())
-      {
-        var xExp = this.expManager.Decoder.UnderlyingVariable(x);
-
-        this.RefineWith(xExp, refinedInterval);
-      }
-    }
-
-    private FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Polynomial<Variable, Expression> pol)
-    {
-      if (pol.Relation != null)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var result = this.EvalPolynomial(pol);
-
-      if (result.IsBottom || result.IsTop)
-      {
-        return CheckOutcome.Top;
-      }
-      if (this.IsGreaterEqualThanZero(result.LowerBound))
-      {
-        return CheckOutcome.True;
-      }
-      else if (this.IsLessThanZero(result.UpperBound))
-      {
-        return CheckOutcome.False;
-      }
-      else
-      {
-        return CheckOutcome.Top;
-      }
-    }
-
-    protected void ToUInt(ref IType v)
-    {
-      Contract.Requires(v != null);
-
-      v = ApplyConversion(ExpressionOperator.ConvertToUInt32, v);
-    }
-
-    protected void ToUInt(ref IType v1, ref IType v2)
-    {
-      Contract.Requires(v1 != null);
-      Contract.Requires(v2 != null);
-
-      Contract.Ensures(Contract.ValueAtReturn(out v1) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out v2) != null);
-
-      ToUInt(ref v1);
-      ToUInt(ref v2);
-      Contract.Assume(v1 != null);
-      Contract.Assume(v2 != null);
-    }
-    
-    #endregion
-
-    #region ToString
-    override public string ToString()
-    {
-      string result;
-
-      if (this.IsBottom)
-      {
-        result = "_|_";
-      }
-      else if (this.IsTop)
-      {
-        result = "Top";
-      }
-      else
-      {
-        var lines = new List<string>();
-
-        foreach (var x in this.Keys)
-        {
-          // REDUNDANT inferred by CC
-/*          var xAsString = this.expManager.Decoder != null ? this.expManager.Decoder.NameOf(x) : x.ToString(); */
-
-          var xAsString = this.expManager.Decoder.NameOf(x); 
-          
-          if (!this[x].IsTop)
-          {
-            lines.Add(xAsString + ": " + this[x]);
-          }
-        }
-
-        lines.Sort();
-
-        var buff = new StringBuilder();
-
-        if (lines.Count >= 2)
-        {
-          for (var i = 0; i < lines.Count - 1; i++)
-          {
-            buff.AppendFormat("{0}, ", lines[i]);
-          }
-        }
-         
-        if(lines.Count >= 1)
-          buff.AppendFormat(lines[lines.Count - 1]);
-       
-        result = buff.ToString();
-      }
-
-      return result;
-    }
-
-    public string ToString(Expression exp)
-    {
-      //if (this.expManager.Decoder != null)
-      {
-        return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
-      }
-/*      else
-      {
-        return "< missing expression decoder >";
-      }
- */ 
-    }
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-
-    #region Visitors
-    protected class IntervalTestVisitor
-    {
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.ttVisitor != null);
-        Contract.Invariant(this.tfVisitor != null);
-      }
-
-      readonly private IntervalsTrueTestVisitor ttVisitor;
-      readonly private IntervalsFalseTestVisitor tfVisitor;
-
-      public IntervalTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      {
-        this.ttVisitor = new IntervalsTrueTestVisitor(decoder);
-        this.tfVisitor = new IntervalsFalseTestVisitor(decoder);
-
-        this.ttVisitor.FalseVisitor = tfVisitor;
-        this.tfVisitor.TrueVisitor = ttVisitor;
-      }
-
-      internal This VisitTrue(Expression guard, This domain)
-      {
-        Contract.Requires(guard != null);
-        Contract.Ensures(Contract.Result<This>() != null);
-
-        return this.ttVisitor.Visit(guard, domain);
-      }
-
-      internal This VisitFalse(Expression guard, This domain)
-      {
-        Contract.Requires(guard != null);
-        Contract.Ensures(Contract.Result<This>() != null);
-
-        return this.tfVisitor.Visit(guard, domain);
-      }
-
-      private class IntervalsTrueTestVisitor :
-        TestTrueVisitor<This, Variable, Expression>
-      {
-        public IntervalsTrueTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
-          : base(decoder)
-        { }
-
 
         /// <summary>
-        /// We override the visitor as in some cases we want to capture information at an higher level.
-        /// For instance for
-        ///   \gt( -( +( sv7 (7), sv10 (10) ), sv48 (107) ), 0 )
-        /// we want to associate to the information ( -( +( sv7 (7), sv10 (10)), sv48 (107)) \in [1, +oo]
+        /// The variables defined in this environment
         /// </summary>
-        protected override This DispatchCompare(GenericExpressionVisitor<This, This, Variable, Expression>.CompareVisitor cmp, Expression left, Expression right, Expression original, This data)
+        public List<Variable> Variables
         {
-          data = cmp(left, right, original, data);
-          return base.DispatchCompare(cmp, left, right, original, data);
-        }
-
-        public override This VisitEqual(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestTrueEqual(left, right);
-        }
-
-        public override This VisitEqual_Obj(Expression left, Expression right, Expression original, This data)
-        {
-          return this.VisitEqual(left, right, original, data);
-        }
-
-        public override This VisitLessEqualThan_Un(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestTrueLessEqualThan_Un(left, right);
-        }
-
-        private bool AreFloat(Expression left, Expression right)
-        {
-          var ltype = this.Decoder.TypeOf(left);
-          if (ltype == ExpressionType.Float32 || ltype == ExpressionType.Float64)
-            return true;
-
-          var rtype = this.Decoder.TypeOf(right);
-
-          return rtype == ExpressionType.Float32 || rtype == ExpressionType.Float64;
-        }
-
-        public override This VisitLessEqualThan(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestTrueLessEqualThan(left, right);
-        }
-
-        public override This VisitLessThan(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestTrueLessThan(left, right);
-        }
-
-        public override This VisitLessThan_Un(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestTrueLessThan_Un(left, right);
-        }
-
-        public override This VisitAddition(Expression left, Expression right, Expression original, This data)
-        {
-          data = base.VisitAddition(left, right, original, data);
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitAnd(Expression left, Expression right, Expression original, This data)
-        {
-          data = base.VisitAnd(left, right, original, data);
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitDivision(Expression left, Expression right, Expression original, This data)
-        {
-          data = base.VisitDivision(left, right, original, data);
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitMultiplication(Expression left, Expression right, Expression original, This data)
-        {
-          data = base.VisitMultiplication(left, right, original, data);
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitShiftLeft(Expression left, Expression right, Expression original, This data)
-        {
-          data = base.VisitShiftLeft(left, right, original, data);
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitUnknown(Expression left, This data)
-        {
-          data = base.VisitUnknown(left, data);
-          return data.TestNotEqualToZero(left);
-        }
-
-        public override This VisitUnaryMinus(Expression left, Expression original, This data)
-        {
-          data = base.VisitUnaryMinus(left, original, data);
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitOr(Expression left, Expression right, Expression original, This data)
-        {
-          data = base.VisitOr(left, right, original, data);
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitNot(Expression left, This data)
-        {
-          var ttVisitor = new IntervalsTrueTestVisitor(data.ExpressionManager.Decoder);
-          var tfVisitor = new IntervalsFalseTestVisitor(data.ExpressionManager.Decoder);
-
-          ttVisitor.FalseVisitor = tfVisitor;
-          tfVisitor.TrueVisitor = ttVisitor;
-
-          return tfVisitor.Visit(left, data);
-        }
-
-        public override This VisitNotEqual(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestNotEqual(left, right);
-        }
-
-        public override This VisitVariable(Variable var, Expression original, This data)
-        {
-          return data.TestNotEqualToZero(original);
-        }
-
-        // left - right != 0
-        public override This VisitSubtraction(Expression left, Expression right, Expression original, This data)
-        {
-          data = data.TestNotEqualToZero(original);
-          return data.TestNotEqual(left, right);
-        }
-
-        // left % right != 0
-        public override This VisitModulus(Expression left, Expression right, Expression original, This data)
-        {
-          // refine the interval by removing zero
-          if (data.CheckIfGreaterEqualThanZero(left).IsTrue())
-          {
-            data = data.TestNotEqualToZero(left);
-          }
-          data = base.VisitModulus(left, right, original, data);
-
-          return data.TestNotEqualToZero(original);
-        }
-
-        public override This VisitXor(Expression left, Expression right, Expression original, This data)
-        {
-          data = base.VisitXor(left, right, original, data);
-
-          return data.TestNotEqualToZero(original);
-        }
-      }
-
-      private class IntervalsFalseTestVisitor :
-        TestFalseVisitor<This, Variable, Expression>
-      {
-        public IntervalsFalseTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
-          : base(decoder)
-        {
-        }
-
-        public override This Visit(Expression exp, This data)
-        {
-          Contract.Ensures(Contract.Result<This>() != null);
-
-          var result = base.Visit(exp, data);
-
-          Contract.Assert(result != null);
-
-          if (this.Decoder.IsBinaryExpression(exp))
-          {
-            var leftExp = this.Decoder.LeftExpressionFor(exp);
-            var rightExp = this.Decoder.RightExpressionFor(exp);
-
-            var k = data.Eval(rightExp);
-
-            if (k.IsBottom)
+            get
             {
-              return result.Bottom;
+                return new List<Variable>(this.Keys);
             }
+        }
 
-            if (!k.IsSingleton)
+        public List<Variable> VariablesNonSlack
+        {
+            get
             {
-              return result;    // No more work to be done ...
-            }
-
-            switch (this.Decoder.OperatorFor(exp))
-            {
-              case ExpressionOperator.Multiplication:
-              case ExpressionOperator.Division:
-                // ignored
-                break;
-
-              case ExpressionOperator.GreaterEqualThan:
-              case ExpressionOperator.GreaterEqualThan_Un:
+                var result = new List<Variable>();
+                foreach (var k in this.Keys)
                 {
-                  // !(left >= [a,b]) -> left < [a,b]
-                  var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
-                  result.AssumeLeftLessThanK(leftExpVar, k);
+                    if (!expManager.Decoder.IsSlackVariable(k))
+                    {
+                        result.Add(k);
+                    }
                 }
-                break;
 
-              case ExpressionOperator.GreaterThan:
-              case ExpressionOperator.GreaterThan_Un:
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Add the variable <code>var</code> to the environment
+        /// </summary>
+        /// <param name="var">Must not be already there</param>
+        public void AddVariable(Variable var)
+        {
+            this.State = AbstractState.Normal;
+
+            this.ProjectVariable(var);
+        }
+
+        /// <summary>
+        /// Projects out the variable <code>var</code>.
+        /// Its value is set to top.
+        /// </summary>
+        public void ProjectVariable(Variable var)
+        {
+            if (this.ContainsKey(var))
+            {
+                this.RemoveElement(var);
+            }
+        }
+
+        /// <summary>
+        /// Removes the variable <code>var</code>
+        /// </summary>
+        /// <param name="var"></param>
+        public void RemoveVariable(Variable var)
+        {
+            this.RemoveElement(var);
+        }
+
+        /// <summary>
+        /// Renames the variable <code>oldName</code> to <code>newName</code>
+        /// </summary>
+        public void RenameVariable(Variable oldName, Variable newName)
+        {
+            if (this.ContainsKey(oldName))
+            {
+                this[newName] = this[oldName];
+                this.RemoveVariable(oldName);
+            }
+        }
+
+        #endregion
+
+        #region Eval
+        protected internal IType EvalPolynomial(Polynomial<Variable, Expression> pol)
+        {
+            Contract.Requires(pol.Relation == null);
+
+            IType i;
+            int l, u;
+            return this.EvalPolynomial(pol, out i, out l, out u);
+        }
+
+        protected internal IType EvalPolynomial(Polynomial<Variable, Expression> pol, out IType finiteBounds, out int infLower, out int infUpper)
+        {
+            Contract.Requires(pol.Relation == null);
+
+            infLower = 0;
+            infUpper = 0;
+
+            var tmpValue = this.IntervalZero;
+            finiteBounds = this.IntervalZero;
+
+            foreach (var m in pol.Left)
+            {
+                var tmpInt = EvalMonomial(m);
+                tmpValue = Interval_Add(tmpValue, tmpInt);
+
+                var newLower = finiteBounds.LowerBound;
+                var newUpper = finiteBounds.UpperBound;
+
+                if (this.IsPlusInfinity(tmpInt.UpperBound))
                 {
-                  // !(left > [a,b]) -> left <= [a,b]
-                  var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
-                  result.AssumeLeftLessEqualThanK(leftExpVar, k);
+                    infUpper++;
                 }
-                break;
-
-              case ExpressionOperator.LessEqualThan:
-              case ExpressionOperator.LessEqualThan_Un:
+                else
                 {
-                  // !(left <= [a,b]) -> left > [a, b]
-                  var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
-                  result.AssumeKLessThanRight(k, leftExpVar);
+                    if (!TryAdd(newUpper, tmpInt.UpperBound, out newUpper))
+                    {
+                        newUpper = this.PlusInfinity;
+                    }
+                    Contract.Assume(!object.Equals(newUpper, null));
                 }
-                break;
-
-              case ExpressionOperator.LessThan:
-              case ExpressionOperator.LessThan_Un:
+                if (this.IsMinusInfinity(tmpInt.LowerBound))
                 {
-                  // !(left < [a,b]) -> left >= [a, b]
-                  var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
-                  result.AssumeKLessEqualThanRight(k, leftExpVar);
+                    infLower++;
                 }
-                break;
+                else
+                {
+                    if (!TryAdd(newLower, tmpInt.LowerBound, out newLower))
+                    {
+                        newLower = this.MinusInfinty;
+                    }
+                    Contract.Assume(!object.Equals(newLower, null));
+                }
+                finiteBounds = For(newLower, newUpper);
             }
-          }
 
-          return result;
+            return tmpValue;
         }
 
-        public override This VisitEqual_Obj(Expression left, Expression right, Expression original, This data)
+        protected IType EvalMonomial(Monomial<Variable> m)
         {
-          return this.VisitEqual(left, right, original, data);
-        }
+            Contract.Ensures(Contract.Result<IType>() != null);
 
-        public override This VisitLessEqualThan(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestTrueLessThan(right, left);
-        }
+            var tmpValue = For(m.K);
+            IType valueForX;
 
-        public override This VisitLessThan(Expression left, Expression right, Expression original, This data)
-        {
-          return data.TestTrueLessEqualThan(right, left);
-        }
-
-        public override This VisitNot(Expression left, This data)
-        {
-          return this.TrueVisitor.Visit(left, data);
-        }
-
-        public override This VisitNotEqual(Expression left, Expression right, Expression original, This data)
-        {
-          return this.TrueVisitor.VisitEqual(left, right, original, data);
-        }
-
-        public override This VisitVariable(Variable var, Expression original, This data)
-        {
-          data[var] = data.Eval(original).Meet(data.IntervalZero);      // guard : [0, 0]
-          return data;
-        }
-      }
-    }
-
-    #region Visitor for CheckIfHolds
-    protected class IntervalsCheckIfHoldsVisitor :
-      CheckIfHoldsVisitor<This, Variable, Expression>
-    {
-      public IntervalsCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-      }
-
-      public override FlatAbstractDomain<bool> VisitConstant(Expression left, FlatAbstractDomain<bool> data)
-      {
-        var valForLeft = this.Domain.Eval(left);
-        NType v;
-
-        if (valForLeft.TryGetSingletonValue(out v))
-        {
-          Contract.Assume(v != null);
-          return this.Domain.IsNotZero(v)? CheckOutcome.True : CheckOutcome.False;
-        }
-        else
-        {
-          return CheckOutcome.Top;
-        }
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        if (this.Decoder.IsNaN(left) || this.Decoder.IsNaN(right))
-        {
-          return CheckOutcome.False;
-        }
-
-        return this.VisitEqual_Internal(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        if (this.Decoder.IsNaN(left) && this.Decoder.IsNaN(right))
-        {
-          return CheckOutcome.True;
-        }
-
-        return this.VisitEqual_Internal(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return this.Domain.CheckIfLessEqualThan(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return this.Domain.CheckIfLessEqualThan_Un(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return this.Domain.CheckIfLessThan(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return this.Domain.CheckIfLessThan_Un(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitNot(Expression left, FlatAbstractDomain<bool> data)
-      {
-        FlatAbstractDomain<bool> leftHolds = this.Visit(left, data);
-
-        if (leftHolds.IsNormal())
-        {
-          return new FlatAbstractDomain<bool>(!leftHolds.BoxedElement);
-        }
-        else
-        {
-          return leftHolds;
-        }
-      }
-
-      public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        long value; // We use long because we do not want Int32.MinValue to be wrapped to zero
-
-        if (this.Decoder.TryValueOf<long>(right, ExpressionType.Int64, out value) && value == 0)
-        { 
-          // left != 0 => we should check if left holds
-          var direct = this.Visit(left, data);
-          
-          if (!direct.IsTop)
-          {
-            return direct;
-          }
-        }
-
-        var areEqual = this.VisitEqual(left, right, original, data);
-
-        if (areEqual.IsNormal())
-        {
-          return new FlatAbstractDomain<bool>(!areEqual.BoxedElement);
-        }
-        else
-        {
-          return areEqual;
-        }
-      }
-
-      public override FlatAbstractDomain<bool> VisitVariable(Variable var, Expression original, FlatAbstractDomain<bool> data)
-      {
-        var intv = this.Domain.Eval(original);
-
-        if (intv.IsTop)
-          return CheckOutcome.Top;
-        
-        if (intv.IsBottom)
-          return CheckOutcome.Bottom;
-
-        if (!intv.IsNormal)
-          return CheckOutcome.Top;
-
-        if (this.Domain.IsGreaterThanZero(intv.LowerBound) || this.Domain.IsLessThanZero(intv.UpperBound))
-          return CheckOutcome.True;
-        
-        if (intv.IsSingleton && this.Domain.IsZero(intv.LowerBound))
-          return CheckOutcome.False;
-
-        return CheckOutcome.Top;
-      }
-
-      private FlatAbstractDomain<bool> VisitEqual_Internal(Expression left, Expression right)
-      {
-        var leftType = this.Decoder.TypeOf(left);
-        var rightType = this.Decoder.TypeOf(right);
-
-        if (!leftType.IsFloatingPointType() && !rightType.IsFloatingPointType() && left.Equals(right))
-        {
-          return CheckOutcome.True;
-        }
-
-        var leftInt = this.Domain.Eval(left);
-        var rightInt = this.Domain.Eval(right);
-
-        if (leftInt.IsSingleton && rightInt.IsSingleton && leftInt.LessEqual(rightInt))
-        {
-          return CheckOutcome.True;
-        }
-
-        if (!leftInt.IsLowerBoundMinusInfinity && !leftInt.IsUpperBoundPlusInfinity && !rightInt.IsLowerBoundMinusInfinity && !rightInt.IsUpperBoundPlusInfinity &&
-          leftInt.LowerBound.Equals(rightInt.LowerBound) && leftInt.UpperBound.Equals(rightInt.UpperBound) && leftInt.LowerBound.Equals(leftInt.UpperBound))
-        {
-          return CheckOutcome.True;
-        }
-
-        if ((!leftInt.IsUpperBoundPlusInfinity && !rightInt.IsLowerBoundMinusInfinity && this.Domain.IsLessThan(leftInt.UpperBound, rightInt.LowerBound)) 
-          || (!rightInt.IsUpperBoundPlusInfinity && !leftInt.IsLowerBoundMinusInfinity && this.Domain.IsLessThan(rightInt.UpperBound, leftInt.LowerBound)))
-        {
-          return CheckOutcome.False;
-        }
-
-
-        var op = this.Decoder.OperatorFor(left);
-        
-        int value;
-
-        if(this.Decoder.IsConstantInt(right, out value) && value == 0)
-        {
-          if (op.IsLessThan())
-        {  
-           // it is (a < b) == 0, that is !(a < b) that is b <= a
-            var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
-            var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
-
-            if (this.Domain.IsLessEqualThan(valForB.UpperBound,valForA.LowerBound))
+            foreach (var x in m.Variables)
             {
-              return CheckOutcome.True;
-            }   
+                if (this.TryGetValue(x, out valueForX))
+                {
+                    tmpValue = Interval_Mul(tmpValue, valueForX);
+                }
+                else
+                {
+                    return IntervalUnknown;
+                }
+            }
+
+            return tmpValue;
         }
 
-          if (op.IsLessEqualThan())
-        {  
-          // it is (a <= b) == 0, that is !(a <= b) that is b > a
-            var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
-            var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+        public IType Eval(Variable v)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
 
-            if (this.Domain.IsLessThan(valForA.UpperBound,valForB.LowerBound))
+            IType val;
+            if (this.TryGetValue(v, out val))
             {
-              return CheckOutcome.True;
+                return val;
             }
+
+            return this.IntervalUnknown;
         }
 
-          if (op.IsGreaterThan())
-        { 
-          // it is (a > b) == 0, that is !(a > b) that is b >= a
-            var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
-            var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+        /// <summary>
+        /// The difference with BoundsFor is in the return type, which is more specific for Eval 
+        /// </summary>
+        public IType Eval(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
 
-            if (this.Domain.IsLessEqualThan(valForA.UpperBound, valForB.LowerBound))
+            Contract.Assume(exp != null);
+
+#if TRACE_PERFORMANCE
+            var watch = new Stopwatch();
+            watch.Start();
+#endif
+            // Such a common situation that we want to short cut it
+            int value;
+            if (expManager.Decoder.IsConstantInt(exp, out value))
             {
-              return CheckOutcome.True;
+                return For(value);
             }
-        }
 
-        if (op.IsGreaterEqualThan())
-        { 
-           // it is (a >= b) == 0, that is !(a >= b) that is b < a
-            var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
-            var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+            // F: funny enough, making evalVisitor a field makes the analysis slower!
+            var evalVisitor = new EvalExpressionVisitor(expManager.Decoder);
 
-            if (this.Domain.IsLessThan(valForB.UpperBound, valForA.LowerBound))
+            var result = evalVisitor.Visit(exp, new Pair<This, int>((This)this, 0));
+
+            Contract.Assert(result != null);
+
+            if (evalVisitor.DuplicatedOccurrences.Count >= 1)
             {
-              return CheckOutcome.True;
+                var intv = default(IType);
+                var isFirst = true;
+
+                foreach (var v in evalVisitor.DuplicatedOccurrences)
+                {
+                    IType intvForV;
+                    if (this.TryGetValue(v, out intvForV)
+                      && intvForV.IsFinite
+                      && this.IsGreaterEqualThanZero(intvForV.LowerBound) // the precision improvement below holds when the interval is non-negative
+                      )
+                    {
+                        var r = EvalWithExtremes(exp, v, intvForV);
+                        if (isFirst)
+                        {
+                            intv = r;
+                            isFirst = false;
+                        }
+                        else
+                        {
+                            Contract.Assert(intv != null);
+                            intv = r.Join(intv);
+                        }
+                    }
+                    Contract.Assert(isFirst || intv != null);
+                }
+
+                result = isFirst ? result : result.Meet(intv);
+                Contract.Assert(result != null);
             }
+
+#if TRACE_PERFORMANCE
+            UpdateTimeSpentInIntervalEval(watch.Elapsed);
+#endif
+            return result;
         }
 
-        if ((op == ExpressionOperator.Equal || op == ExpressionOperator.Equal_Obj) )
-        {  
-            // it is (a == b) == 0, that is !(a == b) that is b != a
-            var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
-            var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
-
-            Contract.Assert(valForA != null);
-            Contract.Assert(valForB != null);
-
-            if ((valForA.Meet(valForB)).IsBottom)
-            { // a \sqcap b == _|_  implies that they are different
-              return CheckOutcome.True;
-            }
-
-            if (valForA.IsNormal() && valForB.IsNormal() && valForA.LessEqual(valForB) && valForB.LessEqual(valForA))
-            {
-              return CheckOutcome.True;
-            }
-        }
-        }
-
-        return CheckOutcome.Top;
-      }
-
-      protected override FlatAbstractDomain<bool> Default(FlatAbstractDomain<bool> data)
-      {
-        return CheckOutcome.Top;
-      }
-    }
-    #endregion
-
-    class EvalExpressionVisitor 
-      : GenericExpressionVisitor<Pair<This, Int32>, IType, Variable, Expression>
-    {
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.evalConstantVisitor != null);
-        Contract.Invariant(this.occurrences != null);
-      }
-
-      #region Private state
-
-      private readonly EvalConstantVisitor evalConstantVisitor;
-      private readonly VariableOccurrences occurrences;
-
-      #endregion
-
-      #region Constructor
-      public EvalExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-
-        this.evalConstantVisitor = new EvalConstantVisitor(decoder);
-        this.occurrences = new VariableOccurrences(decoder);
-      }
-      #endregion
-
-      public List<Variable> DuplicatedOccurrences
-      {
-        get
+        private IType EvalWithExtremes(Expression exp, Variable v, IType intv)
         {
-          Contract.Ensures(Contract.Result<List<Variable>>() != null);
+            Contract.Requires(exp != null);
+            Contract.Ensures(Contract.Result<IType>() != null);
 
-          return this.occurrences.DuplicatedOccurrences;
-        }
-      }
+            var evalVisitor = new EvalExpressionVisitor(expManager.Decoder);
 
-      #region Entrypoint for the visit
-      public override IType Visit(Expression exp, Pair<This, Int32> data)
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
+            this[v] = IntervalSingleton(intv.LowerBound);
 
-        if (data.Two >= IntervalEnvironment_Base<This, Variable, Expression, IType, NType>.MAXDEPTH)
-        {
-          return data.One.IntervalUnknown;
-        }
+            var low = evalVisitor.Visit(exp, new Pair<This, int>((This)this, 0));
 
-        var result = base.Visit(exp, PlusOne(data));
+            this[v] = IntervalSingleton(intv.UpperBound);
 
-        /*
-        if (result == null)
-        {
-          return data.One.IntervalUnknown;
-        }
-        */
-        result = RefineWithTypeRange(result, exp, data.One);
+            var upp = evalVisitor.Visit(exp, new Pair<This, int>((This)this, 0));
 
-        var expVar = this.Decoder.UnderlyingVariable(exp);
-        IType prev_result;
-        if (data.One.TryGetValue(expVar, out prev_result))
-        {
-          result = result.Meet(prev_result);
-          Contract.Assert(result != null);
+            Contract.Assert(upp != null);
+
+            this[v] = intv;
+
+            return low.Join(upp);
         }
 
-        return result;
-      }
-      #endregion
-
-      #region Visits
-      public override IType VisitAddition(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        var sum = data.One.Interval_Add(leftIntv, rightIntv);
-
-        // If we know the type, we can refine the result
-        if (Decoder.TypeOf(left) == ExpressionType.Int32 || Decoder.TypeOf(right) == ExpressionType.Int32)
+        protected IType EvalConstant(Expression exp)
         {
-          // <0 + MaxInt32 = [-1, +oo]
-          if (data.One.IsLessEqualThanZero(leftIntv) && data.One.IsMaxInt32(rightIntv))
-          {
-            sum = sum.Meet(data.One.IntervalGreaterEqualThanMinusOne);
-          }
-        }
+            Contract.Requires(exp != null);
 
-        return sum;
-      }
-
-      public override IType VisitAnd(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        if (data.One.IsGreaterThanZero(rightIntv.LowerBound))
-        {
-          return data.One.Interval_BitwiseAnd(leftIntv , rightIntv);
-        }
-        else
-        {
-          return data.One.IntervalUnknown;
-        }
-      }
-
-      public override IType VisitConstant(Expression left, Pair<This, Int32> data)
-      {
-        return this.evalConstantVisitor.Visit(left, data.One);
-      }
-
-      public override IType VisitConvertToInt8(Expression left, Expression original, Pair<This, int> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.ApplyConversion(ExpressionOperator.ConvertToInt8, Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitConvertToInt32(Expression left, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.ApplyConversion(ExpressionOperator.ConvertToInt32, Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitConvertToUInt16(Expression left, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.ApplyConversion(ExpressionOperator.ConvertToUInt16, Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitConvertToUInt32(Expression left, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.ApplyConversion(ExpressionOperator.ConvertToUInt32, Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitConvertToFloat64(Expression p, Expression original, Pair<This, int> data)
-      {
-        this.occurrences.Add(p);
-
-        return data.One.ApplyConversion(ExpressionOperator.ConvertToFloat64, Visit(p, PlusOne(data)));
-      }
-
-      public override IType VisitConvertToUInt8(Expression left, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.ApplyConversion(ExpressionOperator.ConvertToUInt8, Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitConvertToFloat32(Expression left, Expression original, Pair<This, int> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.ApplyConversion(ExpressionOperator.ConvertToFloat32, Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitDivision(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        return data.One.Interval_Div(leftIntv, rightIntv);
-      }
-
-      public override IType VisitEqual(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitGreaterEqualThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitGreaterThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitLessEqualThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitLessThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitModulus(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        var result = data.One.Interval_Rem(leftIntv,rightIntv);
-
-        if (AreCoPrimes(left, right))
-        {
-          result = result.Meet(data.One.Interval_StrictlyPositive);
-        }
-
-        return result;
-      }
-
-      // [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-      private bool AreCoPrimes(Expression l, Expression r)
-      {
-        int rVal;
-        // Try to match (x * k) % r
-        if (this.Decoder.IsConstantInt(r, out rVal) && rVal != 0 &&
-          this.Decoder.IsBinaryExpression(l) && this.Decoder.OperatorFor(l) == ExpressionOperator.Multiplication)
-        {
-          var ll = this.Decoder.LeftExpressionFor(l);
-          var lr = this.Decoder.RightExpressionFor(l);
-
-          int llVal, lrVal;
-
-          var bll = this.Decoder.IsConstantInt(ll, out llVal);
-          var blr = this.Decoder.IsConstantInt(lr, out lrVal);
-
-          // Review: Why blr && blr ??? cccheck complains about blr==false being constant
-          if ((!bll && !blr) || (bll && blr) || llVal <= 0 || rVal <= 0)
-          {
-            return false;
-          }
-
-          if (bll)
-          {
-            return Rational.GCD(llVal, rVal) == 1;
-          }
-          else
-          {
-            return Rational.GCD(lrVal, rVal) == 1;
-          }
-        }
-
-        return false;
-      }
-
-      public override IType VisitMultiplication(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        return data.One.Interval_Mul(leftIntv, rightIntv);
-      }
-
-      public override IType VisitNot(Expression left, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.Interval_Not(Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitNotEqual(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitOr(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        return data.One.Interval_BitwiseOr(leftIntv, rightIntv);
-      }
-
-      public override IType VisitShiftLeft(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        return data.One.Interval_ShiftLeft(leftIntv, rightIntv);
-      }
-
-      public override IType VisitShiftRight(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        return data.One.Interval_ShiftRight(leftIntv, rightIntv);
-      }
-
-      public override IType VisitSizeOf(Expression sizeofExp, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(sizeofExp);
-
-        int i;
-        if (this.Decoder.TrySizeOf(sizeofExp, out i))
-          return data.One.For (i);
-        else
-          return data.One.Interval_Positive; // This is an upper approximation as we do not consider the size of the actual type 
-      }
-
-      public override IType VisitSubtraction(Expression left, Expression right, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        return data.One.Interval_Sub(leftIntv, rightIntv);
-      }
-
-      public override IType VisitUnaryMinus(Expression left, Expression original, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.Interval_UnaryMinus(Visit(left, PlusOne(data)));
-      }
-
-      public override IType VisitUnknown(Expression left, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitVariable(Variable var, Expression original, Pair<This, Int32> data)
-      {
-        // this.occurrences.Add(var);
-
-        if (data.One.ContainsKey(var))
-          return data.One[var];
-        else
-          return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitWritableBytes(Expression left, Expression wholeExpression, Pair<This, Int32> data)
-      {
-        this.occurrences.Add(left);
-
-        var v = this.Decoder.UnderlyingVariable(wholeExpression);
-        if (data.One.ContainsKey(v))
-          return data.One[v];
-        else
-          return data.One.IntervalUnknown;
-      }
-
-      public override IType VisitXor(Expression left, Expression right, Expression original, Pair<This, int> data)
-      {
-        this.occurrences.Add(left, right);
-
-        var plusOne = PlusOne(data);
-
-        var leftIntv = Visit(left, plusOne);
-        var rightIntv = Visit(right, plusOne);
-
-        return data.One.Interval_BitwiseXor(leftIntv, rightIntv);
-      }
-
-      protected override IType Default(Pair<This, Int32> data)
-      {
-        return data.One.IntervalUnknown;
-      }
-
-      #endregion
-
-      #region Privates
-      static private Pair<This, Int32> PlusOne(Pair<This, Int32> data)
-      {
-        return new Pair<This, int>(data.One, data.Two + 1);
-      }
-
-      private IType RefineWithTypeRange(IType interval, Expression exp, This converter)
-      {
-        Contract.Requires(interval != null);
-        Contract.Ensures(Contract.Result<IType>() != null);
-
-        var type = this.Decoder.TypeOf(exp);
-        switch (type)
-        {
-          case ExpressionType.Bool:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToInt32, interval);
-
-          case ExpressionType.Int8:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToInt8, interval);
-
-          case ExpressionType.Int16:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToInt16, interval);
-
-          case ExpressionType.Int32:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToInt32, interval);
-
-          case ExpressionType.Int64:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToInt64, interval);
-
-          case ExpressionType.UInt8:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToUInt8, interval);
-
-          case ExpressionType.UInt16:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToUInt16, interval);
-
-          case ExpressionType.UInt32:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToUInt32, interval);
-
-          case ExpressionType.UInt64:
-            return converter.ApplyConversion(ExpressionOperator.ConvertToUInt64, interval);
-
-          default:
-            return interval;
-        }
-      }
-
-      #endregion
-
-      #region Occurrences counter
-      class VariableOccurrences
-      {
-        #region Object Invariant
-        [ContractInvariantMethod]
-        void ObjectInvariant()
-        {
-          Contract.Invariant(this.duplicated != null);
-          Contract.Invariant(this.occurrences != null);
-          Contract.Invariant(this.decoder!= null);
+            return new EvalConstantVisitor(this.ExpressionManager.Decoder).Visit(exp, (This)this);
         }
         #endregion
 
-        readonly private Dictionary<Variable, int> occurrences;
-        readonly IExpressionDecoder<Variable, Expression> decoder;
-        readonly List<Variable> duplicated;
-
-        public VariableOccurrences(IExpressionDecoder<Variable, Expression> decoder)
+        #region Checks
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
         {
-          Contract.Requires(decoder != null);
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
 
-          this.occurrences = new Dictionary<Variable,int>();
-          this.decoder = decoder;
-          this.duplicated = new List<Variable>();
+            var result = checkIfHoldsVisitor.Visit(exp, (This)this);
+
+            return result;
         }
 
-        public void Add(Variable v)
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
         {
-          int count;
-          if(this.occurrences.TryGetValue(v, out count))
-          {
-            this.occurrences[v] = count+1;
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
 
-            if (count == 1)
+            var boundsForIndex = this.Eval(exp);
+
+            if (boundsForIndex.IsBottom)
             {
-              this.duplicated.Add(v);
+                return CheckOutcome.Bottom;
             }
-          }
-          else
-          {
-            this.occurrences[v] = 1;
-          }
+            else if (boundsForIndex.IsNormal)
+            {
+                if (this.IsGreaterEqualThanZero(boundsForIndex.LowerBound))
+                {
+                    return CheckOutcome.True;
+                }
+                else if (this.IsLessThanZero(boundsForIndex.UpperBound))
+                {
+                    return CheckOutcome.False;
+                }
+                else
+                {
+                    return CheckOutcome.Top;
+                }
+            }
+
+            // It may be the case that the naive evaluation of the expression may cause a lose of precision (we had this case in mscorlib)
+            // As a consequence, we want to simplify the expression to a polynomial, and reasoning on it
+            Polynomial<Variable, Expression> pol;
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, expManager.Decoder, out pol))
+            {
+                return this.CheckIfGreaterEqualThanZero(pol);
+            }
+            return CheckOutcome.Top;
         }
 
-        public void Add(Expression e)
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
         {
-          this.Add(this.decoder.UnderlyingVariable(e));
+            var v1 = Eval(e1);
+            var v2 = Eval(e2);
+
+            return this.CheckIfLessThan(v1, v2);
         }
 
-        public void Add(params Expression[] exps)
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
         {
-          Contract.Requires(exps != null);
-
-          foreach (var e in exps)
-          {
-            this.Add(e);
-          }
+            return this.CheckIfLessThan(e1, e2);
         }
 
-        public List<Variable> DuplicatedOccurrences
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
         {
-          get
-          {
-            Contract.Ensures(Contract.Result<List<Variable>>() != null);
+            var v1 = EvalFast(e1);
+            var v2 = EvalFast(e2);
 
-            return this.duplicated;
-          }
+            return this.CheckIfLessThan(v1, v2);
         }
 
-        public override string ToString()
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
         {
-          return this.occurrences.ToString();
+            var v1 = Eval(e1);
+            var v2 = Eval(e2);
+
+            if (!expManager.Decoder.TypeOf(e1).IsFloatingPointType() && !expManager.Decoder.TypeOf(e2).IsFloatingPointType())
+            {
+                ToUInt(ref v1, ref v2);
+            }
+            return this.CheckIfLessThan(v1, v2);
         }
-      }
-#endregion
 
-      #region Logic for caching 
-
-      public class Cache
-      {
-        [ContractInvariantMethod]
-        void ObjectInvariant()
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Variable e1, Variable e2)
         {
-          Contract.Invariant(this.cache != null);
+            var v1 = EvalFast(e1);
+            var v2 = EvalFast(e2);
+
+            ToUInt(ref v1, ref v2);
+
+            return this.CheckIfLessThan(v1, v2);
         }
 
-
-        private Dictionary<Variable, IType> cache;
-        private int currversion;
-
-        public Cache(int version)
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
         {
-          this.currversion = version;
-          this.cache = new Dictionary<Variable, IType>();
+            var v1 = Eval(e1);
+            var v2 = Eval(e2);
+
+            return CheckIfLessEqualThan(v1, v2);
         }
 
-        public bool TryGetFromCache(int version, Variable v, out IType result)
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
         {
-          if (version == this.currversion && cache.TryGetValue(v, out result))
-          {
-            return true;
-          }
+            var v1 = EvalFast(e1);
+            var v2 = EvalFast(e2);
 
-          result = default(IType);
-          return false;
+            return this.CheckIfLessEqualThan(v1, v2);
         }
 
-        public void Set(int version, Variable v, IType value)
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
         {
-          if(this.currversion == version)
-          {
-            this.cache[v] = value;
-          }
-          else
-          {
-            this.currversion = version;
-            this.cache = new Dictionary<Variable, IType>();
-          }
+            var v1 = Eval(e1);
+            var v2 = Eval(e2);
+
+            if (!expManager.Decoder.TypeOf(e1).IsFloatingPointType() && !expManager.Decoder.TypeOf(e2).IsFloatingPointType())
+            {
+                ToUInt(ref v1, ref v2);
+            }
+
+            return CheckIfLessEqualThan(v1, v2);
         }
-      }
 
-      #endregion
-    }
-
-    /// <summary>
-    /// Get an interval containing the constant.
-    /// It can be an overapproximation as some values may not be exactly represented as for instance Int64 when the underlying Rational
-    /// are at 32 bits
-    /// </summary>
-    public class EvalConstantVisitor
-      : GenericTypeExpressionVisitor<Variable, Expression, This, IType>
-    {
-      private IType IntervalUnknown;
-
-      public EvalConstantVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-      }
-
-      override public IType Visit(Expression exp, This state)
-      {
-        this.IntervalUnknown = state.IntervalUnknown;
-
-        if (exp != null && this.Decoder.IsConstant(exp))
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Variable e1, Variable e2)
         {
-          // F: WARNING BELOW TO BE FIXED
-          return base.Visit(exp, state);
+            var v1 = EvalFast(e1);
+            var v2 = EvalFast(e2);
+
+            ToUInt(ref v1, ref v2);
+
+            return this.CheckIfLessEqualThan(v1, v2);
         }
-        else
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
         {
-          return Default(exp);
+            IType v1, v2;
+
+            if ((v1 = Eval(e1)).IsSingleton && (v2 = Eval(e2)).IsSingleton)
+            {
+                return CheckIfEqual(v1, v2);
+            }
+            return CheckOutcome.Top;
         }
-      }
 
-      public override IType VisitFloat32(Expression exp, This input)
-      {
-        Single value;
-        IType result;
-
-        if (this.Decoder.TryValueOf<Single>(exp, ExpressionType.Float32, out value))
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
         {
-          result = input.For(value);
-
-          return result;
+            return this.CheckIfEqual(e1, e2);
         }
-        else
+
+        virtual public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
         {
-          return input.IntervalUnknown;
+            var r = this.Eval(e);
+
+            return this.IsNotZero(r);
         }
-      }
 
-      public override IType VisitFloat64(Expression exp, This input)
-      {
-        Double value;
-        IType result;
-
-        if (this.Decoder.TryValueOf<Double>(exp, ExpressionType.Float64, out value))
+        /// <summary>
+        /// Checks if all the elements of the interval <code>v1</code> are smaller than those in <code>v2</code>
+        /// </summary>
+        protected FlatAbstractDomain<bool> CheckIfLessThan(IType v1, IType v2)
         {
-          result = input.For(value);
+            Contract.Requires(v1 != null);
+            Contract.Requires(v2 != null);
 
-          return result;
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            if (!v1.IsNormal || !v2.IsNormal)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var lowerBoundForV1 = v1.LowerBound;
+            var upperBoundForV1 = v1.UpperBound;
+            var lowerBoundForV2 = v2.LowerBound;
+            var upperBoundForV2 = v2.UpperBound;
+
+            if (IsLessThan(upperBoundForV1, lowerBoundForV2))
+            {
+                return CheckOutcome.True;
+            }
+            else if (IsLessEqualThan(upperBoundForV2, lowerBoundForV1))
+            {
+                return CheckOutcome.False;
+            }
+            else
+            {
+                return CheckOutcome.Top;
+            }
         }
-        else
+
+        /// <summary>
+        /// Checks if all the elements of the interval <code>v1</code> are smaller or equal of those in <code>v2</code>
+        /// </summary>
+        protected FlatAbstractDomain<bool> CheckIfLessEqualThan(IType v1, IType v2)
         {
-          return input.IntervalUnknown;
+            Contract.Requires(v1 != null);
+            Contract.Requires(v2 != null);
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            if (!v1.IsNormal || !v2.IsNormal)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var lowerBoundForV1 = v1.LowerBound;
+            var upperBoundForV1 = v1.UpperBound;
+            var lowerBoundForV2 = v2.LowerBound;
+            var upperBoundForV2 = v2.UpperBound;
+
+            if (IsLessEqualThan(upperBoundForV1, lowerBoundForV2))
+            {
+                return CheckOutcome.True;
+            }
+            else if (IsLessThan(upperBoundForV2, lowerBoundForV1))
+            {
+                return CheckOutcome.False;
+            }
+            else
+            {
+                return CheckOutcome.Top;
+            }
         }
-      }
 
-      public override IType VisitInt8(Expression exp, This input)
-      {
-        SByte value;
-        IType result;
-
-        if (this.Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value))
+        protected FlatAbstractDomain<bool> CheckIfEqual(IType v1, IType v2)
         {
-          result = input.For(value);
+            Contract.Requires(v1 != null);
+            Contract.Requires(v2 != null);
+            Contract.Requires(v1.IsSingleton);
+            Contract.Requires(v2.IsSingleton);
 
-          return result;
+            //if (v1.IsSingleton && v2.IsSingleton)
+            {
+                return v1.LowerBound.Equals(v2.LowerBound) ? CheckOutcome.True : CheckOutcome.False;
+            }
+
+            // return CheckOutcome.Top;
         }
-        else
+
+        #endregion
+
+        #region INumericalAbstractDomain
+        public This RemoveRedundanciesWith(INumericalAbstractDomainQuery<Variable, Expression> oracle)
         {
-          return input.IntervalUnknown;
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return this.DuplicateMe();
         }
-      }
 
-      public override IType VisitInt16(Expression exp, This input)
-      {
-        Int16 value;
-
-        if (this.Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value))
+        protected IType EvalFast(Variable v)
         {
-          return input.For(value);
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            IType result;
+            if (this.TryGetValue(v, out result))
+            {
+                return result;
+            }
+            else
+            {
+                return IntervalUnknown;
+            }
         }
-        else
+
+        public virtual List<Pair<Variable, Int32>> IntConstants
         {
-          return input.IntervalUnknown;
+            get
+            {
+                return new List<Pair<Variable, int>>();
+            }
         }
-      }
 
-      public override IType VisitInt32(Expression exp, This input)
-      {
-        Int32 value;
-        IType result;
-
-        if (this.Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value))
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
         {
-          result = input.For(value);
+            var res = new Set<Expression>();
+            var val = this.BoundsFor(v);
 
-          return result;
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.LowerBound.IsInfinity)
+            {
+                if (strict)
+                {
+                    Rational bound; // = strict ? val.LowerBound - 1 : val.LowerBound;
+                    if (Rational.TrySub(val.LowerBound, Rational.For(1), out bound))
+                    {
+                        res.Add(bound.ToExpression(encoder));
+                    }
+                }
+                else
+                {
+                    res.Add(val.LowerBound.ToExpression(encoder));
+                }
+            }
+
+            return res;
         }
-        else
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
         {
-          return input.IntervalUnknown;
+            var res = new Set<Expression>();
+            var val = this.BoundsFor(v);
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.LowerBound.IsInfinity)
+            {
+                if (strict)
+                {
+                    Rational bound; // = strict ? val.LowerBound - 1 : val.LowerBound;
+                    if (Rational.TrySub(val.LowerBound, Rational.For(1), out bound))
+                    {
+                        res.Add(bound.ToExpression(encoder));
+                    }
+                }
+                else
+                {
+                    res.Add(val.LowerBound.ToExpression(encoder));
+                }
+            }
+
+            return res;
         }
-      }
 
-      public override IType VisitInt64(Expression exp, This input)
-      {
-        Int64 value;
-
-        if (this.Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value))
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
         {
-          return input.For(value);
+            var val = this.BoundsFor(v);
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.UpperBound.IsInfinity)
+            {
+                Rational bound; // = strict ? val.UpperBound + 1 : val.UpperBound;
+                if (strict)
+                {
+                    if (Rational.TryAdd(1, val.UpperBound, out bound))
+                    {
+                        yield return bound.ToExpression(encoder);
+                    }
+                }
+                else
+                {
+                    yield return val.UpperBound.ToExpression(encoder);
+                }
+            }
         }
-        else
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
         {
-          return input.IntervalUnknown;
+            var val = this.BoundsFor(v);
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder) && val.IsNormal && !val.UpperBound.IsInfinity)
+            {
+                Rational bound; // = strict ? val.UpperBound + 1 : val.UpperBound;
+                if (strict)
+                {
+                    if (Rational.TryAdd(1, val.UpperBound, out bound))
+                    {
+                        yield return bound.ToExpression(encoder);
+                    }
+                }
+                else
+                {
+                    yield return val.UpperBound.ToExpression(encoder);
+                }
+            }
         }
-      }
 
-      public override IType VisitUInt8(Expression exp, This input)
-      {
-        Byte value;
-
-        if (this.Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value))
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
         {
-          return input.For(value);
+            return new Set<Variable>();
         }
-        else
+
+        virtual public This TestTrue(Expression guard)
         {
-          return input.IntervalUnknown;
+            Contract.Requires(guard != null);
+
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            var res = this.TestNotEqualToZero(expManager.Decoder.UnderlyingVariable(guard));
+            var visitor = new IntervalTestVisitor(expManager.Decoder);
+
+            return visitor.VisitTrue(guard, (This)this);
         }
-      }
 
-      public override IType VisitUInt16(Expression exp, This input)
-      {
-        UInt16 value;
-
-        if (this.Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value))
+        virtual public This TestFalse(Expression guard)
         {
-          return input.For(value);
+            Contract.Requires(guard != null);
+
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            var res = this.TestEqualToZero(expManager.Decoder.UnderlyingVariable(guard));
+            var visitor = new IntervalTestVisitor(expManager.Decoder);
+
+            return visitor.VisitFalse(guard, (This)this);
         }
-        else
+
+        public This TestTrueLessThan(Variable left, Variable right)
         {
-          return input.IntervalUnknown;
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            var kLeft = EvalFast(left);
+            var kRight = EvalFast(right);
+
+            this.AssumeKLessThanRight(kLeft, right);
+            this.AssumeLeftLessThanK(left, kRight);
+
+            return (This)this;
         }
-      }
 
-      public override IType VisitUInt32(Expression exp, This input)
-      {
-        UInt32 value;
-
-        if (this.Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value))
+        /// <summary>
+        /// The handler for the expressions in the form of <code>e1 == e2</code>.
+        /// The default is built invoking by transforming the code into <code>e1 &lt;= e2 &amp;&amp; e2 &lt;= e1</code>
+        /// However, if no encoder is provided, then it evaluates e1, and e2, and then it tests that they are the same interval...
+        /// </summary>
+        public This TestTrueEqual(Expression e1, Expression e2)
         {
-          return input.For(value);
+            Contract.Requires(e1 != null);
+            Contract.Requires(e2 != null);
+
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            var result = (This)this;
+
+            #region 1. Try to see if it is a relational expression
+            // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant
+            // Then it is a boolean expression, so we handle it as it deserves
+            Int32 value;
+            if (this.ExpressionManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.ExpressionManager.Decoder.IsConstantInt(e2, out value))
+            {
+                if (value == 0)
+                { // that is !(e1)
+                    result = this.TestFalse(e1);
+                }
+                else
+                { // that is e1
+                    result = this.TestTrue(e1);
+                }
+            }
+            #endregion
+
+            #region 2. Otherwise, handle the equality
+
+            IExpressionEncoder<Variable, Expression> encoder;
+
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                // assume e1 <= e2; assume e2 <= e1
+                return result.TestTrueLessEqualThan(e1, e2).TestTrueLessEqualThan(e2, e1);
+            }
+            else
+            {
+                var varFore1 = expManager.Decoder.UnderlyingVariable(e1);
+                var varFore2 = expManager.Decoder.UnderlyingVariable(e2);
+
+                if (this.ContainsKey(varFore1))
+                {
+                    var resultTmp = this.DuplicateMe();
+
+                    var newVal = Eval(e1).Meet(Eval(e2));
+                    resultTmp[varFore1] = newVal;
+                    resultTmp[varFore2] = newVal;
+
+                    result = resultTmp;
+                }
+                else if (this.ExpressionManager.Decoder.IsVariable(e1) || this.ExpressionManager.Decoder.IsWritableBytes(e1)) // it is in the form of "x == exp"
+                {
+                    var intervalForE2 = Eval(e2);
+
+                    if (!intervalForE2.IsTop)
+                    { // Avoid putting top in the environment
+                        this[varFore1] = intervalForE2;
+                    }
+                }
+                else if (this.ExpressionManager.Decoder.OperatorFor(e1).IsConversionOperator())
+                { // if it is in the form of "(cast) e1 == e2"
+                    result = TestTrueEqual(this.ExpressionManager.Decoder.LeftExpressionFor(e1), e2);
+                }
+                else if (this.ExpressionManager.Decoder.IsConstant(e1) && this.ExpressionManager.Decoder.IsConstant(e2))
+                {
+                    var tmpRes = Eval(e1).Meet(Eval(e2));
+                    if (tmpRes.IsBottom)
+                    {
+                        return Bottom;
+                    }
+                }
+
+                return result;
+            }
+            #endregion
         }
-        else
+
+        /// <summary>
+        /// Handler for expression in the form of <code>e1 != e2</code>
+        /// </summary>
+        /// <returns>by default, it does <code>e1 &lt; e2 ||  e2 &lt; e1</code></returns>
+        virtual public This TestNotEqual(Expression e1, Expression e2)
         {
-          return input.IntervalUnknown;
-        }
-      }
+            Contract.Requires(e1 != null);
+            Contract.Requires(e2 != null);
 
-      public override IType VisitBool(Expression exp, This input)
-      {
-        bool b;
-        if(this.Decoder.TryValueOf<Boolean>(exp, ExpressionType.Bool, out b))
+            #region 1. Try to see if it is a relational operator
+            int value;
+            // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant 
+            if (this.ExpressionManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.ExpressionManager.Decoder.IsConstantInt(e2, out value))
+            {
+                if (value == 0)
+                { // that is !!(e1)
+                    return this.TestTrue(e1);
+                }
+                else
+                { // that is !e1
+                    return this.TestFalse(e1);
+                }
+            }
+            #endregion
+
+            #region 2. Otherwise handle the inequality by two LT operations
+            var adom1 = this.DuplicateMe();
+            var adom2 = this.DuplicateMe();
+
+            var l1 = adom1.TestTrueLessThan(e1, e2);
+            var l2 = adom2.TestTrueLessThan(e2, e1);
+
+            return l1.Join(l2);
+            #endregion
+        }
+
+        [ContractVerification(false)]
+        protected override string ToLogicalFormula(Variable d, IType c)
         {
-          return b ? input.For(1) : input.For(0);
+            if (!c.IsNormal())
+            {
+                return null;
+            }
+
+            var result = new List<string>();
+
+            if (c.IsSingleton)
+            {
+                result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.Equal, ExpressionPrinter.ToString(d, expManager.Decoder), c.LowerBound.ToString()));
+            }
+            else if (!c.IsLowerBoundMinusInfinity)
+            {
+                result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessEqualThan, c.LowerBound.ToString(), ExpressionPrinter.ToString(d, expManager.Decoder)));
+            }
+            else if (!c.IsUpperBoundPlusInfinity)
+            {
+                result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessEqualThan, ExpressionPrinter.ToString(d, expManager.Decoder), c.UpperBound.ToString()));
+            }
+
+            return ExpressionPrinter.ToLogicalFormula(ExpressionOperator.LogicalAnd, result);
         }
 
-        return input.IntervalUnknown;
-      }
+        protected override T To<T>(Variable d, IType c, IFactory<T> factory)
+        {
+            if (c.IsTop)
+                return factory.IdentityForAnd;
+            if (c.IsBottom)
+                return factory.Constant(false);
 
-      public override IType Default(Expression exp)
-      {
-        return this.IntervalUnknown;
-      }
-    }
-    #endregion
+            NType r;
+            if (c.TryGetSingletonValue(out r))
+            {
+                return factory.EqualTo(factory.Variable(d), To(r, factory));
+            }
 
-    #region IIntervalAbstraction<Variable,Expression> Members (To make the type system happy)
+            T left = c.IsLowerBoundMinusInfinity
+                ? factory.IdentityForAnd
+                : factory.LessEqualThan(To(c.LowerBound, factory), factory.Variable(d));
 
-    bool IIntervalAbstraction<Variable, Expression>.LessEqual(IIntervalAbstraction<Variable, Expression> other)
-    {
-      return this.LessEqual((This)other);
-    }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Join(IIntervalAbstraction<Variable, Expression> other)
-    {
-      return this.Join((This)other); 
-    }
+            T right = c.IsUpperBoundPlusInfinity
+                ? factory.IdentityForAnd
+                : factory.LessEqualThan(factory.Variable(d), To(c.UpperBound, factory));
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Widening(IIntervalAbstraction<Variable, Expression> other)
-    {
-      return this.Widening((This)other) ;
-    }
+            return factory.And(left, right);
+        }
+        #endregion
 
-    List<Pair<Variable, Int32>> IIntervalAbstraction<Variable, Expression>.IntConstants
-    {
-      get { return this.IntConstants; }
-    }
+        #region Proxies to please the compiler
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return this.RemoveRedundanciesWith(oracle);
+        }
 
-    void IIntervalAbstraction<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      this.AssumeInDisInterval(x, value); 
-    }
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            return this.TestTrue(guard);
+        }
 
-    void IIntervalAbstraction<Variable, Expression>.Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      this.Assign(x, exp, preState);
-    }
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression exp)
+        {
+            return this.TestTrueGeqZero(exp);
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return this.RemoveRedundanciesWith(oracle);
-    }
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessThan(exp1, exp2);
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrue(Expression exp)
-    {
-      return this.TestTrue(exp);
-    }
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessEqualThan(exp1, exp2);
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestFalse(Expression exp)
-    {
-      return this.TestFalse(exp);
-    }
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueEqual(exp1, exp2);
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueLessThan(exp1, exp2);
-    }
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            return this.TestFalse(guard);
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Variable v1, Variable v2)
-    {
-      return this.TestTrueLessThan(v1, v2);
-    }
+        public override object Clone()
+        {
+            return this.DuplicateMe();
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueLessEqualThan(exp1, exp2);
-    }
+        #endregion
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Variable v1, Variable v2)
-    {
+        #region TryGetValue
+        public bool TryGetValue(Variable var, bool isSigned, out IType intv)
+        {
+            if (this.TryGetValue(var, out intv))
+            {
+                Contract.Assert(intv != null);
+                intv = isSigned ? intv : intv.ToUnsigned();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region Privates
+
+        private void RefineWithPrestate(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            Contract.Requires(preState != null);
+
+            var refinedInterval = ConvertInterval(preState.BoundsFor(exp).AsInterval);
+
+            if (refinedInterval.IsNormal())
+            {
+                var xExp = expManager.Decoder.UnderlyingVariable(x);
+
+                this.RefineWith(xExp, refinedInterval);
+            }
+        }
+
+        private FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Polynomial<Variable, Expression> pol)
+        {
+            if (pol.Relation != null)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var result = this.EvalPolynomial(pol);
+
+            if (result.IsBottom || result.IsTop)
+            {
+                return CheckOutcome.Top;
+            }
+            if (this.IsGreaterEqualThanZero(result.LowerBound))
+            {
+                return CheckOutcome.True;
+            }
+            else if (this.IsLessThanZero(result.UpperBound))
+            {
+                return CheckOutcome.False;
+            }
+            else
+            {
+                return CheckOutcome.Top;
+            }
+        }
+
+        protected void ToUInt(ref IType v)
+        {
+            Contract.Requires(v != null);
+
+            v = ApplyConversion(ExpressionOperator.ConvertToUInt32, v);
+        }
+
+        protected void ToUInt(ref IType v1, ref IType v2)
+        {
+            Contract.Requires(v1 != null);
+            Contract.Requires(v2 != null);
+
+            Contract.Ensures(Contract.ValueAtReturn(out v1) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out v2) != null);
+
+            ToUInt(ref v1);
+            ToUInt(ref v2);
+            Contract.Assume(v1 != null);
+            Contract.Assume(v2 != null);
+        }
+
+        #endregion
+
+        #region ToString
+        override public string ToString()
+        {
+            string result;
+
+            if (this.IsBottom)
+            {
+                result = "_|_";
+            }
+            else if (this.IsTop)
+            {
+                result = "Top";
+            }
+            else
+            {
+                var lines = new List<string>();
+
+                foreach (var x in this.Keys)
+                {
+                    // REDUNDANT inferred by CC
+                    /*          var xAsString = this.expManager.Decoder != null ? this.expManager.Decoder.NameOf(x) : x.ToString(); */
+
+                    var xAsString = expManager.Decoder.NameOf(x);
+
+                    if (!this[x].IsTop)
+                    {
+                        lines.Add(xAsString + ": " + this[x]);
+                    }
+                }
+
+                lines.Sort();
+
+                var buff = new StringBuilder();
+
+                if (lines.Count >= 2)
+                {
+                    for (var i = 0; i < lines.Count - 1; i++)
+                    {
+                        buff.AppendFormat("{0}, ", lines[i]);
+                    }
+                }
+
+                if (lines.Count >= 1)
+                    buff.AppendFormat(lines[lines.Count - 1]);
+
+                result = buff.ToString();
+            }
+
+            return result;
+        }
+
+        public string ToString(Expression exp)
+        {
+            //if (this.expManager.Decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, expManager.Decoder);
+            }
+            /*      else
+                  {
+                    return "< missing expression decoder >";
+                  }
+             */
+        }
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
+
+        #region Visitors
+        protected class IntervalTestVisitor
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(ttVisitor != null);
+                Contract.Invariant(tfVisitor != null);
+            }
+
+            readonly private IntervalsTrueTestVisitor ttVisitor;
+            readonly private IntervalsFalseTestVisitor tfVisitor;
+
+            public IntervalTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
+            {
+                ttVisitor = new IntervalsTrueTestVisitor(decoder);
+                tfVisitor = new IntervalsFalseTestVisitor(decoder);
+
+                ttVisitor.FalseVisitor = tfVisitor;
+                tfVisitor.TrueVisitor = ttVisitor;
+            }
+
+            internal This VisitTrue(Expression guard, This domain)
+            {
+                Contract.Requires(guard != null);
+                Contract.Ensures(Contract.Result<This>() != null);
+
+                return ttVisitor.Visit(guard, domain);
+            }
+
+            internal This VisitFalse(Expression guard, This domain)
+            {
+                Contract.Requires(guard != null);
+                Contract.Ensures(Contract.Result<This>() != null);
+
+                return tfVisitor.Visit(guard, domain);
+            }
+
+            private class IntervalsTrueTestVisitor :
+              TestTrueVisitor<This, Variable, Expression>
+            {
+                public IntervalsTrueTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
+                  : base(decoder)
+                { }
+
+
+                /// <summary>
+                /// We override the visitor as in some cases we want to capture information at an higher level.
+                /// For instance for
+                ///   \gt( -( +( sv7 (7), sv10 (10) ), sv48 (107) ), 0 )
+                /// we want to associate to the information ( -( +( sv7 (7), sv10 (10)), sv48 (107)) \in [1, +oo]
+                /// </summary>
+                protected override This DispatchCompare(GenericExpressionVisitor<This, This, Variable, Expression>.CompareVisitor cmp, Expression left, Expression right, Expression original, This data)
+                {
+                    data = cmp(left, right, original, data);
+                    return base.DispatchCompare(cmp, left, right, original, data);
+                }
+
+                public override This VisitEqual(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestTrueEqual(left, right);
+                }
+
+                public override This VisitEqual_Obj(Expression left, Expression right, Expression original, This data)
+                {
+                    return this.VisitEqual(left, right, original, data);
+                }
+
+                public override This VisitLessEqualThan_Un(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestTrueLessEqualThan_Un(left, right);
+                }
+
+                private bool AreFloat(Expression left, Expression right)
+                {
+                    var ltype = this.Decoder.TypeOf(left);
+                    if (ltype == ExpressionType.Float32 || ltype == ExpressionType.Float64)
+                        return true;
+
+                    var rtype = this.Decoder.TypeOf(right);
+
+                    return rtype == ExpressionType.Float32 || rtype == ExpressionType.Float64;
+                }
+
+                public override This VisitLessEqualThan(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestTrueLessEqualThan(left, right);
+                }
+
+                public override This VisitLessThan(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestTrueLessThan(left, right);
+                }
+
+                public override This VisitLessThan_Un(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestTrueLessThan_Un(left, right);
+                }
+
+                public override This VisitAddition(Expression left, Expression right, Expression original, This data)
+                {
+                    data = base.VisitAddition(left, right, original, data);
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitAnd(Expression left, Expression right, Expression original, This data)
+                {
+                    data = base.VisitAnd(left, right, original, data);
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitDivision(Expression left, Expression right, Expression original, This data)
+                {
+                    data = base.VisitDivision(left, right, original, data);
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitMultiplication(Expression left, Expression right, Expression original, This data)
+                {
+                    data = base.VisitMultiplication(left, right, original, data);
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitShiftLeft(Expression left, Expression right, Expression original, This data)
+                {
+                    data = base.VisitShiftLeft(left, right, original, data);
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitUnknown(Expression left, This data)
+                {
+                    data = base.VisitUnknown(left, data);
+                    return data.TestNotEqualToZero(left);
+                }
+
+                public override This VisitUnaryMinus(Expression left, Expression original, This data)
+                {
+                    data = base.VisitUnaryMinus(left, original, data);
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitOr(Expression left, Expression right, Expression original, This data)
+                {
+                    data = base.VisitOr(left, right, original, data);
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitNot(Expression left, This data)
+                {
+                    var ttVisitor = new IntervalsTrueTestVisitor(data.ExpressionManager.Decoder);
+                    var tfVisitor = new IntervalsFalseTestVisitor(data.ExpressionManager.Decoder);
+
+                    ttVisitor.FalseVisitor = tfVisitor;
+                    tfVisitor.TrueVisitor = ttVisitor;
+
+                    return tfVisitor.Visit(left, data);
+                }
+
+                public override This VisitNotEqual(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestNotEqual(left, right);
+                }
+
+                public override This VisitVariable(Variable var, Expression original, This data)
+                {
+                    return data.TestNotEqualToZero(original);
+                }
+
+                // left - right != 0
+                public override This VisitSubtraction(Expression left, Expression right, Expression original, This data)
+                {
+                    data = data.TestNotEqualToZero(original);
+                    return data.TestNotEqual(left, right);
+                }
+
+                // left % right != 0
+                public override This VisitModulus(Expression left, Expression right, Expression original, This data)
+                {
+                    // refine the interval by removing zero
+                    if (data.CheckIfGreaterEqualThanZero(left).IsTrue())
+                    {
+                        data = data.TestNotEqualToZero(left);
+                    }
+                    data = base.VisitModulus(left, right, original, data);
+
+                    return data.TestNotEqualToZero(original);
+                }
+
+                public override This VisitXor(Expression left, Expression right, Expression original, This data)
+                {
+                    data = base.VisitXor(left, right, original, data);
+
+                    return data.TestNotEqualToZero(original);
+                }
+            }
+
+            private class IntervalsFalseTestVisitor :
+              TestFalseVisitor<This, Variable, Expression>
+            {
+                public IntervalsFalseTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
+                  : base(decoder)
+                {
+                }
+
+                public override This Visit(Expression exp, This data)
+                {
+                    Contract.Ensures(Contract.Result<This>() != null);
+
+                    var result = base.Visit(exp, data);
+
+                    Contract.Assert(result != null);
+
+                    if (this.Decoder.IsBinaryExpression(exp))
+                    {
+                        var leftExp = this.Decoder.LeftExpressionFor(exp);
+                        var rightExp = this.Decoder.RightExpressionFor(exp);
+
+                        var k = data.Eval(rightExp);
+
+                        if (k.IsBottom)
+                        {
+                            return result.Bottom;
+                        }
+
+                        if (!k.IsSingleton)
+                        {
+                            return result;    // No more work to be done ...
+                        }
+
+                        switch (this.Decoder.OperatorFor(exp))
+                        {
+                            case ExpressionOperator.Multiplication:
+                            case ExpressionOperator.Division:
+                                // ignored
+                                break;
+
+                            case ExpressionOperator.GreaterEqualThan:
+                            case ExpressionOperator.GreaterEqualThan_Un:
+                                {
+                                    // !(left >= [a,b]) -> left < [a,b]
+                                    var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
+                                    result.AssumeLeftLessThanK(leftExpVar, k);
+                                }
+                                break;
+
+                            case ExpressionOperator.GreaterThan:
+                            case ExpressionOperator.GreaterThan_Un:
+                                {
+                                    // !(left > [a,b]) -> left <= [a,b]
+                                    var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
+                                    result.AssumeLeftLessEqualThanK(leftExpVar, k);
+                                }
+                                break;
+
+                            case ExpressionOperator.LessEqualThan:
+                            case ExpressionOperator.LessEqualThan_Un:
+                                {
+                                    // !(left <= [a,b]) -> left > [a, b]
+                                    var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
+                                    result.AssumeKLessThanRight(k, leftExpVar);
+                                }
+                                break;
+
+                            case ExpressionOperator.LessThan:
+                            case ExpressionOperator.LessThan_Un:
+                                {
+                                    // !(left < [a,b]) -> left >= [a, b]
+                                    var leftExpVar = this.Decoder.UnderlyingVariable(leftExp);
+                                    result.AssumeKLessEqualThanRight(k, leftExpVar);
+                                }
+                                break;
+                        }
+                    }
+
+                    return result;
+                }
+
+                public override This VisitEqual_Obj(Expression left, Expression right, Expression original, This data)
+                {
+                    return this.VisitEqual(left, right, original, data);
+                }
+
+                public override This VisitLessEqualThan(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestTrueLessThan(right, left);
+                }
+
+                public override This VisitLessThan(Expression left, Expression right, Expression original, This data)
+                {
+                    return data.TestTrueLessEqualThan(right, left);
+                }
+
+                public override This VisitNot(Expression left, This data)
+                {
+                    return this.TrueVisitor.Visit(left, data);
+                }
+
+                public override This VisitNotEqual(Expression left, Expression right, Expression original, This data)
+                {
+                    return this.TrueVisitor.VisitEqual(left, right, original, data);
+                }
+
+                public override This VisitVariable(Variable var, Expression original, This data)
+                {
+                    data[var] = data.Eval(original).Meet(data.IntervalZero);      // guard : [0, 0]
+                    return data;
+                }
+            }
+        }
+
+        #region Visitor for CheckIfHolds
+        protected class IntervalsCheckIfHoldsVisitor :
+          CheckIfHoldsVisitor<This, Variable, Expression>
+        {
+            public IntervalsCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+            }
+
+            public override FlatAbstractDomain<bool> VisitConstant(Expression left, FlatAbstractDomain<bool> data)
+            {
+                var valForLeft = this.Domain.Eval(left);
+                NType v;
+
+                if (valForLeft.TryGetSingletonValue(out v))
+                {
+                    Contract.Assume(v != null);
+                    return this.Domain.IsNotZero(v) ? CheckOutcome.True : CheckOutcome.False;
+                }
+                else
+                {
+                    return CheckOutcome.Top;
+                }
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                if (this.Decoder.IsNaN(left) || this.Decoder.IsNaN(right))
+                {
+                    return CheckOutcome.False;
+                }
+
+                return this.VisitEqual_Internal(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                if (this.Decoder.IsNaN(left) && this.Decoder.IsNaN(right))
+                {
+                    return CheckOutcome.True;
+                }
+
+                return this.VisitEqual_Internal(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return this.Domain.CheckIfLessEqualThan(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return this.Domain.CheckIfLessEqualThan_Un(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return this.Domain.CheckIfLessThan(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return this.Domain.CheckIfLessThan_Un(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitNot(Expression left, FlatAbstractDomain<bool> data)
+            {
+                FlatAbstractDomain<bool> leftHolds = this.Visit(left, data);
+
+                if (leftHolds.IsNormal())
+                {
+                    return new FlatAbstractDomain<bool>(!leftHolds.BoxedElement);
+                }
+                else
+                {
+                    return leftHolds;
+                }
+            }
+
+            public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                long value; // We use long because we do not want Int32.MinValue to be wrapped to zero
+
+                if (this.Decoder.TryValueOf<long>(right, ExpressionType.Int64, out value) && value == 0)
+                {
+                    // left != 0 => we should check if left holds
+                    var direct = this.Visit(left, data);
+
+                    if (!direct.IsTop)
+                    {
+                        return direct;
+                    }
+                }
+
+                var areEqual = this.VisitEqual(left, right, original, data);
+
+                if (areEqual.IsNormal())
+                {
+                    return new FlatAbstractDomain<bool>(!areEqual.BoxedElement);
+                }
+                else
+                {
+                    return areEqual;
+                }
+            }
+
+            public override FlatAbstractDomain<bool> VisitVariable(Variable var, Expression original, FlatAbstractDomain<bool> data)
+            {
+                var intv = this.Domain.Eval(original);
+
+                if (intv.IsTop)
+                    return CheckOutcome.Top;
+
+                if (intv.IsBottom)
+                    return CheckOutcome.Bottom;
+
+                if (!intv.IsNormal)
+                    return CheckOutcome.Top;
+
+                if (this.Domain.IsGreaterThanZero(intv.LowerBound) || this.Domain.IsLessThanZero(intv.UpperBound))
+                    return CheckOutcome.True;
+
+                if (intv.IsSingleton && this.Domain.IsZero(intv.LowerBound))
+                    return CheckOutcome.False;
+
+                return CheckOutcome.Top;
+            }
+
+            private FlatAbstractDomain<bool> VisitEqual_Internal(Expression left, Expression right)
+            {
+                var leftType = this.Decoder.TypeOf(left);
+                var rightType = this.Decoder.TypeOf(right);
+
+                if (!leftType.IsFloatingPointType() && !rightType.IsFloatingPointType() && left.Equals(right))
+                {
+                    return CheckOutcome.True;
+                }
+
+                var leftInt = this.Domain.Eval(left);
+                var rightInt = this.Domain.Eval(right);
+
+                if (leftInt.IsSingleton && rightInt.IsSingleton && leftInt.LessEqual(rightInt))
+                {
+                    return CheckOutcome.True;
+                }
+
+                if (!leftInt.IsLowerBoundMinusInfinity && !leftInt.IsUpperBoundPlusInfinity && !rightInt.IsLowerBoundMinusInfinity && !rightInt.IsUpperBoundPlusInfinity &&
+                  leftInt.LowerBound.Equals(rightInt.LowerBound) && leftInt.UpperBound.Equals(rightInt.UpperBound) && leftInt.LowerBound.Equals(leftInt.UpperBound))
+                {
+                    return CheckOutcome.True;
+                }
+
+                if ((!leftInt.IsUpperBoundPlusInfinity && !rightInt.IsLowerBoundMinusInfinity && this.Domain.IsLessThan(leftInt.UpperBound, rightInt.LowerBound))
+                  || (!rightInt.IsUpperBoundPlusInfinity && !leftInt.IsLowerBoundMinusInfinity && this.Domain.IsLessThan(rightInt.UpperBound, leftInt.LowerBound)))
+                {
+                    return CheckOutcome.False;
+                }
+
+
+                var op = this.Decoder.OperatorFor(left);
+
+                int value;
+
+                if (this.Decoder.IsConstantInt(right, out value) && value == 0)
+                {
+                    if (op.IsLessThan())
+                    {
+                        // it is (a < b) == 0, that is !(a < b) that is b <= a
+                        var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
+                        var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+
+                        if (this.Domain.IsLessEqualThan(valForB.UpperBound, valForA.LowerBound))
+                        {
+                            return CheckOutcome.True;
+                        }
+                    }
+
+                    if (op.IsLessEqualThan())
+                    {
+                        // it is (a <= b) == 0, that is !(a <= b) that is b > a
+                        var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
+                        var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+
+                        if (this.Domain.IsLessThan(valForA.UpperBound, valForB.LowerBound))
+                        {
+                            return CheckOutcome.True;
+                        }
+                    }
+
+                    if (op.IsGreaterThan())
+                    {
+                        // it is (a > b) == 0, that is !(a > b) that is b >= a
+                        var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
+                        var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+
+                        if (this.Domain.IsLessEqualThan(valForA.UpperBound, valForB.LowerBound))
+                        {
+                            return CheckOutcome.True;
+                        }
+                    }
+
+                    if (op.IsGreaterEqualThan())
+                    {
+                        // it is (a >= b) == 0, that is !(a >= b) that is b < a
+                        var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
+                        var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+
+                        if (this.Domain.IsLessThan(valForB.UpperBound, valForA.LowerBound))
+                        {
+                            return CheckOutcome.True;
+                        }
+                    }
+
+                    if ((op == ExpressionOperator.Equal || op == ExpressionOperator.Equal_Obj))
+                    {
+                        // it is (a == b) == 0, that is !(a == b) that is b != a
+                        var valForA = this.Domain.Eval(this.Decoder.LeftExpressionFor(left));
+                        var valForB = this.Domain.Eval(this.Decoder.RightExpressionFor(left));
+
+                        Contract.Assert(valForA != null);
+                        Contract.Assert(valForB != null);
+
+                        if ((valForA.Meet(valForB)).IsBottom)
+                        { // a \sqcap b == _|_  implies that they are different
+                            return CheckOutcome.True;
+                        }
+
+                        if (valForA.IsNormal() && valForB.IsNormal() && valForA.LessEqual(valForB) && valForB.LessEqual(valForA))
+                        {
+                            return CheckOutcome.True;
+                        }
+                    }
+                }
+
+                return CheckOutcome.Top;
+            }
+
+            protected override FlatAbstractDomain<bool> Default(FlatAbstractDomain<bool> data)
+            {
+                return CheckOutcome.Top;
+            }
+        }
+        #endregion
+
+        private class EvalExpressionVisitor
+          : GenericExpressionVisitor<Pair<This, Int32>, IType, Variable, Expression>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(evalConstantVisitor != null);
+                Contract.Invariant(occurrences != null);
+            }
+
+            #region Private state
+
+            private readonly EvalConstantVisitor evalConstantVisitor;
+            private readonly VariableOccurrences occurrences;
+
+            #endregion
+
+            #region Constructor
+            public EvalExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+
+                evalConstantVisitor = new EvalConstantVisitor(decoder);
+                occurrences = new VariableOccurrences(decoder);
+            }
+            #endregion
+
+            public List<Variable> DuplicatedOccurrences
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<List<Variable>>() != null);
+
+                    return occurrences.DuplicatedOccurrences;
+                }
+            }
+
+            #region Entrypoint for the visit
+            public override IType Visit(Expression exp, Pair<This, Int32> data)
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+
+                if (data.Two >= IntervalEnvironment_Base<This, Variable, Expression, IType, NType>.MAXDEPTH)
+                {
+                    return data.One.IntervalUnknown;
+                }
+
+                var result = base.Visit(exp, PlusOne(data));
+
+                /*
+                if (result == null)
+                {
+                  return data.One.IntervalUnknown;
+                }
+                */
+                result = RefineWithTypeRange(result, exp, data.One);
+
+                var expVar = this.Decoder.UnderlyingVariable(exp);
+                IType prev_result;
+                if (data.One.TryGetValue(expVar, out prev_result))
+                {
+                    result = result.Meet(prev_result);
+                    Contract.Assert(result != null);
+                }
+
+                return result;
+            }
+            #endregion
+
+            #region Visits
+            public override IType VisitAddition(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                var sum = data.One.Interval_Add(leftIntv, rightIntv);
+
+                // If we know the type, we can refine the result
+                if (Decoder.TypeOf(left) == ExpressionType.Int32 || Decoder.TypeOf(right) == ExpressionType.Int32)
+                {
+                    // <0 + MaxInt32 = [-1, +oo]
+                    if (data.One.IsLessEqualThanZero(leftIntv) && data.One.IsMaxInt32(rightIntv))
+                    {
+                        sum = sum.Meet(data.One.IntervalGreaterEqualThanMinusOne);
+                    }
+                }
+
+                return sum;
+            }
+
+            public override IType VisitAnd(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                if (data.One.IsGreaterThanZero(rightIntv.LowerBound))
+                {
+                    return data.One.Interval_BitwiseAnd(leftIntv, rightIntv);
+                }
+                else
+                {
+                    return data.One.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitConstant(Expression left, Pair<This, Int32> data)
+            {
+                return evalConstantVisitor.Visit(left, data.One);
+            }
+
+            public override IType VisitConvertToInt8(Expression left, Expression original, Pair<This, int> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.ApplyConversion(ExpressionOperator.ConvertToInt8, Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitConvertToInt32(Expression left, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.ApplyConversion(ExpressionOperator.ConvertToInt32, Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitConvertToUInt16(Expression left, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.ApplyConversion(ExpressionOperator.ConvertToUInt16, Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitConvertToUInt32(Expression left, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.ApplyConversion(ExpressionOperator.ConvertToUInt32, Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitConvertToFloat64(Expression p, Expression original, Pair<This, int> data)
+            {
+                occurrences.Add(p);
+
+                return data.One.ApplyConversion(ExpressionOperator.ConvertToFloat64, Visit(p, PlusOne(data)));
+            }
+
+            public override IType VisitConvertToUInt8(Expression left, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.ApplyConversion(ExpressionOperator.ConvertToUInt8, Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitConvertToFloat32(Expression left, Expression original, Pair<This, int> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.ApplyConversion(ExpressionOperator.ConvertToFloat32, Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitDivision(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                return data.One.Interval_Div(leftIntv, rightIntv);
+            }
+
+            public override IType VisitEqual(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitGreaterEqualThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitGreaterThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitLessEqualThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitLessThan(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitModulus(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                var result = data.One.Interval_Rem(leftIntv, rightIntv);
+
+                if (AreCoPrimes(left, right))
+                {
+                    result = result.Meet(data.One.Interval_StrictlyPositive);
+                }
+
+                return result;
+            }
+
+            // [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+            private bool AreCoPrimes(Expression l, Expression r)
+            {
+                int rVal;
+                // Try to match (x * k) % r
+                if (this.Decoder.IsConstantInt(r, out rVal) && rVal != 0 &&
+                  this.Decoder.IsBinaryExpression(l) && this.Decoder.OperatorFor(l) == ExpressionOperator.Multiplication)
+                {
+                    var ll = this.Decoder.LeftExpressionFor(l);
+                    var lr = this.Decoder.RightExpressionFor(l);
+
+                    int llVal, lrVal;
+
+                    var bll = this.Decoder.IsConstantInt(ll, out llVal);
+                    var blr = this.Decoder.IsConstantInt(lr, out lrVal);
+
+                    // Review: Why blr && blr ??? cccheck complains about blr==false being constant
+                    if ((!bll && !blr) || (bll && blr) || llVal <= 0 || rVal <= 0)
+                    {
+                        return false;
+                    }
+
+                    if (bll)
+                    {
+                        return Rational.GCD(llVal, rVal) == 1;
+                    }
+                    else
+                    {
+                        return Rational.GCD(lrVal, rVal) == 1;
+                    }
+                }
+
+                return false;
+            }
+
+            public override IType VisitMultiplication(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                return data.One.Interval_Mul(leftIntv, rightIntv);
+            }
+
+            public override IType VisitNot(Expression left, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.Interval_Not(Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitNotEqual(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitOr(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                return data.One.Interval_BitwiseOr(leftIntv, rightIntv);
+            }
+
+            public override IType VisitShiftLeft(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                return data.One.Interval_ShiftLeft(leftIntv, rightIntv);
+            }
+
+            public override IType VisitShiftRight(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                return data.One.Interval_ShiftRight(leftIntv, rightIntv);
+            }
+
+            public override IType VisitSizeOf(Expression sizeofExp, Pair<This, Int32> data)
+            {
+                occurrences.Add(sizeofExp);
+
+                int i;
+                if (this.Decoder.TrySizeOf(sizeofExp, out i))
+                    return data.One.For(i);
+                else
+                    return data.One.Interval_Positive; // This is an upper approximation as we do not consider the size of the actual type 
+            }
+
+            public override IType VisitSubtraction(Expression left, Expression right, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                return data.One.Interval_Sub(leftIntv, rightIntv);
+            }
+
+            public override IType VisitUnaryMinus(Expression left, Expression original, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.Interval_UnaryMinus(Visit(left, PlusOne(data)));
+            }
+
+            public override IType VisitUnknown(Expression left, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitVariable(Variable var, Expression original, Pair<This, Int32> data)
+            {
+                // this.occurrences.Add(var);
+
+                if (data.One.ContainsKey(var))
+                    return data.One[var];
+                else
+                    return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitWritableBytes(Expression left, Expression wholeExpression, Pair<This, Int32> data)
+            {
+                occurrences.Add(left);
+
+                var v = this.Decoder.UnderlyingVariable(wholeExpression);
+                if (data.One.ContainsKey(v))
+                    return data.One[v];
+                else
+                    return data.One.IntervalUnknown;
+            }
+
+            public override IType VisitXor(Expression left, Expression right, Expression original, Pair<This, int> data)
+            {
+                occurrences.Add(left, right);
+
+                var plusOne = PlusOne(data);
+
+                var leftIntv = Visit(left, plusOne);
+                var rightIntv = Visit(right, plusOne);
+
+                return data.One.Interval_BitwiseXor(leftIntv, rightIntv);
+            }
+
+            protected override IType Default(Pair<This, Int32> data)
+            {
+                return data.One.IntervalUnknown;
+            }
+
+            #endregion
+
+            #region Privates
+            static private Pair<This, Int32> PlusOne(Pair<This, Int32> data)
+            {
+                return new Pair<This, int>(data.One, data.Two + 1);
+            }
+
+            private IType RefineWithTypeRange(IType interval, Expression exp, This converter)
+            {
+                Contract.Requires(interval != null);
+                Contract.Ensures(Contract.Result<IType>() != null);
+
+                var type = this.Decoder.TypeOf(exp);
+                switch (type)
+                {
+                    case ExpressionType.Bool:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToInt32, interval);
+
+                    case ExpressionType.Int8:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToInt8, interval);
+
+                    case ExpressionType.Int16:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToInt16, interval);
+
+                    case ExpressionType.Int32:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToInt32, interval);
+
+                    case ExpressionType.Int64:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToInt64, interval);
+
+                    case ExpressionType.UInt8:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToUInt8, interval);
+
+                    case ExpressionType.UInt16:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToUInt16, interval);
+
+                    case ExpressionType.UInt32:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToUInt32, interval);
+
+                    case ExpressionType.UInt64:
+                        return converter.ApplyConversion(ExpressionOperator.ConvertToUInt64, interval);
+
+                    default:
+                        return interval;
+                }
+            }
+
+            #endregion
+
+            #region Occurrences counter
+            private class VariableOccurrences
+            {
+                #region Object Invariant
+                [ContractInvariantMethod]
+                private void ObjectInvariant()
+                {
+                    Contract.Invariant(duplicated != null);
+                    Contract.Invariant(occurrences != null);
+                    Contract.Invariant(decoder != null);
+                }
+                #endregion
+
+                readonly private Dictionary<Variable, int> occurrences;
+                private readonly IExpressionDecoder<Variable, Expression> decoder;
+                private readonly List<Variable> duplicated;
+
+                public VariableOccurrences(IExpressionDecoder<Variable, Expression> decoder)
+                {
+                    Contract.Requires(decoder != null);
+
+                    occurrences = new Dictionary<Variable, int>();
+                    this.decoder = decoder;
+                    duplicated = new List<Variable>();
+                }
+
+                public void Add(Variable v)
+                {
+                    int count;
+                    if (occurrences.TryGetValue(v, out count))
+                    {
+                        occurrences[v] = count + 1;
+
+                        if (count == 1)
+                        {
+                            duplicated.Add(v);
+                        }
+                    }
+                    else
+                    {
+                        occurrences[v] = 1;
+                    }
+                }
+
+                public void Add(Expression e)
+                {
+                    this.Add(decoder.UnderlyingVariable(e));
+                }
+
+                public void Add(params Expression[] exps)
+                {
+                    Contract.Requires(exps != null);
+
+                    foreach (var e in exps)
+                    {
+                        this.Add(e);
+                    }
+                }
+
+                public List<Variable> DuplicatedOccurrences
+                {
+                    get
+                    {
+                        Contract.Ensures(Contract.Result<List<Variable>>() != null);
+
+                        return duplicated;
+                    }
+                }
+
+                public override string ToString()
+                {
+                    return occurrences.ToString();
+                }
+            }
+            #endregion
+
+            #region Logic for caching 
+
+            public class Cache
+            {
+                [ContractInvariantMethod]
+                private void ObjectInvariant()
+                {
+                    Contract.Invariant(cache != null);
+                }
+
+
+                private Dictionary<Variable, IType> cache;
+                private int currversion;
+
+                public Cache(int version)
+                {
+                    currversion = version;
+                    cache = new Dictionary<Variable, IType>();
+                }
+
+                public bool TryGetFromCache(int version, Variable v, out IType result)
+                {
+                    if (version == currversion && cache.TryGetValue(v, out result))
+                    {
+                        return true;
+                    }
+
+                    result = default(IType);
+                    return false;
+                }
+
+                public void Set(int version, Variable v, IType value)
+                {
+                    if (currversion == version)
+                    {
+                        cache[v] = value;
+                    }
+                    else
+                    {
+                        currversion = version;
+                        cache = new Dictionary<Variable, IType>();
+                    }
+                }
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        /// Get an interval containing the constant.
+        /// It can be an overapproximation as some values may not be exactly represented as for instance Int64 when the underlying Rational
+        /// are at 32 bits
+        /// </summary>
+        public class EvalConstantVisitor
+          : GenericTypeExpressionVisitor<Variable, Expression, This, IType>
+        {
+            private IType IntervalUnknown;
+
+            public EvalConstantVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+            }
+
+            override public IType Visit(Expression exp, This state)
+            {
+                IntervalUnknown = state.IntervalUnknown;
+
+                if (exp != null && this.Decoder.IsConstant(exp))
+                {
+                    // F: WARNING BELOW TO BE FIXED
+                    return base.Visit(exp, state);
+                }
+                else
+                {
+                    return Default(exp);
+                }
+            }
+
+            public override IType VisitFloat32(Expression exp, This input)
+            {
+                Single value;
+                IType result;
+
+                if (this.Decoder.TryValueOf<Single>(exp, ExpressionType.Float32, out value))
+                {
+                    result = input.For(value);
+
+                    return result;
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitFloat64(Expression exp, This input)
+            {
+                Double value;
+                IType result;
+
+                if (this.Decoder.TryValueOf<Double>(exp, ExpressionType.Float64, out value))
+                {
+                    result = input.For(value);
+
+                    return result;
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitInt8(Expression exp, This input)
+            {
+                SByte value;
+                IType result;
+
+                if (this.Decoder.TryValueOf<SByte>(exp, ExpressionType.Int8, out value))
+                {
+                    result = input.For(value);
+
+                    return result;
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitInt16(Expression exp, This input)
+            {
+                Int16 value;
+
+                if (this.Decoder.TryValueOf<Int16>(exp, ExpressionType.Int16, out value))
+                {
+                    return input.For(value);
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitInt32(Expression exp, This input)
+            {
+                Int32 value;
+                IType result;
+
+                if (this.Decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out value))
+                {
+                    result = input.For(value);
+
+                    return result;
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitInt64(Expression exp, This input)
+            {
+                Int64 value;
+
+                if (this.Decoder.TryValueOf<Int64>(exp, ExpressionType.Int64, out value))
+                {
+                    return input.For(value);
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitUInt8(Expression exp, This input)
+            {
+                Byte value;
+
+                if (this.Decoder.TryValueOf<Byte>(exp, ExpressionType.UInt8, out value))
+                {
+                    return input.For(value);
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitUInt16(Expression exp, This input)
+            {
+                UInt16 value;
+
+                if (this.Decoder.TryValueOf<UInt16>(exp, ExpressionType.UInt16, out value))
+                {
+                    return input.For(value);
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitUInt32(Expression exp, This input)
+            {
+                UInt32 value;
+
+                if (this.Decoder.TryValueOf<UInt32>(exp, ExpressionType.UInt32, out value))
+                {
+                    return input.For(value);
+                }
+                else
+                {
+                    return input.IntervalUnknown;
+                }
+            }
+
+            public override IType VisitBool(Expression exp, This input)
+            {
+                bool b;
+                if (this.Decoder.TryValueOf<Boolean>(exp, ExpressionType.Bool, out b))
+                {
+                    return b ? input.For(1) : input.For(0);
+                }
+
+                return input.IntervalUnknown;
+            }
+
+            public override IType Default(Expression exp)
+            {
+                return IntervalUnknown;
+            }
+        }
+        #endregion
+
+        #region IIntervalAbstraction<Variable,Expression> Members (To make the type system happy)
+
+        bool IIntervalAbstraction<Variable, Expression>.LessEqual(IIntervalAbstraction<Variable, Expression> other)
+        {
+            return this.LessEqual((This)other);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Join(IIntervalAbstraction<Variable, Expression> other)
+        {
+            return this.Join((This)other);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Widening(IIntervalAbstraction<Variable, Expression> other)
+        {
+            return this.Widening((This)other);
+        }
+
+        List<Pair<Variable, Int32>> IIntervalAbstraction<Variable, Expression>.IntConstants
+        {
+            get { return this.IntConstants; }
+        }
+
+        void IIntervalAbstraction<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            this.AssumeInDisInterval(x, value);
+        }
+
+        void IIntervalAbstraction<Variable, Expression>.Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            this.Assign(x, exp, preState);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return this.RemoveRedundanciesWith(oracle);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrue(Expression exp)
+        {
+            return this.TestTrue(exp);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestFalse(Expression exp)
+        {
+            return this.TestFalse(exp);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessThan(exp1, exp2);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Variable v1, Variable v2)
+        {
+            return this.TestTrueLessThan(v1, v2);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessEqualThan(exp1, exp2);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Variable v1, Variable v2)
+        {
 #if DEBUG
-      System.Diagnostics.Debugger.Break();
+            System.Diagnostics.Debugger.Break();
 #endif
-      return this;
+            return this;
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueEqual(exp1, exp2);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueGeqZero(Expression exp)
+        {
+            return this.TestTrueGeqZero(exp);
+        }
+
+        #endregion
+
+        #region IPureExpressionTest
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        public Variable ToVariable(Expression exp)
+        {
+            return expManager.Decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
     }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+    #region Contracts for IntervalEnvironment_Base
+    [ContractClassFor(typeof(IntervalEnvironment_Base<,,,,>))]
+    abstract public class IntervalEnvironment_BaseContracts<This, Variable, Expression, IType, NType>
+      : IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
+      where IType : IntervalBase<IType, NType>
+      where This : IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
     {
-      return this.TestTrueEqual(exp1, exp2);
-    }
+        protected IntervalEnvironment_BaseContracts() : base((ExpressionManager<Variable, Expression>)null) { }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueGeqZero(Expression exp)
-    {
-      return this.TestTrueGeqZero(exp);
-    }
+        protected override This DuplicateMe()
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+            return default(This);
+        }
 
+        protected override This NewInstance(ExpressionManager<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        protected override IType ConvertInterval(Interval intv)
+        {
+            Contract.Requires(intv != null);
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override This TestTrueGeqZero(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        public override This TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        public override This TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        public override This TestTrueLessThan_Un(Expression exp1, Expression exp2)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        public override This TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        protected override This TestNotEqualToZero(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        protected override This TestNotEqualToZero(Variable v)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        protected override This TestEqualToZero(Variable v)
+        {
+            Contract.Ensures(Contract.Result<This>() != null);
+
+            return default(This);
+        }
+
+        protected override void AssumeKLessThanRight(IType k, Variable right)
+        {
+            Contract.Requires(k != null);
+        }
+
+        protected override void AssumeLeftLessThanK(Variable left, IType k)
+        {
+            Contract.Requires(k != null);
+        }
+
+        public override DisInterval BoundsFor(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return default(DisInterval);
+        }
+
+        public override DisInterval BoundsFor(Variable v)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            return default(DisInterval);
+        }
+
+        protected override void AssumeInDisInterval_Internal(Variable x, DisInterval value)
+        {
+            Contract.Requires(value != null);
+        }
+
+        public override bool IsGreaterEqualThanZero(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool IsGreaterThanZero(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool IsLessThanZero(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool IsLessEqualThanZero(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool IsLessThan(NType val1, NType val2)
+        {
+            Contract.Requires(!object.Equals(val1, null));
+            Contract.Requires(!object.Equals(val2, null));
+
+            return default(bool);
+        }
+
+        public override bool IsLessEqualThan(NType val1, NType val2)
+        {
+            Contract.Requires(!object.Equals(val1, null));
+            Contract.Requires(!object.Equals(val2, null));
+
+            return default(bool);
+        }
+
+        public override bool IsZero(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool IsNotZero(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool IsPlusInfinity(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool IsMinusInfinity(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            return default(bool);
+        }
+
+        public override bool AreEqual(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            throw new NotImplementedException();
+        }
+
+        public override NType PlusInfinity
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override NType MinusInfinty
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override bool TryAdd(NType left, NType right, out NType result)
+        {
+            Contract.Requires(!object.Equals(left, null));
+            Contract.Requires(!object.Equals(right, null));
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out result), null));
+
+            result = default(NType);
+
+            return default(bool);
+        }
+
+        public override IType IntervalUnknown
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+                return default(IType);
+            }
+        }
+
+        public override IType IntervalZero
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+                return default(IType);
+            }
+        }
+
+        public override IType IntervalOne
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+                return default(IType);
+            }
+        }
+
+        public override IType IntervalGreaterEqualThanMinusOne
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+                return default(IType);
+            }
+        }
+
+        public override IType Interval_Positive
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+                return default(IType);
+            }
+        }
+
+        public override IType Interval_StrictlyPositive
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+                return default(IType);
+            }
+        }
+
+        public override IType IntervalSingleton(NType val)
+        {
+            Contract.Requires(!object.Equals(val, null));
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType IntervalRightOpen(NType inf)
+        {
+            Contract.Requires(!object.Equals(inf, null));
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType IntervalLeftOpen(NType sup)
+        {
+            Contract.Requires(!object.Equals(sup, null));
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override bool IsMaxInt32(IType intv)
+        {
+            Contract.Requires(intv != null);
+
+            return default(bool);
+        }
+
+        public override bool IsMinInt32(IType intv)
+        {
+            Contract.Requires(intv != null);
+
+            return default(bool);
+        }
+
+        public override IType Interval_Add(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_Div(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_Sub(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_Mul(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_Not(IType left)
+        {
+            Contract.Requires(left != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_UnaryMinus(IType left)
+        {
+            Contract.Requires(left != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_Rem(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_BitwiseAnd(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_BitwiseOr(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_BitwiseXor(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_ShiftLeft(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Interval_ShiftRight(IType left, IType right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType For(byte v)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+            return default(IType);
+        }
+
+        public override IType For(double d)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+            return default(IType);
+        }
+
+        public override IType For(short v)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+            return default(IType);
+        }
+
+        public override IType For(int v)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+            return default(IType);
+        }
+
+        public override IType For(long v)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+            return default(IType);
+        }
+
+        public override IType For(sbyte s)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+            return default(IType);
+        }
+
+        public override IType For(ushort u)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+            return default(IType);
+        }
+
+        public override IType For(uint u)
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType For(Rational r)
+        {
+            Contract.Requires(!object.Equals(r, null));
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType For(NType inf, NType sup)
+        {
+            Contract.Requires(!object.Equals(inf, null));
+            Contract.Requires(!object.Equals(sup, null));
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        protected override IType ApplyConversion(ExpressionOperator conversionType, IType val)
+        {
+            Contract.Requires(val != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        protected override T To<T>(NType n, IFactory<T> factory)
+        {
+            Contract.Requires(factory != null);
+
+            throw new NotImplementedException();
+        }
+
+        protected override This Factory()
+        {
+            return default(This);
+        }
+    }
     #endregion
-
-    #region IPureExpressionTest
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.expManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-  }
-
-  #region Contracts for IntervalEnvironment_Base
-  [ContractClassFor(typeof(IntervalEnvironment_Base<, , , , >))]
-  abstract public class IntervalEnvironment_BaseContracts<This, Variable, Expression, IType, NType>
-    : IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
-    where IType : IntervalBase<IType, NType>
-    where This : IntervalEnvironment_Base<This, Variable, Expression, IType, NType>
-  {
-
-    protected IntervalEnvironment_BaseContracts() : base((ExpressionManager<Variable, Expression>) null) { }
-
-    protected override This DuplicateMe()
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-      return default(This);
-    }
-
-    protected override This NewInstance(ExpressionManager<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      return default(This);
-    }
-
-    protected override IType ConvertInterval(Interval intv)
-    {
-      Contract.Requires(intv != null);
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override This TestTrueGeqZero(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      return default(This);
-    }
-
-    public override This TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-      
-      return default(This);
-    }
-
-    public override This TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-      
-      return default(This);
-    }
-
-    public override This TestTrueLessThan_Un(Expression exp1, Expression exp2)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-     
-      return default(This);
-    }
-
-    public override This TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-   
-      return default(This);
-    }
-
-    protected override This TestNotEqualToZero(Expression guard)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-  
-      return default(This);
-    }
-
-    protected override This TestNotEqualToZero(Variable v)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
- 
-      return default(This);
-    }
-
-    protected override This TestEqualToZero(Variable v)
-    {
-      Contract.Ensures(Contract.Result<This>() != null);
-
-      return default(This);
-    }
-
-    protected override void AssumeKLessThanRight(IType k, Variable right)
-    {
-      Contract.Requires(k != null);
-    }
-
-    protected override void AssumeLeftLessThanK(Variable left, IType k)
-    {
-      Contract.Requires(k != null);
-    }
-
-    public override DisInterval BoundsFor(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return default(DisInterval);
-    }
-
-    public override DisInterval BoundsFor(Variable v)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      return default(DisInterval);
-    }
-
-    protected override void AssumeInDisInterval_Internal(Variable x, DisInterval value)
-    {
-      Contract.Requires(value != null);
-    }
-
-    public override bool IsGreaterEqualThanZero(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool IsGreaterThanZero(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool IsLessThanZero(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool IsLessEqualThanZero(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool IsLessThan(NType val1, NType val2)
-    {
-      Contract.Requires(!object.Equals(val1, null));
-      Contract.Requires(!object.Equals(val2, null));
-
-      return default(bool);
-    }
-
-    public override bool IsLessEqualThan(NType val1, NType val2)
-    {
-      Contract.Requires(!object.Equals(val1, null));
-      Contract.Requires(!object.Equals(val2, null));
-
-      return default(bool);
-    }
-
-    public override bool IsZero(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool IsNotZero(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool IsPlusInfinity(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool IsMinusInfinity(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      return default(bool);
-    }
-
-    public override bool AreEqual(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      throw new NotImplementedException();
-    }
-
-    public override NType PlusInfinity
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override NType MinusInfinty
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override bool TryAdd(NType left, NType right, out NType result)
-    {
-      Contract.Requires(!object.Equals(left, null));
-      Contract.Requires(!object.Equals(right, null));
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out result), null));
-
-      result = default(NType);
-
-      return default(bool);
-    }
-
-    public override IType IntervalUnknown
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-        return default(IType);
-      }
-    }
-
-    public override IType IntervalZero
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-        return default(IType);
-      }
-    }
-
-    public override IType IntervalOne
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-        return default(IType);
-      }
-    }
-
-    public override IType IntervalGreaterEqualThanMinusOne
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-        return default(IType);
-      }
-    }
-
-    public override IType Interval_Positive
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-        return default(IType);
-      }
-    }
-
-    public override IType Interval_StrictlyPositive
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-        return default(IType);
-      }
-    }
-
-    public override IType IntervalSingleton(NType val)
-    {
-      Contract.Requires(!object.Equals(val, null));
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override IType IntervalRightOpen(NType inf)
-    {
-      Contract.Requires(!object.Equals(inf, null));
-      
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType IntervalLeftOpen(NType sup)
-    {
-      Contract.Requires(!object.Equals(sup, null));
-     
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override bool IsMaxInt32(IType intv)
-    {
-      Contract.Requires(intv != null);
-
-      return default(bool);
-    }
-
-    public override bool IsMinInt32(IType intv)
-    {
-      Contract.Requires(intv != null);
-
-      return default(bool);
-    }
-
-    public override IType Interval_Add(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override IType Interval_Div(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_Sub(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_Mul(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_Not(IType left)
-    {
-      Contract.Requires(left != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_UnaryMinus(IType left)
-    {
-      Contract.Requires(left != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override IType Interval_Rem(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_BitwiseAnd(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_BitwiseOr(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_BitwiseXor(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_ShiftLeft(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType Interval_ShiftRight(IType left, IType right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType For(byte v)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      return default(IType);
-    }
-
-    public override IType For(double d)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      return default(IType);
-    }
-
-    public override IType For(short v)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      return default(IType);
-    }
-
-    public override IType For(int v)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      return default(IType);
-    }
-
-    public override IType For(long v)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      return default(IType);
-    }
-
-    public override IType For(sbyte s)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      return default(IType);
-    }
-
-    public override IType For(ushort u)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      return default(IType);
-    }
-
-    public override IType For(uint u)
-    {
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    public override IType For(Rational r)
-    {
-      Contract.Requires(!object.Equals(r, null));
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override IType For(NType inf, NType sup)
-    {
-      Contract.Requires(!object.Equals(inf, null));
-      Contract.Requires(!object.Equals(sup, null));
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-      
-      return default(IType);
-    }
-
-    protected override IType ApplyConversion(ExpressionOperator conversionType, IType val)
-    {
-      Contract.Requires(val != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    protected override T To<T>(NType n, IFactory<T> factory)
-    {
-      Contract.Requires(factory != null);
-
-      throw new NotImplementedException();
-    }
-
-    protected override This Factory()
-    {
-      return default(This);
-    }
-  }
-  #endregion
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalEnvironment_IEEE754.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/IntervalEnvironment_IEEE754.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation of the environment of intervals
 
@@ -23,594 +12,592 @@ using System.Collections.Generic;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// An interval environment is a map from Variables to intervals
-  /// </summary>
-  public class IntervalEnvironment_IEEE754<Variable, Expression> 
-     : IntervalEnvironment_Base<IntervalEnvironment_IEEE754<Variable, Expression>, Variable, Expression, Interval_IEEE754, Double>
-  {
-    #region Constructor
-
-    public IntervalEnvironment_IEEE754(ExpressionManager<Variable, Expression> expManager)
-      : base(expManager)
-    {
-    }
-
-    public IntervalEnvironment_IEEE754(IntervalEnvironment_IEEE754<Variable, Expression> original)
-      : base(original)
-    {
-    }
-    #endregion
-
-    protected override IntervalEnvironment_IEEE754<Variable, Expression> DuplicateMe()
-    {
-      return new IntervalEnvironment_IEEE754<Variable, Expression>(this);
-    }
-
-    protected override IntervalEnvironment_IEEE754<Variable, Expression> NewInstance(ExpressionManager<Variable, Expression> expManager)
-    {
-      return new IntervalEnvironment_IEEE754<Variable, Expression>(expManager);
-    }
-
-    public override void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      base.AssumeDomainSpecificFact(fact);
-
-      Variable var;
-      Interval_IEEE754 intv;
-      if (fact.IsAssumeInFloatInterval(out var, out intv))
-      {
-        Interval_IEEE754 prev;
-        if (this.TryGetValue(var, out prev))
-        {
-          intv = prev.Meet(intv);
-        }
-
-        this[var] = intv;
-      }
-    }
-
-    public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      return this;
-    }
-
-    public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessThan_Un(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueLessThan(exp1, exp2);
-    }
-
-    public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      var v1 = this.Eval(exp1);
-      var v2 = this.Eval(exp2);
-
-      if (v1.IsNotNaN)
-      {
-        this.AssumeKLessThanRight(v1, this.ExpressionManager.Decoder.UnderlyingVariable(exp2));
-      }
-
-      if (v2.IsNotNaN)
-      {
-        this.AssumeLeftLessThanK(this.ExpressionManager.Decoder.UnderlyingVariable(exp1), v2);
-      }
-
-      return this;
-    }
-
-    public override IntervalEnvironment_IEEE754<Variable, Expression> TestNotEqual(Expression exp1, Expression exp2)
-    {
-      var v1 = this.Eval(exp1);
-      var v2 = this.Eval(exp2);
-
-      if (v1.IsNotNaN)
-      {
-        var exp2Var = this.ExpressionManager.Decoder.UnderlyingVariable(exp2);
-
-        var intv1 = this.IntervalForKLessThanRight(v1, exp2Var);
-        var intv2 = this.IntervalForLeftLessThanK(exp2Var, v1);
-
-        var join = intv1.Join(intv2);
-
-        if (join.IsNormal)
-        {
-          this[exp2Var] = join;
-        }
-      }
-
-      if (v2.IsNotNaN)
-      {
-        var exp1Var = this.ExpressionManager.Decoder.UnderlyingVariable(exp1);
-
-        var intv1 = this.IntervalForKLessThanRight(v2, exp1Var);
-        var intv2 = this.IntervalForLeftLessThanK(exp1Var, v2);
-
-        var join = intv1.Join(intv2);
-
-        if (join.IsNormal)
-        {
-          this[exp1Var] = join;
-        }
-      }
-      return this;
-
-    }
-
-    public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
-    {
-      return TestTrueLessEqualThan(exp1, exp2);
-    }
-
-    public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      var intv1 = this.Eval(exp1);
-      var intv2 = this.Eval(exp2);
-
-      if (intv1.IsNormal)
-      {
-        var v2 = this.ExpressionManager.Decoder.UnderlyingVariable(exp2);
-        this.AssumeKLessEqualThanRight(intv1, v2);
-        this.AssumeKLessEqualThanRight(intv1, this.ExpressionManager.Decoder.UnderlyingVariable(this.ExpressionManager.Decoder.Stripped(exp2)));
-      }
-
-      if (intv2.IsNormal)
-      {
-        var v1 = this.ExpressionManager.Decoder.UnderlyingVariable(exp1);
-        this.AssumeLeftLessEqualThanK(v1, intv2);
-        this.AssumeLeftLessEqualThanK(this.ExpressionManager.Decoder.UnderlyingVariable(this.ExpressionManager.Decoder.Stripped(exp1)), intv2);
-
-      }
-
-      return this;
-    }
-
-    protected override IntervalEnvironment_IEEE754<Variable, Expression> TestNotEqualToZero(Expression guard)
-    {
-      return this; 
-    }
-
-    protected override IntervalEnvironment_IEEE754<Variable, Expression> TestNotEqualToZero(Variable v)
-    {
-      // cannot capture v != 0
-      return this;
-    }
-
-    protected override IntervalEnvironment_IEEE754<Variable, Expression> TestEqualToZero(Variable v)
-    {
-      var intv = Interval_IEEE754.For(0);
-      Interval_IEEE754 prevVal;
-      if (this.TryGetValue(v, out prevVal))
-      {
-        intv = prevVal.Meet(intv);
-      }
-
-      this[v] = intv;
-
-      return this;
-    }
-
-    protected override void AssumeKLessThanRight(Interval_IEEE754 k, Variable leftExp)
-    {
-      if (k.IsSingleton)
-      {
-        if (k.LowerBound.IsZero())
-        {
-          var kPlusEpsilon = Interval_IEEE754.For(Double.Epsilon, Double.PositiveInfinity);
-
-          Interval_IEEE754 prevIntv;
-          if (this.TryGetValue(leftExp, out prevIntv))
-          {
-            this[leftExp] = prevIntv.Meet(kPlusEpsilon);
-          }
-          else
-          {
-            this[leftExp] = kPlusEpsilon;
-          }
-        }
-        else  // We overapproximate
-        {
-          var intv = Interval_IEEE754.For(k.LowerBound, Double.PositiveInfinity);
-          Interval_IEEE754 prevIntv;
-          if (this.TryGetValue(leftExp, out prevIntv))
-          {
-            this[leftExp] = prevIntv.Meet(intv);
-          }
-          else
-          {
-            this[leftExp] = intv;
-          }
-        }
-      }
-    }
-
-    private Interval_IEEE754 IntervalForKLessThanRight(Interval_IEEE754 k, Variable leftExp)
-    {
-      if (k.IsSingleton)
-      {
-        if (k.LowerBound.IsZero())
-        {
-          var kPlusEpsilon = Interval_IEEE754.For(Double.Epsilon, Double.PositiveInfinity);
-
-          Interval_IEEE754 prevIntv;
-          if (this.TryGetValue(leftExp, out prevIntv))
-          {
-            return prevIntv.Meet(kPlusEpsilon);
-          }
-          else
-          {
-            return kPlusEpsilon;
-          }
-        }
-        else  // We overapproximate
-        {
-          var intv = Interval_IEEE754.For(k.LowerBound, Double.PositiveInfinity);
-          Interval_IEEE754 prevIntv;
-          if (this.TryGetValue(leftExp, out prevIntv))
-          {
-            return prevIntv.Meet(intv);
-          }
-          else
-          {
-            return intv;
-          }
-        }
-      }
-
-      return Interval_IEEE754.UnknownInterval;
-    }
-
-    protected override void AssumeLeftLessThanK(Variable leftExp, Interval_IEEE754 k)
-    {
-      if (k.IsSingleton)
-      {
-        Interval_IEEE754 intv;
-        if (k.LowerBound.IsZero())
-        { // leftExp < 0
-          intv = Interval_IEEE754.For(Double.NegativeInfinity, -Double.Epsilon);
-        }
-        else  // We overapproximate
-        {
-          intv = Interval_IEEE754.For(Double.NegativeInfinity, k.LowerBound-double.Epsilon);
-        }
-
-        Interval_IEEE754 prevIntv;
-        if (this.TryGetValue(leftExp, out prevIntv))
-        {
-          this[leftExp] = prevIntv.Meet(intv);
-        }
-        else
-        {
-          this[leftExp] = intv;
-        }
-      }
-    }
-
-    private Interval_IEEE754 IntervalForLeftLessThanK(Variable leftExp, Interval_IEEE754 k)
-    {
-      return Interval_IEEE754.UnknownInterval;
-    }
-
-    public override bool IsGreaterEqualThanZero(double val)
-    {
-      return val >= 0.0;
-    }
-
-    public override bool IsGreaterThanZero(double val)
-    {
-      return val > 0.0;
-    }
-
-    public override bool IsLessThanZero(double val)
-    {
-      return val < 0.0;
-    }
-
-    public override bool IsLessEqualThanZero(double val)
-    {
-      return val <= 0.0;
-    }
-
-    public override bool IsLessThan(double val1, double val2)
-    {
-      return val1 < val2;
-    }
-
-    public override bool IsLessEqualThan(double val1, double val2)
-    {
-      return val1 <= val2;
-    }
-
-    public override bool IsZero(double val)
-    {
-      return val == 0.0;
-    }
-
-    public override bool IsNotZero(double val)
-    {
-      return val != 0.0;
-    }
-
-    public override bool IsMaxInt32(Interval_IEEE754 intv)
-    {
-      return false;
-    }
-
-    public override bool IsMinInt32(Interval_IEEE754 intv)
-    {
-      return false;
-    }
-
-    public override bool IsPlusInfinity(double val)
-    {
-      return Double.IsPositiveInfinity(val);
-    }
-
-    public override bool IsMinusInfinity(double val)
-    {
-      return Double.IsNegativeInfinity(val);
-    }
-
-    public override double PlusInfinity
-    {
-      get { return Double.PositiveInfinity; }
-    }
-
-    public override double MinusInfinty
-    {
-      get { return Double.NegativeInfinity; }
-    }
-
-    public override bool TryAdd(double left, double right, out double result)
-    {
-      result = left + right;
-
-      return true;
-    }
-
-    public override Interval_IEEE754 IntervalUnknown
-    {
-      get { return Interval_IEEE754.UnknownInterval; }
-    }
-
-    public override Interval_IEEE754 IntervalZero
-    {
-      get { return Interval_IEEE754.ZeroInterval_IEEE754; }
-    }
-
-    public override Interval_IEEE754 IntervalOne
-    {
-      get { return Interval_IEEE754.OneInterval_IEEE754; }
-    }
-
-    public override Interval_IEEE754 Interval_Positive
-    {
-      get { return Interval_IEEE754.PositiveInterval; }
-    }
-
-    public override Interval_IEEE754 Interval_StrictlyPositive
-    {
-      get { return this.IntervalRightOpen(1.0); }
-    }
-
-    public override Interval_IEEE754 IntervalGreaterEqualThanMinusOne
-    {
-      get { return Interval_IEEE754.For(-1, double.PositiveInfinity); }
-    }
-
-    public override Interval_IEEE754 IntervalSingleton(double val)
-    {
-      return Interval_IEEE754.For(val);
-    }
-
-    public override Interval_IEEE754 IntervalRightOpen(double inf)
-    {
-      return Interval_IEEE754.For(inf, double.PositiveInfinity);
-    }
-
-    public override Interval_IEEE754 IntervalLeftOpen(double sup)
-    {
-      return Interval_IEEE754.For(double.NegativeInfinity, sup);
-    }
-
-    public override bool AreEqual(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left.IsNormal && right.IsNormal && left.LessEqual(right) && right.LessEqual(left);
-    }
-
-    public override Interval_IEEE754 Interval_Add(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left + right; 
-    }
-
-    public override Interval_IEEE754 Interval_Div(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left / right; 
-    }
-
-    public override Interval_IEEE754 Interval_Sub(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left - right; 
-    }
-
-    public override Interval_IEEE754 Interval_Mul(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left * right; 
-    }
-
-    public override Interval_IEEE754 Interval_UnaryMinus(Interval_IEEE754 left)
-    {
-      return - left;
-    }
-
-    public override Interval_IEEE754 Interval_Not(Interval_IEEE754 left)
-    {
-      double value;
-      if (left.TryGetSingletonValue(out value) && value != 0.0)
-      {
-        return Interval_IEEE754.ZeroInterval_IEEE754;
-      }
-
-      return Interval_IEEE754.UnknownInterval;
-    }
-
-    public override Interval_IEEE754 Interval_Rem(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left % right;
-    }
-
-    public override Interval_IEEE754 Interval_BitwiseAnd(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left & right;
-    }
-
-    public override Interval_IEEE754 Interval_BitwiseOr(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left | right;
-    }
-
-    public override Interval_IEEE754 Interval_BitwiseXor(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return left ^ right;
-    }
-
-    public override Interval_IEEE754 Interval_ShiftLeft(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return Interval_IEEE754.ShiftLeft(left, right);
-    }
-
-    public override Interval_IEEE754 Interval_ShiftRight(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return Interval_IEEE754.ShiftRight(left, right);
-    }
-
-    public override Interval_IEEE754 For(byte v)
-    {
-      return Interval_IEEE754.For(v);
-    }
-
-    public override Interval_IEEE754 For(short v)
-    {
-      return Interval_IEEE754.For(v);
-    }
-
-    public override Interval_IEEE754 For(int v)
-    {
-      return Interval_IEEE754.For(v);
-    }
-
-    public override Interval_IEEE754 For(long v)
-    {
-      return Interval_IEEE754.For(v);
-    }
-
-    public override Interval_IEEE754 For(sbyte s)
-    {
-      return Interval_IEEE754.For(s);
-    }
-
-    public override Interval_IEEE754 For(ushort u)
-    {
-      return Interval_IEEE754.For(u);
-    }
-
-    public override Interval_IEEE754 For(uint u)
-    {
-      return Interval_IEEE754.For(u);
-    }
-
-    public override Interval_IEEE754 For(Rational r)
-    {
-      return Interval_IEEE754.For(r);
-    }
-
-    public override Interval_IEEE754 For(double d)
-    {
-      return For(d, d);
-    }
-
-    public override Interval_IEEE754 For(double inf, double sup)
-    {
-      return Interval_IEEE754.For(inf, sup);
-    }
-
     /// <summary>
-    ///  Abstraction ... For the moment is the identity
+    /// An interval environment is a map from Variables to intervals
     /// </summary>
-    protected override Interval_IEEE754 ApplyConversion(ExpressionOperator conversionType, Interval_IEEE754 val)
+    public class IntervalEnvironment_IEEE754<Variable, Expression>
+       : IntervalEnvironment_Base<IntervalEnvironment_IEEE754<Variable, Expression>, Variable, Expression, Interval_IEEE754, Double>
     {
-      switch (conversionType)
-      {          
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToFloat64:
-          return val;
-        
-        default:
-          return val.Top;
-      }
-    }
+        #region Constructor
 
-    protected override T To<T>(double n, IFactory<T> factory)
-    {
-      return factory.Constant(n);
-    }
-
-    protected override IntervalEnvironment_IEEE754<Variable, Expression> Factory()
-    {
-      return new IntervalEnvironment_IEEE754<Variable, Expression>(this.ExpressionManager);
-    }
-
-    public override DisInterval BoundsFor(Expression exp)
-    {
-      return ConvertInterval_IEEE754(this.Eval(exp));
-    }
-
-    public override DisInterval BoundsFor(Variable var)
-    {
-      Interval_IEEE754 res;
-      if (this.TryGetValue(var, out res))
-      {
-        return ConvertInterval_IEEE754(res);
-      }
-      else
-      {
-        return ConvertInterval_IEEE754(Interval_IEEE754.UnknownInterval);
-      }
-    }
-
-    protected override void AssumeInDisInterval_Internal(Variable x, DisInterval disIntv)
-    {
-      Rational r;
-      if (disIntv.TryGetSingletonValue(out r))
-      {
-        Interval_IEEE754 value;
-        long intValue;
-        if (r.TryInt64(out intValue))
+        public IntervalEnvironment_IEEE754(ExpressionManager<Variable, Expression> expManager)
+          : base(expManager)
         {
-          value = Interval_IEEE754.For(intValue);
-        }
-        else
-        {
-          value = Interval_IEEE754.For((double)r);
         }
 
-        Interval_IEEE754 prev;
-        if (this.TryGetValue(x, out prev))
+        public IntervalEnvironment_IEEE754(IntervalEnvironment_IEEE754<Variable, Expression> original)
+          : base(original)
         {
-          value = value.Meet(prev);
+        }
+        #endregion
+
+        protected override IntervalEnvironment_IEEE754<Variable, Expression> DuplicateMe()
+        {
+            return new IntervalEnvironment_IEEE754<Variable, Expression>(this);
         }
 
-        this[x] = value;
-      }
-    }
+        protected override IntervalEnvironment_IEEE754<Variable, Expression> NewInstance(ExpressionManager<Variable, Expression> expManager)
+        {
+            return new IntervalEnvironment_IEEE754<Variable, Expression>(expManager);
+        }
 
-    protected override Interval_IEEE754 ConvertInterval(Interval intv)
-    {
-      return Interval_IEEE754.ConvertInterval(intv);
-    }
+        public override void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            base.AssumeDomainSpecificFact(fact);
 
-    protected DisInterval ConvertInterval_IEEE754(Interval_IEEE754 intv)
-    {
-      return Interval_IEEE754.ConvertInterval(intv);
+            Variable var;
+            Interval_IEEE754 intv;
+            if (fact.IsAssumeInFloatInterval(out var, out intv))
+            {
+                Interval_IEEE754 prev;
+                if (this.TryGetValue(var, out prev))
+                {
+                    intv = prev.Meet(intv);
+                }
+
+                this[var] = intv;
+            }
+        }
+
+        public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            return this;
+        }
+
+        public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessThan_Un(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessThan(exp1, exp2);
+        }
+
+        public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            var v1 = this.Eval(exp1);
+            var v2 = this.Eval(exp2);
+
+            if (v1.IsNotNaN)
+            {
+                this.AssumeKLessThanRight(v1, this.ExpressionManager.Decoder.UnderlyingVariable(exp2));
+            }
+
+            if (v2.IsNotNaN)
+            {
+                this.AssumeLeftLessThanK(this.ExpressionManager.Decoder.UnderlyingVariable(exp1), v2);
+            }
+
+            return this;
+        }
+
+        public override IntervalEnvironment_IEEE754<Variable, Expression> TestNotEqual(Expression exp1, Expression exp2)
+        {
+            var v1 = this.Eval(exp1);
+            var v2 = this.Eval(exp2);
+
+            if (v1.IsNotNaN)
+            {
+                var exp2Var = this.ExpressionManager.Decoder.UnderlyingVariable(exp2);
+
+                var intv1 = this.IntervalForKLessThanRight(v1, exp2Var);
+                var intv2 = this.IntervalForLeftLessThanK(exp2Var, v1);
+
+                var join = intv1.Join(intv2);
+
+                if (join.IsNormal)
+                {
+                    this[exp2Var] = join;
+                }
+            }
+
+            if (v2.IsNotNaN)
+            {
+                var exp1Var = this.ExpressionManager.Decoder.UnderlyingVariable(exp1);
+
+                var intv1 = this.IntervalForKLessThanRight(v2, exp1Var);
+                var intv2 = this.IntervalForLeftLessThanK(exp1Var, v2);
+
+                var join = intv1.Join(intv2);
+
+                if (join.IsNormal)
+                {
+                    this[exp1Var] = join;
+                }
+            }
+            return this;
+        }
+
+        public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessEqualThan_Un(Expression exp1, Expression exp2)
+        {
+            return TestTrueLessEqualThan(exp1, exp2);
+        }
+
+        public override IntervalEnvironment_IEEE754<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            var intv1 = this.Eval(exp1);
+            var intv2 = this.Eval(exp2);
+
+            if (intv1.IsNormal)
+            {
+                var v2 = this.ExpressionManager.Decoder.UnderlyingVariable(exp2);
+                this.AssumeKLessEqualThanRight(intv1, v2);
+                this.AssumeKLessEqualThanRight(intv1, this.ExpressionManager.Decoder.UnderlyingVariable(this.ExpressionManager.Decoder.Stripped(exp2)));
+            }
+
+            if (intv2.IsNormal)
+            {
+                var v1 = this.ExpressionManager.Decoder.UnderlyingVariable(exp1);
+                this.AssumeLeftLessEqualThanK(v1, intv2);
+                this.AssumeLeftLessEqualThanK(this.ExpressionManager.Decoder.UnderlyingVariable(this.ExpressionManager.Decoder.Stripped(exp1)), intv2);
+            }
+
+            return this;
+        }
+
+        protected override IntervalEnvironment_IEEE754<Variable, Expression> TestNotEqualToZero(Expression guard)
+        {
+            return this;
+        }
+
+        protected override IntervalEnvironment_IEEE754<Variable, Expression> TestNotEqualToZero(Variable v)
+        {
+            // cannot capture v != 0
+            return this;
+        }
+
+        protected override IntervalEnvironment_IEEE754<Variable, Expression> TestEqualToZero(Variable v)
+        {
+            var intv = Interval_IEEE754.For(0);
+            Interval_IEEE754 prevVal;
+            if (this.TryGetValue(v, out prevVal))
+            {
+                intv = prevVal.Meet(intv);
+            }
+
+            this[v] = intv;
+
+            return this;
+        }
+
+        protected override void AssumeKLessThanRight(Interval_IEEE754 k, Variable leftExp)
+        {
+            if (k.IsSingleton)
+            {
+                if (k.LowerBound.IsZero())
+                {
+                    var kPlusEpsilon = Interval_IEEE754.For(Double.Epsilon, Double.PositiveInfinity);
+
+                    Interval_IEEE754 prevIntv;
+                    if (this.TryGetValue(leftExp, out prevIntv))
+                    {
+                        this[leftExp] = prevIntv.Meet(kPlusEpsilon);
+                    }
+                    else
+                    {
+                        this[leftExp] = kPlusEpsilon;
+                    }
+                }
+                else  // We overapproximate
+                {
+                    var intv = Interval_IEEE754.For(k.LowerBound, Double.PositiveInfinity);
+                    Interval_IEEE754 prevIntv;
+                    if (this.TryGetValue(leftExp, out prevIntv))
+                    {
+                        this[leftExp] = prevIntv.Meet(intv);
+                    }
+                    else
+                    {
+                        this[leftExp] = intv;
+                    }
+                }
+            }
+        }
+
+        private Interval_IEEE754 IntervalForKLessThanRight(Interval_IEEE754 k, Variable leftExp)
+        {
+            if (k.IsSingleton)
+            {
+                if (k.LowerBound.IsZero())
+                {
+                    var kPlusEpsilon = Interval_IEEE754.For(Double.Epsilon, Double.PositiveInfinity);
+
+                    Interval_IEEE754 prevIntv;
+                    if (this.TryGetValue(leftExp, out prevIntv))
+                    {
+                        return prevIntv.Meet(kPlusEpsilon);
+                    }
+                    else
+                    {
+                        return kPlusEpsilon;
+                    }
+                }
+                else  // We overapproximate
+                {
+                    var intv = Interval_IEEE754.For(k.LowerBound, Double.PositiveInfinity);
+                    Interval_IEEE754 prevIntv;
+                    if (this.TryGetValue(leftExp, out prevIntv))
+                    {
+                        return prevIntv.Meet(intv);
+                    }
+                    else
+                    {
+                        return intv;
+                    }
+                }
+            }
+
+            return Interval_IEEE754.UnknownInterval;
+        }
+
+        protected override void AssumeLeftLessThanK(Variable leftExp, Interval_IEEE754 k)
+        {
+            if (k.IsSingleton)
+            {
+                Interval_IEEE754 intv;
+                if (k.LowerBound.IsZero())
+                { // leftExp < 0
+                    intv = Interval_IEEE754.For(Double.NegativeInfinity, -Double.Epsilon);
+                }
+                else  // We overapproximate
+                {
+                    intv = Interval_IEEE754.For(Double.NegativeInfinity, k.LowerBound - double.Epsilon);
+                }
+
+                Interval_IEEE754 prevIntv;
+                if (this.TryGetValue(leftExp, out prevIntv))
+                {
+                    this[leftExp] = prevIntv.Meet(intv);
+                }
+                else
+                {
+                    this[leftExp] = intv;
+                }
+            }
+        }
+
+        private Interval_IEEE754 IntervalForLeftLessThanK(Variable leftExp, Interval_IEEE754 k)
+        {
+            return Interval_IEEE754.UnknownInterval;
+        }
+
+        public override bool IsGreaterEqualThanZero(double val)
+        {
+            return val >= 0.0;
+        }
+
+        public override bool IsGreaterThanZero(double val)
+        {
+            return val > 0.0;
+        }
+
+        public override bool IsLessThanZero(double val)
+        {
+            return val < 0.0;
+        }
+
+        public override bool IsLessEqualThanZero(double val)
+        {
+            return val <= 0.0;
+        }
+
+        public override bool IsLessThan(double val1, double val2)
+        {
+            return val1 < val2;
+        }
+
+        public override bool IsLessEqualThan(double val1, double val2)
+        {
+            return val1 <= val2;
+        }
+
+        public override bool IsZero(double val)
+        {
+            return val == 0.0;
+        }
+
+        public override bool IsNotZero(double val)
+        {
+            return val != 0.0;
+        }
+
+        public override bool IsMaxInt32(Interval_IEEE754 intv)
+        {
+            return false;
+        }
+
+        public override bool IsMinInt32(Interval_IEEE754 intv)
+        {
+            return false;
+        }
+
+        public override bool IsPlusInfinity(double val)
+        {
+            return Double.IsPositiveInfinity(val);
+        }
+
+        public override bool IsMinusInfinity(double val)
+        {
+            return Double.IsNegativeInfinity(val);
+        }
+
+        public override double PlusInfinity
+        {
+            get { return Double.PositiveInfinity; }
+        }
+
+        public override double MinusInfinty
+        {
+            get { return Double.NegativeInfinity; }
+        }
+
+        public override bool TryAdd(double left, double right, out double result)
+        {
+            result = left + right;
+
+            return true;
+        }
+
+        public override Interval_IEEE754 IntervalUnknown
+        {
+            get { return Interval_IEEE754.UnknownInterval; }
+        }
+
+        public override Interval_IEEE754 IntervalZero
+        {
+            get { return Interval_IEEE754.ZeroInterval_IEEE754; }
+        }
+
+        public override Interval_IEEE754 IntervalOne
+        {
+            get { return Interval_IEEE754.OneInterval_IEEE754; }
+        }
+
+        public override Interval_IEEE754 Interval_Positive
+        {
+            get { return Interval_IEEE754.PositiveInterval; }
+        }
+
+        public override Interval_IEEE754 Interval_StrictlyPositive
+        {
+            get { return this.IntervalRightOpen(1.0); }
+        }
+
+        public override Interval_IEEE754 IntervalGreaterEqualThanMinusOne
+        {
+            get { return Interval_IEEE754.For(-1, double.PositiveInfinity); }
+        }
+
+        public override Interval_IEEE754 IntervalSingleton(double val)
+        {
+            return Interval_IEEE754.For(val);
+        }
+
+        public override Interval_IEEE754 IntervalRightOpen(double inf)
+        {
+            return Interval_IEEE754.For(inf, double.PositiveInfinity);
+        }
+
+        public override Interval_IEEE754 IntervalLeftOpen(double sup)
+        {
+            return Interval_IEEE754.For(double.NegativeInfinity, sup);
+        }
+
+        public override bool AreEqual(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left.IsNormal && right.IsNormal && left.LessEqual(right) && right.LessEqual(left);
+        }
+
+        public override Interval_IEEE754 Interval_Add(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left + right;
+        }
+
+        public override Interval_IEEE754 Interval_Div(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left / right;
+        }
+
+        public override Interval_IEEE754 Interval_Sub(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left - right;
+        }
+
+        public override Interval_IEEE754 Interval_Mul(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left * right;
+        }
+
+        public override Interval_IEEE754 Interval_UnaryMinus(Interval_IEEE754 left)
+        {
+            return -left;
+        }
+
+        public override Interval_IEEE754 Interval_Not(Interval_IEEE754 left)
+        {
+            double value;
+            if (left.TryGetSingletonValue(out value) && value != 0.0)
+            {
+                return Interval_IEEE754.ZeroInterval_IEEE754;
+            }
+
+            return Interval_IEEE754.UnknownInterval;
+        }
+
+        public override Interval_IEEE754 Interval_Rem(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left % right;
+        }
+
+        public override Interval_IEEE754 Interval_BitwiseAnd(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left & right;
+        }
+
+        public override Interval_IEEE754 Interval_BitwiseOr(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left | right;
+        }
+
+        public override Interval_IEEE754 Interval_BitwiseXor(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return left ^ right;
+        }
+
+        public override Interval_IEEE754 Interval_ShiftLeft(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return Interval_IEEE754.ShiftLeft(left, right);
+        }
+
+        public override Interval_IEEE754 Interval_ShiftRight(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return Interval_IEEE754.ShiftRight(left, right);
+        }
+
+        public override Interval_IEEE754 For(byte v)
+        {
+            return Interval_IEEE754.For(v);
+        }
+
+        public override Interval_IEEE754 For(short v)
+        {
+            return Interval_IEEE754.For(v);
+        }
+
+        public override Interval_IEEE754 For(int v)
+        {
+            return Interval_IEEE754.For(v);
+        }
+
+        public override Interval_IEEE754 For(long v)
+        {
+            return Interval_IEEE754.For(v);
+        }
+
+        public override Interval_IEEE754 For(sbyte s)
+        {
+            return Interval_IEEE754.For(s);
+        }
+
+        public override Interval_IEEE754 For(ushort u)
+        {
+            return Interval_IEEE754.For(u);
+        }
+
+        public override Interval_IEEE754 For(uint u)
+        {
+            return Interval_IEEE754.For(u);
+        }
+
+        public override Interval_IEEE754 For(Rational r)
+        {
+            return Interval_IEEE754.For(r);
+        }
+
+        public override Interval_IEEE754 For(double d)
+        {
+            return For(d, d);
+        }
+
+        public override Interval_IEEE754 For(double inf, double sup)
+        {
+            return Interval_IEEE754.For(inf, sup);
+        }
+
+        /// <summary>
+        ///  Abstraction ... For the moment is the identity
+        /// </summary>
+        protected override Interval_IEEE754 ApplyConversion(ExpressionOperator conversionType, Interval_IEEE754 val)
+        {
+            switch (conversionType)
+            {
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToFloat64:
+                    return val;
+
+                default:
+                    return val.Top;
+            }
+        }
+
+        protected override T To<T>(double n, IFactory<T> factory)
+        {
+            return factory.Constant(n);
+        }
+
+        protected override IntervalEnvironment_IEEE754<Variable, Expression> Factory()
+        {
+            return new IntervalEnvironment_IEEE754<Variable, Expression>(this.ExpressionManager);
+        }
+
+        public override DisInterval BoundsFor(Expression exp)
+        {
+            return ConvertInterval_IEEE754(this.Eval(exp));
+        }
+
+        public override DisInterval BoundsFor(Variable var)
+        {
+            Interval_IEEE754 res;
+            if (this.TryGetValue(var, out res))
+            {
+                return ConvertInterval_IEEE754(res);
+            }
+            else
+            {
+                return ConvertInterval_IEEE754(Interval_IEEE754.UnknownInterval);
+            }
+        }
+
+        protected override void AssumeInDisInterval_Internal(Variable x, DisInterval disIntv)
+        {
+            Rational r;
+            if (disIntv.TryGetSingletonValue(out r))
+            {
+                Interval_IEEE754 value;
+                long intValue;
+                if (r.TryInt64(out intValue))
+                {
+                    value = Interval_IEEE754.For(intValue);
+                }
+                else
+                {
+                    value = Interval_IEEE754.For((double)r);
+                }
+
+                Interval_IEEE754 prev;
+                if (this.TryGetValue(x, out prev))
+                {
+                    value = value.Meet(prev);
+                }
+
+                this[x] = value;
+            }
+        }
+
+        protected override Interval_IEEE754 ConvertInterval(Interval intv)
+        {
+            return Interval_IEEE754.ConvertInterval(intv);
+        }
+
+        protected DisInterval ConvertInterval_IEEE754(Interval_IEEE754 intv)
+        {
+            return Interval_IEEE754.ConvertInterval(intv);
+        }
     }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/Intervals.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/Intervals.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation of the intervals
 
@@ -31,1803 +20,1799 @@ using Microsoft.Research.DataStructures;
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
 #if DEBUG
-  using ReadOnlyIntervalList = ReadOnlyCollection<Interval>;
+    using ReadOnlyIntervalList = ReadOnlyCollection<Interval>;
 #else
-  using ReadOnlyIntervalList = List<Interval>;
+    using ReadOnlyIntervalList = List<Interval>;
 #endif
     /// <summary>
     /// An interval is a pair<code>(LowerBound, UpperBound)</code>.
     /// LowerBound and UpperBound are rational numbers over <code>Int32</code>.
     /// They can be +oo or -oo
     /// </summary>
-   [ContractVerification(true)]
-  public sealed class Interval 
-    : IntervalBase<Interval, Rational>
-  {
-    #region Private state
-    readonly private bool isBottom;
-    readonly private bool isTop;
-    #endregion
+    [ContractVerification(true)]
+    public sealed class Interval
+     : IntervalBase<Interval, Rational>
+    {
+        #region Private state
+        readonly private bool isBottom;
+        readonly private bool isTop;
+        #endregion
 
-    #region Static Constructor
+        #region Static Constructor
 
 #if CACHE
-    static private readonly Dictionary<Pair<Rational, Rational>, Interval> common;
+        static private readonly Dictionary<Pair<Rational, Rational>, Interval> common;
 #endif
-    
-    static private readonly Dictionary<Pair<Rational, Rational>, int> countIntv;
 
-    private static readonly Interval cachedBottom;
-    private static readonly Interval cachedTop;
-    private static readonly Interval cachedPositiveInterval;
-    private static readonly Interval cachedNegativeInterval;
+        static private readonly Dictionary<Pair<Rational, Rational>, int> countIntv;
 
-    static Interval()
-    {
-      countIntv = new Dictionary<Pair<Rational, Rational>, int>();
+        private static readonly Interval cachedBottom;
+        private static readonly Interval cachedTop;
+        private static readonly Interval cachedPositiveInterval;
+        private static readonly Interval cachedNegativeInterval;
 
-      common = new Dictionary<Pair<Rational, Rational>, Interval>();
-
-      common.Add(new Pair<Rational, Rational>(Rational.For(0), Rational.For(0)), new Interval(Rational.For(0), Rational.For(0)));
-      common.Add(new Pair<Rational, Rational>(Rational.For(1), Rational.For(1)), new Interval(Rational.For(1), Rational.For(1)));
-      common.Add(new Pair<Rational, Rational>(Rational.For(0), Rational.PlusInfinity), new Interval(Rational.For(0), Rational.PlusInfinity));
-      common.Add(new Pair<Rational, Rational>(Rational.MinusInfinity, Rational.For(0)), new Interval(Rational.MinusInfinity, Rational.For(0)));
-      common.Add(new Pair<Rational, Rational>(Rational.MinusInfinity, Rational.PlusInfinity), new Interval(Rational.MinusInfinity, Rational.PlusInfinity));
-
-      cachedBottom = new Interval(Rational.PlusInfinity, Rational.MinusInfinity);
-      cachedTop = new Interval(Rational.MinusInfinity, Rational.PlusInfinity);
-      cachedPositiveInterval = new Interval(0, Rational.PlusInfinity);
-      cachedNegativeInterval = new Interval(Rational.MinusInfinity, 0);
-    }
-
-    public static Interval UnknownInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval>() != null);
-
-        return cachedTop;
-      }
-    }
-
-    public static Interval UnreachedInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval>() != null);
-
-        return cachedBottom;
-      }
-    }
-
-
-    public static Interval PositiveInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval>() != null);
-
-        return cachedPositiveInterval;
-      }
-    }
-
-    public static Interval NegativeInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval>() != null);
-
-        return cachedNegativeInterval;
-      }
-    }
-
-
-    #endregion
-
-    #region For
-
-    static public Interval For(Rational lower, Rational upper)
-    {
-      Contract.Requires(!object.Equals(lower, null));
-      Contract.Requires(!object.Equals(upper, null));
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-#if CACHE
-      var key = new Pair<Rational, Rational>(lower, upper);
-
-      Interval val;
-
-      if (common.TryGetValue(key, out val))
-      {
-        Contract.Assume(val != null);
-
-        return val;
-      }
-
-#endif
-      var res = new Interval(lower, upper);
-
-      return res;
-    }
-
-    static public Interval For(Rational r)
-    {
-      Contract.Requires(!object.Equals(r, null));
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      return For(r, r);
-    }
-
-    static public Interval For(Double lower, Double upper, bool dummy)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      // We do not cache intervals for doubles
-      return new Interval(lower, upper, dummy);
-    }
-
-    static  public Interval For(Int64 lower, Rational upper)
-    {
-      Contract.Requires((object)upper != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      
-      return For(Rational.For(lower), upper);
-    }
-
-    static public Interval For(Rational lower, Int64 upper)
-    {
-      Contract.Requires((object)lower != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      
-      return For(lower, Rational.For(upper));
-    }
-
-    static public Interval For(Int64 lower, Int64 upper)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);      
-
-      return For(Rational.For(lower), Rational.For(upper));
-    }
-
-    static public Interval For(UInt32 lower, UInt32 upper)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      return For(Rational.For(lower), Rational.For(upper));
-    }
-
-    static public Interval For(Int64 i)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      var r = Rational.For(i);
-      return For(r, r);
-    }
-
-    // [SuppressMessage("Microsoft.Contracts", "Ensures-26-45", Justification="We know that getting an interval from a byte always gives a normal interval")]
-    static public Interval For(Byte i)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      Contract.Ensures(Contract.Result<Interval>().IsNormal);
-
-      var r = Rational.For(i);
-          
-      return For(r, r);
-    }
-
-    static public Interval For(UInt32 i)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      var r = Rational.For(i);
-      return For(r, r);
-    }
-
-    static public Interval For(UInt64 i)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      var r = Rational.For(i);
-      return For(r, r);
-    }
-
-    #endregion
-
-    #region Constructors
-    private Interval(Int64 lower, Rational upper)
-      : this(Rational.For(lower), upper)
-    {
-      Contract.Requires(((object)upper) != null);
-    }
-
-    private Interval(Rational lower, Int64 upper)
-      : this(lower, Rational.For(upper))
-    {
-      Contract.Requires(((object)lower) != null);
-    }
-
-    private Interval(Int64 lower, Int64 upper)
-      : this(Rational.For(lower), Rational.For(upper))
-    { 
-    }
-
-    public static string Stats
-    {
-      get
-      {
-        var x = new Pair<int, Pair<Rational, Rational>>[countIntv.Count];
-        int i = 0;
-
-        foreach (var pair in countIntv)
+        static Interval()
         {
-          Contract.Assert(x.Length == countIntv.Count);
-           // F: we should assume it because we have no way of relating the iteration counter, i  and the enumerator for countIntv
-          Contract.Assume(i < x.Length); 
+            countIntv = new Dictionary<Pair<Rational, Rational>, int>();
 
-          x[i] = new Pair<int, Pair<Rational, Rational>>(pair.Value, pair.Key);
-          i++;
+            common = new Dictionary<Pair<Rational, Rational>, Interval>();
+
+            common.Add(new Pair<Rational, Rational>(Rational.For(0), Rational.For(0)), new Interval(Rational.For(0), Rational.For(0)));
+            common.Add(new Pair<Rational, Rational>(Rational.For(1), Rational.For(1)), new Interval(Rational.For(1), Rational.For(1)));
+            common.Add(new Pair<Rational, Rational>(Rational.For(0), Rational.PlusInfinity), new Interval(Rational.For(0), Rational.PlusInfinity));
+            common.Add(new Pair<Rational, Rational>(Rational.MinusInfinity, Rational.For(0)), new Interval(Rational.MinusInfinity, Rational.For(0)));
+            common.Add(new Pair<Rational, Rational>(Rational.MinusInfinity, Rational.PlusInfinity), new Interval(Rational.MinusInfinity, Rational.PlusInfinity));
+
+            cachedBottom = new Interval(Rational.PlusInfinity, Rational.MinusInfinity);
+            cachedTop = new Interval(Rational.MinusInfinity, Rational.PlusInfinity);
+            cachedPositiveInterval = new Interval(0, Rational.PlusInfinity);
+            cachedNegativeInterval = new Interval(Rational.MinusInfinity, 0);
         }
 
-        Array.Sort(x, (k1, k2) => k1.One < k2.One ? 1 : (k1.One == k2.One ? 0 : -1));
-
-        StringBuilder res = new StringBuilder();
-
-        res.Append("Intervals allocation statistics" + Environment.NewLine);
-
-        res.AppendFormat("Total allocated intervals: {0}" + Environment.NewLine, x.Length);
-
-        for (i = 0; i < x.Length; i++)
+        public static Interval UnknownInterval
         {
-          res.AppendFormat("[{0},{1}] : {2}" + Environment.NewLine, x[i].Two.One, x[i].Two.Two, x[i].One);
-        }
-
-        return res.ToString();
-      }
-    }
-
-    [Conditional("TRACE_PERFORMANCE")]
-    private void UpdateStatistics(Rational lower, Rational upper)
-    {
-      // begin debug
-      int val;
-      if (countIntv.TryGetValue(new Pair<Rational, Rational>(lower, upper), out val))
-      {
-        val++;
-      }
-      else
-      {
-        val = 1;
-      }
-
-      countIntv[new Pair<Rational, Rational>(lower, upper)] = val;
-      // end debug
-    }
-
-    private Interval(Rational lower, Rational upper)
-      : base(lower, upper)
-    {
-      Contract.Requires(!object.Equals(lower, null));
-      Contract.Requires(!object.Equals(upper, null));
-
-      UpdateStatistics(lower, upper);
-
-      if (lower.IsPlusInfinity && upper.IsPlusInfinity) // the case [+oo, +oo]
-      {
-        this.lowerBound = lower - 1;
-        this.upperBound = upper;
-      }
-      else if (lower.IsMinusInfinity && upper.IsMinusInfinity) // the case [-oo, -oo]
-      {
-        this.lowerBound = lower;
-        this.upperBound = Rational.PlusInfinity;
-
-        Contract.Assert(!object.Equals(this.lowerBound, null));
-        Contract.Assert(!object.Equals(this.upperBound, null));
-      }
-      else
-      {
-        this.lowerBound = lower;
-        this.upperBound = upper;
-      }
-      this.isBottom = this.lowerBound > this.upperBound;
-      this.isTop = this.lowerBound.IsMinusInfinity && this.upperBound.IsPlusInfinity;
-
-      Contract.Assert(!object.Equals(this.lowerBound, null));
-      Contract.Assert(!object.Equals(this.upperBound, null));
-    }
-
-    private Interval(Double inf, Double sup, bool dummy)
-      : base(Rational.MinusInfinity, Rational.PlusInfinity)
-    {
-      if (Double.IsNaN(inf) || Double.IsNaN(sup))
-      {
-        this.lowerBound = Rational.MinusInfinity;
-        this.upperBound = Rational.PlusInfinity;
-        return;
-      }
-
-      if (Double.IsNegativeInfinity(inf))
-      {
-        this.lowerBound = Rational.MinusInfinity;
-      }
-      else
-      {
-        var tmp = (Int64) Math.Floor(inf);
-        
-        // Overflow checking
-        if (OppositeSigns(tmp, inf))
-        {
-          this.lowerBound = Rational.MinusInfinity;
-        }
-        else
-        {
-          this.lowerBound = Rational.For(tmp);
-        }
-      }
-
-      if (Double.IsPositiveInfinity(sup))
-      {
-        this.upperBound = Rational.PlusInfinity;
-      }
-      else
-      {
-        var tmp = (Int64)Math.Ceiling(sup);
-        if (OppositeSigns(tmp, sup))
-        {
-          this.upperBound = Rational.PlusInfinity;
-        }
-        else
-        {
-          this.upperBound = Rational.For(tmp);
-        }
-      }
-      this.isBottom = this.lowerBound > this.upperBound;
-      this.isTop = this.LowerBound.IsMinusInfinity && this.UpperBound.IsPlusInfinity;
-    }
-
-    private Interval(Rational r)
-      : this(r, r)
-    {
-      Contract.Requires((object)r != null);
-    }
-
-
-    private Interval(uint lower, uint upper)
-      : this(Rational.For(lower), Rational.For(upper))
-    { }
-
-    /// <summary>
-    /// Useful to check overflows
-    /// </summary>
-    private bool OppositeSigns(long tmp, double inf)
-    {
-      return (tmp < 0 && inf > 0) || (tmp > 0 && inf < 0);
-    }
-    #endregion
-
-    #region Overridden
-    
-    override public bool IsLowerBoundMinusInfinity
-    {
-      get
-      {
-        return this.LowerBound.IsMinusInfinity;
-      }
-    }
-
-    override public bool IsUpperBoundPlusInfinity
-    {
-      get
-      {
-        return this.UpperBound.IsPlusInfinity;
-      }
-    }
-
-    public override bool IsNormal
-    {
-      get { return !this.IsBottom && !this.IsTop; }
-    }
-
-    public override bool IsInt32
-    {
-      get 
-      {
-        if (this.IsNormal)
-        {
-          try
-          {
-            var blow = this.IsLowerBoundMinusInfinity || this.lowerBound >= Int32.MinValue;
-            var bupp = this.IsUpperBoundPlusInfinity || this.upperBound <= Int32.MaxValue;
-
-            return blow && bupp;
-          }
-          catch (ArithmeticException) 
-          {
-            return false;
-          }
-        }
-
-        return false;
-      }
-    }
-
-    public override bool IsInt64
-    {
-      get { throw new NotImplementedException(); }
-    }
-    #endregion
-
-    #region Interval Members
-
-    public bool IsFiniteAndInt64(out Int64 low, out Int64 upp)
-    {
-      if (base.IsFinite && this.LowerBound.IsInteger && this.UpperBound.IsInteger)
-      {
-        try
-        {
-          checked
-          {
-            low = (Int64)this.LowerBound;
-            upp = (Int64)this.UpperBound;
-          }
-          return true;
-        }
-        catch (ArithmeticException)
-        {
-          low = upp = default(Int64);
-          return false;
-        }
-      }
-
-      low = upp = default(Int64);
-      return false;
-    }
-
-    public bool IsFiniteAndInt32(out Int32 low, out Int32 upp)
-    {
-      if (base.IsFinite && this.LowerBound.IsInt32 && this.UpperBound.IsInt32)
-      {
-        try
-        {
-          checked
-          {
-            low = (Int32)this.LowerBound;
-            upp = (Int32)this.UpperBound;
-          }
-          return true;
-        }
-        catch (ArithmeticException)
-        {
-          low = upp = default(Int32);
-          return false;
-        }
-      }
-
-      low = upp = default(Int32);
-      return false;
-    }
-
-    public bool IsFiniteAndInt32Singleton(out Int32 value)
-    {
-      int low, upp;
-      if (this.IsFiniteAndInt32(out low, out upp) && low == upp)
-      {
-        value = low;
-        return true;
-      }
-
-      value = -567895;
-      return false;
-    }
-
-    public bool IsFiniteAndInt64Singleton(out Int64 value)
-    {
-      long low, upp;
-      if (this.IsFiniteAndInt64(out low, out upp) && low == upp)
-      {
-        value = low;
-        return true;
-      }
-
-      value = -567895;
-      return false;
-    }
-
-
-    /// <returns>
-    /// true iff <code>x</code> is not included in this interval
-    /// </returns>
-    public bool DoesNotInclude(int x)
-    {
-      return !this.IsBottom && (x < this.LowerBound || x > this.UpperBound);
-    }
-
-    public bool DoesInclude(int x)
-    {
-      return this.IsNormal && (this.LowerBound <= x && x <= this.UpperBound);
-    }
-
-    public bool OverlapsWith(Interval other)
-    {
-      Contract.Requires(other != null);
-
-      return !this.Meet(other).IsBottom;
-    }
-
-    public bool OnTheLeftOf(Interval other)
-    {
-      Contract.Requires(other != null);
-
-      if (!this.IsNormal || !other.IsNormal)
-      {
-        return false;
-      }
-
-      return this.UpperBound <= other.LowerBound;
-    }
-
-    #endregion
-
-    #region Arithmetic operations on Intervals
-
-    /// <summary>
-    /// The addition of intervals.
-    /// If the evaluation causes an overflow, the top interval is returned
-    /// </summary>
-    /// <returns></returns>
-    static public Interval operator +(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)    // Propagate bottom
-        return UnreachedInterval;
-
-      if (left.IsTop || right.IsTop)          // Propagate top
-        return UnknownInterval;
-
-      Rational lower, upper;
-
-      if (Rational.TryAdd(left.LowerBound, right.LowerBound, out lower)
-        && Rational.TryAdd(left.UpperBound, right.UpperBound, out upper))
-      {
-        return Interval.For(lower, upper);
-      }
-      else
-      {
-        return UnknownInterval;
-      }
-    }
-
-    static public Interval operator -(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)    // Propagate bottom
-        return left.Bottom;
-
-      if (left.IsTop || right.IsTop)          // Propagate top
-        return UnknownInterval;
-
-      Rational lower, upper;
-
-      if (Rational.TrySub(left.LowerBound, right.UpperBound, out lower)
-        && Rational.TrySub(left.UpperBound, right.LowerBound, out upper))
-      {
-        return new Interval
-          (
-            lower.IsPlusInfinity ? Rational.MinusInfinity : lower,
-            upper.IsMinusInfinity ? Rational.PlusInfinity : upper
-          );
-      }
-      else
-      {
-        return UnknownInterval;
-      }
-    }
-
-    static public Interval operator -(Interval left)
-    {
-      Contract.Requires(left != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (!left.IsNormal)
-      {
-        return left;
-      }
-      else
-      {
-        return Interval.For(-left.UpperBound, -left.LowerBound);
-      }
-    }
-
-    static public Interval operator *(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)    // Propagate bottom
-        return UnreachedInterval;
-
-      if (left.IsTop || right.IsTop)          // Propagate top
-        return UnknownInterval;
-
-      Rational llrl, lurl, llru, luru;
-      Rational lower, upper;
-
-      if (Rational.TryMul(left.LowerBound, right.LowerBound, out llrl)
-        && Rational.TryMul(left.UpperBound, right.LowerBound, out lurl)
-        && Rational.TryMul(left.LowerBound, right.UpperBound, out llru)
-        && Rational.TryMul(left.UpperBound, right.UpperBound, out luru))
-      {
-
-        lower = Rational.Min(Rational.Min(llrl, lurl), Rational.Min(llru, luru));
-        upper = Rational.Max(Rational.Max(llrl, lurl), Rational.Max(llru, luru));
-
-        return Interval.For(lower, upper);
-      }
-      else
-      {
-        return UnknownInterval;
-      }
-    }
-
-    static public Interval operator /(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)    // Propagate bottom
-        return UnreachedInterval;
-
-      if (left.IsTop || right.IsTop)          // Propagate top
-        return UnknownInterval;
-
-      Rational llrl, lurl, llru, luru;
-      Rational lower, upper;
-
-      if (right.LowerBound.IsZero || right.UpperBound.IsZero)
-      {
-        return UnknownInterval;
-      }
-
-      if (Rational.TryDiv(left.LowerBound, right.LowerBound, out llrl)
-        && Rational.TryDiv(left.UpperBound, right.LowerBound, out lurl)
-        && Rational.TryDiv(left.LowerBound, right.UpperBound, out llru)
-        && Rational.TryDiv(left.UpperBound, right.UpperBound, out luru))
-      {
-        lower = Rational.Min(Rational.Min(llrl, lurl), Rational.Min(llru, luru));
-        upper = Rational.Max(Rational.Max(llrl, lurl), Rational.Max(llru, luru));
-
-        return Interval.For(lower, upper);
-      }
-      else
-      {
-        return UnknownInterval;
-      }
-    }
-
-    static public Interval operator %(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)    // Propagate bottom
-        return left.Bottom;
-
-      int leftLow, leftUpp, rightLow, rightUpp;
-
-      try
-      {
-        // Easy cases
-        if (left.IsFiniteAndInt32(out leftLow, out leftUpp) &&
-          right.IsFiniteAndInt32(out rightLow, out rightUpp) &&
-          rightLow != 0 && rightUpp != 0)
-        {
-          // k % [a,b]
-          if (leftLow == leftUpp)
-          {
-            var ll = leftLow % rightLow;
-            var lu = leftLow % rightUpp;
-            var ul = leftUpp % rightLow;
-            var uu = leftUpp % rightUpp;
-
-            var min = Math.Min(Math.Min(ll, lu), Math.Min(ul, uu));
-            var max = Math.Max(Math.Max(ll, lu), Math.Max(ul, uu));
-
-            return Interval.For(min, max);
-          }
-
-          // [a,b] % [c, d]
-          {
-            var ll = leftLow % rightLow;
-            var lu = leftLow % rightUpp;
-            var ul = leftUpp % rightLow;
-            var uu = leftUpp % rightUpp;
-
-            // We need to min with 0 and max with (rightUpp-1) because % is no monotonic
-            var min = Math.Min(0, Math.Min(Math.Min(ll, lu), Math.Min(ul, uu)));
-            var max = Math.Max(Math.Max(Math.Max(ll, lu), Math.Max(ul, uu)), rightUpp - 1);
-
-            return Interval.For(min, max);
-          }
-        }
-
-        if (right.IsTop)
-        {
-          if (left.LowerBound >= 0)
-          { // We ignore the case when right == 0, this should be proven by some other analysis
-            return Interval.For(0, Rational.PlusInfinity);
-          }
-          else
-          { // Propagate top
-            return UnknownInterval;
-          }
-        }
-        // left % 0
-        if (right.LowerBound.IsZero && right.UpperBound.IsZero)
-        {
-          return UnknownInterval;
-        }
-
-        if (!right.UpperBound.IsInfinity)
-        {
-          if (left.IsSingleton && right.IsSingleton)
-          {
-            if (right.LowerBound.IsNotZero && left.LowerBound.IsInteger && right.LowerBound.IsInteger)
+            get
             {
-              Contract.Assume(((Int32)right.LowerBound.PreviousInt32) != 0);
-              return new Interval(Rational.For(((Int32)left.LowerBound) % ((Int32)right.LowerBound.PreviousInt32)));
+                Contract.Ensures(Contract.Result<Interval>() != null);
+
+                return cachedTop;
+            }
+        }
+
+        public static Interval UnreachedInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval>() != null);
+
+                return cachedBottom;
+            }
+        }
+
+
+        public static Interval PositiveInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval>() != null);
+
+                return cachedPositiveInterval;
+            }
+        }
+
+        public static Interval NegativeInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval>() != null);
+
+                return cachedNegativeInterval;
+            }
+        }
+
+
+        #endregion
+
+        #region For
+
+        static public Interval For(Rational lower, Rational upper)
+        {
+            Contract.Requires(!object.Equals(lower, null));
+            Contract.Requires(!object.Equals(upper, null));
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+#if CACHE
+            var key = new Pair<Rational, Rational>(lower, upper);
+
+            Interval val;
+
+            if (common.TryGetValue(key, out val))
+            {
+                Contract.Assume(val != null);
+
+                return val;
+            }
+
+#endif
+            var res = new Interval(lower, upper);
+
+            return res;
+        }
+
+        static public Interval For(Rational r)
+        {
+            Contract.Requires(!object.Equals(r, null));
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            return For(r, r);
+        }
+
+        static public Interval For(Double lower, Double upper, bool dummy)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            // We do not cache intervals for doubles
+            return new Interval(lower, upper, dummy);
+        }
+
+        static public Interval For(Int64 lower, Rational upper)
+        {
+            Contract.Requires((object)upper != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            return For(Rational.For(lower), upper);
+        }
+
+        static public Interval For(Rational lower, Int64 upper)
+        {
+            Contract.Requires((object)lower != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            return For(lower, Rational.For(upper));
+        }
+
+        static public Interval For(Int64 lower, Int64 upper)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            return For(Rational.For(lower), Rational.For(upper));
+        }
+
+        static public Interval For(UInt32 lower, UInt32 upper)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            return For(Rational.For(lower), Rational.For(upper));
+        }
+
+        static public Interval For(Int64 i)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            var r = Rational.For(i);
+            return For(r, r);
+        }
+
+        // [SuppressMessage("Microsoft.Contracts", "Ensures-26-45", Justification="We know that getting an interval from a byte always gives a normal interval")]
+        static public Interval For(Byte i)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+            Contract.Ensures(Contract.Result<Interval>().IsNormal);
+
+            var r = Rational.For(i);
+
+            return For(r, r);
+        }
+
+        static public Interval For(UInt32 i)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            var r = Rational.For(i);
+            return For(r, r);
+        }
+
+        static public Interval For(UInt64 i)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            var r = Rational.For(i);
+            return For(r, r);
+        }
+
+        #endregion
+
+        #region Constructors
+        private Interval(Int64 lower, Rational upper)
+          : this(Rational.For(lower), upper)
+        {
+            Contract.Requires(((object)upper) != null);
+        }
+
+        private Interval(Rational lower, Int64 upper)
+          : this(lower, Rational.For(upper))
+        {
+            Contract.Requires(((object)lower) != null);
+        }
+
+        private Interval(Int64 lower, Int64 upper)
+          : this(Rational.For(lower), Rational.For(upper))
+        {
+        }
+
+        public static string Stats
+        {
+            get
+            {
+                var x = new Pair<int, Pair<Rational, Rational>>[countIntv.Count];
+                int i = 0;
+
+                foreach (var pair in countIntv)
+                {
+                    Contract.Assert(x.Length == countIntv.Count);
+                    // F: we should assume it because we have no way of relating the iteration counter, i  and the enumerator for countIntv
+                    Contract.Assume(i < x.Length);
+
+                    x[i] = new Pair<int, Pair<Rational, Rational>>(pair.Value, pair.Key);
+                    i++;
+                }
+
+                Array.Sort(x, (k1, k2) => k1.One < k2.One ? 1 : (k1.One == k2.One ? 0 : -1));
+
+                StringBuilder res = new StringBuilder();
+
+                res.Append("Intervals allocation statistics" + Environment.NewLine);
+
+                res.AppendFormat("Total allocated intervals: {0}" + Environment.NewLine, x.Length);
+
+                for (i = 0; i < x.Length; i++)
+                {
+                    res.AppendFormat("[{0},{1}] : {2}" + Environment.NewLine, x[i].Two.One, x[i].Two.Two, x[i].One);
+                }
+
+                return res.ToString();
+            }
+        }
+
+        [Conditional("TRACE_PERFORMANCE")]
+        private void UpdateStatistics(Rational lower, Rational upper)
+        {
+            // begin debug
+            int val;
+            if (countIntv.TryGetValue(new Pair<Rational, Rational>(lower, upper), out val))
+            {
+                val++;
             }
             else
             {
-              return Interval.UnknownInterval;
+                val = 1;
             }
-          }
 
-          if (right.UpperBound.IsMinusInfinity || right.UpperBound.IsMinValue)
-          {
-            return Interval.UnknownInterval;
-          }
-
-          var absUpperBound = Rational.Abs(right.UpperBound);
-          if (left.LowerBound >= 0)
-          {
-            return Interval.For(0, absUpperBound - 1);
-          }
-          else if (left.UpperBound <= 0)
-          {
-            return Interval.For(-absUpperBound + 1, 0);
-          }
-          else
-          {
-            return Interval.For(-absUpperBound + 1, absUpperBound - 1);
-          }
+            countIntv[new Pair<Rational, Rational>(lower, upper)] = val;
+            // end debug
         }
-        else if (right.LowerBound > 0)
+
+        private Interval(Rational lower, Rational upper)
+          : base(lower, upper)
         {
-          if (left.LowerBound >= 0)
-          {
-            return Interval.PositiveInterval;
-          }
-          else
-          {
-            return Interval.For(Rational.MinusInfinity, 0);
-          }
-        }
-      }
-      catch (ArithmeticException)
-      {
-        return UnknownInterval;
-      }
+            Contract.Requires(!object.Equals(lower, null));
+            Contract.Requires(!object.Equals(upper, null));
 
-      return UnknownInterval;
-    }
+            UpdateStatistics(lower, upper);
 
-    static public Interval operator &(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)
-      {
-        return left.Bottom;
-      }
-
-      if (right.IsTop)
-      {
-        return right;
-      }
-
-      long l1, l2, r1, r2;
-      if (left.IsFiniteAndInt64(out l1, out l2) && right.IsFiniteAndInt64(out r1, out r2))
-      {
-        // Is it a singleton?
-        if (l1 == l2 && r1 == r2)
-        {
-          return new Interval(Rational.For(l1 & r1));
-        }
-
-        // If one of the two is non negative, the result will be non-negative
-        if (l1 >= 0 || r1 >= 0)
-        {
-          // if l1 >= 0 && r1 >= 0 && l2 < r1 then the result is zero
-          if (l1 >= 0 && r1 >= 0 && l2 < r1)
-          {
-            return new Interval(0, 0);
-          }
-
-          return new Interval(0, Math.Min(l2, r2)); 
-        }
-        
-        return new Interval(Math.Min(l1, r1), Math.Max(l2, r2));
-      }
-
-      if (right.LowerBound >= 0)
-      {
-        if (left.IsTop)
-        { // [-oo, +oo] & [0, r.Upp]
-          return Interval.For(0, right.UpperBound);
-        }
-
-        if (left.UpperBound < 0)
-        { // [-oo, a] & [0, r.Upp]
-          return Interval.For(0, right.UpperBound);
-        }
-
-        if (left.LowerBound >= 0)
-        { //  [0 <= a, +oo] & [0, r.Upp]
-          return Interval.For(0, right.UpperBound);
-        }
-
-        return Interval.PositiveInterval;
-      }
-
-      if (left.LowerBound>= 0)
-      {
-        if (right.IsTop)
-        { // [0, r.Upp] & [-oo, +oo]  
-          return Interval.For(0, left.UpperBound);
-        }
-
-        if (right.UpperBound < 0)
-        { // [0, r.Upp] & [-oo, a] 
-          return Interval.For(0, left.UpperBound);
-        }
-
-        if (right.LowerBound >= 0)
-        { //  [0, r.Upp] & [0 <= a, +oo] 
-          return Interval.For(0, left.UpperBound);
-        }
-
-        return Interval.PositiveInterval;
-      }
-
-
-      return UnknownInterval;
-    }
-
-    static public Interval operator | (Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)
-      {
-        return UnreachedInterval;
-      }
-      if (left.IsTop || right.IsTop)
-      {
-        return UnknownInterval;
-      }
-
-      Interval posInterval;
-      Rational k;
-
-      if (left.LowerBound.IsInteger && left.UpperBound.IsInteger && right.LowerBound.IsInteger && right.UpperBound.IsInteger)
-      {
-        if (left.LowerBound >= 0 && right.LowerBound >= 0 && !left.UpperBound.IsInfinity && !right.UpperBound.IsInfinity)
-        {
-          // F: Assumptions below follow form the 
-          Contract.Assert(left.LowerBound.IsInteger);
-          Contract.Assert(left.UpperBound.IsInteger);
-          Contract.Assert(right.LowerBound.IsInteger);
-          Contract.Assert(right.UpperBound.IsInteger);
-
-          uint min, max;
-          WarrenAlgorithmForBitewiseOr(ToUint(left.LowerBound), ToUint(left.UpperBound), ToUint(right.LowerBound), ToUint(right.UpperBound), out min, out max);
-
-          return Interval.For(min, max);
-        }
-        else if (MatchWithPositiveAndConstant(left, right, out posInterval, out k))
-        {
-          if (k > 0)
-          {// we have ([k1, +oo] | k2) >= max(k1, k2)
-            return Interval.For(Rational.Max(posInterval.LowerBound, k), Rational.PlusInfinity);
-          }
-          else if (k < 0)
-          {
-            return Interval.For(k, Rational.PlusInfinity);
-          }
-          else
-          {
-            return posInterval;
-          }
-        }
-      }
-
-      return UnknownInterval;
-    }
-
-    static public Interval operator ^(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)
-      {
-        return UnreachedInterval;
-      }
-      if (left.IsTop || right.IsTop)
-      {
-        return UnknownInterval;
-      }
-
-      long leftVal, rightVal;
-      if (left.IsFiniteAndInt64Singleton(out leftVal) && right.IsFiniteAndInt64Singleton(out rightVal))
-      {
-        var result = leftVal ^ rightVal;
-        return new Interval(Rational.For(result));
-      }
-
-      return UnknownInterval;
-    }
-
-    static public Interval ShiftLeft(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)
-      {
-        return UnreachedInterval;
-      }
-      if (left.IsTop || right.IsTop)
-      {
-        return UnknownInterval;
-      }
-
-      Rational valForRight;
-      if (right.TryGetSingletonValue(out valForRight))
-      {
-        if (valForRight > 32 || !valForRight.IsInteger)
-        { // According to the ECMA standard, Partition III pag. 92
-          return UnknownInterval;
-        }
-        else
-        { // It is a multiplication by 2^(valForRight)
-          double d = Math.Ceiling(Math.Pow(2, (double)valForRight.NextInt32));     // We know it will not raise an exception...
-          int pow = (int)d;
-          return left * (Interval.For(pow));
-        }
-      }
-      else
-      {
-        return UnknownInterval;
-      }
-    }
-
-    static public Interval ShiftRight(Interval left, Interval right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (left.IsBottom || right.IsBottom)
-      {
-        return left.Bottom;
-      }
-      if (left.IsTop || right.IsTop)
-      {
-        return UnknownInterval;
-      }
-
-      if (left.LowerBound >= 0)
-      {
-        if (left.IsFinite && right.IsFinite)
-        {
-          var low = ((Int64)left.LowerBound.PreviousInt64) >> (Int32) right.UpperBound.NextInt32;
-          var upp = ((Int64)left.UpperBound.NextInt64) >> (Int32)right.LowerBound.PreviousInt32;
-
-          return Interval.For(low, upp);
-        }
-
-        Rational v;        
-        if (right.TryGetSingletonValue(out v) && v.IsInteger)
-        {
-          Rational sq;
-
-          try
-          {
-            var value = (int)v;
-            Contract.Assume(value >= 0);
-
-            sq = Rational.ToThePowerOfTwo(value);
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            return UnknownInterval;
-          }
-
-          if (sq <= 0)
-          {
-            return UnknownInterval;
-          }
-
-          try
-          {
-            var newLower = left.LowerBound / sq;
-            var newUpper = left.UpperBound / sq;
-
-            return Interval.For(newLower, newUpper);
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            return UnknownInterval;
-          }          
-        }
-
-        return PositiveInterval;
-      }
-      return UnknownInterval;
-    }
-
-
-    #endregion
-
-    #region Arithmetic operations onRationals and Intervals
-
-    public static Interval operator +(Rational r, Interval i)
-    {
-      Contract.Requires(i != null);
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      
-
-      if (i.IsTop || i.IsBottom)
-        return i;
-
-      try
-      {
-        return Interval.For(r +i.LowerBound , r + i.UpperBound );
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return Interval.UnknownInterval;
-      }
-    }
-
-    public static Interval operator +(Interval i, Rational r)
-    {
-      Contract.Requires(i != null);
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      
-      return r + i;
-    }
-
-    public static Interval operator -(Rational r, Interval i)
-    {
-      Contract.Requires(i != null);
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      
-
-      if (i.IsTop || i.IsBottom)
-        return i;
-
-      try
-      {
-        return Interval.For(r - i.UpperBound, r - i.LowerBound);
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return Interval.UnknownInterval;
-      }
-    }
-
-    public static Interval operator *(Rational r, Interval i)
-    {
-      Contract.Requires(i != null);
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      
-
-      if (i.IsTop || i.IsBottom)
-        return i;
-
-      if (r.IsZero)
-        return Interval.For(0);
-
-      if (r.Sign < 0)
-      {
-        return Interval.For(
-          Rational.MultiplyWithDefault(r, i.UpperBound, Rational.MinusInfinity), 
-          Rational.MultiplyWithDefault(r, i.LowerBound, Rational.PlusInfinity));
-      }
-      else
-      {
-        return Interval.For(
-          Rational.MultiplyWithDefault(r, i.LowerBound, Rational.MinusInfinity), 
-          Rational.MultiplyWithDefault(r, i.UpperBound, Rational.PlusInfinity));
-      }
-    }
-
-    public static Interval operator *(Interval i, Rational r)
-    {
-      Contract.Requires(i != null);
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);
-      
-
-      return r * i;
-    }
-
-    public static Interval operator /(Interval i, Rational r)
-    {
-      Contract.Requires(i != null);
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(Contract.Result<Interval>() != null);      
-
-      if (i.IsTop || i.IsBottom)
-        return i;
-
-      if (r.IsZero)
-        return Interval.UnknownInterval;
-
-      if (r.Sign < 0)
-      {
-        return Interval.For(
-          Rational.DivideWithDefault(i.UpperBound, r, Rational.MinusInfinity), 
-          Rational.DivideWithDefault(i.LowerBound, r, Rational.PlusInfinity));
-      }
-      else
-      {
-        return Interval.For(
-          Rational.DivideWithDefault(i.LowerBound, r, Rational.MinusInfinity), 
-          Rational.DivideWithDefault(i.UpperBound, r, Rational.PlusInfinity));
-      }
-
-    }
-
-    #endregion
-
-    #region Conversion
-
-    public DisInterval AsDisInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return DisInterval.For(this);
-      }
-    }
-
-
-    public override Interval ToUnsigned()
-    { 
-      int val;
-      if (this.IsFiniteAndInt32Singleton(out val))
-      {
-        if (val >= 0)
-        {
-          return this;
-        }
-        else
-        {
-          return Interval.For((uint)val);
-        }
-      }
-      else
-      {
-        return ApplyConversion(ExpressionOperator.ConvertToUInt32, this); 
-      }  
-    }
-    
-    public Interval ApplyConversion(ExpressionOperator conversionType)
-    {
-      return ApplyConversion(conversionType, this);
-    }
-
-    static public Interval ApplyConversion(ExpressionOperator conversionType, Interval val)
-    {
-      Contract.Requires(val != null);
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (val.IsBottom)
-      {
-        return val;
-      }
-
-      switch (conversionType)
-      {
-        case ExpressionOperator.ConvertToInt8:
-          {
-            return val.RefineIntervalWithTypeRanges(SByte.MinValue, SByte.MaxValue);
-          }
-
-        case ExpressionOperator.ConvertToInt16:
-          {
-            return val.RefineIntervalWithTypeRanges(Int16.MinValue, Int16.MaxValue);
-          }
-        
-        case ExpressionOperator.ConvertToInt32:
-          {
-            return val.RefineIntervalWithTypeRanges(Int32.MinValue, Int32.MaxValue);
-          }
-
-        case ExpressionOperator.ConvertToInt64:
-          {
-            return val.RefineIntervalWithTypeRanges(Int64.MinValue, Int64.MaxValue);
-          }
-
-        case ExpressionOperator.ConvertToUInt8:
-          {
-            return val.RefineIntervalWithTypeRanges(Byte.MinValue, Byte.MaxValue);
-           }
-
-        case ExpressionOperator.ConvertToUInt16:
-          {
-            return val.RefineIntervalWithTypeRanges(UInt16.MinValue, UInt16.MaxValue);
-          }
-
-        case ExpressionOperator.ConvertToUInt32:
-          {
-            if (val.IsSingleton && val.LowerBound.IsInteger)
+            if (lower.IsPlusInfinity && upper.IsPlusInfinity) // the case [+oo, +oo]
             {
-              if (val.LowerBound < Int32.MinValue || val.UpperBound > Int32.MaxValue)
-              {
-                return val;
-              }
-              else
-              {
-                var asInt = (Int32)val.LowerBound;
+                this.lowerBound = lower - 1;
+                this.upperBound = upper;
+            }
+            else if (lower.IsMinusInfinity && upper.IsMinusInfinity) // the case [-oo, -oo]
+            {
+                this.lowerBound = lower;
+                this.upperBound = Rational.PlusInfinity;
 
-                var asUint = (UInt32)(Int32)val.LowerBound;
-                if (asUint < Int32.MaxValue)
+                Contract.Assert(!object.Equals(this.lowerBound, null));
+                Contract.Assert(!object.Equals(this.upperBound, null));
+            }
+            else
+            {
+                this.lowerBound = lower;
+                this.upperBound = upper;
+            }
+            isBottom = this.lowerBound > this.upperBound;
+            isTop = this.lowerBound.IsMinusInfinity && this.upperBound.IsPlusInfinity;
+
+            Contract.Assert(!object.Equals(this.lowerBound, null));
+            Contract.Assert(!object.Equals(this.upperBound, null));
+        }
+
+        private Interval(Double inf, Double sup, bool dummy)
+          : base(Rational.MinusInfinity, Rational.PlusInfinity)
+        {
+            if (Double.IsNaN(inf) || Double.IsNaN(sup))
+            {
+                this.lowerBound = Rational.MinusInfinity;
+                this.upperBound = Rational.PlusInfinity;
+                return;
+            }
+
+            if (Double.IsNegativeInfinity(inf))
+            {
+                this.lowerBound = Rational.MinusInfinity;
+            }
+            else
+            {
+                var tmp = (Int64)Math.Floor(inf);
+
+                // Overflow checking
+                if (OppositeSigns(tmp, inf))
                 {
-                  return Interval.For((int)asUint);
+                    this.lowerBound = Rational.MinusInfinity;
                 }
                 else
                 {
-                  return Interval.For(asUint);
+                    this.lowerBound = Rational.For(tmp);
                 }
-              }
+            }
+
+            if (Double.IsPositiveInfinity(sup))
+            {
+                this.upperBound = Rational.PlusInfinity;
             }
             else
             {
-              if (val.LowerBound >= 0)
-              { // (UInt32)[a, b], con a >= 0 
+                var tmp = (Int64)Math.Ceiling(sup);
+                if (OppositeSigns(tmp, sup))
+                {
+                    this.upperBound = Rational.PlusInfinity;
+                }
+                else
+                {
+                    this.upperBound = Rational.For(tmp);
+                }
+            }
+            isBottom = this.lowerBound > this.upperBound;
+            isTop = this.LowerBound.IsMinusInfinity && this.UpperBound.IsPlusInfinity;
+        }
+
+        private Interval(Rational r)
+          : this(r, r)
+        {
+            Contract.Requires((object)r != null);
+        }
+
+
+        private Interval(uint lower, uint upper)
+          : this(Rational.For(lower), Rational.For(upper))
+        { }
+
+        /// <summary>
+        /// Useful to check overflows
+        /// </summary>
+        private bool OppositeSigns(long tmp, double inf)
+        {
+            return (tmp < 0 && inf > 0) || (tmp > 0 && inf < 0);
+        }
+        #endregion
+
+        #region Overridden
+
+        override public bool IsLowerBoundMinusInfinity
+        {
+            get
+            {
+                return this.LowerBound.IsMinusInfinity;
+            }
+        }
+
+        override public bool IsUpperBoundPlusInfinity
+        {
+            get
+            {
+                return this.UpperBound.IsPlusInfinity;
+            }
+        }
+
+        public override bool IsNormal
+        {
+            get { return !this.IsBottom && !this.IsTop; }
+        }
+
+        public override bool IsInt32
+        {
+            get
+            {
+                if (this.IsNormal)
+                {
+                    try
+                    {
+                        var blow = this.IsLowerBoundMinusInfinity || this.lowerBound >= Int32.MinValue;
+                        var bupp = this.IsUpperBoundPlusInfinity || this.upperBound <= Int32.MaxValue;
+
+                        return blow && bupp;
+                    }
+                    catch (ArithmeticException)
+                    {
+                        return false;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        public override bool IsInt64
+        {
+            get { throw new NotImplementedException(); }
+        }
+        #endregion
+
+        #region Interval Members
+
+        public bool IsFiniteAndInt64(out Int64 low, out Int64 upp)
+        {
+            if (base.IsFinite && this.LowerBound.IsInteger && this.UpperBound.IsInteger)
+            {
+                try
+                {
+                    checked
+                    {
+                        low = (Int64)this.LowerBound;
+                        upp = (Int64)this.UpperBound;
+                    }
+                    return true;
+                }
+                catch (ArithmeticException)
+                {
+                    low = upp = default(Int64);
+                    return false;
+                }
+            }
+
+            low = upp = default(Int64);
+            return false;
+        }
+
+        public bool IsFiniteAndInt32(out Int32 low, out Int32 upp)
+        {
+            if (base.IsFinite && this.LowerBound.IsInt32 && this.UpperBound.IsInt32)
+            {
+                try
+                {
+                    checked
+                    {
+                        low = (Int32)this.LowerBound;
+                        upp = (Int32)this.UpperBound;
+                    }
+                    return true;
+                }
+                catch (ArithmeticException)
+                {
+                    low = upp = default(Int32);
+                    return false;
+                }
+            }
+
+            low = upp = default(Int32);
+            return false;
+        }
+
+        public bool IsFiniteAndInt32Singleton(out Int32 value)
+        {
+            int low, upp;
+            if (this.IsFiniteAndInt32(out low, out upp) && low == upp)
+            {
+                value = low;
+                return true;
+            }
+
+            value = -567895;
+            return false;
+        }
+
+        public bool IsFiniteAndInt64Singleton(out Int64 value)
+        {
+            long low, upp;
+            if (this.IsFiniteAndInt64(out low, out upp) && low == upp)
+            {
+                value = low;
+                return true;
+            }
+
+            value = -567895;
+            return false;
+        }
+
+
+        /// <returns>
+        /// true iff <code>x</code> is not included in this interval
+        /// </returns>
+        public bool DoesNotInclude(int x)
+        {
+            return !this.IsBottom && (x < this.LowerBound || x > this.UpperBound);
+        }
+
+        public bool DoesInclude(int x)
+        {
+            return this.IsNormal && (this.LowerBound <= x && x <= this.UpperBound);
+        }
+
+        public bool OverlapsWith(Interval other)
+        {
+            Contract.Requires(other != null);
+
+            return !this.Meet(other).IsBottom;
+        }
+
+        public bool OnTheLeftOf(Interval other)
+        {
+            Contract.Requires(other != null);
+
+            if (!this.IsNormal || !other.IsNormal)
+            {
+                return false;
+            }
+
+            return this.UpperBound <= other.LowerBound;
+        }
+
+        #endregion
+
+        #region Arithmetic operations on Intervals
+
+        /// <summary>
+        /// The addition of intervals.
+        /// If the evaluation causes an overflow, the top interval is returned
+        /// </summary>
+        /// <returns></returns>
+        static public Interval operator +(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)    // Propagate bottom
+                return UnreachedInterval;
+
+            if (left.IsTop || right.IsTop)          // Propagate top
+                return UnknownInterval;
+
+            Rational lower, upper;
+
+            if (Rational.TryAdd(left.LowerBound, right.LowerBound, out lower)
+              && Rational.TryAdd(left.UpperBound, right.UpperBound, out upper))
+            {
+                return Interval.For(lower, upper);
+            }
+            else
+            {
+                return UnknownInterval;
+            }
+        }
+
+        static public Interval operator -(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)    // Propagate bottom
+                return left.Bottom;
+
+            if (left.IsTop || right.IsTop)          // Propagate top
+                return UnknownInterval;
+
+            Rational lower, upper;
+
+            if (Rational.TrySub(left.LowerBound, right.UpperBound, out lower)
+              && Rational.TrySub(left.UpperBound, right.LowerBound, out upper))
+            {
+                return new Interval
+                  (
+                    lower.IsPlusInfinity ? Rational.MinusInfinity : lower,
+                    upper.IsMinusInfinity ? Rational.PlusInfinity : upper
+                  );
+            }
+            else
+            {
+                return UnknownInterval;
+            }
+        }
+
+        static public Interval operator -(Interval left)
+        {
+            Contract.Requires(left != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (!left.IsNormal)
+            {
+                return left;
+            }
+            else
+            {
+                return Interval.For(-left.UpperBound, -left.LowerBound);
+            }
+        }
+
+        static public Interval operator *(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)    // Propagate bottom
+                return UnreachedInterval;
+
+            if (left.IsTop || right.IsTop)          // Propagate top
+                return UnknownInterval;
+
+            Rational llrl, lurl, llru, luru;
+            Rational lower, upper;
+
+            if (Rational.TryMul(left.LowerBound, right.LowerBound, out llrl)
+              && Rational.TryMul(left.UpperBound, right.LowerBound, out lurl)
+              && Rational.TryMul(left.LowerBound, right.UpperBound, out llru)
+              && Rational.TryMul(left.UpperBound, right.UpperBound, out luru))
+            {
+                lower = Rational.Min(Rational.Min(llrl, lurl), Rational.Min(llru, luru));
+                upper = Rational.Max(Rational.Max(llrl, lurl), Rational.Max(llru, luru));
+
+                return Interval.For(lower, upper);
+            }
+            else
+            {
+                return UnknownInterval;
+            }
+        }
+
+        static public Interval operator /(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)    // Propagate bottom
+                return UnreachedInterval;
+
+            if (left.IsTop || right.IsTop)          // Propagate top
+                return UnknownInterval;
+
+            Rational llrl, lurl, llru, luru;
+            Rational lower, upper;
+
+            if (right.LowerBound.IsZero || right.UpperBound.IsZero)
+            {
+                return UnknownInterval;
+            }
+
+            if (Rational.TryDiv(left.LowerBound, right.LowerBound, out llrl)
+              && Rational.TryDiv(left.UpperBound, right.LowerBound, out lurl)
+              && Rational.TryDiv(left.LowerBound, right.UpperBound, out llru)
+              && Rational.TryDiv(left.UpperBound, right.UpperBound, out luru))
+            {
+                lower = Rational.Min(Rational.Min(llrl, lurl), Rational.Min(llru, luru));
+                upper = Rational.Max(Rational.Max(llrl, lurl), Rational.Max(llru, luru));
+
+                return Interval.For(lower, upper);
+            }
+            else
+            {
+                return UnknownInterval;
+            }
+        }
+
+        static public Interval operator %(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)    // Propagate bottom
+                return left.Bottom;
+
+            int leftLow, leftUpp, rightLow, rightUpp;
+
+            try
+            {
+                // Easy cases
+                if (left.IsFiniteAndInt32(out leftLow, out leftUpp) &&
+                  right.IsFiniteAndInt32(out rightLow, out rightUpp) &&
+                  rightLow != 0 && rightUpp != 0)
+                {
+                    // k % [a,b]
+                    if (leftLow == leftUpp)
+                    {
+                        var ll = leftLow % rightLow;
+                        var lu = leftLow % rightUpp;
+                        var ul = leftUpp % rightLow;
+                        var uu = leftUpp % rightUpp;
+
+                        var min = Math.Min(Math.Min(ll, lu), Math.Min(ul, uu));
+                        var max = Math.Max(Math.Max(ll, lu), Math.Max(ul, uu));
+
+                        return Interval.For(min, max);
+                    }
+
+                    // [a,b] % [c, d]
+                    {
+                        var ll = leftLow % rightLow;
+                        var lu = leftLow % rightUpp;
+                        var ul = leftUpp % rightLow;
+                        var uu = leftUpp % rightUpp;
+
+                        // We need to min with 0 and max with (rightUpp-1) because % is no monotonic
+                        var min = Math.Min(0, Math.Min(Math.Min(ll, lu), Math.Min(ul, uu)));
+                        var max = Math.Max(Math.Max(Math.Max(ll, lu), Math.Max(ul, uu)), rightUpp - 1);
+
+                        return Interval.For(min, max);
+                    }
+                }
+
+                if (right.IsTop)
+                {
+                    if (left.LowerBound >= 0)
+                    { // We ignore the case when right == 0, this should be proven by some other analysis
+                        return Interval.For(0, Rational.PlusInfinity);
+                    }
+                    else
+                    { // Propagate top
+                        return UnknownInterval;
+                    }
+                }
+                // left % 0
+                if (right.LowerBound.IsZero && right.UpperBound.IsZero)
+                {
+                    return UnknownInterval;
+                }
+
+                if (!right.UpperBound.IsInfinity)
+                {
+                    if (left.IsSingleton && right.IsSingleton)
+                    {
+                        if (right.LowerBound.IsNotZero && left.LowerBound.IsInteger && right.LowerBound.IsInteger)
+                        {
+                            Contract.Assume(((Int32)right.LowerBound.PreviousInt32) != 0);
+                            return new Interval(Rational.For(((Int32)left.LowerBound) % ((Int32)right.LowerBound.PreviousInt32)));
+                        }
+                        else
+                        {
+                            return Interval.UnknownInterval;
+                        }
+                    }
+
+                    if (right.UpperBound.IsMinusInfinity || right.UpperBound.IsMinValue)
+                    {
+                        return Interval.UnknownInterval;
+                    }
+
+                    var absUpperBound = Rational.Abs(right.UpperBound);
+                    if (left.LowerBound >= 0)
+                    {
+                        return Interval.For(0, absUpperBound - 1);
+                    }
+                    else if (left.UpperBound <= 0)
+                    {
+                        return Interval.For(-absUpperBound + 1, 0);
+                    }
+                    else
+                    {
+                        return Interval.For(-absUpperBound + 1, absUpperBound - 1);
+                    }
+                }
+                else if (right.LowerBound > 0)
+                {
+                    if (left.LowerBound >= 0)
+                    {
+                        return Interval.PositiveInterval;
+                    }
+                    else
+                    {
+                        return Interval.For(Rational.MinusInfinity, 0);
+                    }
+                }
+            }
+            catch (ArithmeticException)
+            {
+                return UnknownInterval;
+            }
+
+            return UnknownInterval;
+        }
+
+        static public Interval operator &(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)
+            {
+                return left.Bottom;
+            }
+
+            if (right.IsTop)
+            {
+                return right;
+            }
+
+            long l1, l2, r1, r2;
+            if (left.IsFiniteAndInt64(out l1, out l2) && right.IsFiniteAndInt64(out r1, out r2))
+            {
+                // Is it a singleton?
+                if (l1 == l2 && r1 == r2)
+                {
+                    return new Interval(Rational.For(l1 & r1));
+                }
+
+                // If one of the two is non negative, the result will be non-negative
+                if (l1 >= 0 || r1 >= 0)
+                {
+                    // if l1 >= 0 && r1 >= 0 && l2 < r1 then the result is zero
+                    if (l1 >= 0 && r1 >= 0 && l2 < r1)
+                    {
+                        return new Interval(0, 0);
+                    }
+
+                    return new Interval(0, Math.Min(l2, r2));
+                }
+
+                return new Interval(Math.Min(l1, r1), Math.Max(l2, r2));
+            }
+
+            if (right.LowerBound >= 0)
+            {
+                if (left.IsTop)
+                { // [-oo, +oo] & [0, r.Upp]
+                    return Interval.For(0, right.UpperBound);
+                }
+
+                if (left.UpperBound < 0)
+                { // [-oo, a] & [0, r.Upp]
+                    return Interval.For(0, right.UpperBound);
+                }
+
+                if (left.LowerBound >= 0)
+                { //  [0 <= a, +oo] & [0, r.Upp]
+                    return Interval.For(0, right.UpperBound);
+                }
+
+                return Interval.PositiveInterval;
+            }
+
+            if (left.LowerBound >= 0)
+            {
+                if (right.IsTop)
+                { // [0, r.Upp] & [-oo, +oo]  
+                    return Interval.For(0, left.UpperBound);
+                }
+
+                if (right.UpperBound < 0)
+                { // [0, r.Upp] & [-oo, a] 
+                    return Interval.For(0, left.UpperBound);
+                }
+
+                if (right.LowerBound >= 0)
+                { //  [0, r.Upp] & [0 <= a, +oo] 
+                    return Interval.For(0, left.UpperBound);
+                }
+
+                return Interval.PositiveInterval;
+            }
+
+
+            return UnknownInterval;
+        }
+
+        static public Interval operator |(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)
+            {
+                return UnreachedInterval;
+            }
+            if (left.IsTop || right.IsTop)
+            {
+                return UnknownInterval;
+            }
+
+            Interval posInterval;
+            Rational k;
+
+            if (left.LowerBound.IsInteger && left.UpperBound.IsInteger && right.LowerBound.IsInteger && right.UpperBound.IsInteger)
+            {
+                if (left.LowerBound >= 0 && right.LowerBound >= 0 && !left.UpperBound.IsInfinity && !right.UpperBound.IsInfinity)
+                {
+                    // F: Assumptions below follow form the 
+                    Contract.Assert(left.LowerBound.IsInteger);
+                    Contract.Assert(left.UpperBound.IsInteger);
+                    Contract.Assert(right.LowerBound.IsInteger);
+                    Contract.Assert(right.UpperBound.IsInteger);
+
+                    uint min, max;
+                    WarrenAlgorithmForBitewiseOr(ToUint(left.LowerBound), ToUint(left.UpperBound), ToUint(right.LowerBound), ToUint(right.UpperBound), out min, out max);
+
+                    return Interval.For(min, max);
+                }
+                else if (MatchWithPositiveAndConstant(left, right, out posInterval, out k))
+                {
+                    if (k > 0)
+                    {// we have ([k1, +oo] | k2) >= max(k1, k2)
+                        return Interval.For(Rational.Max(posInterval.LowerBound, k), Rational.PlusInfinity);
+                    }
+                    else if (k < 0)
+                    {
+                        return Interval.For(k, Rational.PlusInfinity);
+                    }
+                    else
+                    {
+                        return posInterval;
+                    }
+                }
+            }
+
+            return UnknownInterval;
+        }
+
+        static public Interval operator ^(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)
+            {
+                return UnreachedInterval;
+            }
+            if (left.IsTop || right.IsTop)
+            {
+                return UnknownInterval;
+            }
+
+            long leftVal, rightVal;
+            if (left.IsFiniteAndInt64Singleton(out leftVal) && right.IsFiniteAndInt64Singleton(out rightVal))
+            {
+                var result = leftVal ^ rightVal;
+                return new Interval(Rational.For(result));
+            }
+
+            return UnknownInterval;
+        }
+
+        static public Interval ShiftLeft(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)
+            {
+                return UnreachedInterval;
+            }
+            if (left.IsTop || right.IsTop)
+            {
+                return UnknownInterval;
+            }
+
+            Rational valForRight;
+            if (right.TryGetSingletonValue(out valForRight))
+            {
+                if (valForRight > 32 || !valForRight.IsInteger)
+                { // According to the ECMA standard, Partition III pag. 92
+                    return UnknownInterval;
+                }
+                else
+                { // It is a multiplication by 2^(valForRight)
+                    double d = Math.Ceiling(Math.Pow(2, (double)valForRight.NextInt32));     // We know it will not raise an exception...
+                    int pow = (int)d;
+                    return left * (Interval.For(pow));
+                }
+            }
+            else
+            {
+                return UnknownInterval;
+            }
+        }
+
+        static public Interval ShiftRight(Interval left, Interval right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (left.IsBottom || right.IsBottom)
+            {
+                return left.Bottom;
+            }
+            if (left.IsTop || right.IsTop)
+            {
+                return UnknownInterval;
+            }
+
+            if (left.LowerBound >= 0)
+            {
+                if (left.IsFinite && right.IsFinite)
+                {
+                    var low = ((Int64)left.LowerBound.PreviousInt64) >> (Int32)right.UpperBound.NextInt32;
+                    var upp = ((Int64)left.UpperBound.NextInt64) >> (Int32)right.LowerBound.PreviousInt32;
+
+                    return Interval.For(low, upp);
+                }
+
+                Rational v;
+                if (right.TryGetSingletonValue(out v) && v.IsInteger)
+                {
+                    Rational sq;
+
+                    try
+                    {
+                        var value = (int)v;
+                        Contract.Assume(value >= 0);
+
+                        sq = Rational.ToThePowerOfTwo(value);
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        return UnknownInterval;
+                    }
+
+                    if (sq <= 0)
+                    {
+                        return UnknownInterval;
+                    }
+
+                    try
+                    {
+                        var newLower = left.LowerBound / sq;
+                        var newUpper = left.UpperBound / sq;
+
+                        return Interval.For(newLower, newUpper);
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        return UnknownInterval;
+                    }
+                }
+
+                return PositiveInterval;
+            }
+            return UnknownInterval;
+        }
+
+
+        #endregion
+
+        #region Arithmetic operations onRationals and Intervals
+
+        public static Interval operator +(Rational r, Interval i)
+        {
+            Contract.Requires(i != null);
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+
+            if (i.IsTop || i.IsBottom)
+                return i;
+
+            try
+            {
+                return Interval.For(r + i.LowerBound, r + i.UpperBound);
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return Interval.UnknownInterval;
+            }
+        }
+
+        public static Interval operator +(Interval i, Rational r)
+        {
+            Contract.Requires(i != null);
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            return r + i;
+        }
+
+        public static Interval operator -(Rational r, Interval i)
+        {
+            Contract.Requires(i != null);
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+
+            if (i.IsTop || i.IsBottom)
+                return i;
+
+            try
+            {
+                return Interval.For(r - i.UpperBound, r - i.LowerBound);
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return Interval.UnknownInterval;
+            }
+        }
+
+        public static Interval operator *(Rational r, Interval i)
+        {
+            Contract.Requires(i != null);
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+
+            if (i.IsTop || i.IsBottom)
+                return i;
+
+            if (r.IsZero)
+                return Interval.For(0);
+
+            if (r.Sign < 0)
+            {
+                return Interval.For(
+                  Rational.MultiplyWithDefault(r, i.UpperBound, Rational.MinusInfinity),
+                  Rational.MultiplyWithDefault(r, i.LowerBound, Rational.PlusInfinity));
+            }
+            else
+            {
+                return Interval.For(
+                  Rational.MultiplyWithDefault(r, i.LowerBound, Rational.MinusInfinity),
+                  Rational.MultiplyWithDefault(r, i.UpperBound, Rational.PlusInfinity));
+            }
+        }
+
+        public static Interval operator *(Interval i, Rational r)
+        {
+            Contract.Requires(i != null);
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+
+            return r * i;
+        }
+
+        public static Interval operator /(Interval i, Rational r)
+        {
+            Contract.Requires(i != null);
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (i.IsTop || i.IsBottom)
+                return i;
+
+            if (r.IsZero)
+                return Interval.UnknownInterval;
+
+            if (r.Sign < 0)
+            {
+                return Interval.For(
+                  Rational.DivideWithDefault(i.UpperBound, r, Rational.MinusInfinity),
+                  Rational.DivideWithDefault(i.LowerBound, r, Rational.PlusInfinity));
+            }
+            else
+            {
+                return Interval.For(
+                  Rational.DivideWithDefault(i.LowerBound, r, Rational.MinusInfinity),
+                  Rational.DivideWithDefault(i.UpperBound, r, Rational.PlusInfinity));
+            }
+        }
+
+        #endregion
+
+        #region Conversion
+
+        public DisInterval AsDisInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+                return DisInterval.For(this);
+            }
+        }
+
+
+        public override Interval ToUnsigned()
+        {
+            int val;
+            if (this.IsFiniteAndInt32Singleton(out val))
+            {
+                if (val >= 0)
+                {
+                    return this;
+                }
+                else
+                {
+                    return Interval.For((uint)val);
+                }
+            }
+            else
+            {
+                return ApplyConversion(ExpressionOperator.ConvertToUInt32, this);
+            }
+        }
+
+        public Interval ApplyConversion(ExpressionOperator conversionType)
+        {
+            return ApplyConversion(conversionType, this);
+        }
+
+        static public Interval ApplyConversion(ExpressionOperator conversionType, Interval val)
+        {
+            Contract.Requires(val != null);
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (val.IsBottom)
+            {
                 return val;
-              }
-              else
-              {
-                return new Interval(0, (long)UInt32.MaxValue);
-              }
             }
-          }
 
-        case ExpressionOperator.ConvertToUInt64:
-          // TODO
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToFloat64:
-        default:
-          return val;
-      }
-    }
-
-    public Interval RefineIntervalWithTypeRanges(Int32 min, Int32 max)
-    {
-      var low = this.LowerBound.IsInfinity || !this.LowerBound.IsInRange(min, max)
-        ? Rational.MinusInfinity
-      : this.LowerBound.PreviousInt32;
-
-      var upp = this.UpperBound.IsInfinity || !this.UpperBound.IsInRange(min, max)
-        ? Rational.PlusInfinity
-        : this.UpperBound.NextInt32;
-
-      return Interval.For(low, upp);
-    }
-
-    public Interval RefineIntervalWithTypeRanges(Int64 min, Int64 max)
-    {
-      var low = this.LowerBound.IsInfinity || !this.LowerBound.IsInRange(min, max)
-        ? Rational.MinusInfinity
-      : this.LowerBound.PreviousInt64;
-
-      var upp = this.UpperBound.IsInfinity || !this.UpperBound.IsInRange(min, max)
-        ? Rational.PlusInfinity
-        : this.UpperBound.NextInt64;
-
-      return Interval.For(low, upp);
-    }
-
-    public Interval RefineIntervalWithTypeRanges(UInt32 min, UInt32 max)
-    {
-      var low = this.LowerBound.IsInfinity || !this.LowerBound.IsInRange(min, max)
-        ? Rational.MinusInfinity
-        : this.LowerBound.PreviousInt32;
-
-      var upp = this.UpperBound.IsInfinity || !this.UpperBound.IsInRange(min, max)
-        ? Rational.PlusInfinity
-        : this.UpperBound.NextInt32;
-
-      return Interval.For(low, upp);
-    }
-    #endregion
-
-    #region IAbstractDomain Members
-
-    override public bool IsBottom
-    {
-      get
-      {
-        return this.isBottom;
-        // return this.lowerBound > this.upperBound;
-      }
-    }
-
-    override public bool IsTop
-    {
-      get
-      {
-        return this.isTop;
-        //return this.upperBound.IsPlusInfinity && this.lowerBound.IsMinusInfinity;
-      }
-    }
-
-    public override Interval Bottom
-    {
-      get { return UnreachedInterval; }
-    }
-
-    public override Interval Top
-    {
-      get { return UnknownInterval; }
-    }
-
-    [Pure]
-    override public bool LessEqual(Interval right)
-    {
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
-      {
-        return result;
-      }
-
-      return this.LowerBound >= right.LowerBound && this.UpperBound <= right.UpperBound;
-    }
-
-    [Pure]
-    public bool LessEqual(ReadOnlyIntervalList right)
-    {
-      Contract.Requires(right != null);
-
-      foreach (var intv in right)
-      {
-        Contract.Assume(intv != null);
-
-        if (this.LessEqual(intv))
-        {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    override public Interval/*!*/ Join(Interval/*!*/ right)
-    {
-      Interval/*!*/ result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
-      {
-        return result;
-      }
-
-      var joinInf = Rational.Min(this.LowerBound, right.LowerBound);
-      var joinSup = Rational.Max(this.UpperBound, right.UpperBound);
-
-      return Interval.For(joinInf, joinSup);
-    }
-
-    [Pure]
-    override public Interval/*!*/ Meet(Interval/*!*/ right)
-    {
-      Interval trivialMeet;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, right, out trivialMeet))
-      {
-        return trivialMeet;
-      }
-
-      var meetInf = Rational.Max(this.LowerBound, right.LowerBound);
-      var meetSup = Rational.Min(this.UpperBound, right.UpperBound);
-
-      return Interval.For(meetInf, meetSup);
-    }
-
-    [Pure]
-    override public Interval/*!*/ Widening(Interval/*!*/ prev)
-    {
-      // Trivial cases
-      if (this.IsBottom)
-        return prev;
-      if (this.IsTop)
-        return this;
-      if (prev.IsBottom)
-        return this;
-      if (prev.IsTop)
-        return prev;
-
-      var wideningInf = this.LowerBound < prev.LowerBound ? ThresholdDB.GetPrevious(this.LowerBound) : prev.LowerBound;
-      Contract.Assert(((object)wideningInf) != null);
-
-      var wideningSup = this.UpperBound > prev.UpperBound ? ThresholdDB.GetNext(this.upperBound) : prev.UpperBound;
-      Contract.Assert(((object)wideningSup) != null);
-
-      return Interval.For(wideningInf, wideningSup);
-    }
-    #endregion
-
-    #region ICloneable Members
-
-    public override Interval DuplicateMe()
-    {
-      return Interval.For(this.lowerBound, this.upperBound);
-    }
-
-    #endregion
-
-    #region Overridden (To, ToString, GetHash, Equals)
-
-    public override T To<T>(IFactory<T> factory)
-    {
-      T varName;
-      if (this.IsBottom)
-      {
-        return factory.Constant(false);
-      }
-      else if (this.IsTop)
-      {
-        return factory.Constant(true);
-      }
-      else if (factory.TryGetName(out varName))
-      {
-        T low = default(T), upp = default(T);
-        bool lowSet = false, uppSet = false;
-
-        if (this.lowerBound.IsInteger)
-        {
-          low = factory.LessEqualThan(this.lowerBound.To(factory), varName);
-          lowSet = true;
-        }
-        if (this.upperBound.IsInteger)
-        {
-          upp = factory.LessEqualThan(varName, this.upperBound.To(factory));
-          uppSet = true;
-        }
-        if (lowSet && uppSet)
-        {
-          return factory.And(low, upp);
-        }
-        return lowSet ? low : upp;
-      }
-
-      return factory.Constant(true);
-    }
-
-    public override int GetHashCode()
-    {
-
-      return (Int32)(this.lowerBound + this.upperBound);
-    }
-
-     [Pure]
-    public override bool Equals(object obj)
-    {
-      if (object.ReferenceEquals(this, obj))
-      {
-        return true;
-      }
-
-      var asIntv = obj as Interval;
-
-      if (asIntv == null)
-      {
-        return false;
-      }
-
-      Contract.Assume(((object)asIntv.upperBound) != null);
-      Contract.Assume(((object)asIntv.lowerBound) != null);
-
-      return this.upperBound == asIntv.upperBound && this.lowerBound == asIntv.lowerBound;
-    }
-
-    #endregion
-
-    #region Utils
-    static public bool AreConsecutiveIntegers(Interval prev, Interval next)
-    {
-      Contract.Requires(prev != null);
-      Contract.Requires(next != null);
-
-      if (!prev.IsNormal || !next.IsNormal)
-      {
-        return false;
-      }
-
-      return prev.UpperBound.IsInteger && next.LowerBound.IsInteger && prev.UpperBound + 1 == next.LowerBound;
-    }
-    #endregion
-
-    #region Private, helper methods
-    [Pure]
-    static private uint ToUint(Rational r)
-    {
-      Contract.Requires(!object.ReferenceEquals(r, null));
-      Contract.Requires(r.IsInteger);
-
-      return (uint)((int)r);
-    }
-
-    static private bool MatchWithPositiveAndConstant(Interval left, Interval right, out Interval posInterval, out Rational k)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out posInterval) != null);
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
-
-      bool result;
-      if (left.LowerBound >= 0 && right.IsSingleton)
-      {
-        posInterval = left;
-        k = right.LowerBound;
-        result = true;
-      }
-      else if (right.LowerBound >= 0 && left.IsSingleton)
-      {
-        posInterval = right;
-        k = left.LowerBound;
-        result = true;
-      }
-      else
-      {
-        posInterval = null;
-        k = default(Rational);
-        result = false;
-      }
-      return result;
-    }
-
-
-    private static bool IsPowerOfTwoMinusOne(Rational r)
-    {
-      Contract.Requires((object)r != null);
-
-      return r == 15 || r == 31 || r == 63 || r == 127 || r == 255 || r == 511 || r == 1023 || r == 2047 || r == 4095 || r == 8191 || r == 16385 || r == 32767
-      || r == 65535 || r == 131071 || r == 262143 || r == 524287 || r == 1048575 || r == 2097151 || r == 4194303 || r == 8388607 || r == 16777215;
-    }
-
-    /// <summary>
-    /// The Warren algorithm to find the min and max of two intervals.
-    /// Given <code> a \leq x \leq b</code> and <code>c \leq y \leq d</code>, it finds the <code>min</code> and <code>max</code> of <code>x | y</code>
-    /// </summary>
-    static private void WarrenAlgorithmForBitewiseOr(uint a, uint b, uint c, uint d, out uint min, out uint max)
-    {
-      min = MinOr(a, b, c, d);
-      max = MaxOr(a, b, c, d);
-    }
-
-    static private uint MinOr(uint a, uint b, uint c, uint d)
-    {
-      uint m, tmp;
-      m = 0x80000000;
-      while (m != 0)
-      {
-        if ((~a & c & m) != 0)
-        {
-          tmp = (a | m) & ~m;
-          if (tmp <= b)
-          {
-            a = tmp;
-            break;
-          }
-        }
-        else if ((a & ~c & m) != 0)
-        {
-          tmp = (c | m) & ~m;
-          if (tmp <= d)
-          {
-            c = tmp;
-            break;
-          }
-        }
-        m = m >> 1;
-      }
-      return a | c;
-    }
-
-    static private uint MaxOr(uint a, uint b, uint c, uint d)
-    {
-      uint m, tmp;
-      m = 0x80000000;
-      while (m != 0)
-      {
-        if ((b & d & m) != 0)
-        {
-          tmp = (b - m) | (m - 1);
-          if (tmp >= a)
-          {
-            b = tmp;
-            break;
-          }
-          tmp = (d - m) | (m - 1);
-          if (tmp >= c)
-          {
-            d = tmp;
-            break;
-          }
-        }
-        m = m >> 1;
-      }
-      return b | d;
-    }
-    #endregion
-
-    #region Ranges for basic types
-    static public class Ranges
-    {
-      private static readonly Interval uint8Range = Interval.For(Byte.MinValue, Byte.MaxValue);
-      private static readonly Interval uint16Range = Interval.For(UInt16.MinValue, UInt16.MaxValue);
-      private static readonly Interval uint32Range = Interval.For(UInt32.MinValue, UInt32.MaxValue);
-      private static readonly Interval uint64Range = Interval.For(0, Rational.PlusInfinity);
-
-      private static readonly Interval int8Range = Interval.For(SByte.MinValue, SByte.MaxValue);
-      private static readonly Interval int16Range = Interval.For(Int16.MinValue, Int16.MaxValue);
-      private static readonly Interval int32Range = Interval.For(Int32.MinValue, Int32.MaxValue);
-      private static readonly Interval int64Range = Interval.For(Int64.MinValue, Int64.MaxValue);
-
-      public static Interval UInt8Range
-      {
-        get
-        {
-          return uint8Range;
-        }
-      }
-
-      public static Interval UInt16Range
-      {
-        get
-        {
-          return uint16Range;
-        }
-      }
-
-      public static Interval UInt32Range
-      {
-        get
-        {
-          return uint32Range;
-        }
-      }
-
-      public static Interval UInt64Range
-      {
-        get
-        {
-          return uint64Range;
-        }
-      }
-
-      public static Interval Int8Range
-      {
-        get
-        {
-          return int8Range;
-        }
-      }
-
-      public static Interval Int16Range
-      {
-        get
-        {
-          return int16Range;
-        }
-      }
-
-      public static Interval Int32Range
-      {
-        get
-        {
-          return int32Range;
-        }
-      }
-
-      public static Interval Int64Range
-      {
-        get
-        {
-          return int64Range;
-        }
-      }
-
-      public static Interval EnumRange<Type>(Type t, Func<Type, List<int>> enumranges)
-      {
-        Contract.Requires(enumranges != null);
-
-        Contract.Ensures(Contract.Result<Interval>() != null);
-
-        var ranges = enumranges(t);
-        if (ranges != null)
-        {
-          var min = Int32.MaxValue;
-          var max = Int32.MinValue;
-
-          foreach (var x in ranges)
-          {
-            if (x < min)
+            switch (conversionType)
             {
-              min = x;
-            }
-            if (x > max)
-            {
-              max = x;
-            }
-          }
+                case ExpressionOperator.ConvertToInt8:
+                    {
+                        return val.RefineIntervalWithTypeRanges(SByte.MinValue, SByte.MaxValue);
+                    }
 
-          if (min <= max)
-          {
-            return Interval.For(min, max);
-          }
+                case ExpressionOperator.ConvertToInt16:
+                    {
+                        return val.RefineIntervalWithTypeRanges(Int16.MinValue, Int16.MaxValue);
+                    }
+
+                case ExpressionOperator.ConvertToInt32:
+                    {
+                        return val.RefineIntervalWithTypeRanges(Int32.MinValue, Int32.MaxValue);
+                    }
+
+                case ExpressionOperator.ConvertToInt64:
+                    {
+                        return val.RefineIntervalWithTypeRanges(Int64.MinValue, Int64.MaxValue);
+                    }
+
+                case ExpressionOperator.ConvertToUInt8:
+                    {
+                        return val.RefineIntervalWithTypeRanges(Byte.MinValue, Byte.MaxValue);
+                    }
+
+                case ExpressionOperator.ConvertToUInt16:
+                    {
+                        return val.RefineIntervalWithTypeRanges(UInt16.MinValue, UInt16.MaxValue);
+                    }
+
+                case ExpressionOperator.ConvertToUInt32:
+                    {
+                        if (val.IsSingleton && val.LowerBound.IsInteger)
+                        {
+                            if (val.LowerBound < Int32.MinValue || val.UpperBound > Int32.MaxValue)
+                            {
+                                return val;
+                            }
+                            else
+                            {
+                                var asInt = (Int32)val.LowerBound;
+
+                                var asUint = (UInt32)(Int32)val.LowerBound;
+                                if (asUint < Int32.MaxValue)
+                                {
+                                    return Interval.For((int)asUint);
+                                }
+                                else
+                                {
+                                    return Interval.For(asUint);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (val.LowerBound >= 0)
+                            { // (UInt32)[a, b], con a >= 0 
+                                return val;
+                            }
+                            else
+                            {
+                                return new Interval(0, (long)UInt32.MaxValue);
+                            }
+                        }
+                    }
+
+                case ExpressionOperator.ConvertToUInt64:
+                // TODO
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToFloat64:
+                default:
+                    return val;
+            }
         }
 
-        return Ranges.Int32Range;
-      }
+        public Interval RefineIntervalWithTypeRanges(Int32 min, Int32 max)
+        {
+            var low = this.LowerBound.IsInfinity || !this.LowerBound.IsInRange(min, max)
+              ? Rational.MinusInfinity
+            : this.LowerBound.PreviousInt32;
 
+            var upp = this.UpperBound.IsInfinity || !this.UpperBound.IsInRange(min, max)
+              ? Rational.PlusInfinity
+              : this.UpperBound.NextInt32;
+
+            return Interval.For(low, upp);
+        }
+
+        public Interval RefineIntervalWithTypeRanges(Int64 min, Int64 max)
+        {
+            var low = this.LowerBound.IsInfinity || !this.LowerBound.IsInRange(min, max)
+              ? Rational.MinusInfinity
+            : this.LowerBound.PreviousInt64;
+
+            var upp = this.UpperBound.IsInfinity || !this.UpperBound.IsInRange(min, max)
+              ? Rational.PlusInfinity
+              : this.UpperBound.NextInt64;
+
+            return Interval.For(low, upp);
+        }
+
+        public Interval RefineIntervalWithTypeRanges(UInt32 min, UInt32 max)
+        {
+            var low = this.LowerBound.IsInfinity || !this.LowerBound.IsInRange(min, max)
+              ? Rational.MinusInfinity
+              : this.LowerBound.PreviousInt32;
+
+            var upp = this.UpperBound.IsInfinity || !this.UpperBound.IsInRange(min, max)
+              ? Rational.PlusInfinity
+              : this.UpperBound.NextInt32;
+
+            return Interval.For(low, upp);
+        }
+        #endregion
+
+        #region IAbstractDomain Members
+
+        override public bool IsBottom
+        {
+            get
+            {
+                return isBottom;
+                // return this.lowerBound > this.upperBound;
+            }
+        }
+
+        override public bool IsTop
+        {
+            get
+            {
+                return isTop;
+                //return this.upperBound.IsPlusInfinity && this.lowerBound.IsMinusInfinity;
+            }
+        }
+
+        public override Interval Bottom
+        {
+            get { return UnreachedInterval; }
+        }
+
+        public override Interval Top
+        {
+            get { return UnknownInterval; }
+        }
+
+        [Pure]
+        override public bool LessEqual(Interval right)
+        {
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
+            {
+                return result;
+            }
+
+            return this.LowerBound >= right.LowerBound && this.UpperBound <= right.UpperBound;
+        }
+
+        [Pure]
+        public bool LessEqual(ReadOnlyIntervalList right)
+        {
+            Contract.Requires(right != null);
+
+            foreach (var intv in right)
+            {
+                Contract.Assume(intv != null);
+
+                if (this.LessEqual(intv))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        override public Interval/*!*/ Join(Interval/*!*/ right)
+        {
+            Interval/*!*/ result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
+            {
+                return result;
+            }
+
+            var joinInf = Rational.Min(this.LowerBound, right.LowerBound);
+            var joinSup = Rational.Max(this.UpperBound, right.UpperBound);
+
+            return Interval.For(joinInf, joinSup);
+        }
+
+        [Pure]
+        override public Interval/*!*/ Meet(Interval/*!*/ right)
+        {
+            Interval trivialMeet;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, right, out trivialMeet))
+            {
+                return trivialMeet;
+            }
+
+            var meetInf = Rational.Max(this.LowerBound, right.LowerBound);
+            var meetSup = Rational.Min(this.UpperBound, right.UpperBound);
+
+            return Interval.For(meetInf, meetSup);
+        }
+
+        [Pure]
+        override public Interval/*!*/ Widening(Interval/*!*/ prev)
+        {
+            // Trivial cases
+            if (this.IsBottom)
+                return prev;
+            if (this.IsTop)
+                return this;
+            if (prev.IsBottom)
+                return this;
+            if (prev.IsTop)
+                return prev;
+
+            var wideningInf = this.LowerBound < prev.LowerBound ? ThresholdDB.GetPrevious(this.LowerBound) : prev.LowerBound;
+            Contract.Assert(((object)wideningInf) != null);
+
+            var wideningSup = this.UpperBound > prev.UpperBound ? ThresholdDB.GetNext(this.upperBound) : prev.UpperBound;
+            Contract.Assert(((object)wideningSup) != null);
+
+            return Interval.For(wideningInf, wideningSup);
+        }
+        #endregion
+
+        #region ICloneable Members
+
+        public override Interval DuplicateMe()
+        {
+            return Interval.For(this.lowerBound, this.upperBound);
+        }
+
+        #endregion
+
+        #region Overridden (To, ToString, GetHash, Equals)
+
+        public override T To<T>(IFactory<T> factory)
+        {
+            T varName;
+            if (this.IsBottom)
+            {
+                return factory.Constant(false);
+            }
+            else if (this.IsTop)
+            {
+                return factory.Constant(true);
+            }
+            else if (factory.TryGetName(out varName))
+            {
+                T low = default(T), upp = default(T);
+                bool lowSet = false, uppSet = false;
+
+                if (this.lowerBound.IsInteger)
+                {
+                    low = factory.LessEqualThan(this.lowerBound.To(factory), varName);
+                    lowSet = true;
+                }
+                if (this.upperBound.IsInteger)
+                {
+                    upp = factory.LessEqualThan(varName, this.upperBound.To(factory));
+                    uppSet = true;
+                }
+                if (lowSet && uppSet)
+                {
+                    return factory.And(low, upp);
+                }
+                return lowSet ? low : upp;
+            }
+
+            return factory.Constant(true);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Int32)(this.lowerBound + this.upperBound);
+        }
+
+        [Pure]
+        public override bool Equals(object obj)
+        {
+            if (object.ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            var asIntv = obj as Interval;
+
+            if (asIntv == null)
+            {
+                return false;
+            }
+
+            Contract.Assume(((object)asIntv.upperBound) != null);
+            Contract.Assume(((object)asIntv.lowerBound) != null);
+
+            return this.upperBound == asIntv.upperBound && this.lowerBound == asIntv.lowerBound;
+        }
+
+        #endregion
+
+        #region Utils
+        static public bool AreConsecutiveIntegers(Interval prev, Interval next)
+        {
+            Contract.Requires(prev != null);
+            Contract.Requires(next != null);
+
+            if (!prev.IsNormal || !next.IsNormal)
+            {
+                return false;
+            }
+
+            return prev.UpperBound.IsInteger && next.LowerBound.IsInteger && prev.UpperBound + 1 == next.LowerBound;
+        }
+        #endregion
+
+        #region Private, helper methods
+        [Pure]
+        static private uint ToUint(Rational r)
+        {
+            Contract.Requires(!object.ReferenceEquals(r, null));
+            Contract.Requires(r.IsInteger);
+
+            return (uint)((int)r);
+        }
+
+        static private bool MatchWithPositiveAndConstant(Interval left, Interval right, out Interval posInterval, out Rational k)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out posInterval) != null);
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out k), null));
+
+            bool result;
+            if (left.LowerBound >= 0 && right.IsSingleton)
+            {
+                posInterval = left;
+                k = right.LowerBound;
+                result = true;
+            }
+            else if (right.LowerBound >= 0 && left.IsSingleton)
+            {
+                posInterval = right;
+                k = left.LowerBound;
+                result = true;
+            }
+            else
+            {
+                posInterval = null;
+                k = default(Rational);
+                result = false;
+            }
+            return result;
+        }
+
+
+        private static bool IsPowerOfTwoMinusOne(Rational r)
+        {
+            Contract.Requires((object)r != null);
+
+            return r == 15 || r == 31 || r == 63 || r == 127 || r == 255 || r == 511 || r == 1023 || r == 2047 || r == 4095 || r == 8191 || r == 16385 || r == 32767
+            || r == 65535 || r == 131071 || r == 262143 || r == 524287 || r == 1048575 || r == 2097151 || r == 4194303 || r == 8388607 || r == 16777215;
+        }
+
+        /// <summary>
+        /// The Warren algorithm to find the min and max of two intervals.
+        /// Given <code> a \leq x \leq b</code> and <code>c \leq y \leq d</code>, it finds the <code>min</code> and <code>max</code> of <code>x | y</code>
+        /// </summary>
+        static private void WarrenAlgorithmForBitewiseOr(uint a, uint b, uint c, uint d, out uint min, out uint max)
+        {
+            min = MinOr(a, b, c, d);
+            max = MaxOr(a, b, c, d);
+        }
+
+        static private uint MinOr(uint a, uint b, uint c, uint d)
+        {
+            uint m, tmp;
+            m = 0x80000000;
+            while (m != 0)
+            {
+                if ((~a & c & m) != 0)
+                {
+                    tmp = (a | m) & ~m;
+                    if (tmp <= b)
+                    {
+                        a = tmp;
+                        break;
+                    }
+                }
+                else if ((a & ~c & m) != 0)
+                {
+                    tmp = (c | m) & ~m;
+                    if (tmp <= d)
+                    {
+                        c = tmp;
+                        break;
+                    }
+                }
+                m = m >> 1;
+            }
+            return a | c;
+        }
+
+        static private uint MaxOr(uint a, uint b, uint c, uint d)
+        {
+            uint m, tmp;
+            m = 0x80000000;
+            while (m != 0)
+            {
+                if ((b & d & m) != 0)
+                {
+                    tmp = (b - m) | (m - 1);
+                    if (tmp >= a)
+                    {
+                        b = tmp;
+                        break;
+                    }
+                    tmp = (d - m) | (m - 1);
+                    if (tmp >= c)
+                    {
+                        d = tmp;
+                        break;
+                    }
+                }
+                m = m >> 1;
+            }
+            return b | d;
+        }
+        #endregion
+
+        #region Ranges for basic types
+        static public class Ranges
+        {
+            private static readonly Interval uint8Range = Interval.For(Byte.MinValue, Byte.MaxValue);
+            private static readonly Interval uint16Range = Interval.For(UInt16.MinValue, UInt16.MaxValue);
+            private static readonly Interval uint32Range = Interval.For(UInt32.MinValue, UInt32.MaxValue);
+            private static readonly Interval uint64Range = Interval.For(0, Rational.PlusInfinity);
+
+            private static readonly Interval int8Range = Interval.For(SByte.MinValue, SByte.MaxValue);
+            private static readonly Interval int16Range = Interval.For(Int16.MinValue, Int16.MaxValue);
+            private static readonly Interval int32Range = Interval.For(Int32.MinValue, Int32.MaxValue);
+            private static readonly Interval int64Range = Interval.For(Int64.MinValue, Int64.MaxValue);
+
+            public static Interval UInt8Range
+            {
+                get
+                {
+                    return uint8Range;
+                }
+            }
+
+            public static Interval UInt16Range
+            {
+                get
+                {
+                    return uint16Range;
+                }
+            }
+
+            public static Interval UInt32Range
+            {
+                get
+                {
+                    return uint32Range;
+                }
+            }
+
+            public static Interval UInt64Range
+            {
+                get
+                {
+                    return uint64Range;
+                }
+            }
+
+            public static Interval Int8Range
+            {
+                get
+                {
+                    return int8Range;
+                }
+            }
+
+            public static Interval Int16Range
+            {
+                get
+                {
+                    return int16Range;
+                }
+            }
+
+            public static Interval Int32Range
+            {
+                get
+                {
+                    return int32Range;
+                }
+            }
+
+            public static Interval Int64Range
+            {
+                get
+                {
+                    return int64Range;
+                }
+            }
+
+            public static Interval EnumRange<Type>(Type t, Func<Type, List<int>> enumranges)
+            {
+                Contract.Requires(enumranges != null);
+
+                Contract.Ensures(Contract.Result<Interval>() != null);
+
+                var ranges = enumranges(t);
+                if (ranges != null)
+                {
+                    var min = Int32.MaxValue;
+                    var max = Int32.MinValue;
+
+                    foreach (var x in ranges)
+                    {
+                        if (x < min)
+                        {
+                            min = x;
+                        }
+                        if (x > max)
+                        {
+                            max = x;
+                        }
+                    }
+
+                    if (min <= max)
+                    {
+                        return Interval.For(min, max);
+                    }
+                }
+
+                return Ranges.Int32Range;
+            }
+        }
+        #endregion
     }
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/Intervals_Common.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/Intervals_Common.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation of the intervals
 
@@ -21,302 +10,301 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  [ContractVerification(true)]
-  [ContractClass(typeof(IntervalBaseTypeContracts<,>))]
-  abstract public class IntervalBase<IType, NType> 
-    : IAbstractDomain
-    where IType : IntervalBase<IType, NType>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    [ContractVerification(true)]
+    [ContractClass(typeof(IntervalBaseTypeContracts<,>))]
+    abstract public class IntervalBase<IType, NType>
+      : IAbstractDomain
+      where IType : IntervalBase<IType, NType>
     {
-      Contract.Invariant(!object.Equals(this.lowerBound, null));
-      Contract.Invariant(!object.Equals(this.upperBound, null));
-    }
-    
-    protected /*readonly*/ NType lowerBound;
-    protected /*readonly*/ NType upperBound;
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(!object.Equals(this.lowerBound, null));
+            Contract.Invariant(!object.Equals(this.upperBound, null));
+        }
 
-    protected IntervalBase(NType lower, NType upper)
+        protected /*readonly*/ NType lowerBound;
+        protected /*readonly*/ NType upperBound;
+
+        protected IntervalBase(NType lower, NType upper)
+        {
+            Contract.Requires(!object.Equals(lower, null));
+            Contract.Requires(!object.Equals(upper, null));
+
+            this.lowerBound = lower;
+            this.upperBound = upper;
+        }
+
+
+        #region Common Interval helper methods
+        public NType UpperBound
+        {
+            get
+            {
+                Contract.Ensures(!object.Equals(Contract.Result<NType>(), null));
+
+                return this.upperBound;
+            }
+        }
+
+        public NType LowerBound
+        {
+            get
+            {
+                Contract.Ensures(!object.Equals(Contract.Result<NType>(), null));
+
+                return this.lowerBound;
+            }
+        }
+
+        public bool IsSingleton
+        {
+            get
+            {
+                return this.IsNormal() && lowerBound.Equals(upperBound);
+            }
+        }
+
+        /// <summary>
+        /// Is this a singleton? If it is, then its value is v
+        /// </summary>
+        /// <param name="v"></param>
+        /// <returns></returns>
+        public bool TryGetSingletonValue(out NType v)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || !(object.Equals(Contract.ValueAtReturn(out v), null)));
+
+            if (this.IsNormal && this.IsSingleton)
+            {
+                v = this.LowerBound;
+                return true;
+            }
+            else
+            {
+                v = default(NType);
+                return false;
+            }
+        }
+
+        #endregion
+
+        #region Type information
+
+        abstract public bool IsInt32 { get; }
+
+        abstract public bool IsInt64 { get; }
+
+        #endregion
+
+        #region Unknown intervals, etc.
+
+        public bool IsFinite
+        {
+            get
+            {
+                return this.IsNormal && !this.IsLowerBoundMinusInfinity && !this.IsUpperBoundPlusInfinity;
+            }
+        }
+
+        #endregion
+
+        #region To be overridden
+
+        abstract public bool IsLowerBoundMinusInfinity
+        {
+            get;
+        }
+
+        abstract public bool IsUpperBoundPlusInfinity
+        {
+            get;
+        }
+
+        abstract public bool IsNormal
+        {
+            get;
+        }
+
+        [Pure]
+        abstract public IType ToUnsigned();
+
+        [Pure]
+        abstract public bool LessEqual(IType a);
+
+        abstract public bool IsBottom { get; }
+
+        abstract public bool IsTop { get; }
+
+        abstract public IType Bottom { get; }
+
+        abstract public IType Top { get; }
+
+        [Pure]
+        abstract public IType Join(IType a);
+
+        [Pure]
+        abstract public IType Meet(IType a);
+
+        [Pure]
+        abstract public IType Widening(IType a);
+
+        [Pure]
+        abstract public IType DuplicateMe();
+
+        #endregion
+
+        #region Code to factor out the interface calls
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get
+            {
+                return this.Bottom;
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get
+            {
+                return this.Top;
+            }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            return this.LessEqual((IType)a);
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            return this.Join((IType)a);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            return this.Meet((IType)a);
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain/*!*/ prev)
+        {
+            return this.Widening((IType)prev);
+        }
+        #endregion
+
+        #region To<>
+
+        public virtual T To<T>(IFactory<T> factory)
+        {
+            T varName;
+            if (this.IsBottom)
+            {
+                return factory.Constant(false);
+            }
+            else if (this.IsTop)
+            {
+                return factory.Constant(true);
+            }
+            else if (factory.TryGetName(out varName))
+            {
+            }
+
+            return factory.Constant(true);
+        }
+
+        public override string ToString()
+        {
+            return "[" + this.LowerBound + ", " + this.upperBound + "]" + (this.IsBottom ? "_|_" : "");
+        }
+
+        public object Clone()
+        {
+            return this.DuplicateMe();
+        }
+        #endregion
+    }
+
+
+    [ContractClassFor(typeof(IntervalBase<,>))]
+    internal abstract class IntervalBaseTypeContracts<IType, NType>
+      : IntervalBase<IType, NType>
+      where IType : IntervalBase<IType, NType>
     {
-      Contract.Requires(!object.Equals(lower, null));
-      Contract.Requires(!object.Equals(upper, null));
+        public IntervalBaseTypeContracts(NType lower, NType upper) : base(lower, upper) { }
 
-      this.lowerBound = lower;
-      this.upperBound = upper;
+        abstract public override bool IsInt32 { get; }
+
+        abstract public override bool IsInt64 { get; }
+
+        abstract public override bool IsLowerBoundMinusInfinity { get; }
+
+        abstract public override bool IsUpperBoundPlusInfinity { get; }
+
+        abstract public override bool IsNormal { get; }
+
+        public override bool LessEqual(IType a)
+        {
+            Contract.Requires(a != null);
+
+            return default(bool);
+        }
+
+        abstract public override bool IsBottom { get; }
+
+        abstract public override bool IsTop { get; }
+
+        public override IType Bottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+
+                return default(IType);
+            }
+        }
+
+        public override IType Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IType>() != null);
+
+                return default(IType);
+            }
+        }
+
+        public override IType Join(IType a)
+        {
+            Contract.Requires(a != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Meet(IType a)
+        {
+            Contract.Requires(a != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType Widening(IType a)
+        {
+            Contract.Requires(a != null);
+
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
+
+        public override IType DuplicateMe()
+        {
+            Contract.Ensures(Contract.Result<IType>() != null);
+
+            return default(IType);
+        }
     }
-
-
-    #region Common Interval helper methods
-    public NType UpperBound
-    {
-      get
-      {
-        Contract.Ensures(!object.Equals(Contract.Result<NType>(), null));
-
-        return this.upperBound;
-      }
-    }
-
-    public NType LowerBound
-    {
-      get
-      {
-        Contract.Ensures(!object.Equals(Contract.Result<NType>(), null));
-
-        return this.lowerBound;
-      }
-    }
-
-    public bool IsSingleton
-    {
-      get
-      {
-        return this.IsNormal() && lowerBound.Equals(upperBound);
-      }
-    }
-
-    /// <summary>
-    /// Is this a singleton? If it is, then its value is v
-    /// </summary>
-    /// <param name="v"></param>
-    /// <returns></returns>
-    public bool TryGetSingletonValue(out NType v)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || !(object.Equals(Contract.ValueAtReturn(out v), null)));
-
-      if (this.IsNormal && this.IsSingleton)
-      {
-        v = this.LowerBound;
-        return true;
-      }
-      else
-      {
-        v = default(NType);
-        return false;
-      }
-    }
-
-    #endregion
-
-    #region Type information
-
-    abstract public bool IsInt32 { get; }
-
-    abstract public bool IsInt64 { get; }
-
-    #endregion
-
-    #region Unknown intervals, etc.
-
-    public bool IsFinite
-    {
-      get
-      {
-        return this.IsNormal && !this.IsLowerBoundMinusInfinity && !this.IsUpperBoundPlusInfinity;
-      }
-    }
-
-    #endregion
-
-    #region To be overridden
-
-    abstract public bool IsLowerBoundMinusInfinity
-    {
-      get;
-    }
-
-    abstract public bool IsUpperBoundPlusInfinity
-    {
-      get;
-    }
-
-    abstract public bool IsNormal
-    {
-      get;
-    }
-
-    [Pure]
-    abstract public IType ToUnsigned();
-
-    [Pure]
-    abstract public bool LessEqual(IType a);
-
-    abstract public bool IsBottom { get; }
-
-    abstract public bool IsTop{ get; }
-
-    abstract public IType Bottom { get; }
-
-    abstract public IType Top { get; }
-
-    [Pure]
-    abstract public IType Join(IType a);
-
-    [Pure]
-    abstract public IType Meet(IType a);
-
-    [Pure]
-    abstract public IType Widening(IType a);
-
-    [Pure]
-    abstract public IType DuplicateMe();
-
-    #endregion
-
-    #region Code to factor out the interface calls
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get
-      {
-        return this.Bottom;
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get
-      {
-        return this.Top;
-      }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      return this.LessEqual((IType)a);
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      return this.Join((IType)a);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      return this.Meet((IType)a);
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain/*!*/ prev)
-    {
-      return this.Widening((IType)prev);
-    }
-    #endregion
-
-    #region To<>
-
-    public virtual T To<T>(IFactory<T> factory)
-    {
-      T varName;
-      if (this.IsBottom)
-      {
-        return factory.Constant(false);
-      }
-      else if (this.IsTop)
-      {
-        return factory.Constant(true);
-      }
-      else if(factory.TryGetName(out varName))
-      {
-      }
-
-      return factory.Constant(true);
-    }
-
-    public override string ToString()
-    {
-      return "[" + this.LowerBound+ ", " + this.upperBound+ "]" + (this.IsBottom ? "_|_" : "");
-    }
-
-    public object Clone()
-    {
-      return this.DuplicateMe();
-    }
-    #endregion
-  }
-
-
-  [ContractClassFor(typeof(IntervalBase<,>))]
-  abstract class IntervalBaseTypeContracts<IType, NType>
-    : IntervalBase<IType, NType>
-    where IType : IntervalBase<IType, NType>
-  {
-
-    public IntervalBaseTypeContracts(NType lower, NType upper) : base(lower, upper) { }
-
-    abstract public override bool IsInt32 { get; }
-
-    abstract public override bool IsInt64 { get; }
-
-    abstract public override bool IsLowerBoundMinusInfinity { get; }
-
-    abstract public override bool IsUpperBoundPlusInfinity { get; }
-
-    abstract public override bool IsNormal { get; }
-
-    public override bool LessEqual(IType a)
-    {
-      Contract.Requires(a != null);
-
-      return default(bool);
-    }
-
-    abstract public override bool IsBottom { get; }
-
-    abstract public override bool IsTop { get; }
-
-    public override IType Bottom
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-
-        return default(IType);        
-      }
-    }
-
-    public override IType Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IType>() != null);
-
-        return default(IType);
-      }
-    }
-
-    public override IType Join(IType a)
-    {
-      Contract.Requires(a != null);
-
-        Contract.Ensures(Contract.Result<IType>() != null);
-
-        return default(IType);        
-    }
-
-    public override IType Meet(IType a)
-    {
-      Contract.Requires(a != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override IType Widening(IType a)
-    {
-      Contract.Requires(a != null);
-
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-
-    public override IType DuplicateMe()
-    {      
-      Contract.Ensures(Contract.Result<IType>() != null);
-
-      return default(IType);
-    }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/Intervals_IEEE754.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Intervals/Intervals_IEEE754.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using Microsoft.Research.AbstractDomains;
@@ -21,1954 +10,1950 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// An implementation of Interval sound w.r.t. IEEE floating points
-  /// </summary>
-  public sealed class Interval_IEEE754 
-    : IntervalBase<Interval_IEEE754, Double>
-  {
-    #region The kind of this Interval_IEEE754
-    private enum Kind
-    {
-      // ** Special cases
-      NotInizialized,    // F: This case is not needed in .NET, but we keep it to make easier the sharing of code with the JScriptAI
-      Empty,             // lower > upper
-      Top,               // lower == -oo, top == +oo
-      TopNotNaN,         // any value, but not NaN
-      IncludesNaN,       // lower.IsNaN || upper.IsNaN 
-      // ** Normal cases
-      Mixed,             // lower < 0, upper > 0
-      Zero,              // lower == upper == 0
-      Positive_Zero,     // lower == 0, upper > 0
-      Positive_One,      // lower > 0, upper > 0
-      Negative_Zero,     // lower < 0, upper == 0
-      Negative_One       // lower < 0, upper < 0
-    };
-
-    #endregion
-
-    #region Statics
-    public readonly static Interval_IEEE754 NegativeInterval_IEEE754;
-    public readonly static Interval_IEEE754 ZeroInterval_IEEE754;
-    public readonly static Interval_IEEE754 OneInterval_IEEE754;
-
-    private readonly static Interval_IEEE754 cachedTop, cachedTopNotNaN, cachedBottom, cachedPositiveInterval, cachedNegativeInterval;
-
-    static Interval_IEEE754()
-    {
-      cachedTop = new Interval_IEEE754(Kind.Top, Double.NegativeInfinity, Double.PositiveInfinity);
-      cachedTopNotNaN = new Interval_IEEE754(Kind.TopNotNaN, Double.NegativeInfinity, Double.PositiveInfinity);
-      cachedBottom = new Interval_IEEE754(Kind.Empty, 2.78, -2.78);
-      cachedPositiveInterval = new Interval_IEEE754(Kind.Positive_Zero, FloatingPointExtensions.NegativeZero, Double.PositiveInfinity);      
-
-      cachedNegativeInterval = NegativeInterval_IEEE754 = new Interval_IEEE754(Kind.Negative_Zero, Double.NegativeInfinity, FloatingPointExtensions.PositiveZero);
-      ZeroInterval_IEEE754 = new Interval_IEEE754(Kind.Zero, FloatingPointExtensions.NegativeZero, FloatingPointExtensions.PositiveZero);
-      OneInterval_IEEE754 = new Interval_IEEE754(Kind.Positive_One, 1.0);
-    }
-    #endregion
-
-    #region Static
-
-    public static Interval_IEEE754 UnknownInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-        // It will become a postcondition
-        Contract.Assert(cachedTop != null);
-        return cachedTop;
-      }
-    }
-
-    public static Interval_IEEE754 UnknownIntervalNotNaN
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval_IEEE754 >() != null);
-
-        return cachedTopNotNaN;
-      }
-    }
-
-    public static Interval_IEEE754 UnreachedInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-        Contract.Assert(cachedBottom != null);
-
-        return cachedBottom;
-      }
-    }
-
     /// <summary>
-    /// The interval [0, +oo]
+    /// An implementation of Interval sound w.r.t. IEEE floating points
     /// </summary>
-    public static Interval_IEEE754 PositiveInterval
+    public sealed class Interval_IEEE754
+      : IntervalBase<Interval_IEEE754, Double>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval_IEEE754 >() != null);
-
-        Contract.Assert(cachedPositiveInterval != null);
-        return cachedPositiveInterval;
-      }
-    }
-
-    public static Interval_IEEE754 NegativeInterval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Interval_IEEE754 >() != null);
-
-        return cachedNegativeInterval;
-      }
-    }
-    #endregion
-
-    #region Private state
-
-    readonly private Kind kind;
-
-    #endregion
-
-    #region Constructors
-
-    private Interval_IEEE754(Kind kind, Double lower, Double upper)
-      : base(lower, upper)
-    {
-      Contract.Assume(IsConsistent(kind, lower, upper));
-
-      this.kind = kind;
-     // this.lowerBound = lower;
-     // this.upperBound = upper;
-    }
-
-    private Interval_IEEE754(Kind kind, Double constant)
-      : base(constant, constant)
-    {
-      // As it is a constant, we expect the most precise Kind here
-      Contract.Assume(IsConsistent(kind, constant));
-
-      this.kind = kind;
-
-      switch (this.kind)
-      {
-        case Kind.Empty:
-          this.lowerBound = 45.0;
-          this.upperBound = -44.0;
-          break;
-
-        case Kind.IncludesNaN:
-        case Kind.Mixed:
-          this.lowerBound = this.upperBound = constant;
-          break;
-
-        case Kind.Negative_One:
-        case Kind.Negative_Zero:
-        case Kind.Positive_One:
-        case Kind.Positive_Zero:
-          this.lowerBound = constant;
-          this.upperBound = constant;
-          break;
-
-        case Kind.NotInizialized:
-          this.lowerBound = this.upperBound = default(Double);
-          break;
-
-        case Kind.Top:
-        case Kind.TopNotNaN:
-          this.lowerBound = Double.NegativeInfinity;
-          this.upperBound = Double.PositiveInfinity;
-          break;
-
-        case Kind.Zero:
-          this.lowerBound = FloatingPointExtensions.NegativeZero;
-          this.upperBound = FloatingPointExtensions.PositiveZero;
-          break;
-
-        default:
-          ShouldBeUnreachable<int>();
-          break;
-      }
-    }
-
-    /// <summary>
-    /// The Interval_IEEE754 standing for a value that is not initialized.
-    /// This is a special case, and we want to call it just with false
-    /// </summary>
-    /// <param name="initialized">Should be false!</param>
-    private Interval_IEEE754(bool initialized)
-      : base(Double.NegativeInfinity, Double.PositiveInfinity)
-    {
-      Contract.Requires(!initialized);
-
-      this.kind = !initialized ? Kind.NotInizialized : Kind.Top;
-    }
-
-    #endregion
-
-    #region Construct an Interval_IEEE754 for Int* and UInt* types
-    /// <summary>
-    /// Construct an Interval_IEEE754 for an Int* type
-    /// </summary>
-    static public Interval_IEEE754 For(Int64 lower, Int64 upper)
-    {
-      #region Case 0: Check for constants
-      if (lower == upper)
-      {
-        // TODO F: check for Int64 corner cases 
-
-        var k = lower;
-        if (k == 0)
+        #region The kind of this Interval_IEEE754
+        private enum Kind
         {
-          return new Interval_IEEE754(Kind.Zero, k);
-        }
-        else if (k > 0)
-        {
-          return new Interval_IEEE754(Kind.Positive_One, k);
-        }
-        else if (k < 0)
-        {
-          return new Interval_IEEE754(Kind.Negative_One, k);
-        }
+            // ** Special cases
+            NotInizialized,    // F: This case is not needed in .NET, but we keep it to make easier the sharing of code with the JScriptAI
+            Empty,             // lower > upper
+            Top,               // lower == -oo, top == +oo
+            TopNotNaN,         // any value, but not NaN
+            IncludesNaN,       // lower.IsNaN || upper.IsNaN 
+                               // ** Normal cases
+            Mixed,             // lower < 0, upper > 0
+            Zero,              // lower == upper == 0
+            Positive_Zero,     // lower == 0, upper > 0
+            Positive_One,      // lower > 0, upper > 0
+            Negative_Zero,     // lower < 0, upper == 0
+            Negative_One       // lower < 0, upper < 0
+        };
 
-        return ShouldBeUnreachable<Interval_IEEE754>();
-      }
-      #endregion
-
-      #region Case 1 : Check for Emptyness
-      if (lower > upper)
-      {
-        return new Interval_IEEE754(Kind.Empty, +3.14, -3.14);
-      }
-      #endregion
-
-      #region Case 2 : Check for Top
-
-      if (lower == Int64.MinValue && upper == Int64.MaxValue)
-      {
-        return new Interval_IEEE754(Kind.Empty, Double.NegativeInfinity, Double.PositiveInfinity);
-      }
-      #endregion
-
-      #region Case 3 : The other cases
-      var sign_lower = Math.Sign(lower);
-      var sign_upper = Math.Sign(upper);
-
-      switch (sign_lower)
-      {
-        // lower < 0
-        case -1:
-          switch (sign_upper)
-          {
-            // upper < 0
-            case -1:
-              return new Interval_IEEE754(Kind.Negative_One, lower, upper);
-
-            // upper == 0
-            case 0:
-              return new Interval_IEEE754(Kind.Negative_Zero, lower, upper);
-
-            // upper > 0
-            case +1:
-              return new Interval_IEEE754(Kind.Mixed, lower, upper);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        // lower == 0
-        case 0:
-          switch (sign_upper)
-          {
-            // upper < 0
-            case -1:
-              return new Interval_IEEE754(Kind.Empty, lower, upper);
-
-            // upper == 0
-            case 0:
-              return new Interval_IEEE754(Kind.Zero, 0.0); // We set 0-
-
-            // upper > 0
-            case +1:
-              return new Interval_IEEE754(Kind.Positive_Zero, lower, upper);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        // lower > 0
-        case +1:
-          switch (sign_upper)
-          {
-            // upper < 0
-            // upper == 0
-            case -1:
-            case 0:
-              return new Interval_IEEE754(Kind.Empty, lower, upper);
-
-            // upper > 0
-            case +1:
-              return new Interval_IEEE754(Kind.Positive_One, lower, upper);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        default:
-          return ShouldBeUnreachable<Interval_IEEE754>();
-      }
-
-
-      #endregion
-    }
-
-    static public Interval_IEEE754 For(Int64 r)
-    {
-      return For((Int64)r, (Int64)r);
-    }
-
-    static public Interval_IEEE754 For(Byte b)
-    {
-      // We know we have no problems in representing bytes
-      return For((Int64)b, (Int64)b);
-    }
-
-    static public Interval_IEEE754 For(SByte sByte)
-    {
-      // We know we have no problems in representing bytes
-      return For((Int64)sByte, (Int64)sByte);
-    }
-
-    static public Interval_IEEE754 For(UInt16 u16)
-    {
-      // We know we have no problems in representing uint16
-      return For((Int64)u16, (Int64)u16);
-    }
-
-    static public Interval_IEEE754 For(UInt32 u32)
-    {
-      // We know we have no problems in representing uint32
-      return For((Int64)u32, (Int64)u32);
-    }
-
-    static public Interval_IEEE754 For(Int16 i16)
-    {
-      // We know we have no problems in representing int16
-      return For((Int64)i16, (Int64)i16);
-    }
-
-    static public Interval_IEEE754 For(Int32 i32)
-    {
-      // We know we have no problems in representing int32
-      return For((Int64)i32, (Int64)i32);
-    }
-    #endregion
-
-    #region Construct an Interval_IEEE754 from two Doubles
-    static public Interval_IEEE754 For(Double lower, Double upper)
-    {
-      #region Case 0: Check for constants
-      if (lower.Equals(upper))
-      {
-        // TODO F: check for Int64 corner cases 
-
-        var k = lower;
-
-        if (Double.IsNaN(k))
-        {
-          return new Interval_IEEE754(Kind.IncludesNaN, k);
-        }
-        if (k == 0)
-        {
-          return new Interval_IEEE754(Kind.Zero, k);
-        }
-        if (k > 0)
-        {
-          return new Interval_IEEE754(Kind.Positive_One, k);
-        }
-        if (k < 0)
-        {
-          return new Interval_IEEE754(Kind.Negative_One, k);
-        }
-
-        return ShouldBeUnreachable<Interval_IEEE754>();
-      }
-      #endregion
-
-      #region Case 1 : One the two operands is NaN
-      if (Double.IsNaN(lower) || Double.IsNaN(upper))
-      {
-        return new Interval_IEEE754(Kind.IncludesNaN, lower, upper);
-      }
-      #endregion
-
-      #region Case 2 : Check for Emptyness
-      if (lower > upper)
-      {
-        return new Interval_IEEE754(Kind.Empty, +3.14, -3.14);
-      }
-      #endregion
-
-      #region Case 3 : Check for Top
-
-      if (lower == Double.NegativeInfinity && upper == Double.PositiveInfinity)
-      {
-        return new Interval_IEEE754(Kind.Top, Double.NegativeInfinity, Double.PositiveInfinity);
-      }
-      #endregion
-
-      #region Case 3 : The other cases
-      var sign_lower = Math.Sign(lower);
-      var sign_upper = Math.Sign(upper);
-
-      switch (sign_lower)
-      {
-        // lower < 0
-        case -1:
-          switch (sign_upper)
-          {
-            // upper < 0
-            case -1:
-              return new Interval_IEEE754(Kind.Negative_One, lower, upper);
-
-            // upper == 0
-            case 0:
-              return new Interval_IEEE754(Kind.Negative_Zero, lower, upper);
-
-            // upper > 0
-            case +1:
-              return new Interval_IEEE754(Kind.Mixed, lower, upper);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        // lower == 0
-        case 0:
-          switch (sign_upper)
-          {
-            // upper < 0
-            case -1:
-              return new Interval_IEEE754(Kind.Empty, lower, upper);
-
-            // upper == 0
-            case 0:
-              return new Interval_IEEE754(Kind.Zero, upper);
-
-            // upper > 0
-            case +1:
-              return new Interval_IEEE754(Kind.Positive_Zero, lower, upper);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        // lower > 0
-        case +1:
-          switch (sign_upper)
-          {
-            // upper < 0
-            // upper == 0
-            case -1:
-            case 0:
-              return new Interval_IEEE754(Kind.Empty, lower, upper);
-
-            // upper > 0
-            case +1:
-              return new Interval_IEEE754(Kind.Positive_One, lower, upper);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        default:
-          return ShouldBeUnreachable<Interval_IEEE754>();
-      }
-
-      #endregion
-    }
-
-    static public Interval_IEEE754 For(Double d)
-    {
-      return For(d, d);
-    }
-
-    static public Interval_IEEE754 For(Single s)
-    {
-      return For((Double)s, (Double)s);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    override public bool IsTop
-    {
-      get { return this.kind == Kind.Top; }
-    }
-
-    public bool IsTopButNotNaN
-    {
-      get { return this.kind == Kind.TopNotNaN; }
-    }
-
-    override public bool IsBottom
-    {
-      get { return this.kind == Kind.Empty; }
-    }
-
-    public override Interval_IEEE754 Bottom
-    {
-      get { return Interval_IEEE754.cachedBottom;  }
-    }
-
-    public override Interval_IEEE754 Top
-    {
-      get { return Interval_IEEE754.cachedTop; }
-    }
-
-    override public bool LessEqual(Interval_IEEE754 other)
-    {
-      if (AreEqual(this, other))
-        return true;
-
-      if (this.kind == Kind.Empty)
-      {
-        return true;
-      }
-
-      switch (other.kind)
-      {
-        case Kind.Empty:
-        case Kind.IncludesNaN:
-          return false;
-
-        case Kind.NotInizialized:
-          return this.kind == Kind.NotInizialized;
-
-        case Kind.Top:
-          return true;
-
-        case Kind.TopNotNaN:
-          return this.kind != Kind.IncludesNaN && this.kind != Kind.Top;
-      }
-
-      // At this point we know other != Empty, IncludedNaN, TopNotNaN, Top
-      switch (this.kind)
-      {
-        case Kind.IncludesNaN:
-          return false;
-
-        case Kind.Mixed:
-        case Kind.Negative_One:
-        case Kind.Negative_Zero:
-        case Kind.NotInizialized:
-        case Kind.Positive_One:
-        case Kind.Positive_Zero:
-          return this.lowerBound >= other.lowerBound && this.upperBound <= other.upperBound;
-
-        case Kind.Top:
-          return false;
-
-        case Kind.TopNotNaN:
-          Contract.Assert(other.kind != Kind.Top);
-          return other.kind != Kind.IncludesNaN;
- 
-        case Kind.Zero:
-          return other.lowerBound <= 0;
-
-        default:
-          return ShouldBeUnreachable<bool>();
-      }
-    }
-
-    static private bool AreEqual(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      if (object.ReferenceEquals(left, right))
-      {
-        return true;
-      }
-
-      if (left.kind == right.kind && left.lowerBound.Equals(right.lowerBound) && left.upperBound.Equals(right.upperBound))
-      {
-        return true;
-      }
-
-      return false;
-    }
-
-    override public Interval_IEEE754 Join(Interval_IEEE754 other)
-    {
-      Interval_IEEE754 value;
-      if (IsSpecialCaseForJoin(this, other, out value))
-      {
-        return value;
-      }
-
-      var low = Math.Min(this.lowerBound, other.lowerBound);
-      var upp = Math.Max(this.upperBound, other.upperBound);
-
-      return new Interval_IEEE754(InferKind(low, upp), low, upp);
-    }
-
-
-    override public Interval_IEEE754 Meet(Interval_IEEE754 other)
-    {
-      Interval_IEEE754 value;
-      if (IsSpecialCaseForMeet(this, other, out value))
-      {
-        return value;
-      }
-
-      var low = Math.Max(this.lowerBound, other.lowerBound);
-      var upp = Math.Min(this.upperBound, other.upperBound);
-
-      return new Interval_IEEE754(InferKind(low, upp), low, upp);
-    }
-
-    override public Interval_IEEE754 Widening(Interval_IEEE754 prev)
-    {
-      Interval_IEEE754 value;
-      if (IsSpecialCaseForWidening(this, prev, out value))
-      {
-        return value;
-      }
-
-      var low = this.lowerBound < prev.lowerBound ? ThresholdDB.GetPrevious(this.lowerBound) : prev.lowerBound;
-      var upp = this.upperBound > prev.upperBound ? ThresholdDB.GetNext(this.upperBound) : prev.upperBound;
-
-      return new Interval_IEEE754(InferKind(low, upp), low, upp);
-    }
-
-    override public Interval_IEEE754 DuplicateMe()
-    {
-      return new Interval_IEEE754(this.kind, this.lowerBound, this.upperBound);
-    }
-
-    #endregion
-
-    #region Common Tools
-
-    public bool IsNotNaN
-    {
-      get
-      {
-        switch (this.kind)
-        {
-          case Kind.Empty:
-          case Kind.IncludesNaN:
-          case Kind.NotInizialized:
-          case Kind.Top:
-            return false;
-
-          case Kind.TopNotNaN:
-          case Kind.Mixed:
-          case Kind.Negative_One:
-          case Kind.Negative_Zero:
-          case Kind.Positive_One:
-          case Kind.Positive_Zero:
-          case Kind.Zero:
-            return true;
-
-          default:
-            return false;
-        }
-      }
-    }
-
-    public override bool IsNormal
-    {
-      get 
-      {
-        switch (this.kind)
-        {
-          case Kind.Empty:
-          case Kind.IncludesNaN:
-          case Kind.NotInizialized:
-          case Kind.Top:
-          case Kind.TopNotNaN:
-            return false;
-
-          case Kind.Mixed:
-          case Kind.Negative_One:
-          case Kind.Negative_Zero:
-          case Kind.Positive_One:
-          case Kind.Positive_Zero:
-          case Kind.Zero:
-            return this.lowerBound <= this.upperBound;
-
-          default:
-            return ShouldBeUnreachable<bool>(this.kind.ToString());
-        }
-      }
-    }
-
-    override public bool IsLowerBoundMinusInfinity
-    {
-      get
-      {
-        return Double.IsNegativeInfinity(this.lowerBound);
-      }
-    }
-
-    override public bool IsUpperBoundPlusInfinity
-    {
-      get
-      {
-        return Double.IsPositiveInfinity(this.upperBound);
-      }
-    }
-
-    /// <returns>
-    /// true iff <code>x</code> is not included in this Interval_IEEE754
-    /// </returns>
-    [ContractVerification(true)]
-    [Pure]
-    public bool DoesNotInclude(double x)
-    {
-      switch (this.kind)
-      {
-        case Kind.Empty:
-        case Kind.IncludesNaN:
-        case Kind.NotInizialized:
-        case Kind.Top:
-          return false;
-
-        case Kind.TopNotNaN:
-          return !double.IsNaN(x);
-
-        case Kind.Mixed:
-        case Kind.Negative_One:
-        case Kind.Negative_Zero:
-        case Kind.Positive_One:
-        case Kind.Positive_Zero:
-        case Kind.Zero:
-          return x < this.lowerBound || x > this.upperBound;
-
-        default:
-          return ShouldBeUnreachable<bool>();
-      }
-    }
-
-    #endregion
-
-    #region Arithmetic Operations over Interval_IEEE754s
-
-    [ContractVerification(true)]
-    [Pure]
-    static public Interval_IEEE754 operator +(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      Interval_IEEE754 value;
-      if (PropagateSpecialCases(left, right, out value))
-      {
-        return value;
-      }
-
-      if (left.IsTopButNotNaN || right.IsTopButNotNaN)
-      {
-        // We can get e.g. +oo + -oo
-        return UnknownInterval;
-      }
-
-      var low = FloatingPointExtensions.Add_Low(left.lowerBound, right.lowerBound);
-      var upp = FloatingPointExtensions.Add_Up(left.upperBound, right.upperBound);
-
-      return new Interval_IEEE754(InferKind(low, upp), low, upp);
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    static public Interval_IEEE754 operator -(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      Interval_IEEE754 value;
-      if (PropagateSpecialCases(left, right, out value))
-      {
-        return value;
-      }
-
-      // oo - oo      
-      if (Double.IsInfinity(left.UpperBound) && Double.IsInfinity(right.UpperBound))
-      {
-        // It can be NaN
-        return UnknownInterval;
-      }
-
-      // -oo + oo
-      if(Double.IsInfinity(left.lowerBound) && Double.IsInfinity(right.lowerBound))
-      {
-        // It can be NaN
-        return UnknownInterval;
-      }
-
-      var low = FloatingPointExtensions.Sub_Low(left.lowerBound, right.upperBound);
-      var upp = FloatingPointExtensions.Sub_Up(left.upperBound, right.lowerBound);
-
-        // To handle cases a 0 - inf
-        if (upp < low)
-        {
-          var tmp = upp;
-          upp = low;
-          low = tmp;
-        }
-        return new Interval_IEEE754(InferKind(low, upp), low, upp);
-      
-    }
-
-    [ContractVerification(false)]
-    [Pure]
-    static public Interval_IEEE754 operator *(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      Interval_IEEE754 value;
-      if (PropagateSpecialCases(left, right, out value))
-      {
-        return value;
-      }
-
-      if (left.kind == Kind.IncludesNaN || right.kind == Kind.IncludesNaN)
-      {
-        return new Interval_IEEE754(Kind.IncludesNaN, Double.NaN);
-      }
-
-      if (left.kind == Kind.Zero)
-      {
-        return left;
-      }
-
-      if (right.kind == Kind.Zero)
-      {
-        return right;
-      }
-
-      if (left.IsTopButNotNaN || right.IsTopButNotNaN)
-      {
-        // it can be Nan. We should check for infinities
-        return UnknownInterval;
-      }
-
-      Double low, upp;
-
-      var A = left.lowerBound;
-      var B = left.upperBound;
-      var C = right.lowerBound;
-      var D = right.upperBound;
-
-      switch (left.kind)
-      {
-        #region All the normal cases
-        case Kind.Mixed:
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.Mul_Low(B, C);
-              upp = FloatingPointExtensions.Mul_Up(A, C);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Mixed:
-              low = Math.Min(FloatingPointExtensions.Mul_Low(A, D), FloatingPointExtensions.Mul_Low(B, C));
-              upp = Math.Max(FloatingPointExtensions.Mul_Up(B, D), FloatingPointExtensions.Mul_Up(A, C));
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.Mul_Low(A, D);
-              upp = FloatingPointExtensions.Mul_Up(B, D);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        case Kind.Negative_One:
-        case Kind.Negative_Zero:
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.Mul_Low(B, D);
-              upp = FloatingPointExtensions.Mul_Up(A, C);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Mixed:
-              low = FloatingPointExtensions.Mul_Low(A, D);
-              upp = FloatingPointExtensions.Mul_Up(A, C);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.Mul_Low(A, D);
-              upp = FloatingPointExtensions.Mul_Up(B, C);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        case Kind.Positive_One:
-        case Kind.Positive_Zero:
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.Mul_Low(B, C);
-              upp = FloatingPointExtensions.Mul_Up(A, D);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-
-            case Kind.Mixed:
-              low = FloatingPointExtensions.Mul_Low(B, C);
-              upp = FloatingPointExtensions.Mul_Up(B, D);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.Mul_Low(A, C);
-              upp = FloatingPointExtensions.Mul_Up(B, D);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        case Kind.Zero:
-        case Kind.Top:
-        case Kind.NotInizialized:
-        case Kind.Empty:
-          return ShouldBeUnreachable<Interval_IEEE754>("this case is already handled");
-
-        default:
-          return ShouldBeUnreachable<Interval_IEEE754>("unknown case");
         #endregion
-      }
+
+        #region Statics
+        public readonly static Interval_IEEE754 NegativeInterval_IEEE754;
+        public readonly static Interval_IEEE754 ZeroInterval_IEEE754;
+        public readonly static Interval_IEEE754 OneInterval_IEEE754;
+
+        private readonly static Interval_IEEE754 cachedTop, cachedTopNotNaN, cachedBottom, cachedPositiveInterval, cachedNegativeInterval;
+
+        static Interval_IEEE754()
+        {
+            cachedTop = new Interval_IEEE754(Kind.Top, Double.NegativeInfinity, Double.PositiveInfinity);
+            cachedTopNotNaN = new Interval_IEEE754(Kind.TopNotNaN, Double.NegativeInfinity, Double.PositiveInfinity);
+            cachedBottom = new Interval_IEEE754(Kind.Empty, 2.78, -2.78);
+            cachedPositiveInterval = new Interval_IEEE754(Kind.Positive_Zero, FloatingPointExtensions.NegativeZero, Double.PositiveInfinity);
+
+            cachedNegativeInterval = NegativeInterval_IEEE754 = new Interval_IEEE754(Kind.Negative_Zero, Double.NegativeInfinity, FloatingPointExtensions.PositiveZero);
+            ZeroInterval_IEEE754 = new Interval_IEEE754(Kind.Zero, FloatingPointExtensions.NegativeZero, FloatingPointExtensions.PositiveZero);
+            OneInterval_IEEE754 = new Interval_IEEE754(Kind.Positive_One, 1.0);
+        }
+        #endregion
+
+        #region Static
+
+        public static Interval_IEEE754 UnknownInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+                // It will become a postcondition
+                Contract.Assert(cachedTop != null);
+                return cachedTop;
+            }
+        }
+
+        public static Interval_IEEE754 UnknownIntervalNotNaN
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+                return cachedTopNotNaN;
+            }
+        }
+
+        public static Interval_IEEE754 UnreachedInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+                Contract.Assert(cachedBottom != null);
+
+                return cachedBottom;
+            }
+        }
+
+        /// <summary>
+        /// The interval [0, +oo]
+        /// </summary>
+        public static Interval_IEEE754 PositiveInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+                Contract.Assert(cachedPositiveInterval != null);
+                return cachedPositiveInterval;
+            }
+        }
+
+        public static Interval_IEEE754 NegativeInterval
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+                return cachedNegativeInterval;
+            }
+        }
+        #endregion
+
+        #region Private state
+
+        readonly private Kind kind;
+
+        #endregion
+
+        #region Constructors
+
+        private Interval_IEEE754(Kind kind, Double lower, Double upper)
+          : base(lower, upper)
+        {
+            Contract.Assume(IsConsistent(kind, lower, upper));
+
+            this.kind = kind;
+            // this.lowerBound = lower;
+            // this.upperBound = upper;
+        }
+
+        private Interval_IEEE754(Kind kind, Double constant)
+          : base(constant, constant)
+        {
+            // As it is a constant, we expect the most precise Kind here
+            Contract.Assume(IsConsistent(kind, constant));
+
+            this.kind = kind;
+
+            switch (this.kind)
+            {
+                case Kind.Empty:
+                    this.lowerBound = 45.0;
+                    this.upperBound = -44.0;
+                    break;
+
+                case Kind.IncludesNaN:
+                case Kind.Mixed:
+                    this.lowerBound = this.upperBound = constant;
+                    break;
+
+                case Kind.Negative_One:
+                case Kind.Negative_Zero:
+                case Kind.Positive_One:
+                case Kind.Positive_Zero:
+                    this.lowerBound = constant;
+                    this.upperBound = constant;
+                    break;
+
+                case Kind.NotInizialized:
+                    this.lowerBound = this.upperBound = default(Double);
+                    break;
+
+                case Kind.Top:
+                case Kind.TopNotNaN:
+                    this.lowerBound = Double.NegativeInfinity;
+                    this.upperBound = Double.PositiveInfinity;
+                    break;
+
+                case Kind.Zero:
+                    this.lowerBound = FloatingPointExtensions.NegativeZero;
+                    this.upperBound = FloatingPointExtensions.PositiveZero;
+                    break;
+
+                default:
+                    ShouldBeUnreachable<int>();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// The Interval_IEEE754 standing for a value that is not initialized.
+        /// This is a special case, and we want to call it just with false
+        /// </summary>
+        /// <param name="initialized">Should be false!</param>
+        private Interval_IEEE754(bool initialized)
+          : base(Double.NegativeInfinity, Double.PositiveInfinity)
+        {
+            Contract.Requires(!initialized);
+
+            kind = !initialized ? Kind.NotInizialized : Kind.Top;
+        }
+
+        #endregion
+
+        #region Construct an Interval_IEEE754 for Int* and UInt* types
+        /// <summary>
+        /// Construct an Interval_IEEE754 for an Int* type
+        /// </summary>
+        static public Interval_IEEE754 For(Int64 lower, Int64 upper)
+        {
+            #region Case 0: Check for constants
+            if (lower == upper)
+            {
+                // TODO F: check for Int64 corner cases 
+
+                var k = lower;
+                if (k == 0)
+                {
+                    return new Interval_IEEE754(Kind.Zero, k);
+                }
+                else if (k > 0)
+                {
+                    return new Interval_IEEE754(Kind.Positive_One, k);
+                }
+                else if (k < 0)
+                {
+                    return new Interval_IEEE754(Kind.Negative_One, k);
+                }
+
+                return ShouldBeUnreachable<Interval_IEEE754>();
+            }
+            #endregion
+
+            #region Case 1 : Check for Emptyness
+            if (lower > upper)
+            {
+                return new Interval_IEEE754(Kind.Empty, +3.14, -3.14);
+            }
+            #endregion
+
+            #region Case 2 : Check for Top
+
+            if (lower == Int64.MinValue && upper == Int64.MaxValue)
+            {
+                return new Interval_IEEE754(Kind.Empty, Double.NegativeInfinity, Double.PositiveInfinity);
+            }
+            #endregion
+
+            #region Case 3 : The other cases
+            var sign_lower = Math.Sign(lower);
+            var sign_upper = Math.Sign(upper);
+
+            switch (sign_lower)
+            {
+                // lower < 0
+                case -1:
+                    switch (sign_upper)
+                    {
+                        // upper < 0
+                        case -1:
+                            return new Interval_IEEE754(Kind.Negative_One, lower, upper);
+
+                        // upper == 0
+                        case 0:
+                            return new Interval_IEEE754(Kind.Negative_Zero, lower, upper);
+
+                        // upper > 0
+                        case +1:
+                            return new Interval_IEEE754(Kind.Mixed, lower, upper);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                // lower == 0
+                case 0:
+                    switch (sign_upper)
+                    {
+                        // upper < 0
+                        case -1:
+                            return new Interval_IEEE754(Kind.Empty, lower, upper);
+
+                        // upper == 0
+                        case 0:
+                            return new Interval_IEEE754(Kind.Zero, 0.0); // We set 0-
+
+                        // upper > 0
+                        case +1:
+                            return new Interval_IEEE754(Kind.Positive_Zero, lower, upper);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                // lower > 0
+                case +1:
+                    switch (sign_upper)
+                    {
+                        // upper < 0
+                        // upper == 0
+                        case -1:
+                        case 0:
+                            return new Interval_IEEE754(Kind.Empty, lower, upper);
+
+                        // upper > 0
+                        case +1:
+                            return new Interval_IEEE754(Kind.Positive_One, lower, upper);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                default:
+                    return ShouldBeUnreachable<Interval_IEEE754>();
+            }
+
+            #endregion
+        }
+
+        static public Interval_IEEE754 For(Int64 r)
+        {
+            return For((Int64)r, (Int64)r);
+        }
+
+        static public Interval_IEEE754 For(Byte b)
+        {
+            // We know we have no problems in representing bytes
+            return For((Int64)b, (Int64)b);
+        }
+
+        static public Interval_IEEE754 For(SByte sByte)
+        {
+            // We know we have no problems in representing bytes
+            return For((Int64)sByte, (Int64)sByte);
+        }
+
+        static public Interval_IEEE754 For(UInt16 u16)
+        {
+            // We know we have no problems in representing uint16
+            return For((Int64)u16, (Int64)u16);
+        }
+
+        static public Interval_IEEE754 For(UInt32 u32)
+        {
+            // We know we have no problems in representing uint32
+            return For((Int64)u32, (Int64)u32);
+        }
+
+        static public Interval_IEEE754 For(Int16 i16)
+        {
+            // We know we have no problems in representing int16
+            return For((Int64)i16, (Int64)i16);
+        }
+
+        static public Interval_IEEE754 For(Int32 i32)
+        {
+            // We know we have no problems in representing int32
+            return For((Int64)i32, (Int64)i32);
+        }
+        #endregion
+
+        #region Construct an Interval_IEEE754 from two Doubles
+        static public Interval_IEEE754 For(Double lower, Double upper)
+        {
+            #region Case 0: Check for constants
+            if (lower.Equals(upper))
+            {
+                // TODO F: check for Int64 corner cases 
+
+                var k = lower;
+
+                if (Double.IsNaN(k))
+                {
+                    return new Interval_IEEE754(Kind.IncludesNaN, k);
+                }
+                if (k == 0)
+                {
+                    return new Interval_IEEE754(Kind.Zero, k);
+                }
+                if (k > 0)
+                {
+                    return new Interval_IEEE754(Kind.Positive_One, k);
+                }
+                if (k < 0)
+                {
+                    return new Interval_IEEE754(Kind.Negative_One, k);
+                }
+
+                return ShouldBeUnreachable<Interval_IEEE754>();
+            }
+            #endregion
+
+            #region Case 1 : One the two operands is NaN
+            if (Double.IsNaN(lower) || Double.IsNaN(upper))
+            {
+                return new Interval_IEEE754(Kind.IncludesNaN, lower, upper);
+            }
+            #endregion
+
+            #region Case 2 : Check for Emptyness
+            if (lower > upper)
+            {
+                return new Interval_IEEE754(Kind.Empty, +3.14, -3.14);
+            }
+            #endregion
+
+            #region Case 3 : Check for Top
+
+            if (lower == Double.NegativeInfinity && upper == Double.PositiveInfinity)
+            {
+                return new Interval_IEEE754(Kind.Top, Double.NegativeInfinity, Double.PositiveInfinity);
+            }
+            #endregion
+
+            #region Case 3 : The other cases
+            var sign_lower = Math.Sign(lower);
+            var sign_upper = Math.Sign(upper);
+
+            switch (sign_lower)
+            {
+                // lower < 0
+                case -1:
+                    switch (sign_upper)
+                    {
+                        // upper < 0
+                        case -1:
+                            return new Interval_IEEE754(Kind.Negative_One, lower, upper);
+
+                        // upper == 0
+                        case 0:
+                            return new Interval_IEEE754(Kind.Negative_Zero, lower, upper);
+
+                        // upper > 0
+                        case +1:
+                            return new Interval_IEEE754(Kind.Mixed, lower, upper);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                // lower == 0
+                case 0:
+                    switch (sign_upper)
+                    {
+                        // upper < 0
+                        case -1:
+                            return new Interval_IEEE754(Kind.Empty, lower, upper);
+
+                        // upper == 0
+                        case 0:
+                            return new Interval_IEEE754(Kind.Zero, upper);
+
+                        // upper > 0
+                        case +1:
+                            return new Interval_IEEE754(Kind.Positive_Zero, lower, upper);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                // lower > 0
+                case +1:
+                    switch (sign_upper)
+                    {
+                        // upper < 0
+                        // upper == 0
+                        case -1:
+                        case 0:
+                            return new Interval_IEEE754(Kind.Empty, lower, upper);
+
+                        // upper > 0
+                        case +1:
+                            return new Interval_IEEE754(Kind.Positive_One, lower, upper);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                default:
+                    return ShouldBeUnreachable<Interval_IEEE754>();
+            }
+
+            #endregion
+        }
+
+        static public Interval_IEEE754 For(Double d)
+        {
+            return For(d, d);
+        }
+
+        static public Interval_IEEE754 For(Single s)
+        {
+            return For((Double)s, (Double)s);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        override public bool IsTop
+        {
+            get { return kind == Kind.Top; }
+        }
+
+        public bool IsTopButNotNaN
+        {
+            get { return kind == Kind.TopNotNaN; }
+        }
+
+        override public bool IsBottom
+        {
+            get { return kind == Kind.Empty; }
+        }
+
+        public override Interval_IEEE754 Bottom
+        {
+            get { return Interval_IEEE754.cachedBottom; }
+        }
+
+        public override Interval_IEEE754 Top
+        {
+            get { return Interval_IEEE754.cachedTop; }
+        }
+
+        override public bool LessEqual(Interval_IEEE754 other)
+        {
+            if (AreEqual(this, other))
+                return true;
+
+            if (kind == Kind.Empty)
+            {
+                return true;
+            }
+
+            switch (other.kind)
+            {
+                case Kind.Empty:
+                case Kind.IncludesNaN:
+                    return false;
+
+                case Kind.NotInizialized:
+                    return kind == Kind.NotInizialized;
+
+                case Kind.Top:
+                    return true;
+
+                case Kind.TopNotNaN:
+                    return kind != Kind.IncludesNaN && kind != Kind.Top;
+            }
+
+            // At this point we know other != Empty, IncludedNaN, TopNotNaN, Top
+            switch (kind)
+            {
+                case Kind.IncludesNaN:
+                    return false;
+
+                case Kind.Mixed:
+                case Kind.Negative_One:
+                case Kind.Negative_Zero:
+                case Kind.NotInizialized:
+                case Kind.Positive_One:
+                case Kind.Positive_Zero:
+                    return this.lowerBound >= other.lowerBound && this.upperBound <= other.upperBound;
+
+                case Kind.Top:
+                    return false;
+
+                case Kind.TopNotNaN:
+                    Contract.Assert(other.kind != Kind.Top);
+                    return other.kind != Kind.IncludesNaN;
+
+                case Kind.Zero:
+                    return other.lowerBound <= 0;
+
+                default:
+                    return ShouldBeUnreachable<bool>();
+            }
+        }
+
+        static private bool AreEqual(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            if (object.ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            if (left.kind == right.kind && left.lowerBound.Equals(right.lowerBound) && left.upperBound.Equals(right.upperBound))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        override public Interval_IEEE754 Join(Interval_IEEE754 other)
+        {
+            Interval_IEEE754 value;
+            if (IsSpecialCaseForJoin(this, other, out value))
+            {
+                return value;
+            }
+
+            var low = Math.Min(this.lowerBound, other.lowerBound);
+            var upp = Math.Max(this.upperBound, other.upperBound);
+
+            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        }
+
+
+        override public Interval_IEEE754 Meet(Interval_IEEE754 other)
+        {
+            Interval_IEEE754 value;
+            if (IsSpecialCaseForMeet(this, other, out value))
+            {
+                return value;
+            }
+
+            var low = Math.Max(this.lowerBound, other.lowerBound);
+            var upp = Math.Min(this.upperBound, other.upperBound);
+
+            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        }
+
+        override public Interval_IEEE754 Widening(Interval_IEEE754 prev)
+        {
+            Interval_IEEE754 value;
+            if (IsSpecialCaseForWidening(this, prev, out value))
+            {
+                return value;
+            }
+
+            var low = this.lowerBound < prev.lowerBound ? ThresholdDB.GetPrevious(this.lowerBound) : prev.lowerBound;
+            var upp = this.upperBound > prev.upperBound ? ThresholdDB.GetNext(this.upperBound) : prev.upperBound;
+
+            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        }
+
+        override public Interval_IEEE754 DuplicateMe()
+        {
+            return new Interval_IEEE754(kind, this.lowerBound, this.upperBound);
+        }
+
+        #endregion
+
+        #region Common Tools
+
+        public bool IsNotNaN
+        {
+            get
+            {
+                switch (kind)
+                {
+                    case Kind.Empty:
+                    case Kind.IncludesNaN:
+                    case Kind.NotInizialized:
+                    case Kind.Top:
+                        return false;
+
+                    case Kind.TopNotNaN:
+                    case Kind.Mixed:
+                    case Kind.Negative_One:
+                    case Kind.Negative_Zero:
+                    case Kind.Positive_One:
+                    case Kind.Positive_Zero:
+                    case Kind.Zero:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        public override bool IsNormal
+        {
+            get
+            {
+                switch (kind)
+                {
+                    case Kind.Empty:
+                    case Kind.IncludesNaN:
+                    case Kind.NotInizialized:
+                    case Kind.Top:
+                    case Kind.TopNotNaN:
+                        return false;
+
+                    case Kind.Mixed:
+                    case Kind.Negative_One:
+                    case Kind.Negative_Zero:
+                    case Kind.Positive_One:
+                    case Kind.Positive_Zero:
+                    case Kind.Zero:
+                        return this.lowerBound <= this.upperBound;
+
+                    default:
+                        return ShouldBeUnreachable<bool>(kind.ToString());
+                }
+            }
+        }
+
+        override public bool IsLowerBoundMinusInfinity
+        {
+            get
+            {
+                return Double.IsNegativeInfinity(this.lowerBound);
+            }
+        }
+
+        override public bool IsUpperBoundPlusInfinity
+        {
+            get
+            {
+                return Double.IsPositiveInfinity(this.upperBound);
+            }
+        }
+
+        /// <returns>
+        /// true iff <code>x</code> is not included in this Interval_IEEE754
+        /// </returns>
+        [ContractVerification(true)]
+        [Pure]
+        public bool DoesNotInclude(double x)
+        {
+            switch (kind)
+            {
+                case Kind.Empty:
+                case Kind.IncludesNaN:
+                case Kind.NotInizialized:
+                case Kind.Top:
+                    return false;
+
+                case Kind.TopNotNaN:
+                    return !double.IsNaN(x);
+
+                case Kind.Mixed:
+                case Kind.Negative_One:
+                case Kind.Negative_Zero:
+                case Kind.Positive_One:
+                case Kind.Positive_Zero:
+                case Kind.Zero:
+                    return x < this.lowerBound || x > this.upperBound;
+
+                default:
+                    return ShouldBeUnreachable<bool>();
+            }
+        }
+
+        #endregion
+
+        #region Arithmetic Operations over Interval_IEEE754s
+
+        [ContractVerification(true)]
+        [Pure]
+        static public Interval_IEEE754 operator +(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            Interval_IEEE754 value;
+            if (PropagateSpecialCases(left, right, out value))
+            {
+                return value;
+            }
+
+            if (left.IsTopButNotNaN || right.IsTopButNotNaN)
+            {
+                // We can get e.g. +oo + -oo
+                return UnknownInterval;
+            }
+
+            var low = FloatingPointExtensions.Add_Low(left.lowerBound, right.lowerBound);
+            var upp = FloatingPointExtensions.Add_Up(left.upperBound, right.upperBound);
+
+            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        static public Interval_IEEE754 operator -(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            Interval_IEEE754 value;
+            if (PropagateSpecialCases(left, right, out value))
+            {
+                return value;
+            }
+
+            // oo - oo      
+            if (Double.IsInfinity(left.UpperBound) && Double.IsInfinity(right.UpperBound))
+            {
+                // It can be NaN
+                return UnknownInterval;
+            }
+
+            // -oo + oo
+            if (Double.IsInfinity(left.lowerBound) && Double.IsInfinity(right.lowerBound))
+            {
+                // It can be NaN
+                return UnknownInterval;
+            }
+
+            var low = FloatingPointExtensions.Sub_Low(left.lowerBound, right.upperBound);
+            var upp = FloatingPointExtensions.Sub_Up(left.upperBound, right.lowerBound);
+
+            // To handle cases a 0 - inf
+            if (upp < low)
+            {
+                var tmp = upp;
+                upp = low;
+                low = tmp;
+            }
+            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        }
+
+        [ContractVerification(false)]
+        [Pure]
+        static public Interval_IEEE754 operator *(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            Interval_IEEE754 value;
+            if (PropagateSpecialCases(left, right, out value))
+            {
+                return value;
+            }
+
+            if (left.kind == Kind.IncludesNaN || right.kind == Kind.IncludesNaN)
+            {
+                return new Interval_IEEE754(Kind.IncludesNaN, Double.NaN);
+            }
+
+            if (left.kind == Kind.Zero)
+            {
+                return left;
+            }
+
+            if (right.kind == Kind.Zero)
+            {
+                return right;
+            }
+
+            if (left.IsTopButNotNaN || right.IsTopButNotNaN)
+            {
+                // it can be Nan. We should check for infinities
+                return UnknownInterval;
+            }
+
+            Double low, upp;
+
+            var A = left.lowerBound;
+            var B = left.upperBound;
+            var C = right.lowerBound;
+            var D = right.upperBound;
+
+            switch (left.kind)
+            {
+                #region All the normal cases
+                case Kind.Mixed:
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.Mul_Low(B, C);
+                            upp = FloatingPointExtensions.Mul_Up(A, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Mixed:
+                            low = Math.Min(FloatingPointExtensions.Mul_Low(A, D), FloatingPointExtensions.Mul_Low(B, C));
+                            upp = Math.Max(FloatingPointExtensions.Mul_Up(B, D), FloatingPointExtensions.Mul_Up(A, C));
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.Mul_Low(A, D);
+                            upp = FloatingPointExtensions.Mul_Up(B, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                case Kind.Negative_One:
+                case Kind.Negative_Zero:
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.Mul_Low(B, D);
+                            upp = FloatingPointExtensions.Mul_Up(A, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Mixed:
+                            low = FloatingPointExtensions.Mul_Low(A, D);
+                            upp = FloatingPointExtensions.Mul_Up(A, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.Mul_Low(A, D);
+                            upp = FloatingPointExtensions.Mul_Up(B, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                case Kind.Positive_One:
+                case Kind.Positive_Zero:
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.Mul_Low(B, C);
+                            upp = FloatingPointExtensions.Mul_Up(A, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+
+                        case Kind.Mixed:
+                            low = FloatingPointExtensions.Mul_Low(B, C);
+                            upp = FloatingPointExtensions.Mul_Up(B, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.Mul_Low(A, C);
+                            upp = FloatingPointExtensions.Mul_Up(B, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                case Kind.Zero:
+                case Kind.Top:
+                case Kind.NotInizialized:
+                case Kind.Empty:
+                    return ShouldBeUnreachable<Interval_IEEE754>("this case is already handled");
+
+                default:
+                    return ShouldBeUnreachable<Interval_IEEE754>("unknown case");
+                    #endregion
+            }
+        }
+
+        [ContractVerification(false)]
+        [Pure]
+        static public Interval_IEEE754 operator /(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            Interval_IEEE754 value;
+            if (PropagateSpecialCases(left, right, out value))
+            {
+                return value;
+            }
+
+            if (left.kind == Kind.IncludesNaN || right.kind == Kind.IncludesNaN)
+            {
+                return new Interval_IEEE754(Kind.IncludesNaN, Double.NaN, Double.NaN);
+            }
+
+            if (right.kind == Kind.Zero)
+            {
+                return new Interval_IEEE754(Kind.IncludesNaN, Double.NaN);
+            }
+
+            if (left.kind == Kind.Zero)
+            {
+                return left;
+            }
+
+            if (left.IsTopButNotNaN || right.IsTopButNotNaN)
+            {
+                // it can be NaN
+                return UnknownInterval;
+            }
+
+            var A = left.lowerBound;
+            var B = left.upperBound;
+            var C = right.lowerBound;
+            var D = right.upperBound;
+
+            double low, upp;
+
+            double tmp1, tmp2;
+
+            switch (left.kind)
+            {
+                case Kind.Mixed:
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.Div_Low(B, D);
+                            upp = FloatingPointExtensions.Div_Up(A, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Mixed:
+                            return UnknownInterval;
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.Div_Low(A, C);
+                            upp = FloatingPointExtensions.Div_Up(B, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+
+                case Kind.Negative_One:
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.Div_Low(B, C);
+                            upp = FloatingPointExtensions.Div_Up(A, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Mixed:
+                            tmp1 = FloatingPointExtensions.Div_Up(B, D);
+                            tmp2 = FloatingPointExtensions.Div_Low(B, C);
+
+                            return new Interval_IEEE754(InferKind(Double.NegativeInfinity, tmp1), Double.NegativeInfinity, tmp1).Join
+                              (new Interval_IEEE754(InferKind(tmp2, Double.PositiveInfinity), tmp2, Double.PositiveInfinity)); // - { 0} 
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.Div_Low(A, C);
+                            upp = FloatingPointExtensions.Div_Up(B, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                case Kind.Negative_Zero:
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.PositiveZero;
+                            upp = FloatingPointExtensions.Div_Up(A, D);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Mixed:
+                            return UnknownInterval;
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.Div_Low(A, C);
+                            upp = FloatingPointExtensions.NegativeZero;
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+
+                case Kind.Positive_One:
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.Div_Low(B, D);
+                            upp = FloatingPointExtensions.Div_Up(A, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Mixed:
+                            tmp1 = FloatingPointExtensions.Div_Up(A, C);
+                            tmp2 = FloatingPointExtensions.Div_Low(A, D);
+
+                            return new Interval_IEEE754(InferKind(Double.NegativeInfinity, tmp1), Double.NegativeInfinity, tmp1).Join(
+                              new Interval_IEEE754(InferKind(tmp2, Double.PositiveInfinity), tmp2, Double.PositiveInfinity));
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.Div_Low(A, D);
+                            upp = FloatingPointExtensions.Div_Up(B, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                case Kind.Positive_Zero:
+
+                    switch (right.kind)
+                    {
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                            low = FloatingPointExtensions.Div_Low(B, D);
+                            upp = FloatingPointExtensions.NegativeZero;
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        case Kind.Mixed:
+                            return UnknownInterval;
+
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                            low = FloatingPointExtensions.PositiveZero;
+                            upp = FloatingPointExtensions.Div_Up(B, C);
+
+                            return new Interval_IEEE754(InferKind(low, upp), low, upp);
+
+                        default:
+                            return ShouldBeUnreachable<Interval_IEEE754>();
+                    }
+
+                case Kind.Zero:
+                case Kind.NotInizialized:
+                case Kind.Empty:
+                case Kind.IncludesNaN:
+                    return ShouldBeUnreachable<Interval_IEEE754>("this case whould have been already treated");
+
+                default:
+                    return ShouldBeUnreachable<Interval_IEEE754>("Unknown case?");
+            }
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        static public Interval_IEEE754 operator -(Interval_IEEE754 left)
+        {
+            Contract.Requires(left != null);
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            switch (left.kind)
+            {
+                case Kind.Empty:
+                case Kind.NotInizialized:
+                case Kind.Top:
+                case Kind.TopNotNaN:
+                case Kind.Zero:
+                    return left;
+
+                case Kind.IncludesNaN:
+                    return UnknownInterval;
+
+                case Kind.Mixed:
+                    return new Interval_IEEE754(Kind.Mixed, -left.upperBound, -left.lowerBound);
+
+                case Kind.Negative_One:
+                    return new Interval_IEEE754(Kind.Positive_One, -left.upperBound);
+
+                case Kind.Negative_Zero:
+                    return PositiveInterval;
+
+                case Kind.Positive_One:
+                    return new Interval_IEEE754(Kind.Negative_One, -left.lowerBound);
+
+                case Kind.Positive_Zero:
+                    return NegativeInterval_IEEE754;
+
+                default:
+                    return ShouldBeUnreachable<Interval_IEEE754>();
+            }
+        }
+
+        static public Interval_IEEE754 operator &(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            return UnknownInterval;
+        }
+
+        static public Interval_IEEE754 operator |(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            return UnknownInterval;
+        }
+
+        static public Interval_IEEE754 operator %(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            return UnknownInterval;
+        }
+
+        /// <summary>
+        /// F: TODO!!!
+        /// </summary>
+        static public Interval_IEEE754 operator ^(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            return UnknownInterval;
+        }
+
+        #endregion
+
+        #region Helpers for arithmetic operations over Interval_IEEE754s
+
+        [ContractVerification(true)]
+        [Pure]
+        static private bool PropagateSpecialCases(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
+
+            // Top is the strongest
+            if (left.IsTop || right.IsTop)
+            {
+                value = left.Top;
+                return true;
+            }
+
+            if (left.IsBottom || right.IsBottom)
+            {
+                value = left.Bottom;
+                return true;
+            }
+
+            if (left.kind == Kind.NotInizialized || right.kind == Kind.NotInizialized)
+            {
+                value = new Interval_IEEE754(false);
+                return true;
+            }
+
+            value = default(Interval_IEEE754);
+            return false;
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        static private bool PropagateSpecialCaseForIsTopButNotNaN(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
+
+            if (left.IsTopButNotNaN && right.IsNotNaN)
+            {
+                value = left;
+                return true;
+            }
+
+            if (right.IsTopButNotNaN && left.IsNotNaN)
+            {
+                value = right;
+                return true;
+            }
+
+            value = default(Interval_IEEE754);
+            return false;
+        }
+
+        [ContractVerification(true)]
+        static private Kind InferKind(double left, double right)
+        {
+            if (Double.IsNaN(left) || Double.IsNaN(right))
+            {
+                return Kind.IncludesNaN;
+            }
+
+            var sign_left = Math.Sign(left);
+            var sign_right = Math.Sign(right);
+
+            switch (sign_left)
+            {
+                // left < 0
+                case -1:
+                    switch (sign_right)
+                    {
+                        // right < 0
+                        case -1:
+                            return Kind.Negative_One;
+
+                        // right == 0
+                        case 0:
+                            return Kind.Negative_Zero;
+
+                        // right > 0
+                        case +1:
+                            return Kind.Mixed;
+
+                        default:
+                            return ShouldBeUnreachable<Kind>();
+                    }
+
+                // left == 0
+                case 0:
+                    switch (sign_right)
+                    {
+                        // right < 0
+                        case -1:
+                            return Kind.Empty;
+
+                        // right == 0
+                        case 0:
+                            return Kind.Zero;
+
+                        // right > 0
+                        case +1:
+                            return Kind.Positive_Zero;
+
+                        default:
+                            return ShouldBeUnreachable<Kind>();
+                    }
+
+                // left > 0
+                case +1:
+                    switch (sign_right)
+                    {
+                        // right < 0
+                        case -1:
+                        // right == 0
+                        case 0:
+                            return Kind.Empty;
+
+                        // right > 0
+                        case +1:
+                            return Kind.Positive_One;
+
+                        default:
+                            return ShouldBeUnreachable<Kind>();
+                    }
+
+                default:
+                    return ShouldBeUnreachable<Kind>();
+            }
+        }
+
+        [ContractVerification(true)]
+        static private bool IsConsistent(Kind kind, double lower, double upper)
+        {
+            switch (kind)
+            {
+                case Kind.Empty:
+                    return lower > upper;
+
+                case Kind.Mixed:
+                    return lower < upper;
+
+                case Kind.Negative_One:
+                    return lower < 0 && upper < 0;
+
+                case Kind.Negative_Zero:
+                    return lower < 0 && (double)upper == 0;
+
+                case Kind.NotInizialized:
+                    return false;
+
+                case Kind.Positive_One:
+                    return lower > 0 && upper > 0;
+
+                case Kind.Positive_Zero:
+                    return lower == 0 && upper > 0;
+
+                case Kind.Top:
+                case Kind.TopNotNaN:
+                    return double.IsNegativeInfinity(lower) && double.IsPositiveInfinity(upper);
+
+                case Kind.Zero:
+                    return (double)lower == 0 && (double)upper == 0;
+
+                case Kind.IncludesNaN:
+                    return Double.IsNaN(lower) || Double.IsNaN(upper);
+
+                default:
+                    Contract.Assert(false);
+                    return false;   // Impossible case?
+            }
+        }
+
+        [ContractVerification(true)]
+        static private bool IsConsistent(Kind kind, double k)
+        {
+            switch (kind)
+            {
+                case Kind.Empty:
+                    return false;
+
+                case Kind.IncludesNaN:
+                    return Double.IsNaN(k);
+
+                case Kind.Mixed:
+                    return false;
+
+                case Kind.Negative_One:
+                    return k < 0;
+
+                case Kind.Negative_Zero:
+                    return false;
+
+                case Kind.NotInizialized:
+                    return false;
+
+                case Kind.Positive_One:
+                    return k > 0;
+
+                case Kind.Positive_Zero:
+                    return false;
+
+                case Kind.Top:
+                case Kind.TopNotNaN:
+                    return false;
+
+                case Kind.Zero:
+                    return (double)k == 0;
+
+                default:
+                    Contract.Assert(false);
+                    return false;
+            }
+        }
+
+        #endregion
+
+        #region Helpers for the operations over the abstract domains
+        [ContractVerification(true)]
+        [Pure]
+        static private bool IsSpecialCaseForJoin(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
+
+            if (AreEqual(left, right))
+            {
+                value = left;
+                return true;
+            }
+
+            value = default(Interval_IEEE754);
+
+            return IsSpecialCaseForJoinInternal(left, right, ref value) || IsSpecialCaseForJoinInternal(right, left, ref value);
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        static private bool IsSpecialCaseForJoinInternal(Interval_IEEE754 left, Interval_IEEE754 right, ref Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(!Contract.Result<bool>() || value != null);
+
+            switch (left.kind)
+            {
+                case Kind.Empty:
+                    value = right;
+                    return true;
+
+                case Kind.IncludesNaN:
+                    // We assume at this point that we've already checked that left != right
+                    value = UnknownInterval;
+                    return true;
+
+                case Kind.NotInizialized:
+                    // We assume at this point that we've already checked that left != right
+                    switch (right.kind)
+                    {
+                        case Kind.Mixed:
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                        case Kind.Zero:
+                        case Kind.Top:
+                            value = right;
+                            return true;
+
+                        default:
+                            value = UnknownInterval;
+                            return true;
+                    }
+
+                case Kind.Top:
+                    value = left;
+                    return true;
+
+                case Kind.TopNotNaN:
+                    value = right.kind != Kind.IncludesNaN ? UnknownInterval : left;
+                    return true;
+            }
+
+            return false;
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        static private bool IsSpecialCaseForMeet(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
+
+            if (AreEqual(left, right))
+            {
+                value = left;
+                return true;
+            }
+
+            value = default(Interval_IEEE754);
+
+            return IsSpecialCaseForMeetInternal(left, right, ref value) || IsSpecialCaseForMeetInternal(right, left, ref value);
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        static private bool IsSpecialCaseForMeetInternal(Interval_IEEE754 left, Interval_IEEE754 right, ref Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
+
+            switch (left.kind)
+            {
+                case Kind.Empty:
+                    value = left;
+                    return true;
+
+                case Kind.IncludesNaN:
+                    // We assume at this point that we've already checked that left != right
+                    value = UnreachedInterval;
+                    return true;
+
+                case Kind.NotInizialized:
+                case Kind.Top:
+                    value = right;
+                    return true;
+
+                case Kind.TopNotNaN:
+                    value = right.kind == Kind.IncludesNaN ? UnreachedInterval : right;
+                    return true;
+            }
+
+            return false;
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        static private bool IsSpecialCaseForWidening(Interval_IEEE754 left, Interval_IEEE754 prev, out Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(prev != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
+
+            if (AreEqual(left, prev))
+            {
+                value = left;
+                return true;
+            }
+
+            value = default(Interval_IEEE754);
+
+            return IsSpecialCaseForWideningInternal(left, prev, ref value);
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        // [SuppressMessage("Microsoft.Contracts", "UnreachedCode")]
+        [ContractVerification(true)]
+        [Pure]
+        static private bool IsSpecialCaseForWideningInternal(Interval_IEEE754 left, Interval_IEEE754 prev, ref Interval_IEEE754 value)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(prev != null);
+            Contract.Ensures(!Contract.Result<bool>() || value != null);
+
+            switch (prev.kind)
+            {
+                case Kind.Empty:
+                    value = left;
+                    return true;
+
+                case Kind.TopNotNaN:
+                    if (left.kind != Kind.IncludesNaN)
+                    {
+                        value = left;
+                        return true;
+                    }
+                    else
+                    {
+                        break;
+                    }
+
+                case Kind.Top:
+                    value = prev;
+                    return true;
+            }
+
+            switch (left.kind)
+            {
+                case Kind.Empty:
+                    value = prev;
+                    return true;
+
+                case Kind.IncludesNaN:
+                    // We assume at this point that we've already checked that left != right
+                    value = UnknownInterval;
+                    return true;
+
+                case Kind.NotInizialized:
+                    // We assume at this point that we've already checked that left != right
+                    switch (prev.kind)
+                    {
+                        case Kind.Mixed:
+                        case Kind.Negative_One:
+                        case Kind.Negative_Zero:
+                        case Kind.Positive_One:
+                        case Kind.Positive_Zero:
+                        case Kind.Zero:
+                        case Kind.Top:
+                            value = prev;
+                            return true;
+
+                        default:
+                            value = UnknownInterval;
+                            return true;
+                    }
+
+                case Kind.TopNotNaN:
+                    if (prev.kind == Kind.IncludesNaN)
+                    {
+                        value = UnknownInterval;
+                        return true;
+                    }
+                    else
+                    {
+                        value = UnknownIntervalNotNaN;
+                        return true;
+                    }
+
+                case Kind.Top:
+                    value = left;
+                    return true;
+            }
+
+            return false;
+        }
+
+
+        #endregion
+
+        #region Routines for fail
+        [ContractVerification(false)]
+        static private T ShouldBeUnreachable<T>(string why)
+        {
+            Contract.Requires(false);
+            Contract.Ensures(false);
+
+            throw new Exception(why);
+        }
+
+        [ContractVerification(false)]
+        static private T ShouldBeUnreachable<T>()
+        {
+            Contract.Requires(false);
+            Contract.Ensures(false);
+
+            return ShouldBeUnreachable<T>("Unexpected case!");
+        }
+        #endregion
+
+        #region Types
+        public override bool IsInt32
+        {
+            get { return false; }
+        }
+
+        public override bool IsInt64
+        {
+            get { return false; }
+        }
+        #endregion
+
+        #region ToString
+        [ContractVerification(true)]
+        public override string ToString()
+        {
+            switch (kind)
+            {
+                case Kind.Empty:
+                    return "_|_";
+
+                case Kind.IncludesNaN:
+                case Kind.Mixed:
+                case Kind.Negative_One:
+                case Kind.Negative_Zero:
+                case Kind.Positive_One:
+                case Kind.Positive_Zero:
+                case Kind.Zero:
+                    return "[" + this.lowerBound + ", " + this.upperBound + "]";
+
+                case Kind.NotInizialized:
+                    return "_()_";
+
+                case Kind.TopNotNaN:
+                    return "!= NaN";
+
+                case Kind.Top:
+                    return "Top";
+
+                default:
+                    return ShouldBeUnreachable<string>("Unknown case");
+            }
+        }
+        #endregion
+
+        public override Interval_IEEE754 ToUnsigned()
+        {
+            return this;
+        }
+
+        internal static Interval_IEEE754 ShiftLeft(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            return UnknownInterval;
+        }
+
+        internal static Interval_IEEE754 ShiftRight(Interval_IEEE754 left, Interval_IEEE754 right)
+        {
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            return UnknownInterval;
+        }
+
+
+        public static Interval_IEEE754 For(Rational r)
+        {
+            Contract.Requires(!object.Equals(r, null));
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            // F: wrong: should be an interval!
+            var asDouble = (double)r;
+            return For(asDouble);
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        public static DisInterval ConvertInterval(Interval_IEEE754 intv)
+        {
+            Contract.Requires(intv != null);
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            switch (intv.kind)
+            {
+                case Kind.Empty:
+                    return DisInterval.UnreachedInterval;
+
+                case Kind.IncludesNaN:
+                    return DisInterval.UnknownInterval;
+
+                case Kind.Mixed:
+                case Kind.Negative_One:
+                case Kind.Negative_Zero:
+                case Kind.Positive_One:
+                case Kind.Positive_Zero:
+                    return Interval.For(intv.lowerBound, intv.upperBound, true).AsDisInterval;
+
+                case Kind.NotInizialized:
+                    return DisInterval.UnknownInterval;
+
+                case Kind.Top:
+                case Kind.TopNotNaN:
+                    return DisInterval.UnknownInterval;
+
+                case Kind.Zero:
+                    return DisInterval.For(0);
+
+                default:
+                    return ShouldBeUnreachable<DisInterval>();
+            }
+        }
+
+        [ContractVerification(true)]
+        [Pure]
+        public static Interval_IEEE754 ConvertInterval(Interval intv)
+        {
+            Contract.Requires(intv != null);
+
+            Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+
+            if (intv.IsBottom)
+                return cachedBottom;
+            if (intv.IsTop)
+                return cachedTop;
+
+            var inf = intv.LowerBound.IsMinusInfinity ? Double.NegativeInfinity : intv.LowerBound.Floor;
+            var sup = intv.UpperBound.IsPlusInfinity ? Double.PositiveInfinity : intv.UpperBound.Ceiling;
+
+            return new Interval_IEEE754(InferKind(inf, sup), inf, sup);
+        }
+
+        #region Refinements
+
+        public Interval_IEEE754 RefineIntervalWithTypeRanges(Int32 min, Int32 max)
+        {
+            var low = this.LowerBound.IsInfinity() || !this.LowerBound.IsInRange(min, max)
+              ? Double.NegativeInfinity
+            : Math.Ceiling(this.LowerBound);
+
+            var upp = this.UpperBound.IsInfinity() || !this.UpperBound.IsInRange(min, max)
+              ? Double.PositiveInfinity
+              : Math.Floor(this.UpperBound);
+
+            return Interval_IEEE754.For(low, upp);
+        }
+
+        public Interval_IEEE754 RefineIntervalWithTypeRanges(Int64 min, Int64 max)
+        {
+            var low = this.LowerBound.IsInfinity() || !this.LowerBound.IsInRange(min, max)
+              ? Double.NegativeInfinity
+            : Math.Ceiling(this.LowerBound);
+
+            var upp = this.UpperBound.IsInfinity() || !this.UpperBound.IsInRange(min, max)
+              ? Double.PositiveInfinity
+              : Math.Floor(this.UpperBound);
+
+            return Interval_IEEE754.For(low, upp);
+        }
+
+        public Interval_IEEE754 RefineIntervalWithTypeRanges(UInt32 min, UInt32 max)
+        {
+            var low = this.LowerBound.IsInfinity() || !this.LowerBound.IsInRange(min, max)
+              ? Double.NegativeInfinity
+              : Math.Ceiling(this.LowerBound);
+
+            var upp = this.UpperBound.IsInfinity() || !this.UpperBound.IsInRange(min, max)
+              ? Double.PositiveInfinity
+              : Math.Floor(this.UpperBound);
+
+            return Interval_IEEE754.For(low, upp);
+        }
+
+        #endregion
     }
 
-    [ContractVerification(false)]
-    [Pure]
-    static public Interval_IEEE754 operator /(Interval_IEEE754 left, Interval_IEEE754 right)
+    static public class FloatingPointExtensions
     {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
+        static private readonly Double negativeZero = BitConverter.Int64BitsToDouble(-9223372036854775808L);
 
-      Interval_IEEE754 value;
-      if (PropagateSpecialCases(left, right, out value))
-      {
-        return value;
-      }
+        static public bool IsInRange(this Double d, Int32 min, Int32 max)
+        {
+            return min <= d && d <= max;
+        }
 
-      if (left.kind == Kind.IncludesNaN || right.kind == Kind.IncludesNaN)
-      {
-        return new Interval_IEEE754(Kind.IncludesNaN, Double.NaN, Double.NaN);
-      }
+        static public bool IsInRange(this Double d, Int64 min, Int64 max)
+        {
+            return min <= d && d <= max;
+        }
 
-      if (right.kind == Kind.Zero)
-      {
-        return new Interval_IEEE754(Kind.IncludesNaN, Double.NaN);
-      }
+        static public bool IsInfinity(this Double d)
+        {
+            return Double.IsInfinity(d);
+        }
 
-      if (left.kind == Kind.Zero)
-      {
-        return left;
-      }
+        static public Double PositiveZero
+        {
+            get
+            {
+                return 0.0D;
+            }
+        }
 
-      if (left.IsTopButNotNaN || right.IsTopButNotNaN)
-      {
-        // it can be NaN
-        return UnknownInterval;
-      }
+        static public Double NegativeZero
+        {
+            get
+            {
+                return negativeZero;
+            }
+        }
 
-      var A = left.lowerBound;
-      var B = left.upperBound;
-      var C = right.lowerBound;
-      var D = right.upperBound;
+        static public bool IsZero(this Single s)
+        {
+            return s == 0.0f;
+        }
 
-      double low, upp;
+        static public bool IsZeroPositive(this Single s)
+        {
+            return s == 0.0f && BitConverter.DoubleToInt64Bits((double)s) == 0;
+        }
 
-      double tmp1, tmp2;
+        static public bool IsZeroNegative(this Single s)
+        {
+            return s == 0.0f && BitConverter.DoubleToInt64Bits((double)s) < 0;
+        }
 
-      switch (left.kind)
-      {
-        case Kind.Mixed:
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.Div_Low(B, D);
-              upp = FloatingPointExtensions.Div_Up(A, D);
+        static public bool IsZero(this Double d)
+        {
+            return d == 0.0D;
+        }
 
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        static public bool IsZeroPositive(this Double d)
+        {
+            return d == 0.0D && BitConverter.DoubleToInt64Bits(d) == 0;
+        }
 
-            case Kind.Mixed:
-              return UnknownInterval;
+        static public bool IsZeroNegative(this Double d)
+        {
+            return d == 0.0D && BitConverter.DoubleToInt64Bits(d) < 0;
+        }
 
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.Div_Low(A, C);
-              upp = FloatingPointExtensions.Div_Up(B, C);
+        static public Double Add_Up(Double left, Double right)
+        {
+            return left + right;
+        }
 
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        static public Double Sub_Up(Double left, Double right)
+        {
+            return left - right;
+        }
 
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
+        static public Double Mul_Up(Double left, Double right)
+        {
+            return left * right;
+        }
 
+        static public Double Div_Up(Double left, Double right)
+        {
+            return left / right;
+        }
 
-        case Kind.Negative_One:
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.Div_Low(B, C);
-              upp = FloatingPointExtensions.Div_Up(A, D);
+        static public Double Add_Low(Double left, Double right)
+        {
+            return left + right;
+        }
 
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
+        static public Double Sub_Low(Double left, Double right)
+        {
+            return left - right;
+        }
 
-            case Kind.Mixed:
-              tmp1 = FloatingPointExtensions.Div_Up(B, D);
-              tmp2 = FloatingPointExtensions.Div_Low(B, C);
+        static public Double Mul_Low(Double left, Double right)
+        {
+            return left * right;
+        }
 
-              return new Interval_IEEE754(InferKind(Double.NegativeInfinity, tmp1), Double.NegativeInfinity, tmp1).Join
-                (new Interval_IEEE754(InferKind(tmp2, Double.PositiveInfinity), tmp2, Double.PositiveInfinity)); // - { 0} 
-
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.Div_Low(A, C);
-              upp = FloatingPointExtensions.Div_Up(B, D);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        case Kind.Negative_Zero:
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.PositiveZero;
-              upp = FloatingPointExtensions.Div_Up(A, D);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Mixed:
-              return UnknownInterval;
-
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.Div_Low(A, C);
-              upp = FloatingPointExtensions.NegativeZero;
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-
-        case Kind.Positive_One:
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.Div_Low(B, D);
-              upp = FloatingPointExtensions.Div_Up(A, C);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Mixed:
-              tmp1 = FloatingPointExtensions.Div_Up(A, C);
-              tmp2 = FloatingPointExtensions.Div_Low(A, D);
-
-              return new Interval_IEEE754(InferKind(Double.NegativeInfinity, tmp1), Double.NegativeInfinity, tmp1).Join(
-                new Interval_IEEE754(InferKind(tmp2, Double.PositiveInfinity), tmp2, Double.PositiveInfinity));
-
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.Div_Low(A, D);
-              upp = FloatingPointExtensions.Div_Up(B, C);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        case Kind.Positive_Zero:
-
-          switch (right.kind)
-          {
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-              low = FloatingPointExtensions.Div_Low(B, D);
-              upp = FloatingPointExtensions.NegativeZero;
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            case Kind.Mixed:
-              return UnknownInterval;
-
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-              low = FloatingPointExtensions.PositiveZero;
-              upp = FloatingPointExtensions.Div_Up(B, C);
-
-              return new Interval_IEEE754(InferKind(low, upp), low, upp);
-
-            default:
-              return ShouldBeUnreachable<Interval_IEEE754>();
-          }
-
-        case Kind.Zero:
-        case Kind.NotInizialized:
-        case Kind.Empty:
-        case Kind.IncludesNaN:
-          return ShouldBeUnreachable<Interval_IEEE754>("this case whould have been already treated");
-
-        default:
-          return ShouldBeUnreachable<Interval_IEEE754>("Unknown case?");
-      }
+        static public Double Div_Low(Double left, Double right)
+        {
+            return left / right;
+        }
     }
-
-    [ContractVerification(true)]
-    [Pure]
-    static public Interval_IEEE754 operator -(Interval_IEEE754 left)
-    {
-      Contract.Requires(left != null);
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      switch (left.kind)
-      {
-        case Kind.Empty:
-        case Kind.NotInizialized:
-        case Kind.Top:
-        case Kind.TopNotNaN:
-        case Kind.Zero:
-          return left;
-
-        case Kind.IncludesNaN:
-          return UnknownInterval;
-
-        case Kind.Mixed:
-          return new Interval_IEEE754(Kind.Mixed, -left.upperBound, -left.lowerBound);
-
-        case Kind.Negative_One:
-          return new Interval_IEEE754(Kind.Positive_One, -left.upperBound);
-
-        case Kind.Negative_Zero:
-          return PositiveInterval;
-
-        case Kind.Positive_One:
-          return new Interval_IEEE754(Kind.Negative_One, -left.lowerBound);
-
-        case Kind.Positive_Zero:
-          return NegativeInterval_IEEE754;
-
-        default:
-          return ShouldBeUnreachable<Interval_IEEE754>();
-      }
-    }
-
-    static public Interval_IEEE754 operator &(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      return UnknownInterval;
-    }
-
-    static public Interval_IEEE754 operator |(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      return UnknownInterval;
-    }
-
-    static public Interval_IEEE754 operator %(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      return UnknownInterval;
-    }
-
-    /// <summary>
-    /// F: TODO!!!
-    /// </summary>
-    static public Interval_IEEE754 operator ^(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      return UnknownInterval;
-    }
-
-    #endregion
-
-    #region Helpers for arithmetic operations over Interval_IEEE754s
-
-    [ContractVerification(true)]
-    [Pure]
-    static private bool PropagateSpecialCases(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
-
-      // Top is the strongest
-      if (left.IsTop || right.IsTop)
-      {
-        value = left.Top;
-        return true;
-      }      
-
-      if (left.IsBottom || right.IsBottom)
-      {
-        value = left.Bottom;
-        return true;
-      }
-
-      if (left.kind == Kind.NotInizialized || right.kind == Kind.NotInizialized)
-      {
-        value = new Interval_IEEE754(false);
-        return true;
-      }
-
-      value = default(Interval_IEEE754);
-      return false;
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    static private bool PropagateSpecialCaseForIsTopButNotNaN(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
-
-      if (left.IsTopButNotNaN && right.IsNotNaN)
-      {
-        value = left;
-        return true;
-      }
-
-      if (right.IsTopButNotNaN && left.IsNotNaN)
-      {
-        value = right;
-        return true;
-      }
-
-      value = default(Interval_IEEE754);
-      return false;
-    }
-
-    [ContractVerification(true)]
-    static private Kind InferKind(double left, double right)
-    {
-      if (Double.IsNaN(left) || Double.IsNaN(right))
-      {
-        return Kind.IncludesNaN;
-      }
-
-      var sign_left = Math.Sign(left);
-      var sign_right = Math.Sign(right);
-
-      switch (sign_left)
-      {
-        // left < 0
-        case -1:
-          switch (sign_right)
-          {
-            // right < 0
-            case -1:
-              return Kind.Negative_One;
-
-            // right == 0
-            case 0:
-              return Kind.Negative_Zero;
-
-            // right > 0
-            case +1:
-              return Kind.Mixed;
-
-            default:
-              return ShouldBeUnreachable<Kind>();
-          }
-
-        // left == 0
-        case 0:
-          switch (sign_right)
-          {
-            // right < 0
-            case -1:
-              return Kind.Empty;
-
-            // right == 0
-            case 0:
-              return Kind.Zero;
-
-            // right > 0
-            case +1:
-              return Kind.Positive_Zero;
-
-            default:
-              return ShouldBeUnreachable<Kind>();
-          }
-
-        // left > 0
-        case +1:
-          switch (sign_right)
-          {
-            // right < 0
-            case -1:
-            // right == 0
-            case 0:
-              return Kind.Empty;
-
-            // right > 0
-            case +1:
-              return Kind.Positive_One;
-
-            default:
-              return ShouldBeUnreachable<Kind>();
-          }
-
-        default:
-          return ShouldBeUnreachable<Kind>();
-      }
-
-
-    }
-
-    [ContractVerification(true)]
-    static private bool IsConsistent(Kind kind, double lower, double upper)
-    {
-      switch (kind)
-      {
-        case Kind.Empty:
-          return lower > upper;
-
-        case Kind.Mixed:
-          return lower < upper;
-
-        case Kind.Negative_One:
-          return lower < 0 && upper < 0;
-
-        case Kind.Negative_Zero:
-          return lower < 0 && (double)upper == 0;
-
-        case Kind.NotInizialized:
-          return false;
-
-        case Kind.Positive_One:
-          return lower > 0 && upper > 0;
-
-        case Kind.Positive_Zero:
-          return lower == 0 && upper > 0;
-
-        case Kind.Top:
-        case Kind.TopNotNaN:
-          return double.IsNegativeInfinity(lower) && double.IsPositiveInfinity(upper);
-
-        case Kind.Zero:
-          return (double)lower == 0 && (double)upper == 0;
-
-        case Kind.IncludesNaN:
-          return Double.IsNaN(lower) || Double.IsNaN(upper);
-
-        default:
-          Contract.Assert(false);
-          return false;   // Impossible case?
-      }
-    }
-
-    [ContractVerification(true)]
-    static private bool IsConsistent(Kind kind, double k)
-    {
-      switch (kind)
-      {
-        case Kind.Empty:
-          return false;
-
-        case Kind.IncludesNaN:
-          return Double.IsNaN(k);
-
-        case Kind.Mixed:
-          return false;
-
-        case Kind.Negative_One:
-          return k < 0;
-
-        case Kind.Negative_Zero:
-          return false;
-
-        case Kind.NotInizialized:
-          return false;
-
-        case Kind.Positive_One:
-          return k > 0;
-
-        case Kind.Positive_Zero:
-          return false;
-
-        case Kind.Top:
-        case Kind.TopNotNaN:
-          return false;
-
-        case Kind.Zero:
-          return (double)k == 0;
-
-        default:
-          Contract.Assert(false);
-          return false;
-      }
-    }
-
-    #endregion
-
-    #region Helpers for the operations over the abstract domains
-    [ContractVerification(true)]
-    [Pure]
-    static private bool IsSpecialCaseForJoin(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
-
-      if (AreEqual(left, right))
-      {
-        value = left;
-        return true;
-      }
-
-      value = default(Interval_IEEE754);
-
-      return IsSpecialCaseForJoinInternal(left, right, ref value) || IsSpecialCaseForJoinInternal(right, left, ref value);
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    static private bool IsSpecialCaseForJoinInternal(Interval_IEEE754 left, Interval_IEEE754 right, ref Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(!Contract.Result<bool>() || value != null);
-
-      switch (left.kind)
-      {
-        case Kind.Empty:
-          value = right;
-          return true;
-
-        case Kind.IncludesNaN:
-          // We assume at this point that we've already checked that left != right
-          value = UnknownInterval;
-          return true;
-
-        case Kind.NotInizialized:
-          // We assume at this point that we've already checked that left != right
-          switch (right.kind)
-          {
-            case Kind.Mixed:
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-            case Kind.Zero:
-            case Kind.Top:
-              value = right;
-              return true;
-
-            default:
-              value = UnknownInterval;
-              return true;
-          }
-
-        case Kind.Top:
-          value = left;
-          return true;
-
-        case Kind.TopNotNaN:
-          value = right.kind != Kind.IncludesNaN ? UnknownInterval : left;
-          return true;
-      }
-
-      return false;
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    static private bool IsSpecialCaseForMeet(Interval_IEEE754 left, Interval_IEEE754 right, out Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
-
-      if (AreEqual(left, right))
-      {
-        value = left;
-        return true;
-      }
-
-      value = default(Interval_IEEE754);
-
-      return IsSpecialCaseForMeetInternal(left, right, ref value) || IsSpecialCaseForMeetInternal(right, left, ref value);
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    static private bool IsSpecialCaseForMeetInternal(Interval_IEEE754 left, Interval_IEEE754 right, ref Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
-
-      switch (left.kind)
-      {
-        case Kind.Empty:
-          value = left;
-          return true;
-
-        case Kind.IncludesNaN:
-          // We assume at this point that we've already checked that left != right
-          value = UnreachedInterval;
-          return true;
-
-        case Kind.NotInizialized:
-        case Kind.Top:
-          value = right;
-          return true;
-
-        case Kind.TopNotNaN:
-          value = right.kind == Kind.IncludesNaN ? UnreachedInterval : right;
-          return true;
-      }
-
-      return false;
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    static private bool IsSpecialCaseForWidening(Interval_IEEE754 left, Interval_IEEE754 prev, out Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(prev != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn<Interval_IEEE754>(out value) != null);
-
-      if (AreEqual(left, prev))
-      {
-        value = left;
-        return true;
-      }
-
-      value = default(Interval_IEEE754);
-
-      return IsSpecialCaseForWideningInternal(left, prev, ref value);
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    // [SuppressMessage("Microsoft.Contracts", "UnreachedCode")]
-    [ContractVerification(true)]
-    [Pure]
-    static private bool IsSpecialCaseForWideningInternal(Interval_IEEE754 left, Interval_IEEE754 prev, ref Interval_IEEE754 value)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(prev != null);
-      Contract.Ensures(!Contract.Result<bool>() || value != null);
-
-      switch (prev.kind)
-      {
-        case Kind.Empty:
-          value = left;
-          return true;
-
-        case Kind.TopNotNaN:
-          if (left.kind != Kind.IncludesNaN)
-          {
-            value = left;
-            return true;
-          }
-          else
-          {
-            break;
-          }
-
-        case Kind.Top:
-          value = prev;
-          return true;
-      }
-
-      switch (left.kind)
-      {
-        case Kind.Empty:
-          value = prev;
-          return true;
-
-        case Kind.IncludesNaN:
-          // We assume at this point that we've already checked that left != right
-          value = UnknownInterval;
-          return true;
-
-        case Kind.NotInizialized:
-          // We assume at this point that we've already checked that left != right
-          switch (prev.kind)
-          {
-            case Kind.Mixed:
-            case Kind.Negative_One:
-            case Kind.Negative_Zero:
-            case Kind.Positive_One:
-            case Kind.Positive_Zero:
-            case Kind.Zero:
-            case Kind.Top:
-              value = prev;
-              return true;
-
-            default:
-              value = UnknownInterval;
-              return true;
-          }
-
-        case Kind.TopNotNaN:
-          if(prev.kind == Kind.IncludesNaN)
-          {
-            value = UnknownInterval;
-            return true;
-          }
-          else
-          {
-            value = UnknownIntervalNotNaN;
-            return true;
-          }
-
-        case Kind.Top:
-          value = left;
-          return true;
-      }
-
-      return false;
-    }
-
-
-    #endregion
-
-    #region Routines for fail
-    [ContractVerification(false)]
-    static private T ShouldBeUnreachable<T>(string why)
-    {
-      Contract.Requires(false);
-      Contract.Ensures(false);
-
-      throw new Exception(why);
-    }
-
-    [ContractVerification(false)]
-    static private T ShouldBeUnreachable<T>()
-    {
-      Contract.Requires(false);
-      Contract.Ensures(false);
-
-      return ShouldBeUnreachable<T>("Unexpected case!");
-    }
-    #endregion
-
-    #region Types
-    public override bool IsInt32
-    {
-      get { return false; }
-    }
-
-    public override bool IsInt64
-    {
-      get { return false; }
-    }
-    #endregion
-
-    #region ToString
-    [ContractVerification(true)]
-    public override string ToString()
-    {
-      switch (this.kind)
-      {
-        case Kind.Empty:
-          return "_|_";
-
-        case Kind.IncludesNaN:
-        case Kind.Mixed:
-        case Kind.Negative_One:
-        case Kind.Negative_Zero:
-        case Kind.Positive_One:
-        case Kind.Positive_Zero:
-        case Kind.Zero:
-          return "[" + this.lowerBound + ", " + this.upperBound + "]";
-
-        case Kind.NotInizialized:
-          return "_()_";
-
-        case Kind.TopNotNaN:
-          return "!= NaN";
-
-        case Kind.Top:
-          return "Top";
-
-        default:
-          return ShouldBeUnreachable<string>("Unknown case");
-      }
-    }
-    #endregion
-
-    public override Interval_IEEE754 ToUnsigned()
-    {
-      return this;
-    }
-
-    internal static Interval_IEEE754 ShiftLeft(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      return UnknownInterval;
-    }
-
-    internal static Interval_IEEE754 ShiftRight(Interval_IEEE754 left, Interval_IEEE754 right)
-    {
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      return UnknownInterval;
-    }
-
-
-    public static Interval_IEEE754 For(Rational r)
-    {
-      Contract.Requires(!object.Equals(r, null));
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      // F: wrong: should be an interval!
-      var asDouble = (double)r;
-      return For(asDouble);
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    public static DisInterval ConvertInterval(Interval_IEEE754 intv)
-    {
-      Contract.Requires(intv != null);
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      switch (intv.kind)
-      {
-        case Kind.Empty:
-          return DisInterval.UnreachedInterval;
-
-        case Kind.IncludesNaN:
-          return DisInterval.UnknownInterval;
-
-        case Kind.Mixed:
-        case Kind.Negative_One:
-        case Kind.Negative_Zero:
-        case Kind.Positive_One:
-        case Kind.Positive_Zero:
-          return Interval.For(intv.lowerBound, intv.upperBound, true).AsDisInterval;        
-        
-        case Kind.NotInizialized:
-          return DisInterval.UnknownInterval;
-
-        case Kind.Top:
-        case Kind.TopNotNaN:
-          return DisInterval.UnknownInterval;
-
-        case Kind.Zero:
-          return DisInterval.For(0);
-
-        default:
-          return ShouldBeUnreachable<DisInterval>();
-      }
-    }
-
-    [ContractVerification(true)]
-    [Pure]
-    public static Interval_IEEE754 ConvertInterval(Interval intv)
-    {
-      Contract.Requires(intv != null);
-
-      Contract.Ensures(Contract.Result<Interval_IEEE754>() != null);
-
-      if (intv.IsBottom)
-        return cachedBottom;
-      if (intv.IsTop)
-        return cachedTop;
-
-      var inf = intv.LowerBound.IsMinusInfinity ? Double.NegativeInfinity : intv.LowerBound.Floor;
-      var sup = intv.UpperBound.IsPlusInfinity ? Double.PositiveInfinity : intv.UpperBound.Ceiling;
-
-      return new Interval_IEEE754(InferKind(inf, sup), inf, sup);
-    }
-
-    #region Refinements
-
-    public Interval_IEEE754 RefineIntervalWithTypeRanges(Int32 min, Int32 max)
-    {
-      var low = this.LowerBound.IsInfinity() || !this.LowerBound.IsInRange(min, max)
-        ? Double.NegativeInfinity
-      : Math.Ceiling(this.LowerBound);
-
-      var upp = this.UpperBound.IsInfinity() || !this.UpperBound.IsInRange(min, max)
-        ? Double.PositiveInfinity
-        : Math.Floor(this.UpperBound);
-
-      return Interval_IEEE754.For(low, upp);
-    }
-
-    public Interval_IEEE754 RefineIntervalWithTypeRanges(Int64 min, Int64 max)
-    {
-      var low = this.LowerBound.IsInfinity() || !this.LowerBound.IsInRange(min, max)
-        ? Double.NegativeInfinity
-      : Math.Ceiling(this.LowerBound);
-
-      var upp = this.UpperBound.IsInfinity() || !this.UpperBound.IsInRange(min, max)
-        ? Double.PositiveInfinity
-        : Math.Floor(this.UpperBound);
-
-      return Interval_IEEE754.For(low, upp);
-    }
-
-    public Interval_IEEE754 RefineIntervalWithTypeRanges(UInt32 min, UInt32 max)
-    {
-      var low = this.LowerBound.IsInfinity() || !this.LowerBound.IsInRange(min, max)
-        ? Double.NegativeInfinity
-        : Math.Ceiling(this.LowerBound);
-
-      var upp = this.UpperBound.IsInfinity() || !this.UpperBound.IsInRange(min, max)
-        ? Double.PositiveInfinity
-        : Math.Floor(this.UpperBound);
-
-      return Interval_IEEE754.For(low, upp);
-    }
-    
-    #endregion
-  }
-
-  static public class FloatingPointExtensions
-  {
-    static private readonly Double negativeZero = BitConverter.Int64BitsToDouble(-9223372036854775808L);
-
-    static public bool IsInRange(this Double d, Int32 min, Int32 max)
-    {
-      return min <= d && d <= max;
-    }
-
-    static public bool IsInRange(this Double d, Int64 min, Int64 max)
-    {
-      return min <= d && d <= max;
-    }
-
-    static public bool IsInfinity(this Double d)
-    {
-      return Double.IsInfinity(d);
-    }
-
-    static public Double PositiveZero
-    {
-      get
-      {
-        return 0.0D;
-      }
-    }
-
-    static public Double NegativeZero
-    {
-      get
-      {
-        return negativeZero;
-      }
-    }
-
-    static public bool IsZero(this Single s)
-    {
-      return s == 0.0f;
-    }
-
-    static public bool IsZeroPositive(this Single s)
-    {
-      return s == 0.0f && BitConverter.DoubleToInt64Bits((double)s) == 0;
-    }
-
-    static public bool IsZeroNegative(this Single s)
-    {
-      return s == 0.0f && BitConverter.DoubleToInt64Bits((double)s) < 0;
-    }
-
-    static public bool IsZero(this Double d)
-    {
-      return d == 0.0D;
-    }
-
-    static public bool IsZeroPositive(this Double d)
-    {
-      return d == 0.0D && BitConverter.DoubleToInt64Bits(d) == 0;
-    }
-
-    static public bool IsZeroNegative(this Double d)
-    {
-      return d == 0.0D && BitConverter.DoubleToInt64Bits(d) < 0;
-    }
-
-    static public Double Add_Up(Double left, Double right)
-    {
-      return left + right;
-    }
-
-    static public Double Sub_Up(Double left, Double right)
-    {
-      return left - right;
-    }
-
-    static public Double Mul_Up(Double left, Double right)
-    {
-      return left * right;
-    }
-
-    static public Double Div_Up(Double left, Double right)
-    {
-      return left / right;
-    }
-
-    static public Double Add_Low(Double left, Double right)
-    {
-      return left + right;
-    }
-
-    static public Double Sub_Low(Double left, Double right)
-    {
-      return left - right;
-    }
-
-    static public Double Mul_Low(Double left, Double right)
-    {
-      return left * right;
-    }
-
-    static public Double Div_Low(Double left, Double right)
-    {
-      return left / right;
-    }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/LinearEqualities.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/LinearEqualities.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This file contains the classes and the abstract domains for implementing the abstract domain of Linear equalities
 
@@ -46,2691 +35,2682 @@ using Microsoft.SolverFoundation.Services;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  using System.Diagnostics.Contracts;
+    using System.Diagnostics.Contracts;
 
-  [ContractVerification(true)]
-  public class LinearEqualitiesEnvironment
-  {
-    #region Constants
+    [ContractVerification(true)]
+    public class LinearEqualitiesEnvironment
+    {
+        #region Constants
 
-    protected enum LinearEqualitiesState { Normal, StrongRowEchelon, Bottom };
+        protected enum LinearEqualitiesState { Normal, StrongRowEchelon, Bottom };
 
-    protected const int INITIAL_VARS_FOR_EQUATION_COUNT = 3;
-    protected const int INITIAL_EQUATIONS_COUNT = 10;
-    protected const int MAX_VARS_FOR_CLOSURE = 2;
+        protected const int INITIAL_VARS_FOR_EQUATION_COUNT = 3;
+        protected const int INITIAL_EQUATIONS_COUNT = 10;
+        protected const int MAX_VARS_FOR_CLOSURE = 2;
 
-    // The ratio and the maximum absolute number above which we give up having a precise projection, and we simply throw away variables
-    protected const int MAX_RATIO_FOR_USING_WEAK_PROJECTION = 10;
-    protected const int MAX_VARIABLES_TO_REMOVE_FOR_USING_WEAK_PROJECTION = 1000;
+        // The ratio and the maximum absolute number above which we give up having a precise projection, and we simply throw away variables
+        protected const int MAX_RATIO_FOR_USING_WEAK_PROJECTION = 10;
+        protected const int MAX_VARIABLES_TO_REMOVE_FOR_USING_WEAK_PROJECTION = 1000;
 
-    readonly protected int HUGE_RENAMING = 1000;
+        readonly protected int HUGE_RENAMING = 1000;
 
-    #endregion
+        #endregion
 
 #if TRACEPERFORMANCE
-    private static int maxColumns;
-    private static int maxRows;
-    private static int maxVars;
-    private static int maxUnused;
-    private static int maxPairwiseEq;
+        private static int maxColumns;
+        private static int maxRows;
+        private static int maxVars;
+        private static int maxUnused;
+        private static int maxPairwiseEq;
 #endif
 
-    readonly protected bool PrintWarnsForLargeTargets =
+        readonly protected bool PrintWarnsForLargeTargets =
 #if DEBUG
       true;
 #else
      false;
 #endif
 
-    readonly private static bool verbose;
+        readonly private static bool verbose;
 
 
-    static LinearEqualitiesEnvironment()
-    {
-      verbose = false;
-    }
+        static LinearEqualitiesEnvironment()
+        {
+            verbose = false;
+        }
 
-    protected LinearEqualitiesEnvironment()
-    {
-    }
+        protected LinearEqualitiesEnvironment()
+        {
+        }
 
-    /// <summary>
-    /// Get the statics for the usage of the LinearEqualitiesEnvironment
-    /// </summary>
-    static public string Statistics
-    {
-      get
-      {
+        /// <summary>
+        /// Get the statics for the usage of the LinearEqualitiesEnvironment
+        /// </summary>
+        static public string Statistics
+        {
+            get
+            {
 #if TRACEPERFORMANCE
-        var maxCol = "Maximum number of Columns : " + MaxColumns + Environment.NewLine;
-        var maxRows = "Maximum number of Rows : " + MaxRows + Environment.NewLine;
-        var maxUnused = "Maximum number of Unused columns " + MaxUnusedDim + Environment.NewLine;
-        var maxPairWiseEq = "Maximum number of Pairwise Equalities " + MaxPairwiseEq + Environment.NewLine;
+                var maxCol = "Maximum number of Columns : " + MaxColumns + Environment.NewLine;
+                var maxRows = "Maximum number of Rows : " + MaxRows + Environment.NewLine;
+                var maxUnused = "Maximum number of Unused columns " + MaxUnusedDim + Environment.NewLine;
+                var maxPairWiseEq = "Maximum number of Pairwise Equalities " + MaxPairwiseEq + Environment.NewLine;
 
-        return maxCol + maxRows + maxUnused + maxPairWiseEq;
+                return maxCol + maxRows + maxUnused + maxPairWiseEq;
 #else
-        return "Performance tracing is off";
+                return "Performance tracing is off";
 #endif
-      }
-    }
-
-    public static int AdaptiveRenamingInSubpolyhedraThreshold { set; get; }
-
-#if TRACEPERFORMANCE
-    public static int MaxColumns
-    {
-      get
-      {
-        return maxColumns;
-      }
-    }
-
-    public static int MaxRows
-    {
-      get
-      {
-        return maxRows;
-      }
-    }
-
-    public static int MaxVars
-    {
-      get
-      {
-        return maxVars;
-      }
-    }
-
-    public static int MaxUnusedDim
-    {
-      get
-      {
-        return maxUnused;
-      }
-    }
-
-    public static int MaxPairwiseEq
-    {
-      get
-      {
-        return maxPairwiseEq;
-      }
-    }
-#endif
-
-    [Conditional("TRACEPERFORMANCE")]
-    public static void UpdateMaxColumns(int newVal)
-    {
-#if TRACEPERFORMANCE
-      Update(ref maxColumns, newVal, "Max columns so far {0}");
-#endif
-    }
-
-    [Conditional("TRACEPERFORMANCE")]
-    public static void UpdateMaxRows(int newVal)
-    {
-#if TRACEPERFORMANCE
-      Update(ref maxRows, newVal, "Max rows so far {0}");
-#endif
-    }
-
-    public static void UpdateMaxVariables(int newVal)
-    {
-#if TRACEPERFORMANCE
-      Update(ref maxVars, newVal, "Max vars so far {0}");
-#endif
-    }
-
-    [Conditional("TRACEPERFORMANCE")]
-    public static void UpdateMaxUnusedVariables(int newVal)
-    {
-#if TRACEPERFORMANCE
-      Update(ref maxUnused, newVal, "Max unused dimensions so far {0}");
-#endif
-    }
-
-    [Conditional("TRACEPERFORMANCE")]
-    public static void UpdateMaxPairwiseEq(int newVal)
-    {
-#if TRACEPERFORMANCE
-      Update(ref maxPairwiseEq, newVal, "Max pairwise eq so far {0}");
-#endif
-    }
-
-    [Conditional("TRACEPERFORMANCE")]
-    private static void Update(ref int what, int newVal, string msg)
-    {
-      if (newVal > what)
-      {
-        what = newVal;
-        if (verbose)
-        {
-          Console.WriteLine(msg, newVal);
+            }
         }
-      }
-    }
 
-    [Conditional("TRACEPERFORMANCE")]
-    protected static void LogPerformance(string format, params string[] args)
-    {
-      Console.WriteLine(format, args);
-    }
+        public static int AdaptiveRenamingInSubpolyhedraThreshold { set; get; }
 
-    [Conditional("TRACEPERFORMANCE")]
-    protected static void LogPerformanceWithTreshold(int treshold, string format, int value)
-    {
-      if (value > treshold)
-      {
-        Console.WriteLine(format, value.ToString());
-      }
-    }
-
-    [Conditional("TRACEPERFORMANCE")]
-    protected static void LogPerformanceWithTreshold(TimeSpan treshold, string format, TimeSpan value)
-    {
-      if (value > treshold)
-      {
-        Console.WriteLine(format, value.ToString());
-      }
-    }
-  }
-
-  /// <summary>
-  /// The abstract numerical domain of linear equalities
-  /// </summary> 
-  [ContractVerification(false)]
-  [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-this.varsToDimensions.LessThan(this.NumberOfColumns - 1)")]
-  public class LinearEqualitiesEnvironment<Variable, Expression> :
-      LinearEqualitiesEnvironment, // just for the statistics
-      INumericalAbstractDomain<Variable, Expression>
-  {
-
-    #region Invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.equations != null);
-      Contract.Invariant(this.varsToDimensions != null);
-      Contract.Invariant(this.expManager != null);
-      Contract.Invariant(this.testTrue != null);
-      Contract.Invariant(this.testFalse != null);
-      Contract.Invariant(this.checkIfHolds != null);
-
-      Contract.Invariant(this.varsToDimensions.LessThan(this.NumberOfColumns - 1));
-    }
-
-    #endregion
-
-    #region State
-    protected LinearEqualitiesState state;                              // The state of this linear equality
-    protected LinearEquations<Variable, Expression> equations;          // The equations of the environment
-
-    protected int numberOfRows;                 // The next free slot for a linear constraint
-    protected int numberOfCols;                 // The number of columns
-
-    protected VarsToDimensions varsToDimensions;        // The map from variables to dimensions
-
-    protected ExpressionManagerWithEncoder<Variable, Expression> expManager;
-
-    internal VisitorForTestTrue testTrue;
-    internal VisitorForTestFalse testFalse;
-    internal VisitorForCheckIfHolds checkIfHolds;
-
-    #endregion
-
-    #region The properties
-
-    public ExpressionManager<Variable, Expression> ExpressionManager
-    {
-      get
-      {
-        return this.expManager;
-      }
-    }
-
-    public bool ContainsOnlyConstants
-    {
-      get
-      {
-        for (int row = 0; row < this.NumberOfRows; row++)
+#if TRACEPERFORMANCE
+        public static int MaxColumns
         {
-          if (!this.equations.IsConstantRow(row))
-            return false;
+            get
+            {
+                return maxColumns;
+            }
         }
-        return true;
-      }
-    }
 
-    protected int NumberOfColumns
-    {
-      get
-      {
-        UpdateMaxColumns(this.numberOfCols);
+        public static int MaxRows
+        {
+            get
+            {
+                return maxRows;
+            }
+        }
 
-        return this.numberOfCols;
-      }
-      set
-      {
-        UpdateMaxColumns(value);
+        public static int MaxVars
+        {
+            get
+            {
+                return maxVars;
+            }
+        }
 
-        this.numberOfCols = value;
-      }
-    }
+        public static int MaxUnusedDim
+        {
+            get
+            {
+                return maxUnused;
+            }
+        }
 
-    public int NumberOfVariables
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
+        public static int MaxPairwiseEq
+        {
+            get
+            {
+                return maxPairwiseEq;
+            }
+        }
+#endif
 
-        UpdateMaxVariables(this.varsToDimensions.Count);
+        [Conditional("TRACEPERFORMANCE")]
+        public static void UpdateMaxColumns(int newVal)
+        {
+#if TRACEPERFORMANCE
+            Update(ref maxColumns, newVal, "Max columns so far {0}");
+#endif
+        }
 
-        return this.varsToDimensions.Count;
-      }
-    }
+        [Conditional("TRACEPERFORMANCE")]
+        public static void UpdateMaxRows(int newVal)
+        {
+#if TRACEPERFORMANCE
+            Update(ref maxRows, newVal, "Max rows so far {0}");
+#endif
+        }
 
-    public int NumberOfRows
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        Contract.Ensures(Contract.Result<int>() == this.numberOfRows);
+        public static void UpdateMaxVariables(int newVal)
+        {
+#if TRACEPERFORMANCE
+            Update(ref maxVars, newVal, "Max vars so far {0}");
+#endif
+        }
 
-        UpdateMaxRows(this.numberOfRows);
+        [Conditional("TRACEPERFORMANCE")]
+        public static void UpdateMaxUnusedVariables(int newVal)
+        {
+#if TRACEPERFORMANCE
+            Update(ref maxUnused, newVal, "Max unused dimensions so far {0}");
+#endif
+        }
 
-        return this.numberOfRows;
-      }
-    }
+        [Conditional("TRACEPERFORMANCE")]
+        public static void UpdateMaxPairwiseEq(int newVal)
+        {
+#if TRACEPERFORMANCE
+            Update(ref maxPairwiseEq, newVal, "Max pairwise eq so far {0}");
+#endif
+        }
 
-    protected int GrowSizeForColumns
-    {
-      get
-      {
-        return 4;
-      }
-    }
+        [Conditional("TRACEPERFORMANCE")]
+        private static void Update(ref int what, int newVal, string msg)
+        {
+            if (newVal > what)
+            {
+                what = newVal;
+                if (verbose)
+                {
+                    Console.WriteLine(msg, newVal);
+                }
+            }
+        }
 
-    public int UnusedColumns
-    {
-      get
-      {
-        return this.NumberOfColumns - (this.varsToDimensions.Count + 1);
-      }
-    }
+        [Conditional("TRACEPERFORMANCE")]
+        protected static void LogPerformance(string format, params string[] args)
+        {
+            Console.WriteLine(format, args);
+        }
 
-    #endregion
+        [Conditional("TRACEPERFORMANCE")]
+        protected static void LogPerformanceWithTreshold(int treshold, string format, int value)
+        {
+            if (value > treshold)
+            {
+                Console.WriteLine(format, value.ToString());
+            }
+        }
 
-    #region Constructors
-
-    /// <summary>
-    /// How many linear equalities?
-    /// </summary>
-    /// <param name="decoder">The decoder for expressions</param>
-    [ContractVerification(true)]
-    public LinearEqualitiesEnvironment(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : this(INITIAL_VARS_FOR_EQUATION_COUNT, INITIAL_EQUATIONS_COUNT, expManager)
-    {
-      Contract.Requires(expManager != null);
-    }
-
-    /// <summary>
-    /// Build a Linear equalities environment with <code>n</code> dimensions
-    /// </summary>
-    /// <param name="var">The initial number of variables</param>
-    /// <param name="equationsCount">The initial number of equations</param>
-    [ContractVerification(true)]
-    public LinearEqualitiesEnvironment(int var, int equationsCount, ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
-
-      Contract.Requires(var > 0);
-      Contract.Requires(equationsCount > 0);
-
-      this.equations = new LinearEquations<Variable, Expression>(this, equationsCount);
-
-      this.numberOfRows = 0;
-      this.NumberOfColumns = var + 1;
-
-      this.state = LinearEqualitiesState.Normal;
-      this.varsToDimensions = new VarsToDimensions();
-
-      this.expManager = expManager;
-      SetUpVisitors();
-    }
-
-    /// <summary>
-    /// A cosntructor used mainly for the internal operations of the abstract domain
-    /// </summary>
-    [ContractVerification(true)]
-    protected LinearEqualitiesEnvironment(LinearEquations<Variable, Expression> equations, int numOfRows, int numOfCols,
-      VarsToDimensions varsToDimensions,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(equations != null);
-      Contract.Requires(varsToDimensions != null);
-      Contract.Requires(expManager != null);
-
-      this.equations = equations;
-      this.numberOfRows = numOfRows;
-      this.NumberOfColumns = numOfCols;
-
-      this.state = LinearEqualitiesState.Normal;
-
-      if (numOfRows > 0 && !this.equations.IsNullRow(0))
-      {
-        this.varsToDimensions = varsToDimensions;
-      }
-      else // The matrix is empty, so all the varsToDimensions are unusefull
-      {
-        this.varsToDimensions = new VarsToDimensions();
-      }
-
-      this.expManager = expManager;
-
-      SetUpVisitors();
-    }
-
-    [ContractVerification(true)]
-    protected LinearEqualitiesEnvironment(SparseRationalArray[] equations, int numOfRows, int numOfCols, VarsToDimensions varsToDimensions,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : this(new LinearEquations<Variable, Expression>(null, equations), numOfRows, numOfCols, varsToDimensions, expManager)
-    {
-      Contract.Requires(equations != null);
-      Contract.Requires(varsToDimensions != null);
-      Contract.Requires(expManager != null);
-
-      this.equations = new LinearEquations<Variable, Expression>(this, equations);
-    }
-
-    [ContractVerification(true)]
-    protected LinearEqualitiesEnvironment(LinearEqualitiesEnvironment<Variable, Expression> l)
-    {
-      Contract.Requires(l != null);
-
-      Contract.Assume(l.equations != null);
-      Contract.Assume(l.varsToDimensions != null);
-      Contract.Assume(l.expManager != null);
-      Contract.Assume(l.testTrue != null);
-      Contract.Assume(l.testFalse != null);
-      Contract.Assume(l.checkIfHolds != null);
-
-      this.equations = l.equations.AddSharing(this);
-      this.numberOfRows = l.numberOfRows;
-      this.numberOfCols = l.numberOfCols;
-      this.state = l.state;
-      this.varsToDimensions = new VarsToDimensions(l.varsToDimensions);
-      this.expManager = l.expManager;
-      this.testTrue = l.testTrue;
-      this.testFalse = l.testFalse;
-      this.checkIfHolds = l.checkIfHolds;
-    }
-
-    [ContractVerification(true)]
-    protected void CloneThisFrom(LinearEqualitiesEnvironment<Variable, Expression> orig)
-    {
-      Contract.Requires(orig != null);
-
-      Contract.Assume(orig.equations != null);
-      Contract.Assume(orig.varsToDimensions != null);
-      Contract.Assume(orig.expManager != null);
-      Contract.Assume(orig.testTrue != null);
-      Contract.Assume(orig.testFalse != null);
-      Contract.Assume(orig.checkIfHolds != null);
-
-      this.equations = orig.equations;
-      this.numberOfCols = orig.numberOfCols;
-      this.numberOfRows = orig.numberOfRows;
-      this.state = orig.state;
-      this.varsToDimensions = orig.varsToDimensions;
-      this.expManager = orig.expManager;
-      this.testTrue = orig.testTrue;
-      this.testFalse = orig.testFalse;
-      this.checkIfHolds = orig.checkIfHolds;
-
-      // destroy the state of orig, to prevent bugs
-      orig.equations = null;
-      orig.varsToDimensions = null;
-
+        [Conditional("TRACEPERFORMANCE")]
+        protected static void LogPerformanceWithTreshold(TimeSpan treshold, string format, TimeSpan value)
+        {
+            if (value > treshold)
+            {
+                Console.WriteLine(format, value.ToString());
+            }
+        }
     }
 
     /// <summary>
-    /// Set up the visitors
-    /// </summary>
-    [ContractVerification(true)]
-    private void SetUpVisitors()
-    {
-      this.testTrue = new VisitorForTestTrue(this.expManager.Decoder);
-      this.testFalse = new VisitorForTestFalse(this.expManager.Decoder);
-
-      this.testTrue.FalseVisitor = this.testFalse;
-      this.testFalse.TrueVisitor = this.testTrue;
-
-      this.checkIfHolds = new VisitorForCheckIfHolds(this.expManager);
-    }
-
-    [ContractVerification(true)]
-    protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
-
-      return new LinearEqualitiesEnvironment<Variable, Expression>(expManager);
-    }
-
-    [ContractVerification(true)]
-    protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(int var, int eqs,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(var > 0);
-      Contract.Requires(eqs > 0);
-      Contract.Requires(expManager != null);
-
-      return new LinearEqualitiesEnvironment<Variable, Expression>(var, eqs, this.expManager);
-    }
-
-    [ContractVerification(true)]
-    protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(LinearEqualitiesEnvironment<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      return new LinearEqualitiesEnvironment<Variable, Expression>(other);
-    }
-
-    [ContractVerification(true)]
-    protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(SparseRationalArray[] JoinedMatrix,
-      int numberOfRowsInResult, int p, VarsToDimensions freshMap,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(JoinedMatrix != null);
-      Contract.Requires(freshMap != null);
-      Contract.Requires(expManager != null);
-
-      return new LinearEqualitiesEnvironment<Variable, Expression>(JoinedMatrix, numberOfRowsInResult, p, freshMap, expManager);
-    }
-
-    #endregion
-
-    #region ToString
-
+    /// The abstract numerical domain of linear equalities
+    /// </summary> 
     [ContractVerification(false)]
-    public T To<T>(IFactory<T> factory)
+    [SuppressMessage("Microsoft.Contracts", "InvariantInMethod-this.varsToDimensions.LessThan(this.NumberOfColumns - 1)")]
+    public class LinearEqualitiesEnvironment<Variable, Expression> :
+        LinearEqualitiesEnvironment, // just for the statistics
+        INumericalAbstractDomain<Variable, Expression>
     {
-      if (this.IsBottom)
-        return factory.Constant(false);
-      if (this.IsTop)
-        return factory.Constant(true);
+        #region Invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.equations != null);
+            Contract.Invariant(this.varsToDimensions != null);
+            Contract.Invariant(this.expManager != null);
+            Contract.Invariant(this.testTrue != null);
+            Contract.Invariant(this.testFalse != null);
+            Contract.Invariant(this.checkIfHolds != null);
 
-      var result = factory.IdentityForAnd;
+            Contract.Invariant(this.varsToDimensions.LessThan(this.NumberOfColumns - 1));
+        }
 
-      for (int i = 0; i < this.numberOfRows; i++)
-      {
-        result = factory.And(result, To(i, factory));
-      }
+        #endregion
 
-      return result;
-    }
+        #region State
+        protected LinearEqualitiesState state;                              // The state of this linear equality
+        protected LinearEquations<Variable, Expression> equations;          // The equations of the environment
 
-    [ContractVerification(false)]
-    private T To<T>(int i, IFactory<T> factory)
-    {
-      var result = factory.IdentityForAdd;
+        protected int numberOfRows;                 // The next free slot for a linear constraint
+        protected int numberOfCols;                 // The number of columns
 
-      var coefficients = new List<Rational>();
-      var variables = new List<Variable>();
+        protected VarsToDimensions varsToDimensions;        // The map from variables to dimensions
 
-      for (int j = 0; j < this.NumberOfColumns - 1; j++)
-      {
+        protected ExpressionManagerWithEncoder<Variable, Expression> expManager;
 
-        Variable var;
+        internal VisitorForTestTrue testTrue;
+        internal VisitorForTestFalse testFalse;
+        internal VisitorForCheckIfHolds checkIfHolds;
+
+        #endregion
+
+        #region The properties
+
+        public ExpressionManager<Variable, Expression> ExpressionManager
+        {
+            get
+            {
+                return this.expManager;
+            }
+        }
+
+        public bool ContainsOnlyConstants
+        {
+            get
+            {
+                for (int row = 0; row < this.NumberOfRows; row++)
+                {
+                    if (!this.equations.IsConstantRow(row))
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        protected int NumberOfColumns
+        {
+            get
+            {
+                UpdateMaxColumns(this.numberOfCols);
+
+                return this.numberOfCols;
+            }
+            set
+            {
+                UpdateMaxColumns(value);
+
+                this.numberOfCols = value;
+            }
+        }
+
+        public int NumberOfVariables
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                UpdateMaxVariables(this.varsToDimensions.Count);
+
+                return this.varsToDimensions.Count;
+            }
+        }
+
+        public int NumberOfRows
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                Contract.Ensures(Contract.Result<int>() == this.numberOfRows);
+
+                UpdateMaxRows(this.numberOfRows);
+
+                return this.numberOfRows;
+            }
+        }
+
+        protected int GrowSizeForColumns
+        {
+            get
+            {
+                return 4;
+            }
+        }
+
+        public int UnusedColumns
+        {
+            get
+            {
+                return this.NumberOfColumns - (this.varsToDimensions.Count + 1);
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// How many linear equalities?
+        /// </summary>
+        /// <param name="decoder">The decoder for expressions</param>
+        [ContractVerification(true)]
+        public LinearEqualitiesEnvironment(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : this(INITIAL_VARS_FOR_EQUATION_COUNT, INITIAL_EQUATIONS_COUNT, expManager)
+        {
+            Contract.Requires(expManager != null);
+        }
+
+        /// <summary>
+        /// Build a Linear equalities environment with <code>n</code> dimensions
+        /// </summary>
+        /// <param name="var">The initial number of variables</param>
+        /// <param name="equationsCount">The initial number of equations</param>
+        [ContractVerification(true)]
+        public LinearEqualitiesEnvironment(int var, int equationsCount, ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
+
+            Contract.Requires(var > 0);
+            Contract.Requires(equationsCount > 0);
+
+            this.equations = new LinearEquations<Variable, Expression>(this, equationsCount);
+
+            this.numberOfRows = 0;
+            this.NumberOfColumns = var + 1;
+
+            this.state = LinearEqualitiesState.Normal;
+            this.varsToDimensions = new VarsToDimensions();
+
+            this.expManager = expManager;
+            SetUpVisitors();
+        }
+
+        /// <summary>
+        /// A cosntructor used mainly for the internal operations of the abstract domain
+        /// </summary>
+        [ContractVerification(true)]
+        protected LinearEqualitiesEnvironment(LinearEquations<Variable, Expression> equations, int numOfRows, int numOfCols,
+          VarsToDimensions varsToDimensions,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(equations != null);
+            Contract.Requires(varsToDimensions != null);
+            Contract.Requires(expManager != null);
+
+            this.equations = equations;
+            this.numberOfRows = numOfRows;
+            this.NumberOfColumns = numOfCols;
+
+            this.state = LinearEqualitiesState.Normal;
+
+            if (numOfRows > 0 && !this.equations.IsNullRow(0))
+            {
+                this.varsToDimensions = varsToDimensions;
+            }
+            else // The matrix is empty, so all the varsToDimensions are unusefull
+            {
+                this.varsToDimensions = new VarsToDimensions();
+            }
+
+            this.expManager = expManager;
+
+            SetUpVisitors();
+        }
+
+        [ContractVerification(true)]
+        protected LinearEqualitiesEnvironment(SparseRationalArray[] equations, int numOfRows, int numOfCols, VarsToDimensions varsToDimensions,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : this(new LinearEquations<Variable, Expression>(null, equations), numOfRows, numOfCols, varsToDimensions, expManager)
+        {
+            Contract.Requires(equations != null);
+            Contract.Requires(varsToDimensions != null);
+            Contract.Requires(expManager != null);
+
+            this.equations = new LinearEquations<Variable, Expression>(this, equations);
+        }
+
+        [ContractVerification(true)]
+        protected LinearEqualitiesEnvironment(LinearEqualitiesEnvironment<Variable, Expression> l)
+        {
+            Contract.Requires(l != null);
+
+            Contract.Assume(l.equations != null);
+            Contract.Assume(l.varsToDimensions != null);
+            Contract.Assume(l.expManager != null);
+            Contract.Assume(l.testTrue != null);
+            Contract.Assume(l.testFalse != null);
+            Contract.Assume(l.checkIfHolds != null);
+
+            this.equations = l.equations.AddSharing(this);
+            this.numberOfRows = l.numberOfRows;
+            this.numberOfCols = l.numberOfCols;
+            this.state = l.state;
+            this.varsToDimensions = new VarsToDimensions(l.varsToDimensions);
+            this.expManager = l.expManager;
+            this.testTrue = l.testTrue;
+            this.testFalse = l.testFalse;
+            this.checkIfHolds = l.checkIfHolds;
+        }
+
+        [ContractVerification(true)]
+        protected void CloneThisFrom(LinearEqualitiesEnvironment<Variable, Expression> orig)
+        {
+            Contract.Requires(orig != null);
+
+            Contract.Assume(orig.equations != null);
+            Contract.Assume(orig.varsToDimensions != null);
+            Contract.Assume(orig.expManager != null);
+            Contract.Assume(orig.testTrue != null);
+            Contract.Assume(orig.testFalse != null);
+            Contract.Assume(orig.checkIfHolds != null);
+
+            this.equations = orig.equations;
+            this.numberOfCols = orig.numberOfCols;
+            this.numberOfRows = orig.numberOfRows;
+            this.state = orig.state;
+            this.varsToDimensions = orig.varsToDimensions;
+            this.expManager = orig.expManager;
+            this.testTrue = orig.testTrue;
+            this.testFalse = orig.testFalse;
+            this.checkIfHolds = orig.checkIfHolds;
+
+            // destroy the state of orig, to prevent bugs
+            orig.equations = null;
+            orig.varsToDimensions = null;
+        }
+
+        /// <summary>
+        /// Set up the visitors
+        /// </summary>
+        [ContractVerification(true)]
+        private void SetUpVisitors()
+        {
+            this.testTrue = new VisitorForTestTrue(this.expManager.Decoder);
+            this.testFalse = new VisitorForTestFalse(this.expManager.Decoder);
+
+            this.testTrue.FalseVisitor = this.testFalse;
+            this.testFalse.TrueVisitor = this.testTrue;
+
+            this.checkIfHolds = new VisitorForCheckIfHolds(this.expManager);
+        }
+
+        [ContractVerification(true)]
+        protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
+
+            return new LinearEqualitiesEnvironment<Variable, Expression>(expManager);
+        }
+
+        [ContractVerification(true)]
+        protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(int var, int eqs,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(var > 0);
+            Contract.Requires(eqs > 0);
+            Contract.Requires(expManager != null);
+
+            return new LinearEqualitiesEnvironment<Variable, Expression>(var, eqs, this.expManager);
+        }
+
+        [ContractVerification(true)]
+        protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(LinearEqualitiesEnvironment<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            return new LinearEqualitiesEnvironment<Variable, Expression>(other);
+        }
+
+        [ContractVerification(true)]
+        protected virtual LinearEqualitiesEnvironment<Variable, Expression> New(SparseRationalArray[] JoinedMatrix,
+          int numberOfRowsInResult, int p, VarsToDimensions freshMap,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(JoinedMatrix != null);
+            Contract.Requires(freshMap != null);
+            Contract.Requires(expManager != null);
+
+            return new LinearEqualitiesEnvironment<Variable, Expression>(JoinedMatrix, numberOfRowsInResult, p, freshMap, expManager);
+        }
+
+        #endregion
+
+        #region ToString
+
+        [ContractVerification(false)]
+        public T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.Constant(false);
+            if (this.IsTop)
+                return factory.Constant(true);
+
+            var result = factory.IdentityForAnd;
+
+            for (int i = 0; i < this.numberOfRows; i++)
+            {
+                result = factory.And(result, To(i, factory));
+            }
+
+            return result;
+        }
+
+        [ContractVerification(false)]
+        private T To<T>(int i, IFactory<T> factory)
+        {
+            var result = factory.IdentityForAdd;
+
+            var coefficients = new List<Rational>();
+            var variables = new List<Variable>();
+
+            for (int j = 0; j < this.NumberOfColumns - 1; j++)
+            {
+                Variable var;
 
 #if false
-        if (this.varsToDimensions.TryGetValue(j, out var) && this.equations.At(i, j).IsNotZero)
-        {
-          var k = factory.Constant(this.equations.At(i, j));
-          var x = factory.Variable(var);
-
-          result = factory.Add(result, factory.Mul(k, x));
-        }
-#endif
-        if (this.varsToDimensions.TryGetValue(j, out var))
-        {
-          var k = this.equations.At(i, j);
-          if(k.IsNotZero)
-          {
-            coefficients.Add(k);
-            variables.Add(var);
-          }
-        }
-      }
-
-      Contract.Assert(coefficients.Count == variables.Count);
-
-      var knownValue = this.equations.At(i, this.NumberOfColumns - 1);
-
-      coefficients.Add(knownValue);
-
-      var normalizedCoefficients = NormalizeCoeffiecients(coefficients);
-      if (normalizedCoefficients != null)
-      {
-        for (var j = 0; j < normalizedCoefficients.Count - 1 /* the last element is the known value */ ; j++)
-        {
-          var coeff = normalizedCoefficients[j];
-          if (coeff > 0)
-          {
-            result = factory.Add(result, factory.Mul(factory.Constant(coeff), factory.Variable(variables[j])));
-          }
-          else
-          {
-            Contract.Assume(coeff < 0);
-            result = factory.Sub(result, factory.Mul(factory.Constant(-coeff), factory.Variable(variables[j])));
-          }
-        }
-        
-        result = factory.EqualTo(result, factory.Constant(normalizedCoefficients.Last()));
-      }
-      else // if something went wrong, we simply return the raw equation
-      {
-        for (int j = 0; j < this.NumberOfColumns - 1; j++)
-        {
-
-          Variable var;
-          if (this.varsToDimensions.TryGetValue(j, out var) && this.equations.At(i, j).IsNotZero)
-          {
-            var k = factory.Constant(this.equations.At(i, j));
-            var x = factory.Variable(var);
-
-            result = factory.Add(result, factory.Mul(k, x));
-          }
-        }
-
-        result = factory.EqualTo(result, factory.Constant(knownValue));
-      }
-      return result;
-    }
-
-    [ContractVerification(false)]
-    private List<Rational> NormalizeCoeffiecients(List<Rational> coefficients)
-    {
-      Contract.Requires(coefficients != null);
-      Contract.Ensures(Contract.Result<List<Rational>>() == null || Contract.Result<List<Rational>>().Count == coefficients.Count);
-
-      try
-      {
-        var mul = 1L;
-        foreach (var c in coefficients)
-        {
-          var down = c.Down;
-          long min, max;
-          if (down < mul)
-          {
-            min = down;
-            max = mul;
-          }
-          else
-          {
-            min = mul;
-            max = down;
-          }
-          if (min % max != 0)
-          {
-            mul *= c.Down;
-          }
-        }
-
-        Contract.Assume(mul != 0);
-
-        return coefficients.ApplyToAll<Rational, Rational>(c => c * mul).ToList();
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return null;
-      }
-    }
-
-    public override string ToString()
-    {
-      if (this.IsTop)
-      {
-        return "Top (Karr) ";
-      }
-
-      // Pretty print the constraints
-      var result = new StringBuilder();
-
-      result.AppendLine("Linear Equalities:");
-#if VERBOSEOUTPUT
-      result.AppendLine(string.Format("Vars -> Dimensions map" + Environment.NewLine + "{0}", this.varsToDimensions));
-
-      result.AppendLine(this.IsConsistent ? "Consistent" : "Warning: The representation is NOT consistent");
-#endif
-
-      if (this.state == LinearEqualitiesState.Bottom)
-      {
-        result.AppendLine("_|_");
-        return result.ToString();
-      }
-
-      // We want to sort the lines, to obtain a more deterministic debugging output
-      var lines = new List<List<string>>();
-
-      for (int i = 0; i < this.numberOfRows; i++)
-      {
-        var equation = new List<string>();
-
-        for (var j = 0; j < this.NumberOfColumns - 1; j++)
-        {
-          if(this.varsToDimensions.ContainsValue(j))
-          {
-            var variable = this.varsToDimensions.KeyForValue(j);
-            var value = this.equations.At(i, j);
-            var monomial = new StringBuilder();
-
-            if (value == 0)
-            {
-              monomial.Append(" ");
-            }
-            else
-            {
-              if (value != 1)
-              {
-                monomial.Append(value == -1 ? "-" : value.ToString() + " ");
-              }
-              var asString = this.ToString(variable);
-              monomial.Append(asString);
-            }
-            equation.Add(monomial.ToString());
-          }
-        }
-
-        var constant = this.equations.At(i, NumberOfColumns-1);
-
-        equation.Add(" = ");
-        equation.Add(constant.ToString());
-
-        lines.Add(equation);
-      }
-
-      // Compute the column widths
-      var widths = new List<int>();
-      foreach (var line in lines)
-      {
-        var i = 0;
-        foreach (var monom in line)
-        {
-          var max = Math.Max(monom.Length, widths.ElementAtOrDefault(i));
-          if (i < widths.Count)
-          {
-            widths[i] = max;
-          }
-          else
-          {
-            widths.Add(max);
-          }
-          i++;
-        }
-      }
-
-      var formattedlines = new List<string>();
-
-      foreach (var line in lines)
-      {
-        var formattedLine = new StringBuilder();
-        for (var i = 0; i < line.Count; i++)
-        {
-          var mask = "{0," + widths[i] +"}";
-          var formattedString = string.Format(mask, line[i]);
-          formattedLine.Append(formattedString);
-        }
-        formattedlines.Add(formattedLine.ToString());
-      }
-      
-      return Print(this.state, formattedlines);
-    }
-
-    static private string Print(LinearEqualitiesState state, List<string> strs)
-    {
-      var sb = new StringBuilder();
-      sb.AppendFormat("State : {0}\n", state);
-      foreach (var s in strs)
-      {
-        sb.AppendLine(s);
-      }
-
-      return sb.ToString();
-    }
-
-    public string ToString(Expression exp)
-    {
-      if (this.expManager.Decoder!= null)
-      {
-        return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
-      }
-      else
-      {
-        return "< missing expression decoder >";
-      }
-    }
-
-    public string ToString(Variable v)
-    {
-      return this.expManager.Decoder.NameOf(v);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-    /// <summary>
-    /// Return true iff this set of constraints is contradictory
-    /// </summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    public bool IsBottom
-    {
-      get
-      {
-        return PerformanceMeasure.Measure<bool>(
-          PerformanceMeasure.ActionTags.KarrIsBottom,
-        () =>
-        {
-          return this.IsEmpty();
-        }
-          );
-      }
-    }
-
-    /// <summary>
-    /// Return true iff this set set of constraints is empty
-    /// </summary>
-    public bool IsTop
-    {
-      get
-      {
-        return this.numberOfRows == 0;      // No contstraint => top element
-      }
-    }
-
-    /// <summary>
-    /// In order to check if <code>this \leq a</code>, we do <code>this.Meet(a)</code>, and check if the matrix is this one
-    /// </summary>
-    public bool LessEqual(IAbstractDomain a)
-    {
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
-      {
-        return result;
-      }
-
-      var right = a as LinearEqualitiesEnvironment<Variable, Expression>;
-
-      Debug.Assert(a != null, "I was expecting an instance of " + this.GetType().ToString() + ". I found " + a.GetType().ToString());
-
-      var meet = this.Meet(right);
-
-      if (meet.IsBottom)
-      {
-        return false;     // It means that the two elements are not comparable
-      }
-
-      Debug.Assert(!meet.IsTop, "It is strange that the meet, at this point is top...");
-
-      var meetAsLE = meet as LinearEqualitiesEnvironment<Variable, Expression>;
-      Debug.Assert(meetAsLE != null, "I was expecting an instance of " + this.GetType().ToString() + ". I found " + meet.GetType().ToString());
-
-
-      // Now we check that the meet == this;
-
-      if (this.NumberOfRows != meetAsLE.NumberOfRows)
-      {
-        return false;
-      }
-
-      if (!this.equations.IsNullRow(0) && !meetAsLE.equations.IsNullRow(0))
-      {
-        if (this.equations.RowLength(0) != meetAsLE.equations.RowLength(0))
-        {
-          return false;
-        }
-        else
-        {
-          UniformEnvironments(this, meetAsLE);
-          this.PutIntoWeakRowEchelonForm();
-          meetAsLE.PutIntoWeakRowEchelonForm();
-
-          for (int row = 0; row < this.numberOfRows; row++)
-          {
-            for (int col = 0; col < this.NumberOfColumns; col++)
-            {
-              Rational l, r;
-
-              var bl = this.equations.IsIndexOfNonDefaultElement(row, col, out l);
-              var br = meetAsLE.equations.IsIndexOfNonDefaultElement(row, col, out r);
-
-              if (bl && br && l != r)
-              {
-                return false;
-              }
-            }
-          }
-          return true;
-        }
-      }
-      else
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// Returns a contradictory system
-    /// </summary>
-    public IAbstractDomain Bottom
-    {
-      get
-      {
-        var bott = New(1, 1, this.expManager);
-
-        var b = SparseRationalArray.New(2, 0);
-        b[0] = Rational.For(0);
-        b[1] = Rational.For(1);
-
-        bott.AddConstraint(b);
-
-        return bott;
-      }
-    }
-
-    /// <summary>
-    /// Returns a system without constraints
-    /// </summary>
-    public IAbstractDomain Top
-    {
-      get
-      {
-        return New(1, 3, this.expManager);
-      }
-    }
-
-    /// <summary>
-    /// The join follows the [Kar76] algorithm.
-    /// The algorithm works in place, and it modifies the receiver <b>AND</b> <code>a</code>
-    /// </summary>
-    /// <returns>The disjunction of the two</returns>
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var other = a as LinearEqualitiesEnvironment<Variable, Expression>;
-      Contract.Assume(other != null);
-      return this.Join(other);
-    }
-
-    public LinearEqualitiesEnvironment<Variable, Expression> Join(LinearEqualitiesEnvironment<Variable, Expression> a)
-    {
-      Contract.Requires(a != null);
-      Contract.Ensures(Contract.Result<LinearEqualitiesEnvironment<Variable, Expression>>() != null);
-
-      var obj = new List<Polynomial<Variable, Expression>>();
-      return Join(a, ref obj, ref obj);
-    }
-
-    virtual internal LinearEqualitiesEnvironment<Variable, Expression> Join(IAbstractDomain a, ref List<Polynomial<Variable, Expression>> deletedLeft, ref List<Polynomial<Variable, Expression>> deletedRight)
-    {
-      IAbstractDomain/*!*/ trivialresult;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivialresult))
-      {
-        if (trivialresult.IsTop)
-        {
-          deletedLeft.AddRange(this.ToPolynomial(false));
-          deletedRight.AddRange((a as LinearEqualitiesEnvironment<Variable, Expression>).ToPolynomial(false));
-        }
-        return trivialresult as LinearEqualitiesEnvironment<Variable, Expression>;
-      }
-
-      var right = a as LinearEqualitiesEnvironment<Variable, Expression>;
-
-      Contract.Assert(a != null, "I was expecting an instance of " + this.GetType().ToString() + ". I found " + a.GetType().ToString());
-
-      if (this.equations.AreSharingTheEquations(this, right))
-      {
-        return New(this);
-      }
-
-      LogPerformance("Equalities x == y at join point (left arg) : {0}/{1}", this.CountPairwiseEqualities().ToString(), this.NumberOfRows.ToString());
-      LogPerformance("Equalities x == y at join point (rightarg) : {0}/{1}", right.CountPairwiseEqualities().ToString(), right.NumberOfRows.ToString());
-
-      // 1. Make the domains the same, by uniforming the maps, and swapping columns
-      this.PutIntoRowEchelonForm();
-      this.RecoverUnusedColumns(8);
-
-      right.PutIntoRowEchelonForm();
-      right.RecoverUnusedColumns(8);
-
-      UniformEnvironments(this, right);
-
-      this.PutIntoWeakRowEchelonForm();
-      right.PutIntoWeakRowEchelonForm();
-
-      LogPerformance("Unused variables at join point (left arg of join) : {0}", this.UnusedColumns.ToString());
-      LogPerformance("Unused variables at join point (right arg of join) : {0}", right.UnusedColumns.ToString());
-
-      if (this.state == LinearEqualitiesState.Bottom)
-      {
-        return New(right);
-      }
-
-      if (right.state == LinearEqualitiesState.Bottom)
-      {
-        return New(this);
-      }
-
-      Contract.Assert(this.NumberOfColumns == right.NumberOfColumns);
-
-      // 2. The join is computed according to Karr 1976 paper
-      var A = this.equations.GetClonedEquations();      // We clone the matrixes as Karr works with side effects
-      var B = right.equations.GetClonedEquations();
-
-      int numberOfRowsInResult;
-      var JoinedMatrix = DisjunctionOfLinearSpaces(A, B, this.NumberOfRows, right.numberOfRows, out numberOfRowsInResult, ref deletedLeft, ref deletedRight);
-
-      // 3. Create a clone of the current private state
-      var freshMap = new VarsToDimensions(this.varsToDimensions);
-
-      var result = New(JoinedMatrix, numberOfRowsInResult, this.NumberOfColumns, freshMap, this.expManager);
-      result.state = LinearEqualitiesState.Normal; // the condition implied by Karr's algorithm is weaker than what we call now row echelon form
-
-      LogPerformance("Unused variables after join point : {0}", result.UnusedColumns.ToString());
-      UpdateMaxUnusedVariables(result.UnusedColumns);
-
-      LogPerformance("Equalities x == y at return from join : {0}/{1}", result.CountPairwiseEqualities().ToString(), result.NumberOfRows.ToString());
-
-      result.RecoverUnusedColumns();
-
-      return result;
-    }
-
-    /// <summary>
-    /// The matrix can grow very large, and get many unused entries. 
-    /// This method recover the unused space if there are more than 2 * GrowSizeForColumns unused columns 
-    /// </summary>
-    protected void RecoverUnusedColumns()
-    {
-      RecoverUnusedColumns(2 * GrowSizeForColumns);
-    }
-
-    /// <summary>
-    /// The matrix can grow very large, and get many unused entries. 
-    /// This method recover the unused space.
-    /// </summary>
-    protected void RecoverUnusedColumns(int treshold)
-    {
-      var isConsistent = this.IsConsistent;
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      Contract.Assert(matrix.Length >= this.NumberOfRows);
-
-      if (this.NumberOfColumns - this.varsToDimensions.Count > treshold)
-      {
-        LogPerformance("Performing column recovering. Unused dims : {0}", this.UnusedColumns.ToString());
-
-        var newMatrix = new SparseRationalArray[this.NumberOfRows];
-        var newMappings = new VarsToDimensions();
-
-        var newNumberOfColumns = this.varsToDimensions.Count + 1;
-        for (int row = 0; row < this.NumberOfRows; row++)
-        {
-          newMatrix[row] = FreshRow(newNumberOfColumns);
-        }
-
-        var nextFreePos = 0;
-
-        for (int i = 0; i < this.NumberOfColumns - 1; i++)
-        {
-          if (!IsZeroCol(matrix, this.NumberOfRows, i))
-          {
-            // 1. Update the mapping var <-> dim
-            newMappings[this.varsToDimensions.KeyForValue(i)] = nextFreePos;
-
-            // 2. Copy the column
-            for (int row = 0; row < this.NumberOfRows; row++)
-            {
-              newMatrix[row][nextFreePos] = matrix[row][i];
-            }
-
-            nextFreePos++;
-          }
-        }
-
-        // 3. Update the column of the coefficients
-        for (int row = 0; row < this.NumberOfRows; row++)
-        {
-          newMatrix[row][newNumberOfColumns - 1] = matrix[row][NumberOfColumns - 1];
-        }
-
-        this.equations = new LinearEquations<Variable, Expression>(this, newMatrix);
-        this.varsToDimensions = newMappings;
-        this.numberOfCols = newNumberOfColumns;
-      }
-      else
-      {
-        LogPerformance("No columns to recover, treshold not reached. Unused columns: {0}; Treshold: {1} > {2}",
-          this.UnusedColumns.ToString(), (this.NumberOfColumns - this.varsToDimensions.Count).ToString(), treshold.ToString());
-      }
-
-      CheckConsistency(isConsistent);
-    }
-
-    /// <summary>
-    /// The meet of two system of equations just puts the two system one beneath the other.
-    /// It modifies <b>BOTH</b>the receiver and <code>a</code>
-    /// </summary>
-    /// <returns></returns>
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      IAbstractDomain trivialMeet;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
-      {
-        return trivialMeet;
-      }
-
-      var right = a as LinearEqualitiesEnvironment<Variable, Expression>;
-      Debug.Assert(a != null, "I was expecting an instance of " + this.GetType().ToString() + ", I found a " + a.GetType().ToString());
-
-      if (this.equations.AreSharingTheEquations(this, right))
-      {
-        return New(this);
-      }
-
-      // 1. Make the domains the same, by uniforming the maps, and swapping columns
-      UniformEnvironments(this, right);
-
-      Debug.Assert(this.NumberOfColumns == right.NumberOfColumns);
-
-      // 2. The meet is just putting one matrix beneath the other
-      var result = new SparseRationalArray[this.numberOfRows + right.numberOfRows];
-
-      int numberOfCols = this.NumberOfColumns;
-
-      // Copy all the constraints
-      for (int i = 0; i < this.numberOfRows; i++)
-      {
-        result[i] = SparseRationalArray.New(numberOfCols, 0);
-
-        this.equations.CopyRowTo(i, result[i], numberOfCols);
-      }
-      for (int i = 0; i < right.numberOfRows; i++)
-      {
-        int index = i + this.numberOfRows;
-        result[index] = SparseRationalArray.New(numberOfCols, 0);
-
-        right.equations.CopyRowTo(i, result[index], numberOfCols);
-      }
-
-      var vars2Dim = new VarsToDimensions(this.varsToDimensions);
-
-      return New(result, result.Length, numberOfCols, vars2Dim, this.expManager);
-    }
-
-    /// <summary>
-    /// As the abstract domain of linear equalities satisfies the ACC, the widening is just the join
-    /// </summary>
-    /// <param name="prev">The previous value</param>
-    /// <returns>The join of this with <code>prev</code></returns>
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      return this.Join((LinearEqualitiesEnvironment<Variable, Expression>)prev);
-    }
-
-    public LinearEqualitiesEnvironment<Variable, Expression> Widening(LinearEqualitiesEnvironment<Variable, Expression> prev)
-    {
-      return this.Join((LinearEqualitiesEnvironment<Variable, Expression>)prev);
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Rational,Expression> Members
-
-    /// <returns>
-    /// An interval for the expression <code>v</code>.
-    /// The interval is one of the two: a singleton or top.
-    /// </returns>
-    public DisInterval BoundsFor(Expression v)
-    {
-      var directTry = this.BoundsForQuick(v);
-
-      // Give another chance to fins a bound for
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.expManager.TryGetEncoder(out encoder) && !directTry.IsNormal() && !this.expManager.Decoder.IsVariable(v) )
-      {
-        // Fast path
-        Polynomial<Variable, Expression> polFast;
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(v, this.expManager.Decoder, out polFast)
-          && polFast.IsLinear && !polFast.IsTautology)
-        {
-          var result = Interval.For(0);
-
-          foreach (var mon in polFast.Left)
-          {
-            if (mon.IsConstant)
-            {
-              result = result + mon.K;
-            }
-            else
-            {
-              var boundForX = BoundsFor(mon.VariableAt(0)).AsInterval;
-              if (boundForX.IsTop)
-              {
-                goto slowPath;
-              }
-
-              if (mon.K > 0)
-              {
-                result = result + boundForX;
-              }
-              else
-              {
-                result = result - boundForX;
-              }
-            }
-          }
-
-          return result.AsDisInterval;
-        }
-
-
-        // Slow path
-      slowPath:
-        var tmpVar = encoder.FreshVariable<int>();
-
-        Polynomial<Variable, Expression> pol;
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, tmpVar, v, this.expManager.Decoder, out pol))
-        {
-          if (pol.IsLinear && !pol.IsTautology)
-          {
-            var dup = this.Duplicate();
-
-            dup = dup.TestTrue(pol);
-
-            return dup.BoundsForQuick_Internal(tmpVar);
-          }
-        }
-      }
-
-      return directTry;
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      return this.BoundsForQuick_Internal(v);
-    }
-
-    private DisInterval BoundsForQuick(Expression v)
-    {
-      var decoder = this.expManager.Decoder;
-      int k;
-      if (decoder.IsConstantInt(v, out k))
-      {
-        return DisInterval.For(k);
-      }
-
-      return BoundsForQuick_Internal(decoder.UnderlyingVariable(v));
-    }
-
-    private DisInterval BoundsForQuick_Internal(Variable v)
-    {
-      Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-      if (!this.varsToDimensions.ContainsKey(v))
-      {
-        return DisInterval.UnknownInterval;
-      }
-
-      this.PutIntoRowEchelonForm();
-      var colForv = this.varsToDimensions[v];
-
-      Rational r;
-
-      for (int row = 0; row < this.numberOfRows; row++)
-      {
-        if (this.equations.At(row, colForv).IsNotZero)
-        {
-          // Check if there is some other nonzero variable
-          foreach (var pair in this.equations.GetElementsForRow(row))
-          {
-            int nextCol = pair.Key;
-            if (nextCol == colForv || nextCol == this.NumberOfColumns - 1)
-              continue;
-
-            goto exit;
-          }
-
-          r = this.equations.At(row, this.NumberOfColumns - 1);
-
-          return DisInterval.For(r);
-        }
-      }
-
-    exit:
-      return DisInterval.UnknownInterval;
-    }
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return new List<Pair<Variable, Int32>>();
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      yield break; //not implemented -- too expensive
-    }
-
-    #region IPureExpressionAssignmentsWithForward<Expression> Members
-
-    /// <summary>
-    /// The assignment for the domain. 
-    /// If <code>exp</code> is a linear equaality, then we are done.
-    /// Otherwise, we project the variable <code>x</code>
-    /// </summary>
-    /// <param name="x">The variable to be assigned</param>
-    /// <param name="exp">The value for the variable</param>
-    public void Assign(Expression x, Expression exp)
-    {
-      this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      Contract.Assert(this.IsConsistent, "LinEq inconsistent @ Assign");
-
-      var xVar = this.ExpressionManager.Decoder.UnderlyingVariable(x);
-
-      Polynomial<Variable, Expression> pol;
-
-      if (!Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.ExpressionManager.Decoder, out pol))
-      {
-        return;
-      }
-
-      if (pol.Relation != null)
-      {
-        return;
-      }
-
-      if (pol.IsLinear)
-      {
-        var colForX = GetDimensionFor(xVar);
-        var polAsVector = AsVector(pol);
-        var coeffForX = polAsVector[colForX];
-
-        #region Case 1. It is an invertible assignment
-        if (pol.Variables.Contains(xVar))
-        {
-          var matrix = this.equations.Unshare(this, ref this.equations);
-
-          for (int row = 0; row < this.NumberOfRows; row++)
-          {
-            var k = (matrix[row][colForX] / coeffForX);
-
-            // Process the coefficents of the variables
-            for (int col = 0; col < this.NumberOfColumns - 1; col++)
-            {
-              if (col != colForX)
-              {
-                matrix[row][col] = matrix[row][col] - k * polAsVector[col];
-              }
-              else
-              {
-                matrix[row][col] = k;
-              }
-            }
-            // Process the constant
-            matrix[row][this.NumberOfColumns - 1] = matrix[row][this.NumberOfColumns - 1] - k * polAsVector[this.NumberOfColumns - 1];
-          }
-
-          this.equations = new LinearEquations<Variable, Expression>(this, matrix);
-        }
-        #endregion
-
-        #region Case 2. It is not invertible
-        else
-        {
-          this.ProjectVariable(xVar);
-          var newConstraint = ConstraintFor(xVar, pol);
-
-          Debug.Assert(newConstraint.Length == this.NumberOfColumns);
-
-          this.AddConstraint(newConstraint);
-        }
-        #endregion
-      }
-      else
-      { // Nothing to do, so we project it
-        this.ProjectVariable(xVar);
-      }
-    }
-
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      if (this.varsToDimensions.ContainsKey(x))
-        this.ProjectVariable(x);
-    }
-
-    virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-    }
-
-    private int GetDimensionFor(Variable x)
-    {
-      if (!this.varsToDimensions.ContainsKey(x))
-        this.AddVariable(x);
-
-      return this.varsToDimensions[x];
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    /// <summary>
-    /// The variables defined in this linear equality
-    /// </summary>
-    public List<Variable> Variables
-    {
-      get
-      {
-        return new List<Variable>(this.varsToDimensions.Keys);
-      }
-    }
-
-    protected IEnumerable<Variable> Variables_Internal
-    {
-      get
-      {
-        return this.varsToDimensions.Keys;
-      }
-    }
-
-    public bool ContainsKey(Variable var)
-    {
-      return this.varsToDimensions.ContainsKey(var);
-    }
-
-    /// <summary>
-    /// Add a variable to this set of linear equalities
-    /// </summary>
-    /// <param name="var">The name of the variable to add</param>
-    public void AddVariable(Variable var)
-    {
-      int dummy;
-      AddVariable(var, out dummy);
-    }
-
-    public void AddVariable(Variable var, out int dim)
-    {
-      if (this.varsToDimensions.TryGetValue(var, out dim))
-      {
-        return;
-      }
-      else
-      {
-        this.AddVariable_Internal(var, out dim);
-      }
-    }
-
-    private void AddVariable_Internal(Variable var, out int freshCol)
-    {
-      if (this.TryGetAFreshDimension(out freshCol))
-      {
-        this.equations.ZeroCol(this, freshCol, ref this.equations);
-        this.varsToDimensions[var] = freshCol;
-      }
-      else
-      {
-        this.AddColumnsToTheEnvironment(GrowSizeForColumns);
-        this.AddVariable_Internal(var, out freshCol);
-      }
-    }
-
-    /// <summary>
-    /// Project the value of the variable from this set of linear equalities
-    /// </summary>
-    /// <param name="var">The variable to be projected</param>
-    public void ProjectVariable(Variable var)
-    {
-      if (!this.varsToDimensions.ContainsKey(var))
-      {
-        //The variable to project is not in this linear equalities
-        return;
-      }
-      else
-      {
-        this.PutIntoRowEchelonForm();
-        this.ProjectDimension(this.varsToDimensions[var]);
-      }
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      RemoveVariable(var, false);
-    }
-
-    /// <summary>
-    /// Remove the variable from the constraints.
-    /// The mapping from variables to dimensions may be changed if and only if <paramref name="preserveVariableMappings"/> is false
-    /// </summary>
-    /// <param name="var">The variable to be removed</param>
-    /// <param name="preserveVariableMappings">Make it true if you rely on the order of the variables</param>
-    public void RemoveVariable(Variable var, bool preserveVariableMappings)
-    {
-      Polynomial<Variable, Expression> row;
-      int dim;
-      RemoveVariable(var, preserveVariableMappings, out row, out dim);
-    }
-
-    public void RemoveVariable(Variable var, bool preserveVariableMappings, out Polynomial<Variable, Expression> deleted, out int dim)
-#if TRACEPERFORMANCE
-    {
-      Polynomial<Variable, Expression> deletedTMP = default(Polynomial<Variable, Expression>);
-      int dimTMP = -1 ;
-
-      var dummy = PerformanceMeasure.Measure<int>(PerformanceMeasure.ActionTags.KarrRemoveVars, () => { RemoveVariableInternal(var, preserveVariableMappings, out deletedTMP, out dimTMP); return -1; });
-
-      deleted = deletedTMP;
-      dim = dimTMP;
-    }
-    public void RemoveVariableInternal(Variable var, bool preserveVariableMappings, out Polynomial<Variable, Expression> deleted, out int dim)
-#endif
-    {
-      var b = this.IsConsistent;
-
-      if (!this.varsToDimensions.ContainsKey(var))
-      {
-        dim = 0;
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted))
-        {
-          throw new AbstractInterpretationException("Impossible case");
-        }
-
-        return;
-      }
-
-      if (!preserveVariableMappings)
-      {
-        this.PutIntoRowEchelonForm();
-      }
-
-      // Cannot use this.varsToDimensions.TryGetValue(...) as PutIntoRowEchelonForm could have changed the mapping
-      // Cannot have dim = this.varsToDimensions[var] as ProjectDimension can change the mappings  
-
-      this.ProjectDimension(this.varsToDimensions[var], preserveVariableMappings, out deleted);              // Project the dimensions
-
-      dim = this.varsToDimensions[var];
-
-      this.varsToDimensions.Remove(var);                                              // Remove the variable from the mapping
-
-      Contract.Assert(b ? this.IsConsistent : true, "LinEq not consistent @ ExitPoint of RemoveVariable");    // We want to check it only if at the entry point it was in a valid state
-    }
-
-    public void RemoveVariables(List<Variable> var, bool preserveVariableMappings)
-    {
-      if (var.Count == 0)
-      {
-        return;
-      }
-
-      if (this.varsToDimensions.Count == var.Count)
-      {
-        this.varsToDimensions = new VarsToDimensions();
-        this.equations = new LinearEquations<Variable, Expression>(this, 0);
-        this.numberOfRows = 0;
-
-        return;
-      }
-
-      var ratio = var.Count / (this.varsToDimensions.Count - var.Count);
-      if (ratio >= MAX_RATIO_FOR_USING_WEAK_PROJECTION || var.Count > MAX_VARIABLES_TO_REMOVE_FOR_USING_WEAK_PROJECTION)
-      {
-        this.expManager.Log(string.Format("Too many variables to remove (variables = {0}, ratio = {1}), giving up a precise projection", var.Count, ratio));
-
-        this.PutIntoRowEchelonForm();
-
-        var indexes = new bool[this.NumberOfColumns];
-        foreach (var v in var)
-        {
-          int dim;
-          if (this.varsToDimensions.TryGetValue(v, out dim))
-          {
-            indexes[dim] = true;
-            this.varsToDimensions.Remove(v);
-          }
-        }
-
-        var matrix = this.equations.Unshare(this, ref this.equations);
-        for (var rowCount = 0; rowCount < this.NumberOfRows; rowCount++)
-        {
-          foreach (var pair in matrix[rowCount].GetElements())
-          {
-            if (indexes[pair.Key])
-            {
-              RemoveRow(rowCount);
-              rowCount--;
-              break;
-            }
-          }
-        }
-      }
-      else
-      {
-        foreach (var x in var)
-        {
-          this.RemoveVariable(x, preserveVariableMappings);
-        }
-      }
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      if (OldName.Equals(NewName))
-      {
-        return;
-      }
-
-      int dim;
-      if (varsToDimensions.TryGetValue(OldName, out dim))
-      {
-        this.varsToDimensions[NewName] = dim;
-        this.varsToDimensions.Remove(OldName);
-      }
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-     public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-
-      return this.testTrue.Visit(guard, this);
-    }
-
-    public LinearEqualitiesEnvironment<Variable, Expression> TestTrue(Polynomial<Variable, Expression> pol)
-    {
-      if (pol.IsLinear && !pol.IsTautology)
-      {
-        var asVector = this.AsVector(pol.LeftAsPolynomial);
-        asVector[asVector.Length - 1] = pol.Right[0].K;
-
-        this.AddConstraint(asVector);
-      }
-      return this;
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      return this.testFalse.Visit(guard, this);
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
-    {
-      return this;
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression/*!*/ exp1, Expression/*!*/ exp2)
-    {
-      return this.TestTrueEqual(exp1, exp2);
-    }
-
-    public LinearEqualitiesEnvironment<Variable, Expression> TestTrueEqual(Expression left, Expression right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<LinearEqualitiesEnvironment<Variable, Expression>>() != null);
-
-      CheckStateInvariant();
-
-      var decoder = this.ExpressionManager.Decoder;
-      var varLeft = decoder.UnderlyingVariable(left);
-      var varRight = decoder.UnderlyingVariable(right);
-
-      if (varLeft.Equals(varRight))
-      {
-        return this;
-      }
-
-      if (decoder.IsSlackOrFrameworkVariable(varLeft) &&
-              decoder.IsSlackOrFrameworkVariable(varRight))
-      // 1. Add left == right
-      {
-        int leftConst, rightConst;
-        if (decoder.IsConstantInt(left, out leftConst) && decoder.IsVariable(right))
-        {
-          this.AddConstraintVariableEqConst(varRight, Rational.For(leftConst));
-
-          return this;
-        }
-
-        if (decoder.IsConstantInt(right, out rightConst) && decoder.IsVariable(left))
-        {
-          this.AddConstraintVariableEqConst(varLeft, Rational.For(rightConst));
-
-          return this;
-        }
-
-        this.AddConstraintVariableEqVariable(varLeft, varRight);
-
-        if (decoder.IsAtomicExpression(left) && decoder.IsAtomicExpression(right))
-        {
-          return this;
-        }
-      }
-      // 2. add left == right by going inside them
-      Polynomial<Variable, Expression> tmpPoly;
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, this.ExpressionManager.Decoder, out tmpPoly))
-      {
-        if (tmpPoly.IsLinear && !tmpPoly.IsTautology)
-        {
-          AddConstraintPolynomialEqConstant(tmpPoly.LeftAsPolynomial, tmpPoly.Right[0].K);
-        }
-      }
-
-      return this;
-    }
-
-    public LinearEqualitiesEnvironment<Variable, Expression> TestTrueEqual(Variable left, Expression right)
-    {
-      CheckStateInvariant();
-
-      if (this.ExpressionManager.Decoder.IsVariable(right))
-      {
-        var rightVar = this.ExpressionManager.Decoder.UnderlyingVariable(right);
-        this.AddConstraintVariableEqVariable(left, rightVar);
-
-        return this;
-      }
-
-      int value;
-      if (this.ExpressionManager.Decoder.IsConstantInt(right, out value))
-      {
-        this.AddConstraintVariableEqConst(left, Rational.For(value));
-
-        return this;
-      }
-
-      Polynomial<Variable, Expression> tmpPoly;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, this.ExpressionManager.Decoder, out tmpPoly))
-      {
-        if (tmpPoly.IsLinear && !tmpPoly.IsTautology)
-        {
-          var asVector = this.AsVector(tmpPoly.LeftAsPolynomial);
-          asVector[asVector.Length - 1] = tmpPoly.Right[0].K;
-
-          this.AddConstraint(asVector);
-        }
-      }
-      return this;
-    }
-
-    #endregion
-
-    #region Checking
-    /// <summary>
-    /// Check if the condition <code>exp</code> holds for this set of linear equalities
-    /// </summary>
-    /// <param name="exp"></param>
-    /// <returns></returns>
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression/*!*/ exp)
-    {
-      return this.checkIfHolds.Visit(exp, this);
-    }
-
-    /// <summary>
-    /// Check if the expression <code>exp</code> is greater than zero
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      var boundForExp = this.BoundsFor(exp);
-
-      if (!boundForExp.IsNormal())
-        return CheckOutcome.Top;
-
-      if (boundForExp.LowerBound >= 0)
-        return CheckOutcome.True;
-
-      return CheckOutcome.Top;
-    }
-
-    /// <summary>
-    /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      if (e1.Equals(e2))
-      {
-        return CheckOutcome.False;
-      }
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if(this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        // e2 - e1
-        var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
-
-        if (!e2SubE1.IsNormal())
-          return CheckOutcome.Top;
-
-        if (e2SubE1.LowerBound > 0)
-          return CheckOutcome.True;
-
-        if (e2SubE1.UpperBound <= 0)
-          return CheckOutcome.False;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    /// <summary>
-    /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
-    {
-      if (e1.Equals(e2))
-      {
-        return CheckOutcome.False;
-      }
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-
-      {
-        // e2 - e1
-        var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
-
-        if (!e2SubE1.IsNormal())
-          return CheckOutcome.Top;
-
-        if (e2SubE1.LowerBound > 0)
-          return CheckOutcome.True;
-
-        if (e2SubE1.UpperBound <= 0)
-          return CheckOutcome.False;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      if (e1.Equals(e2))
-      {
-        return CheckOutcome.True;
-      }
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        // e2 - e1
-        var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
-
-        if (!e2SubE1.IsNormal())
-          return CheckOutcome.Top;
-
-        if (e2SubE1.LowerBound >= 0)
-          return CheckOutcome.True;
-
-        if (e2SubE1.UpperBound < 0)
-          return CheckOutcome.False;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-
-    /// <summary>
-    /// For the moment we return Unknown. We want to refine it
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      if (e1.Equals(e2))
-      {
-        return CheckOutcome.True;
-      }
- 
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        // e2 - e1
-        var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
-
-        if (!e2SubE1.IsNormal())
-          return CheckOutcome.Top;
-
-        if (e2SubE1.LowerBound >= 0)
-          return CheckOutcome.True;
-
-        if (e2SubE1.UpperBound < 0)
-          return CheckOutcome.False;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessEqualThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        // e2 - e1
-        var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
-
-        if (!e2SubE1.IsNormal())
-          return CheckOutcome.Top;
-
-        if (e2SubE1.IsSingleton)
-        {
-          return e2SubE1.LowerBound.IsZero ? CheckOutcome.True : CheckOutcome.False;
-        }
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        // e2 - e1
-        var e2SubE1 = this.BoundsForQuick(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
-
-        if (!e2SubE1.IsNormal())
-          return CheckOutcome.Top;
-
-        if (e2SubE1.IsSingleton)
-        {
-          return e2SubE1.LowerBound.IsZero ? CheckOutcome.True : CheckOutcome.False;
-        }
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    /// <summary>
-    /// Check if exp != 0
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
-    {
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        var zero = encoder.ConstantFor(0);
-        var nonZeroExp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, exp, zero);
-
-        return this.CheckIfHolds(nonZeroExp);
-      }
-      else
-      {
-        return CheckOutcome.Top;
-      }
-    }
-
-    #endregion
-
-    #region Basic Operations
-
-    protected bool TryGetAFreshDimension(out int freshcol)
-    {
-      if (this.varsToDimensions.TryGetFirstAvailableDimension(out freshcol) 
-        && freshcol < this.NumberOfColumns - 1)
-      {
-        return true;
-      }
-      return false;
-    }
-
-    public SparseRationalArray AddConstraintEqual(Variable x, Rational v)
-    {
-      this.AddVariable(x);
-      var newRow = FreshRow(this.NumberOfColumns);
-      newRow[this.varsToDimensions[x]] = Rational.For(1);
-      newRow[this.NumberOfColumns - 1] = v;
-
-      this.AddConstraint(newRow, true);
-
-      return newRow;
-    }
-
-    private void AddConstraintPolynomialEqConstant(Polynomial<Variable, Expression> pol, Rational k)
-    {
-      if (pol.ContainsDummyVariables(this.ExpressionManager.Decoder))
-      {
-        return;
-      }
-
-      var asVector = this.AsVector(pol);
-      asVector[asVector.Length - 1] = k;
-
-      this.AddConstraint(asVector);
-    }
-
-    private void AddConstraintVariableEqVariable(Variable left, Variable right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      if (left.Equals(right))
-      {
-        return;
-      }
-
-      // Adding the two variables
-      this.AddVariable(left);
-      this.AddVariable(right);
-
-      var freshRow = FreshRow(this.NumberOfColumns);
-      freshRow[this.varsToDimensions[left]] = Rational.For(1);
-      freshRow[this.varsToDimensions[right]] = Rational.For(-1);
-      freshRow[this.numberOfCols - 1] = Rational.For(0);
-
-      this.AddConstraint(freshRow, true);
-    }
-
-    private void AddConstraintVariableEqConst(Variable left, Rational k)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(!object.ReferenceEquals(k, null));
-
-      this.AddVariable(left);
-      var freshRow = FreshRow(this.NumberOfColumns);
-      freshRow[this.varsToDimensions[left]] = Rational.For(1);
-      freshRow[this.numberOfCols - 1] = k;
-
-      this.AddConstraint(freshRow, true);
-    }
-
-    public void AddConstraint(SparseRationalArray newConstraint)
-    {
-      AddConstraint(newConstraint, false);
-    }
-
-    public void AddConstraint(Polynomial<Variable, Expression> pol)
-    {
-      var newRow = this.AsVector(pol);
-      this.AddConstraint(newRow);
-    }
-
-    /// <summary>
-    /// Add the new constraint to this set of linear equalities.
-    /// We copy the pointer of the vector, so you do not want to modify it!
-    /// </summary>
-    /// <param name="newConstraint">A vector of size <code>this.NumberOfVariables</code></param>    
-    public void AddConstraint(SparseRationalArray newConstraint, bool isNormalized)
-    {
-      Contract.Assert(this.NumberOfColumns == 0 || newConstraint.Length == this.NumberOfColumns,
-        "You must add to the LE a vector of the same size");
-
-      // Here there used to be some checks for redundancy. It seems it works without, deserve some testing before refactoring
-      CheckStateInvariant();
-
-      AddConstraintInternal(newConstraint, isNormalized);
-
-      CheckStateInvariant();
-    }
-
-    private void AddConstraintInternal(SparseRationalArray newConstraint, bool isNormalized)
-    {
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      if (this.NumberOfRows == matrix.Length)
-      { // We have no more rows for adding a constraint, so we enlarge it
-        Array.Resize(ref matrix, matrix.Length * 2 + 1);
-
-        this.equations = new LinearEquations<Variable, Expression>(this, matrix);
-
-        AddConstraintInternal(newConstraint, isNormalized);
-      }
-      else
-      {
-        var normalizedNewConstraint = isNormalized ? newConstraint : NormalizeConstraint(newConstraint);
-
-        matrix[numberOfRows] = normalizedNewConstraint;
-        this.numberOfRows++;
-
-        if (this.NumberOfRows == 1)
-        {
-          this.state = LinearEqualitiesState.Normal;
-          this.equations = new LinearEquations<Variable, Expression>(this, matrix);
-
-          this.PutIntoRowEchelonForm();
-
-          CheckStateInvariant();
-
-          return;
-        }
-
-        Rational val;
-        if (this.state == LinearEqualitiesState.StrongRowEchelon
-          && this.NumberOfRows <= this.NumberOfColumns
-          && normalizedNewConstraint.IsIndexOfNonDefaultElement(this.numberOfRows - 1, out val)
-          && val == 1)
-        {
-          // We want to see if the new constraint preserves the Row echelon form
-
-          if (normalizedNewConstraint.SmallestIndexOfNonDefaultElement < this.numberOfRows - 1)
-          {
-            goto Normal;
-          }
-
-          for (int row = 0; row < this.numberOfRows - 2; row++)
-          {
-            if (matrix[row].IsIndexOfNonDefaultElement(this.numberOfRows - 1))
-            {
-              goto Normal;
-            }
-          }
-
-          this.state = LinearEqualitiesState.StrongRowEchelon;
-          this.equations = new LinearEquations<Variable, Expression>(this, matrix);
-
-          CheckStateInvariant();
-          return;
-        }
-
-      Normal:
-        // If we reach this point, the constraint breaks the row echelon form
-        this.state = LinearEqualitiesState.Normal;
-        this.equations = new LinearEquations<Variable, Expression>(this, matrix);
-
-        CheckStateInvariant();
-      }
-    }
-
-    private static SparseRationalArray NormalizeConstraint(SparseRationalArray newConstraint)
-    {
-      var result = SparseRationalArray.New(newConstraint.Length, 0);
-
-      int pivotKey = newConstraint.SmallestIndexOfNonDefaultElement;
-      if (pivotKey >= 0)
-      {
-        var pivot = newConstraint[pivotKey];
-
-        Contract.Assert(pivot.IsNotZero);
-
-        // Already normalized?
-        if (pivot == 1)
-        {
-          return newConstraint;
-        }
-
-        foreach (var pair in newConstraint.GetElements())
-        {
-          // result[pair.Key] = pair.Value / pivot;
-          Rational newVal;
-          if (!Rational.TryDiv(pair.Value, pivot, out newVal))
-          {
-            return newConstraint;
-          }
-          result[pair.Key] = newVal;
-        }
-
-        return result;
-      }
-      else
-      {
-        return newConstraint;
-      }
-    }
-
-    [Conditional("CHECKINVARIANTS")]
-    internal void CheckStateInvariant()
-    {
-      if (this.state != LinearEqualitiesState.StrongRowEchelon)
-        return;
-
-      for (int row = 0; row < this.NumberOfRows; row++)
-      {
-        Debug.Assert(this.equations.At(row, row) == 1);
-
-        for (int col = 0; col < row; col++)
-        {
-          Debug.Assert(this.equations.At(row, col).IsZero);
-        }
-      }
-    }
-
-    [Pure]
-    static internal void CheckHaveUniformEnvironment(LinearEqualitiesEnvironment<Variable, Expression> left, LinearEqualitiesEnvironment<Variable, Expression> right)
-    {
-      Debug.Assert(left.Variables.Count == right.Variables.Count);
-
-      foreach (var x in left.Variables)
-      {
-        Debug.Assert(right.Variables.Contains(x));
-
-        var xDim = left.varsToDimensions[x];
-        var yDim = right.varsToDimensions[x];
-
-        Debug.Assert(yDim == xDim);
-      }
-    }
-
-    [Conditional("CHECKINVARIANTS")]
-    [Pure]
-    internal void CheckConsistency(bool expected)
-    {
-      if (!expected)
-      {
-        return;
-      }
-
-      Contract.Assert(this.IsConsistent);
-    }
-
-    [Conditional("CHECKINVARIANTS")]
-    [Pure]
-    protected void CheckAreAllZeroAt(SparseRationalArray[] matrix, Variable var, int row, bool shouldBreak)
-    {
-      if (!AreAllZeroAt(matrix, var, row))
-      {
-        if (shouldBreak)
-        {
-          System.Diagnostics.Debugger.Break();
-        }
-        else
-        {
-          Contract.Assert(false);
-        }
-      }
-    }
-
-    [Pure]
-    protected bool AreAllZeroAt(SparseRationalArray[] matrix, Variable var, int row)
-    {
-      var oldCol = this.varsToDimensions[var];
-      for (int i = 0; i < this.NumberOfRows; i++)
-      {
-        if (matrix[i] == null)
-          continue;   // this can be a bug, but we abstract away from it
-
-        if (i != (row) && matrix[i][oldCol].IsNotZero)
-        {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    /// <summary>
-    /// Put the current set of equalities into a row echelon form. 
-    /// This is a stronger condition than the one in Karr 1976, because the first <code>NumberOfRows</code> columns 
-    /// will represent the identity matrix
-    /// The <code>varsToDimensions</code> map may be modified.
-    /// </summary>
-   
-    public void PutIntoRowEchelonForm()
-#if TRACEPERFORMANCE2
-    {
-      PerformanceMeasure.Measure<int>(PerformanceMeasure.ActionTags.KarrPutIntoRowEchelonForm, () => {PutIntoRowEchelonFormInternal(); return 0; }, true);
-    }
-    
-    public void PutIntoRowEchelonFormInternal()
-#else
-#endif
-    {
-      CheckStateInvariant();
-      var expectedConsistency = this.IsConsistent;
-
-      if (this.state == LinearEqualitiesState.StrongRowEchelon || this.state == LinearEqualitiesState.Bottom)
-      {
-        return;
-      }
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      try
-      {
-        int i, j;
-        i = 0;    // row
-        j = 0;    // col
-        var timeout = this.expManager.TimeOut;
-
-        while (i < this.NumberOfRows && j < this.NumberOfColumns - 1)
-        {
-          timeout.CheckTimeOut("Row Echelon mode computation");
-
-          if (matrix[i][j].IsZero)
-          {
-            for (int r = i + 1; r < this.NumberOfRows; r++)
-            {
-              if (matrix[r][j].IsNotZero)
-              { // We swap the rows
-                Swap(ref matrix[i], ref matrix[r]);
-
-                goto continueNormally;
-              }
-            }
-
-            if (j < this.NumberOfColumns - 2)
-            {
-              j++;
-
-              continue;
-            }
-            else
-            { // Here we know that all remaining rows are zeros : checking consistency, then deleting them
-              this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.StrongRowEchelon;
-
-              for (int u = i; u < this.NumberOfRows; u++)
-              {
-                //if this.Matrix[u][this.NumberOfColumns - 1] != 0
-                if (matrix[u].IsIndexOfNonDefaultElement(this.NumberOfColumns - 1))
+                if (this.varsToDimensions.TryGetValue(j, out var) && this.equations.At(i, j).IsNotZero)
                 {
-                  this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Bottom;
-                  return;
+                    var k = factory.Constant(this.equations.At(i, j));
+                    var x = factory.Variable(var);
+
+                    result = factory.Add(result, factory.Mul(k, x));
                 }
-
-              }
-              numberOfRows = i;
-
-              return;
-            }
-          }
-
-          CheckConsistency(expectedConsistency);
-
-        continueNormally:
-
-          int v;
-          var this_matrix_i_ = matrix[i];
-          var mij = this_matrix_i_[j];
-          var caughtException = false;
-
-          // divide each entry of the vector this.matrix[i,*] by this.matrix[i, j];
-          if (mij != 1)
-          {
-            // for (k = 0; k < this.NumberOfColumns; k++)
-            var indexes = new Set<int>(this_matrix_i_.IndexesOfNonDefaultElements);
-
-            foreach (int t in indexes)
-            {
-              // Optimization: locality
-              Rational div;
-              if (!Rational.TryDiv(this_matrix_i_[t], mij, out div) || div.IsInfinity)
-              {
-                this.RemoveRow(i);
-                caughtException = true;
-
-                break;
-              }
-              this_matrix_i_[t] = div;
-            }
-          }
-
-          if (caughtException)
-          {
-            continue;
-          }
-
-          CheckConsistency(expectedConsistency);
-
-          // apply the linear combination to all the other vectors
-          for (v = 0; v < this.NumberOfRows; v++)
-          {
-            // Rational initial = this.matrix[v][i];
-            var initial = matrix[v][j];
-
-            if (v == i || initial.IsZero)
-            {
-              continue;
-            }
-
-            var this_matrix_v_ = matrix[v];
-
-            for (int k = 0; k < this.NumberOfColumns; k++)
-            {
-              Rational comb;
-              Rational this_matrix_v_k, this_matrix_i_k;
-
-              var b1 = this_matrix_v_.IsIndexOfNonDefaultElement(k, out this_matrix_v_k);
-              var b2 = this_matrix_i_.IsIndexOfNonDefaultElement(k, out this_matrix_i_k);
-
-              if (!b1 && !b2)
-              {
-                continue;
-              }
-
-              try
-              {
-                if (b1)
+#endif
+                if (this.varsToDimensions.TryGetValue(j, out var))
                 {
-                  if (b2)
-                  {
-                    comb = this_matrix_v_k - this_matrix_i_k * initial;
-                  }
-                  else
-                  {
-                    comb = this_matrix_v_k;
-                  }
+                    var k = this.equations.At(i, j);
+                    if (k.IsNotZero)
+                    {
+                        coefficients.Add(k);
+                        variables.Add(var);
+                    }
                 }
-                else
-                { // We know b2 is true here
-                  comb = -this_matrix_i_k * initial;
+            }
+
+            Contract.Assert(coefficients.Count == variables.Count);
+
+            var knownValue = this.equations.At(i, this.NumberOfColumns - 1);
+
+            coefficients.Add(knownValue);
+
+            var normalizedCoefficients = NormalizeCoeffiecients(coefficients);
+            if (normalizedCoefficients != null)
+            {
+                for (var j = 0; j < normalizedCoefficients.Count - 1 /* the last element is the known value */ ; j++)
+                {
+                    var coeff = normalizedCoefficients[j];
+                    if (coeff > 0)
+                    {
+                        result = factory.Add(result, factory.Mul(factory.Constant(coeff), factory.Variable(variables[j])));
+                    }
+                    else
+                    {
+                        Contract.Assume(coeff < 0);
+                        result = factory.Sub(result, factory.Mul(factory.Constant(-coeff), factory.Variable(variables[j])));
+                    }
                 }
-              }
-              catch (ArithmeticExceptionRational)
-              {
-                CleanUp(ref i, ref v);
-                break;
-              }
 
-              if (comb.IsInfinity)
-              {
-                CleanUp(ref i, ref v);
-                break;
-              }
-              else
-              {
-                matrix[v][k] = comb;
-              }
+                result = factory.EqualTo(result, factory.Constant(normalizedCoefficients.Last()));
             }
-          }
-
-          CheckConsistency(expectedConsistency);
-
-          SwapColumnsAndVariables(i, j);
-
-          CheckConsistency(expectedConsistency);
-
-          i++;
-          j++;
-        }
-
-        this.state = LinearEqualitiesState.StrongRowEchelon;
-        for (int u = i; u < this.NumberOfRows; u++)
-        {
-          // if this.Matrix[u][this.NumberOfColumns - 1] != 0
-          if (matrix[u].IsIndexOfNonDefaultElement(this.NumberOfColumns - 1))
-          {
-            this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Bottom;
-            return;
-          }
-        }
-
-        numberOfRows = i;
-
-        CheckConsistency(expectedConsistency);
-      }
-      catch (ArithmeticException)
-      {
-        Contract.Assert(false, "Exception should have been caught earlier");
-      }
-
-
-      CheckStateInvariant();
-    }
-
-    private void CleanUp(ref int i, ref int v)
-    {
-      Contract.Requires(i >= 0);
-
-      if (v < i)
-      {
-        for (int z = v; z < i; z++)
-        {
-          SwapColumnsAndVariables(z, z + 1);
-        }
-        i--;
-      }
-      this.RemoveRow(v);
-      v--;
-    }
-
-    /// <summary>
-    /// Put the current set of equalities into a row echelon form. This puts the matrix in the form used in Karr's algorithm ; the state is not changed to StrongRowEchelon.
-    /// This method ensures that the <code>varsToDimensions</code> map is not changed.
-    /// </summary>
-    /* private */
-    public void PutIntoWeakRowEchelonForm()
-    {
-      if (this.state == LinearEqualitiesState.StrongRowEchelon || this.state == LinearEqualitiesState.Bottom)
-      {
-        return;
-      }
-  
-      int i, j;
-      i = 0;    // row
-      j = 0;    // col
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      while (i < this.NumberOfRows && j < this.NumberOfColumns - 1)
-      {
-        this.expManager.TimeOut.CheckTimeOut("Row Echelon mode");
-
-        if (matrix[i][j].IsZero)
-        {
-          for (int r = i + 1; r < this.NumberOfRows; r++)
-          {
-            if (matrix[r][j].IsNotZero)
-            { // We swap the rows
-              Swap(ref matrix[i], ref matrix[r]);
-
-              goto continueNormally;
-            }
-          }
-
-          if (j < this.NumberOfColumns - 2)
-          {
-            j++;
-            continue;
-          }
-          else
-          { // Here we now that all remaining rows are zeros : checking consistency, then deleting them
-            this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.StrongRowEchelon;
-            for (int u = i; u < this.NumberOfRows; u++)
+            else // if something went wrong, we simply return the raw equation
             {
-              if (matrix[u].IsIndexOfNonDefaultElement(this.NumberOfColumns - 1))
-              {
-                this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Bottom;
-                return;
-              }
+                for (int j = 0; j < this.NumberOfColumns - 1; j++)
+                {
+                    Variable var;
+                    if (this.varsToDimensions.TryGetValue(j, out var) && this.equations.At(i, j).IsNotZero)
+                    {
+                        var k = factory.Constant(this.equations.At(i, j));
+                        var x = factory.Variable(var);
+
+                        result = factory.Add(result, factory.Mul(k, x));
+                    }
+                }
+
+                result = factory.EqualTo(result, factory.Constant(knownValue));
             }
-            numberOfRows = i;
-            return;
-          }
+            return result;
         }
 
-      continueNormally:
-
-        int k, v;
-        var mij = matrix[i][j];
-        bool caughtException = false;
-
-        // divide each entry of the vector this.matrix[i,*] by this.matrix[i, j];
-        if (mij != 1)
+        [ContractVerification(false)]
+        private List<Rational> NormalizeCoeffiecients(List<Rational> coefficients)
         {
-
-          //for (k = 0; k < this.NumberOfColumns; k++)
-          var indexes = new Set<int>(matrix[i].IndexesOfNonDefaultElements);
-          foreach (var t in indexes)
-          {
-            // this.matrix[i][t] = this.matrix[i][t] / mij;
-            Rational value;
-
-            if (!Rational.TryDiv(matrix[i][t], mij, out value) || value.IsInfinity)
-            {
-              this.RemoveRow(i);
-              caughtException = true;
-
-              break;
-            }
-
-            matrix[i][t] = value;
-          }
-        }
-
-        if (caughtException)
-        {
-          continue;
-        }
-
-        // apply the linear combination to all the other vectors
-        for (v = 0; v < this.NumberOfRows; v++)
-        {
-          // Rational initial = this.matrix[u][i];
-          var initial = matrix[v][j];
-
-          if (v == i || initial.IsZero)
-          {
-            continue;
-          }
-
-          for (k = 0; k < this.NumberOfColumns; k++)
-          {
-
-            Rational r1, r2;
-            var b1 = matrix[v].IsIndexOfNonDefaultElement(k, out r1);
-            var b2 = matrix[i].IsIndexOfNonDefaultElement(k, out r2);
-
-            if (!b1 && !b2)
-            {
-              continue;
-            }
+            Contract.Requires(coefficients != null);
+            Contract.Ensures(Contract.Result<List<Rational>>() == null || Contract.Result<List<Rational>>().Count == coefficients.Count);
 
             try
             {
-              // this.matrix[v][k] = this.matrix[v][k] - this.matrix[i][k] * initial;
+                var mul = 1L;
+                foreach (var c in coefficients)
+                {
+                    var down = c.Down;
+                    long min, max;
+                    if (down < mul)
+                    {
+                        min = down;
+                        max = mul;
+                    }
+                    else
+                    {
+                        min = mul;
+                        max = down;
+                    }
+                    if (min % max != 0)
+                    {
+                        mul *= c.Down;
+                    }
+                }
 
-              matrix[v][k] = r1 - r2 * initial;
+                Contract.Assume(mul != 0);
 
-              if (matrix[v][k].IsInfinity)
-              {
-                CleanUp_PutIntoWeakEchelonForm(ref i, ref v);
-              }
+                return coefficients.ApplyToAll<Rational, Rational>(c => c * mul).ToList();
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return null;
+            }
+        }
+
+        public override string ToString()
+        {
+            if (this.IsTop)
+            {
+                return "Top (Karr) ";
+            }
+
+            // Pretty print the constraints
+            var result = new StringBuilder();
+
+            result.AppendLine("Linear Equalities:");
+#if VERBOSEOUTPUT
+            result.AppendLine(string.Format("Vars -> Dimensions map" + Environment.NewLine + "{0}", this.varsToDimensions));
+
+            result.AppendLine(this.IsConsistent ? "Consistent" : "Warning: The representation is NOT consistent");
+#endif
+
+            if (this.state == LinearEqualitiesState.Bottom)
+            {
+                result.AppendLine("_|_");
+                return result.ToString();
+            }
+
+            // We want to sort the lines, to obtain a more deterministic debugging output
+            var lines = new List<List<string>>();
+
+            for (int i = 0; i < this.numberOfRows; i++)
+            {
+                var equation = new List<string>();
+
+                for (var j = 0; j < this.NumberOfColumns - 1; j++)
+                {
+                    if (this.varsToDimensions.ContainsValue(j))
+                    {
+                        var variable = this.varsToDimensions.KeyForValue(j);
+                        var value = this.equations.At(i, j);
+                        var monomial = new StringBuilder();
+
+                        if (value == 0)
+                        {
+                            monomial.Append(" ");
+                        }
+                        else
+                        {
+                            if (value != 1)
+                            {
+                                monomial.Append(value == -1 ? "-" : value.ToString() + " ");
+                            }
+                            var asString = this.ToString(variable);
+                            monomial.Append(asString);
+                        }
+                        equation.Add(monomial.ToString());
+                    }
+                }
+
+                var constant = this.equations.At(i, NumberOfColumns - 1);
+
+                equation.Add(" = ");
+                equation.Add(constant.ToString());
+
+                lines.Add(equation);
+            }
+
+            // Compute the column widths
+            var widths = new List<int>();
+            foreach (var line in lines)
+            {
+                var i = 0;
+                foreach (var monom in line)
+                {
+                    var max = Math.Max(monom.Length, widths.ElementAtOrDefault(i));
+                    if (i < widths.Count)
+                    {
+                        widths[i] = max;
+                    }
+                    else
+                    {
+                        widths.Add(max);
+                    }
+                    i++;
+                }
+            }
+
+            var formattedlines = new List<string>();
+
+            foreach (var line in lines)
+            {
+                var formattedLine = new StringBuilder();
+                for (var i = 0; i < line.Count; i++)
+                {
+                    var mask = "{0," + widths[i] + "}";
+                    var formattedString = string.Format(mask, line[i]);
+                    formattedLine.Append(formattedString);
+                }
+                formattedlines.Add(formattedLine.ToString());
+            }
+
+            return Print(this.state, formattedlines);
+        }
+
+        static private string Print(LinearEqualitiesState state, List<string> strs)
+        {
+            var sb = new StringBuilder();
+            sb.AppendFormat("State : {0}\n", state);
+            foreach (var s in strs)
+            {
+                sb.AppendLine(s);
+            }
+
+            return sb.ToString();
+        }
+
+        public string ToString(Expression exp)
+        {
+            if (this.expManager.Decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
+            }
+            else
+            {
+                return "< missing expression decoder >";
+            }
+        }
+
+        public string ToString(Variable v)
+        {
+            return this.expManager.Decoder.NameOf(v);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+        /// <summary>
+        /// Return true iff this set of constraints is contradictory
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public bool IsBottom
+        {
+            get
+            {
+                return PerformanceMeasure.Measure<bool>(
+                  PerformanceMeasure.ActionTags.KarrIsBottom,
+                () =>
+                {
+                    return this.IsEmpty();
+                }
+                  );
+            }
+        }
+
+        /// <summary>
+        /// Return true iff this set set of constraints is empty
+        /// </summary>
+        public bool IsTop
+        {
+            get
+            {
+                return this.numberOfRows == 0;      // No contstraint => top element
+            }
+        }
+
+        /// <summary>
+        /// In order to check if <code>this \leq a</code>, we do <code>this.Meet(a)</code>, and check if the matrix is this one
+        /// </summary>
+        public bool LessEqual(IAbstractDomain a)
+        {
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
+            {
+                return result;
+            }
+
+            var right = a as LinearEqualitiesEnvironment<Variable, Expression>;
+
+            Debug.Assert(a != null, "I was expecting an instance of " + this.GetType().ToString() + ". I found " + a.GetType().ToString());
+
+            var meet = this.Meet(right);
+
+            if (meet.IsBottom)
+            {
+                return false;     // It means that the two elements are not comparable
+            }
+
+            Debug.Assert(!meet.IsTop, "It is strange that the meet, at this point is top...");
+
+            var meetAsLE = meet as LinearEqualitiesEnvironment<Variable, Expression>;
+            Debug.Assert(meetAsLE != null, "I was expecting an instance of " + this.GetType().ToString() + ". I found " + meet.GetType().ToString());
+
+
+            // Now we check that the meet == this;
+
+            if (this.NumberOfRows != meetAsLE.NumberOfRows)
+            {
+                return false;
+            }
+
+            if (!this.equations.IsNullRow(0) && !meetAsLE.equations.IsNullRow(0))
+            {
+                if (this.equations.RowLength(0) != meetAsLE.equations.RowLength(0))
+                {
+                    return false;
+                }
+                else
+                {
+                    UniformEnvironments(this, meetAsLE);
+                    this.PutIntoWeakRowEchelonForm();
+                    meetAsLE.PutIntoWeakRowEchelonForm();
+
+                    for (int row = 0; row < this.numberOfRows; row++)
+                    {
+                        for (int col = 0; col < this.NumberOfColumns; col++)
+                        {
+                            Rational l, r;
+
+                            var bl = this.equations.IsIndexOfNonDefaultElement(row, col, out l);
+                            var br = meetAsLE.equations.IsIndexOfNonDefaultElement(row, col, out r);
+
+                            if (bl && br && l != r)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                    return true;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns a contradictory system
+        /// </summary>
+        public IAbstractDomain Bottom
+        {
+            get
+            {
+                var bott = New(1, 1, this.expManager);
+
+                var b = SparseRationalArray.New(2, 0);
+                b[0] = Rational.For(0);
+                b[1] = Rational.For(1);
+
+                bott.AddConstraint(b);
+
+                return bott;
+            }
+        }
+
+        /// <summary>
+        /// Returns a system without constraints
+        /// </summary>
+        public IAbstractDomain Top
+        {
+            get
+            {
+                return New(1, 3, this.expManager);
+            }
+        }
+
+        /// <summary>
+        /// The join follows the [Kar76] algorithm.
+        /// The algorithm works in place, and it modifies the receiver <b>AND</b> <code>a</code>
+        /// </summary>
+        /// <returns>The disjunction of the two</returns>
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var other = a as LinearEqualitiesEnvironment<Variable, Expression>;
+            Contract.Assume(other != null);
+            return this.Join(other);
+        }
+
+        public LinearEqualitiesEnvironment<Variable, Expression> Join(LinearEqualitiesEnvironment<Variable, Expression> a)
+        {
+            Contract.Requires(a != null);
+            Contract.Ensures(Contract.Result<LinearEqualitiesEnvironment<Variable, Expression>>() != null);
+
+            var obj = new List<Polynomial<Variable, Expression>>();
+            return Join(a, ref obj, ref obj);
+        }
+
+        virtual internal LinearEqualitiesEnvironment<Variable, Expression> Join(IAbstractDomain a, ref List<Polynomial<Variable, Expression>> deletedLeft, ref List<Polynomial<Variable, Expression>> deletedRight)
+        {
+            IAbstractDomain/*!*/ trivialresult;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivialresult))
+            {
+                if (trivialresult.IsTop)
+                {
+                    deletedLeft.AddRange(this.ToPolynomial(false));
+                    deletedRight.AddRange((a as LinearEqualitiesEnvironment<Variable, Expression>).ToPolynomial(false));
+                }
+                return trivialresult as LinearEqualitiesEnvironment<Variable, Expression>;
+            }
+
+            var right = a as LinearEqualitiesEnvironment<Variable, Expression>;
+
+            Contract.Assert(a != null, "I was expecting an instance of " + this.GetType().ToString() + ". I found " + a.GetType().ToString());
+
+            if (this.equations.AreSharingTheEquations(this, right))
+            {
+                return New(this);
+            }
+
+            LogPerformance("Equalities x == y at join point (left arg) : {0}/{1}", this.CountPairwiseEqualities().ToString(), this.NumberOfRows.ToString());
+            LogPerformance("Equalities x == y at join point (rightarg) : {0}/{1}", right.CountPairwiseEqualities().ToString(), right.NumberOfRows.ToString());
+
+            // 1. Make the domains the same, by uniforming the maps, and swapping columns
+            this.PutIntoRowEchelonForm();
+            this.RecoverUnusedColumns(8);
+
+            right.PutIntoRowEchelonForm();
+            right.RecoverUnusedColumns(8);
+
+            UniformEnvironments(this, right);
+
+            this.PutIntoWeakRowEchelonForm();
+            right.PutIntoWeakRowEchelonForm();
+
+            LogPerformance("Unused variables at join point (left arg of join) : {0}", this.UnusedColumns.ToString());
+            LogPerformance("Unused variables at join point (right arg of join) : {0}", right.UnusedColumns.ToString());
+
+            if (this.state == LinearEqualitiesState.Bottom)
+            {
+                return New(right);
+            }
+
+            if (right.state == LinearEqualitiesState.Bottom)
+            {
+                return New(this);
+            }
+
+            Contract.Assert(this.NumberOfColumns == right.NumberOfColumns);
+
+            // 2. The join is computed according to Karr 1976 paper
+            var A = this.equations.GetClonedEquations();      // We clone the matrixes as Karr works with side effects
+            var B = right.equations.GetClonedEquations();
+
+            int numberOfRowsInResult;
+            var JoinedMatrix = DisjunctionOfLinearSpaces(A, B, this.NumberOfRows, right.numberOfRows, out numberOfRowsInResult, ref deletedLeft, ref deletedRight);
+
+            // 3. Create a clone of the current private state
+            var freshMap = new VarsToDimensions(this.varsToDimensions);
+
+            var result = New(JoinedMatrix, numberOfRowsInResult, this.NumberOfColumns, freshMap, this.expManager);
+            result.state = LinearEqualitiesState.Normal; // the condition implied by Karr's algorithm is weaker than what we call now row echelon form
+
+            LogPerformance("Unused variables after join point : {0}", result.UnusedColumns.ToString());
+            UpdateMaxUnusedVariables(result.UnusedColumns);
+
+            LogPerformance("Equalities x == y at return from join : {0}/{1}", result.CountPairwiseEqualities().ToString(), result.NumberOfRows.ToString());
+
+            result.RecoverUnusedColumns();
+
+            return result;
+        }
+
+        /// <summary>
+        /// The matrix can grow very large, and get many unused entries. 
+        /// This method recover the unused space if there are more than 2 * GrowSizeForColumns unused columns 
+        /// </summary>
+        protected void RecoverUnusedColumns()
+        {
+            RecoverUnusedColumns(2 * GrowSizeForColumns);
+        }
+
+        /// <summary>
+        /// The matrix can grow very large, and get many unused entries. 
+        /// This method recover the unused space.
+        /// </summary>
+        protected void RecoverUnusedColumns(int treshold)
+        {
+            var isConsistent = this.IsConsistent;
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            Contract.Assert(matrix.Length >= this.NumberOfRows);
+
+            if (this.NumberOfColumns - this.varsToDimensions.Count > treshold)
+            {
+                LogPerformance("Performing column recovering. Unused dims : {0}", this.UnusedColumns.ToString());
+
+                var newMatrix = new SparseRationalArray[this.NumberOfRows];
+                var newMappings = new VarsToDimensions();
+
+                var newNumberOfColumns = this.varsToDimensions.Count + 1;
+                for (int row = 0; row < this.NumberOfRows; row++)
+                {
+                    newMatrix[row] = FreshRow(newNumberOfColumns);
+                }
+
+                var nextFreePos = 0;
+
+                for (int i = 0; i < this.NumberOfColumns - 1; i++)
+                {
+                    if (!IsZeroCol(matrix, this.NumberOfRows, i))
+                    {
+                        // 1. Update the mapping var <-> dim
+                        newMappings[this.varsToDimensions.KeyForValue(i)] = nextFreePos;
+
+                        // 2. Copy the column
+                        for (int row = 0; row < this.NumberOfRows; row++)
+                        {
+                            newMatrix[row][nextFreePos] = matrix[row][i];
+                        }
+
+                        nextFreePos++;
+                    }
+                }
+
+                // 3. Update the column of the coefficients
+                for (int row = 0; row < this.NumberOfRows; row++)
+                {
+                    newMatrix[row][newNumberOfColumns - 1] = matrix[row][NumberOfColumns - 1];
+                }
+
+                this.equations = new LinearEquations<Variable, Expression>(this, newMatrix);
+                this.varsToDimensions = newMappings;
+                this.numberOfCols = newNumberOfColumns;
+            }
+            else
+            {
+                LogPerformance("No columns to recover, treshold not reached. Unused columns: {0}; Treshold: {1} > {2}",
+                  this.UnusedColumns.ToString(), (this.NumberOfColumns - this.varsToDimensions.Count).ToString(), treshold.ToString());
+            }
+
+            CheckConsistency(isConsistent);
+        }
+
+        /// <summary>
+        /// The meet of two system of equations just puts the two system one beneath the other.
+        /// It modifies <b>BOTH</b>the receiver and <code>a</code>
+        /// </summary>
+        /// <returns></returns>
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            IAbstractDomain trivialMeet;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, a, out trivialMeet))
+            {
+                return trivialMeet;
+            }
+
+            var right = a as LinearEqualitiesEnvironment<Variable, Expression>;
+            Debug.Assert(a != null, "I was expecting an instance of " + this.GetType().ToString() + ", I found a " + a.GetType().ToString());
+
+            if (this.equations.AreSharingTheEquations(this, right))
+            {
+                return New(this);
+            }
+
+            // 1. Make the domains the same, by uniforming the maps, and swapping columns
+            UniformEnvironments(this, right);
+
+            Debug.Assert(this.NumberOfColumns == right.NumberOfColumns);
+
+            // 2. The meet is just putting one matrix beneath the other
+            var result = new SparseRationalArray[this.numberOfRows + right.numberOfRows];
+
+            int numberOfCols = this.NumberOfColumns;
+
+            // Copy all the constraints
+            for (int i = 0; i < this.numberOfRows; i++)
+            {
+                result[i] = SparseRationalArray.New(numberOfCols, 0);
+
+                this.equations.CopyRowTo(i, result[i], numberOfCols);
+            }
+            for (int i = 0; i < right.numberOfRows; i++)
+            {
+                int index = i + this.numberOfRows;
+                result[index] = SparseRationalArray.New(numberOfCols, 0);
+
+                right.equations.CopyRowTo(i, result[index], numberOfCols);
+            }
+
+            var vars2Dim = new VarsToDimensions(this.varsToDimensions);
+
+            return New(result, result.Length, numberOfCols, vars2Dim, this.expManager);
+        }
+
+        /// <summary>
+        /// As the abstract domain of linear equalities satisfies the ACC, the widening is just the join
+        /// </summary>
+        /// <param name="prev">The previous value</param>
+        /// <returns>The join of this with <code>prev</code></returns>
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            return this.Join((LinearEqualitiesEnvironment<Variable, Expression>)prev);
+        }
+
+        public LinearEqualitiesEnvironment<Variable, Expression> Widening(LinearEqualitiesEnvironment<Variable, Expression> prev)
+        {
+            return this.Join((LinearEqualitiesEnvironment<Variable, Expression>)prev);
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomain<Rational,Expression> Members
+
+        /// <returns>
+        /// An interval for the expression <code>v</code>.
+        /// The interval is one of the two: a singleton or top.
+        /// </returns>
+        public DisInterval BoundsFor(Expression v)
+        {
+            var directTry = this.BoundsForQuick(v);
+
+            // Give another chance to fins a bound for
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.expManager.TryGetEncoder(out encoder) && !directTry.IsNormal() && !this.expManager.Decoder.IsVariable(v))
+            {
+                // Fast path
+                Polynomial<Variable, Expression> polFast;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(v, this.expManager.Decoder, out polFast)
+                  && polFast.IsLinear && !polFast.IsTautology)
+                {
+                    var result = Interval.For(0);
+
+                    foreach (var mon in polFast.Left)
+                    {
+                        if (mon.IsConstant)
+                        {
+                            result = result + mon.K;
+                        }
+                        else
+                        {
+                            var boundForX = BoundsFor(mon.VariableAt(0)).AsInterval;
+                            if (boundForX.IsTop)
+                            {
+                                goto slowPath;
+                            }
+
+                            if (mon.K > 0)
+                            {
+                                result = result + boundForX;
+                            }
+                            else
+                            {
+                                result = result - boundForX;
+                            }
+                        }
+                    }
+
+                    return result.AsDisInterval;
+                }
+
+
+            // Slow path
+            slowPath:
+                var tmpVar = encoder.FreshVariable<int>();
+
+                Polynomial<Variable, Expression> pol;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, tmpVar, v, this.expManager.Decoder, out pol))
+                {
+                    if (pol.IsLinear && !pol.IsTautology)
+                    {
+                        var dup = this.Duplicate();
+
+                        dup = dup.TestTrue(pol);
+
+                        return dup.BoundsForQuick_Internal(tmpVar);
+                    }
+                }
+            }
+
+            return directTry;
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            return this.BoundsForQuick_Internal(v);
+        }
+
+        private DisInterval BoundsForQuick(Expression v)
+        {
+            var decoder = this.expManager.Decoder;
+            int k;
+            if (decoder.IsConstantInt(v, out k))
+            {
+                return DisInterval.For(k);
+            }
+
+            return BoundsForQuick_Internal(decoder.UnderlyingVariable(v));
+        }
+
+        private DisInterval BoundsForQuick_Internal(Variable v)
+        {
+            Contract.Ensures(Contract.Result<DisInterval>() != null);
+
+            if (!this.varsToDimensions.ContainsKey(v))
+            {
+                return DisInterval.UnknownInterval;
+            }
+
+            this.PutIntoRowEchelonForm();
+            var colForv = this.varsToDimensions[v];
+
+            Rational r;
+
+            for (int row = 0; row < this.numberOfRows; row++)
+            {
+                if (this.equations.At(row, colForv).IsNotZero)
+                {
+                    // Check if there is some other nonzero variable
+                    foreach (var pair in this.equations.GetElementsForRow(row))
+                    {
+                        int nextCol = pair.Key;
+                        if (nextCol == colForv || nextCol == this.NumberOfColumns - 1)
+                            continue;
+
+                        goto exit;
+                    }
+
+                    r = this.equations.At(row, this.NumberOfColumns - 1);
+
+                    return DisInterval.For(r);
+                }
+            }
+
+        exit:
+            return DisInterval.UnknownInterval;
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                return new List<Pair<Variable, Int32>>();
+            }
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            yield break; //not implemented -- too expensive
+        }
+
+        #region IPureExpressionAssignmentsWithForward<Expression> Members
+
+        /// <summary>
+        /// The assignment for the domain. 
+        /// If <code>exp</code> is a linear equaality, then we are done.
+        /// Otherwise, we project the variable <code>x</code>
+        /// </summary>
+        /// <param name="x">The variable to be assigned</param>
+        /// <param name="exp">The value for the variable</param>
+        public void Assign(Expression x, Expression exp)
+        {
+            this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
+
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            Contract.Assert(this.IsConsistent, "LinEq inconsistent @ Assign");
+
+            var xVar = this.ExpressionManager.Decoder.UnderlyingVariable(x);
+
+            Polynomial<Variable, Expression> pol;
+
+            if (!Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.ExpressionManager.Decoder, out pol))
+            {
+                return;
+            }
+
+            if (pol.Relation != null)
+            {
+                return;
+            }
+
+            if (pol.IsLinear)
+            {
+                var colForX = GetDimensionFor(xVar);
+                var polAsVector = AsVector(pol);
+                var coeffForX = polAsVector[colForX];
+
+                #region Case 1. It is an invertible assignment
+                if (pol.Variables.Contains(xVar))
+                {
+                    var matrix = this.equations.Unshare(this, ref this.equations);
+
+                    for (int row = 0; row < this.NumberOfRows; row++)
+                    {
+                        var k = (matrix[row][colForX] / coeffForX);
+
+                        // Process the coefficents of the variables
+                        for (int col = 0; col < this.NumberOfColumns - 1; col++)
+                        {
+                            if (col != colForX)
+                            {
+                                matrix[row][col] = matrix[row][col] - k * polAsVector[col];
+                            }
+                            else
+                            {
+                                matrix[row][col] = k;
+                            }
+                        }
+                        // Process the constant
+                        matrix[row][this.NumberOfColumns - 1] = matrix[row][this.NumberOfColumns - 1] - k * polAsVector[this.NumberOfColumns - 1];
+                    }
+
+                    this.equations = new LinearEquations<Variable, Expression>(this, matrix);
+                }
+                #endregion
+
+                #region Case 2. It is not invertible
+                else
+                {
+                    this.ProjectVariable(xVar);
+                    var newConstraint = ConstraintFor(xVar, pol);
+
+                    Debug.Assert(newConstraint.Length == this.NumberOfColumns);
+
+                    this.AddConstraint(newConstraint);
+                }
+                #endregion
+            }
+            else
+            { // Nothing to do, so we project it
+                this.ProjectVariable(xVar);
+            }
+        }
+
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            if (this.varsToDimensions.ContainsKey(x))
+                this.ProjectVariable(x);
+        }
+
+        virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+        }
+
+        private int GetDimensionFor(Variable x)
+        {
+            if (!this.varsToDimensions.ContainsKey(x))
+                this.AddVariable(x);
+
+            return this.varsToDimensions[x];
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        /// <summary>
+        /// The variables defined in this linear equality
+        /// </summary>
+        public List<Variable> Variables
+        {
+            get
+            {
+                return new List<Variable>(this.varsToDimensions.Keys);
+            }
+        }
+
+        protected IEnumerable<Variable> Variables_Internal
+        {
+            get
+            {
+                return this.varsToDimensions.Keys;
+            }
+        }
+
+        public bool ContainsKey(Variable var)
+        {
+            return this.varsToDimensions.ContainsKey(var);
+        }
+
+        /// <summary>
+        /// Add a variable to this set of linear equalities
+        /// </summary>
+        /// <param name="var">The name of the variable to add</param>
+        public void AddVariable(Variable var)
+        {
+            int dummy;
+            AddVariable(var, out dummy);
+        }
+
+        public void AddVariable(Variable var, out int dim)
+        {
+            if (this.varsToDimensions.TryGetValue(var, out dim))
+            {
+                return;
+            }
+            else
+            {
+                this.AddVariable_Internal(var, out dim);
+            }
+        }
+
+        private void AddVariable_Internal(Variable var, out int freshCol)
+        {
+            if (this.TryGetAFreshDimension(out freshCol))
+            {
+                this.equations.ZeroCol(this, freshCol, ref this.equations);
+                this.varsToDimensions[var] = freshCol;
+            }
+            else
+            {
+                this.AddColumnsToTheEnvironment(GrowSizeForColumns);
+                this.AddVariable_Internal(var, out freshCol);
+            }
+        }
+
+        /// <summary>
+        /// Project the value of the variable from this set of linear equalities
+        /// </summary>
+        /// <param name="var">The variable to be projected</param>
+        public void ProjectVariable(Variable var)
+        {
+            if (!this.varsToDimensions.ContainsKey(var))
+            {
+                //The variable to project is not in this linear equalities
+                return;
+            }
+            else
+            {
+                this.PutIntoRowEchelonForm();
+                this.ProjectDimension(this.varsToDimensions[var]);
+            }
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            RemoveVariable(var, false);
+        }
+
+        /// <summary>
+        /// Remove the variable from the constraints.
+        /// The mapping from variables to dimensions may be changed if and only if <paramref name="preserveVariableMappings"/> is false
+        /// </summary>
+        /// <param name="var">The variable to be removed</param>
+        /// <param name="preserveVariableMappings">Make it true if you rely on the order of the variables</param>
+        public void RemoveVariable(Variable var, bool preserveVariableMappings)
+        {
+            Polynomial<Variable, Expression> row;
+            int dim;
+            RemoveVariable(var, preserveVariableMappings, out row, out dim);
+        }
+
+        public void RemoveVariable(Variable var, bool preserveVariableMappings, out Polynomial<Variable, Expression> deleted, out int dim)
+#if TRACEPERFORMANCE
+        {
+            Polynomial<Variable, Expression> deletedTMP = default(Polynomial<Variable, Expression>);
+            int dimTMP = -1;
+
+            var dummy = PerformanceMeasure.Measure<int>(PerformanceMeasure.ActionTags.KarrRemoveVars, () => { RemoveVariableInternal(var, preserveVariableMappings, out deletedTMP, out dimTMP); return -1; });
+
+            deleted = deletedTMP;
+            dim = dimTMP;
+        }
+        public void RemoveVariableInternal(Variable var, bool preserveVariableMappings, out Polynomial<Variable, Expression> deleted, out int dim)
+#endif
+        {
+            var b = this.IsConsistent;
+
+            if (!this.varsToDimensions.ContainsKey(var))
+            {
+                dim = 0;
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted))
+                {
+                    throw new AbstractInterpretationException("Impossible case");
+                }
+
+                return;
+            }
+
+            if (!preserveVariableMappings)
+            {
+                this.PutIntoRowEchelonForm();
+            }
+
+            // Cannot use this.varsToDimensions.TryGetValue(...) as PutIntoRowEchelonForm could have changed the mapping
+            // Cannot have dim = this.varsToDimensions[var] as ProjectDimension can change the mappings  
+
+            this.ProjectDimension(this.varsToDimensions[var], preserveVariableMappings, out deleted);              // Project the dimensions
+
+            dim = this.varsToDimensions[var];
+
+            this.varsToDimensions.Remove(var);                                              // Remove the variable from the mapping
+
+            Contract.Assert(b ? this.IsConsistent : true, "LinEq not consistent @ ExitPoint of RemoveVariable");    // We want to check it only if at the entry point it was in a valid state
+        }
+
+        public void RemoveVariables(List<Variable> var, bool preserveVariableMappings)
+        {
+            if (var.Count == 0)
+            {
+                return;
+            }
+
+            if (this.varsToDimensions.Count == var.Count)
+            {
+                this.varsToDimensions = new VarsToDimensions();
+                this.equations = new LinearEquations<Variable, Expression>(this, 0);
+                this.numberOfRows = 0;
+
+                return;
+            }
+
+            var ratio = var.Count / (this.varsToDimensions.Count - var.Count);
+            if (ratio >= MAX_RATIO_FOR_USING_WEAK_PROJECTION || var.Count > MAX_VARIABLES_TO_REMOVE_FOR_USING_WEAK_PROJECTION)
+            {
+                this.expManager.Log(string.Format("Too many variables to remove (variables = {0}, ratio = {1}), giving up a precise projection", var.Count, ratio));
+
+                this.PutIntoRowEchelonForm();
+
+                var indexes = new bool[this.NumberOfColumns];
+                foreach (var v in var)
+                {
+                    int dim;
+                    if (this.varsToDimensions.TryGetValue(v, out dim))
+                    {
+                        indexes[dim] = true;
+                        this.varsToDimensions.Remove(v);
+                    }
+                }
+
+                var matrix = this.equations.Unshare(this, ref this.equations);
+                for (var rowCount = 0; rowCount < this.NumberOfRows; rowCount++)
+                {
+                    foreach (var pair in matrix[rowCount].GetElements())
+                    {
+                        if (indexes[pair.Key])
+                        {
+                            RemoveRow(rowCount);
+                            rowCount--;
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                foreach (var x in var)
+                {
+                    this.RemoveVariable(x, preserveVariableMappings);
+                }
+            }
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            if (OldName.Equals(NewName))
+            {
+                return;
+            }
+
+            int dim;
+            if (varsToDimensions.TryGetValue(OldName, out dim))
+            {
+                this.varsToDimensions[NewName] = dim;
+                this.varsToDimensions.Remove(OldName);
+            }
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            return this.testTrue.Visit(guard, this);
+        }
+
+        public LinearEqualitiesEnvironment<Variable, Expression> TestTrue(Polynomial<Variable, Expression> pol)
+        {
+            if (pol.IsLinear && !pol.IsTautology)
+            {
+                var asVector = this.AsVector(pol.LeftAsPolynomial);
+                asVector[asVector.Length - 1] = pol.Right[0].K;
+
+                this.AddConstraint(asVector);
+            }
+            return this;
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            return this.testFalse.Visit(guard, this);
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
+        {
+            return this;
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression/*!*/ exp1, Expression/*!*/ exp2)
+        {
+            return this.TestTrueEqual(exp1, exp2);
+        }
+
+        public LinearEqualitiesEnvironment<Variable, Expression> TestTrueEqual(Expression left, Expression right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<LinearEqualitiesEnvironment<Variable, Expression>>() != null);
+
+            CheckStateInvariant();
+
+            var decoder = this.ExpressionManager.Decoder;
+            var varLeft = decoder.UnderlyingVariable(left);
+            var varRight = decoder.UnderlyingVariable(right);
+
+            if (varLeft.Equals(varRight))
+            {
+                return this;
+            }
+
+            if (decoder.IsSlackOrFrameworkVariable(varLeft) &&
+                    decoder.IsSlackOrFrameworkVariable(varRight))
+            // 1. Add left == right
+            {
+                int leftConst, rightConst;
+                if (decoder.IsConstantInt(left, out leftConst) && decoder.IsVariable(right))
+                {
+                    this.AddConstraintVariableEqConst(varRight, Rational.For(leftConst));
+
+                    return this;
+                }
+
+                if (decoder.IsConstantInt(right, out rightConst) && decoder.IsVariable(left))
+                {
+                    this.AddConstraintVariableEqConst(varLeft, Rational.For(rightConst));
+
+                    return this;
+                }
+
+                this.AddConstraintVariableEqVariable(varLeft, varRight);
+
+                if (decoder.IsAtomicExpression(left) && decoder.IsAtomicExpression(right))
+                {
+                    return this;
+                }
+            }
+            // 2. add left == right by going inside them
+            Polynomial<Variable, Expression> tmpPoly;
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, this.ExpressionManager.Decoder, out tmpPoly))
+            {
+                if (tmpPoly.IsLinear && !tmpPoly.IsTautology)
+                {
+                    AddConstraintPolynomialEqConstant(tmpPoly.LeftAsPolynomial, tmpPoly.Right[0].K);
+                }
+            }
+
+            return this;
+        }
+
+        public LinearEqualitiesEnvironment<Variable, Expression> TestTrueEqual(Variable left, Expression right)
+        {
+            CheckStateInvariant();
+
+            if (this.ExpressionManager.Decoder.IsVariable(right))
+            {
+                var rightVar = this.ExpressionManager.Decoder.UnderlyingVariable(right);
+                this.AddConstraintVariableEqVariable(left, rightVar);
+
+                return this;
+            }
+
+            int value;
+            if (this.ExpressionManager.Decoder.IsConstantInt(right, out value))
+            {
+                this.AddConstraintVariableEqConst(left, Rational.For(value));
+
+                return this;
+            }
+
+            Polynomial<Variable, Expression> tmpPoly;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, this.ExpressionManager.Decoder, out tmpPoly))
+            {
+                if (tmpPoly.IsLinear && !tmpPoly.IsTautology)
+                {
+                    var asVector = this.AsVector(tmpPoly.LeftAsPolynomial);
+                    asVector[asVector.Length - 1] = tmpPoly.Right[0].K;
+
+                    this.AddConstraint(asVector);
+                }
+            }
+            return this;
+        }
+
+        #endregion
+
+        #region Checking
+        /// <summary>
+        /// Check if the condition <code>exp</code> holds for this set of linear equalities
+        /// </summary>
+        /// <param name="exp"></param>
+        /// <returns></returns>
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression/*!*/ exp)
+        {
+            return this.checkIfHolds.Visit(exp, this);
+        }
+
+        /// <summary>
+        /// Check if the expression <code>exp</code> is greater than zero
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            var boundForExp = this.BoundsFor(exp);
+
+            if (!boundForExp.IsNormal())
+                return CheckOutcome.Top;
+
+            if (boundForExp.LowerBound >= 0)
+                return CheckOutcome.True;
+
+            return CheckOutcome.Top;
+        }
+
+        /// <summary>
+        /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            if (e1.Equals(e2))
+            {
+                return CheckOutcome.False;
+            }
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                // e2 - e1
+                var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
+
+                if (!e2SubE1.IsNormal())
+                    return CheckOutcome.Top;
+
+                if (e2SubE1.LowerBound > 0)
+                    return CheckOutcome.True;
+
+                if (e2SubE1.UpperBound <= 0)
+                    return CheckOutcome.False;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        /// <summary>
+        /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
+        {
+            if (e1.Equals(e2))
+            {
+                return CheckOutcome.False;
+            }
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+
+            {
+                // e2 - e1
+                var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
+
+                if (!e2SubE1.IsNormal())
+                    return CheckOutcome.Top;
+
+                if (e2SubE1.LowerBound > 0)
+                    return CheckOutcome.True;
+
+                if (e2SubE1.UpperBound <= 0)
+                    return CheckOutcome.False;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            if (e1.Equals(e2))
+            {
+                return CheckOutcome.True;
+            }
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                // e2 - e1
+                var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
+
+                if (!e2SubE1.IsNormal())
+                    return CheckOutcome.Top;
+
+                if (e2SubE1.LowerBound >= 0)
+                    return CheckOutcome.True;
+
+                if (e2SubE1.UpperBound < 0)
+                    return CheckOutcome.False;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+
+        /// <summary>
+        /// For the moment we return Unknown. We want to refine it
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            if (e1.Equals(e2))
+            {
+                return CheckOutcome.True;
+            }
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                // e2 - e1
+                var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
+
+                if (!e2SubE1.IsNormal())
+                    return CheckOutcome.Top;
+
+                if (e2SubE1.LowerBound >= 0)
+                    return CheckOutcome.True;
+
+                if (e2SubE1.UpperBound < 0)
+                    return CheckOutcome.False;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessEqualThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                // e2 - e1
+                var e2SubE1 = this.BoundsFor(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
+
+                if (!e2SubE1.IsNormal())
+                    return CheckOutcome.Top;
+
+                if (e2SubE1.IsSingleton)
+                {
+                    return e2SubE1.LowerBound.IsZero ? CheckOutcome.True : CheckOutcome.False;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                // e2 - e1
+                var e2SubE1 = this.BoundsForQuick(encoder.SmartSubtraction(e2, e1, this.ExpressionManager.Decoder));
+
+                if (!e2SubE1.IsNormal())
+                    return CheckOutcome.Top;
+
+                if (e2SubE1.IsSingleton)
+                {
+                    return e2SubE1.LowerBound.IsZero ? CheckOutcome.True : CheckOutcome.False;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        /// <summary>
+        /// Check if exp != 0
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
+        {
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                var zero = encoder.ConstantFor(0);
+                var nonZeroExp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, exp, zero);
+
+                return this.CheckIfHolds(nonZeroExp);
+            }
+            else
+            {
+                return CheckOutcome.Top;
+            }
+        }
+
+        #endregion
+
+        #region Basic Operations
+
+        protected bool TryGetAFreshDimension(out int freshcol)
+        {
+            if (this.varsToDimensions.TryGetFirstAvailableDimension(out freshcol)
+              && freshcol < this.NumberOfColumns - 1)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public SparseRationalArray AddConstraintEqual(Variable x, Rational v)
+        {
+            this.AddVariable(x);
+            var newRow = FreshRow(this.NumberOfColumns);
+            newRow[this.varsToDimensions[x]] = Rational.For(1);
+            newRow[this.NumberOfColumns - 1] = v;
+
+            this.AddConstraint(newRow, true);
+
+            return newRow;
+        }
+
+        private void AddConstraintPolynomialEqConstant(Polynomial<Variable, Expression> pol, Rational k)
+        {
+            if (pol.ContainsDummyVariables(this.ExpressionManager.Decoder))
+            {
+                return;
+            }
+
+            var asVector = this.AsVector(pol);
+            asVector[asVector.Length - 1] = k;
+
+            this.AddConstraint(asVector);
+        }
+
+        private void AddConstraintVariableEqVariable(Variable left, Variable right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            if (left.Equals(right))
+            {
+                return;
+            }
+
+            // Adding the two variables
+            this.AddVariable(left);
+            this.AddVariable(right);
+
+            var freshRow = FreshRow(this.NumberOfColumns);
+            freshRow[this.varsToDimensions[left]] = Rational.For(1);
+            freshRow[this.varsToDimensions[right]] = Rational.For(-1);
+            freshRow[this.numberOfCols - 1] = Rational.For(0);
+
+            this.AddConstraint(freshRow, true);
+        }
+
+        private void AddConstraintVariableEqConst(Variable left, Rational k)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(!object.ReferenceEquals(k, null));
+
+            this.AddVariable(left);
+            var freshRow = FreshRow(this.NumberOfColumns);
+            freshRow[this.varsToDimensions[left]] = Rational.For(1);
+            freshRow[this.numberOfCols - 1] = k;
+
+            this.AddConstraint(freshRow, true);
+        }
+
+        public void AddConstraint(SparseRationalArray newConstraint)
+        {
+            AddConstraint(newConstraint, false);
+        }
+
+        public void AddConstraint(Polynomial<Variable, Expression> pol)
+        {
+            var newRow = this.AsVector(pol);
+            this.AddConstraint(newRow);
+        }
+
+        /// <summary>
+        /// Add the new constraint to this set of linear equalities.
+        /// We copy the pointer of the vector, so you do not want to modify it!
+        /// </summary>
+        /// <param name="newConstraint">A vector of size <code>this.NumberOfVariables</code></param>    
+        public void AddConstraint(SparseRationalArray newConstraint, bool isNormalized)
+        {
+            Contract.Assert(this.NumberOfColumns == 0 || newConstraint.Length == this.NumberOfColumns,
+              "You must add to the LE a vector of the same size");
+
+            // Here there used to be some checks for redundancy. It seems it works without, deserve some testing before refactoring
+            CheckStateInvariant();
+
+            AddConstraintInternal(newConstraint, isNormalized);
+
+            CheckStateInvariant();
+        }
+
+        private void AddConstraintInternal(SparseRationalArray newConstraint, bool isNormalized)
+        {
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            if (this.NumberOfRows == matrix.Length)
+            { // We have no more rows for adding a constraint, so we enlarge it
+                Array.Resize(ref matrix, matrix.Length * 2 + 1);
+
+                this.equations = new LinearEquations<Variable, Expression>(this, matrix);
+
+                AddConstraintInternal(newConstraint, isNormalized);
+            }
+            else
+            {
+                var normalizedNewConstraint = isNormalized ? newConstraint : NormalizeConstraint(newConstraint);
+
+                matrix[numberOfRows] = normalizedNewConstraint;
+                this.numberOfRows++;
+
+                if (this.NumberOfRows == 1)
+                {
+                    this.state = LinearEqualitiesState.Normal;
+                    this.equations = new LinearEquations<Variable, Expression>(this, matrix);
+
+                    this.PutIntoRowEchelonForm();
+
+                    CheckStateInvariant();
+
+                    return;
+                }
+
+                Rational val;
+                if (this.state == LinearEqualitiesState.StrongRowEchelon
+                  && this.NumberOfRows <= this.NumberOfColumns
+                  && normalizedNewConstraint.IsIndexOfNonDefaultElement(this.numberOfRows - 1, out val)
+                  && val == 1)
+                {
+                    // We want to see if the new constraint preserves the Row echelon form
+
+                    if (normalizedNewConstraint.SmallestIndexOfNonDefaultElement < this.numberOfRows - 1)
+                    {
+                        goto Normal;
+                    }
+
+                    for (int row = 0; row < this.numberOfRows - 2; row++)
+                    {
+                        if (matrix[row].IsIndexOfNonDefaultElement(this.numberOfRows - 1))
+                        {
+                            goto Normal;
+                        }
+                    }
+
+                    this.state = LinearEqualitiesState.StrongRowEchelon;
+                    this.equations = new LinearEquations<Variable, Expression>(this, matrix);
+
+                    CheckStateInvariant();
+                    return;
+                }
+
+            Normal:
+                // If we reach this point, the constraint breaks the row echelon form
+                this.state = LinearEqualitiesState.Normal;
+                this.equations = new LinearEquations<Variable, Expression>(this, matrix);
+
+                CheckStateInvariant();
+            }
+        }
+
+        private static SparseRationalArray NormalizeConstraint(SparseRationalArray newConstraint)
+        {
+            var result = SparseRationalArray.New(newConstraint.Length, 0);
+
+            int pivotKey = newConstraint.SmallestIndexOfNonDefaultElement;
+            if (pivotKey >= 0)
+            {
+                var pivot = newConstraint[pivotKey];
+
+                Contract.Assert(pivot.IsNotZero);
+
+                // Already normalized?
+                if (pivot == 1)
+                {
+                    return newConstraint;
+                }
+
+                foreach (var pair in newConstraint.GetElements())
+                {
+                    // result[pair.Key] = pair.Value / pivot;
+                    Rational newVal;
+                    if (!Rational.TryDiv(pair.Value, pivot, out newVal))
+                    {
+                        return newConstraint;
+                    }
+                    result[pair.Key] = newVal;
+                }
+
+                return result;
+            }
+            else
+            {
+                return newConstraint;
+            }
+        }
+
+        [Conditional("CHECKINVARIANTS")]
+        internal void CheckStateInvariant()
+        {
+            if (this.state != LinearEqualitiesState.StrongRowEchelon)
+                return;
+
+            for (int row = 0; row < this.NumberOfRows; row++)
+            {
+                Debug.Assert(this.equations.At(row, row) == 1);
+
+                for (int col = 0; col < row; col++)
+                {
+                    Debug.Assert(this.equations.At(row, col).IsZero);
+                }
+            }
+        }
+
+        [Pure]
+        static internal void CheckHaveUniformEnvironment(LinearEqualitiesEnvironment<Variable, Expression> left, LinearEqualitiesEnvironment<Variable, Expression> right)
+        {
+            Debug.Assert(left.Variables.Count == right.Variables.Count);
+
+            foreach (var x in left.Variables)
+            {
+                Debug.Assert(right.Variables.Contains(x));
+
+                var xDim = left.varsToDimensions[x];
+                var yDim = right.varsToDimensions[x];
+
+                Debug.Assert(yDim == xDim);
+            }
+        }
+
+        [Conditional("CHECKINVARIANTS")]
+        [Pure]
+        internal void CheckConsistency(bool expected)
+        {
+            if (!expected)
+            {
+                return;
+            }
+
+            Contract.Assert(this.IsConsistent);
+        }
+
+        [Conditional("CHECKINVARIANTS")]
+        [Pure]
+        protected void CheckAreAllZeroAt(SparseRationalArray[] matrix, Variable var, int row, bool shouldBreak)
+        {
+            if (!AreAllZeroAt(matrix, var, row))
+            {
+                if (shouldBreak)
+                {
+                    System.Diagnostics.Debugger.Break();
+                }
+                else
+                {
+                    Contract.Assert(false);
+                }
+            }
+        }
+
+        [Pure]
+        protected bool AreAllZeroAt(SparseRationalArray[] matrix, Variable var, int row)
+        {
+            var oldCol = this.varsToDimensions[var];
+            for (int i = 0; i < this.NumberOfRows; i++)
+            {
+                if (matrix[i] == null)
+                    continue;   // this can be a bug, but we abstract away from it
+
+                if (i != (row) && matrix[i][oldCol].IsNotZero)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Put the current set of equalities into a row echelon form. 
+        /// This is a stronger condition than the one in Karr 1976, because the first <code>NumberOfRows</code> columns 
+        /// will represent the identity matrix
+        /// The <code>varsToDimensions</code> map may be modified.
+        /// </summary>
+
+        public void PutIntoRowEchelonForm()
+#if TRACEPERFORMANCE2
+        {
+            PerformanceMeasure.Measure<int>(PerformanceMeasure.ActionTags.KarrPutIntoRowEchelonForm, () => { PutIntoRowEchelonFormInternal(); return 0; }, true);
+        }
+
+        public void PutIntoRowEchelonFormInternal()
+#else
+#endif
+        {
+            CheckStateInvariant();
+            var expectedConsistency = this.IsConsistent;
+
+            if (this.state == LinearEqualitiesState.StrongRowEchelon || this.state == LinearEqualitiesState.Bottom)
+            {
+                return;
+            }
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            try
+            {
+                int i, j;
+                i = 0;    // row
+                j = 0;    // col
+                var timeout = this.expManager.TimeOut;
+
+                while (i < this.NumberOfRows && j < this.NumberOfColumns - 1)
+                {
+                    timeout.CheckTimeOut("Row Echelon mode computation");
+
+                    if (matrix[i][j].IsZero)
+                    {
+                        for (int r = i + 1; r < this.NumberOfRows; r++)
+                        {
+                            if (matrix[r][j].IsNotZero)
+                            { // We swap the rows
+                                Swap(ref matrix[i], ref matrix[r]);
+
+                                goto continueNormally;
+                            }
+                        }
+
+                        if (j < this.NumberOfColumns - 2)
+                        {
+                            j++;
+
+                            continue;
+                        }
+                        else
+                        { // Here we know that all remaining rows are zeros : checking consistency, then deleting them
+                            this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.StrongRowEchelon;
+
+                            for (int u = i; u < this.NumberOfRows; u++)
+                            {
+                                //if this.Matrix[u][this.NumberOfColumns - 1] != 0
+                                if (matrix[u].IsIndexOfNonDefaultElement(this.NumberOfColumns - 1))
+                                {
+                                    this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Bottom;
+                                    return;
+                                }
+                            }
+                            numberOfRows = i;
+
+                            return;
+                        }
+                    }
+
+                    CheckConsistency(expectedConsistency);
+
+                continueNormally:
+
+                    int v;
+                    var this_matrix_i_ = matrix[i];
+                    var mij = this_matrix_i_[j];
+                    var caughtException = false;
+
+                    // divide each entry of the vector this.matrix[i,*] by this.matrix[i, j];
+                    if (mij != 1)
+                    {
+                        // for (k = 0; k < this.NumberOfColumns; k++)
+                        var indexes = new Set<int>(this_matrix_i_.IndexesOfNonDefaultElements);
+
+                        foreach (int t in indexes)
+                        {
+                            // Optimization: locality
+                            Rational div;
+                            if (!Rational.TryDiv(this_matrix_i_[t], mij, out div) || div.IsInfinity)
+                            {
+                                this.RemoveRow(i);
+                                caughtException = true;
+
+                                break;
+                            }
+                            this_matrix_i_[t] = div;
+                        }
+                    }
+
+                    if (caughtException)
+                    {
+                        continue;
+                    }
+
+                    CheckConsistency(expectedConsistency);
+
+                    // apply the linear combination to all the other vectors
+                    for (v = 0; v < this.NumberOfRows; v++)
+                    {
+                        // Rational initial = this.matrix[v][i];
+                        var initial = matrix[v][j];
+
+                        if (v == i || initial.IsZero)
+                        {
+                            continue;
+                        }
+
+                        var this_matrix_v_ = matrix[v];
+
+                        for (int k = 0; k < this.NumberOfColumns; k++)
+                        {
+                            Rational comb;
+                            Rational this_matrix_v_k, this_matrix_i_k;
+
+                            var b1 = this_matrix_v_.IsIndexOfNonDefaultElement(k, out this_matrix_v_k);
+                            var b2 = this_matrix_i_.IsIndexOfNonDefaultElement(k, out this_matrix_i_k);
+
+                            if (!b1 && !b2)
+                            {
+                                continue;
+                            }
+
+                            try
+                            {
+                                if (b1)
+                                {
+                                    if (b2)
+                                    {
+                                        comb = this_matrix_v_k - this_matrix_i_k * initial;
+                                    }
+                                    else
+                                    {
+                                        comb = this_matrix_v_k;
+                                    }
+                                }
+                                else
+                                { // We know b2 is true here
+                                    comb = -this_matrix_i_k * initial;
+                                }
+                            }
+                            catch (ArithmeticExceptionRational)
+                            {
+                                CleanUp(ref i, ref v);
+                                break;
+                            }
+
+                            if (comb.IsInfinity)
+                            {
+                                CleanUp(ref i, ref v);
+                                break;
+                            }
+                            else
+                            {
+                                matrix[v][k] = comb;
+                            }
+                        }
+                    }
+
+                    CheckConsistency(expectedConsistency);
+
+                    SwapColumnsAndVariables(i, j);
+
+                    CheckConsistency(expectedConsistency);
+
+                    i++;
+                    j++;
+                }
+
+                this.state = LinearEqualitiesState.StrongRowEchelon;
+                for (int u = i; u < this.NumberOfRows; u++)
+                {
+                    // if this.Matrix[u][this.NumberOfColumns - 1] != 0
+                    if (matrix[u].IsIndexOfNonDefaultElement(this.NumberOfColumns - 1))
+                    {
+                        this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Bottom;
+                        return;
+                    }
+                }
+
+                numberOfRows = i;
+
+                CheckConsistency(expectedConsistency);
             }
             catch (ArithmeticException)
             {
-              // ALog.WriteStatistics("Arithmetic Exception", "in row combination"); // used to find occurrences using VERBOSEOUTPUT, loglevel 0
-              CleanUp_PutIntoWeakEchelonForm(ref i, ref v);
-
-              break;
+                Contract.Assert(false, "Exception should have been caught earlier");
             }
-          }
+
+
+            CheckStateInvariant();
         }
-        i++;
-        j++;
-      }
 
-      if (this.numberOfRows > this.numberOfCols - 1)
-      {
-        this.numberOfRows = this.numberOfCols - 1;
-      }
+        private void CleanUp(ref int i, ref int v)
+        {
+            Contract.Requires(i >= 0);
 
-    }
+            if (v < i)
+            {
+                for (int z = v; z < i; z++)
+                {
+                    SwapColumnsAndVariables(z, z + 1);
+                }
+                i--;
+            }
+            this.RemoveRow(v);
+            v--;
+        }
 
-    private void CleanUp_PutIntoWeakEchelonForm(ref int i, ref int v)
-    {
-      Contract.Requires(v >= 0);
+        /// <summary>
+        /// Put the current set of equalities into a row echelon form. This puts the matrix in the form used in Karr's algorithm ; the state is not changed to StrongRowEchelon.
+        /// This method ensures that the <code>varsToDimensions</code> map is not changed.
+        /// </summary>
+        /* private */
+        public void PutIntoWeakRowEchelonForm()
+        {
+            if (this.state == LinearEqualitiesState.StrongRowEchelon || this.state == LinearEqualitiesState.Bottom)
+            {
+                return;
+            }
 
-      this.RemoveRow(v);
-      v--;
-      if (v < i)
-      {
-        i--;
-      }
-    }
+            int i, j;
+            i = 0;    // row
+            j = 0;    // col
 
-    /// <summary>
-    /// Check if the concretization of the current set of linear inequalities is empty or not
-    /// </summary>
-    private bool IsEmpty()
-    {
-      if (this.state == LinearEqualitiesState.Bottom)
-      {
-        return true;
-      }
+            var matrix = this.equations.Unshare(this, ref this.equations);
 
-      if (this.state != LinearEqualitiesState.StrongRowEchelon)
-      {
-        this.PutIntoRowEchelonForm();
-      }
+            while (i < this.NumberOfRows && j < this.NumberOfColumns - 1)
+            {
+                this.expManager.TimeOut.CheckTimeOut("Row Echelon mode");
 
-      if (this.state == LinearEqualitiesState.Bottom)
-      {
-        return true;
-      }
+                if (matrix[i][j].IsZero)
+                {
+                    for (int r = i + 1; r < this.NumberOfRows; r++)
+                    {
+                        if (matrix[r][j].IsNotZero)
+                        { // We swap the rows
+                            Swap(ref matrix[i], ref matrix[r]);
+
+                            goto continueNormally;
+                        }
+                    }
+
+                    if (j < this.NumberOfColumns - 2)
+                    {
+                        j++;
+                        continue;
+                    }
+                    else
+                    { // Here we now that all remaining rows are zeros : checking consistency, then deleting them
+                        this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.StrongRowEchelon;
+                        for (int u = i; u < this.NumberOfRows; u++)
+                        {
+                            if (matrix[u].IsIndexOfNonDefaultElement(this.NumberOfColumns - 1))
+                            {
+                                this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Bottom;
+                                return;
+                            }
+                        }
+                        numberOfRows = i;
+                        return;
+                    }
+                }
+
+            continueNormally:
+
+                int k, v;
+                var mij = matrix[i][j];
+                bool caughtException = false;
+
+                // divide each entry of the vector this.matrix[i,*] by this.matrix[i, j];
+                if (mij != 1)
+                {
+                    //for (k = 0; k < this.NumberOfColumns; k++)
+                    var indexes = new Set<int>(matrix[i].IndexesOfNonDefaultElements);
+                    foreach (var t in indexes)
+                    {
+                        // this.matrix[i][t] = this.matrix[i][t] / mij;
+                        Rational value;
+
+                        if (!Rational.TryDiv(matrix[i][t], mij, out value) || value.IsInfinity)
+                        {
+                            this.RemoveRow(i);
+                            caughtException = true;
+
+                            break;
+                        }
+
+                        matrix[i][t] = value;
+                    }
+                }
+
+                if (caughtException)
+                {
+                    continue;
+                }
+
+                // apply the linear combination to all the other vectors
+                for (v = 0; v < this.NumberOfRows; v++)
+                {
+                    // Rational initial = this.matrix[u][i];
+                    var initial = matrix[v][j];
+
+                    if (v == i || initial.IsZero)
+                    {
+                        continue;
+                    }
+
+                    for (k = 0; k < this.NumberOfColumns; k++)
+                    {
+                        Rational r1, r2;
+                        var b1 = matrix[v].IsIndexOfNonDefaultElement(k, out r1);
+                        var b2 = matrix[i].IsIndexOfNonDefaultElement(k, out r2);
+
+                        if (!b1 && !b2)
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            // this.matrix[v][k] = this.matrix[v][k] - this.matrix[i][k] * initial;
+
+                            matrix[v][k] = r1 - r2 * initial;
+
+                            if (matrix[v][k].IsInfinity)
+                            {
+                                CleanUp_PutIntoWeakEchelonForm(ref i, ref v);
+                            }
+                        }
+                        catch (ArithmeticException)
+                        {
+                            // ALog.WriteStatistics("Arithmetic Exception", "in row combination"); // used to find occurrences using VERBOSEOUTPUT, loglevel 0
+                            CleanUp_PutIntoWeakEchelonForm(ref i, ref v);
+
+                            break;
+                        }
+                    }
+                }
+                i++;
+                j++;
+            }
+
+            if (this.numberOfRows > this.numberOfCols - 1)
+            {
+                this.numberOfRows = this.numberOfCols - 1;
+            }
+        }
+
+        private void CleanUp_PutIntoWeakEchelonForm(ref int i, ref int v)
+        {
+            Contract.Requires(v >= 0);
+
+            this.RemoveRow(v);
+            v--;
+            if (v < i)
+            {
+                i--;
+            }
+        }
+
+        /// <summary>
+        /// Check if the concretization of the current set of linear inequalities is empty or not
+        /// </summary>
+        private bool IsEmpty()
+        {
+            if (this.state == LinearEqualitiesState.Bottom)
+            {
+                return true;
+            }
+
+            if (this.state != LinearEqualitiesState.StrongRowEchelon)
+            {
+                this.PutIntoRowEchelonForm();
+            }
+
+            if (this.state == LinearEqualitiesState.Bottom)
+            {
+                return true;
+            }
 
 #if false
-      var rows = this.NumberOfRows;
-      var cols = this.NumberOfColumns;
-      var eqs = this.equations;
-      for (int i = 0; i < rows; i++)
-      {
+            var rows = this.NumberOfRows;
+            var cols = this.NumberOfColumns;
+            var eqs = this.equations;
+            for (int i = 0; i < rows; i++)
+            {
 #if false
-        // for (int j = 0; j < this.NumberOfColumns - 1; j++)
-        foreach (KeyValuePair<int, Rational> pair in this.matrix[i].GetElements())
-        {
-          if (pair.Key < this.NumberOfColumns - 1)
-          {
-            // skip this vector
-            goto Skip;
-          }
-        }
-        // If we reach this point, all the this.matrix[i, 0..this.NumbersOfColums-1) == 0. 
-        // So we check if this.matrix[i, this.NumbersOfColums-1] != 0, which implies the contraddiction
-        if (this.matrix[i][this.NumberOfColumns - 1].IsNotZero)
-        {
-          this.state = LinearEqualitiesState.Bottom;
-          return true;
-        }
-      Skip:
-        ;
+                // for (int j = 0; j < this.NumberOfColumns - 1; j++)
+                foreach (KeyValuePair<int, Rational> pair in this.matrix[i].GetElements())
+                {
+                    if (pair.Key < this.NumberOfColumns - 1)
+                    {
+                        // skip this vector
+                        goto Skip;
+                    }
+                }
+                // If we reach this point, all the this.matrix[i, 0..this.NumbersOfColums-1) == 0. 
+                // So we check if this.matrix[i, this.NumbersOfColums-1] != 0, which implies the contraddiction
+                if (this.matrix[i][this.NumberOfColumns - 1].IsNotZero)
+                {
+                    this.state = LinearEqualitiesState.Bottom;
+                    return true;
+                }
+            Skip:
+                ;
 #else
         if (eqs.RowCount(i) <= 1 && eqs.At(i, cols - 1).IsNotZero)
         {
@@ -2739,2632 +2719,2624 @@ namespace Microsoft.Research.AbstractDomains.Numerical
         }
 #endif
 
-      }
+            }
 #endif
-      return false;
-    }
-
-    /// <summary>
-    /// Uniform the two maps, so that \forall x \in dom(left.varsToDimensions) \cap dom(right.varsToDimensions). left.varsToDimensions(x) == right.varsToDimensions(x).
-    /// It works with side effects
-    /// </summary>
-    /// <param name="left"></param>
-    /// <param name="right"></param>
-    protected static void UniformEnvironments(LinearEqualitiesEnvironment<Variable, Expression> left, LinearEqualitiesEnvironment<Variable, Expression> right)
-    {
-      Contract.Assert(left.IsConsistent);
-      Contract.Assert(right.IsConsistent);
-
-      var leftMap = left.varsToDimensions;
-      var rightMap = right.varsToDimensions;
-
-      var allvariables = new Set<Variable>(leftMap.Keys);
-      allvariables.AddRange(rightMap.Keys);
-
-      left.expManager.Log("Uniforming the two environments");
-      left.expManager.Log(string.Format("Left argument contains {0} variables", left.Variables.Count));
-      left.expManager.Log(string.Format("Right argument contains {0} variables", right.Variables.Count));
-
-
-      // We can use lists as the code below will guarantee that the three data structures are disjoints
-      var toRemoveLeft = new List<Variable>();
-      var toRemoveRight = new List<Variable>();
-      var intersection = new List<Variable>();
-
-      foreach (var x in allvariables)
-      {
-        var inLeft = leftMap.ContainsKey(x);
-        var inRight = rightMap.ContainsKey(x);
-
-        if (inLeft && inRight)
-        { // If both environments have the variable x, we want it to point to the same dimension
-          intersection.Add(x);
-        }
-        else
-        { // It is a variable that we want to project
-          if (inLeft)
-            toRemoveLeft.Add(x);
-          else if (inRight)
-            toRemoveRight.Add(x);
-          else
-            Contract.Assert(false, "Impossible case?");
-        }
-      }
-
-      Contract.Assert(allvariables.Count == intersection.Count + toRemoveLeft.Count + toRemoveRight.Count);
-
-      left.expManager.Log(string.Format("Intersection contains {0} variables", intersection.Count));
-
-      left.RemoveVariables(toRemoveLeft, false);
-      left.RecoverUnusedColumns();
-
-      right.RemoveVariables(toRemoveRight, false);
-      right.RecoverUnusedColumns();
-
-      foreach (var toUniform in intersection)
-      {
-        int leftDim, rightDim;
-
-        var leftMapContainsToUniform = left.varsToDimensions.TryGetValue(toUniform, out leftDim);
-        var rightMapContainsToUniform = right.varsToDimensions.TryGetValue(toUniform, out rightDim);
-
-        if (leftMapContainsToUniform && rightMapContainsToUniform)
-        {
-          // this can be false for slack variables removed by dependencies.
-          right.SwapColumnsAndVariables(leftDim, rightDim);
-        }
-        else
-        {
-          // Removing the variables above can also have removed some variable in the intersection
-
-          if (leftMapContainsToUniform)
-            left.RemoveVariable(toUniform, true);
-
-          if (rightMapContainsToUniform)
-            right.RemoveVariable(toUniform, true);
-        }
-      }
-
-      Contract.Assert(left.IsConsistent);
-      Contract.Assert(right.IsConsistent);
-
-      if (left.NumberOfColumns != right.NumberOfColumns)
-      {
-        int newSize = Math.Min(left.NumberOfColumns, right.NumberOfColumns);
-
-        left.RemoveColumnsTo(newSize);
-        right.RemoveColumnsTo(newSize);
-      }
-
-      left.expManager.Log(string.Format("After uniforming, left contains {0}", left.Variables.Count));
-      left.expManager.Log(string.Format("After uniforming, right contains {0}", right.Variables.Count));
-
-      Contract.Assert(left.IsConsistent);
-      Contract.Assert(right.IsConsistent);
-    }
-
-    public void RemoveColumnsTo(int newSize)
-    {
-      Contract.Requires(newSize >= 0);
-
-      if (newSize == this.NumberOfColumns)
-      {
-        return;
-      }
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      for (int row = 0; row < matrix.Length; row++)
-      {
-        if (matrix[row] != null)
-        {
-          var k = matrix[row][matrix[row].Length - 1];
-          var shorterRow = FreshRow(newSize);
-
-          shorterRow.CopyFrom(matrix[row], newSize);
-
-          shorterRow[newSize - 1] = k;
-
-          matrix[row] = shorterRow;
-        }
-      }
-
-      this.NumberOfColumns = newSize;
-
-      Contract.Assert(this.IsConsistent);
-    }
-
-    /// <summary>
-    /// Project the dimension <paramref name="d"/>, with the option to preserve the variable mappings, which corresponds to not assuming strong row echelon form.
-    /// </summary>
-    /// <param name="d">The dimension to project</param>
-    /// <param name="preserveVariableMappings">set it to true if you may not assume strong row echelon form</param>
-    private void ProjectDimension(int d, bool preserveVariableMappings)
-    {
-      Polynomial<Variable, Expression> row;
-      ProjectDimension(d, preserveVariableMappings, out row);
-    }
-
-    private void ProjectDimension(int d, bool preserveVariableMappings, out Polynomial<Variable, Expression> deleted)
-    {
-      if (preserveVariableMappings)
-      {
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted))
-        {
-          SwapColumnsAndVariables(0, d);
-          PutIntoWeakRowEchelonForm();
-
-          var matrix = this.equations.Unshare(this, ref this.equations);
-
-          for (int row = 0; row < this.numberOfRows; row++)
-          {
-            var currRow = matrix[row];
-            if (currRow[0].IsNotZero)
-            {
-              deleted = ToPolynomial(currRow);
-              this.RemoveRow(row);
-              row--;
-              this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal;
-            }
-          }
-        }
-        SwapColumnsAndVariables(0, d);
-      }
-      else
-      {
-        ProjectDimension(d, out deleted);
-      }
-    }
-
-    /// <summary>
-    /// Project the dimension <code>d</code> from this system of equalities
-    /// </summary>
-    /// <param name="d">The dimension to be projected</param>
-    private void ProjectDimension(int d)
-    {
-      Polynomial<Variable, Expression> row;
-      ProjectDimension(d, out row);
-    }
-
-    private void ProjectDimension(int d, out Polynomial<Variable, Expression> deleted)
-    {
-      Contract.Requires(d >= 0);
-
-      Contract.Requires(d < this.NumberOfColumns - 1);
-
-      // Requires the state is RowEchelonForm ; otherwise putting into row echelon form might give a different d
-      Contract.Requires(this.state != LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal, "Call PutIntoRowEchelonForm before projecting");
-
-
-      // 2. Find the row that will enable us to put d in the basis
-      var allZero = true;
-      var nonZeroRow = -1;
-      for (var row = 0; row < this.numberOfRows; row++)
-      {
-        if (this.equations.At(row, d).IsNotZero)
-        {
-          allZero = false;
-          nonZeroRow = row;
-
-          break;
-        }
-      }
-      if (allZero)
-      {
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted))
-        {
-          throw new AbstractInterpretationException("Impossible case");
-        }
-
-        return;
-      }
-
-      // 3. Put the dimension in basis
-      int exceptionRow;
-
-      if (!this.TrySwapColumnsInRowEchelonForm(nonZeroRow, d, out exceptionRow))
-      {
-        this.RemoveRow(exceptionRow);
-      }
-
-      // 4. Remove all the constraints that contain a non-zero entry for the dimension d
-      // (should be only one if b is true)
-      Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted);
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      for (int row = 0; row < this.numberOfRows; row++)
-      {
-        if (matrix[row][nonZeroRow].IsNotZero)
-        {
-          deleted = ToPolynomial(matrix[row]);
-          this.RemoveRow(row);
-          row--;
-          this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal;
-        }
-      }
-    }
-
-    public SparseRationalArray[] DisjunctionOfLinearSpaces(SparseRationalArray[] A, SparseRationalArray[] B, out Int32 nRows)
-    {
-      var delLeft = new List<Polynomial<Variable, Expression>>();
-      var delRight = new List<Polynomial<Variable, Expression>>();
-
-      return DisjunctionOfLinearSpaces(A, B, A.Length, B.Length, out nRows, ref delLeft, ref delRight);
-    }
-
-    /// <summary>
-    /// The union of linear spaces according to the Karr's algorithm.
-    /// Please note that the Karr's algorithm works with side effects on <code>A</code> and <code>B</code>
-    /// </summary>
-    /// <param name="A">A matrix in row echelon form</param>
-    /// <param name="B">A matrix in row echelon form</param>
-    public SparseRationalArray[] DisjunctionOfLinearSpaces(SparseRationalArray[] A, SparseRationalArray[] B,
-      int ALength, int BLength,
-      out Int32 nRows,
-      ref List<Polynomial<Variable, Expression>> deletedInLeft, ref List<Polynomial<Variable, Expression>> deletedInRight)
-    {
-      Contract.Requires(A != null);
-      Contract.Requires(B != null);
-
-      Contract.Ensures(Contract.Result<SparseRationalArray[]>() != null);
-
-      bool swapped = false;
-      int nDeletedLeft = 0;
-      int nDeletedRight = 0;
-
-      // If one of the two matrixes has no constraints, then we return it
-      if (A.Length == 0 || A[0] == null || IsZeroRow(A[0]))
-      {
-        nRows = 0;
-        for (int i = 0; i < B.Length && B[i] != null && !IsZeroRow(B[i]); i++)
-        {
-          deletedInRight.Add(ToPolynomial(B[i]));
-        }
-
-        if (swapped)
-        {
-          Swap(ref deletedInLeft, ref deletedInRight);
-        }
-
-        return A;
-      }
-
-      if (B.Length == 0 || B[0] == null || IsZeroRow(B[0]))
-      {
-        nRows = 0;
-        for (int i = 0; i < A.Length && A[i] != null && !IsZeroRow(A[i]); i++)
-        {
-          deletedInLeft.Add(ToPolynomial(A[i]));
-        }
-
-        if (swapped)
-        {
-          Swap(ref deletedInLeft, ref deletedInRight);
-        }
-
-        return B;
-      }
-
-      // The number of columns
-      int nCols = A[0].Length;
-
-      // We just use it, and we do not create the C matrix, unlike the Karr's algorithm
-
-      int rowsInC = -1;
-
-      for (int s = 0; s < nCols; s++)
-      {
-        int r = rowsInC + 1;
-
-        #region Case 0 A is empty or B is empty
-        if (A[0] == null || IsZeroRow(A[0]))
-        {
-          nRows = 0;
-
-          for (int i = 0; i < B.Length && B[i] != null && !IsZeroRow(B[i]); i++)
-          {
-            deletedInRight.Add(ToPolynomial(B[i]));
-          }
-
-          if (swapped)
-          {
-            Swap(ref deletedInLeft, ref deletedInRight);
-          }
-          return A;
-        }
-
-        if (B[0] == null || IsZeroRow(B[0]))
-        {
-          nRows = 0;
-
-          for (int i = 0; i < A.Length && A[i] != null && !IsZeroRow(A[i]); i++)
-          {
-            deletedInLeft.Add(ToPolynomial(A[i]));
-          }
-
-          if (swapped)
-          {
-            Swap(ref deletedInLeft, ref deletedInRight);
-          }
-
-          return B;
-        }
-        #endregion
-
-        bool ArsIsZero = r == ALength || A[r] == null || A[r][s].IsZero;
-        bool BrsIsZero = r == BLength || B[r] == null || B[r][s].IsZero;
-        bool ArsIsOne = r < ALength && A[r] != null && A[r][s] == 1;
-        bool BrsIsOne = r < BLength && B[r] != null && B[r][s] == 1;
-
-        #region Case 1
-        if (ArsIsOne && BrsIsOne)
-        {
-          this.expManager.Log("Applied case 1");
-
-          // C[r][s] = 1;
-
-          rowsInC++;
-        }
-        #endregion
-
-        #region Case 2
-        else if ((ArsIsOne && BrsIsZero) || (ArsIsZero && BrsIsOne))
-        {
-          this.expManager.Log("Applied case 2");
-
-          // Swap the matrixes so to make the two cases symmetrical
-          if (BrsIsOne)
-          {
-            swapped = !swapped;
-
-            // Swap the matrixes
-            Swap(ref A, ref B);
-
-            // Swap the lengths
-            Swap(ref ALength, ref BLength);
-
-            // Swap the deleted values
-            Swap(ref deletedInLeft, ref deletedInRight);
-            Swap(ref nDeletedLeft, ref nDeletedRight);
-          }
-
-          // Do the linear combination for all the rows over it
-
-          for (int i = 0; i < r; i++)
-          {
-            var bi = B[i][s];
-
-            var newRow = SparseRationalArray.New(nCols, 0);
-
-            if (bi.IsNotZero)
-            {
-              try
-              {
-                for (int j = 0; j < nCols; j++)
-                {
-                  //   newRow[j] = A[r][j] * bi + A[i][j];
-                  // We optimize it with some inling
-                  Rational A_r_j, A_i_j;
-                  if (A[r].IsIndexOfNonDefaultElement(j, out A_r_j))
-                  {
-                    if (A[i].IsIndexOfNonDefaultElement(j, out A_i_j))
-                    {
-                      newRow[j] = A_r_j * bi + A_i_j;
-                    }
-                    else
-                    {
-                      newRow[j] = A_r_j * bi;
-                    }
-                  }
-                  else
-                  {
-                    if (A[i].IsIndexOfNonDefaultElement(j, out A_i_j))
-                    {
-                      newRow[j] = A_i_j;
-                    }
-                    else
-                    {
-                      continue;
-                    }
-                  }
-                }
-
-                A[i] = newRow;
-              }
-              catch (ArithmeticExceptionRational)
-              {
-                // Deleting row i in A and B
-                RemoveRow(A, i);
-                RemoveRow(B, i);
-
-                ALength--;
-                BLength--;
-                r--;
-                i--;
-                rowsInC--;
-              }
-            }
-          }
-
-          // Delete the row A[r]
-          deletedInLeft.Add(ToPolynomial(A[r]));
-          nDeletedLeft++;
-
-          RemoveRow(A, r);
-
-        }
-        #endregion
-
-        #region Case 3
-        else if (ArsIsZero && BrsIsZero)
-        {
-          this.expManager.Log("Applied case 3");
-
-          bool simpleCase = true;
-          int t = -1;
-          for (int k = 0; k < r; k++)
-          {
-            if (A[k][s] != B[k][s])
-            {
-              try
-              {
-                // we try to catch the exception caused by A[t][s] - B[t][s] here because it would be harder to remove the right row later
-                var diff = A[k][s] - B[k][s];
-                simpleCase = false;
-                t = k;      // we need this information!
-              }
-              catch (ArithmeticExceptionRational)
-              { // deleting row k in A and B
-
-                RemoveRow(A, k);
-                RemoveRow(B, k);
-
-                ALength--;
-                BLength--;
-                r--;
-                k--;
-                rowsInC--;
-              }
-            }
-          }
-
-          if (!simpleCase)
-          {
-            // Do some linear combinations
-            for (int i = 0; i < t; i++)
-            {
-              var newRowInA = SparseRationalArray.New(nCols, 0);
-              var newRowInB = SparseRationalArray.New(nCols, 0);
-              try
-              {
-                var coeff = (A[i][s] - B[i][s]) / (A[t][s] - B[t][s]);
-
-                if (coeff.IsNotZero)
-                {
-                  for (int j = 0; j < nCols; j++)
-                  {
-                    // newRowInA[j] = A[i][j] - coeff * A[t][j];
-                    ApplyLinearCombinationInDisjunctionOfLinearSpaces(A, t, i, newRowInA, coeff, j);
-
-                    // newRowInB[j] = B[i][j] - coeff * B[t][j];
-                    ApplyLinearCombinationInDisjunctionOfLinearSpaces(B, t, i, newRowInB, coeff, j);
-                  }
-
-                  A[i] = newRowInA;
-                  B[i] = newRowInB;
-                }
-              }
-              catch (ArithmeticExceptionRational)
-              {
-                // deleting row i in A and B
-                RemoveRow(A, i);
-                RemoveRow(B, i);
-
-                ALength--;
-                BLength--;
-                r--;
-                i--;
-                t--;
-                rowsInC--;
-              }
-            }
-
-            // Remove the row t from both matrixes
-            deletedInLeft.Add(ToPolynomial(A[t]));
-            nDeletedLeft++;
-            deletedInRight.Add(ToPolynomial(B[t]));
-            nDeletedRight++;
-
-            RemoveRow(A, t);
-
-            RemoveRow(B, t);
-
-            A[ALength - 1] = FreshRow(nCols);
-            B[BLength - 1] = FreshRow(nCols);
-
-            rowsInC--;    // Check it!!!
-          }
-        }
-        #endregion
-
-        else if (A[r] != null && B[r] != null & A[r][s] != B[r][s])
-        {
-          // Remove the row r from both matrixes
-          RemoveRow(A, r);
-          RemoveRow(B, r);
-
-          A[ALength - 1] = FreshRow(nCols);
-          B[BLength - 1] = FreshRow(nCols);
-
-          rowsInC--;    // Check it!!!
-        }
-
-        else
-        {
-          throw new AbstractInterpretationException("Unknown case in the join of two system of linear equations");
-        }
-      }
-
-      nRows = rowsInC + 1;
-
-      for (int i = nRows; i < ALength; i++)
-      {
-        A[i] = FreshRow(nCols);
-      }
-
-      Contract.Assert(nRows >= 0);
-      Contract.Assert(nRows <= ALength);
-
-      if (swapped)
-      {
-        Swap(ref deletedInLeft, ref deletedInRight);
-      }
-
-      return A;
-    }
-
-    private static void ApplyLinearCombinationInDisjunctionOfLinearSpaces(SparseRationalArray[] row, int t, int i, SparseRationalArray newRowInA, Rational coeff, int j)
-    {
-      Rational row_i_j, row_t_j;
-
-      var b1 = row[i].IsIndexOfNonDefaultElement(j, out row_i_j);
-      var b2 = row[t].IsIndexOfNonDefaultElement(j, out row_t_j);
-
-      if (!b1 && !b2)
-      {
-        return;
-      }
-
-      if (b1)
-      {
-        if (b2)
-        {
-          newRowInA[j] = row_i_j - coeff * row_t_j;
-        }
-        else
-        {
-          newRowInA[j] = row_i_j;
-        }
-      }
-      else if (b2)
-      {
-        newRowInA[j] = -coeff * row_t_j;
-      }
-      else
-      {
-        // unreachable code
-      }
-    }
-
-    private static void Swap<T>(ref T a, ref T b)
-    {
-      T tmp = a;
-      a = b;
-      b = tmp;
-    }
-
-    /// <summary>
-    /// Generate a row to be added to the matrix
-    /// </summary>
-    /// <param name="x"></param>
-    /// <param name="pol">A linear polynomial</param>
-    /// <returns></returns>
-    private SparseRationalArray ConstraintFor(Variable x, Polynomial<Variable, Expression> pol)
-    {
-      Contract.Requires(pol.IsLinear);
-
-      var result = FreshRow(this.NumberOfColumns);
-
-      var colForX = this.varsToDimensions[x];
-
-      result[colForX] = Rational.For(1);
-
-      foreach (var m in pol.Left)
-      {
-        if (!m.IsConstant)
-        {
-          int col = this.varsToDimensions[m.VariableAt(0)];
-
-          if (colForX != col)
-          {
-            Contract.Assert(result[col].IsZero, "You already have assigned this???");
-
-            result[col] = -m.K;
-          }
-          else
-          {
-            Contract.Assert(result[col].IsZero, "You already have assigned this???");
-
-            result[col] = m.K;
-          }
-        }
-        else
-        {
-          Contract.Assert(result[this.NumberOfColumns - 1].IsZero, "You already have assigned this???");
-
-          result[this.NumberOfColumns - 1] = m.K;
-        }
-      }
-
-      return result;
-    }
-
-    /// <returns>
-    /// A representation of <code>pol</code> in the form of a vector
-    /// </returns>
-    /// <param name="pol">A polynomial that must be already linear and in canonical form</param>
-    internal SparseRationalArray AsVector(Polynomial<Variable, Expression> pol)
-    {
-      Contract.Requires(pol.IsLinear, "Expecting a linear polynomial");
-
-      // It is important that we first add the variables, so that if there are not enough columns, the matrix can be enlarged
-      foreach (var var in pol.Variables)
-      {
-        this.AddVariable(var);
-      }
-
-      var result = FreshRow(this.NumberOfColumns);
-
-      switch (pol.Relation)
-      {
-        case null:
-          foreach (var m in pol.Left)
-          {
-            if (!m.IsConstant)
-            {
-              var var = m.VariableAt(0);
-              var col = this.varsToDimensions[var];
-              Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
-
-              result[col] = m.K;
-            }
-            else
-            {
-              var col = this.NumberOfColumns - 1;
-              Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
-
-              result[col] = -m.K;
-            }
-          }
-          break;
-
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          foreach (var m in pol.Left)
-          {
-            if (!m.IsConstant)
-            {
-              var var = m.VariableAt(0);
-              var col = this.varsToDimensions[var];
-              Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
-
-              result[col] = m.K;
-            }
-            else
-            {
-              var col = this.NumberOfColumns - 1;
-              Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
-
-              result[col] = -m.K;
-            }
-          }
-
-          var constant = pol.Right[0].K;
-          int lastCol = this.NumberOfColumns - 1;
-
-          Contract.Assert(result[lastCol].IsZero, "You've already written the position " + lastCol + " ?");
-
-          result[lastCol] = constant;
-          break;
-
-        default:
-          throw new AbstractInterpretationException("trying to convert a polynomial that doesn't correspond to an equality");
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Add <code>howManyNewColumns</code> new columns to the matrix.
-    /// It adds also the new columns to the available dimensions
-    /// </summary>
-    protected void AddColumnsToTheEnvironment(int howManyNewColumns)
-    {
-      Contract.Requires(howManyNewColumns >= 0);
-
-      var columnsBefore = this.NumberOfColumns;
-      var columnsAfter = columnsBefore + howManyNewColumns;
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      for (int row = 0; row < matrix.Length; row++)
-      {
-        var theRow = matrix[row];
-
-        if (theRow != null)
-        {
-          var k = theRow[this.NumberOfColumns - 1];
-
-          theRow.ExpandBy(howManyNewColumns);
-
-          theRow.ResetToDefaultElement(this.NumberOfColumns - 1);
-
-          theRow[columnsAfter - 1] = k;
-        }
-      }
-
-      this.NumberOfColumns = columnsAfter;
-    }
-
-    #endregion
-
-    #region Helper functions for matrixes
-
-    /// <summary>
-    /// Swap the column x with y
-    /// </summary>
-    private void SwapColums(int x, int y)
-    {
-      Contract.Requires(x >= 0);
-      Contract.Requires(y >= 0);
-
-      if (y > this.NumberOfColumns - 2)
-      {
-        this.AddColumnsToTheEnvironment(y - this.NumberOfColumns + 2);
-      }
-
-      if (x > this.NumberOfColumns - 2)
-      {
-        this.AddColumnsToTheEnvironment(x - this.NumberOfColumns + 2);
-      }
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      for (int i = 0; i < this.numberOfRows; i++)
-      {
-        Contract.Assume(matrix[i] != null);
-        matrix[i].Swap(x, y);
-      }
-
-      this.state = LinearEqualitiesState.Normal;      // At this point it is no more in the row echelon form
-    }
-
-    private void SwapColumnsAndVariables(int x, int y)
-    {
-      if (x == y)
-      {
-        return;
-      }
-
-      Variable varX, varY;
-      bool bX = varsToDimensions.TryGetValue(x, out varX);
-      bool bY = varsToDimensions.TryGetValue(y, out varY);
-
-      if (bX)
-      {
-        if (bY)
-        {
-          varsToDimensions[varX] = y;
-          varsToDimensions[varY] = x;
-        }
-        else
-        {
-          varsToDimensions[varX] = y;
-        }
-      }
-      else
-      {
-        if (bY)
-        {
-          varsToDimensions[varY] = x;
-        }
-      }
-
-      SwapColums(x, y);
-    }
-
-    /// <summary>
-    /// Swap the columns <paramref name="x"/> and <paramref name="y"/>, if possible, assuming that the state is RowEchelonForm, then puts the result in RowEchelonForm
-    /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
-    /// <param name="exceptionRow">if an arithmetic exception occurred, it correspond to the row which threw the exception</param>
-    /// <returns>true iff the swap was possible</returns>
-    protected bool TrySwapColumnsInRowEchelonForm(int x, int y, out int exceptionRow)
-    {
-      exceptionRow = -1;
-
-      if (x == y)
-      {
-        return true;
-      }
-
-      Contract.Assert(x >= 0);
-      Contract.Assert(y >= 0);
-      Contract.Assert(this.state != LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal);
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      if (x < this.NumberOfRows)
-      {
-        if (y < this.NumberOfRows)
-        {
-          Swap(ref matrix[x], ref matrix[y]);
-          SwapColumnsAndVariables(x, y);
-        }
-        else
-        {
-          SwapColumnsAndVariables(x, y);
-          var k = matrix[x][x];
-
-          if (k.IsZero)
-          {
             return false;
-          }
+        }
 
-          if (k != 1)
-          {
-            try
+        /// <summary>
+        /// Uniform the two maps, so that \forall x \in dom(left.varsToDimensions) \cap dom(right.varsToDimensions). left.varsToDimensions(x) == right.varsToDimensions(x).
+        /// It works with side effects
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        protected static void UniformEnvironments(LinearEqualitiesEnvironment<Variable, Expression> left, LinearEqualitiesEnvironment<Variable, Expression> right)
+        {
+            Contract.Assert(left.IsConsistent);
+            Contract.Assert(right.IsConsistent);
+
+            var leftMap = left.varsToDimensions;
+            var rightMap = right.varsToDimensions;
+
+            var allvariables = new Set<Variable>(leftMap.Keys);
+            allvariables.AddRange(rightMap.Keys);
+
+            left.expManager.Log("Uniforming the two environments");
+            left.expManager.Log(string.Format("Left argument contains {0} variables", left.Variables.Count));
+            left.expManager.Log(string.Format("Right argument contains {0} variables", right.Variables.Count));
+
+
+            // We can use lists as the code below will guarantee that the three data structures are disjoints
+            var toRemoveLeft = new List<Variable>();
+            var toRemoveRight = new List<Variable>();
+            var intersection = new List<Variable>();
+
+            foreach (var x in allvariables)
             {
-              var row = matrix[x];
-              var indexes = new List<int>(row.IndexesOfNonDefaultElements);
+                var inLeft = leftMap.ContainsKey(x);
+                var inRight = rightMap.ContainsKey(x);
 
-              foreach (int j in indexes)
-              {
-                // Optimization: locality
-                var row_j = row[j] / k;
+                if (inLeft && inRight)
+                { // If both environments have the variable x, we want it to point to the same dimension
+                    intersection.Add(x);
+                }
+                else
+                { // It is a variable that we want to project
+                    if (inLeft)
+                        toRemoveLeft.Add(x);
+                    else if (inRight)
+                        toRemoveRight.Add(x);
+                    else
+                        Contract.Assert(false, "Impossible case?");
+                }
+            }
 
-                if (row_j.IsInfinity)
+            Contract.Assert(allvariables.Count == intersection.Count + toRemoveLeft.Count + toRemoveRight.Count);
+
+            left.expManager.Log(string.Format("Intersection contains {0} variables", intersection.Count));
+
+            left.RemoveVariables(toRemoveLeft, false);
+            left.RecoverUnusedColumns();
+
+            right.RemoveVariables(toRemoveRight, false);
+            right.RecoverUnusedColumns();
+
+            foreach (var toUniform in intersection)
+            {
+                int leftDim, rightDim;
+
+                var leftMapContainsToUniform = left.varsToDimensions.TryGetValue(toUniform, out leftDim);
+                var rightMapContainsToUniform = right.varsToDimensions.TryGetValue(toUniform, out rightDim);
+
+                if (leftMapContainsToUniform && rightMapContainsToUniform)
                 {
-                  exceptionRow = x;
-                  return false;
+                    // this can be false for slack variables removed by dependencies.
+                    right.SwapColumnsAndVariables(leftDim, rightDim);
                 }
                 else
                 {
-                  row[j] = row_j;
+                    // Removing the variables above can also have removed some variable in the intersection
+
+                    if (leftMapContainsToUniform)
+                        left.RemoveVariable(toUniform, true);
+
+                    if (rightMapContainsToUniform)
+                        right.RemoveVariable(toUniform, true);
                 }
-              }
-            }
-            catch (ArithmeticExceptionRational)
-            {
-              exceptionRow = x;
-              return false;
-            }
-          }
-
-          for (int i = 0; i < NumberOfRows; i++)
-          {
-            var row = matrix[i];
-
-            var initial = row[x];
-
-            if (i == x || initial.IsZero)
-            {
-              continue;
             }
 
-            for (int l = 0; l < NumberOfColumns; l++)
+            Contract.Assert(left.IsConsistent);
+            Contract.Assert(right.IsConsistent);
+
+            if (left.NumberOfColumns != right.NumberOfColumns)
             {
-              if (!row.IsIndexOfNonDefaultElement(l) && !matrix[x].IsIndexOfNonDefaultElement(l))
-              {
-                continue;
-              }
+                int newSize = Math.Min(left.NumberOfColumns, right.NumberOfColumns);
 
-              try
-              {
-                // Optimization: locality
-                var Matrix_i_l = row[l] - initial * matrix[x][l];
+                left.RemoveColumnsTo(newSize);
+                right.RemoveColumnsTo(newSize);
+            }
 
-                if (Matrix_i_l.IsInfinity)
+            left.expManager.Log(string.Format("After uniforming, left contains {0}", left.Variables.Count));
+            left.expManager.Log(string.Format("After uniforming, right contains {0}", right.Variables.Count));
+
+            Contract.Assert(left.IsConsistent);
+            Contract.Assert(right.IsConsistent);
+        }
+
+        public void RemoveColumnsTo(int newSize)
+        {
+            Contract.Requires(newSize >= 0);
+
+            if (newSize == this.NumberOfColumns)
+            {
+                return;
+            }
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            for (int row = 0; row < matrix.Length; row++)
+            {
+                if (matrix[row] != null)
                 {
-                  exceptionRow = i;
-                  return false;
+                    var k = matrix[row][matrix[row].Length - 1];
+                    var shorterRow = FreshRow(newSize);
+
+                    shorterRow.CopyFrom(matrix[row], newSize);
+
+                    shorterRow[newSize - 1] = k;
+
+                    matrix[row] = shorterRow;
+                }
+            }
+
+            this.NumberOfColumns = newSize;
+
+            Contract.Assert(this.IsConsistent);
+        }
+
+        /// <summary>
+        /// Project the dimension <paramref name="d"/>, with the option to preserve the variable mappings, which corresponds to not assuming strong row echelon form.
+        /// </summary>
+        /// <param name="d">The dimension to project</param>
+        /// <param name="preserveVariableMappings">set it to true if you may not assume strong row echelon form</param>
+        private void ProjectDimension(int d, bool preserveVariableMappings)
+        {
+            Polynomial<Variable, Expression> row;
+            ProjectDimension(d, preserveVariableMappings, out row);
+        }
+
+        private void ProjectDimension(int d, bool preserveVariableMappings, out Polynomial<Variable, Expression> deleted)
+        {
+            if (preserveVariableMappings)
+            {
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted))
+                {
+                    SwapColumnsAndVariables(0, d);
+                    PutIntoWeakRowEchelonForm();
+
+                    var matrix = this.equations.Unshare(this, ref this.equations);
+
+                    for (int row = 0; row < this.numberOfRows; row++)
+                    {
+                        var currRow = matrix[row];
+                        if (currRow[0].IsNotZero)
+                        {
+                            deleted = ToPolynomial(currRow);
+                            this.RemoveRow(row);
+                            row--;
+                            this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal;
+                        }
+                    }
+                }
+                SwapColumnsAndVariables(0, d);
+            }
+            else
+            {
+                ProjectDimension(d, out deleted);
+            }
+        }
+
+        /// <summary>
+        /// Project the dimension <code>d</code> from this system of equalities
+        /// </summary>
+        /// <param name="d">The dimension to be projected</param>
+        private void ProjectDimension(int d)
+        {
+            Polynomial<Variable, Expression> row;
+            ProjectDimension(d, out row);
+        }
+
+        private void ProjectDimension(int d, out Polynomial<Variable, Expression> deleted)
+        {
+            Contract.Requires(d >= 0);
+
+            Contract.Requires(d < this.NumberOfColumns - 1);
+
+            // Requires the state is RowEchelonForm ; otherwise putting into row echelon form might give a different d
+            Contract.Requires(this.state != LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal, "Call PutIntoRowEchelonForm before projecting");
+
+
+            // 2. Find the row that will enable us to put d in the basis
+            var allZero = true;
+            var nonZeroRow = -1;
+            for (var row = 0; row < this.numberOfRows; row++)
+            {
+                if (this.equations.At(row, d).IsNotZero)
+                {
+                    allZero = false;
+                    nonZeroRow = row;
+
+                    break;
+                }
+            }
+            if (allZero)
+            {
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted))
+                {
+                    throw new AbstractInterpretationException("Impossible case");
+                }
+
+                return;
+            }
+
+            // 3. Put the dimension in basis
+            int exceptionRow;
+
+            if (!this.TrySwapColumnsInRowEchelonForm(nonZeroRow, d, out exceptionRow))
+            {
+                this.RemoveRow(exceptionRow);
+            }
+
+            // 4. Remove all the constraints that contain a non-zero entry for the dimension d
+            // (should be only one if b is true)
+            Polynomial<Variable, Expression>.TryToPolynomialForm(new Monomial<Variable>[0], out deleted);
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            for (int row = 0; row < this.numberOfRows; row++)
+            {
+                if (matrix[row][nonZeroRow].IsNotZero)
+                {
+                    deleted = ToPolynomial(matrix[row]);
+                    this.RemoveRow(row);
+                    row--;
+                    this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal;
+                }
+            }
+        }
+
+        public SparseRationalArray[] DisjunctionOfLinearSpaces(SparseRationalArray[] A, SparseRationalArray[] B, out Int32 nRows)
+        {
+            var delLeft = new List<Polynomial<Variable, Expression>>();
+            var delRight = new List<Polynomial<Variable, Expression>>();
+
+            return DisjunctionOfLinearSpaces(A, B, A.Length, B.Length, out nRows, ref delLeft, ref delRight);
+        }
+
+        /// <summary>
+        /// The union of linear spaces according to the Karr's algorithm.
+        /// Please note that the Karr's algorithm works with side effects on <code>A</code> and <code>B</code>
+        /// </summary>
+        /// <param name="A">A matrix in row echelon form</param>
+        /// <param name="B">A matrix in row echelon form</param>
+        public SparseRationalArray[] DisjunctionOfLinearSpaces(SparseRationalArray[] A, SparseRationalArray[] B,
+          int ALength, int BLength,
+          out Int32 nRows,
+          ref List<Polynomial<Variable, Expression>> deletedInLeft, ref List<Polynomial<Variable, Expression>> deletedInRight)
+        {
+            Contract.Requires(A != null);
+            Contract.Requires(B != null);
+
+            Contract.Ensures(Contract.Result<SparseRationalArray[]>() != null);
+
+            bool swapped = false;
+            int nDeletedLeft = 0;
+            int nDeletedRight = 0;
+
+            // If one of the two matrixes has no constraints, then we return it
+            if (A.Length == 0 || A[0] == null || IsZeroRow(A[0]))
+            {
+                nRows = 0;
+                for (int i = 0; i < B.Length && B[i] != null && !IsZeroRow(B[i]); i++)
+                {
+                    deletedInRight.Add(ToPolynomial(B[i]));
+                }
+
+                if (swapped)
+                {
+                    Swap(ref deletedInLeft, ref deletedInRight);
+                }
+
+                return A;
+            }
+
+            if (B.Length == 0 || B[0] == null || IsZeroRow(B[0]))
+            {
+                nRows = 0;
+                for (int i = 0; i < A.Length && A[i] != null && !IsZeroRow(A[i]); i++)
+                {
+                    deletedInLeft.Add(ToPolynomial(A[i]));
+                }
+
+                if (swapped)
+                {
+                    Swap(ref deletedInLeft, ref deletedInRight);
+                }
+
+                return B;
+            }
+
+            // The number of columns
+            int nCols = A[0].Length;
+
+            // We just use it, and we do not create the C matrix, unlike the Karr's algorithm
+
+            int rowsInC = -1;
+
+            for (int s = 0; s < nCols; s++)
+            {
+                int r = rowsInC + 1;
+
+                #region Case 0 A is empty or B is empty
+                if (A[0] == null || IsZeroRow(A[0]))
+                {
+                    nRows = 0;
+
+                    for (int i = 0; i < B.Length && B[i] != null && !IsZeroRow(B[i]); i++)
+                    {
+                        deletedInRight.Add(ToPolynomial(B[i]));
+                    }
+
+                    if (swapped)
+                    {
+                        Swap(ref deletedInLeft, ref deletedInRight);
+                    }
+                    return A;
+                }
+
+                if (B[0] == null || IsZeroRow(B[0]))
+                {
+                    nRows = 0;
+
+                    for (int i = 0; i < A.Length && A[i] != null && !IsZeroRow(A[i]); i++)
+                    {
+                        deletedInLeft.Add(ToPolynomial(A[i]));
+                    }
+
+                    if (swapped)
+                    {
+                        Swap(ref deletedInLeft, ref deletedInRight);
+                    }
+
+                    return B;
+                }
+                #endregion
+
+                bool ArsIsZero = r == ALength || A[r] == null || A[r][s].IsZero;
+                bool BrsIsZero = r == BLength || B[r] == null || B[r][s].IsZero;
+                bool ArsIsOne = r < ALength && A[r] != null && A[r][s] == 1;
+                bool BrsIsOne = r < BLength && B[r] != null && B[r][s] == 1;
+
+                #region Case 1
+                if (ArsIsOne && BrsIsOne)
+                {
+                    this.expManager.Log("Applied case 1");
+
+                    // C[r][s] = 1;
+
+                    rowsInC++;
+                }
+                #endregion
+
+                #region Case 2
+                else if ((ArsIsOne && BrsIsZero) || (ArsIsZero && BrsIsOne))
+                {
+                    this.expManager.Log("Applied case 2");
+
+                    // Swap the matrixes so to make the two cases symmetrical
+                    if (BrsIsOne)
+                    {
+                        swapped = !swapped;
+
+                        // Swap the matrixes
+                        Swap(ref A, ref B);
+
+                        // Swap the lengths
+                        Swap(ref ALength, ref BLength);
+
+                        // Swap the deleted values
+                        Swap(ref deletedInLeft, ref deletedInRight);
+                        Swap(ref nDeletedLeft, ref nDeletedRight);
+                    }
+
+                    // Do the linear combination for all the rows over it
+
+                    for (int i = 0; i < r; i++)
+                    {
+                        var bi = B[i][s];
+
+                        var newRow = SparseRationalArray.New(nCols, 0);
+
+                        if (bi.IsNotZero)
+                        {
+                            try
+                            {
+                                for (int j = 0; j < nCols; j++)
+                                {
+                                    //   newRow[j] = A[r][j] * bi + A[i][j];
+                                    // We optimize it with some inling
+                                    Rational A_r_j, A_i_j;
+                                    if (A[r].IsIndexOfNonDefaultElement(j, out A_r_j))
+                                    {
+                                        if (A[i].IsIndexOfNonDefaultElement(j, out A_i_j))
+                                        {
+                                            newRow[j] = A_r_j * bi + A_i_j;
+                                        }
+                                        else
+                                        {
+                                            newRow[j] = A_r_j * bi;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (A[i].IsIndexOfNonDefaultElement(j, out A_i_j))
+                                        {
+                                            newRow[j] = A_i_j;
+                                        }
+                                        else
+                                        {
+                                            continue;
+                                        }
+                                    }
+                                }
+
+                                A[i] = newRow;
+                            }
+                            catch (ArithmeticExceptionRational)
+                            {
+                                // Deleting row i in A and B
+                                RemoveRow(A, i);
+                                RemoveRow(B, i);
+
+                                ALength--;
+                                BLength--;
+                                r--;
+                                i--;
+                                rowsInC--;
+                            }
+                        }
+                    }
+
+                    // Delete the row A[r]
+                    deletedInLeft.Add(ToPolynomial(A[r]));
+                    nDeletedLeft++;
+
+                    RemoveRow(A, r);
+                }
+                #endregion
+
+                #region Case 3
+                else if (ArsIsZero && BrsIsZero)
+                {
+                    this.expManager.Log("Applied case 3");
+
+                    bool simpleCase = true;
+                    int t = -1;
+                    for (int k = 0; k < r; k++)
+                    {
+                        if (A[k][s] != B[k][s])
+                        {
+                            try
+                            {
+                                // we try to catch the exception caused by A[t][s] - B[t][s] here because it would be harder to remove the right row later
+                                var diff = A[k][s] - B[k][s];
+                                simpleCase = false;
+                                t = k;      // we need this information!
+                            }
+                            catch (ArithmeticExceptionRational)
+                            { // deleting row k in A and B
+                                RemoveRow(A, k);
+                                RemoveRow(B, k);
+
+                                ALength--;
+                                BLength--;
+                                r--;
+                                k--;
+                                rowsInC--;
+                            }
+                        }
+                    }
+
+                    if (!simpleCase)
+                    {
+                        // Do some linear combinations
+                        for (int i = 0; i < t; i++)
+                        {
+                            var newRowInA = SparseRationalArray.New(nCols, 0);
+                            var newRowInB = SparseRationalArray.New(nCols, 0);
+                            try
+                            {
+                                var coeff = (A[i][s] - B[i][s]) / (A[t][s] - B[t][s]);
+
+                                if (coeff.IsNotZero)
+                                {
+                                    for (int j = 0; j < nCols; j++)
+                                    {
+                                        // newRowInA[j] = A[i][j] - coeff * A[t][j];
+                                        ApplyLinearCombinationInDisjunctionOfLinearSpaces(A, t, i, newRowInA, coeff, j);
+
+                                        // newRowInB[j] = B[i][j] - coeff * B[t][j];
+                                        ApplyLinearCombinationInDisjunctionOfLinearSpaces(B, t, i, newRowInB, coeff, j);
+                                    }
+
+                                    A[i] = newRowInA;
+                                    B[i] = newRowInB;
+                                }
+                            }
+                            catch (ArithmeticExceptionRational)
+                            {
+                                // deleting row i in A and B
+                                RemoveRow(A, i);
+                                RemoveRow(B, i);
+
+                                ALength--;
+                                BLength--;
+                                r--;
+                                i--;
+                                t--;
+                                rowsInC--;
+                            }
+                        }
+
+                        // Remove the row t from both matrixes
+                        deletedInLeft.Add(ToPolynomial(A[t]));
+                        nDeletedLeft++;
+                        deletedInRight.Add(ToPolynomial(B[t]));
+                        nDeletedRight++;
+
+                        RemoveRow(A, t);
+
+                        RemoveRow(B, t);
+
+                        A[ALength - 1] = FreshRow(nCols);
+                        B[BLength - 1] = FreshRow(nCols);
+
+                        rowsInC--;    // Check it!!!
+                    }
+                }
+                #endregion
+
+                else if (A[r] != null && B[r] != null & A[r][s] != B[r][s])
+                {
+                    // Remove the row r from both matrixes
+                    RemoveRow(A, r);
+                    RemoveRow(B, r);
+
+                    A[ALength - 1] = FreshRow(nCols);
+                    B[BLength - 1] = FreshRow(nCols);
+
+                    rowsInC--;    // Check it!!!
+                }
+
+                else
+                {
+                    throw new AbstractInterpretationException("Unknown case in the join of two system of linear equations");
+                }
+            }
+
+            nRows = rowsInC + 1;
+
+            for (int i = nRows; i < ALength; i++)
+            {
+                A[i] = FreshRow(nCols);
+            }
+
+            Contract.Assert(nRows >= 0);
+            Contract.Assert(nRows <= ALength);
+
+            if (swapped)
+            {
+                Swap(ref deletedInLeft, ref deletedInRight);
+            }
+
+            return A;
+        }
+
+        private static void ApplyLinearCombinationInDisjunctionOfLinearSpaces(SparseRationalArray[] row, int t, int i, SparseRationalArray newRowInA, Rational coeff, int j)
+        {
+            Rational row_i_j, row_t_j;
+
+            var b1 = row[i].IsIndexOfNonDefaultElement(j, out row_i_j);
+            var b2 = row[t].IsIndexOfNonDefaultElement(j, out row_t_j);
+
+            if (!b1 && !b2)
+            {
+                return;
+            }
+
+            if (b1)
+            {
+                if (b2)
+                {
+                    newRowInA[j] = row_i_j - coeff * row_t_j;
                 }
                 else
                 {
-                  row[l] = Matrix_i_l;
+                    newRowInA[j] = row_i_j;
                 }
-              }
-              catch (ArithmeticExceptionRational)
-              {
-                exceptionRow = i;
-                return false;
-              }
+            }
+            else if (b2)
+            {
+                newRowInA[j] = -coeff * row_t_j;
+            }
+            else
+            {
+                // unreachable code
+            }
+        }
+
+        private static void Swap<T>(ref T a, ref T b)
+        {
+            T tmp = a;
+            a = b;
+            b = tmp;
+        }
+
+        /// <summary>
+        /// Generate a row to be added to the matrix
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="pol">A linear polynomial</param>
+        /// <returns></returns>
+        private SparseRationalArray ConstraintFor(Variable x, Polynomial<Variable, Expression> pol)
+        {
+            Contract.Requires(pol.IsLinear);
+
+            var result = FreshRow(this.NumberOfColumns);
+
+            var colForX = this.varsToDimensions[x];
+
+            result[colForX] = Rational.For(1);
+
+            foreach (var m in pol.Left)
+            {
+                if (!m.IsConstant)
+                {
+                    int col = this.varsToDimensions[m.VariableAt(0)];
+
+                    if (colForX != col)
+                    {
+                        Contract.Assert(result[col].IsZero, "You already have assigned this???");
+
+                        result[col] = -m.K;
+                    }
+                    else
+                    {
+                        Contract.Assert(result[col].IsZero, "You already have assigned this???");
+
+                        result[col] = m.K;
+                    }
+                }
+                else
+                {
+                    Contract.Assert(result[this.NumberOfColumns - 1].IsZero, "You already have assigned this???");
+
+                    result[this.NumberOfColumns - 1] = m.K;
+                }
             }
 
-          }
+            return result;
         }
-      }
-      else
-      {
-        if (y < this.NumberOfRows)
+
+        /// <returns>
+        /// A representation of <code>pol</code> in the form of a vector
+        /// </returns>
+        /// <param name="pol">A polynomial that must be already linear and in canonical form</param>
+        internal SparseRationalArray AsVector(Polynomial<Variable, Expression> pol)
         {
-          return TrySwapColumnsInRowEchelonForm(y, x, out exceptionRow);
-        }
-        else
-        {
-          SwapColumnsAndVariables(x, y);
-        }
-      }
+            Contract.Requires(pol.IsLinear, "Expecting a linear polynomial");
 
-      this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.StrongRowEchelon;
-      return true;
-    }
-
-    /// <summary>
-    /// Remove the row r;
-    /// </summary>
-    protected void RemoveRow(int rowToDelete)
-    {
-      Contract.Requires(0 <= rowToDelete);
-      Contract.Requires(rowToDelete < this.NumberOfRows);
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      RemoveRow(matrix, rowToDelete);
-
-      this.numberOfRows--;
-    }
-
-    protected static void RemoveRow(SparseRationalArray[] matrix, int rowToDelete)
-    {
-      Contract.Requires(matrix != null);
-      Contract.Requires(0 <= rowToDelete);
-      Contract.Requires(rowToDelete < matrix.Length);
-
-      Array.Copy(matrix, rowToDelete + 1, matrix, rowToDelete, matrix.Length - rowToDelete - 1);
-      matrix[matrix.Length - 1] = null;
-    }
-
-    /// <summary>
-    /// A fresh row with <code>col</code> columns
-    /// </summary>
-    /// <param name="col">The number of columns of the vector</param>
-    static protected SparseRationalArray FreshRow(int col)
-    {
-      return SparseRationalArray.New(col, 0);
-    }
-
-    /// <returns>true iff all the column <code>col</code> is zero</returns>
-    [ContractVerification(true)]
-    [Pure]
-    static protected bool IsZeroCol(SparseRationalArray[] matrix, int rows, int col)
-    {
-      Contract.Requires(matrix != null);
-      Contract.Requires(rows <= matrix.Length);
-      Contract.Requires(col >= 0);
-      Contract.Requires(Contract.ForAll(0, rows, i => matrix[i] != null));
-
-      for (int row = 0; row < rows; row++)
-      {
-        var matrix_row = matrix[row];
-
-        // Implied by the precondition
-        /*
-        if (matrix_row == null)
-        {
-          continue;
-        }
-        */
-        if (matrix_row.IsIndexOfNonDefaultElement(col))
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    [Pure]
-    static protected bool IsZeroRow(SparseRationalArray row)
-    {
-      return row.NonDefaultElementsCount == 0;
-    }
-
-    [Pure]
-    static protected bool IsConstantRow(SparseRationalArray row, out int dim)
-    {
-      dim = -1;
-
-      foreach (var pair in row.GetElements())
-      {
-        if (pair.Key < row.Length - 1)
-        {
-          if (dim >= 0)
-          { // We already saw a coefficient
-            return false;
-          }
-          else
-          {
-            dim = pair.Key;
-          }
-        }
-      }
-
-      return dim >= 0;
-    }
-
-
-
-    /// <summary>
-    /// Finds the first row of <code>m</code> filled with all zeros
-    /// </summary>
-    static protected int FirstZeroRow(SparseRationalArray[] m)
-    {
-      int r = m.Length - 1;
-      for (int row = r - 1; row >= 0; row--)
-      {
-        if (m[row] == null)
-        {
-          r = row;
-        }
-        else if (!IsZeroRow(m[row]))
-        {
-          return r;
-        }
-        else
-        {
-          r = row;
-        }
-      }
-      return r;
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    /// <summary>
-    /// Make a deep copy of this LinearEqualities object
-    /// </summary>
-    /// <returns></returns>
-    public virtual object Clone()
-    {
-      return this.Duplicate();
-    }
-
-    public LinearEqualitiesEnvironment<Variable, Expression> DuplicateMe()
-    {
-      return this.Duplicate();
-    }
-
-    /// <summary>
-    /// A type safe version of <code>Clone</code>
-    /// </summary>
-    virtual protected LinearEqualitiesEnvironment<Variable, Expression> Duplicate()
-    {
-      return new LinearEqualitiesEnvironment<Variable, Expression>(this);
-    }
-
-    #endregion
-
-    #endregion
-
-    #region INumericalAbstractDomain<int,Expression> Members
-
-    public virtual void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargetsInitial, Converter<Variable, Expression> convert)
-    {
-      Contract.Assert(this.IsConsistent, "LinEq inconstistent @ AssignInParallel entry");
-
-      LogPerformance("Equalities x == y before assign in parallel : {0}/{1}", this.CountPairwiseEqualities().ToString(), this.NumberOfRows.ToString());
-      LogPerformance("#of cols/rows on entry {0}/{1}", this.numberOfCols.ToString(), this.NumberOfRows.ToString());
-
-      var tmp = new LinearEqualitiesEnvironment<Variable, Expression>(this);
-      var decoder = this.ExpressionManager.Decoder;
-
-      // adding the domain-generated variables to the map as identity
-      var sourcesToTargets = new Dictionary<Variable, FList<Variable>>(sourcesToTargetsInitial);
-      var toSkip = new Set<Variable>();
-
-      foreach (var x in this.varsToDimensions.Keys)
-      {
-        if (!sourcesToTargets.ContainsKey(x))
-        {
-          if (!toSkip.Contains(x)) // otherwise, it already represents a target variable and should not be removed
-          {
-            tmp.RemoveVariable(x, false);
-          }
-
-          continue;
-        }
-
-        // choosing the canonical element
-        var xTargets = sourcesToTargets[x];
-        var target = (xTargets.Length() > 1 && x.Equals(xTargets.Head))
-          ? xTargets.Tail.Head
-          : xTargets.Head;
-
-        if (x.Equals(target))
-        { // If it is the identity there is nothing to do...
-          continue;
-        }
-
-        if (tmp.varsToDimensions.ContainsKey(target))
-        {
-          tmp.RemoveVariable(target, false);
-          toSkip.Add(target);
-        }
-
-        int dimX = tmp.varsToDimensions[x];
-        tmp.varsToDimensions.Remove(x);
-        tmp.varsToDimensions[target] = dimX;
-
-        Contract.Assert(tmp.IsConsistent);
-      }
-
-      // now adding equalities between targets of a same source
-
-      // We first count how many x -> { y, z} we have. This is to avoid, in the presence of huge renamings to allocate a couple of columns, 
-      // then fill them, then copy, then allocate another bunch, etc.
-
-      #region Enlarge the matrix
-      var equalities = 0;
-      var filtered = new Dictionary<Variable, FList<Variable>>();
-      foreach (var pair in sourcesToTargets)
-      {
-        var sourceConverted = convert(pair.Key);
-
-        // f: Hack to have a better handling of constants (in particular with Int64)
-        if (decoder.IsConstant(decoder.Stripped(sourceConverted)))
-        {
-          foreach (var x in pair.Value.GetEnumerable())
-          {
-            tmp = tmp.TestTrueEqual(x, sourceConverted);
-          }
-        }
-        else
-        {
-          var length = pair.Value.Length();
-          if (length >= 2)
-          {
-
-            if (base.PrintWarnsForLargeTargets && length > 10)
+            // It is important that we first add the variables, so that if there are not enough columns, the matrix can be enlarged
+            foreach (var var in pol.Variables)
             {
-              Console.WriteLine("[KARR] Found more than 10 pairwise equalities!!! (exactly {0})", length);
+                this.AddVariable(var);
             }
 
-            equalities++;
-            filtered.Add(pair.Key, pair.Value);
-          }
-        }
-      }
+            var result = FreshRow(this.NumberOfColumns);
 
-      // more columns
-      tmp.AddColumnsToTheEnvironment(equalities * 2);
-
-      // more rows
-      LinearEquations<Variable, Expression> equations = null;
-      var matrix = tmp.equations.Unshare(tmp, ref equations);
-      Array.Resize(ref matrix, Math.Max(matrix.Length, equalities));
-      tmp.equations = new LinearEquations<Variable, Expression>(tmp, matrix);
-      #endregion
-
-
-      // for huge renamings we Bypass TestTrue, and simply add the equalites sv1 == sv2
-      if (sourcesToTargets.Count > HUGE_RENAMING)
-      {
-        this.expManager.Log("[KARR] Found a huge renaming ({0} renamings, {1} after filtering). Pre-allocating the matrix", 
-          () => sourcesToTargets.Count.ToString(), 
-          () => filtered.Count.ToString());
-
-        foreach (var pair in filtered)
-        {
-          if (pair.Value.Length() <= 1)
-          {
-            continue;
-          }
-          var target = pair.Key.Equals(pair.Value.Head)
-            ? pair.Value.Tail.Head
-            : pair.Value.Head;
-
-          foreach (var otherTarget in pair.Value.GetEnumerable())
-          {
-            if (otherTarget.Equals(target))
+            switch (pol.Relation)
             {
-              continue;
+                case null:
+                    foreach (var m in pol.Left)
+                    {
+                        if (!m.IsConstant)
+                        {
+                            var var = m.VariableAt(0);
+                            var col = this.varsToDimensions[var];
+                            Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
+
+                            result[col] = m.K;
+                        }
+                        else
+                        {
+                            var col = this.NumberOfColumns - 1;
+                            Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
+
+                            result[col] = -m.K;
+                        }
+                    }
+                    break;
+
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    foreach (var m in pol.Left)
+                    {
+                        if (!m.IsConstant)
+                        {
+                            var var = m.VariableAt(0);
+                            var col = this.varsToDimensions[var];
+                            Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
+
+                            result[col] = m.K;
+                        }
+                        else
+                        {
+                            var col = this.NumberOfColumns - 1;
+                            Contract.Assert(result[col].IsZero, "You've already written the position " + col + " ?");
+
+                            result[col] = -m.K;
+                        }
+                    }
+
+                    var constant = pol.Right[0].K;
+                    int lastCol = this.NumberOfColumns - 1;
+
+                    Contract.Assert(result[lastCol].IsZero, "You've already written the position " + lastCol + " ?");
+
+                    result[lastCol] = constant;
+                    break;
+
+                default:
+                    throw new AbstractInterpretationException("trying to convert a polynomial that doesn't correspond to an equality");
             }
 
-            tmp.AddConstraintVariableEqVariable(target, otherTarget);
-          }
+            return result;
         }
-      }
-      else
-      {
 
-        foreach (var pair in filtered)
+        /// <summary>
+        /// Add <code>howManyNewColumns</code> new columns to the matrix.
+        /// It adds also the new columns to the available dimensions
+        /// </summary>
+        protected void AddColumnsToTheEnvironment(int howManyNewColumns)
         {
-          Contract.Assert(pair.Value.Length() >= 2);
-          var target = pair.Key.Equals(pair.Value.Head)
-            ? pair.Value.Tail.Head
-            : pair.Value.Head;
+            Contract.Requires(howManyNewColumns >= 0);
 
-          var targetExp = convert(target);
+            var columnsBefore = this.NumberOfColumns;
+            var columnsAfter = columnsBefore + howManyNewColumns;
 
-          foreach (var otherTarget in pair.Value.GetEnumerable())
-          {
-            if (otherTarget.Equals(target))
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            for (int row = 0; row < matrix.Length; row++)
             {
-              continue;
+                var theRow = matrix[row];
+
+                if (theRow != null)
+                {
+                    var k = theRow[this.NumberOfColumns - 1];
+
+                    theRow.ExpandBy(howManyNewColumns);
+
+                    theRow.ResetToDefaultElement(this.NumberOfColumns - 1);
+
+                    theRow[columnsAfter - 1] = k;
+                }
             }
 
-            var otherTargetExp = convert(otherTarget);
-
-            tmp = tmp.TestTrueEqual(targetExp, otherTargetExp);
-          }
+            this.NumberOfColumns = columnsAfter;
         }
-#if old
-        foreach (var pair in sourcesToTargets)
+
+        #endregion
+
+        #region Helper functions for matrixes
+
+        /// <summary>
+        /// Swap the column x with y
+        /// </summary>
+        private void SwapColums(int x, int y)
         {
-          var sourceConverted = convert(pair.Key);
- 
-          // f: Hack to have a better handling of constants (in particular with Int64)
-          if (this.ExpressionManager.Decoder.IsConstant(this.ExpressionManager.Decoder.Stripped(sourceConverted)))
-          {
-            foreach (var x in pair.Value.GetEnumerable())
+            Contract.Requires(x >= 0);
+            Contract.Requires(y >= 0);
+
+            if (y > this.NumberOfColumns - 2)
             {
-              tmp = tmp.TestTrueEqual(x, sourceConverted);
+                this.AddColumnsToTheEnvironment(y - this.NumberOfColumns + 2);
             }
-          }
-          else
-          {
-            if (pair.Value.Length() >= 2)
+
+            if (x > this.NumberOfColumns - 2)
             {
+                this.AddColumnsToTheEnvironment(x - this.NumberOfColumns + 2);
+            }
 
-              var target = pair.Key.Equals(pair.Value.Head)
-                ? pair.Value.Tail.Head
-                : pair.Value.Head;
+            var matrix = this.equations.Unshare(this, ref this.equations);
 
-              var targetExp = convert(target);
+            for (int i = 0; i < this.numberOfRows; i++)
+            {
+                Contract.Assume(matrix[i] != null);
+                matrix[i].Swap(x, y);
+            }
 
-              foreach (var otherTarget in pair.Value.GetEnumerable())
-              {
-                if (otherTarget.Equals(target))
+            this.state = LinearEqualitiesState.Normal;      // At this point it is no more in the row echelon form
+        }
+
+        private void SwapColumnsAndVariables(int x, int y)
+        {
+            if (x == y)
+            {
+                return;
+            }
+
+            Variable varX, varY;
+            bool bX = varsToDimensions.TryGetValue(x, out varX);
+            bool bY = varsToDimensions.TryGetValue(y, out varY);
+
+            if (bX)
+            {
+                if (bY)
+                {
+                    varsToDimensions[varX] = y;
+                    varsToDimensions[varY] = x;
+                }
+                else
+                {
+                    varsToDimensions[varX] = y;
+                }
+            }
+            else
+            {
+                if (bY)
+                {
+                    varsToDimensions[varY] = x;
+                }
+            }
+
+            SwapColums(x, y);
+        }
+
+        /// <summary>
+        /// Swap the columns <paramref name="x"/> and <paramref name="y"/>, if possible, assuming that the state is RowEchelonForm, then puts the result in RowEchelonForm
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="exceptionRow">if an arithmetic exception occurred, it correspond to the row which threw the exception</param>
+        /// <returns>true iff the swap was possible</returns>
+        protected bool TrySwapColumnsInRowEchelonForm(int x, int y, out int exceptionRow)
+        {
+            exceptionRow = -1;
+
+            if (x == y)
+            {
+                return true;
+            }
+
+            Contract.Assert(x >= 0);
+            Contract.Assert(y >= 0);
+            Contract.Assert(this.state != LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.Normal);
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            if (x < this.NumberOfRows)
+            {
+                if (y < this.NumberOfRows)
+                {
+                    Swap(ref matrix[x], ref matrix[y]);
+                    SwapColumnsAndVariables(x, y);
+                }
+                else
+                {
+                    SwapColumnsAndVariables(x, y);
+                    var k = matrix[x][x];
+
+                    if (k.IsZero)
+                    {
+                        return false;
+                    }
+
+                    if (k != 1)
+                    {
+                        try
+                        {
+                            var row = matrix[x];
+                            var indexes = new List<int>(row.IndexesOfNonDefaultElements);
+
+                            foreach (int j in indexes)
+                            {
+                                // Optimization: locality
+                                var row_j = row[j] / k;
+
+                                if (row_j.IsInfinity)
+                                {
+                                    exceptionRow = x;
+                                    return false;
+                                }
+                                else
+                                {
+                                    row[j] = row_j;
+                                }
+                            }
+                        }
+                        catch (ArithmeticExceptionRational)
+                        {
+                            exceptionRow = x;
+                            return false;
+                        }
+                    }
+
+                    for (int i = 0; i < NumberOfRows; i++)
+                    {
+                        var row = matrix[i];
+
+                        var initial = row[x];
+
+                        if (i == x || initial.IsZero)
+                        {
+                            continue;
+                        }
+
+                        for (int l = 0; l < NumberOfColumns; l++)
+                        {
+                            if (!row.IsIndexOfNonDefaultElement(l) && !matrix[x].IsIndexOfNonDefaultElement(l))
+                            {
+                                continue;
+                            }
+
+                            try
+                            {
+                                // Optimization: locality
+                                var Matrix_i_l = row[l] - initial * matrix[x][l];
+
+                                if (Matrix_i_l.IsInfinity)
+                                {
+                                    exceptionRow = i;
+                                    return false;
+                                }
+                                else
+                                {
+                                    row[l] = Matrix_i_l;
+                                }
+                            }
+                            catch (ArithmeticExceptionRational)
+                            {
+                                exceptionRow = i;
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (y < this.NumberOfRows)
+                {
+                    return TrySwapColumnsInRowEchelonForm(y, x, out exceptionRow);
+                }
+                else
+                {
+                    SwapColumnsAndVariables(x, y);
+                }
+            }
+
+            this.state = LinearEqualitiesEnvironment<Variable, Expression>.LinearEqualitiesState.StrongRowEchelon;
+            return true;
+        }
+
+        /// <summary>
+        /// Remove the row r;
+        /// </summary>
+        protected void RemoveRow(int rowToDelete)
+        {
+            Contract.Requires(0 <= rowToDelete);
+            Contract.Requires(rowToDelete < this.NumberOfRows);
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            RemoveRow(matrix, rowToDelete);
+
+            this.numberOfRows--;
+        }
+
+        protected static void RemoveRow(SparseRationalArray[] matrix, int rowToDelete)
+        {
+            Contract.Requires(matrix != null);
+            Contract.Requires(0 <= rowToDelete);
+            Contract.Requires(rowToDelete < matrix.Length);
+
+            Array.Copy(matrix, rowToDelete + 1, matrix, rowToDelete, matrix.Length - rowToDelete - 1);
+            matrix[matrix.Length - 1] = null;
+        }
+
+        /// <summary>
+        /// A fresh row with <code>col</code> columns
+        /// </summary>
+        /// <param name="col">The number of columns of the vector</param>
+        static protected SparseRationalArray FreshRow(int col)
+        {
+            return SparseRationalArray.New(col, 0);
+        }
+
+        /// <returns>true iff all the column <code>col</code> is zero</returns>
+        [ContractVerification(true)]
+        [Pure]
+        static protected bool IsZeroCol(SparseRationalArray[] matrix, int rows, int col)
+        {
+            Contract.Requires(matrix != null);
+            Contract.Requires(rows <= matrix.Length);
+            Contract.Requires(col >= 0);
+            Contract.Requires(Contract.ForAll(0, rows, i => matrix[i] != null));
+
+            for (int row = 0; row < rows; row++)
+            {
+                var matrix_row = matrix[row];
+
+                // Implied by the precondition
+                /*
+                if (matrix_row == null)
                 {
                   continue;
                 }
-
-                var otherTargetExp = convert(otherTarget);
-
-                tmp = tmp.TestTrueEqual(targetExp, otherTargetExp);
-              }
-            }
-          }
-        }
-#endif
-      }
-      // We change the state of this, using tmp
-      CloneThisFrom(tmp);
-
-      LogPerformance("Equalities x == y after assign in parallel : {0}/{1}", this.CountPairwiseEqualities().ToString(), this.NumberOfRows.ToString());
-      LogPerformance("#of cols/rows on exit {0}/{1}", this.numberOfCols.ToString(), this.NumberOfRows.ToString());
-
-      Contract.Assert(this.IsConsistent, "LinEq inconstistent @ AssignInParallel exit");
-    }
-    #endregion
-
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      var result = New(this.expManager);
-
-      IExpressionEncoder<Variable, Expression> encoder;
-      if (this.ExpressionManager.TryGetEncoder(out encoder))
-      {
-        for (int i = 0; i < this.NumberOfRows; i++)
-        {
-          var exp = this.ToPolynomial(i).ToPureExpression(encoder);
-
-          var redundant = oracle.CheckIfHolds(exp);
-
-          if (!redundant.IsNormal() || !redundant.BoxedElement)
-          { // If it is not implied by the oracle, we add it in the result
-            result = result.TestTrue(exp) as LinearEqualitiesEnvironment<Variable, Expression>;
-          }
-        }
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Gets the polynomials that are equals to the expression <code>x</code>
-    /// </summary>
-    public Set<Polynomial<Variable, Expression>> EqualsTo(Variable x)
-    {
-      if (!this.varsToDimensions.ContainsKey(x))
-      {
-        return new Set<Polynomial<Variable, Expression>>();
-      }
-
-      var tmp = this.Duplicate();
-      int initialRows = tmp.NumberOfRows;
-
-      foreach (var var in tmp.Variables)
-      {
-        tmp.Close(tmp.varsToDimensions[var], MAX_VARS_FOR_CLOSURE, initialRows);
-      }
-
-      return tmp.LookForEqualities(x);
-    }
-
-    /// <returns>
-    /// A set of pairs <code>(exp, val)</code> 
-    /// </returns>
-    public Set<Pair<Variable, Rational>> ConstantValues()
-    {
-      var result = new Set<Pair<Variable, Rational>>();
-
-      var tmp = this.Duplicate();
-      tmp.PutIntoRowEchelonForm();
-
-      int dim;
-
-      for (int i = 0; i < tmp.numberOfRows; i++)
-      {
-        Variable var;
-        if (tmp.equations.IsConstantRow(i, out dim) && this.varsToDimensions.TryGetValue(dim, out var))
-        {
-          result.Add(new Pair<Variable, Rational>(var, tmp.equations.At(i, tmp.NumberOfColumns - 1)));
-        }
-      }
-
-      return result;
-    }
-
-    //static int __count;
-
-    /// <returns>
-    /// A set of equalities (e1, e2) implied by the current state.
-    /// </returns>
-    public IEnumerable<Pair<Expression, Expression>> PairWiseEqualities(int max)
-    {
-      Contract.Requires(max >= 0);
-      Contract.Ensures(Contract.Result<IEnumerable<Pair<Expression, Expression>>>() != null);
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      //__count++;
-      //Console.WriteLine("#{0}: Rows = {1}", __count, this.numberOfRows); 
-
-      int count = 0;
-
-      for (int i = 0; i < this.NumberOfRows && count < max; i++)
-      {
-        var Matrix_i = matrix[i];
-
-        if (this.equations.IsConstantRow(i))
-        {
-          continue;
-        }
-
-        for (int j = i; j < this.NumberOfRows && count < max; j++)
-        {
-          SparseRationalArray tmpVector;
-
-          if (i == j)
-          {
-            tmpVector = Matrix_i;
-          }
-          else
-          {
-            var Matrix_j = matrix[j];
-
-            tmpVector = FreshRow(this.NumberOfColumns);
-
-            // Set union seems to allocate too much space. 
-            // So we simply go for two disjoint cycles and manually track if we've already seen some element
-            var visited = new bool[this.NumberOfColumns];
-
-            foreach (var k in Matrix_i.IndexesOfNonDefaultElements)
-            {
-              // Pairwise sum
-              // tmpVector[k] = Matrix_i[k] + Matrix_j[k];
-
-              Rational add;
-              if (Rational.TryAdd(Matrix_i[k], Matrix_j[k], out add))
-              {
-                visited[k] = true;
-                tmpVector[k] = add;
-              }
-              else
-              {
-                goto nextIteration;
-              }
-            }
-
-            foreach (var k in Matrix_j.IndexesOfNonDefaultElements)
-            {
-              // Pairwise sum
-              // tmpVector[k] = Matrix_i[k] + Matrix_j[k];
-
-              if (visited[k])
-              {
-                continue;
-              }
-
-              Rational add;
-              if (Rational.TryAdd(Matrix_i[k], Matrix_j[k], out add))
-              {
-                tmpVector[k] = add;
-              }
-              else
-              {
-                goto nextIteration;
-              }
-            }
-          }
-
-          Variable x, y, z;
-
-          var encoder = this.expManager.Encoder;
-
-          if (this.MatchXEqY(tmpVector, out x, out  y))
-          {
-            var xExp = encoder.VariableFor(x);
-            var yExp = encoder.VariableFor(y);
-
-            yield return new Pair<Expression, Expression>(xExp, yExp);
-
-            count++;
-            continue;
-          }
-
-          if (this.MatchXPlusYEqZ(tmpVector, out x, out y, out z))
-          {
-            var xExp = encoder.VariableFor(x);
-            var yExp = encoder.VariableFor(y);
-            var zExp = encoder.VariableFor(z);
-
-            yield return new Pair<Expression, Expression>(encoder.CompoundExpressionFor(ExpressionType.Int32,
-              ExpressionOperator.Addition, xExp, yExp),
-              zExp);
-
-            count++;
-            continue;
-          }
-
-        nextIteration: ;
-        }
-      }
-
-      LogPerformanceWithTreshold(50, "Size of equalities : {0}", count);
-
-      yield break;
-    }
-
-    private int CountPairwiseEqualities()
-    {
-      #region Contracts
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      #endregion
-
-      var count = 0;
-
-      for (var row = 0; row < this.NumberOfRows; row++)
-      {
-        if (this.equations.IsXeqYRow(row))
-          count++;
-      }
-
-      return count;
-    }
-
-    #region Helpers
-    private bool MatchXEqY(SparseRationalArray vector, out Variable x, out Variable y)
-    {
-      Contract.Requires(vector.Length == this.NumberOfColumns);
-
-      x = default(Variable);
-      y = default(Variable);
-
-      if (vector[this.NumberOfColumns - 1].IsNotZero)
-      {
-        return false;
-      }
-
-      int indexForX = -1;
-      int indexForY = -1;
-
-      foreach (var pair in vector.GetElements())
-      {
-        if (pair.Value.IsNotZero)
-        {// We need to check that the coefficients are all unary
-          if (pair.Value != -1 && pair.Value != 1)
-          {
-            return false;
-          }
-
-          if (indexForX < 0)
-            indexForX = pair.Key;
-
-          else if (indexForY < 0)
-            indexForY = pair.Key;
-          else
-            return false; // That is, there are at least three non-zero variables 
-        }
-      }
-
-      if (indexForX < 0 || indexForY < 0)
-      {
-        return false;
-      }
-
-      // If we reach this point, then we have exactly two variables in the lineaer equation, and we want to check thay have opposite signs
-      var valueForX = vector[indexForX];
-      var valueForY = vector[indexForY];
-
-      if (valueForX.Sign != valueForY.Sign)
-      {
-        x = this.varsToDimensions[indexForX];
-        y = this.varsToDimensions[indexForY];
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-
-    }
-
-    private bool MatchXPlusYEqZ(SparseRationalArray vector, out Variable x, out Variable y, out Variable z)
-    {
-      Contract.Requires(vector.Length == this.NumberOfColumns);
-
-      x = default(Variable);
-      y = default(Variable);
-      z = default(Variable);
-
-      if (vector[this.NumberOfColumns - 1].IsNotZero)
-      {
-        return false;
-      }
-
-      int indexForX = -1;
-      int indexForY = -1;
-      int indexForZ = -1;
-
-      foreach (var pair in vector.GetElements())
-      {
-        if (pair.Value.IsNotZero)
-        {// We need to check that the coefficients are all unary
-          if (pair.Value != -1 && pair.Value != 1)
-            return false;
-          if (indexForX < 0)
-            indexForX = pair.Key;
-          else if (indexForY < 0)
-            indexForY = pair.Key;
-          else if (indexForZ < 0)
-            indexForZ = pair.Key;
-          else
-            return false; // That is, there are at least four non-zero variables 
-        }
-      }
-
-      if (indexForX < 0 || indexForY < 0 || indexForZ < 0)
-      {
-        return false;
-      }
-
-      // If we reach this point, then we have exactly three variables in the linear equation, and we want to check that their signs match
-      var valueForX = vector[indexForX];
-      var valueForY = vector[indexForY];
-      var valueForZ = vector[indexForZ];
-
-      if (valueForX.Sign + valueForY.Sign + valueForZ.Sign == 1)
-      {
-        if (valueForX.Sign == -1)
-        {
-          z = this.varsToDimensions[indexForX];
-          y = this.varsToDimensions[indexForY];
-          x = this.varsToDimensions[indexForZ];
-          return true;
-        }
-        if (valueForY.Sign == -1)
-        {
-          y = this.varsToDimensions[indexForX];
-          z = this.varsToDimensions[indexForY];
-          x = this.varsToDimensions[indexForZ];
-          return true;
-        }
-        if (valueForZ.Sign == -1)
-        {
-          x = this.varsToDimensions[indexForX];
-          y = this.varsToDimensions[indexForY];
-          z = this.varsToDimensions[indexForZ];
-          return true;
-        }
-      }
-      else if (valueForX.Sign + valueForY.Sign + valueForZ.Sign == -1)
-      {
-        if (valueForX.Sign == 1)
-        {
-          z = this.varsToDimensions[indexForX];
-          y = this.varsToDimensions[indexForY];
-          x = this.varsToDimensions[indexForZ];
-          return true;
-        }
-        if (valueForY.Sign == 1)
-        {
-          y = this.varsToDimensions[indexForX];
-          z = this.varsToDimensions[indexForY];
-          x = this.varsToDimensions[indexForZ];
-          return true;
-        }
-        if (valueForZ.Sign == 1)
-        {
-          x = this.varsToDimensions[indexForX];
-          y = this.varsToDimensions[indexForY];
-          z = this.varsToDimensions[indexForZ];
-          return true;
-        }
-      }
-      return false;
-
-    }
-
-    /// <summary>
-    /// A set of polynomial equalities implied by this state
-    /// </summary>
-    /// <param name="complete">true for polynomials obtained by combining one or two rows, false for only one polynomial per row</param>
-    /// <returns>A set of polynomials</returns>
-    public Set<Polynomial<Variable, Expression>>/*!*/ ToPolynomial(bool complete)
-    {
-      Contract.Ensures(Contract.Result<Set<Polynomial<Variable, Expression>>>() != null);
-
-      var result = new Set<Polynomial<Variable, Expression>>();
-
-      for (var i = 0; i < numberOfRows; i++)
-      {
-        var poli = ToPolynomial(i);
-
-        result.Add(poli);
-
-        if (complete)
-        {
-          for (int j = i + 1; j < numberOfRows; j++)
-          {
-            var polj = ToPolynomial(j);
-            var commonVars = poli.Variables.Intersection(polj.Variables);
-            foreach (var e in commonVars)
-            {
-              try
-              {
-                Polynomial<Variable, Expression> pol;
-                if (TryCombine(poli, polj, e, out pol))
+                */
+                if (matrix_row.IsIndexOfNonDefaultElement(col))
                 {
-                  result.Add(pol);
+                    return false;
                 }
-              }
-              catch (ArithmeticExceptionRational)
-              {
-                // We ignore it
-              }
-              break; // only one addition as others are likely to give the same polynomial
-            }
-          }
-        }
-      }
-      return result;
-    }
-
-    /// <summary>
-    /// Returns a set of polynomials obtained by linear combination of <paramref name="template"/> and a row of this state
-    /// </summary>
-    /// <param name="template">Will be used in the combination</param>
-    /// <returns>A set of polynomials that all contain exactly one slack variable</returns>
-    internal Set<Polynomial<Variable, Expression>> Combine(
-      Polynomial<Variable, Expression> template, int numberOfSlackInTemplate, int maxNumberOfSlackInResult, int depth)
-    {
-      Contract.Requires(depth >= 0);
-
-      Contract.Ensures(Contract.Result<Set<Polynomial<Variable, Expression>>>() != null);
-
-      var result = new Set<Polynomial<Variable, Expression>>();
-
-      if (depth == 0)
-      {
-        return result;
-      }
-
-      if (numberOfSlackInTemplate <= maxNumberOfSlackInResult)
-      {
-        if (!template.IsTautology && !(template.Relation == null && template.Left.Length == 1 && template.Left[0].IsConstant))
-        {
-          result.Add(template);
-        }
-
-        return result;
-      }
-
-      var polynomials = this.ToPolynomial(false);
-      foreach (var pol in polynomials)
-      {
-        var commonvars = template.Variables.Intersection(pol.Variables);
-
-        foreach (var e in commonvars)
-        {
-          if (!this.expManager.Decoder.IsSlackVariable(e))
-          {
-            continue;
-          }
-
-          Polynomial<Variable, Expression> temp;
-          if (!TryCombine(template, pol, e, out temp))
-          {
-            continue;
-          }
-          Variable v;
-          int k = SubPolyhedra<Variable, Expression>.IsBetaDefinition(temp, out v, this.expManager.Decoder);
-
-          if (k >= numberOfSlackInTemplate)
-          {
-            continue;
-          }
-
-          if (k <= maxNumberOfSlackInResult)
-          {
-            if (!temp.IsTautology)
-            {
-              result.Add(temp);
-            }
-          }
-          else
-          {
-            var newPolynomials = Combine(temp, k, maxNumberOfSlackInResult, depth - 1);
-            result.AddRange(newPolynomials);
-          }
-        }
-      }
-      return result;
-    }
-
-    static internal bool TryCombine(
-      Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right, Variable pivot,
-      out Polynomial<Variable, Expression> result)
-    {
-      if (left.Relation == null)
-      { // transform p into p == 0
-        Polynomial<Variable, Expression>.TryToPolynomialForm(true, ExpressionOperator.Equal,
-          (new List<Monomial<Variable>>(left.Left)).ToArray(),
-          new Monomial<Variable>[] { new Monomial<Variable>(0) }, out left);
-      }
-      if (right.Relation == null)
-      { // transform p into p == 0
-        Polynomial<Variable, Expression>.TryToPolynomialForm(true, ExpressionOperator.Equal,
-          (new List<Monomial<Variable>>(right.Left)).ToArray(),
-          new Monomial<Variable>[] { new Monomial<Variable>(0) }, out right);
-      }
-
-      var leftK = Rational.For(0);
-      var rightK = Rational.For(0);
-      foreach (var m in left.Left)
-      {
-        if (m.VariableAt(0).Equals(pivot))
-        {
-          leftK = m.K;
-
-          break;
-        }
-      }
-
-      foreach (var m in right.Left)
-      {
-        if (m.VariableAt(0).Equals(pivot))
-        {
-          rightK = m.K;
-
-          break;
-        }
-      }
-
-      var res = new List<Monomial<Variable>>();
-      foreach (var m in left.Left)
-      {
-        res.Add(new Monomial<Variable>(rightK * m.K, m.VariableAt(0)));
-      }
-
-      foreach (var m in right.Left)
-      {
-        res.Add(new Monomial<Variable>(-leftK * m.K, m.VariableAt(0)));
-      }
-      res.Add(new Monomial<Variable>(leftK * right.Right[0].K - rightK * left.Right[0].K));
-
-
-      return
-        Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, res.ToArray(), new Monomial<Variable>[0], out result);
-    }
-
-    /// <summary>
-    /// This is a potential *very* expensive operation, so we'd like to avoid using it if possible
-    /// </summary>
-    /// <returns></returns>
-    public Set<Polynomial<Variable, Expression>>/*!*/ ToPolynomial()
-    {
-      var tmp = this.Duplicate();
-
-      int initalRows = tmp.NumberOfRows;
-
-
-      foreach (var var in tmp.Variables)
-      {
-        tmp.Close(tmp.varsToDimensions[var], MAX_VARS_FOR_CLOSURE, initalRows);
-      }
-
-      var result = new Set<Polynomial<Variable, Expression>>(tmp.NumberOfRows);
-
-      for (int row = 0; row < tmp.NumberOfRows; row++)
-      {
-        var newPolynomial = tmp.ToPolynomial(row);
-
-        result.Add(newPolynomial);
-      }
-
-      return result;
-    }
-
-    /// <returns>
-    /// A set of expression representing the equations in this state
-    /// </returns>
-    public Set<Expression> ToExpressions()
-    {
-      var result = new Set<Expression>();
-
-      if (this.IsBottom)
-      {
-        return result;
-      }
-
-      foreach (var p in this.ToPolynomial())
-      {
-        result.Add(p.ToPureExpression(this.expManager.Encoder));
-      }
-
-      return result;
-    }
-
-    /// <returns>
-    /// A view as polynomial of the row <code>row</code>
-    /// </returns>
-    protected Polynomial<Variable, Expression>/*!*/ ToPolynomial(int row)
-    {
-      Contract.Requires(row >= 0);
-      Contract.Requires(row < this.numberOfRows);
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      return ToPolynomial(matrix[row]);
-    }
-
-    protected Polynomial<Variable, Expression> ToPolynomial(SparseRationalArray vector)
-    {
-      Contract.Requires(vector != null);
-
-      if (vector.Length != this.NumberOfColumns)
-      {
-        throw new AbstractInterpretationException("Trying to convert a vector with the wrong length");
-      }
-
-      var left = new List<Monomial<Variable>>();
-      var right = new List<Monomial<Variable>>();
-
-      foreach (var pair in vector.GetElements())
-      {
-        if (pair.Key == this.NumberOfColumns - 1)
-        {
-          continue;
-        }
-
-        var k = pair.Value;
-        var x = this.varsToDimensions[pair.Key];
-        left.Add(new Monomial<Variable>(k, x));
-      }
-
-      if (left.Count == 0)
-      {
-        left.Add(new Monomial<Variable>(0));
-      }
-
-      right.Add(new Monomial<Variable>(vector[this.NumberOfColumns - 1]));
-
-      Polynomial<Variable, Expression> result;
-      if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, ExpressionOperator.Equal, left.ToArray(), right.ToArray(), out result))
-      {
-        throw new AbstractInterpretationException("Converting two monomials into a polynomial should never rise an exception");
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Close the matrix w.r.t. the <code>dimension</code>
-    /// </summary>
-    /// <param name="dim">The dimension to close</param>
-    /// <param name="n">The maximum number of variables that we want to keep in a constraint</param>
-    private void Close(int dim, int n, int initialRows)
-    {
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      for (int row = 0; row < initialRows; row++)
-      {
-        for (int internalRow = row + 1; internalRow < initialRows; internalRow++)
-        {
-          // If combining the two rows gives zero for the dimension, then we want to keep this row
-          if ((matrix[row][dim] + matrix[internalRow][dim]).IsZero)
-          {
-            var newRow = FreshRow(this.NumberOfColumns);
-
-            // F: I perform two loops because I hope that this is less expensive than allocating a set, put the elements in it and then iterate over
-            foreach (var i in matrix[row].IndexesOfNonDefaultElements)
-            {
-              try
-              {
-                newRow[i] = matrix[row][i] + matrix[internalRow][i];
-              }
-              catch (ArithmeticExceptionRational)
-              {
-                // Abstraction: If we overflow, we forget the constraints
-                goto next;
-              }
             }
 
-            foreach (var i in matrix[internalRow].IndexesOfNonDefaultElements)
-            {
-              try
-              {
-                newRow[i] = matrix[row][i] + matrix[internalRow][i];
-              }
-              catch (ArithmeticExceptionRational)
-              {
-                // Abstraction: If we overflow, we forget the constraints
-                goto next;
-              }
-            }
-
-            if (ContainsAtMostNVariables(newRow, n + 1))
-            {
-              this.AddConstraint(newRow);
-            }
-          }
-
-        next:
-          ;
+            return true;
         }
-      }
-    }
 
-    static private bool ContainsAtMostNVariables(SparseRationalArray row, int maxVariables)
-    {
-      //Debug.Assert(maxVariables >= 0);
-      //Debug.Assert(maxVariables < row.Length - 1);
-
-      // return row.Count <= maxVariables;
-
-      return maxVariables >= 0 && maxVariables < row.Length - 1 && row.Count <= maxVariables;
-    }
-
-    /// <returns>
-    /// A set of poynomials such that for each polynomial <code>p \in \result</code> <code>x == p</code> holds in this abstract domain
-    /// </returns>
-    private Set<Polynomial<Variable, Expression>> LookForEqualities(Variable/*!*/ x)
-    {
-      var result = new Set<Polynomial<Variable, Expression>>();
-      Polynomial<Variable, Expression> tmpPol;
-
-      int dim = this.varsToDimensions[x];
-
-      for (int row = 0; row < this.NumberOfRows; row++)
-      {
-        var k = this.equations.At(row, dim);
-        if (k.IsNotZero)
+        [Pure]
+        static protected bool IsZeroRow(SparseRationalArray row)
         {
-          var monomials = new List<Monomial<Variable>>();
-          Monomial<Variable> newMonomial;
-
-          foreach (var pair in this.equations.GetElementsForRow(row))
-          {
-            var i = pair.Key;
-            var k1 = -pair.Value / k;
-            if (i != dim && k1.IsNotZero && i < this.NumberOfColumns - 1)
-            {
-              var v = this.varsToDimensions[i];
-              newMonomial = new Monomial<Variable>(k1, v);
-              monomials.Add(newMonomial);
-            }
-          }
-
-          monomials.Add(new Monomial<Variable>(this.equations.At(row, this.numberOfCols - 1) / k));
-
-          if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, monomials.ToArray(), out tmpPol))
-          {
-            throw new AbstractInterpretationException("It can never be the case that a list of monomials fails to be converted into a polynomial");
-          }
-
-          result.Add(tmpPol);
+            return row.NonDefaultElementsCount == 0;
         }
-      }
 
-      return result;
-    }
-    #endregion
-
-    #region Class Invariants
-
-    // We make the body conditionally compiled as the checking is quite expensive and we use the attribute "Conditional" (it is a getter)
-    internal bool IsConsistent
-    {
-      get
-      {
-#if CHECKINVARIANTS
-        foreach (var x in this.varsToDimensions.DirectMap.Keys)
+        [Pure]
+        static protected bool IsConstantRow(SparseRationalArray row, out int dim)
         {
-          if (this.varsToDimensions.DirectMap[x] >= this.NumberOfColumns)
-          {
-            return false;
-          }
+            dim = -1;
+
+            foreach (var pair in row.GetElements())
+            {
+                if (pair.Key < row.Length - 1)
+                {
+                    if (dim >= 0)
+                    { // We already saw a coefficient
+                        return false;
+                    }
+                    else
+                    {
+                        dim = pair.Key;
+                    }
+                }
+            }
+
+            return dim >= 0;
         }
 
 
-        // As this is for debugging only, we iterate all over the columns explictly
-        for (int row = 0; row < this.NumberOfRows; row++)
+
+        /// <summary>
+        /// Finds the first row of <code>m</code> filled with all zeros
+        /// </summary>
+        static protected int FirstZeroRow(SparseRationalArray[] m)
         {
-          for (int col = 0; col < this.NumberOfColumns - 1; col++)
-          {
-            if (this.equations.At(row,col).IsNotZero)
+            int r = m.Length - 1;
+            for (int row = r - 1; row >= 0; row--)
             {
-              if (!this.varsToDimensions.InverseMap.ContainsKey(col))
-              { // We have a nonzero element in a col that is suppoed not to be used
-                ALog.Message(StringClosure.For("There is no variable associated with the matrix element ({0},{1})", StringClosure.For(row), StringClosure.For(col)));
-
-                // We want to stop the execution for debugger...
-                // System.Diagnostics.Debugger.Break();
-
-                return false;
-              }
+                if (m[row] == null)
+                {
+                    r = row;
+                }
+                else if (!IsZeroRow(m[row]))
+                {
+                    return r;
+                }
+                else
+                {
+                    r = row;
+                }
             }
-          }
-        }
-        return true;
-#else
-        if (this.equations == null)
-          return false;
-
-        return true;
-#endif
-      }
-    }
-
-    private bool IsFinite
-    {
-      get
-      {
-#if VERBOSEOUTPUT
-        for (int i = 0; i < this.numberOfRows; i++)
-          if (!this.equations.IsNullRow(i))
-            for (int j = 0; j < this.equations.RowLength(i); j++)
-              if (this.equations.At(i, j).IsInfinity) return false;
-#endif
-        return true;
-      }
-    }
-
-    private bool AreAllConstants
-    {
-      get
-      {
-        for (int i = 0; i < this.NumberOfRows; i++)
-        {
-          // If it is not constant
-          if (this.equations.RowCount(i) >= 3)
-          {
-            return false;
-          }
+            return r;
         }
 
-        return true;
-      }
-    }
-    #endregion
+        #endregion
 
-    #region Visitors
+        #region ICloneable Members
 
-    internal class VisitorForTestTrue
-      : TestTrueVisitor<LinearEqualitiesEnvironment<Variable, Expression>, Variable, Expression>
-    {
-      public VisitorForTestTrue(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
-        : base(decoder)
-      {
-      }
-
-      public override LinearEqualitiesEnvironment<Variable, Expression> VisitEqual_Obj(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
-      {
-        return this.VisitEqual(left, right, original, data);
-      }
-
-      public override LinearEqualitiesEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
-      {
-        return data.TestTrueEqual(left, right);
-      }
-
-      public override LinearEqualitiesEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
-      {
-        return Default(data);
-      }
-
-      public override LinearEqualitiesEnvironment<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
-      {
-        return Default(data);
-      }
-
-      public override LinearEqualitiesEnvironment<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
-      {
-        return Default(data);
-      }
-
-      public override LinearEqualitiesEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
-      {
-        return Default(data);
-      }
-    }
-
-    internal class VisitorForTestFalse
-      : TestFalseVisitor<LinearEqualitiesEnvironment<Variable, Expression>, Variable, Expression>
-    {
-      public VisitorForTestFalse(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-      }
-
-      public override LinearEqualitiesEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
-      {
-        return Default(data);
-      }
-    }
-
-    internal class VisitorForCheckIfHolds
-      : CheckIfHoldsVisitor<LinearEqualitiesEnvironment<Variable, Expression>, Variable, Expression>
-    {
-      private IExpressionEncoder<Variable, Expression> encoder;
-
-      public VisitorForCheckIfHolds(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-        : base(expManager.Decoder)
-      {
-        Contract.Requires(expManager != null); 
-
-        this.encoder = expManager.Encoder;
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        Polynomial<Variable, Expression> pol;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, Decoder, out pol))
+        /// <summary>
+        /// Make a deep copy of this LinearEqualities object
+        /// </summary>
+        /// <returns></returns>
+        public virtual object Clone()
         {
-          // We check if it is a trivial equality...
-          if (pol.IsTautology)
-          {
-            return CheckOutcome.True;
-          }
+            return this.Duplicate();
+        }
 
-          if (pol.IsInconsistent)
-          {
-            return CheckOutcome.False;
-          }
+        public LinearEqualitiesEnvironment<Variable, Expression> DuplicateMe()
+        {
+            return this.Duplicate();
+        }
 
-          if (pol.IsLinear)
-          {
-            var asVector = Domain.AsVector(pol.LeftAsPolynomial);
-            asVector[asVector.Length - 1] = pol.Right[0].K;
+        /// <summary>
+        /// A type safe version of <code>Clone</code>
+        /// </summary>
+        virtual protected LinearEqualitiesEnvironment<Variable, Expression> Duplicate()
+        {
+            return new LinearEqualitiesEnvironment<Variable, Expression>(this);
+        }
 
-            var duplicate = Domain.Duplicate();
-            duplicate.PutIntoRowEchelonForm();
+        #endregion
 
-            int prevRowsCount = duplicate.NumberOfRows;
+        #endregion
 
-            duplicate.AddConstraint(asVector);
+        #region INumericalAbstractDomain<int,Expression> Members
 
-            Debug.Assert(prevRowsCount <= duplicate.NumberOfRows);  // we should not have more constraints here!
+        public virtual void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargetsInitial, Converter<Variable, Expression> convert)
+        {
+            Contract.Assert(this.IsConsistent, "LinEq inconstistent @ AssignInParallel entry");
 
-            duplicate.PutIntoRowEchelonForm();
+            LogPerformance("Equalities x == y before assign in parallel : {0}/{1}", this.CountPairwiseEqualities().ToString(), this.NumberOfRows.ToString());
+            LogPerformance("#of cols/rows on entry {0}/{1}", this.numberOfCols.ToString(), this.NumberOfRows.ToString());
 
-            // Is the new constraint a linear combination of the previous one? 
-            if (duplicate.NumberOfRows == prevRowsCount)
+            var tmp = new LinearEqualitiesEnvironment<Variable, Expression>(this);
+            var decoder = this.ExpressionManager.Decoder;
+
+            // adding the domain-generated variables to the map as identity
+            var sourcesToTargets = new Dictionary<Variable, FList<Variable>>(sourcesToTargetsInitial);
+            var toSkip = new Set<Variable>();
+
+            foreach (var x in this.varsToDimensions.Keys)
             {
-              return CheckOutcome.True;
+                if (!sourcesToTargets.ContainsKey(x))
+                {
+                    if (!toSkip.Contains(x)) // otherwise, it already represents a target variable and should not be removed
+                    {
+                        tmp.RemoveVariable(x, false);
+                    }
+
+                    continue;
+                }
+
+                // choosing the canonical element
+                var xTargets = sourcesToTargets[x];
+                var target = (xTargets.Length() > 1 && x.Equals(xTargets.Head))
+                  ? xTargets.Tail.Head
+                  : xTargets.Head;
+
+                if (x.Equals(target))
+                { // If it is the identity there is nothing to do...
+                    continue;
+                }
+
+                if (tmp.varsToDimensions.ContainsKey(target))
+                {
+                    tmp.RemoveVariable(target, false);
+                    toSkip.Add(target);
+                }
+
+                int dimX = tmp.varsToDimensions[x];
+                tmp.varsToDimensions.Remove(x);
+                tmp.varsToDimensions[target] = dimX;
+
+                Contract.Assert(tmp.IsConsistent);
             }
-            else if (duplicate.IsBottom)
+
+            // now adding equalities between targets of a same source
+
+            // We first count how many x -> { y, z} we have. This is to avoid, in the presence of huge renamings to allocate a couple of columns, 
+            // then fill them, then copy, then allocate another bunch, etc.
+
+            #region Enlarge the matrix
+            var equalities = 0;
+            var filtered = new Dictionary<Variable, FList<Variable>>();
+            foreach (var pair in sourcesToTargets)
             {
-              return CheckOutcome.False;
+                var sourceConverted = convert(pair.Key);
+
+                // f: Hack to have a better handling of constants (in particular with Int64)
+                if (decoder.IsConstant(decoder.Stripped(sourceConverted)))
+                {
+                    foreach (var x in pair.Value.GetEnumerable())
+                    {
+                        tmp = tmp.TestTrueEqual(x, sourceConverted);
+                    }
+                }
+                else
+                {
+                    var length = pair.Value.Length();
+                    if (length >= 2)
+                    {
+                        if (base.PrintWarnsForLargeTargets && length > 10)
+                        {
+                            Console.WriteLine("[KARR] Found more than 10 pairwise equalities!!! (exactly {0})", length);
+                        }
+
+                        equalities++;
+                        filtered.Add(pair.Key, pair.Value);
+                    }
+                }
             }
-            else if (duplicate.IsEmpty())
+
+            // more columns
+            tmp.AddColumnsToTheEnvironment(equalities * 2);
+
+            // more rows
+            LinearEquations<Variable, Expression> equations = null;
+            var matrix = tmp.equations.Unshare(tmp, ref equations);
+            Array.Resize(ref matrix, Math.Max(matrix.Length, equalities));
+            tmp.equations = new LinearEquations<Variable, Expression>(tmp, matrix);
+            #endregion
+
+
+            // for huge renamings we Bypass TestTrue, and simply add the equalites sv1 == sv2
+            if (sourcesToTargets.Count > HUGE_RENAMING)
             {
-              return CheckOutcome.True;
+                this.expManager.Log("[KARR] Found a huge renaming ({0} renamings, {1} after filtering). Pre-allocating the matrix",
+                  () => sourcesToTargets.Count.ToString(),
+                  () => filtered.Count.ToString());
+
+                foreach (var pair in filtered)
+                {
+                    if (pair.Value.Length() <= 1)
+                    {
+                        continue;
+                    }
+                    var target = pair.Key.Equals(pair.Value.Head)
+                      ? pair.Value.Tail.Head
+                      : pair.Value.Head;
+
+                    foreach (var otherTarget in pair.Value.GetEnumerable())
+                    {
+                        if (otherTarget.Equals(target))
+                        {
+                            continue;
+                        }
+
+                        tmp.AddConstraintVariableEqVariable(target, otherTarget);
+                    }
+                }
             }
             else
             {
-              // Checking all the constants can be 
-              if (!duplicate.AreAllConstants)
-              {
-                var asPolynomial = Domain.ToPolynomial();
-                if (asPolynomial.Exists(delegate(Polynomial<Variable, Expression> other) { return pol.IsEquivalentTo(other); }))
+                foreach (var pair in filtered)
                 {
-                  return CheckOutcome.True;
+                    Contract.Assert(pair.Value.Length() >= 2);
+                    var target = pair.Key.Equals(pair.Value.Head)
+                      ? pair.Value.Tail.Head
+                      : pair.Value.Head;
+
+                    var targetExp = convert(target);
+
+                    foreach (var otherTarget in pair.Value.GetEnumerable())
+                    {
+                        if (otherTarget.Equals(target))
+                        {
+                            continue;
+                        }
+
+                        var otherTargetExp = convert(otherTarget);
+
+                        tmp = tmp.TestTrueEqual(targetExp, otherTargetExp);
+                    }
                 }
-              }
-              return CheckOutcome.Top;
+#if old
+                foreach (var pair in sourcesToTargets)
+                {
+                    var sourceConverted = convert(pair.Key);
+
+                    // f: Hack to have a better handling of constants (in particular with Int64)
+                    if (this.ExpressionManager.Decoder.IsConstant(this.ExpressionManager.Decoder.Stripped(sourceConverted)))
+                    {
+                        foreach (var x in pair.Value.GetEnumerable())
+                        {
+                            tmp = tmp.TestTrueEqual(x, sourceConverted);
+                        }
+                    }
+                    else
+                    {
+                        if (pair.Value.Length() >= 2)
+                        {
+
+                            var target = pair.Key.Equals(pair.Value.Head)
+                              ? pair.Value.Tail.Head
+                              : pair.Value.Head;
+
+                            var targetExp = convert(target);
+
+                            foreach (var otherTarget in pair.Value.GetEnumerable())
+                            {
+                                if (otherTarget.Equals(target))
+                                {
+                                    continue;
+                                }
+
+                                var otherTargetExp = convert(otherTarget);
+
+                                tmp = tmp.TestTrueEqual(targetExp, otherTargetExp);
+                            }
+                        }
+                    }
+                }
+#endif
             }
-          }
-        }
-        return CheckOutcome.Top;
-      }
+            // We change the state of this, using tmp
+            CloneThisFrom(tmp);
 
-      public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return this.VisitEqual(left, right, original, data);
-      }
+            LogPerformance("Equalities x == y after assign in parallel : {0}/{1}", this.CountPairwiseEqualities().ToString(), this.NumberOfRows.ToString());
+            LogPerformance("#of cols/rows on exit {0}/{1}", this.numberOfCols.ToString(), this.NumberOfRows.ToString());
 
-      public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        if (this.encoder == null)
-        {
-          return base.VisitNotEqual(left, right, original, data);
-        }
-
-        var eq = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
-        var range = this.Domain.BoundsFor(eq);
-
-        if (range.IsNormal() && range.IsSingleton)
-        {
-          return range.LowerBound.IsZero ? CheckOutcome.False : CheckOutcome.True;
-        }
-
-        return CheckOutcome.Top;
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        var result = VisitEqual(left, right, original, data);
-
-        return result.IsTrue() ? result : CheckOutcome.Top;
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return Default(data);
-      }
-
-    }
-
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-
-    internal void RemoveUnusedVariables()
-    {
-      this.PutIntoRowEchelonForm();
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      var toRemove = new List<Variable>();
-
-      foreach (var pair in this.varsToDimensions)
-      {
-        if (IsZeroCol(matrix, this.NumberOfRows, pair.Value))
-        {
-          toRemove.Add(pair.Key);
-        }
-      }
-
-      //Console.WriteLine("Candidate to be removed {0}", toRemove.Count);
-
-      var count = this.NumberOfColumns - this.varsToDimensions.Count;
-
-      //Console.WriteLine("Unused before {0}", count);
-
-      foreach (var x in toRemove)
-      {
-        this.RemoveVariable(x);
-      }
-
-      if (count > 2 * GrowSizeForColumns)
-      {
-        // We move from the right to the left
-        int j;
-
-        #region Special case for the first segment (we should move the coefficient too)
-        for (j = NumberOfColumns - 2; j >= 0 && !this.varsToDimensions.ContainsValue(j); j--)
-        {
-          if (!IsZeroCol(matrix, this.NumberOfRows, j))
-          {
-            break;
-          }
-        }
-
-        if (j >= 0)
-        {
-          var OldNumberOfColumns = NumberOfColumns;
-          NumberOfColumns = j + 2;
-          for (int i = 0; i < this.NumberOfRows; i++)
-          {
-            var tmp = matrix[i][OldNumberOfColumns - 1];
-            matrix[i].ShrinkTo(NumberOfColumns);
-            matrix[i][NumberOfColumns - 1] = tmp;
-          }
+            Contract.Assert(this.IsConsistent, "LinEq inconstistent @ AssignInParallel exit");
         }
         #endregion
 
-        // TODO: Add the intervals
-      }
-
-      //Console.WriteLine("Unused after {0}", this.NumberOfColumns - this.varsToDimensions.Keys.Count);
-    }
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.ExpressionManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-
-    #region Statistics
-
-    new public string Statistics()
-    {
-      if (this.state == LinearEqualitiesState.Normal || this.state == LinearEqualitiesState.StrongRowEchelon)
-      {
-        return string.Format("{0}; Rows: {1}, Cols: {2}, vars2Dim count : {3}", this.equations.Statistics(), this.numberOfRows, this.numberOfCols, this.varsToDimensions.Count);
-      }
-      else
-      {
-        return "bottom";
-      }
-    }
-    
-    #endregion
-
-    protected class VarsToDimensions
-    {
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.varsToDimensions != null);
-        Contract.Invariant(this.map != null);
-
-        Contract.Invariant(this.IsConsistent());
-      }
-
-      [Pure]
-      private bool IsConsistent()
-      {
-        foreach (var pair in this.varsToDimensions)
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
         {
-          if (!this.map[pair.Value])
+            var result = New(this.expManager);
+
+            IExpressionEncoder<Variable, Expression> encoder;
+            if (this.ExpressionManager.TryGetEncoder(out encoder))
+            {
+                for (int i = 0; i < this.NumberOfRows; i++)
+                {
+                    var exp = this.ToPolynomial(i).ToPureExpression(encoder);
+
+                    var redundant = oracle.CheckIfHolds(exp);
+
+                    if (!redundant.IsNormal() || !redundant.BoxedElement)
+                    { // If it is not implied by the oracle, we add it in the result
+                        result = result.TestTrue(exp) as LinearEqualitiesEnvironment<Variable, Expression>;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the polynomials that are equals to the expression <code>x</code>
+        /// </summary>
+        public Set<Polynomial<Variable, Expression>> EqualsTo(Variable x)
+        {
+            if (!this.varsToDimensions.ContainsKey(x))
+            {
+                return new Set<Polynomial<Variable, Expression>>();
+            }
+
+            var tmp = this.Duplicate();
+            int initialRows = tmp.NumberOfRows;
+
+            foreach (var var in tmp.Variables)
+            {
+                tmp.Close(tmp.varsToDimensions[var], MAX_VARS_FOR_CLOSURE, initialRows);
+            }
+
+            return tmp.LookForEqualities(x);
+        }
+
+        /// <returns>
+        /// A set of pairs <code>(exp, val)</code> 
+        /// </returns>
+        public Set<Pair<Variable, Rational>> ConstantValues()
+        {
+            var result = new Set<Pair<Variable, Rational>>();
+
+            var tmp = this.Duplicate();
+            tmp.PutIntoRowEchelonForm();
+
+            int dim;
+
+            for (int i = 0; i < tmp.numberOfRows; i++)
+            {
+                Variable var;
+                if (tmp.equations.IsConstantRow(i, out dim) && this.varsToDimensions.TryGetValue(dim, out var))
+                {
+                    result.Add(new Pair<Variable, Rational>(var, tmp.equations.At(i, tmp.NumberOfColumns - 1)));
+                }
+            }
+
+            return result;
+        }
+
+        //static int __count;
+
+        /// <returns>
+        /// A set of equalities (e1, e2) implied by the current state.
+        /// </returns>
+        public IEnumerable<Pair<Expression, Expression>> PairWiseEqualities(int max)
+        {
+            Contract.Requires(max >= 0);
+            Contract.Ensures(Contract.Result<IEnumerable<Pair<Expression, Expression>>>() != null);
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            //__count++;
+            //Console.WriteLine("#{0}: Rows = {1}", __count, this.numberOfRows); 
+
+            int count = 0;
+
+            for (int i = 0; i < this.NumberOfRows && count < max; i++)
+            {
+                var Matrix_i = matrix[i];
+
+                if (this.equations.IsConstantRow(i))
+                {
+                    continue;
+                }
+
+                for (int j = i; j < this.NumberOfRows && count < max; j++)
+                {
+                    SparseRationalArray tmpVector;
+
+                    if (i == j)
+                    {
+                        tmpVector = Matrix_i;
+                    }
+                    else
+                    {
+                        var Matrix_j = matrix[j];
+
+                        tmpVector = FreshRow(this.NumberOfColumns);
+
+                        // Set union seems to allocate too much space. 
+                        // So we simply go for two disjoint cycles and manually track if we've already seen some element
+                        var visited = new bool[this.NumberOfColumns];
+
+                        foreach (var k in Matrix_i.IndexesOfNonDefaultElements)
+                        {
+                            // Pairwise sum
+                            // tmpVector[k] = Matrix_i[k] + Matrix_j[k];
+
+                            Rational add;
+                            if (Rational.TryAdd(Matrix_i[k], Matrix_j[k], out add))
+                            {
+                                visited[k] = true;
+                                tmpVector[k] = add;
+                            }
+                            else
+                            {
+                                goto nextIteration;
+                            }
+                        }
+
+                        foreach (var k in Matrix_j.IndexesOfNonDefaultElements)
+                        {
+                            // Pairwise sum
+                            // tmpVector[k] = Matrix_i[k] + Matrix_j[k];
+
+                            if (visited[k])
+                            {
+                                continue;
+                            }
+
+                            Rational add;
+                            if (Rational.TryAdd(Matrix_i[k], Matrix_j[k], out add))
+                            {
+                                tmpVector[k] = add;
+                            }
+                            else
+                            {
+                                goto nextIteration;
+                            }
+                        }
+                    }
+
+                    Variable x, y, z;
+
+                    var encoder = this.expManager.Encoder;
+
+                    if (this.MatchXEqY(tmpVector, out x, out y))
+                    {
+                        var xExp = encoder.VariableFor(x);
+                        var yExp = encoder.VariableFor(y);
+
+                        yield return new Pair<Expression, Expression>(xExp, yExp);
+
+                        count++;
+                        continue;
+                    }
+
+                    if (this.MatchXPlusYEqZ(tmpVector, out x, out y, out z))
+                    {
+                        var xExp = encoder.VariableFor(x);
+                        var yExp = encoder.VariableFor(y);
+                        var zExp = encoder.VariableFor(z);
+
+                        yield return new Pair<Expression, Expression>(encoder.CompoundExpressionFor(ExpressionType.Int32,
+                          ExpressionOperator.Addition, xExp, yExp),
+                          zExp);
+
+                        count++;
+                        continue;
+                    }
+
+                nextIteration:;
+                }
+            }
+
+            LogPerformanceWithTreshold(50, "Size of equalities : {0}", count);
+
+            yield break;
+        }
+
+        private int CountPairwiseEqualities()
+        {
+            #region Contracts
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            #endregion
+
+            var count = 0;
+
+            for (var row = 0; row < this.NumberOfRows; row++)
+            {
+                if (this.equations.IsXeqYRow(row))
+                    count++;
+            }
+
+            return count;
+        }
+
+        #region Helpers
+        private bool MatchXEqY(SparseRationalArray vector, out Variable x, out Variable y)
+        {
+            Contract.Requires(vector.Length == this.NumberOfColumns);
+
+            x = default(Variable);
+            y = default(Variable);
+
+            if (vector[this.NumberOfColumns - 1].IsNotZero)
+            {
+                return false;
+            }
+
+            int indexForX = -1;
+            int indexForY = -1;
+
+            foreach (var pair in vector.GetElements())
+            {
+                if (pair.Value.IsNotZero)
+                {// We need to check that the coefficients are all unary
+                    if (pair.Value != -1 && pair.Value != 1)
+                    {
+                        return false;
+                    }
+
+                    if (indexForX < 0)
+                        indexForX = pair.Key;
+
+                    else if (indexForY < 0)
+                        indexForY = pair.Key;
+                    else
+                        return false; // That is, there are at least three non-zero variables 
+                }
+            }
+
+            if (indexForX < 0 || indexForY < 0)
+            {
+                return false;
+            }
+
+            // If we reach this point, then we have exactly two variables in the lineaer equation, and we want to check thay have opposite signs
+            var valueForX = vector[indexForX];
+            var valueForY = vector[indexForY];
+
+            if (valueForX.Sign != valueForY.Sign)
+            {
+                x = this.varsToDimensions[indexForX];
+                y = this.varsToDimensions[indexForY];
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private bool MatchXPlusYEqZ(SparseRationalArray vector, out Variable x, out Variable y, out Variable z)
+        {
+            Contract.Requires(vector.Length == this.NumberOfColumns);
+
+            x = default(Variable);
+            y = default(Variable);
+            z = default(Variable);
+
+            if (vector[this.NumberOfColumns - 1].IsNotZero)
+            {
+                return false;
+            }
+
+            int indexForX = -1;
+            int indexForY = -1;
+            int indexForZ = -1;
+
+            foreach (var pair in vector.GetElements())
+            {
+                if (pair.Value.IsNotZero)
+                {// We need to check that the coefficients are all unary
+                    if (pair.Value != -1 && pair.Value != 1)
+                        return false;
+                    if (indexForX < 0)
+                        indexForX = pair.Key;
+                    else if (indexForY < 0)
+                        indexForY = pair.Key;
+                    else if (indexForZ < 0)
+                        indexForZ = pair.Key;
+                    else
+                        return false; // That is, there are at least four non-zero variables 
+                }
+            }
+
+            if (indexForX < 0 || indexForY < 0 || indexForZ < 0)
+            {
+                return false;
+            }
+
+            // If we reach this point, then we have exactly three variables in the linear equation, and we want to check that their signs match
+            var valueForX = vector[indexForX];
+            var valueForY = vector[indexForY];
+            var valueForZ = vector[indexForZ];
+
+            if (valueForX.Sign + valueForY.Sign + valueForZ.Sign == 1)
+            {
+                if (valueForX.Sign == -1)
+                {
+                    z = this.varsToDimensions[indexForX];
+                    y = this.varsToDimensions[indexForY];
+                    x = this.varsToDimensions[indexForZ];
+                    return true;
+                }
+                if (valueForY.Sign == -1)
+                {
+                    y = this.varsToDimensions[indexForX];
+                    z = this.varsToDimensions[indexForY];
+                    x = this.varsToDimensions[indexForZ];
+                    return true;
+                }
+                if (valueForZ.Sign == -1)
+                {
+                    x = this.varsToDimensions[indexForX];
+                    y = this.varsToDimensions[indexForY];
+                    z = this.varsToDimensions[indexForZ];
+                    return true;
+                }
+            }
+            else if (valueForX.Sign + valueForY.Sign + valueForZ.Sign == -1)
+            {
+                if (valueForX.Sign == 1)
+                {
+                    z = this.varsToDimensions[indexForX];
+                    y = this.varsToDimensions[indexForY];
+                    x = this.varsToDimensions[indexForZ];
+                    return true;
+                }
+                if (valueForY.Sign == 1)
+                {
+                    y = this.varsToDimensions[indexForX];
+                    z = this.varsToDimensions[indexForY];
+                    x = this.varsToDimensions[indexForZ];
+                    return true;
+                }
+                if (valueForZ.Sign == 1)
+                {
+                    x = this.varsToDimensions[indexForX];
+                    y = this.varsToDimensions[indexForY];
+                    z = this.varsToDimensions[indexForZ];
+                    return true;
+                }
+            }
             return false;
         }
 
-        for (var i = 0; i < this.map.Length; i++)
+        /// <summary>
+        /// A set of polynomial equalities implied by this state
+        /// </summary>
+        /// <param name="complete">true for polynomials obtained by combining one or two rows, false for only one polynomial per row</param>
+        /// <returns>A set of polynomials</returns>
+        public Set<Polynomial<Variable, Expression>>/*!*/ ToPolynomial(bool complete)
         {
-          var p = map[i];
-          var q = this.varsToDimensions.ContainsValue(i);
+            Contract.Ensures(Contract.Result<Set<Polynomial<Variable, Expression>>>() != null);
 
-          if (p != q)
-            return false;
+            var result = new Set<Polynomial<Variable, Expression>>();
+
+            for (var i = 0; i < numberOfRows; i++)
+            {
+                var poli = ToPolynomial(i);
+
+                result.Add(poli);
+
+                if (complete)
+                {
+                    for (int j = i + 1; j < numberOfRows; j++)
+                    {
+                        var polj = ToPolynomial(j);
+                        var commonVars = poli.Variables.Intersection(polj.Variables);
+                        foreach (var e in commonVars)
+                        {
+                            try
+                            {
+                                Polynomial<Variable, Expression> pol;
+                                if (TryCombine(poli, polj, e, out pol))
+                                {
+                                    result.Add(pol);
+                                }
+                            }
+                            catch (ArithmeticExceptionRational)
+                            {
+                                // We ignore it
+                            }
+                            break; // only one addition as others are likely to give the same polynomial
+                        }
+                    }
+                }
+            }
+            return result;
         }
 
-        return true;
-      }
-
-      readonly private BijectiveMap<Variable, int> varsToDimensions;
-      readonly private BitArray map;
-
-      public VarsToDimensions()
-      {
-        this.varsToDimensions = new BijectiveMap<Variable, int>();
-        this.map = new BitArray(256);
-      }
-
-      public VarsToDimensions(VarsToDimensions original)
-      {
-        this.varsToDimensions = new BijectiveMap<Variable, int>(original.varsToDimensions);
-        this.map = new BitArray(original.map);
-      }
-
-      public int Count
-      {
-        get
+        /// <summary>
+        /// Returns a set of polynomials obtained by linear combination of <paramref name="template"/> and a row of this state
+        /// </summary>
+        /// <param name="template">Will be used in the combination</param>
+        /// <returns>A set of polynomials that all contain exactly one slack variable</returns>
+        internal Set<Polynomial<Variable, Expression>> Combine(
+          Polynomial<Variable, Expression> template, int numberOfSlackInTemplate, int maxNumberOfSlackInResult, int depth)
         {
-          Contract.Ensures(Contract.Result<int>() >= 0);
+            Contract.Requires(depth >= 0);
 
-          return this.varsToDimensions.Count;
-        }
-      }
+            Contract.Ensures(Contract.Result<Set<Polynomial<Variable, Expression>>>() != null);
 
-      public IEnumerable<Variable> Keys
-      {
-        get
-        {
-          return this.varsToDimensions.Keys;
-        }
-      }
+            var result = new Set<Polynomial<Variable, Expression>>();
 
-      public IEnumerator<KeyValuePair<Variable, int>> GetEnumerator()
-      {
-        return this.varsToDimensions.GetEnumerator();
-      }
+            if (depth == 0)
+            {
+                return result;
+            }
 
-      public int this[Variable key]
-      {
-        get
-        {
-          Contract.Ensures(Contract.Result<int>() >= 0);
+            if (numberOfSlackInTemplate <= maxNumberOfSlackInResult)
+            {
+                if (!template.IsTautology && !(template.Relation == null && template.Left.Length == 1 && template.Left[0].IsConstant))
+                {
+                    result.Add(template);
+                }
 
-          return this.varsToDimensions[key];
-        }
-        set
-        {
-          Contract.Requires(value >= 0);
+                return result;
+            }
 
-          EnsureMapSize(value);
+            var polynomials = this.ToPolynomial(false);
+            foreach (var pol in polynomials)
+            {
+                var commonvars = template.Variables.Intersection(pol.Variables);
 
-          int prev;
-          if (this.TryGetValue(key, out prev))
-          {
-            this.map[prev] = false;
-          }
+                foreach (var e in commonvars)
+                {
+                    if (!this.expManager.Decoder.IsSlackVariable(e))
+                    {
+                        continue;
+                    }
 
-          this.map[value] = true;
+                    Polynomial<Variable, Expression> temp;
+                    if (!TryCombine(template, pol, e, out temp))
+                    {
+                        continue;
+                    }
+                    Variable v;
+                    int k = SubPolyhedra<Variable, Expression>.IsBetaDefinition(temp, out v, this.expManager.Decoder);
 
+                    if (k >= numberOfSlackInTemplate)
+                    {
+                        continue;
+                    }
 
-          this.varsToDimensions[key] = value;
-        }
-      }
-
-      public Variable this[int dim]
-      {
-        get
-        {
-          Contract.Requires(dim >= 0);
- 
-          return this.varsToDimensions.InverseMap[dim];
-        }
-      }
-
-      public Dictionary<int, Variable> InverseMap
-      {
-        get
-        {
-          return this.varsToDimensions.InverseMap;
-        }
-      }
-
-      [Pure]
-      public bool TryGetValue(Variable v, out int dim)
-      {
-        return this.varsToDimensions.TryGetValue(v, out dim);
-      }
-
-      [Pure]
-      public bool TryGetValue(int dim, out Variable v)
-      {
-        Contract.Requires(dim >= 0);
-
-        v = default(Variable);
-        return dim < this.map.Length && this.map[dim] && this.varsToDimensions.InverseMap.TryGetValue(dim, out v);
-      }
-
-      [Pure]
-      public bool TryGetFirstAvailableDimension(out int dim)
-      {
-        for (var i = 0; i < this.map.Length; i++)
-        {
-          if(!this.map[i])
-          {
-            dim = i;
-            return true;
-          }
+                    if (k <= maxNumberOfSlackInResult)
+                    {
+                        if (!temp.IsTautology)
+                        {
+                            result.Add(temp);
+                        }
+                    }
+                    else
+                    {
+                        var newPolynomials = Combine(temp, k, maxNumberOfSlackInResult, depth - 1);
+                        result.AddRange(newPolynomials);
+                    }
+                }
+            }
+            return result;
         }
 
-        map.Length++;
-
-        dim = map.Length;
-
-        return true;
-      }
-
-      public void Remove(Variable v)
-      {
-        int dim;
-        if (this.TryGetValue(v, out dim))
+        static internal bool TryCombine(
+          Polynomial<Variable, Expression> left, Polynomial<Variable, Expression> right, Variable pivot,
+          out Polynomial<Variable, Expression> result)
         {
-          this.map[dim] = false;
-          this.varsToDimensions.Remove(v);
-        }
-      }
+            if (left.Relation == null)
+            { // transform p into p == 0
+                Polynomial<Variable, Expression>.TryToPolynomialForm(true, ExpressionOperator.Equal,
+                  (new List<Monomial<Variable>>(left.Left)).ToArray(),
+                  new Monomial<Variable>[] { new Monomial<Variable>(0) }, out left);
+            }
+            if (right.Relation == null)
+            { // transform p into p == 0
+                Polynomial<Variable, Expression>.TryToPolynomialForm(true, ExpressionOperator.Equal,
+                  (new List<Monomial<Variable>>(right.Left)).ToArray(),
+                  new Monomial<Variable>[] { new Monomial<Variable>(0) }, out right);
+            }
 
-      [Pure]
-      public bool ContainsKey(Variable v)
-      {
-        return this.varsToDimensions.ContainsKey(v);
-      }
+            var leftK = Rational.For(0);
+            var rightK = Rational.For(0);
+            foreach (var m in left.Left)
+            {
+                if (m.VariableAt(0).Equals(pivot))
+                {
+                    leftK = m.K;
 
-      [Pure]
-      public bool ContainsValue(int i)
-      {
-        Contract.Requires(i >= 0);
+                    break;
+                }
+            }
 
-        return i < this.map.Length && this.map[i];
-      }
+            foreach (var m in right.Left)
+            {
+                if (m.VariableAt(0).Equals(pivot))
+                {
+                    rightK = m.K;
 
-      [Pure]
-      public Variable KeyForValue(int value)
-      {
-        return this.varsToDimensions.InverseMap[value];
-      }
+                    break;
+                }
+            }
 
-      public override string ToString()
-      {
-        return varsToDimensions.ToString();
-      }
+            var res = new List<Monomial<Variable>>();
+            foreach (var m in left.Left)
+            {
+                res.Add(new Monomial<Variable>(rightK * m.K, m.VariableAt(0)));
+            }
 
-      private void EnsureMapSize(int dim)
-      {
-        Contract.Requires(dim >= 0);
-        Contract.Ensures(dim < this.map.Length);
+            foreach (var m in right.Left)
+            {
+                res.Add(new Monomial<Variable>(-leftK * m.K, m.VariableAt(0)));
+            }
+            res.Add(new Monomial<Variable>(leftK * right.Right[0].K - rightK * left.Right[0].K));
 
-        if (this.map.Length <= dim)
-        {
-          this.map.Length = dim+1;
-        }
-      }
 
-      /// <summary>
-      /// Only for debugging
-      /// </summary>
-      [Pure]
-      internal bool LessThan(int max)
-      {
-        foreach (var dim in this.varsToDimensions.Values)
-        {
-          if (dim >= max)
-            return false;
+            return
+              Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, res.ToArray(), new Monomial<Variable>[0], out result);
         }
 
-        return true;
-      }
+        /// <summary>
+        /// This is a potential *very* expensive operation, so we'd like to avoid using it if possible
+        /// </summary>
+        /// <returns></returns>
+        public Set<Polynomial<Variable, Expression>>/*!*/ ToPolynomial()
+        {
+            var tmp = this.Duplicate();
+
+            int initalRows = tmp.NumberOfRows;
+
+
+            foreach (var var in tmp.Variables)
+            {
+                tmp.Close(tmp.varsToDimensions[var], MAX_VARS_FOR_CLOSURE, initalRows);
+            }
+
+            var result = new Set<Polynomial<Variable, Expression>>(tmp.NumberOfRows);
+
+            for (int row = 0; row < tmp.NumberOfRows; row++)
+            {
+                var newPolynomial = tmp.ToPolynomial(row);
+
+                result.Add(newPolynomial);
+            }
+
+            return result;
+        }
+
+        /// <returns>
+        /// A set of expression representing the equations in this state
+        /// </returns>
+        public Set<Expression> ToExpressions()
+        {
+            var result = new Set<Expression>();
+
+            if (this.IsBottom)
+            {
+                return result;
+            }
+
+            foreach (var p in this.ToPolynomial())
+            {
+                result.Add(p.ToPureExpression(this.expManager.Encoder));
+            }
+
+            return result;
+        }
+
+        /// <returns>
+        /// A view as polynomial of the row <code>row</code>
+        /// </returns>
+        protected Polynomial<Variable, Expression>/*!*/ ToPolynomial(int row)
+        {
+            Contract.Requires(row >= 0);
+            Contract.Requires(row < this.numberOfRows);
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            return ToPolynomial(matrix[row]);
+        }
+
+        protected Polynomial<Variable, Expression> ToPolynomial(SparseRationalArray vector)
+        {
+            Contract.Requires(vector != null);
+
+            if (vector.Length != this.NumberOfColumns)
+            {
+                throw new AbstractInterpretationException("Trying to convert a vector with the wrong length");
+            }
+
+            var left = new List<Monomial<Variable>>();
+            var right = new List<Monomial<Variable>>();
+
+            foreach (var pair in vector.GetElements())
+            {
+                if (pair.Key == this.NumberOfColumns - 1)
+                {
+                    continue;
+                }
+
+                var k = pair.Value;
+                var x = this.varsToDimensions[pair.Key];
+                left.Add(new Monomial<Variable>(k, x));
+            }
+
+            if (left.Count == 0)
+            {
+                left.Add(new Monomial<Variable>(0));
+            }
+
+            right.Add(new Monomial<Variable>(vector[this.NumberOfColumns - 1]));
+
+            Polynomial<Variable, Expression> result;
+            if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, ExpressionOperator.Equal, left.ToArray(), right.ToArray(), out result))
+            {
+                throw new AbstractInterpretationException("Converting two monomials into a polynomial should never rise an exception");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Close the matrix w.r.t. the <code>dimension</code>
+        /// </summary>
+        /// <param name="dim">The dimension to close</param>
+        /// <param name="n">The maximum number of variables that we want to keep in a constraint</param>
+        private void Close(int dim, int n, int initialRows)
+        {
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            for (int row = 0; row < initialRows; row++)
+            {
+                for (int internalRow = row + 1; internalRow < initialRows; internalRow++)
+                {
+                    // If combining the two rows gives zero for the dimension, then we want to keep this row
+                    if ((matrix[row][dim] + matrix[internalRow][dim]).IsZero)
+                    {
+                        var newRow = FreshRow(this.NumberOfColumns);
+
+                        // F: I perform two loops because I hope that this is less expensive than allocating a set, put the elements in it and then iterate over
+                        foreach (var i in matrix[row].IndexesOfNonDefaultElements)
+                        {
+                            try
+                            {
+                                newRow[i] = matrix[row][i] + matrix[internalRow][i];
+                            }
+                            catch (ArithmeticExceptionRational)
+                            {
+                                // Abstraction: If we overflow, we forget the constraints
+                                goto next;
+                            }
+                        }
+
+                        foreach (var i in matrix[internalRow].IndexesOfNonDefaultElements)
+                        {
+                            try
+                            {
+                                newRow[i] = matrix[row][i] + matrix[internalRow][i];
+                            }
+                            catch (ArithmeticExceptionRational)
+                            {
+                                // Abstraction: If we overflow, we forget the constraints
+                                goto next;
+                            }
+                        }
+
+                        if (ContainsAtMostNVariables(newRow, n + 1))
+                        {
+                            this.AddConstraint(newRow);
+                        }
+                    }
+
+                next:
+                    ;
+                }
+            }
+        }
+
+        static private bool ContainsAtMostNVariables(SparseRationalArray row, int maxVariables)
+        {
+            //Debug.Assert(maxVariables >= 0);
+            //Debug.Assert(maxVariables < row.Length - 1);
+
+            // return row.Count <= maxVariables;
+
+            return maxVariables >= 0 && maxVariables < row.Length - 1 && row.Count <= maxVariables;
+        }
+
+        /// <returns>
+        /// A set of poynomials such that for each polynomial <code>p \in \result</code> <code>x == p</code> holds in this abstract domain
+        /// </returns>
+        private Set<Polynomial<Variable, Expression>> LookForEqualities(Variable/*!*/ x)
+        {
+            var result = new Set<Polynomial<Variable, Expression>>();
+            Polynomial<Variable, Expression> tmpPol;
+
+            int dim = this.varsToDimensions[x];
+
+            for (int row = 0; row < this.NumberOfRows; row++)
+            {
+                var k = this.equations.At(row, dim);
+                if (k.IsNotZero)
+                {
+                    var monomials = new List<Monomial<Variable>>();
+                    Monomial<Variable> newMonomial;
+
+                    foreach (var pair in this.equations.GetElementsForRow(row))
+                    {
+                        var i = pair.Key;
+                        var k1 = -pair.Value / k;
+                        if (i != dim && k1.IsNotZero && i < this.NumberOfColumns - 1)
+                        {
+                            var v = this.varsToDimensions[i];
+                            newMonomial = new Monomial<Variable>(k1, v);
+                            monomials.Add(newMonomial);
+                        }
+                    }
+
+                    monomials.Add(new Monomial<Variable>(this.equations.At(row, this.numberOfCols - 1) / k));
+
+                    if (!Polynomial<Variable, Expression>.TryToPolynomialForm(true, monomials.ToArray(), out tmpPol))
+                    {
+                        throw new AbstractInterpretationException("It can never be the case that a list of monomials fails to be converted into a polynomial");
+                    }
+
+                    result.Add(tmpPol);
+                }
+            }
+
+            return result;
+        }
+        #endregion
+
+        #region Class Invariants
+
+        // We make the body conditionally compiled as the checking is quite expensive and we use the attribute "Conditional" (it is a getter)
+        internal bool IsConsistent
+        {
+            get
+            {
+#if CHECKINVARIANTS
+                foreach (var x in this.varsToDimensions.DirectMap.Keys)
+                {
+                    if (this.varsToDimensions.DirectMap[x] >= this.NumberOfColumns)
+                    {
+                        return false;
+                    }
+                }
+
+
+                // As this is for debugging only, we iterate all over the columns explictly
+                for (int row = 0; row < this.NumberOfRows; row++)
+                {
+                    for (int col = 0; col < this.NumberOfColumns - 1; col++)
+                    {
+                        if (this.equations.At(row, col).IsNotZero)
+                        {
+                            if (!this.varsToDimensions.InverseMap.ContainsKey(col))
+                            { // We have a nonzero element in a col that is suppoed not to be used
+                                ALog.Message(StringClosure.For("There is no variable associated with the matrix element ({0},{1})", StringClosure.For(row), StringClosure.For(col)));
+
+                                // We want to stop the execution for debugger...
+                                // System.Diagnostics.Debugger.Break();
+
+                                return false;
+                            }
+                        }
+                    }
+                }
+                return true;
+#else
+                if (this.equations == null)
+                    return false;
+
+                return true;
+#endif
+            }
+        }
+
+        private bool IsFinite
+        {
+            get
+            {
+#if VERBOSEOUTPUT
+                for (int i = 0; i < this.numberOfRows; i++)
+                    if (!this.equations.IsNullRow(i))
+                        for (int j = 0; j < this.equations.RowLength(i); j++)
+                            if (this.equations.At(i, j).IsInfinity) return false;
+#endif
+                return true;
+            }
+        }
+
+        private bool AreAllConstants
+        {
+            get
+            {
+                for (int i = 0; i < this.NumberOfRows; i++)
+                {
+                    // If it is not constant
+                    if (this.equations.RowCount(i) >= 3)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+        #endregion
+
+        #region Visitors
+
+        internal class VisitorForTestTrue
+          : TestTrueVisitor<LinearEqualitiesEnvironment<Variable, Expression>, Variable, Expression>
+        {
+            public VisitorForTestTrue(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
+              : base(decoder)
+            {
+            }
+
+            public override LinearEqualitiesEnvironment<Variable, Expression> VisitEqual_Obj(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
+            {
+                return this.VisitEqual(left, right, original, data);
+            }
+
+            public override LinearEqualitiesEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
+            {
+                return data.TestTrueEqual(left, right);
+            }
+
+            public override LinearEqualitiesEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
+            {
+                return Default(data);
+            }
+
+            public override LinearEqualitiesEnvironment<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
+            {
+                return Default(data);
+            }
+
+            public override LinearEqualitiesEnvironment<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
+            {
+                return Default(data);
+            }
+
+            public override LinearEqualitiesEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
+            {
+                return Default(data);
+            }
+        }
+
+        internal class VisitorForTestFalse
+          : TestFalseVisitor<LinearEqualitiesEnvironment<Variable, Expression>, Variable, Expression>
+        {
+            public VisitorForTestFalse(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+            }
+
+            public override LinearEqualitiesEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, LinearEqualitiesEnvironment<Variable, Expression> data)
+            {
+                return Default(data);
+            }
+        }
+
+        internal class VisitorForCheckIfHolds
+          : CheckIfHoldsVisitor<LinearEqualitiesEnvironment<Variable, Expression>, Variable, Expression>
+        {
+            private IExpressionEncoder<Variable, Expression> encoder;
+
+            public VisitorForCheckIfHolds(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+              : base(expManager.Decoder)
+            {
+                Contract.Requires(expManager != null);
+
+                encoder = expManager.Encoder;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                Polynomial<Variable, Expression> pol;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, Decoder, out pol))
+                {
+                    // We check if it is a trivial equality...
+                    if (pol.IsTautology)
+                    {
+                        return CheckOutcome.True;
+                    }
+
+                    if (pol.IsInconsistent)
+                    {
+                        return CheckOutcome.False;
+                    }
+
+                    if (pol.IsLinear)
+                    {
+                        var asVector = Domain.AsVector(pol.LeftAsPolynomial);
+                        asVector[asVector.Length - 1] = pol.Right[0].K;
+
+                        var duplicate = Domain.Duplicate();
+                        duplicate.PutIntoRowEchelonForm();
+
+                        int prevRowsCount = duplicate.NumberOfRows;
+
+                        duplicate.AddConstraint(asVector);
+
+                        Debug.Assert(prevRowsCount <= duplicate.NumberOfRows);  // we should not have more constraints here!
+
+                        duplicate.PutIntoRowEchelonForm();
+
+                        // Is the new constraint a linear combination of the previous one? 
+                        if (duplicate.NumberOfRows == prevRowsCount)
+                        {
+                            return CheckOutcome.True;
+                        }
+                        else if (duplicate.IsBottom)
+                        {
+                            return CheckOutcome.False;
+                        }
+                        else if (duplicate.IsEmpty())
+                        {
+                            return CheckOutcome.True;
+                        }
+                        else
+                        {
+                            // Checking all the constants can be 
+                            if (!duplicate.AreAllConstants)
+                            {
+                                var asPolynomial = Domain.ToPolynomial();
+                                if (asPolynomial.Exists(delegate (Polynomial<Variable, Expression> other) { return pol.IsEquivalentTo(other); }))
+                                {
+                                    return CheckOutcome.True;
+                                }
+                            }
+                            return CheckOutcome.Top;
+                        }
+                    }
+                }
+                return CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return this.VisitEqual(left, right, original, data);
+            }
+
+            public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                if (encoder == null)
+                {
+                    return base.VisitNotEqual(left, right, original, data);
+                }
+
+                var eq = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
+                var range = this.Domain.BoundsFor(eq);
+
+                if (range.IsNormal() && range.IsSingleton)
+                {
+                    return range.LowerBound.IsZero ? CheckOutcome.False : CheckOutcome.True;
+                }
+
+                return CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                var result = VisitEqual(left, right, original, data);
+
+                return result.IsTrue() ? result : CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return Default(data);
+            }
+        }
+
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
+
+        internal void RemoveUnusedVariables()
+        {
+            this.PutIntoRowEchelonForm();
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            var toRemove = new List<Variable>();
+
+            foreach (var pair in this.varsToDimensions)
+            {
+                if (IsZeroCol(matrix, this.NumberOfRows, pair.Value))
+                {
+                    toRemove.Add(pair.Key);
+                }
+            }
+
+            //Console.WriteLine("Candidate to be removed {0}", toRemove.Count);
+
+            var count = this.NumberOfColumns - this.varsToDimensions.Count;
+
+            //Console.WriteLine("Unused before {0}", count);
+
+            foreach (var x in toRemove)
+            {
+                this.RemoveVariable(x);
+            }
+
+            if (count > 2 * GrowSizeForColumns)
+            {
+                // We move from the right to the left
+                int j;
+
+                #region Special case for the first segment (we should move the coefficient too)
+                for (j = NumberOfColumns - 2; j >= 0 && !this.varsToDimensions.ContainsValue(j); j--)
+                {
+                    if (!IsZeroCol(matrix, this.NumberOfRows, j))
+                    {
+                        break;
+                    }
+                }
+
+                if (j >= 0)
+                {
+                    var OldNumberOfColumns = NumberOfColumns;
+                    NumberOfColumns = j + 2;
+                    for (int i = 0; i < this.NumberOfRows; i++)
+                    {
+                        var tmp = matrix[i][OldNumberOfColumns - 1];
+                        matrix[i].ShrinkTo(NumberOfColumns);
+                        matrix[i][NumberOfColumns - 1] = tmp;
+                    }
+                }
+                #endregion
+
+                // TODO: Add the intervals
+            }
+
+            //Console.WriteLine("Unused after {0}", this.NumberOfColumns - this.varsToDimensions.Keys.Count);
+        }
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        public Variable ToVariable(Expression exp)
+        {
+            return this.ExpressionManager.Decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
+
+        #region Statistics
+
+        new public string Statistics()
+        {
+            if (this.state == LinearEqualitiesState.Normal || this.state == LinearEqualitiesState.StrongRowEchelon)
+            {
+                return string.Format("{0}; Rows: {1}, Cols: {2}, vars2Dim count : {3}", this.equations.Statistics(), this.numberOfRows, this.numberOfCols, this.varsToDimensions.Count);
+            }
+            else
+            {
+                return "bottom";
+            }
+        }
+
+        #endregion
+
+        protected class VarsToDimensions
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(varsToDimensions != null);
+                Contract.Invariant(map != null);
+
+                Contract.Invariant(this.IsConsistent());
+            }
+
+            [Pure]
+            private bool IsConsistent()
+            {
+                foreach (var pair in varsToDimensions)
+                {
+                    if (!map[pair.Value])
+                        return false;
+                }
+
+                for (var i = 0; i < map.Length; i++)
+                {
+                    var p = map[i];
+                    var q = varsToDimensions.ContainsValue(i);
+
+                    if (p != q)
+                        return false;
+                }
+
+                return true;
+            }
+
+            readonly private BijectiveMap<Variable, int> varsToDimensions;
+            readonly private BitArray map;
+
+            public VarsToDimensions()
+            {
+                varsToDimensions = new BijectiveMap<Variable, int>();
+                map = new BitArray(256);
+            }
+
+            public VarsToDimensions(VarsToDimensions original)
+            {
+                varsToDimensions = new BijectiveMap<Variable, int>(original.varsToDimensions);
+                map = new BitArray(original.map);
+            }
+
+            public int Count
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<int>() >= 0);
+
+                    return varsToDimensions.Count;
+                }
+            }
+
+            public IEnumerable<Variable> Keys
+            {
+                get
+                {
+                    return varsToDimensions.Keys;
+                }
+            }
+
+            public IEnumerator<KeyValuePair<Variable, int>> GetEnumerator()
+            {
+                return varsToDimensions.GetEnumerator();
+            }
+
+            public int this[Variable key]
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<int>() >= 0);
+
+                    return varsToDimensions[key];
+                }
+                set
+                {
+                    Contract.Requires(value >= 0);
+
+                    EnsureMapSize(value);
+
+                    int prev;
+                    if (this.TryGetValue(key, out prev))
+                    {
+                        map[prev] = false;
+                    }
+
+                    map[value] = true;
+
+
+                    varsToDimensions[key] = value;
+                }
+            }
+
+            public Variable this[int dim]
+            {
+                get
+                {
+                    Contract.Requires(dim >= 0);
+
+                    return varsToDimensions.InverseMap[dim];
+                }
+            }
+
+            public Dictionary<int, Variable> InverseMap
+            {
+                get
+                {
+                    return varsToDimensions.InverseMap;
+                }
+            }
+
+            [Pure]
+            public bool TryGetValue(Variable v, out int dim)
+            {
+                return varsToDimensions.TryGetValue(v, out dim);
+            }
+
+            [Pure]
+            public bool TryGetValue(int dim, out Variable v)
+            {
+                Contract.Requires(dim >= 0);
+
+                v = default(Variable);
+                return dim < map.Length && map[dim] && varsToDimensions.InverseMap.TryGetValue(dim, out v);
+            }
+
+            [Pure]
+            public bool TryGetFirstAvailableDimension(out int dim)
+            {
+                for (var i = 0; i < map.Length; i++)
+                {
+                    if (!map[i])
+                    {
+                        dim = i;
+                        return true;
+                    }
+                }
+
+                map.Length++;
+
+                dim = map.Length;
+
+                return true;
+            }
+
+            public void Remove(Variable v)
+            {
+                int dim;
+                if (this.TryGetValue(v, out dim))
+                {
+                    map[dim] = false;
+                    varsToDimensions.Remove(v);
+                }
+            }
+
+            [Pure]
+            public bool ContainsKey(Variable v)
+            {
+                return varsToDimensions.ContainsKey(v);
+            }
+
+            [Pure]
+            public bool ContainsValue(int i)
+            {
+                Contract.Requires(i >= 0);
+
+                return i < map.Length && map[i];
+            }
+
+            [Pure]
+            public Variable KeyForValue(int value)
+            {
+                return varsToDimensions.InverseMap[value];
+            }
+
+            public override string ToString()
+            {
+                return varsToDimensions.ToString();
+            }
+
+            private void EnsureMapSize(int dim)
+            {
+                Contract.Requires(dim >= 0);
+                Contract.Ensures(dim < map.Length);
+
+                if (map.Length <= dim)
+                {
+                    map.Length = dim + 1;
+                }
+            }
+
+            /// <summary>
+            /// Only for debugging
+            /// </summary>
+            [Pure]
+            internal bool LessThan(int max)
+            {
+                foreach (var dim in varsToDimensions.Values)
+                {
+                    if (dim >= max)
+                        return false;
+                }
+
+                return true;
+            }
+        }
     }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/LinearEquations.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/LinearEquations.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,273 +11,272 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  public class LinearEquations<Variable, Expression>
-  {
-    private SparseRationalArray[] matrix;                                               // The equations
-    private List<LinearEqualitiesEnvironment<Variable, Expression>> sharinglist;        // The list of linearequalities environments sharing those equations
-
-    public LinearEquations(LinearEqualitiesEnvironment<Variable, Expression> parent, int equationsCount)
+    public class LinearEquations<Variable, Expression>
     {
-      Contract.Requires(equationsCount >= 0);
+        private SparseRationalArray[] matrix;                                               // The equations
+        private List<LinearEqualitiesEnvironment<Variable, Expression>> sharinglist;        // The list of linearequalities environments sharing those equations
 
-      this.matrix = new SparseRationalArray[equationsCount];
-      this.sharinglist = new List<LinearEqualitiesEnvironment<Variable, Expression>>() { parent };
-    }
-
-    public LinearEquations(LinearEqualitiesEnvironment<Variable, Expression> parent, SparseRationalArray[] matrix)
-    {
-      this.matrix = matrix;
-      this.sharinglist = new List<LinearEqualitiesEnvironment<Variable, Expression>>() { parent };
-    }
-
-    [Pure]
-    public Rational At(int i, int j)
-    {
-      Contract.Requires(i >= 0);
-      Contract.Requires(j >= 0);
-
-      return this.matrix[i][j];
-    }
-
-    [Pure]
-    public IEnumerable<KeyValuePair<int, Rational>> GetElementsForRow(int i)
-    {
-      Contract.Requires(i >= 0);
-
-      return this.matrix[i].GetElements();
-    }
-
-    public void CopyRowTo(int from, SparseRationalArray to, int len)
-    {
-      to.CopyFrom(this.matrix[from], len);
-    }
-
-    [Pure]
-    public int RowLength(int row)
-    {
-      return this.matrix[row].Length;
-    }
-
-    [Pure]
-    public int RowCount(int row)
-    {
-      return this.matrix[row].Count;
-    }
-
-    [Pure]
-    public bool IsNullRow(int row)
-    {
-      return this.matrix[row] == null;
-    }
-
-    [Pure]
-    public bool IsConstantRow(int row)
-    {
-      return this.matrix[row].IsConstantRow();
-    }
-
-    [Pure]
-    public bool IsConstantRow(int rowIndex, out int dim)
-    {
-      dim = -1;
-
-      var row = this.matrix[rowIndex];
-
-      foreach (var pair in row.GetElements())
-      {
-        if (pair.Key < row.Length - 1)
+        public LinearEquations(LinearEqualitiesEnvironment<Variable, Expression> parent, int equationsCount)
         {
-          if (dim >= 0)
-          { // We already saw a coefficient
-            return false;
-          }
-          else
-          {
-            dim = pair.Key;
-          }
+            Contract.Requires(equationsCount >= 0);
+
+            matrix = new SparseRationalArray[equationsCount];
+            sharinglist = new List<LinearEqualitiesEnvironment<Variable, Expression>>() { parent };
         }
-      }
 
-      return dim >= 0;
-    }
-
-    [Pure]
-    public bool IsXeqYRow(int rowIndex)
-    {
-      var row = this.matrix[rowIndex];
-
-      if (row.NonDefaultElementsCount != 2)
-      {
-        return false;
-      }
-
-      var k1 = default(Rational);
-      var k2 = default(Rational);
-      var k1Set = false;
-      var k2Set = false;
-
-      foreach (var pair in row.GetElements())
-      {
-        if (pair.Key == row.Length - 1)
+        public LinearEquations(LinearEqualitiesEnvironment<Variable, Expression> parent, SparseRationalArray[] matrix)
         {
-          // To make the code more robust
-          if (pair.Value != 0)
-            return false;
+            this.matrix = matrix;
+            sharinglist = new List<LinearEqualitiesEnvironment<Variable, Expression>>() { parent };
         }
 
-        if (pair.Value.IsMinValue || Rational.Abs(pair.Value) != 1)
+        [Pure]
+        public Rational At(int i, int j)
         {
-          return false;
+            Contract.Requires(i >= 0);
+            Contract.Requires(j >= 0);
+
+            return matrix[i][j];
         }
-        if (!k1Set)
+
+        [Pure]
+        public IEnumerable<KeyValuePair<int, Rational>> GetElementsForRow(int i)
         {
-          k1 = pair.Value;
-          k1Set = true;
-          continue;
+            Contract.Requires(i >= 0);
+
+            return matrix[i].GetElements();
         }
 
-        if (!k2Set)
+        public void CopyRowTo(int from, SparseRationalArray to, int len)
         {
-          k2 = pair.Value;
-          k2Set = true;
-          break;
+            to.CopyFrom(matrix[from], len);
         }
-      }
 
-      return (k1 * k2) == -1;
-    }
-
-    [Pure]
-    public bool IsIndexOfNonDefaultElement(int row, int col, out Rational v)
-    {
-      return this.matrix[row].IsIndexOfNonDefaultElement(col, out v);
-    }
-
-    [Pure]
-    public bool IsZeroCol(int rows, int col)
-    {
-      for (int row = 0; row < rows; row++)
-      {
-        if (this.matrix[row] == null)
+        [Pure]
+        public int RowLength(int row)
         {
-          continue;
+            return matrix[row].Length;
         }
 
-        if (this.matrix[row].IsIndexOfNonDefaultElement(col))
+        [Pure]
+        public int RowCount(int row)
         {
-          return false;
+            return matrix[row].Count;
         }
-      }
-      return true;
-    }
 
-
-    public void ZeroCol(LinearEqualitiesEnvironment<Variable, Expression> env, int col, ref LinearEquations<Variable, Expression> equations)
-    {
-      if (this.sharinglist.Count == 1)
-      {
-        ZeroCol(this.matrix, col);
-
-        equations = this;
-      }
-      else
-      {
-        var result = this.Unshare(env, ref equations);
-        ZeroCol(result, col);
-
-        equations = new LinearEquations<Variable, Expression>(env, result);
-      }
-    }
-
-    private static void ZeroCol(SparseRationalArray[] who, int col)
-    {
-      for (int row = 0; row < who.Length; row++)
-      {
-        var currRow = who[row];
-        if (currRow == null)
+        [Pure]
+        public bool IsNullRow(int row)
         {
-          continue;
+            return matrix[row] == null;
         }
 
-        // This is just a quick way of doing: matrix[row][col] = 0;
-        currRow.ResetToDefaultElement(col);
-      }
-    }
-
-    public bool AreSharingTheEquations(LinearEqualitiesEnvironment<Variable, Expression> left, LinearEqualitiesEnvironment<Variable, Expression> right)
-    {
-        return this.sharinglist.Contains(left) && this.sharinglist.Contains(right);
-    }
-
-    public LinearEquations<Variable, Expression> AddSharing(LinearEqualitiesEnvironment<Variable, Expression> newSharing)
-    {
-      Contract.Ensures(Contract.Result<LinearEquations<Variable, Expression>>() != null);
-
-      this.sharinglist.Add(newSharing);
-
-      return this;
-    }
-
-    /// <summary>
-    /// If <code>who</code>is the only one sharing this set of equations, then we simply return the set of equations
-    /// Otherwise, we create a copy of the set of equations, we remove <code>who</code> from the sharing list of those equations, and
-    /// we update equations
-    /// </summary>
-    /// <param name="equations">The new set of linear equations</param>
-    public SparseRationalArray[] Unshare(LinearEqualitiesEnvironment<Variable, Expression> who, ref LinearEquations<Variable, Expression> equations)
-    {
-      Contract.Ensures(Contract.Result<SparseRationalArray[]>() != null);
-      Contract.Ensures(Contract.Result<SparseRationalArray[]>().Length == this.matrix.Length);
-
-      lock (this.sharinglist)
-      {
-        if (this.sharinglist.Count > 1)
+        [Pure]
+        public bool IsConstantRow(int row)
         {
-          this.sharinglist.Remove(who);
-
-          var result = this.GetClonedEquations();
-
-          equations = new LinearEquations<Variable, Expression>(who, result);
-
-          return result;
+            return matrix[row].IsConstantRow();
         }
-        else
-        { // Nothing to do, we just return the previous ones 
-          equations = this;
-          return this.matrix;
-        }
-      }
-    }
 
-    public SparseRationalArray[] GetClonedEquations()
-    {
-      var result = new SparseRationalArray[this.matrix.Length];
-
-      for (int row = 0; row < this.matrix.Length; row++)
-      {
-        var currRow = this.matrix[row];
-        if (currRow != null)
+        [Pure]
+        public bool IsConstantRow(int rowIndex, out int dim)
         {
-          result[row] = SparseRationalArray.New(currRow.Length, 0);
-          result[row].CopyFrom(currRow, currRow.Length);
+            dim = -1;
+
+            var row = matrix[rowIndex];
+
+            foreach (var pair in row.GetElements())
+            {
+                if (pair.Key < row.Length - 1)
+                {
+                    if (dim >= 0)
+                    { // We already saw a coefficient
+                        return false;
+                    }
+                    else
+                    {
+                        dim = pair.Key;
+                    }
+                }
+            }
+
+            return dim >= 0;
         }
-        else
+
+        [Pure]
+        public bool IsXeqYRow(int rowIndex)
         {
-          result[row] = null;
+            var row = matrix[rowIndex];
+
+            if (row.NonDefaultElementsCount != 2)
+            {
+                return false;
+            }
+
+            var k1 = default(Rational);
+            var k2 = default(Rational);
+            var k1Set = false;
+            var k2Set = false;
+
+            foreach (var pair in row.GetElements())
+            {
+                if (pair.Key == row.Length - 1)
+                {
+                    // To make the code more robust
+                    if (pair.Value != 0)
+                        return false;
+                }
+
+                if (pair.Value.IsMinValue || Rational.Abs(pair.Value) != 1)
+                {
+                    return false;
+                }
+                if (!k1Set)
+                {
+                    k1 = pair.Value;
+                    k1Set = true;
+                    continue;
+                }
+
+                if (!k2Set)
+                {
+                    k2 = pair.Value;
+                    k2Set = true;
+                    break;
+                }
+            }
+
+            return (k1 * k2) == -1;
         }
-      }
 
-      return result;
+        [Pure]
+        public bool IsIndexOfNonDefaultElement(int row, int col, out Rational v)
+        {
+            return matrix[row].IsIndexOfNonDefaultElement(col, out v);
+        }
+
+        [Pure]
+        public bool IsZeroCol(int rows, int col)
+        {
+            for (int row = 0; row < rows; row++)
+            {
+                if (matrix[row] == null)
+                {
+                    continue;
+                }
+
+                if (matrix[row].IsIndexOfNonDefaultElement(col))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+
+        public void ZeroCol(LinearEqualitiesEnvironment<Variable, Expression> env, int col, ref LinearEquations<Variable, Expression> equations)
+        {
+            if (sharinglist.Count == 1)
+            {
+                ZeroCol(matrix, col);
+
+                equations = this;
+            }
+            else
+            {
+                var result = this.Unshare(env, ref equations);
+                ZeroCol(result, col);
+
+                equations = new LinearEquations<Variable, Expression>(env, result);
+            }
+        }
+
+        private static void ZeroCol(SparseRationalArray[] who, int col)
+        {
+            for (int row = 0; row < who.Length; row++)
+            {
+                var currRow = who[row];
+                if (currRow == null)
+                {
+                    continue;
+                }
+
+                // This is just a quick way of doing: matrix[row][col] = 0;
+                currRow.ResetToDefaultElement(col);
+            }
+        }
+
+        public bool AreSharingTheEquations(LinearEqualitiesEnvironment<Variable, Expression> left, LinearEqualitiesEnvironment<Variable, Expression> right)
+        {
+            return sharinglist.Contains(left) && sharinglist.Contains(right);
+        }
+
+        public LinearEquations<Variable, Expression> AddSharing(LinearEqualitiesEnvironment<Variable, Expression> newSharing)
+        {
+            Contract.Ensures(Contract.Result<LinearEquations<Variable, Expression>>() != null);
+
+            sharinglist.Add(newSharing);
+
+            return this;
+        }
+
+        /// <summary>
+        /// If <code>who</code>is the only one sharing this set of equations, then we simply return the set of equations
+        /// Otherwise, we create a copy of the set of equations, we remove <code>who</code> from the sharing list of those equations, and
+        /// we update equations
+        /// </summary>
+        /// <param name="equations">The new set of linear equations</param>
+        public SparseRationalArray[] Unshare(LinearEqualitiesEnvironment<Variable, Expression> who, ref LinearEquations<Variable, Expression> equations)
+        {
+            Contract.Ensures(Contract.Result<SparseRationalArray[]>() != null);
+            Contract.Ensures(Contract.Result<SparseRationalArray[]>().Length == matrix.Length);
+
+            lock (sharinglist)
+            {
+                if (sharinglist.Count > 1)
+                {
+                    sharinglist.Remove(who);
+
+                    var result = this.GetClonedEquations();
+
+                    equations = new LinearEquations<Variable, Expression>(who, result);
+
+                    return result;
+                }
+                else
+                { // Nothing to do, we just return the previous ones 
+                    equations = this;
+                    return matrix;
+                }
+            }
+        }
+
+        public SparseRationalArray[] GetClonedEquations()
+        {
+            var result = new SparseRationalArray[matrix.Length];
+
+            for (int row = 0; row < matrix.Length; row++)
+            {
+                var currRow = matrix[row];
+                if (currRow != null)
+                {
+                    result[row] = SparseRationalArray.New(currRow.Length, 0);
+                    result[row].CopyFrom(currRow, currRow.Length);
+                }
+                else
+                {
+                    result[row] = null;
+                }
+            }
+
+            return result;
+        }
+
+        #region Statistics
+
+        public string Statistics()
+        {
+            return string.Format("matrix length: {0}", matrix.Length);
+        }
+
+        #endregion
     }
-
-    #region Statistics
-
-    public string Statistics()
-    {
-      return string.Format("matrix length: {0}", this.matrix.Length);
-    }
-
-    #endregion
-
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/NonRelationalValueAbstraction.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/NonRelationalValueAbstraction.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,1117 +10,1115 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  // **** Important *****
-  // We have a bunch of invariants in this class, which cannot proven by C# type system but Clousot can do.
-  // As a consequence we always want to have 0 warnings on this class
-  [ContractVerification(true)]
-  public class NonRelationalValueAbstraction<Variable, Expression>
-    : IAbstractDomainForArraySegmentationAbstraction<NonRelationalValueAbstraction<Variable, Expression>, Variable>
-  {
-    #region Object invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    // **** Important *****
+    // We have a bunch of invariants in this class, which cannot proven by C# type system but Clousot can do.
+    // As a consequence we always want to have 0 warnings on this class
+    [ContractVerification(true)]
+    public class NonRelationalValueAbstraction<Variable, Expression>
+      : IAbstractDomainForArraySegmentationAbstraction<NonRelationalValueAbstraction<Variable, Expression>, Variable>
     {
-      Contract.Invariant(this.disInterval != null);
-      Contract.Invariant(this.symbolicConditions != null);
-      Contract.Invariant(weaklyRelationalDomains != null);
-      Contract.Invariant(weaklyRelationalDomains.Length == WeaklyRelationalDomainsCount);
-      Contract.Invariant(Contract.ForAll(weaklyRelationalDomains, dom => dom != null));
-    }
-    #endregion
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(disInterval != null);
+            Contract.Invariant(symbolicConditions != null);
+            Contract.Invariant(weaklyRelationalDomains != null);
+            Contract.Invariant(weaklyRelationalDomains.Length == WeaklyRelationalDomainsCount);
+            Contract.Invariant(Contract.ForAll(weaklyRelationalDomains, dom => dom != null));
+        }
+        #endregion
 
-    #region State
+        #region State
 
-    private readonly DisInterval disInterval;
-    private readonly SymbolicExpressionTracker<Variable, Expression> symbolicConditions;
+        private readonly DisInterval disInterval;
+        private readonly SymbolicExpressionTracker<Variable, Expression> symbolicConditions;
 
-    private const int WeaklyRelationalDomainsCount = 5;
-    private readonly SetOfConstraints<Variable>[] weaklyRelationalDomains;
+        private const int WeaklyRelationalDomainsCount = 5;
+        private readonly SetOfConstraints<Variable>[] weaklyRelationalDomains;
 
-    public enum ADomains { Equalities = 0, DisEqualities = 1, WeakUpperBounds = 2, StrictUpperBounds = 3, Existential = 4 }
+        public enum ADomains { Equalities = 0, DisEqualities = 1, WeakUpperBounds = 2, StrictUpperBounds = 3, Existential = 4 }
 
-    // Meaning:
-    // weaklyRelationalDomains[0] == Equalities
-    // weaklyRelationalDomains[1] == DisEqualities
-    // weaklyRelationalDomains[2] == WeakUpperBounds
-    // weaklyRelationalDomains[3] == StrictUpperBounds 
-    // weaklyRelationalDomains[4] == Existential
+        // Meaning:
+        // weaklyRelationalDomains[0] == Equalities
+        // weaklyRelationalDomains[1] == DisEqualities
+        // weaklyRelationalDomains[2] == WeakUpperBounds
+        // weaklyRelationalDomains[3] == StrictUpperBounds 
+        // weaklyRelationalDomains[4] == Existential
 
-    #endregion
+        #endregion
 
-    #region Constructor
+        #region Constructor
 
-    public NonRelationalValueAbstraction(DisInterval interval)
-      : this(interval, SymbolicExpressionTracker<Variable, Expression>.Unknown,
-      SetOfConstraints<Variable>.Unknown, SetOfConstraints<Variable>.Unknown,
-      SetOfConstraints<Variable>.Unknown,
-      SetOfConstraints<Variable>.Unknown, SetOfConstraints<Variable>.Unknown)
-    {
-      Contract.Requires(interval != null);
-    }
+        public NonRelationalValueAbstraction(DisInterval interval)
+          : this(interval, SymbolicExpressionTracker<Variable, Expression>.Unknown,
+          SetOfConstraints<Variable>.Unknown, SetOfConstraints<Variable>.Unknown,
+          SetOfConstraints<Variable>.Unknown,
+          SetOfConstraints<Variable>.Unknown, SetOfConstraints<Variable>.Unknown)
+        {
+            Contract.Requires(interval != null);
+        }
 
-    public NonRelationalValueAbstraction(
-      DisInterval interval, SymbolicExpressionTracker<Variable, Expression> symbolicConditions,
-      SetOfConstraints<Variable> equalities, SetOfConstraints<Variable> disequalities,
-      SetOfConstraints<Variable> weakUpperBounds, SetOfConstraints<Variable> strictUpperBounds,
-      SetOfConstraints<Variable> existential)
-    {
-      Contract.Requires(interval != null);
-      Contract.Requires(symbolicConditions != null);
-      Contract.Requires(disequalities != null);
-      Contract.Requires(equalities != null);
-      Contract.Requires(weakUpperBounds != null);
-      Contract.Requires(strictUpperBounds != null);
-      Contract.Requires(existential != null);
+        public NonRelationalValueAbstraction(
+          DisInterval interval, SymbolicExpressionTracker<Variable, Expression> symbolicConditions,
+          SetOfConstraints<Variable> equalities, SetOfConstraints<Variable> disequalities,
+          SetOfConstraints<Variable> weakUpperBounds, SetOfConstraints<Variable> strictUpperBounds,
+          SetOfConstraints<Variable> existential)
+        {
+            Contract.Requires(interval != null);
+            Contract.Requires(symbolicConditions != null);
+            Contract.Requires(disequalities != null);
+            Contract.Requires(equalities != null);
+            Contract.Requires(weakUpperBounds != null);
+            Contract.Requires(strictUpperBounds != null);
+            Contract.Requires(existential != null);
 
-      this.disInterval = interval;
-      this.symbolicConditions = symbolicConditions;
-      this.weaklyRelationalDomains = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount]
-      {
-        equalities, 
+            disInterval = interval;
+            this.symbolicConditions = symbolicConditions;
+            weaklyRelationalDomains = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount]
+            {
+        equalities,
         disequalities,
-        weakUpperBounds, 
+        weakUpperBounds,
         strictUpperBounds,
         existential
-      };
-    }
-
-    private NonRelationalValueAbstraction(
-      DisInterval interval, SymbolicExpressionTracker<Variable, Expression> symbolicConditions,
-      SetOfConstraints<Variable>[] domains)
-    {
-      Contract.Requires(interval != null);
-      Contract.Requires(symbolicConditions != null);
-      Contract.Requires(domains != null);
-
-      Contract.Requires(domains.Length == WeaklyRelationalDomainsCount);
-      Contract.Requires(Contract.ForAll(domains, el => el != null));
-
-      this.disInterval = interval;
-      this.symbolicConditions = symbolicConditions;
-      this.weaklyRelationalDomains = domains;
-    }
-
-    #endregion
-
-    #region Statics
-    static public NonRelationalValueAbstraction<Variable, Expression> Unknown
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-        var allTop = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
-
-        for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
-        {
-          allTop[i] = SetOfConstraints<Variable>.Unknown;
+            };
         }
 
-        return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnknownInterval, SymbolicExpressionTracker<Variable, Expression>.Unknown, allTop);
-      }
-    }
-
-    static public NonRelationalValueAbstraction<Variable, Expression> Unreached
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-        var allBottom = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
-
-        for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
+        private NonRelationalValueAbstraction(
+          DisInterval interval, SymbolicExpressionTracker<Variable, Expression> symbolicConditions,
+          SetOfConstraints<Variable>[] domains)
         {
-          allBottom[i] = SetOfConstraints<Variable>.Unreached;
+            Contract.Requires(interval != null);
+            Contract.Requires(symbolicConditions != null);
+            Contract.Requires(domains != null);
+
+            Contract.Requires(domains.Length == WeaklyRelationalDomainsCount);
+            Contract.Requires(Contract.ForAll(domains, el => el != null));
+
+            disInterval = interval;
+            this.symbolicConditions = symbolicConditions;
+            weaklyRelationalDomains = domains;
         }
 
-        return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnreachedInterval, SymbolicExpressionTracker<Variable, Expression>.Unreached, allBottom);
-      }
-    }
+        #endregion
 
-    #endregion
-
-    #region Properties
-    public DisInterval Interval
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<DisInterval>() != null);
-
-        return this.disInterval;
-      }
-    }
-
-    public SetOfConstraints<Variable> Equalities
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
-
-        return this.weaklyRelationalDomains[(int)ADomains.Equalities];
-      }
-    }
-
-    public SetOfConstraints<Variable> DisEqualities
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
-
-        return this.weaklyRelationalDomains[(int)ADomains.DisEqualities];
-      }
-    }
-
-    public SetOfConstraints<Variable> StrictUpperBounds
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
-
-        return this.weaklyRelationalDomains[(int)ADomains.StrictUpperBounds];
-      }
-    }
-
-    public SetOfConstraints<Variable> WeakUpperBounds
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
-
-        return this.weaklyRelationalDomains[(int)ADomains.WeakUpperBounds];
-      }
-    }
-
-    public SetOfConstraints<Variable> Existential
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
-
-        return this.weaklyRelationalDomains[(int)ADomains.Existential];
-      }
-    }
-
-    public SymbolicExpressionTracker<Variable, Expression> SymbolicConditions
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-
-        return this.symbolicConditions;
-      }
-    }
-
-    #endregion
-
-    #region Check For contraddictions
-
-    /// <summary>
-    /// Check for contraddictions.
-    /// The understanding here is that:
-    ///   - 'this' is interpreted as existential and 'exists' as universal
-    ///   - 'that' is interpreted as universal and 'exists' as existential
-    /// </summary>
-    public bool AreInContraddiction(NonRelationalValueAbstraction<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      if (this.Interval.Meet(other.Interval).IsBottom)
-        return true;
-
-      if (!this.DisEqualities.Join(other.Equalities).IsTop)
-        return true;
-
-      if (!this.Equalities.Join(other.DisEqualities).IsTop)
-        return true;
-
-      if (!this.Equalities.Join(other.StrictUpperBounds).IsTop)
-        return true;
-
-      if (!this.StrictUpperBounds.Join(other.Equalities).IsTop)
-        return true;
-
-      return false;
-    }
-
-    #endregion
-
-    #region Assumptions
-
-    public NonRelationalValueAbstraction<Variable, Expression> TestTrueEqual(Variable v)
-    {
-      if (this.DisEqualities.Contains(v) || this.StrictUpperBounds.Contains(v))
-      {
-        return this.Bottom;
-      }
-
-      var equalities = this.Equalities.Add(v);
-      var weakupperbounds = this.WeakUpperBounds.Add(v);
-
-      return new NonRelationalValueAbstraction<Variable, Expression>(
-        this.Interval, this.SymbolicConditions,
-        equalities, // updated
-        this.DisEqualities,
-        weakupperbounds,  // updated
-        this.StrictUpperBounds, this.Existential);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get
-      {
-        return this.disInterval.IsBottom || this.symbolicConditions.IsBottom || this.weaklyRelationalDomains.Any(x => x.IsBottom);
-      }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.disInterval.IsTop && this.symbolicConditions.IsTop && this.weaklyRelationalDomains.All(x => x.IsTop);
-      }
-    }
-
-    public bool LessEqual(NonRelationalValueAbstraction<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      if (!this.disInterval.LessEqual(other.Interval))
-      {
-        return false;
-      }
-      Contract.Assert(other.symbolicConditions != null);
-      if (!this.symbolicConditions.LessEqual(other.symbolicConditions))
-      {
-        return false;
-      }
-
-      // F: Assuming the object invariant for other
-      Contract.Assert(other.weaklyRelationalDomains != null);
-      Contract.Assume(Contract.ForAll(other.weaklyRelationalDomains, dom => dom != null));
-      Contract.Assume(this.weaklyRelationalDomains.Length == other.weaklyRelationalDomains.Length, "assuming object invariant");
-      for (var i = 0; i < this.weaklyRelationalDomains.Length; i++)
-      {
-        if (!this.weaklyRelationalDomains[i].LessEqual(other.weaklyRelationalDomains[i]))
-          return false;
-      }
-
-      return true;
-    }
-
-    public NonRelationalValueAbstraction<Variable, Expression> Bottom
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-        var allBottom = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
-
-        for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
+        #region Statics
+        static public NonRelationalValueAbstraction<Variable, Expression> Unknown
         {
-          allBottom[i] = SetOfConstraints<Variable>.Unreached;
-        }
-
-        return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnreachedInterval, SymbolicExpressionTracker<Variable, Expression>.Unreached, allBottom);
-      }
-    }
-
-    public NonRelationalValueAbstraction<Variable, Expression> Top
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-        var allTop = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
-
-        for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
-        {
-          allTop[i] = SetOfConstraints<Variable>.Unknown;
-        }
-
-        return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnknownInterval, SymbolicExpressionTracker<Variable, Expression>.Unknown, allTop);
-      }
-    }
-
-    [Pure]
-    public NonRelationalValueAbstraction<Variable, Expression> Join(NonRelationalValueAbstraction<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-      NonRelationalValueAbstraction<Variable, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
-      {
-        return result;
-      }
-
-      var intv = this.disInterval.Join(other.Interval);
-      var symbolicConditions = this.symbolicConditions.Join(other.symbolicConditions);
-
-      Contract.Assume(this.weaklyRelationalDomains.Length == other.weaklyRelationalDomains.Length);
-
-      var newWeaklyDomains = ParallelOperation(this.weaklyRelationalDomains, other.weaklyRelationalDomains, (x, y) => x.Join(y));
-
-      return new NonRelationalValueAbstraction<Variable, Expression>(intv, symbolicConditions, newWeaklyDomains);
-    }
-
-    [Pure]
-    public NonRelationalValueAbstraction<Variable, Expression> Meet(NonRelationalValueAbstraction<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-      NonRelationalValueAbstraction<Variable, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
-      {
-        return result;
-      }
-
-      var intv = this.disInterval.Meet(other.Interval);
-
-      Contract.Assert(other.symbolicConditions != null);
-      var symbolicConditions = this.symbolicConditions.Meet(other.symbolicConditions);
-
-      Contract.Assert(other.weaklyRelationalDomains != null);
-      Contract.Assume(this.weaklyRelationalDomains.Length == other.weaklyRelationalDomains.Length);
-
-      var newWeaklyDomains = ParallelOperation(this.weaklyRelationalDomains, other.weaklyRelationalDomains, (x, y) => x.Meet(y));
-
-      return new NonRelationalValueAbstraction<Variable, Expression>(intv, symbolicConditions, newWeaklyDomains);
-    }
-
-    [Pure]
-    public NonRelationalValueAbstraction<Variable, Expression> Widening(NonRelationalValueAbstraction<Variable, Expression> prev)
-    {
-      Contract.Requires(prev != null);
-      Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-      NonRelationalValueAbstraction<Variable, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
-      {
-        return result;
-      }
-
-      var intv = this.disInterval.Widening(prev.Interval);
-      var symbolicConditions = this.symbolicConditions.Join(prev.symbolicConditions);
-
-      Contract.Assume(this.weaklyRelationalDomains.Length == prev.weaklyRelationalDomains.Length);
-
-      var newWeaklyDomains = ParallelOperation(this.weaklyRelationalDomains, prev.weaklyRelationalDomains, (x, y) => x.Widening(y));
-
-      return new NonRelationalValueAbstraction<Variable, Expression>(intv, SymbolicConditions, newWeaklyDomains);
-    }
-
-    #endregion
-
-    #region To
-
-    public T To<T>(IFactory<T> factory)
-    {
-      var result = factory.And(this.disInterval.To(factory), this.symbolicConditions.To(factory));
-
-      T name;
-
-      if (factory.TryGetName(out name))
-      {
-        for (var i = 0; i < this.weaklyRelationalDomains.Length; i++)
-        {
-          if (this.weaklyRelationalDomains[i].IsNormal())
-          {
-            result = factory.And(result, To(i, factory, name));
-          }
-        }
-      }
-      return result;
-    }
-
-    private T To<T>(int i, IFactory<T> factory, T name)
-    {
-      Contract.Requires(i >= 0);
-      Contract.Requires(i < this.weaklyRelationalDomains.Length);
-      Contract.Requires(factory != null);
-
-      var result = factory.IdentityForAnd;
-
-      var constraints = this.weaklyRelationalDomains[i];
-
-      switch (i)
-      {
-        // weaklyRelationalDomains[0] == Equalities
-        case 0:
-          return MakeFact<T>(name, result, constraints.Values, factory, factory.EqualTo);
-
-        // weaklyRelationalDomains[1] == DisEqualities
-        case 1:
-          return MakeFact<T>(name, result, constraints.Values, factory, factory.NotEqualTo);
-
-        // weaklyRelationalDomains[2] == WeakUpperBounds
-        case 2:
-          return MakeFact<T>(name, result, constraints.Values, factory, factory.LessEqualThan);
-
-        // weaklyRelationalDomains[3] == StrictUpperBounds 
-        case 3:
-          return MakeFact<T>(name, result, constraints.Values, factory, factory.LessThan);
-
-        // weaklyRelationalDomains[4] == Existential
-        case 4:
-          return result;
-
-        default:
-          Contract.Assert(false);
-          return factory.IdentityForAnd;
-      }
-    }
-
-    private static T MakeFact<T>(T name, T result, IEnumerable<Variable> constraints,
-      IFactory<T> factory, Func<T, T, T> op)
-    {
-      Contract.Requires(constraints != null);
-      Contract.Requires(factory != null);
-      Contract.Requires(op != null);
-
-      foreach (var x in constraints)
-      {
-        result = factory.And(result, op(name, factory.Variable(x)));
-      }
-      return result;
-    }
-
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      return this.DuplicateMe();
-    }
-
-    public NonRelationalValueAbstraction<Variable, Expression> DuplicateMe()
-    {
-      Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-      var newArr = new SetOfConstraints<Variable>[this.weaklyRelationalDomains.Length];
-      Array.Copy(this.weaklyRelationalDomains, newArr, this.weaklyRelationalDomains.Length);
-      return new NonRelationalValueAbstraction<Variable, Expression>(this.disInterval, this.symbolicConditions, newArr);
-    }
-
-    #endregion
-
-    #region To Please the compiler
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      var other = a as NonRelationalValueAbstraction<Variable, Expression>;
-      Contract.Assume(other != null);
-
-      return this.LessEqual(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { return this.Bottom; }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { return this.Top; }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var other = a as NonRelationalValueAbstraction<Variable, Expression>;
-      Contract.Assume(other != null);
-
-      return this.Join(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      var other = a as NonRelationalValueAbstraction<Variable, Expression>;
-      Contract.Assume(other != null);
-
-      return this.Meet(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      var other = prev as NonRelationalValueAbstraction<Variable, Expression>;
-      Contract.Assume(other != null);
-
-      return this.Widening(other);
-    }
-
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      if (this.IsTop)
-      {
-        return "Top";
-      }
-      if (this.IsBottom)
-      {
-        return "_|_";
-      }
-
-      var result = this.disInterval.ToString();
-
-      result += this.symbolicConditions.IsTop ? "" : string.Format("({0})", this.symbolicConditions.ToString());
-
-      for (var i = 0; i < this.weaklyRelationalDomains.Length; i++)
-      {
-        var dom = this.weaklyRelationalDomains[i];
-        if (!dom.IsTop)
-        {
-          result = result + " " + OperatorFor((ADomains)i) + "{" + dom.ToString() + "}";
-        }
-      }
-
-      return result;
-    }
-    #endregion
-
-    #region IAbstractDomainWithRenaming<NonRelationalValueAbstraction<Variable,Expression>,Variable> Members
-
-    [Pure]
-    public NonRelationalValueAbstraction<Variable, Expression> Rename(Dictionary<Variable, FList<Variable>> renaming)
-    {
-      // Rename the symbolic conditions
-      var renamedExpressions = this.symbolicConditions.Rename(renaming);
-
-      // Rename the set of constraints
-      var renamedConstraints = new SetOfConstraints<Variable>[weaklyRelationalDomains.Length];
-      for (var i = 0; i < this.weaklyRelationalDomains.Length; i++)
-      {
-        var dom = this.weaklyRelationalDomains[i];
-        if (dom.IsNormal())
-        {
-          var renamedStrict = new Set<Variable>();
-
-          foreach (var prev in dom.Values)
-          {
-            FList<Variable> targets;
-            if (renaming.TryGetValue(prev, out targets))
+            get
             {
-              foreach (var next in targets.GetEnumerable())
-              {
-                renamedStrict.Add(next);
-              }
+                Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+                var allTop = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
+
+                for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
+                {
+                    allTop[i] = SetOfConstraints<Variable>.Unknown;
+                }
+
+                return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnknownInterval, SymbolicExpressionTracker<Variable, Expression>.Unknown, allTop);
             }
-          }
-          renamedConstraints[i] = new SetOfConstraints<Variable>(renamedStrict, false);
         }
-        else
+
+        static public NonRelationalValueAbstraction<Variable, Expression> Unreached
         {
-          renamedConstraints[i] = dom;
+            get
+            {
+                Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+                var allBottom = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
+
+                for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
+                {
+                    allBottom[i] = SetOfConstraints<Variable>.Unreached;
+                }
+
+                return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnreachedInterval, SymbolicExpressionTracker<Variable, Expression>.Unreached, allBottom);
+            }
         }
-      }
 
-      return new NonRelationalValueAbstraction<Variable, Expression>(this.Interval, renamedExpressions, renamedConstraints);
-    }
+        #endregion
 
-    #endregion
-
-    #region Helper functions
-    [Pure]
-    static private SetOfConstraints<Variable>[] ParallelOperation(
-      SetOfConstraints<Variable>[] left, SetOfConstraints<Variable>[] right,
-      Func<SetOfConstraints<Variable>, SetOfConstraints<Variable>, SetOfConstraints<Variable>> op)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Requires(left.Length == right.Length);
-      Contract.Requires(op != null);
-
-      Contract.Ensures(Contract.Result<SetOfConstraints<Variable>[]>() != null);
-      Contract.Ensures(Contract.Result<SetOfConstraints<Variable>[]>().Length == left.Length);
-      Contract.Ensures(
-        Contract.ForAll(Contract.Result<SetOfConstraints<Variable>[]>(), el => el != null));
-
-      var result = new SetOfConstraints<Variable>[left.Length];
-
-      for (var i = 0; i < left.Length; i++)
-      {
-        var r = op(left[i], right[i]);
-        Contract.Assume(r != null);
-
-        result[i] = r;
-      }
-
-      return result;
-    }
-
-    [Pure]
-    [ContractVerification(true)]
-    private static string OperatorFor(ADomains index)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      Contract.Assert(index >= 0);
-      Contract.Assert((int)index < WeaklyRelationalDomainsCount);
-
-      switch (index)
-      {
-        case ADomains.Equalities:
-          return "=";
-        case ADomains.DisEqualities:
-          return "!=";
-        case ADomains.StrictUpperBounds:
-          return "<";
-        case ADomains.WeakUpperBounds:
-          return "<=";
-        case ADomains.Existential:
-          return "E";
-        default:
-          {
-            Contract.Assert(false); // should be unreachable
-            return "";
-          }
-      }
-    }
-    #endregion
-
-    #region IAbstractDomainForArraySegmentationAbstraction<NonRelationalValueAbstraction<Variable,Expression>,Variable> Members
-
-    /// <summary>
-    /// We only add less equals
-    /// </summary>
-    public NonRelationalValueAbstraction<Variable, Expression> AssumeInformationFrom<Exp>(INumericalAbstractDomainQuery<Variable, Exp> oracle)
-    {
-      var result = this;
-
-      if (this.IsNormal())
-      {
-        #region Update <
-        if (this.StrictUpperBounds.IsNormal())
+        #region Properties
+        public DisInterval Interval
         {
-          var newConstraints = new Set<Variable>(this.StrictUpperBounds.Values);
+            get
+            {
+                Contract.Ensures(Contract.Result<DisInterval>() != null);
 
-          foreach (var x in this.StrictUpperBounds.Values)
-          {
-            // Add S such that x <= S
-            var newBounds = oracle.UpperBoundsFor(x, true).ApplyToAll(oracle.ToVariable);
-            Contract.Assert(newBounds != null);
-            newConstraints.AddRange(newBounds);
-          }
+                return disInterval;
+            }
+        }
 
-          result = result.Update(ADomains.StrictUpperBounds, new SetOfConstraints<Variable>(newConstraints, false));
+        public SetOfConstraints<Variable> Equalities
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
+
+                return weaklyRelationalDomains[(int)ADomains.Equalities];
+            }
+        }
+
+        public SetOfConstraints<Variable> DisEqualities
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
+
+                return weaklyRelationalDomains[(int)ADomains.DisEqualities];
+            }
+        }
+
+        public SetOfConstraints<Variable> StrictUpperBounds
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
+
+                return weaklyRelationalDomains[(int)ADomains.StrictUpperBounds];
+            }
+        }
+
+        public SetOfConstraints<Variable> WeakUpperBounds
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
+
+                return weaklyRelationalDomains[(int)ADomains.WeakUpperBounds];
+            }
+        }
+
+        public SetOfConstraints<Variable> Existential
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Variable>>() != null);
+
+                return weaklyRelationalDomains[(int)ADomains.Existential];
+            }
+        }
+
+        public SymbolicExpressionTracker<Variable, Expression> SymbolicConditions
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+
+                return symbolicConditions;
+            }
+        }
+
+        #endregion
+
+        #region Check For contraddictions
+
+        /// <summary>
+        /// Check for contraddictions.
+        /// The understanding here is that:
+        ///   - 'this' is interpreted as existential and 'exists' as universal
+        ///   - 'that' is interpreted as universal and 'exists' as existential
+        /// </summary>
+        public bool AreInContraddiction(NonRelationalValueAbstraction<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            if (this.Interval.Meet(other.Interval).IsBottom)
+                return true;
+
+            if (!this.DisEqualities.Join(other.Equalities).IsTop)
+                return true;
+
+            if (!this.Equalities.Join(other.DisEqualities).IsTop)
+                return true;
+
+            if (!this.Equalities.Join(other.StrictUpperBounds).IsTop)
+                return true;
+
+            if (!this.StrictUpperBounds.Join(other.Equalities).IsTop)
+                return true;
+
+            return false;
+        }
+
+        #endregion
+
+        #region Assumptions
+
+        public NonRelationalValueAbstraction<Variable, Expression> TestTrueEqual(Variable v)
+        {
+            if (this.DisEqualities.Contains(v) || this.StrictUpperBounds.Contains(v))
+            {
+                return this.Bottom;
+            }
+
+            var equalities = this.Equalities.Add(v);
+            var weakupperbounds = this.WeakUpperBounds.Add(v);
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(
+              this.Interval, this.SymbolicConditions,
+              equalities, // updated
+              this.DisEqualities,
+              weakupperbounds,  // updated
+              this.StrictUpperBounds, this.Existential);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        public bool IsBottom
+        {
+            get
+            {
+                return disInterval.IsBottom || symbolicConditions.IsBottom || weaklyRelationalDomains.Any(x => x.IsBottom);
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return disInterval.IsTop && symbolicConditions.IsTop && weaklyRelationalDomains.All(x => x.IsTop);
+            }
+        }
+
+        public bool LessEqual(NonRelationalValueAbstraction<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            if (!disInterval.LessEqual(other.Interval))
+            {
+                return false;
+            }
+            Contract.Assert(other.symbolicConditions != null);
+            if (!symbolicConditions.LessEqual(other.symbolicConditions))
+            {
+                return false;
+            }
+
+            // F: Assuming the object invariant for other
+            Contract.Assert(other.weaklyRelationalDomains != null);
+            Contract.Assume(Contract.ForAll(other.weaklyRelationalDomains, dom => dom != null));
+            Contract.Assume(weaklyRelationalDomains.Length == other.weaklyRelationalDomains.Length, "assuming object invariant");
+            for (var i = 0; i < weaklyRelationalDomains.Length; i++)
+            {
+                if (!weaklyRelationalDomains[i].LessEqual(other.weaklyRelationalDomains[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public NonRelationalValueAbstraction<Variable, Expression> Bottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+                var allBottom = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
+
+                for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
+                {
+                    allBottom[i] = SetOfConstraints<Variable>.Unreached;
+                }
+
+                return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnreachedInterval, SymbolicExpressionTracker<Variable, Expression>.Unreached, allBottom);
+            }
+        }
+
+        public NonRelationalValueAbstraction<Variable, Expression> Top
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+                var allTop = new SetOfConstraints<Variable>[WeaklyRelationalDomainsCount];
+
+                for (var i = 0; i < WeaklyRelationalDomainsCount; i++)
+                {
+                    allTop[i] = SetOfConstraints<Variable>.Unknown;
+                }
+
+                return new NonRelationalValueAbstraction<Variable, Expression>(DisInterval.UnknownInterval, SymbolicExpressionTracker<Variable, Expression>.Unknown, allTop);
+            }
+        }
+
+        [Pure]
+        public NonRelationalValueAbstraction<Variable, Expression> Join(NonRelationalValueAbstraction<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+            NonRelationalValueAbstraction<Variable, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
+            {
+                return result;
+            }
+
+            var intv = disInterval.Join(other.Interval);
+            var symbolicConditions = this.symbolicConditions.Join(other.symbolicConditions);
+
+            Contract.Assume(weaklyRelationalDomains.Length == other.weaklyRelationalDomains.Length);
+
+            var newWeaklyDomains = ParallelOperation(weaklyRelationalDomains, other.weaklyRelationalDomains, (x, y) => x.Join(y));
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(intv, symbolicConditions, newWeaklyDomains);
+        }
+
+        [Pure]
+        public NonRelationalValueAbstraction<Variable, Expression> Meet(NonRelationalValueAbstraction<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+            NonRelationalValueAbstraction<Variable, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
+            {
+                return result;
+            }
+
+            var intv = disInterval.Meet(other.Interval);
+
+            Contract.Assert(other.symbolicConditions != null);
+            var symbolicConditions = this.symbolicConditions.Meet(other.symbolicConditions);
+
+            Contract.Assert(other.weaklyRelationalDomains != null);
+            Contract.Assume(weaklyRelationalDomains.Length == other.weaklyRelationalDomains.Length);
+
+            var newWeaklyDomains = ParallelOperation(weaklyRelationalDomains, other.weaklyRelationalDomains, (x, y) => x.Meet(y));
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(intv, symbolicConditions, newWeaklyDomains);
+        }
+
+        [Pure]
+        public NonRelationalValueAbstraction<Variable, Expression> Widening(NonRelationalValueAbstraction<Variable, Expression> prev)
+        {
+            Contract.Requires(prev != null);
+            Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+            NonRelationalValueAbstraction<Variable, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
+            {
+                return result;
+            }
+
+            var intv = disInterval.Widening(prev.Interval);
+            var symbolicConditions = this.symbolicConditions.Join(prev.symbolicConditions);
+
+            Contract.Assume(weaklyRelationalDomains.Length == prev.weaklyRelationalDomains.Length);
+
+            var newWeaklyDomains = ParallelOperation(weaklyRelationalDomains, prev.weaklyRelationalDomains, (x, y) => x.Widening(y));
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(intv, SymbolicConditions, newWeaklyDomains);
+        }
+
+        #endregion
+
+        #region To
+
+        public T To<T>(IFactory<T> factory)
+        {
+            var result = factory.And(disInterval.To(factory), symbolicConditions.To(factory));
+
+            T name;
+
+            if (factory.TryGetName(out name))
+            {
+                for (var i = 0; i < weaklyRelationalDomains.Length; i++)
+                {
+                    if (weaklyRelationalDomains[i].IsNormal())
+                    {
+                        result = factory.And(result, To(i, factory, name));
+                    }
+                }
+            }
+            return result;
+        }
+
+        private T To<T>(int i, IFactory<T> factory, T name)
+        {
+            Contract.Requires(i >= 0);
+            Contract.Requires(i < weaklyRelationalDomains.Length);
+            Contract.Requires(factory != null);
+
+            var result = factory.IdentityForAnd;
+
+            var constraints = weaklyRelationalDomains[i];
+
+            switch (i)
+            {
+                // weaklyRelationalDomains[0] == Equalities
+                case 0:
+                    return MakeFact<T>(name, result, constraints.Values, factory, factory.EqualTo);
+
+                // weaklyRelationalDomains[1] == DisEqualities
+                case 1:
+                    return MakeFact<T>(name, result, constraints.Values, factory, factory.NotEqualTo);
+
+                // weaklyRelationalDomains[2] == WeakUpperBounds
+                case 2:
+                    return MakeFact<T>(name, result, constraints.Values, factory, factory.LessEqualThan);
+
+                // weaklyRelationalDomains[3] == StrictUpperBounds 
+                case 3:
+                    return MakeFact<T>(name, result, constraints.Values, factory, factory.LessThan);
+
+                // weaklyRelationalDomains[4] == Existential
+                case 4:
+                    return result;
+
+                default:
+                    Contract.Assert(false);
+                    return factory.IdentityForAnd;
+            }
+        }
+
+        private static T MakeFact<T>(T name, T result, IEnumerable<Variable> constraints,
+          IFactory<T> factory, Func<T, T, T> op)
+        {
+            Contract.Requires(constraints != null);
+            Contract.Requires(factory != null);
+            Contract.Requires(op != null);
+
+            foreach (var x in constraints)
+            {
+                result = factory.And(result, op(name, factory.Variable(x)));
+            }
+            return result;
+        }
+
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            return this.DuplicateMe();
+        }
+
+        public NonRelationalValueAbstraction<Variable, Expression> DuplicateMe()
+        {
+            Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+            var newArr = new SetOfConstraints<Variable>[weaklyRelationalDomains.Length];
+            Array.Copy(weaklyRelationalDomains, newArr, weaklyRelationalDomains.Length);
+            return new NonRelationalValueAbstraction<Variable, Expression>(disInterval, symbolicConditions, newArr);
+        }
+
+        #endregion
+
+        #region To Please the compiler
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            var other = a as NonRelationalValueAbstraction<Variable, Expression>;
+            Contract.Assume(other != null);
+
+            return this.LessEqual(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { return this.Bottom; }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { return this.Top; }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var other = a as NonRelationalValueAbstraction<Variable, Expression>;
+            Contract.Assume(other != null);
+
+            return this.Join(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            var other = a as NonRelationalValueAbstraction<Variable, Expression>;
+            Contract.Assume(other != null);
+
+            return this.Meet(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            var other = prev as NonRelationalValueAbstraction<Variable, Expression>;
+            Contract.Assume(other != null);
+
+            return this.Widening(other);
+        }
+
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            if (this.IsTop)
+            {
+                return "Top";
+            }
+            if (this.IsBottom)
+            {
+                return "_|_";
+            }
+
+            var result = disInterval.ToString();
+
+            result += symbolicConditions.IsTop ? "" : string.Format("({0})", symbolicConditions.ToString());
+
+            for (var i = 0; i < weaklyRelationalDomains.Length; i++)
+            {
+                var dom = weaklyRelationalDomains[i];
+                if (!dom.IsTop)
+                {
+                    result = result + " " + OperatorFor((ADomains)i) + "{" + dom.ToString() + "}";
+                }
+            }
+
+            return result;
         }
         #endregion
 
-        #region Update <=
-        if (this.WeakUpperBounds.IsNormal())
+        #region IAbstractDomainWithRenaming<NonRelationalValueAbstraction<Variable,Expression>,Variable> Members
+
+        [Pure]
+        public NonRelationalValueAbstraction<Variable, Expression> Rename(Dictionary<Variable, FList<Variable>> renaming)
         {
-          var newConstraints = new Set<Variable>(this.WeakUpperBounds.Values);
+            // Rename the symbolic conditions
+            var renamedExpressions = symbolicConditions.Rename(renaming);
 
-          foreach (var x in this.WeakUpperBounds.Values)
-          {
-            // Add S such that x <= S
-            var newBounds = oracle.UpperBoundsFor(x, false).ApplyToAll(oracle.ToVariable);
-            Contract.Assert(newBounds != null);
-            newConstraints.AddRange(newBounds);
-          }
+            // Rename the set of constraints
+            var renamedConstraints = new SetOfConstraints<Variable>[weaklyRelationalDomains.Length];
+            for (var i = 0; i < weaklyRelationalDomains.Length; i++)
+            {
+                var dom = weaklyRelationalDomains[i];
+                if (dom.IsNormal())
+                {
+                    var renamedStrict = new Set<Variable>();
 
-          result = result.Update(ADomains.WeakUpperBounds, new SetOfConstraints<Variable>(newConstraints, false));
+                    foreach (var prev in dom.Values)
+                    {
+                        FList<Variable> targets;
+                        if (renaming.TryGetValue(prev, out targets))
+                        {
+                            foreach (var next in targets.GetEnumerable())
+                            {
+                                renamedStrict.Add(next);
+                            }
+                        }
+                    }
+                    renamedConstraints[i] = new SetOfConstraints<Variable>(renamedStrict, false);
+                }
+                else
+                {
+                    renamedConstraints[i] = dom;
+                }
+            }
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(this.Interval, renamedExpressions, renamedConstraints);
+        }
+
+        #endregion
+
+        #region Helper functions
+        [Pure]
+        static private SetOfConstraints<Variable>[] ParallelOperation(
+          SetOfConstraints<Variable>[] left, SetOfConstraints<Variable>[] right,
+          Func<SetOfConstraints<Variable>, SetOfConstraints<Variable>, SetOfConstraints<Variable>> op)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Requires(left.Length == right.Length);
+            Contract.Requires(op != null);
+
+            Contract.Ensures(Contract.Result<SetOfConstraints<Variable>[]>() != null);
+            Contract.Ensures(Contract.Result<SetOfConstraints<Variable>[]>().Length == left.Length);
+            Contract.Ensures(
+              Contract.ForAll(Contract.Result<SetOfConstraints<Variable>[]>(), el => el != null));
+
+            var result = new SetOfConstraints<Variable>[left.Length];
+
+            for (var i = 0; i < left.Length; i++)
+            {
+                var r = op(left[i], right[i]);
+                Contract.Assume(r != null);
+
+                result[i] = r;
+            }
+
+            return result;
+        }
+
+        [Pure]
+        [ContractVerification(true)]
+        private static string OperatorFor(ADomains index)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            Contract.Assert(index >= 0);
+            Contract.Assert((int)index < WeaklyRelationalDomainsCount);
+
+            switch (index)
+            {
+                case ADomains.Equalities:
+                    return "=";
+                case ADomains.DisEqualities:
+                    return "!=";
+                case ADomains.StrictUpperBounds:
+                    return "<";
+                case ADomains.WeakUpperBounds:
+                    return "<=";
+                case ADomains.Existential:
+                    return "E";
+                default:
+                    {
+                        Contract.Assert(false); // should be unreachable
+                        return "";
+                    }
+            }
         }
         #endregion
-      }
 
-      return result;
-    }
+        #region IAbstractDomainForArraySegmentationAbstraction<NonRelationalValueAbstraction<Variable,Expression>,Variable> Members
 
-    #endregion
-
-    #region Update
-
-    public NonRelationalValueAbstraction<Variable, Expression> UpdateDisInterval(DisInterval disIntv)
-    {
-      #region Contracts
-
-      Contract.Requires(disIntv != null);
-
-      Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-      #endregion
-
-      return new NonRelationalValueAbstraction<Variable, Expression>(
-        disIntv,
-        this.symbolicConditions, this.weaklyRelationalDomains);
-    }
-
-    public NonRelationalValueAbstraction<Variable, Expression> UpdateSymbolicCondition(SymbolicExpressionTracker<Variable, Expression> sc)
-    {
-      #region Contracts
-
-      Contract.Requires(sc != null);
-
-      Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-      #endregion
-
-      return new NonRelationalValueAbstraction<Variable, Expression>(this.disInterval,
-        sc,
-        this.weaklyRelationalDomains);
-    }
-
-    public NonRelationalValueAbstraction<Variable, Expression> Update(ADomains what, SetOfConstraints<Variable> value)
-    {
-      #region Contracts
-
-      Contract.Requires(value != null);
-      Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
-
-      Contract.Assert(Enum.IsDefined(typeof(ADomains), what));
-
-      #endregion
-
-      var copy = new SetOfConstraints<Variable>[this.weaklyRelationalDomains.Length];
-      Array.Copy(this.weaklyRelationalDomains, copy, this.weaklyRelationalDomains.Length);
-
-      copy[(int)what] = value;
-
-      return new NonRelationalValueAbstraction<Variable, Expression>(this.disInterval, this.symbolicConditions, copy);
-    }
-
-    #endregion
-  }
-
-  public class SymbolicExpressionTracker<Variable, Expression>
-    : IAbstractDomainWithRenaming<SymbolicExpressionTracker<Variable, Expression>, Variable>
-  {
-    #region Object invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.symbolicConditions != null);
-    }
-
-    #endregion
-
-    #region State
-
-    readonly Variable slackVar;
-    readonly SetOfConstraints<Expression> symbolicConditions;
-
-    public delegate Expression Renaming(Expression exp, Dictionary<Variable, FList<Variable>> renaming);
-    public delegate Expression ReplaceVariable(Expression exp, Variable oldVar, Variable newVar);
-
-    // It can be set only once
-    [ThreadStatic]
-    private static Renaming expressionRenamer;
-    public static Renaming ExpressionRenamer
-    {
-      set
-      {
-        Contract.Requires(value != null);
-
-        expressionRenamer = value;
-      }
-    }
-
-    // Removed the ThreadStatic as this should run be set only once, and we run some code below in parallel, which will cause a to have a fresh, thread-local, value for variableReplacer 
-    //[ThreadStatic] 
-    private static ReplaceVariable variableReplacer;
-    public static ReplaceVariable VariableReplacer
-    {
-      set
-      {
-        Contract.Requires(value != null);
-
-        variableReplacer = value;
-      }
-    }
-
-
-    #endregion
-
-    #region Constructor
-
-    public SymbolicExpressionTracker(Variable slackVar, SetOfConstraints<Expression> symbolicConditions)
-    {
-      Contract.Requires(symbolicConditions != null);
-
-      this.slackVar = slackVar;
-      this.symbolicConditions = symbolicConditions;
-    }
-
-    public SymbolicExpressionTracker(Variable slackVar, Expression exp)
-      : this(slackVar, new SetOfConstraints<Expression>(exp))
-    {
-    }
-
-    #endregion
-
-    #region Statics
-
-    public static SymbolicExpressionTracker<Variable, Expression> Unknown
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-
-        return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unknown);
-      }
-    }
-
-    public static SymbolicExpressionTracker<Variable, Expression> Unreached
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-
-        return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unreached);
-      }
-    }
-
-    #endregion
-
-    #region Getters
-
-    public Variable SlackVariable
-    {
-      get
-      {
-        return this.slackVar;
-      }
-    }
-
-    public SetOfConstraints<Expression> Conditions
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<SetOfConstraints<Expression>>() != null);
-
-        return this.symbolicConditions;
-      }
-    }
-
-    #endregion
-
-    #region IAbstractDomainWithRenaming<SymbolicExpressionTracker<Variable,Expression>,Variable> Members
-
-    public SymbolicExpressionTracker<Variable, Expression> Rename(Dictionary<Variable, FList<Variable>> renaming)
-    {
-      return RenameInternal(renaming, this.slackVar);
-    }
-
-    private SymbolicExpressionTracker<Variable, Expression> RenameInternal(Dictionary<Variable, FList<Variable>> renaming, Variable slackVar)
-    {
-      Contract.Requires(renaming != null);
-      Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-      Contract.Ensures(renaming.Count == Contract.OldValue(renaming.Count));
-
-      if (this.symbolicConditions.IsNormal())
-      {
-        renaming[slackVar] = FList<Variable>.Cons(slackVar, FList<Variable>.Empty);
-
-        Set<Expression> result = new Set<Expression>();
-
-        foreach (var exp in this.symbolicConditions.Values)
+        /// <summary>
+        /// We only add less equals
+        /// </summary>
+        public NonRelationalValueAbstraction<Variable, Expression> AssumeInformationFrom<Exp>(INumericalAbstractDomainQuery<Variable, Exp> oracle)
         {
-          result.AddIfNotNull(expressionRenamer(exp, renaming));
+            var result = this;
+
+            if (this.IsNormal())
+            {
+                #region Update <
+                if (this.StrictUpperBounds.IsNormal())
+                {
+                    var newConstraints = new Set<Variable>(this.StrictUpperBounds.Values);
+
+                    foreach (var x in this.StrictUpperBounds.Values)
+                    {
+                        // Add S such that x <= S
+                        var newBounds = oracle.UpperBoundsFor(x, true).ApplyToAll(oracle.ToVariable);
+                        Contract.Assert(newBounds != null);
+                        newConstraints.AddRange(newBounds);
+                    }
+
+                    result = result.Update(ADomains.StrictUpperBounds, new SetOfConstraints<Variable>(newConstraints, false));
+                }
+                #endregion
+
+                #region Update <=
+                if (this.WeakUpperBounds.IsNormal())
+                {
+                    var newConstraints = new Set<Variable>(this.WeakUpperBounds.Values);
+
+                    foreach (var x in this.WeakUpperBounds.Values)
+                    {
+                        // Add S such that x <= S
+                        var newBounds = oracle.UpperBoundsFor(x, false).ApplyToAll(oracle.ToVariable);
+                        Contract.Assert(newBounds != null);
+                        newConstraints.AddRange(newBounds);
+                    }
+
+                    result = result.Update(ADomains.WeakUpperBounds, new SetOfConstraints<Variable>(newConstraints, false));
+                }
+                #endregion
+            }
+
+            return result;
         }
-        var renamedExpressions =
-          result.Count != 0 ?
-          new SetOfConstraints<Expression>(result, false) :
-          SetOfConstraints<Expression>.Unknown;
 
-        renaming.Remove(slackVar);  // We should remove the slack variable!
+        #endregion
 
-        return new SymbolicExpressionTracker<Variable, Expression>(this.slackVar, symbolicConditions);
-      }
-      else
-      {
-        return this;
-      }
+        #region Update
+
+        public NonRelationalValueAbstraction<Variable, Expression> UpdateDisInterval(DisInterval disIntv)
+        {
+            #region Contracts
+
+            Contract.Requires(disIntv != null);
+
+            Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+            #endregion
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(
+              disIntv,
+              symbolicConditions, weaklyRelationalDomains);
+        }
+
+        public NonRelationalValueAbstraction<Variable, Expression> UpdateSymbolicCondition(SymbolicExpressionTracker<Variable, Expression> sc)
+        {
+            #region Contracts
+
+            Contract.Requires(sc != null);
+
+            Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+            #endregion
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(disInterval,
+              sc,
+              weaklyRelationalDomains);
+        }
+
+        public NonRelationalValueAbstraction<Variable, Expression> Update(ADomains what, SetOfConstraints<Variable> value)
+        {
+            #region Contracts
+
+            Contract.Requires(value != null);
+            Contract.Ensures(Contract.Result<NonRelationalValueAbstraction<Variable, Expression>>() != null);
+
+            Contract.Assert(Enum.IsDefined(typeof(ADomains), what));
+
+            #endregion
+
+            var copy = new SetOfConstraints<Variable>[weaklyRelationalDomains.Length];
+            Array.Copy(weaklyRelationalDomains, copy, weaklyRelationalDomains.Length);
+
+            copy[(int)what] = value;
+
+            return new NonRelationalValueAbstraction<Variable, Expression>(disInterval, symbolicConditions, copy);
+        }
+
+        #endregion
     }
 
-    #endregion
-
-    #region Abstract operations
-    public bool LessEqual(SymbolicExpressionTracker<Variable, Expression> other)
+    public class SymbolicExpressionTracker<Variable, Expression>
+      : IAbstractDomainWithRenaming<SymbolicExpressionTracker<Variable, Expression>, Variable>
     {
-      Contract.Requires(other != null);
+        #region Object invariant
 
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, other, out result))
-      {
-        return result;
-      }
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(symbolicConditions != null);
+        }
 
-      other = this.UnifySlackVariableWith(other);
+        #endregion
 
-      return this.symbolicConditions.LessEqual(other.symbolicConditions);
+        #region State
+
+        private readonly Variable slackVar;
+        private readonly SetOfConstraints<Expression> symbolicConditions;
+
+        public delegate Expression Renaming(Expression exp, Dictionary<Variable, FList<Variable>> renaming);
+        public delegate Expression ReplaceVariable(Expression exp, Variable oldVar, Variable newVar);
+
+        // It can be set only once
+        [ThreadStatic]
+        private static Renaming expressionRenamer;
+        public static Renaming ExpressionRenamer
+        {
+            set
+            {
+                Contract.Requires(value != null);
+
+                expressionRenamer = value;
+            }
+        }
+
+        // Removed the ThreadStatic as this should run be set only once, and we run some code below in parallel, which will cause a to have a fresh, thread-local, value for variableReplacer 
+        //[ThreadStatic] 
+        private static ReplaceVariable variableReplacer;
+        public static ReplaceVariable VariableReplacer
+        {
+            set
+            {
+                Contract.Requires(value != null);
+
+                variableReplacer = value;
+            }
+        }
+
+
+        #endregion
+
+        #region Constructor
+
+        public SymbolicExpressionTracker(Variable slackVar, SetOfConstraints<Expression> symbolicConditions)
+        {
+            Contract.Requires(symbolicConditions != null);
+
+            this.slackVar = slackVar;
+            this.symbolicConditions = symbolicConditions;
+        }
+
+        public SymbolicExpressionTracker(Variable slackVar, Expression exp)
+          : this(slackVar, new SetOfConstraints<Expression>(exp))
+        {
+        }
+
+        #endregion
+
+        #region Statics
+
+        public static SymbolicExpressionTracker<Variable, Expression> Unknown
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+
+                return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unknown);
+            }
+        }
+
+        public static SymbolicExpressionTracker<Variable, Expression> Unreached
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+
+                return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unreached);
+            }
+        }
+
+        #endregion
+
+        #region Getters
+
+        public Variable SlackVariable
+        {
+            get
+            {
+                return slackVar;
+            }
+        }
+
+        public SetOfConstraints<Expression> Conditions
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SetOfConstraints<Expression>>() != null);
+
+                return symbolicConditions;
+            }
+        }
+
+        #endregion
+
+        #region IAbstractDomainWithRenaming<SymbolicExpressionTracker<Variable,Expression>,Variable> Members
+
+        public SymbolicExpressionTracker<Variable, Expression> Rename(Dictionary<Variable, FList<Variable>> renaming)
+        {
+            return RenameInternal(renaming, slackVar);
+        }
+
+        private SymbolicExpressionTracker<Variable, Expression> RenameInternal(Dictionary<Variable, FList<Variable>> renaming, Variable slackVar)
+        {
+            Contract.Requires(renaming != null);
+            Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+            Contract.Ensures(renaming.Count == Contract.OldValue(renaming.Count));
+
+            if (symbolicConditions.IsNormal())
+            {
+                renaming[slackVar] = FList<Variable>.Cons(slackVar, FList<Variable>.Empty);
+
+                Set<Expression> result = new Set<Expression>();
+
+                foreach (var exp in symbolicConditions.Values)
+                {
+                    result.AddIfNotNull(expressionRenamer(exp, renaming));
+                }
+                var renamedExpressions =
+                  result.Count != 0 ?
+                  new SetOfConstraints<Expression>(result, false) :
+                  SetOfConstraints<Expression>.Unknown;
+
+                renaming.Remove(slackVar);  // We should remove the slack variable!
+
+                return new SymbolicExpressionTracker<Variable, Expression>(this.slackVar, symbolicConditions);
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        #endregion
+
+        #region Abstract operations
+        public bool LessEqual(SymbolicExpressionTracker<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, other, out result))
+            {
+                return result;
+            }
+
+            other = this.UnifySlackVariableWith(other);
+
+            return symbolicConditions.LessEqual(other.symbolicConditions);
+        }
+
+        public SymbolicExpressionTracker<Variable, Expression> Bottom
+        {
+            get { return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unreached); }
+        }
+
+        public SymbolicExpressionTracker<Variable, Expression> Top
+        {
+            get { return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unknown); }
+        }
+
+        public SymbolicExpressionTracker<Variable, Expression> Join(SymbolicExpressionTracker<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+
+            SymbolicExpressionTracker<Variable, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
+            {
+                return result;
+            }
+
+            other = UnifySlackVariableWith(other);
+
+            return new SymbolicExpressionTracker<Variable, Expression>(slackVar, symbolicConditions.Join(other.symbolicConditions));
+        }
+
+        public SymbolicExpressionTracker<Variable, Expression> Meet(SymbolicExpressionTracker<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+
+            SymbolicExpressionTracker<Variable, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
+            {
+                return result;
+            }
+
+            other = UnifySlackVariableWith(other);
+
+            return new SymbolicExpressionTracker<Variable, Expression>(slackVar, symbolicConditions.Meet(other.symbolicConditions));
+        }
+
+        public SymbolicExpressionTracker<Variable, Expression> Widening(SymbolicExpressionTracker<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+
+            return this.Join(other);
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        public bool IsBottom
+        {
+            get { return symbolicConditions.IsBottom; }
+        }
+
+        public bool IsTop
+        {
+            get { return symbolicConditions.IsTop; }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            var other = a as SymbolicExpressionTracker<Variable, Expression>;
+            Contract.Assume(a != null);
+
+            return this.LessEqual(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Bottom
+        {
+            get { return this.Bottom; }
+        }
+
+        IAbstractDomain IAbstractDomain.Top
+        {
+            get { return this.Top; }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            var other = a as SymbolicExpressionTracker<Variable, Expression>;
+            Contract.Assume(a != null);
+
+            return this.Join(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            var other = a as SymbolicExpressionTracker<Variable, Expression>;
+            Contract.Assume(a != null);
+
+            return this.Meet(other);
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            var other = prev as SymbolicExpressionTracker<Variable, Expression>;
+            Contract.Assume(prev != null);
+
+            return this.Widening(other);
+        }
+
+        public T To<T>(IFactory<T> factory)
+        {
+            return symbolicConditions.To(factory);
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        object ICloneable.Clone()
+        {
+            return this;
+        }
+
+        #endregion
+
+        #region Utils
+
+        private SymbolicExpressionTracker<Variable, Expression> UnifySlackVariableWith(SymbolicExpressionTracker<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
+
+            if (!other.IsNormal() || object.Equals(other.slackVar, slackVar))
+            {
+                return other;
+            }
+
+            var result = new Set<Expression>();
+            foreach (var exp in other.symbolicConditions.Values)
+            {
+                result.AddIfNotNull(variableReplacer(exp, other.slackVar, slackVar));
+            }
+
+            return result.Count != 0 ?
+              new SymbolicExpressionTracker<Variable, Expression>(slackVar, new SetOfConstraints<Expression>(result, false)) :
+              this.Top;
+        }
+
+        #endregion
+
+        #region ToString
+
+        public override string ToString()
+        {
+            if (this.IsBottom)
+                return "_|_";
+
+            if (this.IsTop)
+                return "Top";
+
+            return string.Format("({0} -> {1})",
+              slackVar != null ? slackVar.ToString() : "null", symbolicConditions.ToString());
+        }
+
+        #endregion
     }
-
-    public SymbolicExpressionTracker<Variable, Expression> Bottom
-    {
-      get { return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unreached); }
-    }
-
-    public SymbolicExpressionTracker<Variable, Expression> Top
-    {
-      get { return new SymbolicExpressionTracker<Variable, Expression>(default(Variable), SetOfConstraints<Expression>.Unknown); }
-    }
-
-    public SymbolicExpressionTracker<Variable, Expression> Join(SymbolicExpressionTracker<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-
-      SymbolicExpressionTracker<Variable, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
-      {
-        return result;
-      }
-
-      other = UnifySlackVariableWith(other);
-
-      return new SymbolicExpressionTracker<Variable, Expression>(this.slackVar, this.symbolicConditions.Join(other.symbolicConditions));
-    }
-
-    public SymbolicExpressionTracker<Variable, Expression> Meet(SymbolicExpressionTracker<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-
-      SymbolicExpressionTracker<Variable, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, other, out result))
-      {
-        return result;
-      }
-
-      other = UnifySlackVariableWith(other);
-
-      return new SymbolicExpressionTracker<Variable, Expression>(this.slackVar, this.symbolicConditions.Meet(other.symbolicConditions));
-
-    }
-
-    public SymbolicExpressionTracker<Variable, Expression> Widening(SymbolicExpressionTracker<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-
-      return this.Join(other);
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get { return this.symbolicConditions.IsBottom; }
-    }
-
-    public bool IsTop
-    {
-      get { return this.symbolicConditions.IsTop; }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      var other = a as SymbolicExpressionTracker<Variable, Expression>;
-      Contract.Assume(a != null);
-
-      return this.LessEqual(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Bottom
-    {
-      get { return this.Bottom; }
-    }
-
-    IAbstractDomain IAbstractDomain.Top
-    {
-      get { return this.Top; }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      var other = a as SymbolicExpressionTracker<Variable, Expression>;
-      Contract.Assume(a != null);
-
-      return this.Join(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      var other = a as SymbolicExpressionTracker<Variable, Expression>;
-      Contract.Assume(a != null);
-
-      return this.Meet(other);
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      var other = prev as SymbolicExpressionTracker<Variable, Expression>;
-      Contract.Assume(prev != null);
-
-      return this.Widening(other);
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      return this.symbolicConditions.To(factory);
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    object ICloneable.Clone()
-    {
-      return this;
-    }
-
-    #endregion
-
-    #region Utils
-
-    private SymbolicExpressionTracker<Variable, Expression> UnifySlackVariableWith(SymbolicExpressionTracker<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<SymbolicExpressionTracker<Variable, Expression>>() != null);
-
-      if (!other.IsNormal() || object.Equals(other.slackVar, this.slackVar))
-      {
-        return other;
-      }
-
-      var result = new Set<Expression>();
-      foreach (var exp in other.symbolicConditions.Values)
-      {
-        result.AddIfNotNull(variableReplacer(exp, other.slackVar, this.slackVar));
-      }
-
-      return result.Count != 0 ?
-        new SymbolicExpressionTracker<Variable, Expression>(this.slackVar, new SetOfConstraints<Expression>(result, false)) :
-        this.Top;
-
-    }
-
-    #endregion
-
-    #region ToString
-
-    public override string ToString()
-    {
-      if (this.IsBottom)
-        return "_|_";
-
-      if (this.IsTop)
-        return "Top";
-
-      return string.Format("({0} -> {1})",
-        this.slackVar != null ? this.slackVar.ToString() : "null", this.symbolicConditions.ToString());
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Octagons/OctagonConstraint.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Octagons/OctagonConstraint.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The file contains the constraints that are understood by the CoreOctagon abstract domain
 
@@ -21,536 +10,528 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  ///<summary>
-  /// The common superclass for octagon constraints.
-  /// An CoreOctagon constraint is in the form s * X + s' * Y &lt; C, where s, s' \in { +, -, 0 }, X, Y are variables and C is an integer constant 
-  /// </summary>
-  public abstract class OctagonConstraint
-  {
-
-    #region Private fields: The X, Y, C in the octagonal constraint
-    protected int x;
-    public int X
+    ///<summary>
+    /// The common superclass for octagon constraints.
+    /// An CoreOctagon constraint is in the form s * X + s' * Y &lt; C, where s, s' \in { +, -, 0 }, X, Y are variables and C is an integer constant 
+    /// </summary>
+    public abstract class OctagonConstraint
     {
-      get
-      {
-        return this.x;
-      }
+        #region Private fields: The X, Y, C in the octagonal constraint
+        protected int x;
+        public int X
+        {
+            get
+            {
+                return this.x;
+            }
+        }
+
+        protected int y;
+        public int Y
+        {
+            get
+            {
+                return this.y;
+            }
+        }
+
+        protected Rational c;
+        public Rational C
+        {
+            get
+            {
+                return this.c;
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Obtain an octagon constraint equivalent to <code>a.x \leq k</code>
+        /// </summary>
+        static public OctagonConstraint For(int a, int x, int k)
+        {
+            if (a == 1)
+            { //  x <= k
+                return new OctagonConstraintX(x, k);
+            }
+            else if (a == -1)
+            { // -x <= k
+                return new OctagonConstraintMinusX(x, k);
+            }
+            else
+            {
+                //^ assert false;
+                Debug.Assert(false, "I do not know how to handle this constraints");
+
+                return null;
+            }
+        }
+
+        static public OctagonConstraint For(int a, int x, Rational k)
+        {
+            return OctagonConstraint.For(a, x, (Int32)k);
+        }
+
+        /// <summary>
+        /// Obtain an octagon constraint equivalent to <code>a.x + b.y \leq k</code>
+        /// </summary>
+        static public OctagonConstraint For(int a, int x, int b, int y, int k)
+        {
+            if (a == 1 && b == 1)
+            {   // x + y <= k 
+                return new OctagonConstraintXY(x, y, k);
+            }
+            else if (a == 1 && b == -1)
+            {   // x - y <= k
+                return new OctagonConstraintXMinusY(x, y, k);
+            }
+            else if (a == -1 && b == 1)
+            {   // -x + y <= k
+                return new OctagonConstraintMinusXY(x, y, k);
+            }
+            else if (a == -1 && b == -1)
+            {   // -x - y <= k
+                return new OctagonConstraintMinusXMinusY(x, y, k);
+            }
+            else if (a == 0)
+            {   // y <= k or -y <= k
+                return For(b, y, k);
+            }
+            else if (b == 0)
+            {   // x <= k or -x <= k
+                return For(a, x, k);
+            }
+            else
+            {
+                //^ assert false;
+                Debug.Assert(false, " I do not know how to handle this constraints");
+
+                return null;
+            }
+        }
+
+        static public OctagonConstraint For(int a, int x, int b, int y, Rational k)
+        {
+            return OctagonConstraint.For(a, x, b, y, (Int32)k);
+        }
+
+        ///<summary>
+        /// Add this constraint to the octagon passed as a parameter
+        ///</summary>
+        ///<param name="oct">The octagon where to add the constraints</param>
+        ///<returns>True iff the constraint has been added</returns>
+        public bool AddToOctagon(CoreOctagon oct)
+        {
+            return this.AddToOctagon(oct, new Set<int>());
+        }
+
+        ///<summary>
+        /// Add this constraint to the octagon passed as parameter
+        /// </summary>
+        ///<param name="oct">the octagon where to add the constraint</param>
+        ///<param name="affectedDimensions">The dimensions affected by the constraints</param>
+        ///<returns>true iff the constraint has been added</returns>
+        abstract public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions);
+
+        ///<summary>
+        /// Create a set of octagonal constraints from a given interval, and an integer that stands for the dimension to constraint
+        ///</summary>
+        static public ICollection<OctagonConstraint> CreateConstraintsFromInterval(int dim, Interval interval)
+        {
+            ICollection<OctagonConstraint> constraints = new List<OctagonConstraint>();
+
+            if (interval.IsBottom)
+                return constraints;
+
+            if (interval.LowerBound == interval.UpperBound)
+            {       // it is 'dim = val'
+                OctagonConstraint con = new OctagonConstraintXEqualConst(dim, interval.LowerBound);
+                constraints.Add(con);
+            }
+
+            // Do the lower bound
+            if (!interval.LowerBound.IsInfinity)
+            {
+                OctagonConstraint con = new OctagonConstraintMinusX(dim, -interval.LowerBound);
+                constraints.Add(con);
+            }
+
+            // Do the upper bound
+            if (!interval.UpperBound.IsInfinity)
+            {
+                OctagonConstraint con = new OctagonConstraintX(dim, interval.UpperBound);
+                constraints.Add(con);
+            }
+
+            return constraints;
+        }
+
+        #region "Utility" methods
+        protected int Matpos2(int i, int j)
+        {
+            return j > i ? Matpos(j ^ 1, i ^ 1) : Matpos(i, j);
+        }
+
+        private int Matpos(int i, int j)
+        {
+            return (j + ((i + 1) * (i + 1)) / 2);
+        }
+
+        #endregion
     }
 
-    protected int y;
-    public int Y
+    ///<summary>
+    /// A constraint in the form of <code>x + y &lt;= c</code>
+    ///</summary>
+    public class OctagonConstraintXY : OctagonConstraint
     {
-      get
-      {
-        return this.y;
-      }
+        ///<summary>
+        ///Constructs a constraint x + y &lt;= c
+        ///</summary>
+        public OctagonConstraintXY(int x, int y, Rational c)
+        {
+            this.x = x;
+            this.y = y;
+            this.c = c;
+        }
+
+        public OctagonConstraintXY(int x, int y, Int32 c)
+          : this(x, y, Rational.For(c))
+        {
+        }
+        ///<summary>
+        /// Add this constraint to the octagon <code>oct</code>
+        ///</summary>
+        ///<param name="affectedDimensions">The dimensions "affected" by this constraint</param>
+        ///<returns>True if the octagon is modified</returns>
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            int j = 2 * this.x;
+            int i = 2 * this.y + 1;
+
+            affectedDimensions.Add(this.x);
+            affectedDimensions.Add(this.y);
+
+            if (this.c <= oct.octagon[Matpos2(i, j)])
+            {
+                oct.octagon[Matpos2(i, j)] = this.c;
+                return true;
+            }
+            return false;
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "v" + this.x + " + v" + this.y + " <= " + this.c + Environment.NewLine;
+        }
     }
 
-    protected Rational c;
-    public Rational C
+    ///<summary>
+    /// A constraint in the form of x - y &lt;= c
+    ///</summary>
+    public class OctagonConstraintXMinusY : OctagonConstraint
     {
-      get
-      {
-        return this.c;
-      }
+        ///<summary>
+        /// Constructs a constraint <code>x - y &lt;= c </code>
+        ///</summary>
+        public OctagonConstraintXMinusY(int x, int y, Rational c)
+        {
+            this.x = x;
+            this.y = y;
+            this.c = c;
+        }
+        public OctagonConstraintXMinusY(int x, int y, Int32 c)
+          : this(x, y, Rational.For(c))
+        {
+        }
+
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            int j = 2 * this.x;
+            int i = 2 * this.y;
+
+            affectedDimensions.Add(this.x);
+            affectedDimensions.Add(this.y);
+
+            if (this.c <= oct.octagon[Matpos2(i, j)])
+            {
+                oct.octagon[Matpos2(i, j)] = this.c;
+                return true;
+            }
+            return false;
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "v" + this.x + " - v" + this.y + " <= " + this.c + Environment.NewLine;
+        }
     }
-    #endregion
 
     /// <summary>
-    /// Obtain an octagon constraint equivalent to <code>a.x \leq k</code>
+    /// A constraint in the form of -x + y &lt;= c, with c <code>int</code> constant
     /// </summary>
-    static public OctagonConstraint For(int a, int x, int k)
+    public class OctagonConstraintMinusXY : OctagonConstraint
     {
-      if (a == 1)
-      { //  x <= k
-        return new OctagonConstraintX(x, k);
-      }
-      else if (a == -1)
-      { // -x <= k
-        return new OctagonConstraintMinusX(x, k);
-      }
-      else
-      {
-        //^ assert false;
-        Debug.Assert(false, "I do not know how to handle this constraints");
-
-        return null;
-      }
-    }
-
-    static public OctagonConstraint For(int a, int x, Rational k)
-    {
-      return OctagonConstraint.For(a, x, (Int32)k);
-    }
-
-    /// <summary>
-    /// Obtain an octagon constraint equivalent to <code>a.x + b.y \leq k</code>
-    /// </summary>
-    static public OctagonConstraint For(int a, int x, int b, int y, int k)
-    {
-      if (a == 1 && b == 1)
-      {   // x + y <= k 
-        return new OctagonConstraintXY(x, y, k);
-      }
-      else if (a == 1 && b == -1)
-      {   // x - y <= k
-        return new OctagonConstraintXMinusY(x, y, k);
-      }
-      else if (a == -1 && b == 1)
-      {   // -x + y <= k
-        return new OctagonConstraintMinusXY(x, y, k);
-      }
-      else if (a == -1 && b == -1)
-      {   // -x - y <= k
-        return new OctagonConstraintMinusXMinusY(x, y, k);
-      }
-      else if (a == 0)
-      {   // y <= k or -y <= k
-        return For(b, y, k);
-      }
-      else if (b == 0)
-      {   // x <= k or -x <= k
-        return For(a, x, k);
-      }
-      else
-      {
-        //^ assert false;
-        Debug.Assert(false, " I do not know how to handle this constraints");
-
-        return null;
-      }
-    }
-
-    static public OctagonConstraint For(int a, int x, int b, int y, Rational k)
-    {
-      return OctagonConstraint.For(a, x, b, y, (Int32)k);
-    }
-
-    ///<summary>
-    /// Add this constraint to the octagon passed as a parameter
-    ///</summary>
-    ///<param name="oct">The octagon where to add the constraints</param>
-    ///<returns>True iff the constraint has been added</returns>
-    public bool AddToOctagon(CoreOctagon oct)
-    {
-      return this.AddToOctagon(oct, new Set<int>());
-    }
-
-    ///<summary>
-    /// Add this constraint to the octagon passed as parameter
-    /// </summary>
-    ///<param name="oct">the octagon where to add the constraint</param>
-    ///<param name="affectedDimensions">The dimensions affected by the constraints</param>
-    ///<returns>true iff the constraint has been added</returns>
-    abstract public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions);
-
-    ///<summary>
-    /// Create a set of octagonal constraints from a given interval, and an integer that stands for the dimension to constraint
-    ///</summary>
-    static public ICollection<OctagonConstraint> CreateConstraintsFromInterval(int dim, Interval interval)
-    {
-      ICollection<OctagonConstraint> constraints = new List<OctagonConstraint>();
-
-      if (interval.IsBottom)
-        return constraints;
-
-      if (interval.LowerBound == interval.UpperBound)
-      {		// it is 'dim = val'
-        OctagonConstraint con = new OctagonConstraintXEqualConst(dim, interval.LowerBound);
-        constraints.Add(con);
-      }
-
-      // Do the lower bound
-      if (!interval.LowerBound.IsInfinity)
-      {
-        OctagonConstraint con = new OctagonConstraintMinusX(dim, -interval.LowerBound);
-        constraints.Add(con);
-      }
-
-      // Do the upper bound
-      if (!interval.UpperBound.IsInfinity)
-      {
-        OctagonConstraint con = new OctagonConstraintX(dim, interval.UpperBound);
-        constraints.Add(con);
-      }
-
-      return constraints;
-    }
-
-    #region "Utility" methods
-    protected int Matpos2(int i, int j)
-    {
-      return j > i ? Matpos(j ^ 1, i ^ 1) : Matpos(i, j);
-    }
-
-    private int Matpos(int i, int j)
-    {
-      return (j + ((i + 1) * (i + 1)) / 2);
-    }
-
-
-    #endregion
-
-  }
-
-  ///<summary>
-  /// A constraint in the form of <code>x + y &lt;= c</code>
-  ///</summary>
-  public class OctagonConstraintXY : OctagonConstraint
-  {
-    ///<summary>
-    ///Constructs a constraint x + y &lt;= c
-    ///</summary>
-    public OctagonConstraintXY(int x, int y, Rational c)
-    {
-      this.x = x;
-      this.y = y;
-      this.c = c;
-    }
-
-    public OctagonConstraintXY(int x, int y, Int32 c)
-      : this(x, y, Rational.For(c))
-    {
-    }
-    ///<summary>
-    /// Add this constraint to the octagon <code>oct</code>
-    ///</summary>
-    ///<param name="affectedDimensions">The dimensions "affected" by this constraint</param>
-    ///<returns>True if the octagon is modified</returns>
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
-    {
-      int j = 2 * this.x;
-      int i = 2 * this.y + 1;
-
-      affectedDimensions.Add(this.x);
-      affectedDimensions.Add(this.y);
-
-      if (this.c <= oct.octagon[Matpos2(i, j)])
-      {
-        oct.octagon[Matpos2(i, j)] = this.c;
-        return true;
-      }
-      return false;
-    }
-
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
-      return "v" + this.x + " + v" + this.y + " <= " + this.c + Environment.NewLine;
-    }
-
-  }
-
-  ///<summary>
-  /// A constraint in the form of x - y &lt;= c
-  ///</summary>
-  public class OctagonConstraintXMinusY : OctagonConstraint
-  {
-
-    ///<summary>
-    /// Constructs a constraint <code>x - y &lt;= c </code>
-    ///</summary>
-    public OctagonConstraintXMinusY(int x, int y, Rational c)
-    {
-      this.x = x;
-      this.y = y;
-      this.c = c;
-    }
-    public OctagonConstraintXMinusY(int x, int y, Int32 c)
-      : this(x, y, Rational.For(c))
-    {
-    }
-
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
-    {
-      int j = 2 * this.x;
-      int i = 2 * this.y;
-
-      affectedDimensions.Add(this.x);
-      affectedDimensions.Add(this.y);
-
-      if (this.c <= oct.octagon[Matpos2(i, j)])
-      {
-        oct.octagon[Matpos2(i, j)] = this.c;
-        return true;
-      }
-      return false;
-    }
-
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
-      return "v" + this.x + " - v" + this.y + " <= " + this.c + Environment.NewLine;
-    }
-  }
-
-  /// <summary>
-  /// A constraint in the form of -x + y &lt;= c, with c <code>int</code> constant
-  /// </summary>
-  public class OctagonConstraintMinusXY : OctagonConstraint
-  {
-    ///<summary>
-    ///Constructs a constraint -x + y &lt;= c
-    ///</summary>
-    public OctagonConstraintMinusXY(int x, int y, Rational c)
-    {
-      this.x = x;
-      this.y = y;
-      this.c = c;
-    }
+        ///<summary>
+        ///Constructs a constraint -x + y &lt;= c
+        ///</summary>
+        public OctagonConstraintMinusXY(int x, int y, Rational c)
+        {
+            this.x = x;
+            this.y = y;
+            this.c = c;
+        }
 
         public OctagonConstraintMinusXY(int x, int y, Int32 c)
       : this(x, y, Rational.For(c))
-    {
+        {
+        }
+
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            int j = 2 * this.x + 1;
+            int i = 2 * this.y + 1;
+
+            affectedDimensions.Add(this.x);
+            affectedDimensions.Add(this.y);
+
+            if (this.c <= oct.octagon[Matpos2(i, j)])
+            {
+                oct.octagon[Matpos2(i, j)] = this.c;
+                return true;
+            }
+            return false;
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "-v" + this.x + " + v" + this.y + " <= " + this.c + Environment.NewLine;
+        }
     }
-
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
-    {
-      int j = 2 * this.x + 1;
-      int i = 2 * this.y + 1;
-
-      affectedDimensions.Add(this.x);
-      affectedDimensions.Add(this.y);
-
-      if (this.c <= oct.octagon[Matpos2(i, j)])
-      {
-        oct.octagon[Matpos2(i, j)] = this.c;
-        return true;
-      }
-      return false;
-    }
-
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
-      return "-v" + this.x + " + v" + this.y + " <= " + this.c + Environment.NewLine;
-    }
-  }
-
-  /// <summary>
-  /// A constraint in  the form -x - y &lt;= c
-  /// </summary>
-  public class OctagonConstraintMinusXMinusY : OctagonConstraint
-  {
-    public OctagonConstraintMinusXMinusY(int x, int y, Rational c)
-    {
-      this.x = x;
-      this.y = y;
-      this.c = c;
-    }
-
-    public OctagonConstraintMinusXMinusY(int x, int y, Int32 c)
-      : this(x, y, Rational.For(c))
-    {
-    }
-
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
-    {
-      int j = 2 * this.x + 1;
-      int i = 2 * this.y;
-
-      affectedDimensions.Add(this.x);
-      affectedDimensions.Add(this.y);
-
-      if (this.c <= oct.octagon[Matpos2(i, j)])
-      {
-        oct.octagon[Matpos2(i, j)] = this.c;
-        return true;
-      }
-      return false;
-    }
-
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
-      return "-v" + this.x + " - v" + this.y + " <= " + this.c + Environment.NewLine;
-    }
-  }
-
-  ///<summary>
-  /// A constraint in the form of x == y
-  ///</summary>
-  public class OctagonConstraintXEqualY : OctagonConstraint
-  {
-    private OctagonConstraint cachedXLeqY;
-    private OctagonConstraint cachedYLeqX;
 
     /// <summary>
-    /// Creates the octagonal constraint x = y
+    /// A constraint in  the form -x - y &lt;= c
     /// </summary>
-    public OctagonConstraintXEqualY(int x, int y)
+    public class OctagonConstraintMinusXMinusY : OctagonConstraint
     {
-      this.x = x;
-      this.y = y;
-      this.c = Rational.For(0);
-
-      this.cachedXLeqY = new OctagonConstraintXMinusY(this.x, this.y, 0);	// x <= y
-      this.cachedYLeqX = new OctagonConstraintXMinusY(this.y, this.x, 0);  // y <= x
-    }
-
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
-    {
-      bool b1 = this.cachedXLeqY.AddToOctagon(oct, affectedDimensions);
-      bool b2 = this.cachedYLeqX.AddToOctagon(oct, affectedDimensions);
-
-      return b1 || b2;
-    }
-
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
-      return "v" + this.x + " == v" + this.y;
-    }
-
-  }
-
-  /// <summary>
-  /// A constraint in the form of x == c, with c <code>int</code> constant
-  /// </summary>
-  public class OctagonConstraintXEqualConst : OctagonConstraint
-  {
-
-    protected OctagonConstraint inf;
-    protected OctagonConstraint sup;
-    protected IMutableSet<OctagonConstraint> toAdd;
-
-    ///<summary>
-    /// Construct an object for the equality x == c
-    ///</summary>
-    public OctagonConstraintXEqualConst(int i, Rational c)
-    {
-      this.x = i;
-      this.y = -1;
-      this.c = c;
-
-      this.inf = new OctagonConstraintMinusX(i, -this.c);
-      this.sup = new OctagonConstraintX(i, this.c);
-
-      this.toAdd = new Set<OctagonConstraint>();
-
-      this.toAdd.Add(this.inf);
-      this.toAdd.Add(this.sup);
-    }
-
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
-    {
-      bool bInf = this.inf.AddToOctagon(oct, affectedDimensions);
-      bool bSup = this.sup.AddToOctagon(oct, affectedDimensions);
-
-      return bInf || bSup;
-    }
-
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
-      return "x" + this.x + " = " + this.c;
-    }
-  }
-
-  /// <summary>
-  /// A constraint in the form of x &lt;= c, with c <code>int</code> constant
-  /// </summary>
-  public class OctagonConstraintX : OctagonConstraint
-  {
-
-    public OctagonConstraintX(int x, Rational c)
-    {
-      this.x = x;
-      this.y = -12;
-      this.c = c;
-    }
-
-    public OctagonConstraintX(int x, Int32 c)
-      : this(x, Rational.For(c))
-  {
-  }
-
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
-    {
-      int j = 2 * this.x;
-      int i = 2 * this.x + 1;
-
-      try
-      {
-        Rational c = this.c * 2;
-
-        affectedDimensions.Add(this.x);
-
-        if (c <= oct.octagon[Matpos2(i, j)])
+        public OctagonConstraintMinusXMinusY(int x, int y, Rational c)
         {
-          oct.octagon[Matpos2(i, j)] = c;
-          return true;
+            this.x = x;
+            this.y = y;
+            this.c = c;
         }
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        // We could not add the constraint because of an arithmetic exception
 
-        return false;
-      }
+        public OctagonConstraintMinusXMinusY(int x, int y, Int32 c)
+          : this(x, y, Rational.For(c))
+        {
+        }
 
-      return false;
-    }
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            int j = 2 * this.x + 1;
+            int i = 2 * this.y;
 
-    //^ [Confined]
-    override public string/*!*/ ToString()
-    {
-      return "v" + this.x + " <= " + this.c + Environment.NewLine;
-    }
-  }
+            affectedDimensions.Add(this.x);
+            affectedDimensions.Add(this.y);
 
-  ///<summary>
-  ///A constraint of the form of -x &lt;= c, with x a variable and <code>c</code> an integer
-  ///</summary>
-  public class OctagonConstraintMinusX : OctagonConstraint
-  {
-    public OctagonConstraintMinusX(int x, Rational c)
-    {
-      this.x = x;
-      this.y = -1;
-      this.c = c;
-    }
+            if (this.c <= oct.octagon[Matpos2(i, j)])
+            {
+                oct.octagon[Matpos2(i, j)] = this.c;
+                return true;
+            }
+            return false;
+        }
 
-    public OctagonConstraintMinusX(int x, Int32 c)
-      : this(x, Rational.For(c))
-    {
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "-v" + this.x + " - v" + this.y + " <= " + this.c + Environment.NewLine;
+        }
     }
 
     ///<summary>
-    /// Add this constraint to the octagon
+    /// A constraint in the form of x == y
     ///</summary>
-    override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+    public class OctagonConstraintXEqualY : OctagonConstraint
     {
-      int j = 2 * this.x + 1;
-      int i = 2 * this.x;
+        private OctagonConstraint cachedXLeqY;
+        private OctagonConstraint cachedYLeqX;
 
-      affectedDimensions.Add(this.x);
-
-      try
-      {
-        Rational c = this.c * 2;
-
-        if (Rational.Min(c, oct.octagon[Matpos2(i, j)]) == c)
+        /// <summary>
+        /// Creates the octagonal constraint x = y
+        /// </summary>
+        public OctagonConstraintXEqualY(int x, int y)
         {
-          oct.octagon[Matpos2(i, j)] = c;
-          return true;
+            this.x = x;
+            this.y = y;
+            this.c = Rational.For(0);
+
+            cachedXLeqY = new OctagonConstraintXMinusY(this.x, this.y, 0); // x <= y
+            cachedYLeqX = new OctagonConstraintXMinusY(this.y, this.x, 0);  // y <= x
         }
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        // We could not add the constraint because of an arithmetic exception
 
-        return false;
-      }
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            bool b1 = cachedXLeqY.AddToOctagon(oct, affectedDimensions);
+            bool b2 = cachedYLeqX.AddToOctagon(oct, affectedDimensions);
 
-      return false;
+            return b1 || b2;
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "v" + this.x + " == v" + this.y;
+        }
     }
 
-    //^ [Confined]
-    override public string/*!*/ ToString()
+    /// <summary>
+    /// A constraint in the form of x == c, with c <code>int</code> constant
+    /// </summary>
+    public class OctagonConstraintXEqualConst : OctagonConstraint
     {
-      return "-v" + this.x + " <= " + this.c + Environment.NewLine;
+        protected OctagonConstraint inf;
+        protected OctagonConstraint sup;
+        protected IMutableSet<OctagonConstraint> toAdd;
+
+        ///<summary>
+        /// Construct an object for the equality x == c
+        ///</summary>
+        public OctagonConstraintXEqualConst(int i, Rational c)
+        {
+            this.x = i;
+            this.y = -1;
+            this.c = c;
+
+            this.inf = new OctagonConstraintMinusX(i, -this.c);
+            this.sup = new OctagonConstraintX(i, this.c);
+
+            this.toAdd = new Set<OctagonConstraint>();
+
+            this.toAdd.Add(this.inf);
+            this.toAdd.Add(this.sup);
+        }
+
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            bool bInf = this.inf.AddToOctagon(oct, affectedDimensions);
+            bool bSup = this.sup.AddToOctagon(oct, affectedDimensions);
+
+            return bInf || bSup;
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "x" + this.x + " = " + this.c;
+        }
     }
-  }
+
+    /// <summary>
+    /// A constraint in the form of x &lt;= c, with c <code>int</code> constant
+    /// </summary>
+    public class OctagonConstraintX : OctagonConstraint
+    {
+        public OctagonConstraintX(int x, Rational c)
+        {
+            this.x = x;
+            this.y = -12;
+            this.c = c;
+        }
+
+        public OctagonConstraintX(int x, Int32 c)
+          : this(x, Rational.For(c))
+        {
+        }
+
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            int j = 2 * this.x;
+            int i = 2 * this.x + 1;
+
+            try
+            {
+                Rational c = this.c * 2;
+
+                affectedDimensions.Add(this.x);
+
+                if (c <= oct.octagon[Matpos2(i, j)])
+                {
+                    oct.octagon[Matpos2(i, j)] = c;
+                    return true;
+                }
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                // We could not add the constraint because of an arithmetic exception
+
+                return false;
+            }
+
+            return false;
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "v" + this.x + " <= " + this.c + Environment.NewLine;
+        }
+    }
+
+    ///<summary>
+    ///A constraint of the form of -x &lt;= c, with x a variable and <code>c</code> an integer
+    ///</summary>
+    public class OctagonConstraintMinusX : OctagonConstraint
+    {
+        public OctagonConstraintMinusX(int x, Rational c)
+        {
+            this.x = x;
+            this.y = -1;
+            this.c = c;
+        }
+
+        public OctagonConstraintMinusX(int x, Int32 c)
+          : this(x, Rational.For(c))
+        {
+        }
+
+        ///<summary>
+        /// Add this constraint to the octagon
+        ///</summary>
+        override public bool AddToOctagon(CoreOctagon oct, IMutableSet<int> affectedDimensions)
+        {
+            int j = 2 * this.x + 1;
+            int i = 2 * this.x;
+
+            affectedDimensions.Add(this.x);
+
+            try
+            {
+                Rational c = this.c * 2;
+
+                if (Rational.Min(c, oct.octagon[Matpos2(i, j)]) == c)
+                {
+                    oct.octagon[Matpos2(i, j)] = c;
+                    return true;
+                }
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                // We could not add the constraint because of an arithmetic exception
+
+                return false;
+            }
+
+            return false;
+        }
+
+        //^ [Confined]
+        override public string/*!*/ ToString()
+        {
+            return "-v" + this.x + " <= " + this.c + Environment.NewLine;
+        }
+    }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Octagons/OctagonConstraintInference.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Octagons/OctagonConstraintInference.cs
@@ -1,22 +1,11 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This file contains the part of the class OctagonEnvironment<Variable, Expression> that handles the inference of constraints
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;   
+using System.Diagnostics;
 using System.Text;
 using Microsoft.Research.AbstractDomains.Expressions;
 using System.Diagnostics.Contracts;
@@ -24,1668 +13,1655 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  public sealed partial class OctagonEnvironment<Variable, Expression>
-  {
-
-    #region Assignment
-
-    /// <summary>
-    /// Perform the assignment in the abstract environment.
-    /// First, it simplifies the pure expression <code>exp</code>.
-    /// Then, if it is an assignment that can be handled by the domain, it handles it directly (both for invertible and not-invertible assignments).
-    /// Otherwise, it uses the abstract domain of Intervals to compute un upper and lower bound for <code>x</code>
-    /// </summary>
-    public void Assign(Expression x, Expression/*!*/ exp)
+    public sealed partial class OctagonEnvironment<Variable, Expression>
     {
-      //if (base.Dimensions > 50)
-       // Console.Write("{0};", base.Dimensions);
+        #region Assignment
 
-      var decoder = this.expManager.Decoder;
-
-      if (Precision == OctagonPrecision.FullPrecision)
-      {
-        // 1. Simplify exp
-        PolynomialOfInt<Variable, Expression> polyExp;
-        if (!PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(exp, decoder, out polyExp))
+        /// <summary>
+        /// Perform the assignment in the abstract environment.
+        /// First, it simplifies the pure expression <code>exp</code>.
+        /// Then, if it is an assignment that can be handled by the domain, it handles it directly (both for invertible and not-invertible assignments).
+        /// Otherwise, it uses the abstract domain of Intervals to compute un upper and lower bound for <code>x</code>
+        /// </summary>
+        public void Assign(Expression x, Expression/*!*/ exp)
         {
-          AssignWithIntervals(x, exp);
+            //if (base.Dimensions > 50)
+            // Console.Write("{0};", base.Dimensions);
 
-          return;
+            var decoder = expManager.Decoder;
+
+            if (Precision == OctagonPrecision.FullPrecision)
+            {
+                // 1. Simplify exp
+                PolynomialOfInt<Variable, Expression> polyExp;
+                if (!PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(exp, decoder, out polyExp))
+                {
+                    AssignWithIntervals(x, exp);
+
+                    return;
+                }
+
+                // 2. Determine the abstract domain that must handle the assignment
+
+                // 2.1 It is an octagon constraint, so we are happy and we handle the assignment precisely
+                if (polyExp.IsLinearOctagon && !polyExp.Relation.HasValue)
+                {
+                    AssignWithOctagons(x, polyExp);
+                }
+                // 2.2 It is not an octagon constraint, so we approximate its value
+                else
+                {
+                    AssignWithIntervals(x, polyExp);
+                }
+            }
+            else
+            {
+                var xVar = decoder.UnderlyingVariable(x);
+                this.ProjectVariable(xVar);
+            }
         }
 
-        // 2. Determine the abstract domain that must handle the assignment
-
-        // 2.1 It is an octagon constraint, so we are happy and we handle the assignment precisely
-        if (polyExp.IsLinearOctagon && ! polyExp.Relation.HasValue)
+        public void Assign(Expression x, Expression/*!*/ exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
         {
-          AssignWithOctagons(x, polyExp);
-        }
-        // 2.2 It is not an octagon constraint, so we approximate its value
-        else
-        {
-          AssignWithIntervals(x, polyExp);
-        }
-      }
-      else
-      {
-        var xVar = decoder.UnderlyingVariable(x);
-        this.ProjectVariable(xVar);
-      }
-    }
+            var watch = new Stopwatch();
+            watch.Start();
 
-    public void Assign(Expression x, Expression/*!*/ exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      var watch = new Stopwatch();
-      watch.Start();
+            CheckConsistency();
 
-      CheckConsistency();
+            if (Precision == OctagonPrecision.FullPrecision)
+            {
+                // 1. Infers the "simple" constraints
 
-      if (Precision == OctagonPrecision.FullPrecision)
-      {
-        // 1. Infers the "simple" constraints
+                var NewConstraints = new Set<Expression>();
 
-        var NewConstraints = new Set<Expression>();
+                // Discover new constraints
+                foreach (var constraintsFetcher in constraintsForAssignment)
+                {
+                    NewConstraints.AddRange(constraintsFetcher.InferConstraints(x, exp, preState));
+                }
 
-        // Discover new constraints
-        foreach (var constraintsFetcher in this.constraintsForAssignment)
-        {
-          NewConstraints.AddRange(constraintsFetcher.InferConstraints(x, exp, preState));
-        }
+                // Assume them
+                foreach (var newConstraint in NewConstraints)
+                {
+                    this.TestTrue(newConstraint);
+                }
 
-        // Assume them
-        foreach (var newConstraint in NewConstraints)
-        {
-          this.TestTrue(newConstraint);
+                // 2. Perform the usual assignment
+                this.Assign(x, exp);
+            }
+            else
+            {
+                var decoder = expManager.Decoder;
+
+                var xVar = decoder.UnderlyingVariable(x);
+                this.ProjectVariable(xVar);
+            }
+
+            CheckConsistency();
+
+#if TRACE_AD_PERFORMANCES
+            AddTimeElapsedFromStart("Assign", ref timeSpentInAssignments, watch.Elapsed);
+#endif
         }
 
-        // 2. Perform the usual assignment
-        this.Assign(x, exp);
-      }
-      else
-      {
-        var decoder = this.expManager.Decoder;
-
-        var xVar = decoder.UnderlyingVariable(x);
-        this.ProjectVariable(xVar);
-      }
-
-      CheckConsistency();
-
-      #if  TRACE_AD_PERFORMANCES
-      AddTimeElapsedFromStart("Assign", ref timeSpentInAssignments, watch.Elapsed);
-      #endif
-    }
-
-    [Conditional("VERBOSE")]
-    new void CheckConsistency()
-    {
-      base.CheckConsistency();
-
-      foreach (var x in this.variables2dimensions.Keys)
-      {
-        Contract.Assert(!this.availableDimensions.Contains(this.variables2dimensions[x]), string.Format("Incosistency detected for the dimension {0} (i.e. the variable {1})", this.variables2dimensions[x], x));
-      }
-
-      foreach (var i in this.AllocatedDimensions)
-      {
-        Contract.Assert(this.variables2dimensions.InverseMap.ContainsKey(i));
-      }
-    }
-
-    #endregion
-
-    #region TestTrue and TestFalse
-    public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestTrue(Expression/*!*/ guard)
-    {
-      CheckConsistency();
-
-      var result = this.trueTestVisitor.Visit(guard, this);
-
-      CheckConsistency();
-
-      return result;
-    }
-
-    public OctagonEnvironment<Variable, Expression>/*!*/ TestTrueNotRefining(Expression/*!*/ guard)
-    {
-      CheckConsistency();
-
-      var result = this.trueTestNotRefiningVisitor.Visit(guard, this);
-
-      CheckConsistency();
-
-      return result;
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestFalse(Expression/*!*/ guard)
-    {
-      CheckConsistency();
-
-      var result = this.falseTestVisitor.Visit(guard, this);
-
-      CheckConsistency();
-
-      return result;
-    }
-    
-#endregion
-
-    #region Helper methods for assign
-    /// <summary>
-    /// Use the abstract domain of intervals to find lower and upper bounds for <code>x</code>.
-    /// Essentually, <code>exp</code> is evaluated with intervals
-    /// </summary>
-
-    private void AssignWithIntervals(Expression x, PolynomialOfInt<Variable, Expression> exp)
-
-    {
-      var boundsForX = ConstraintsAsIntervalsFor(x, exp);
-
-      var xVar = this.expManager.Decoder.UnderlyingVariable(x);
-
-      this.ProjectVariable(xVar);
-      this.AddConstraints(boundsForX);
-    }
-
-    /// <summary>
-    /// Use this method when you were unable to obtain a polynomial form from the expressions
-    /// </summary>
-    private void AssignWithIntervals(Expression x, Expression exp)
-    {
-      var boundsForX = ConstraintsAsIntervalsFor(x, exp);
-
-      var xVar = this.expManager.Decoder.UnderlyingVariable(x);
-
-      this.ProjectVariable(xVar);
-      this.AddConstraints(boundsForX);
-    }
-
-    /// <summary>
-    /// Try to infer some constraints from the linear expression <code>polyExpSimplified</code>, which then uses for the octagon
-    /// </summary>
-    /// <param name="x">The variable to be assigned</param>
-    /// <param name="polyExpSimplified">Must be a linear relation</param>
-
-    private void AssignNonOctagonLinear(Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
-
-    //^ requires polyExpSimplified.IsLinear;
-    {
-      // We distinguish two cases, if the assigment is invertible or not
-      if (polyExpSimplified.Variables.Contains(x))   // It is an assigment in the form of x = x + k, with k a constant
-      {
-        // Renames "x + k" to "x' + k"
-
-        var xOld = this.expManager.Encoder.FreshVariable<int>();
-        this.AddVariable(xOld);
-
-        var equalConstraint = new OctagonConstraintXEqualY(this.DimensionForVar(x), this.DimensionForVar(xOld));
-        this.AddConstraint(equalConstraint);
-
-        var renamedExp = polyExpSimplified.Rename(x, xOld);
-
-        var newConstraints = ConstraintsForNonOctagonLinearForm(x, renamedExp);
-        this.ProjectDimension(this.DimensionForVar(x));
-        this.AddConstraints(newConstraints);
-
-        this.RemoveVariable(xOld);
-      }
-      else
-      {
-        var newConstraints = ConstraintsForNonOctagonLinearForm(x, polyExpSimplified);
-        this.ProjectVariable(x);            // set the value of x to top, force the closure of the octagon
-        this.AddConstraints(newConstraints);
-      }
-    }
-    #endregion
-
-    /// <summary>
-    /// The assignment can be handled by octagons
-    /// </summary>
-    /// <param name="x">Must be a variable</param>
-
-    private void AssignWithOctagons(Expression x, PolynomialOfInt<Variable, Expression> exp)
-    {
-      Contract.Assert(exp.IsLinearOctagon, "I was expecting an octagon assigment, but I've got " + exp + " instead");
-
-      // We distinguish two cases, if the assigment is invertible or not
-      var xVar = this.expManager.Decoder.UnderlyingVariable(x);
-      if (exp.Variables.Contains(xVar))   // It is an assigment in the form of x = x + k, with k a constant
-      {
-        // Renames "x + k" to "x' + k"
-
-        var xOld = this.expManager.Encoder.FreshVariable<int>();
-        this.AddVariable(xOld);
-
-        var equalConstraint = new OctagonConstraintXEqualY(this.DimensionForVar(xVar), this.DimensionForVar(xOld));
-        this.AddConstraint(equalConstraint);
-
-        var renamedExp = exp.Rename(xVar, xOld);
-
-        var newConstraints = ConstraintsForOctagonForm(xVar, renamedExp);
-        this.ProjectDimension(this.DimensionForVar(xVar));
-        this.AddConstraints(newConstraints);
-
-        this.RemoveVariable(xOld);
-      }
-      else
-      {
-        var newConstraints = ConstraintsForOctagonForm(xVar, exp);
-        this.ProjectVariable(xVar);            // set the value of x to top, force the closure of the octagon
-        this.AddConstraints(newConstraints);
-      }
-    }
-
-    #region Constraints inference
-
-    /// <returns>
-    /// A set of constraints that stands for the assignment <code>+/- x +/- y \leq k </code>. 
-    /// Please note that <code>x</code> must not appear in <code>exp</code> in order to be correct
-    /// </returns>            
-
-    private Set<OctagonConstraint> ConstraintsForOctagonForm(Variable x, PolynomialOfInt<Variable, Expression> exp)
-    {
-      Contract.Assert(exp.IsLinearOctagon, string.Format("{0} is not in Octagonal form", exp));
-
-      var result = new Set<OctagonConstraint>();
-      
-      if (exp.Left.Count == 1)    // x = y or or x = -y or x = k
-      {
-        var m = exp.Left[0];
-        if (m.IsConstant)       // case x = k, k constant
+        [Conditional("VERBOSE")]
+        private new void CheckConsistency()
         {
-          result.Add(new OctagonConstraintXEqualConst(this.DimensionForVar(x), Rational.For(m.K)));
-        }
-        else if (m.K == 1)      // case x = y
-        {
-          var y = m.Variables[0];
+            base.CheckConsistency();
 
-          result.Add(new OctagonConstraintXEqualY(this.DimensionForVar(x), this.DimensionForVar(y)));
-        }
-        else if (m.K == -1)      // case x = -y
-        {
-          var y = m.Variables[0];
+            foreach (var x in variables2dimensions.Keys)
+            {
+                Contract.Assert(!this.availableDimensions.Contains(variables2dimensions[x]), string.Format("Incosistency detected for the dimension {0} (i.e. the variable {1})", variables2dimensions[x], x));
+            }
 
-          result.Add(new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), 0));             //  x + y <= 0
-          result.Add(new OctagonConstraintMinusXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), 0));   // -x - y <= 0
-        }
-        else
-        {
-          Contract.Assert(false, "Unknown case : " + x + " == " + exp);
-           }
-      }
-      else // x = {+, -} y + k, k constant
-      {
-        var signOfY = (int)exp.Left[0].K;
-        var y = exp.Left[0].Variables[0];
-        var k = (int)exp.Left[1].K;
-
-        if (signOfY == 1)               // x = y + k, k constant
-        {
-          result.Add(new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k));     // x - y <= k
-          result.Add(new OctagonConstraintXMinusY(this.DimensionForVar(y), this.DimensionForVar(x), (int)-k));    // y - x <= -k
-        }
-        else if (signOfY == -1)         // x = -y + k, k constant
-        {
-          result.Add(new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k));           //   x + y <= k
-          result.Add(new OctagonConstraintMinusXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), (int)-k)); // - x - y <= -k
-        }
-        else
-        {
-          Contract.Assert(false, "Unknown case : " + x + " == " + exp);
-        }
-      }
-      
-      return result;
-    }
-
-    /// <summary>
-    /// Try to infer some constraints from the linear expression <code>x == polyExpSimplified</code>
-    /// </summary>
-    /// <param name="x">The variable to be assigned</param>
-    /// <param name="polyExpSimplified">Must be a linear relation</param>
-
-    private Set<OctagonConstraint> ConstraintsForNonOctagonLinearForm(Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
-    {
-      Contract.Assert(polyExpSimplified.IsLinear, "Expecting a linear polynomial");
-
-      var newConstraints = new Set<OctagonConstraint>();
-
-      // If polyExpSimplified is in the form of a1 * x1 + a2 * x2 + ... where \forall a_i. a_i \in {-1 , +1}
-      if (HasUnaryCoefficients(polyExpSimplified))
-      {
-        #region 1. Get the bounds for all the variables in polyExpSimplified
-
-        var boundsFor = new Dictionary<Variable, Interval>();     // The interval bounds for the variable
-        var signFor = new Dictionary<Variable, int>();                           // The sign for each variable
-        int constant = 0;                                                                                       // The constant (if any) in the expression
-
-        foreach (var m in polyExpSimplified.Left)
-        {
-          Contract.Assert(m.IsLinear); //^ assert m.IsLinear;
-
-          if (!m.IsConstant)
-          {
-            boundsFor[m.Variables[0]] = this.BoundsFor(m.Variables[0]).AsInterval;
-            signFor[m.Variables[0]] = Math.Sign(m.K);
-          }
-          else
-          {
-            constant = m.K;
-          }
+            foreach (var i in this.AllocatedDimensions)
+            {
+                Contract.Assert(variables2dimensions.InverseMap.ContainsKey(i));
+            }
         }
 
-        Contract.Assert(boundsFor.Keys.Count == signFor.Keys.Count, "Something is wrong...");
-        //^ assert boundsFor.Keys.Count == signFor.Keys.Count;
         #endregion
 
-        #region 2. Try to reduce the polynomial to ai * xi + I, where ai is in {+1 , -1}I is a closed interval
-
-        foreach (var xi in boundsFor.Keys)       // Try all the expressions
+        #region TestTrue and TestFalse
+        public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestTrue(Expression/*!*/ guard)
         {
-          OctagonConstraint constraintForLowerBound = null;
-          OctagonConstraint constraintForUpperBound = null;
+            CheckConsistency();
 
-          if (!x.Equals(xi))
-          {
-            #region Try to get the constraints for x = xi + I
-            var I = Interval.For(constant);
+            var result = trueTestVisitor.Visit(guard, this);
 
-            // Evaluate all the other variables
-            foreach (var y in boundsFor.Keys)
+            CheckConsistency();
+
+            return result;
+        }
+
+        public OctagonEnvironment<Variable, Expression>/*!*/ TestTrueNotRefining(Expression/*!*/ guard)
+        {
+            CheckConsistency();
+
+            var result = trueTestNotRefiningVisitor.Visit(guard, this);
+
+            CheckConsistency();
+
+            return result;
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestFalse(Expression/*!*/ guard)
+        {
+            CheckConsistency();
+
+            var result = falseTestVisitor.Visit(guard, this);
+
+            CheckConsistency();
+
+            return result;
+        }
+
+        #endregion
+
+        #region Helper methods for assign
+        /// <summary>
+        /// Use the abstract domain of intervals to find lower and upper bounds for <code>x</code>.
+        /// Essentually, <code>exp</code> is evaluated with intervals
+        /// </summary>
+
+        private void AssignWithIntervals(Expression x, PolynomialOfInt<Variable, Expression> exp)
+
+        {
+            var boundsForX = ConstraintsAsIntervalsFor(x, exp);
+
+            var xVar = expManager.Decoder.UnderlyingVariable(x);
+
+            this.ProjectVariable(xVar);
+            this.AddConstraints(boundsForX);
+        }
+
+        /// <summary>
+        /// Use this method when you were unable to obtain a polynomial form from the expressions
+        /// </summary>
+        private void AssignWithIntervals(Expression x, Expression exp)
+        {
+            var boundsForX = ConstraintsAsIntervalsFor(x, exp);
+
+            var xVar = expManager.Decoder.UnderlyingVariable(x);
+
+            this.ProjectVariable(xVar);
+            this.AddConstraints(boundsForX);
+        }
+
+        /// <summary>
+        /// Try to infer some constraints from the linear expression <code>polyExpSimplified</code>, which then uses for the octagon
+        /// </summary>
+        /// <param name="x">The variable to be assigned</param>
+        /// <param name="polyExpSimplified">Must be a linear relation</param>
+
+        private void AssignNonOctagonLinear(Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
+
+        //^ requires polyExpSimplified.IsLinear;
+        {
+            // We distinguish two cases, if the assigment is invertible or not
+            if (polyExpSimplified.Variables.Contains(x))   // It is an assigment in the form of x = x + k, with k a constant
             {
-              if (!y.Equals(xi))
-              {
-                if (signFor[y] == 1)
-                {
-                  I = I + boundsFor[y];          // I += [y]
-                }
-                else if (signFor[y] == -1)
-                {
+                // Renames "x + k" to "x' + k"
 
-                  I = I - boundsFor[y];   // I -= [y]
+                var xOld = expManager.Encoder.FreshVariable<int>();
+                this.AddVariable(xOld);
+
+                var equalConstraint = new OctagonConstraintXEqualY(this.DimensionForVar(x), this.DimensionForVar(xOld));
+                this.AddConstraint(equalConstraint);
+
+                var renamedExp = polyExpSimplified.Rename(x, xOld);
+
+                var newConstraints = ConstraintsForNonOctagonLinearForm(x, renamedExp);
+                this.ProjectDimension(this.DimensionForVar(x));
+                this.AddConstraints(newConstraints);
+
+                this.RemoveVariable(xOld);
+            }
+            else
+            {
+                var newConstraints = ConstraintsForNonOctagonLinearForm(x, polyExpSimplified);
+                this.ProjectVariable(x);            // set the value of x to top, force the closure of the octagon
+                this.AddConstraints(newConstraints);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// The assignment can be handled by octagons
+        /// </summary>
+        /// <param name="x">Must be a variable</param>
+
+        private void AssignWithOctagons(Expression x, PolynomialOfInt<Variable, Expression> exp)
+        {
+            Contract.Assert(exp.IsLinearOctagon, "I was expecting an octagon assigment, but I've got " + exp + " instead");
+
+            // We distinguish two cases, if the assigment is invertible or not
+            var xVar = expManager.Decoder.UnderlyingVariable(x);
+            if (exp.Variables.Contains(xVar))   // It is an assigment in the form of x = x + k, with k a constant
+            {
+                // Renames "x + k" to "x' + k"
+
+                var xOld = expManager.Encoder.FreshVariable<int>();
+                this.AddVariable(xOld);
+
+                var equalConstraint = new OctagonConstraintXEqualY(this.DimensionForVar(xVar), this.DimensionForVar(xOld));
+                this.AddConstraint(equalConstraint);
+
+                var renamedExp = exp.Rename(xVar, xOld);
+
+                var newConstraints = ConstraintsForOctagonForm(xVar, renamedExp);
+                this.ProjectDimension(this.DimensionForVar(xVar));
+                this.AddConstraints(newConstraints);
+
+                this.RemoveVariable(xOld);
+            }
+            else
+            {
+                var newConstraints = ConstraintsForOctagonForm(xVar, exp);
+                this.ProjectVariable(xVar);            // set the value of x to top, force the closure of the octagon
+                this.AddConstraints(newConstraints);
+            }
+        }
+
+        #region Constraints inference
+
+        /// <returns>
+        /// A set of constraints that stands for the assignment <code>+/- x +/- y \leq k </code>. 
+        /// Please note that <code>x</code> must not appear in <code>exp</code> in order to be correct
+        /// </returns>            
+
+        private Set<OctagonConstraint> ConstraintsForOctagonForm(Variable x, PolynomialOfInt<Variable, Expression> exp)
+        {
+            Contract.Assert(exp.IsLinearOctagon, string.Format("{0} is not in Octagonal form", exp));
+
+            var result = new Set<OctagonConstraint>();
+
+            if (exp.Left.Count == 1)    // x = y or or x = -y or x = k
+            {
+                var m = exp.Left[0];
+                if (m.IsConstant)       // case x = k, k constant
+                {
+                    result.Add(new OctagonConstraintXEqualConst(this.DimensionForVar(x), Rational.For(m.K)));
+                }
+                else if (m.K == 1)      // case x = y
+                {
+                    var y = m.Variables[0];
+
+                    result.Add(new OctagonConstraintXEqualY(this.DimensionForVar(x), this.DimensionForVar(y)));
+                }
+                else if (m.K == -1)      // case x = -y
+                {
+                    var y = m.Variables[0];
+
+                    result.Add(new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), 0));             //  x + y <= 0
+                    result.Add(new OctagonConstraintMinusXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), 0));   // -x - y <= 0
                 }
                 else
                 {
-                  Contract.Assert(false, "Expecting +1 or -1 as coefficent, found " + boundsFor[y]);
-                  //^ assert false;
+                    Contract.Assert(false, "Unknown case : " + x + " == " + exp);
                 }
-              }
             }
-            // At this point we have I = [a,b], and x = xi + [a, b]. We want to generate the two constraints x - xi >= a and x - xi <= b
-
-            // Case x {+, -} xi >= a, a > -oo
-            if (!I.IsLowerBoundMinusInfinity)
+            else // x = {+, -} y + k, k constant
             {
-              constraintForLowerBound = OctagonConstraint.For(-1, this.DimensionForVar(x), +1 * signFor[xi], this.variables2dimensions[xi], -1 * I.LowerBound);
-            }
+                var signOfY = (int)exp.Left[0].K;
+                var y = exp.Left[0].Variables[0];
+                var k = (int)exp.Left[1].K;
 
-            // Case x {+, -} xi <= b, b < +oo
-            if (!I.IsUpperBoundPlusInfinity)
-            {
-              constraintForUpperBound = OctagonConstraint.For(+1, this.DimensionForVar(x), -1 * signFor[xi], this.variables2dimensions[xi],  I.UpperBound);
-            }
-            #endregion
-          }
-          else // x == xi
-          {
-            #region Get the constraints for x = x + I
-            Interval I = Interval.For(constant);
-            foreach (var y in boundsFor.Keys)
-            {
-              if (signFor[y] == 1)
-              {
-                I = I + boundsFor[y];          // I += [y]
-              }
-              else if (signFor[y] == -1)
-              {
-
-                I = I - boundsFor[y];   // I -= [y]
-              }
-              else
-              {
-                Contract.Assert(false, "Expecting +1 or -1 as coefficent, found " + boundsFor[y]);
-              }
+                if (signOfY == 1)               // x = y + k, k constant
+                {
+                    result.Add(new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k));     // x - y <= k
+                    result.Add(new OctagonConstraintXMinusY(this.DimensionForVar(y), this.DimensionForVar(x), (int)-k));    // y - x <= -k
+                }
+                else if (signOfY == -1)         // x = -y + k, k constant
+                {
+                    result.Add(new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k));           //   x + y <= k
+                    result.Add(new OctagonConstraintMinusXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), (int)-k)); // - x - y <= -k
+                }
+                else
+                {
+                    Contract.Assert(false, "Unknown case : " + x + " == " + exp);
+                }
             }
 
-            // Case x >= a, a > -oo
-            if (!I.IsLowerBoundMinusInfinity)
+            return result;
+        }
+
+        /// <summary>
+        /// Try to infer some constraints from the linear expression <code>x == polyExpSimplified</code>
+        /// </summary>
+        /// <param name="x">The variable to be assigned</param>
+        /// <param name="polyExpSimplified">Must be a linear relation</param>
+
+        private Set<OctagonConstraint> ConstraintsForNonOctagonLinearForm(Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
+        {
+            Contract.Assert(polyExpSimplified.IsLinear, "Expecting a linear polynomial");
+
+            var newConstraints = new Set<OctagonConstraint>();
+
+            // If polyExpSimplified is in the form of a1 * x1 + a2 * x2 + ... where \forall a_i. a_i \in {-1 , +1}
+            if (HasUnaryCoefficients(polyExpSimplified))
             {
-              constraintForLowerBound = OctagonConstraint.For(-1, this.DimensionForVar(x), -1 * I.LowerBound);
-            }
+                #region 1. Get the bounds for all the variables in polyExpSimplified
 
-            // Case x <= b, b < +oo
-            if (!I.IsUpperBoundPlusInfinity)
+                var boundsFor = new Dictionary<Variable, Interval>();     // The interval bounds for the variable
+                var signFor = new Dictionary<Variable, int>();                           // The sign for each variable
+                int constant = 0;                                                                                       // The constant (if any) in the expression
+
+                foreach (var m in polyExpSimplified.Left)
+                {
+                    Contract.Assert(m.IsLinear); //^ assert m.IsLinear;
+
+                    if (!m.IsConstant)
+                    {
+                        boundsFor[m.Variables[0]] = this.BoundsFor(m.Variables[0]).AsInterval;
+                        signFor[m.Variables[0]] = Math.Sign(m.K);
+                    }
+                    else
+                    {
+                        constant = m.K;
+                    }
+                }
+
+                Contract.Assert(boundsFor.Keys.Count == signFor.Keys.Count, "Something is wrong...");
+                //^ assert boundsFor.Keys.Count == signFor.Keys.Count;
+                #endregion
+
+                #region 2. Try to reduce the polynomial to ai * xi + I, where ai is in {+1 , -1}I is a closed interval
+
+                foreach (var xi in boundsFor.Keys)       // Try all the expressions
+                {
+                    OctagonConstraint constraintForLowerBound = null;
+                    OctagonConstraint constraintForUpperBound = null;
+
+                    if (!x.Equals(xi))
+                    {
+                        #region Try to get the constraints for x = xi + I
+                        var I = Interval.For(constant);
+
+                        // Evaluate all the other variables
+                        foreach (var y in boundsFor.Keys)
+                        {
+                            if (!y.Equals(xi))
+                            {
+                                if (signFor[y] == 1)
+                                {
+                                    I = I + boundsFor[y];          // I += [y]
+                                }
+                                else if (signFor[y] == -1)
+                                {
+                                    I = I - boundsFor[y];   // I -= [y]
+                                }
+                                else
+                                {
+                                    Contract.Assert(false, "Expecting +1 or -1 as coefficent, found " + boundsFor[y]);
+                                    //^ assert false;
+                                }
+                            }
+                        }
+                        // At this point we have I = [a,b], and x = xi + [a, b]. We want to generate the two constraints x - xi >= a and x - xi <= b
+
+                        // Case x {+, -} xi >= a, a > -oo
+                        if (!I.IsLowerBoundMinusInfinity)
+                        {
+                            constraintForLowerBound = OctagonConstraint.For(-1, this.DimensionForVar(x), +1 * signFor[xi], variables2dimensions[xi], -1 * I.LowerBound);
+                        }
+
+                        // Case x {+, -} xi <= b, b < +oo
+                        if (!I.IsUpperBoundPlusInfinity)
+                        {
+                            constraintForUpperBound = OctagonConstraint.For(+1, this.DimensionForVar(x), -1 * signFor[xi], variables2dimensions[xi], I.UpperBound);
+                        }
+                        #endregion
+                    }
+                    else // x == xi
+                    {
+                        #region Get the constraints for x = x + I
+                        Interval I = Interval.For(constant);
+                        foreach (var y in boundsFor.Keys)
+                        {
+                            if (signFor[y] == 1)
+                            {
+                                I = I + boundsFor[y];          // I += [y]
+                            }
+                            else if (signFor[y] == -1)
+                            {
+                                I = I - boundsFor[y];   // I -= [y]
+                            }
+                            else
+                            {
+                                Contract.Assert(false, "Expecting +1 or -1 as coefficent, found " + boundsFor[y]);
+                            }
+                        }
+
+                        // Case x >= a, a > -oo
+                        if (!I.IsLowerBoundMinusInfinity)
+                        {
+                            constraintForLowerBound = OctagonConstraint.For(-1, this.DimensionForVar(x), -1 * I.LowerBound);
+                        }
+
+                        // Case x <= b, b < +oo
+                        if (!I.IsUpperBoundPlusInfinity)
+                        {
+                            constraintForUpperBound = OctagonConstraint.For(-1, this.DimensionForVar(x), -I.UpperBound);
+                        }
+                        #endregion
+                    }
+
+                    if (constraintForLowerBound != null)
+                        newConstraints.Add(constraintForLowerBound);
+                    if (constraintForUpperBound != null)
+                        newConstraints.Add(constraintForUpperBound);
+                }
+                #endregion
+
+
+
+            }  //  If polyExpSimplified is in the form a * x + b, where a, b are arbitary rationals
+            else if (IsSimpleLine(polyExpSimplified))
             {
-              constraintForUpperBound = OctagonConstraint.For(-1, this.DimensionForVar(x), -I.UpperBound);
-            }
-            #endregion
-          }
-
-          if (constraintForLowerBound != null)
-            newConstraints.Add(constraintForLowerBound);
-          if (constraintForUpperBound != null)
-            newConstraints.Add(constraintForUpperBound);
-        }
-        #endregion
-  
-       
-
-      }  //  If polyExpSimplified is in the form a * x + b, where a, b are arbitary rationals
-      else if (IsSimpleLine(polyExpSimplified))
-      {
-        #region Try to infer something
-        Contract.Assert(polyExpSimplified.Left.Count == 2);
- 
-
-        var m1 = polyExpSimplified.Left[0];
-        var m2 = polyExpSimplified.Left[1];
-
-        Contract.Assert(m2.Variables.Count == 0);
-
-        var a = m1.K;
-        var z = m1.Variables[0];
-        var b = m2.K;
-
-        if (!z.Equals(x))
-        {
-
-          var boundsForZ = this.BoundsFor(z);   // TODO5: Performance, avoid closing the octagon here, or close it just for x
-
-          if (b % (1 - a) != 0) // not an int
-          {
-            return newConstraints;
-          }
-
-          var frontier = b/ (1 - a);    // the point where x == a * z + b
-
-          if (boundsForZ.LowerBound > frontier)
-          {
-            // At this point we can create the constraint x < z, i.e. x - z <= -1 .
-            newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(z), -1));
-          }
-          else if (boundsForZ.LowerBound == frontier)
-          {
-            // At this point we can create the constraint x <= z, i.e. x - z <= 0 .
-            newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(z), 0));
-          }
-
-          if (boundsForZ.UpperBound < frontier)
-          {
-            // At this point we can create the constrain x > z, i.e.  z - x <= -1 . 
-            newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(z), this.DimensionForVar(x), -1));
-          }
-          else if (boundsForZ.UpperBound == frontier)
-          {
-            // At this point we can create the constrain x >= z, i.e.  z - x <= 0 . 
-            newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(z), this.DimensionForVar(x), 0));
-          }
-
-          // eval = a * z + b
-          var boundsForZAsRational = Interval.For(boundsForZ.LowerBound, boundsForZ.UpperBound);
-          var eval = (Interval.For(a))* boundsForZAsRational  + (Interval.For(b));
-
-          if (!eval.LowerBound.IsInfinity)
-          { // Add the constraints x >= eval.LowerBound
-            newConstraints.Add(new OctagonConstraintMinusX(this.DimensionForVar(x), -eval.LowerBound.PreviousInt32));
-          }
-          if (!eval.UpperBound.IsInfinity)
-          { // Add the constraint x <= eval.UpperBound
-            newConstraints.Add(new OctagonConstraintX(this.DimensionForVar(x), eval.UpperBound.NextInt32));
-          }
-
-          Contract.Assert(newConstraints.Count <= 3, "At this point you can add at most 3 constraints! Found " + newConstraints.Count);
-          
-        }
-        else // x == z
-        {
-            // Do nothing
-        }
-        #endregion
-      }
-      else
-      {
-        #region Try to find upperbounds for x, if polyExpSimplified is monotonic, otherwise use the intervals
-        bool polyIsMonotonic = true;
-
-        // Check if the polynomial is monotonic 
-
-        foreach (var m in polyExpSimplified.Left)
-        {
-          if (!m.IsConstant && m.K < 0)
-          {
-            polyIsMonotonic = false;
-            break;
-          }
-        }
-
-        if (polyIsMonotonic && !polyExpSimplified.Variables.Contains(x))
-        {
-          newConstraints = ConstraintsForNonOctagonLinearFormWithUpperBounds(x, polyExpSimplified);
-        }
-        else
-        {
-          var xExp = this.expManager.Encoder.VariableFor(x);
-          newConstraints = ConstraintsAsIntervalsFor(xExp, polyExpSimplified);
-        }
-        #endregion
-      }
-
-      return newConstraints;
-    }
-
-    /// <returns>
-    /// At most two octagon constraints that stands for the Interval in which <code>x</code> lay.
-    /// If <code>x</code> is contradictory, then it returns bottom
-    /// </returns>
-    private Set<OctagonConstraint> ConstraintsAsIntervalsFor(Expression x, PolynomialOfInt<Variable, Expression> exp)
-    {
-      if (this.expManager.Encoder == null)
-      {
-        return new Set<OctagonConstraint>();
-      }
-
-      var xVar = this.expManager.Decoder.UnderlyingVariable(x);
-
-      // Create an interval environment with just the variables in polyExpSimplified
-      Set<OctagonConstraint> boundsForX;
-      var varsInExp = exp.Variables;
-      int dimensionForX;
-
-      var tmpInterval = new IntervalEnvironment<Variable, Expression>(this.expManager);
-      foreach (var var in varsInExp)
-      {
-        tmpInterval.AssumeInDisInterval(var, this.BoundsFor(var));
-      }
-
-      if (!tmpInterval.Variables.Contains(xVar))    //if it is not an assignement like "x = exp[x]" we add x to the environment 
-      {
-        tmpInterval.AddVariable(xVar);
-      }
-
-      tmpInterval.Assign(x, exp.ToPureExpression(this.expManager.Encoder));
-
-      var v = tmpInterval.BoundsFor(x);
-      
-      dimensionForX = this.DimensionForVar(xVar);
-      boundsForX = new Set<OctagonConstraint>(2);
-
-      if (!v.LowerBound.IsInfinity)
-      {
-        boundsForX.Add(new OctagonConstraintMinusX(dimensionForX, -v.LowerBound));
-      }
-      if (!v.UpperBound.IsInfinity)
-      {
-        boundsForX.Add(new OctagonConstraintX(dimensionForX, v.UpperBound));
-      }
-
-      if (boundsForX.Count != 0)
-      {   // If we have at least one constraint
-        return boundsForX;
-      }
-      else
-      {   // No new constraints.. It can be either top or bottom
-        if (v.IsTop)
-        {
-          return boundsForX;
-        }
-        else
-        {   
-          Contract.Assert(v.IsBottom);
-
-          // Add a contraddiction
-          OctagonConstraint xLTZero = new OctagonConstraintX(dimensionForX, -1);
-          OctagonConstraint xGTZero = new OctagonConstraintMinusX(dimensionForX, -1);
-
-          boundsForX.Add(xLTZero);
-          boundsForX.Add(xGTZero);
-
-          return boundsForX;
-        }
-      }
-    }
-
-    /// <returns>
-    /// At most two octagon constraints that stands for the Interval in which <code>x</code> lay.
-    /// If <code>x</code> is contradictory, then it returns bottom
-    /// </returns>
-    private Set<OctagonConstraint> ConstraintsAsIntervalsFor(Expression x, Expression exp)
-    {
-      // Create an interval environment with just the variables in polyExpSimplified
-      var boundsForX = new Set<OctagonConstraint>();
-      var varsInExp = this.expManager.Decoder.VariablesIn(exp);
-      Interval v;
-      int dimensionForX;
-
-      var xVar = this.expManager.Decoder.UnderlyingVariable(x);
-
-      var tmpInterval = new IntervalEnvironment<Variable, Expression>(this.expManager);
-      foreach (var var in varsInExp)
-      {
-        tmpInterval.AssumeInDisInterval(var, this.BoundsFor(var));
-      }
-
-      if (!tmpInterval.ContainsKey(xVar))    //if it is not an assignement like "x = exp[x]" we add x to the environment 
-      {
-        tmpInterval.AddVariable(xVar);
-      }
-
-      tmpInterval.Assign(x, exp);
-
-      v = tmpInterval.BoundsFor(x).AsInterval;
-
-      dimensionForX = this.DimensionForVar(xVar);
-      boundsForX = new Set<OctagonConstraint>(2);
-
-      if (!v.LowerBound.IsInfinity)
-      {
-        boundsForX.Add(new OctagonConstraintMinusX(dimensionForX, -v.LowerBound));
-      }
-      if (!v.UpperBound.IsInfinity)
-      {
-        boundsForX.Add(new OctagonConstraintX(dimensionForX, v.UpperBound));
-      }
-
-      if (boundsForX.Count != 0)
-      {   // If we have at least one constraint
-        return boundsForX;
-      }
-      else
-      {   // No new constraints.. It can be either top or bottom
-        if (v.IsTop)
-        {
-          return boundsForX;
-        }
-        else if (v.IsBottom)
-        {
-
-          // Add a contraddiction
-          var xLTZero = new OctagonConstraintX(dimensionForX, -1);
-          var xGTZero = new OctagonConstraintMinusX(dimensionForX, -1);
-
-          boundsForX.Add(xLTZero);
-          boundsForX.Add(xGTZero);
-
-          return boundsForX;
-        }
-        else
-        { // this is the case when v is a very large value 
-          return boundsForX;
-        }
-      }
-    }
-
-    /// <summary>
-    /// Try to find symbolic upper bounds for the variable x, and then do the assignment.
-    /// At the moment, we require <code>polyExpSimplified</code> to have all the coefficents >= 0, i.e. it is a strictly monotonic function
-    /// </summary>
-    /// <param name="x">The variable to be assigned</param>
-    /// <param name="polyExpSimplified">The polynomial, which must be linear and with all the coefficents >= 0</param>
-
-    private Set<OctagonConstraint> ConstraintsForNonOctagonLinearFormWithUpperBounds(Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
-
-    {
-      Contract.Assert(polyExpSimplified.IsLinear);
-      Contract.Assert(!polyExpSimplified.Variables.Contains(x));
-
-      var variables = new Set<Variable>();
-      var newConstraints = new Set<OctagonConstraint>();
-
-      var varsToUpperBounds = new Dictionary<Variable, Set<PolynomialOfInt<Variable, Expression>>>();
-
-
-      #region 1. Get the upper bounds for the variables in polyExpSimplified
-      // Get the variables in the polynomial
-
-      foreach (var m in polyExpSimplified.Left)
-
-      {
-        if (!m.IsConstant)
-        {
-          var v = m.Variables[0];      // We know there is just one variable as the polynomial is linear
-          variables.Add(v);
-        }
-      }
-
-      // Get the symbolic upper bounds for the variables in the monomial
-      foreach (var v in variables)
-      {
-        var symbolicBoundsForV = BoundsInSymbolicFormFor(v);
-        varsToUpperBounds[v] = symbolicBoundsForV;
-      }
-      #endregion
-
-      #region 2. Substitute the upper bounds for the variables in polyExpSimplified, and try to infer an upper bound for x
-
-      var currentSubstitutions = new Dictionary<Variable, PolynomialOfInt<Variable, Expression>>();
-      var variablesAsArray = new Variable[varsToUpperBounds.Count];
-
-      int i = 0;
-      foreach (var var in varsToUpperBounds.Keys)
-      {
-        variablesAsArray[i] = var;
-        i++;
-      }
-
-      // Get the upper bound constraints
-      QuestForNewConstraints(0, variablesAsArray, varsToUpperBounds, currentSubstitutions, newConstraints, x, polyExpSimplified);
-
-      // Get the lower bound constraints (as intervals!)
-      var xExp = this.expManager.Encoder.VariableFor(x);
-      var constraintsFromIntervals = this.ConstraintsAsIntervalsFor(xExp, polyExpSimplified);
-
-      newConstraints.AddRange(constraintsFromIntervals);
-      #endregion
-
-      return newConstraints;
-    }
-
-    /// <returns>
-    /// A constraint that stands for the relation <code>x \leq exp</code>. 
-    /// Please note that <code>x</code> must not appear in <code>exp</code> in order to be correct
-    /// </returns>            
-
-    OctagonConstraint ConstraintsForUpperBound(Variable x, PolynomialOfInt<Variable, Expression> exp)
-    {
-      Contract.Assert(!exp.Variables.Contains(x), "The variable " + x + " is not allowed to stay in " + exp);
-
-      OctagonConstraint result;
-
-      if (exp.Left.Count == 1)    // x <= y or or x <= -y or x <= k
-      {
-
-        var m = exp.Left[0];
-
-        if (m.IsConstant)       // case x <= k, k constant
-        {
-          result = new OctagonConstraintX(this.DimensionForVar(x), (int)m.K);
-        }
-        else if (m.K == 1)      // case x <= y
-        {
-          var y = m.Variables[0];
-
-          result = new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), 0);
-        }
-        else if (m.K == -1)      // case x <= -y
-        {
-          var y = m.Variables[0];
-
-          result = new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), 0);             //  x + y <= 0
-        }
-        else
-        {
-          Contract.Assert(false, "Unknown case : " + x + " == " + exp);
-
-          throw new AbstractInterpretationException("Unknown case");
-        }
-      }
-      else // x = {+, -} y + k, k constant
-      {
-        int signOfY = (int)exp.Left[0].K;
-        var y = exp.Left[0].Variables[0];
-        int k = (int)exp.Left[1].K;
-
-        if (signOfY == 1)               // x <= y + k, k constant
-        {
-          result = new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k);     // x - y <= k
-        }
-        else if (signOfY == -1)         // x <= -y + k, k constant
-        {
-          result = new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k);           //   x + y <= k
-        }
-        else
-        {
-          Contract.Assert(false, "Unknown case : " + x + " == " + exp);
-
-          throw new AbstractInterpretationException("Unknown case");
-        }
-      }
-
-      return result;
-    }
-
-    /// <returns>
-    /// The symbolic bound corresponding to the variable <code>x</code>
-    /// </returns>
-
-    private Set<PolynomialOfInt<Variable, Expression>> BoundsInSymbolicFormFor(Variable x)
-    {
-      var result = new Set<PolynomialOfInt<Variable, Expression>>();
-
-      MonomialOfInt<Variable> kAsMonomial;
-      MonomialOfInt<Variable> yAsMonomial;
-
-      Rational k;
-
-      #region Gets the bounds x <= k -y and x <= y +k
-      foreach (var y in this.Variables)
-      {
-        if (x.Equals(y))
-          continue;
-
-        // The constraint -y + x <= k, that is the upper bound x <= k + y
-        k = this.ConstantForMinusXY(this.DimensionForVar(y), this.DimensionForVar(x));
-        if (!k.IsInfinity && k.IsInteger)
-        {
-          kAsMonomial = new MonomialOfInt<Variable>((int)k);        //  k * 1
-          yAsMonomial = new MonomialOfInt<Variable>(1, y);    //  1 * y
-          PolynomialOfInt<Variable, Expression> kMinusy;  // = new PolynomialOfInt<Variable, Expression>(kAsMonomial, yAsMonomial); // k * 1 + 1 * y
-
-          var asList = new List<MonomialOfInt<Variable>>() { kAsMonomial, yAsMonomial };
-
-          if (!PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(asList, out kMinusy))
-          {
-            throw new AbstractInterpretationException("The conversion of a list of monomials into a polynomial should never fail");
-          }
-
-          result.Add(kMinusy);
-        }
-      }
-      #endregion
-
-      #region Gets the bound x <= k
-      k = this.ConstantForX(this.DimensionForVar(x));
-      if (!k.IsInfinity && k.IsInteger)
-      {
-
-        PolynomialOfInt<Variable, Expression> lessThank; // = new PolynomialOfInt<Variable, Expression>(kAsMonomial);     // 1 * k
-
-        if (!PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>((Int32) k)}, out lessThank))
-        {
-          throw new AbstractInterpretationException("The conversion of a list of monomials into a polynomial should never fail");
-        }
-
-        result.Add(lessThank);
-      }
-      #endregion
-
-      return result;
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="p">The current position in the variables order to visit</param>
-    /// <param name="variables">The array containing all the variables to be assigned</param>
-    /// <param name="varsToUpperBounds">The map between variables and their upper bounds w.r.t. <code>x</code></param>
-    /// <param name="currentSubstitutions">The substitution we have computed up to now</param>
-    /// <param name="newConstraints">The new inferred constraints</param>
-    /// <param name="x">The variable we want to infer constraints for</param>
-   /// <param name="polyExpSimplified">The original PolynomialOfInt</param>
-    private void QuestForNewConstraints(int p, Variable[] variables, IDictionary<Variable, Set<PolynomialOfInt<Variable, Expression>>> varsToUpperBounds,
-      IDictionary<Variable, PolynomialOfInt<Variable, Expression>> currentSubstitutions, Set<OctagonConstraint> newConstraints, Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
-
-    {
-      Contract.Assert(p >= 0);
-
-      #region Case 1. We still have to generate a polynomial, to be propagated to the bottom of the tree
-      if (p < varsToUpperBounds.Count)
-      {
-
-        Variable currentVariable = variables[p];      // The current variable
-        var upperbounds = varsToUpperBounds[currentVariable];
-        foreach (var upperBoundForCurrentVariable in upperbounds)
-        {
-          currentSubstitutions[currentVariable] = upperBoundForCurrentVariable;
-          QuestForNewConstraints(p + 1, variables, varsToUpperBounds, currentSubstitutions, newConstraints, x, polyExpSimplified);
-        }
-
-        return;
-      }
-      #endregion
-
-      #region Case 2. We have an assignment for all the variables (we are at the bottom of tree)
-      if (p == varsToUpperBounds.Count)
-      {
-        var canonicalOne = polyExpSimplified.Rename(currentSubstitutions);    // Get the polynomial containing the substitutions...
-        
-        if (canonicalOne.IsLinearOctagon)
-        {
-          var asConstraint = ConstraintsForUpperBound(x, canonicalOne);
-          newConstraints.Add(asConstraint);
-        }
-        else
-        {
-          // do nothing as we have any new octagonal constraints...
-        }
-        return;
-      }
-      #endregion
-
-
-      //Unreachable code
-      throw new AbstractInterpretationException("Unreachable code?");
-    }
-    #endregion
-
-    #region Helper for TestTrue
-
-    /// <summary>
-    /// Assume <code>exp1 \leq exp2</code>
-    /// </summary>
-    public OctagonEnvironment<Variable, Expression> TestTrueLessEqualThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
-    {
-      this.CheckConsistency();
-
-      // First step: Add exp1 <= exp2 (that is exp1 -exp2 <= 0)
-      PolynomialOfInt<Variable, Expression> pol;
-
-      var intvForE1 = this.constantVisitor.Visit(exp1, new IntervalEnvironment<Variable, Expression>(this.expManager));
-      var intvForE2 = this.constantVisitor.Visit(exp2, new IntervalEnvironment<Variable, Expression>(this.expManager));
-
-      var exp1Var = this.expManager.Decoder.UnderlyingVariable(exp1);
-      var exp2Var = this.expManager.Decoder.UnderlyingVariable(exp2);
-
-      OctagonConstraint directConstraint = null;
-      Rational valForE1, valForE2;
-
-      var b1 = intvForE1.TryGetSingletonValue(out valForE1);
-      var b2 = intvForE2.TryGetSingletonValue(out valForE2);
-
-      // The four cases...
-      if (b1 && !b2)
-      { // k - e2 <= 0
-        if (valForE1.IsInteger)
-        {
-          directConstraint = OctagonConstraint.For(-1, this.DimensionForVar(exp2Var), - ((Int32)valForE1));
-        }
-      }
-      else if (!b1 && b2)
-      { // e1 - k <= 0
-        if (valForE2.IsInteger)
-        {
-          directConstraint = OctagonConstraint.For(1, this.DimensionForVar(exp1Var), 0 + ((Int32)valForE2));
-        }
-      }
-      else if (b1 && b2)
-      {
-        if (!(valForE1 <= valForE2))
-        {
-          return (OctagonEnvironment<Variable, Expression>)this.Bottom;
-        }
-      }
-      else
-      {
-        directConstraint = OctagonConstraint.For(1, this.DimensionForVar(exp1Var), -1, this.DimensionForVar(exp2Var), Rational.For(0));
-      }
-
-      if (directConstraint != null)
-      {
-        this.AddConstraint(directConstraint);
-      }
-
-      TestTrueLessEqualThanSpecialCaseForPartitionAnalysis(exp1, exp2);
-
-      if (! PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, exp1, exp2, this.expManager.Decoder, out pol))
-      {
-        return this;
-      }
-
-      if (pol.IsOctagonForm)
-      {
-        OctagonConstraint constraintForGuard;
-
-        // We check to see which kind of octagon constraint is
-        if (pol.Relation == ExpressionOperator.LessEqualThan)
-        {
-          if (pol.Left.Count == 2)
-          {   // It is a constraint in the form a.x + b.y <= k
-            var a = pol.Left[0].K;
-            var b = pol.Left[1].K;
-
-            var x = pol.Left[0].Variables[0];
-            var y = pol.Left[1].Variables[0];
-
-            var k = pol.Right[0].K;
-
-            constraintForGuard = OctagonConstraint.For(a, this.DimensionForVar(x), b, this.DimensionForVar(y), k);
-          }
-          else if (pol.Left.Count == 1)
-          {   // It is a constraint in the form of a.x <= k or k1 <= k2
-            var a = pol.Left[0].K;
-
-            if (pol.Left[0].Variables.Count > 0 && a != 0) // there is at least one variable, so it is not a straignforward constraints
-            {
-              var x = pol.Left[0].Variables[0];
-
-              int k = (int)pol.Right[0].K;
-
-              constraintForGuard = OctagonConstraint.For(a, this.DimensionForVar(x), k);
+                #region Try to infer something
+                Contract.Assert(polyExpSimplified.Left.Count == 2);
+
+
+                var m1 = polyExpSimplified.Left[0];
+                var m2 = polyExpSimplified.Left[1];
+
+                Contract.Assert(m2.Variables.Count == 0);
+
+                var a = m1.K;
+                var z = m1.Variables[0];
+                var b = m2.K;
+
+                if (!z.Equals(x))
+                {
+                    var boundsForZ = this.BoundsFor(z);   // TODO5: Performance, avoid closing the octagon here, or close it just for x
+
+                    if (b % (1 - a) != 0) // not an int
+                    {
+                        return newConstraints;
+                    }
+
+                    var frontier = b / (1 - a);    // the point where x == a * z + b
+
+                    if (boundsForZ.LowerBound > frontier)
+                    {
+                        // At this point we can create the constraint x < z, i.e. x - z <= -1 .
+                        newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(z), -1));
+                    }
+                    else if (boundsForZ.LowerBound == frontier)
+                    {
+                        // At this point we can create the constraint x <= z, i.e. x - z <= 0 .
+                        newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(z), 0));
+                    }
+
+                    if (boundsForZ.UpperBound < frontier)
+                    {
+                        // At this point we can create the constrain x > z, i.e.  z - x <= -1 . 
+                        newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(z), this.DimensionForVar(x), -1));
+                    }
+                    else if (boundsForZ.UpperBound == frontier)
+                    {
+                        // At this point we can create the constrain x >= z, i.e.  z - x <= 0 . 
+                        newConstraints.Add(new OctagonConstraintXMinusY(this.DimensionForVar(z), this.DimensionForVar(x), 0));
+                    }
+
+                    // eval = a * z + b
+                    var boundsForZAsRational = Interval.For(boundsForZ.LowerBound, boundsForZ.UpperBound);
+                    var eval = (Interval.For(a)) * boundsForZAsRational + (Interval.For(b));
+
+                    if (!eval.LowerBound.IsInfinity)
+                    { // Add the constraints x >= eval.LowerBound
+                        newConstraints.Add(new OctagonConstraintMinusX(this.DimensionForVar(x), -eval.LowerBound.PreviousInt32));
+                    }
+                    if (!eval.UpperBound.IsInfinity)
+                    { // Add the constraint x <= eval.UpperBound
+                        newConstraints.Add(new OctagonConstraintX(this.DimensionForVar(x), eval.UpperBound.NextInt32));
+                    }
+
+                    Contract.Assert(newConstraints.Count <= 3, "At this point you can add at most 3 constraints! Found " + newConstraints.Count);
+                }
+                else // x == z
+                {
+                    // Do nothing
+                }
+                #endregion
             }
             else
-            {   // No Variables, so it is a constraint in the form of k1 <= k2, with k1 and k2 int constants
+            {
+                #region Try to find upperbounds for x, if polyExpSimplified is monotonic, otherwise use the intervals
+                bool polyIsMonotonic = true;
 
-              // We compare the coefficents using rationals, i.e. more precise 
-              var aAsRational = pol.Left[0].K;
-              var b = pol.Right[0].K;
-              if (aAsRational <= b)
-              {   // nothing new, is a tautology
-                return this;
-              }
-              else
-              {   // is a contraddiction
-                return (OctagonEnvironment<Variable, Expression>)this.Bottom;
-              }
+                // Check if the polynomial is monotonic 
+
+                foreach (var m in polyExpSimplified.Left)
+                {
+                    if (!m.IsConstant && m.K < 0)
+                    {
+                        polyIsMonotonic = false;
+                        break;
+                    }
+                }
+
+                if (polyIsMonotonic && !polyExpSimplified.Variables.Contains(x))
+                {
+                    newConstraints = ConstraintsForNonOctagonLinearFormWithUpperBounds(x, polyExpSimplified);
+                }
+                else
+                {
+                    var xExp = expManager.Encoder.VariableFor(x);
+                    newConstraints = ConstraintsAsIntervalsFor(xExp, polyExpSimplified);
+                }
+                #endregion
             }
-          }
-          else
-          {   // We are not supposed to be there....
-            Contract.Assert(false, "Error: wrong octogonal constraint: " + pol);
 
-            return null;
-          }
-
-          this.CheckConsistency();
-
-          this.AddConstraint(constraintForGuard);     // Add the constraint to the environment
-
-          return this;
+            return newConstraints;
         }
-        else
+
+        /// <returns>
+        /// At most two octagon constraints that stands for the Interval in which <code>x</code> lay.
+        /// If <code>x</code> is contradictory, then it returns bottom
+        /// </returns>
+        private Set<OctagonConstraint> ConstraintsAsIntervalsFor(Expression x, PolynomialOfInt<Variable, Expression> exp)
         {
-          return this;
+            if (expManager.Encoder == null)
+            {
+                return new Set<OctagonConstraint>();
+            }
+
+            var xVar = expManager.Decoder.UnderlyingVariable(x);
+
+            // Create an interval environment with just the variables in polyExpSimplified
+            Set<OctagonConstraint> boundsForX;
+            var varsInExp = exp.Variables;
+            int dimensionForX;
+
+            var tmpInterval = new IntervalEnvironment<Variable, Expression>(expManager);
+            foreach (var var in varsInExp)
+            {
+                tmpInterval.AssumeInDisInterval(var, this.BoundsFor(var));
+            }
+
+            if (!tmpInterval.Variables.Contains(xVar))    //if it is not an assignement like "x = exp[x]" we add x to the environment 
+            {
+                tmpInterval.AddVariable(xVar);
+            }
+
+            tmpInterval.Assign(x, exp.ToPureExpression(expManager.Encoder));
+
+            var v = tmpInterval.BoundsFor(x);
+
+            dimensionForX = this.DimensionForVar(xVar);
+            boundsForX = new Set<OctagonConstraint>(2);
+
+            if (!v.LowerBound.IsInfinity)
+            {
+                boundsForX.Add(new OctagonConstraintMinusX(dimensionForX, -v.LowerBound));
+            }
+            if (!v.UpperBound.IsInfinity)
+            {
+                boundsForX.Add(new OctagonConstraintX(dimensionForX, v.UpperBound));
+            }
+
+            if (boundsForX.Count != 0)
+            {   // If we have at least one constraint
+                return boundsForX;
+            }
+            else
+            {   // No new constraints.. It can be either top or bottom
+                if (v.IsTop)
+                {
+                    return boundsForX;
+                }
+                else
+                {
+                    Contract.Assert(v.IsBottom);
+
+                    // Add a contraddiction
+                    OctagonConstraint xLTZero = new OctagonConstraintX(dimensionForX, -1);
+                    OctagonConstraint xGTZero = new OctagonConstraintMinusX(dimensionForX, -1);
+
+                    boundsForX.Add(xLTZero);
+                    boundsForX.Add(xGTZero);
+
+                    return boundsForX;
+                }
+            }
         }
-      }
-      else
-      {
-        return this;
-      }
+
+        /// <returns>
+        /// At most two octagon constraints that stands for the Interval in which <code>x</code> lay.
+        /// If <code>x</code> is contradictory, then it returns bottom
+        /// </returns>
+        private Set<OctagonConstraint> ConstraintsAsIntervalsFor(Expression x, Expression exp)
+        {
+            // Create an interval environment with just the variables in polyExpSimplified
+            var boundsForX = new Set<OctagonConstraint>();
+            var varsInExp = expManager.Decoder.VariablesIn(exp);
+            Interval v;
+            int dimensionForX;
+
+            var xVar = expManager.Decoder.UnderlyingVariable(x);
+
+            var tmpInterval = new IntervalEnvironment<Variable, Expression>(expManager);
+            foreach (var var in varsInExp)
+            {
+                tmpInterval.AssumeInDisInterval(var, this.BoundsFor(var));
+            }
+
+            if (!tmpInterval.ContainsKey(xVar))    //if it is not an assignement like "x = exp[x]" we add x to the environment 
+            {
+                tmpInterval.AddVariable(xVar);
+            }
+
+            tmpInterval.Assign(x, exp);
+
+            v = tmpInterval.BoundsFor(x).AsInterval;
+
+            dimensionForX = this.DimensionForVar(xVar);
+            boundsForX = new Set<OctagonConstraint>(2);
+
+            if (!v.LowerBound.IsInfinity)
+            {
+                boundsForX.Add(new OctagonConstraintMinusX(dimensionForX, -v.LowerBound));
+            }
+            if (!v.UpperBound.IsInfinity)
+            {
+                boundsForX.Add(new OctagonConstraintX(dimensionForX, v.UpperBound));
+            }
+
+            if (boundsForX.Count != 0)
+            {   // If we have at least one constraint
+                return boundsForX;
+            }
+            else
+            {   // No new constraints.. It can be either top or bottom
+                if (v.IsTop)
+                {
+                    return boundsForX;
+                }
+                else if (v.IsBottom)
+                {
+                    // Add a contraddiction
+                    var xLTZero = new OctagonConstraintX(dimensionForX, -1);
+                    var xGTZero = new OctagonConstraintMinusX(dimensionForX, -1);
+
+                    boundsForX.Add(xLTZero);
+                    boundsForX.Add(xGTZero);
+
+                    return boundsForX;
+                }
+                else
+                { // this is the case when v is a very large value 
+                    return boundsForX;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Try to find symbolic upper bounds for the variable x, and then do the assignment.
+        /// At the moment, we require <code>polyExpSimplified</code> to have all the coefficents >= 0, i.e. it is a strictly monotonic function
+        /// </summary>
+        /// <param name="x">The variable to be assigned</param>
+        /// <param name="polyExpSimplified">The polynomial, which must be linear and with all the coefficents >= 0</param>
+
+        private Set<OctagonConstraint> ConstraintsForNonOctagonLinearFormWithUpperBounds(Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
+
+        {
+            Contract.Assert(polyExpSimplified.IsLinear);
+            Contract.Assert(!polyExpSimplified.Variables.Contains(x));
+
+            var variables = new Set<Variable>();
+            var newConstraints = new Set<OctagonConstraint>();
+
+            var varsToUpperBounds = new Dictionary<Variable, Set<PolynomialOfInt<Variable, Expression>>>();
+
+
+            #region 1. Get the upper bounds for the variables in polyExpSimplified
+            // Get the variables in the polynomial
+
+            foreach (var m in polyExpSimplified.Left)
+
+            {
+                if (!m.IsConstant)
+                {
+                    var v = m.Variables[0];      // We know there is just one variable as the polynomial is linear
+                    variables.Add(v);
+                }
+            }
+
+            // Get the symbolic upper bounds for the variables in the monomial
+            foreach (var v in variables)
+            {
+                var symbolicBoundsForV = BoundsInSymbolicFormFor(v);
+                varsToUpperBounds[v] = symbolicBoundsForV;
+            }
+            #endregion
+
+            #region 2. Substitute the upper bounds for the variables in polyExpSimplified, and try to infer an upper bound for x
+
+            var currentSubstitutions = new Dictionary<Variable, PolynomialOfInt<Variable, Expression>>();
+            var variablesAsArray = new Variable[varsToUpperBounds.Count];
+
+            int i = 0;
+            foreach (var var in varsToUpperBounds.Keys)
+            {
+                variablesAsArray[i] = var;
+                i++;
+            }
+
+            // Get the upper bound constraints
+            QuestForNewConstraints(0, variablesAsArray, varsToUpperBounds, currentSubstitutions, newConstraints, x, polyExpSimplified);
+
+            // Get the lower bound constraints (as intervals!)
+            var xExp = expManager.Encoder.VariableFor(x);
+            var constraintsFromIntervals = this.ConstraintsAsIntervalsFor(xExp, polyExpSimplified);
+
+            newConstraints.AddRange(constraintsFromIntervals);
+            #endregion
+
+            return newConstraints;
+        }
+
+        /// <returns>
+        /// A constraint that stands for the relation <code>x \leq exp</code>. 
+        /// Please note that <code>x</code> must not appear in <code>exp</code> in order to be correct
+        /// </returns>            
+
+        private OctagonConstraint ConstraintsForUpperBound(Variable x, PolynomialOfInt<Variable, Expression> exp)
+        {
+            Contract.Assert(!exp.Variables.Contains(x), "The variable " + x + " is not allowed to stay in " + exp);
+
+            OctagonConstraint result;
+
+            if (exp.Left.Count == 1)    // x <= y or or x <= -y or x <= k
+            {
+                var m = exp.Left[0];
+
+                if (m.IsConstant)       // case x <= k, k constant
+                {
+                    result = new OctagonConstraintX(this.DimensionForVar(x), (int)m.K);
+                }
+                else if (m.K == 1)      // case x <= y
+                {
+                    var y = m.Variables[0];
+
+                    result = new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), 0);
+                }
+                else if (m.K == -1)      // case x <= -y
+                {
+                    var y = m.Variables[0];
+
+                    result = new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), 0);             //  x + y <= 0
+                }
+                else
+                {
+                    Contract.Assert(false, "Unknown case : " + x + " == " + exp);
+
+                    throw new AbstractInterpretationException("Unknown case");
+                }
+            }
+            else // x = {+, -} y + k, k constant
+            {
+                int signOfY = (int)exp.Left[0].K;
+                var y = exp.Left[0].Variables[0];
+                int k = (int)exp.Left[1].K;
+
+                if (signOfY == 1)               // x <= y + k, k constant
+                {
+                    result = new OctagonConstraintXMinusY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k);     // x - y <= k
+                }
+                else if (signOfY == -1)         // x <= -y + k, k constant
+                {
+                    result = new OctagonConstraintXY(this.DimensionForVar(x), this.DimensionForVar(y), (int)k);           //   x + y <= k
+                }
+                else
+                {
+                    Contract.Assert(false, "Unknown case : " + x + " == " + exp);
+
+                    throw new AbstractInterpretationException("Unknown case");
+                }
+            }
+
+            return result;
+        }
+
+        /// <returns>
+        /// The symbolic bound corresponding to the variable <code>x</code>
+        /// </returns>
+
+        private Set<PolynomialOfInt<Variable, Expression>> BoundsInSymbolicFormFor(Variable x)
+        {
+            var result = new Set<PolynomialOfInt<Variable, Expression>>();
+
+            MonomialOfInt<Variable> kAsMonomial;
+            MonomialOfInt<Variable> yAsMonomial;
+
+            Rational k;
+
+            #region Gets the bounds x <= k -y and x <= y +k
+            foreach (var y in this.Variables)
+            {
+                if (x.Equals(y))
+                    continue;
+
+                // The constraint -y + x <= k, that is the upper bound x <= k + y
+                k = this.ConstantForMinusXY(this.DimensionForVar(y), this.DimensionForVar(x));
+                if (!k.IsInfinity && k.IsInteger)
+                {
+                    kAsMonomial = new MonomialOfInt<Variable>((int)k);        //  k * 1
+                    yAsMonomial = new MonomialOfInt<Variable>(1, y);    //  1 * y
+                    PolynomialOfInt<Variable, Expression> kMinusy;  // = new PolynomialOfInt<Variable, Expression>(kAsMonomial, yAsMonomial); // k * 1 + 1 * y
+
+                    var asList = new List<MonomialOfInt<Variable>>() { kAsMonomial, yAsMonomial };
+
+                    if (!PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(asList, out kMinusy))
+                    {
+                        throw new AbstractInterpretationException("The conversion of a list of monomials into a polynomial should never fail");
+                    }
+
+                    result.Add(kMinusy);
+                }
+            }
+            #endregion
+
+            #region Gets the bound x <= k
+            k = this.ConstantForX(this.DimensionForVar(x));
+            if (!k.IsInfinity && k.IsInteger)
+            {
+                PolynomialOfInt<Variable, Expression> lessThank; // = new PolynomialOfInt<Variable, Expression>(kAsMonomial);     // 1 * k
+
+                if (!PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>((Int32)k) }, out lessThank))
+                {
+                    throw new AbstractInterpretationException("The conversion of a list of monomials into a polynomial should never fail");
+                }
+
+                result.Add(lessThank);
+            }
+            #endregion
+
+            return result;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="p">The current position in the variables order to visit</param>
+        /// <param name="variables">The array containing all the variables to be assigned</param>
+        /// <param name="varsToUpperBounds">The map between variables and their upper bounds w.r.t. <code>x</code></param>
+        /// <param name="currentSubstitutions">The substitution we have computed up to now</param>
+        /// <param name="newConstraints">The new inferred constraints</param>
+        /// <param name="x">The variable we want to infer constraints for</param>
+        /// <param name="polyExpSimplified">The original PolynomialOfInt</param>
+        private void QuestForNewConstraints(int p, Variable[] variables, IDictionary<Variable, Set<PolynomialOfInt<Variable, Expression>>> varsToUpperBounds,
+          IDictionary<Variable, PolynomialOfInt<Variable, Expression>> currentSubstitutions, Set<OctagonConstraint> newConstraints, Variable x, PolynomialOfInt<Variable, Expression> polyExpSimplified)
+
+        {
+            Contract.Assert(p >= 0);
+
+            #region Case 1. We still have to generate a polynomial, to be propagated to the bottom of the tree
+            if (p < varsToUpperBounds.Count)
+            {
+                Variable currentVariable = variables[p];      // The current variable
+                var upperbounds = varsToUpperBounds[currentVariable];
+                foreach (var upperBoundForCurrentVariable in upperbounds)
+                {
+                    currentSubstitutions[currentVariable] = upperBoundForCurrentVariable;
+                    QuestForNewConstraints(p + 1, variables, varsToUpperBounds, currentSubstitutions, newConstraints, x, polyExpSimplified);
+                }
+
+                return;
+            }
+            #endregion
+
+            #region Case 2. We have an assignment for all the variables (we are at the bottom of tree)
+            if (p == varsToUpperBounds.Count)
+            {
+                var canonicalOne = polyExpSimplified.Rename(currentSubstitutions);    // Get the polynomial containing the substitutions...
+
+                if (canonicalOne.IsLinearOctagon)
+                {
+                    var asConstraint = ConstraintsForUpperBound(x, canonicalOne);
+                    newConstraints.Add(asConstraint);
+                }
+                else
+                {
+                    // do nothing as we have any new octagonal constraints...
+                }
+                return;
+            }
+            #endregion
+
+
+            //Unreachable code
+            throw new AbstractInterpretationException("Unreachable code?");
+        }
+        #endregion
+
+        #region Helper for TestTrue
+
+        /// <summary>
+        /// Assume <code>exp1 \leq exp2</code>
+        /// </summary>
+        public OctagonEnvironment<Variable, Expression> TestTrueLessEqualThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
+        {
+            this.CheckConsistency();
+
+            // First step: Add exp1 <= exp2 (that is exp1 -exp2 <= 0)
+            PolynomialOfInt<Variable, Expression> pol;
+
+            var intvForE1 = constantVisitor.Visit(exp1, new IntervalEnvironment<Variable, Expression>(expManager));
+            var intvForE2 = constantVisitor.Visit(exp2, new IntervalEnvironment<Variable, Expression>(expManager));
+
+            var exp1Var = expManager.Decoder.UnderlyingVariable(exp1);
+            var exp2Var = expManager.Decoder.UnderlyingVariable(exp2);
+
+            OctagonConstraint directConstraint = null;
+            Rational valForE1, valForE2;
+
+            var b1 = intvForE1.TryGetSingletonValue(out valForE1);
+            var b2 = intvForE2.TryGetSingletonValue(out valForE2);
+
+            // The four cases...
+            if (b1 && !b2)
+            { // k - e2 <= 0
+                if (valForE1.IsInteger)
+                {
+                    directConstraint = OctagonConstraint.For(-1, this.DimensionForVar(exp2Var), -((Int32)valForE1));
+                }
+            }
+            else if (!b1 && b2)
+            { // e1 - k <= 0
+                if (valForE2.IsInteger)
+                {
+                    directConstraint = OctagonConstraint.For(1, this.DimensionForVar(exp1Var), 0 + ((Int32)valForE2));
+                }
+            }
+            else if (b1 && b2)
+            {
+                if (!(valForE1 <= valForE2))
+                {
+                    return (OctagonEnvironment<Variable, Expression>)this.Bottom;
+                }
+            }
+            else
+            {
+                directConstraint = OctagonConstraint.For(1, this.DimensionForVar(exp1Var), -1, this.DimensionForVar(exp2Var), Rational.For(0));
+            }
+
+            if (directConstraint != null)
+            {
+                this.AddConstraint(directConstraint);
+            }
+
+            TestTrueLessEqualThanSpecialCaseForPartitionAnalysis(exp1, exp2);
+
+            if (!PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, exp1, exp2, expManager.Decoder, out pol))
+            {
+                return this;
+            }
+
+            if (pol.IsOctagonForm)
+            {
+                OctagonConstraint constraintForGuard;
+
+                // We check to see which kind of octagon constraint is
+                if (pol.Relation == ExpressionOperator.LessEqualThan)
+                {
+                    if (pol.Left.Count == 2)
+                    {   // It is a constraint in the form a.x + b.y <= k
+                        var a = pol.Left[0].K;
+                        var b = pol.Left[1].K;
+
+                        var x = pol.Left[0].Variables[0];
+                        var y = pol.Left[1].Variables[0];
+
+                        var k = pol.Right[0].K;
+
+                        constraintForGuard = OctagonConstraint.For(a, this.DimensionForVar(x), b, this.DimensionForVar(y), k);
+                    }
+                    else if (pol.Left.Count == 1)
+                    {   // It is a constraint in the form of a.x <= k or k1 <= k2
+                        var a = pol.Left[0].K;
+
+                        if (pol.Left[0].Variables.Count > 0 && a != 0) // there is at least one variable, so it is not a straignforward constraints
+                        {
+                            var x = pol.Left[0].Variables[0];
+
+                            int k = (int)pol.Right[0].K;
+
+                            constraintForGuard = OctagonConstraint.For(a, this.DimensionForVar(x), k);
+                        }
+                        else
+                        {   // No Variables, so it is a constraint in the form of k1 <= k2, with k1 and k2 int constants
+                            // We compare the coefficents using rationals, i.e. more precise 
+                            var aAsRational = pol.Left[0].K;
+                            var b = pol.Right[0].K;
+                            if (aAsRational <= b)
+                            {   // nothing new, is a tautology
+                                return this;
+                            }
+                            else
+                            {   // is a contraddiction
+                                return (OctagonEnvironment<Variable, Expression>)this.Bottom;
+                            }
+                        }
+                    }
+                    else
+                    {   // We are not supposed to be there....
+                        Contract.Assert(false, "Error: wrong octogonal constraint: " + pol);
+
+                        return null;
+                    }
+
+                    this.CheckConsistency();
+
+                    this.AddConstraint(constraintForGuard);     // Add the constraint to the environment
+
+                    return this;
+                }
+                else
+                {
+                    return this;
+                }
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        private OctagonEnvironment<Variable, Expression> TestTrueEqualNotRefininingLeftArgumentsInternal(Expression/*!*/ exp1, Expression/*!*/ exp2)
+        {
+            var constraints = new Set<OctagonConstraint>();
+
+            PolynomialOfInt<Variable, Expression> exp2Pol;
+            if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(exp2, expManager.Decoder, out exp2Pol) && exp2Pol.IsLinearOctagon)
+            {
+                OctagonConstraint c1 = null, c2 = null;
+                var dim1 = this.DimensionForVar(expManager.Decoder.UnderlyingVariable(exp1));
+
+                if (exp2Pol.Left.Count == 1)
+                { // exp1 == m
+                    var k = exp2Pol.Left[0].K;
+
+                    if (exp2Pol.Left[0].IsConstant)
+                    { // exp1 == k
+                        c1 = OctagonConstraint.For(1, dim1, k);
+                        c2 = OctagonConstraint.For(-1, dim1, -k);
+                    }
+                    else
+                    { // exp1 == v
+                        var dim2 = this.DimensionForVar(exp2Pol.Left[0].Variables[0]);
+                        c1 = OctagonConstraint.For(1, dim1, -1, dim2, 0);
+                        c2 = OctagonConstraint.For(-1, dim1, 1, dim2, 0);
+                    }
+                }
+                else if (exp2Pol.Left.Count == 2)
+                {
+                    // exp1 == v + k
+                    var dim2 = this.DimensionForVar(exp2Pol.Left[0].Variables[0]);
+                    var k = exp2Pol.Left[1].K;
+
+                    c1 = OctagonConstraint.For(1, dim1, -1, dim2, k);
+                    c2 = OctagonConstraint.For(-1, dim1, 1, dim2, -k);
+                }
+
+                constraints.Add(c1);
+                constraints.Add(c2);
+
+                this.AddConstraints(constraints);
+            }
+
+            return this;
+        }
+
+        #endregion
+
+        #region Miscellanea helper functions (HasUnaryCoefficients, IsSimpleLine)
+
+
+        private static readonly Predicate<MonomialOfInt<Variable>> oneOrMinusOne = delegate (MonomialOfInt<Variable> m) { return m.K == 1 || m.K == -1; };
+
+
+        /// <returns>
+        /// true iff polyExpSimplified is in the form of a1 * x1 + a2 * x2 + ... where \forall a_i. a_i \in {-1 , +1}
+        /// </returns>
+
+        private static bool HasUnaryCoefficients(PolynomialOfInt<Variable, Expression> polyExpSimplified)
+
+        {
+            foreach (var m in polyExpSimplified.Left)
+            {
+                if (!oneOrMinusOne(m))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <param name="polyExpSimplified">Must be a linear PolynomialOfInt</param>
+        /// <returns>
+        /// true iff <code>polyExpSimplified</code> is in the form of a1 * x1 + a2, where a1, a2 are <code>int</code> and <code>x</code> is a variable 
+        /// </returns>
+        private static bool IsSimpleLine(PolynomialOfInt<Variable, Expression> polyExpSimplified)
+
+        //^ requires polyExpSimplified.IsLinear;
+        {
+            Contract.Assert(polyExpSimplified.IsLinear, "I was expecting " + polyExpSimplified + " to be linear");
+
+            if (polyExpSimplified.Left.Count == 2)
+            { // matches polyExpSimplified with m + k
+                var m = polyExpSimplified.Left[0];
+                var k = polyExpSimplified.Left[1];
+
+                return (m.Variables.Count == 1 && k.Variables.Count == 0) || (m.Variables.Count == 0 && k.Variables.Count == 1);
+            }
+            else
+            {
+                return false;
+            }
+        }
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        public Variable ToVariable(Expression exp)
+        {
+            return expManager.Decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
     }
 
-    private OctagonEnvironment<Variable, Expression> TestTrueEqualNotRefininingLeftArgumentsInternal(Expression/*!*/ exp1, Expression/*!*/ exp2)
+    #region Visitors for the guards (TestTrue, TestFalse, CheckIfHolds)
+
+    internal class OctagonsTrueTestVisitor<Variable, Expression>
+    : TestTrueVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
     {
-      var constraints = new Set<OctagonConstraint>();
-
-      PolynomialOfInt<Variable, Expression> exp2Pol;
-      if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(exp2, this.expManager.Decoder, out exp2Pol) && exp2Pol.IsLinearOctagon)
-      {
-        OctagonConstraint c1 = null, c2 = null;
-        var dim1 = this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(exp1));
-
-        if (exp2Pol.Left.Count == 1)
-        { // exp1 == m
-
-          var k = exp2Pol.Left[0].K;
-
-          if (exp2Pol.Left[0].IsConstant)
-          { // exp1 == k
-            c1 = OctagonConstraint.For(1, dim1, k);
-            c2 = OctagonConstraint.For(-1, dim1, -k);
-          }
-          else
-          { // exp1 == v
-            var dim2 = this.DimensionForVar(exp2Pol.Left[0].Variables[0]);
-            c1 = OctagonConstraint.For(1, dim1, -1, dim2, 0);
-            c2 = OctagonConstraint.For(-1, dim1, 1, dim2, 0);
-          }
-
-        }
-        else if (exp2Pol.Left.Count == 2)
+        public OctagonsTrueTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
         {
-          // exp1 == v + k
-          var dim2 = this.DimensionForVar(exp2Pol.Left[0].Variables[0]);
-          var k = exp2Pol.Left[1].K;
-
-          c1 = OctagonConstraint.For(1, dim1, -1, dim2, k);
-          c2 = OctagonConstraint.For(-1, dim1, 1, dim2, -k);
         }
 
-        constraints.Add(c1);
-        constraints.Add(c2);
 
-        this.AddConstraints(constraints);
-      }
+        public override OctagonEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
 
-      return this;
+        {
+            return data.TestTrueEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueLessEqualThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueLessThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueNotEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data;
+        }
     }
 
+
+    internal class OctagonsTrueTestNotRefiningVisitor<Variable, Expression>
+    : TestTrueVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
+    {
+        public OctagonsTrueTestNotRefiningVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
+        {
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitAnd(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            var isLeftAVar = this.Decoder.IsVariable(left);
+            var isLeftAConst = this.Decoder.IsConstant(left);
+            var isRightAVar = this.Decoder.IsVariable(right);
+            var isRightAConst = this.Decoder.IsConstant(right);
+
+            if ((isLeftAVar && isRightAConst) || (isLeftAConst && isRightAVar))
+            {
+                //this.result = data;
+                return data;
+            }
+            else
+            {
+                var oct = (OctagonEnvironment<Variable, Expression>)data.Clone();
+
+                oct = oct.TestTrueNotRefining(left);
+                oct = oct.TestTrueNotRefining(right);
+
+                return oct;
+            }
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueEqualNotRefininingLeftArguments(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueLessEqualThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueLessThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueNotEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitVariable(Variable var, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data;
+        }
+    }
+
+    internal class OctagonsFalseTestVisitor<Variable, Expression>
+      : TestFalseVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
+    {
+        public OctagonsFalseTestVisitor(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
+          : base(decoder)
+        { }
+
+        public override OctagonEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueNotEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data.TestTrueEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
+        }
+
+        public override OctagonEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, OctagonEnvironment<Variable, Expression> data)
+        {
+            return data;
+        }
+    }
+
+    internal class OctagonsCheckIfHoldsVisitor<Variable, Expression>
+      : CheckIfHoldsVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
+    {
+        public OctagonsCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
+        {
+        }
+
+        public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            var resultLeft = Domain.CheckIfLessEqualThan(left, right);
+
+            if (!resultLeft.IsBottom && !resultLeft.IsTop)
+            {
+                var resultRight = Domain.CheckIfLessEqualThan(right, left);
+
+                if (!resultRight.IsBottom && !resultRight.IsTop)
+                {
+                    return resultLeft.Meet(resultRight);
+                }
+                else
+                {
+                    return resultRight;
+                }
+            }
+            else
+            {
+                return resultLeft;
+            }
+        }
+
+        public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return VisitEqual(left, right, original, data);
+        }
+
+        public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return Domain.CheckIfLessEqualThan(left, right);
+        }
+
+        public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return Domain.CheckIfLessThan(left, right);
+        }
+
+        public override FlatAbstractDomain<bool> VisitVariable(Variable variable, Expression original, FlatAbstractDomain<bool> data)
+        {
+            var intv = this.Domain.BoundsFor(variable);
+
+            if (intv.IsBottom)
+                return CheckOutcome.Bottom;
+
+            if (intv.IsTop)
+                return CheckOutcome.Top;
+
+            Rational v;
+            if (intv.TryGetSingletonValue(out v))
+            {
+                return v.IsZero ? CheckOutcome.False : CheckOutcome.True;
+            }
+
+            return CheckOutcome.Top;
+        }
+    }
     #endregion
 
-    #region Miscellanea helper functions (HasUnaryCoefficients, IsSimpleLine)
+    #region Visitor for Inferring Octagon Constraints
 
 
-    private static readonly Predicate<MonomialOfInt<Variable>> oneOrMinusOne = delegate(MonomialOfInt<Variable> m) { return m.K == 1 || m.K == -1; };
-
-
-    /// <returns>
-    /// true iff polyExpSimplified is in the form of a1 * x1 + a2 * x2 + ... where \forall a_i. a_i \in {-1 , +1}
-    /// </returns>
-
-    private static bool HasUnaryCoefficients(PolynomialOfInt<Variable, Expression> polyExpSimplified)
-
+    internal abstract class TryVisitAtMostTwoMonomialsOfInt<Variable, Expression, In, Data>
     {
-      foreach(var m in polyExpSimplified.Left)
-      {
-        if (!oneOrMinusOne(m))
-          return false;
-      }
+        /// <summary>
+        /// We want it to be used by the subclasses, but not called from clients
+        /// </summary>
 
-      return true;
+        protected bool Dispatch(PolynomialOfInt<Variable, Expression> exp, ref Data result)
+        {
+            Variable x, y;
+            int a, b, k;
+
+            if (PolynomialOfIntHelper.Match_k1XLessEqualThank2(exp, out a, out x, out k))
+            { // a * x <= k
+                if (a < 0)
+                {
+                    return this.VisitMinusXLessEqualThan(a, x, k, ref result);
+                }
+                else if (a > 0)
+                {
+                    return this.VisitXLessEqualThan(a, x, k, ref result);
+                }
+                else // a == 0
+                {
+                    return Default(ref result);
+                }
+            }
+            else if (PolynomialOfIntHelper.Match_k1XLessThank2(exp, out a, out x, out k))
+            { // "a * x < k " == "a * x  <= k-1"
+                if (a < 0)
+                {
+                    return this.VisitMinusXLessEqualThan(a, x, k - 1, ref result);
+                }
+                else if (a > 0)
+                {
+                    return this.VisitXLessEqualThan(a, x, k - 1, ref result);
+                }
+                else
+                {
+                    return Default(ref result);
+                }
+            }
+            else if (PolynomialOfIntHelper.Match_k1XPlusk2YLessEqualThanK(exp, out a, out x, out b, out y, out k))
+            { // "a * x + b * y <= k" 
+                if (a == 1 && b == 1)
+                {
+                    return VisitXYLessEqualThanK(x, y, k, ref result);
+                }
+                else if (a == 1 && b == -1)
+                {
+                    return this.VisitXMinusYLessEqualThan(x, y, k, ref result);
+                }
+                else if (a == -1 && b == 1)
+                {
+                    return this.VisitXMinusYLessEqualThan(y, x, k, ref result);
+                }
+                else if (a == -1 && b == -1)
+                {
+                    return this.VisitMinusXMinusYLessEqualThan(x, y, k, ref result);
+                }
+                else
+                {
+                    // Todo: Do we want a visitor for other cases here?
+                    return Default(ref result);
+                }
+            }
+            else if (PolynomialOfIntHelper.Match_k1XPlusk2YLessThanK(exp, out a, out x, out b, out y, out k))
+            { // "a * x + b * y < k" is "a * x + b * y <=  k-1"
+                if (a == 1 && b == 1)
+                {
+                    return this.VisitXYLessEqualThanK(x, y, k - 1, ref result);
+                }
+                else if (a == 1 && b == -1)
+                {
+                    return this.VisitXMinusYLessEqualThan(x, y, k - 1, ref result);
+                }
+                else if (a == -1 && b == 1)
+                {
+                    return this.VisitXMinusYLessEqualThan(y, x, k - 1, ref result);
+                }
+                else if (a == -1 && b == -1)
+                {
+                    return this.VisitMinusXMinusYLessEqualThan(x, y, k - 1, ref result);
+                }
+                else
+                {
+                    // Todo: Do we want a visitor for other cases here?
+                    return Default(ref result);
+                }
+            }
+            else
+            {
+                return Default(ref result);
+            }
+        }
+
+        abstract public bool Visit(PolynomialOfInt<Variable, Expression> exp, In input, ref Data result);
+
+        abstract protected bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, int k, ref Data result);
+
+        abstract protected bool VisitXMinusYLessEqualThan(Variable x, Variable y, int k, ref Data result);
+
+        abstract protected bool VisitXYLessEqualThanK(Variable x, Variable y, int k, ref Data result);
+
+        abstract protected bool VisitXLessEqualThan(int a, Variable x, int k, ref Data result);
+
+        abstract protected bool VisitMinusXLessEqualThan(int a, Variable x, int k, ref Data result);
+
+
+        private bool Default(ref Data result)
+        {
+            return false;
+        }
     }
 
-    /// <param name="polyExpSimplified">Must be a linear PolynomialOfInt</param>
-    /// <returns>
-    /// true iff <code>polyExpSimplified</code> is in the form of a1 * x1 + a2, where a1, a2 are <code>int</code> and <code>x</code> is a variable 
-    /// </returns>
-    private static bool IsSimpleLine(PolynomialOfInt<Variable, Expression> polyExpSimplified)
 
-    //^ requires polyExpSimplified.IsLinear;
+    internal class InferOctagonConstraints<Variable, Expression>
+      : TryVisitAtMostTwoMonomialsOfInt<Variable, Expression, OctagonEnvironment<Variable, Expression>, Set<OctagonConstraint>>
+
     {
-      Contract.Assert(polyExpSimplified.IsLinear, "I was expecting " + polyExpSimplified + " to be linear");
+        private OctagonEnvironment<Variable, Expression> octagon;
 
-      if (polyExpSimplified.Left.Count == 2)
-      { // matches polyExpSimplified with m + k
-        var m = polyExpSimplified.Left[0];
-        var k = polyExpSimplified.Left[1];
+        public InferOctagonConstraints()
+        {
+            octagon = null;
+        }
 
-        return (m.Variables.Count == 1 && k.Variables.Count == 0) || (m.Variables.Count == 0 && k.Variables.Count == 1);
-      }
-      else
-      {
-        return false;
-      }
+        public override bool Visit(PolynomialOfInt<Variable, Expression> exp, OctagonEnvironment<Variable, Expression> input, ref Set<OctagonConstraint> result)
+
+        {
+            octagon = input;
+
+            bool ok = this.Dispatch(exp, ref result);
+
+            octagon = null;
+
+            return ok;
+        }
+
+
+        protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, int k, ref Set<OctagonConstraint> result)
+        {
+            result.Add(new OctagonConstraintMinusXMinusY(octagon.DimensionForVar(x), octagon.DimensionForVar(y), k));
+
+            return true;
+        }
+
+
+        protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, int k, ref Set<OctagonConstraint> result)
+        {
+            result.Add(new OctagonConstraintXMinusY(octagon.DimensionForVar(x), octagon.DimensionForVar(y), k));
+
+            return true;
+        }
+
+        protected override bool VisitXYLessEqualThanK(Variable x, Variable y, int k, ref Set<OctagonConstraint> result)
+        {
+            result.Add(new OctagonConstraintXY(octagon.DimensionForVar(x), octagon.DimensionForVar(y), k));
+
+            return true;
+        }
+
+        protected override bool VisitXLessEqualThan(int a, Variable x, int k, ref Set<OctagonConstraint> result)
+        {
+            Contract.Assert(a > 0);
+
+            if (k % a == 0)
+            {
+                result.Add(new OctagonConstraintX(octagon.DimensionForVar(x), (k / Math.Abs(a))));
+                return true;
+            }
+
+            return false;
+        }
+
+
+        protected override bool VisitMinusXLessEqualThan(int a, Variable x, int k, ref Set<OctagonConstraint> result)
+        {
+            Contract.Assert(a < 0);
+
+            if (k % a == 0)
+            {
+                result.Add(new OctagonConstraintMinusX(octagon.DimensionForVar(x), (k / Math.Abs(a))));
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    // This class is just for sharing code, you do not want to use it or give some meaning
+
+    internal class CheckLessThanOrLessEqualThan<Variable, Expression>
+      : TryVisitAtMostTwoMonomialsOfInt<Variable, Expression, OctagonEnvironment<Variable, Expression>, FlatAbstractDomain<bool>>
+    {
+        private OctagonEnvironment<Variable, Expression> octagon;
+
+        public CheckLessThanOrLessEqualThan()
+        {
+            octagon = null;
+        }
+
+        /// <summary>
+        /// Tries to see if <code>exp</code> holds in input.
+        /// If it can figure it out a definite value (true or false), it returns true, and the value will be in <code>result</code>
+        /// </summary>
+
+        public override bool Visit(PolynomialOfInt<Variable, Expression> exp, OctagonEnvironment<Variable, Expression> input, ref FlatAbstractDomain<bool> result)
+        {
+            octagon = input;
+
+            if (octagon.IsEmpty)
+            {
+                result = CheckOutcome.Top; // In theory the client should not access this value
+                return false;
+            }
+
+            bool success = this.Dispatch(exp, ref result);
+
+            octagon = null;
+
+            return success;
+        }
+
+        protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, int k, ref FlatAbstractDomain<bool> result)
+        {
+            Rational val;
+            if (octagon.TryConstantForMinusXMinusY(x, y, out val))
+            {
+                result = val <= k ? CheckOutcome.True : CheckOutcome.Top;
+                return true;
+            }
+            else
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+        }
+
+
+        protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, int k, ref FlatAbstractDomain<bool> result)
+        {
+            Rational val;
+            if (octagon.TryConstantForXMinusY(x, y, out val))
+            {
+                result = val <= k ? CheckOutcome.True : CheckOutcome.Top;
+                return true;
+            }
+            else
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+        }
+
+        protected override bool VisitXYLessEqualThanK(Variable x, Variable y, int k, ref FlatAbstractDomain<bool> result)
+        {
+            Rational val;
+            if (octagon.TryConstantForXY(x, y, out val))
+            {
+                result = val <= k ? CheckOutcome.True : CheckOutcome.Top;
+                return true;
+            }
+            else
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+        }
+
+
+        protected override bool VisitXLessEqualThan(int a, Variable x, int k, ref FlatAbstractDomain<bool> result)
+        {
+            Rational val;
+            if (octagon.TryConstantForX(x, out val))
+            {
+                result = val <= (k / a) ? CheckOutcome.True : CheckOutcome.Top;
+                return true;
+            }
+            else
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+        }
+
+        protected override bool VisitMinusXLessEqualThan(int a, Variable x, int k, ref FlatAbstractDomain<bool> result)
+        {
+            Rational val;
+            if (octagon.TryConstantForMinusX(x, out val))
+            {
+                result = val <= -(k / a) ? CheckOutcome.True : CheckOutcome.Top;
+                return true;
+            }
+            else
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+        }
     }
     #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.expManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-  }
-
-  #region Visitors for the guards (TestTrue, TestFalse, CheckIfHolds)
-
-  class OctagonsTrueTestVisitor<Variable, Expression>
-  : TestTrueVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
-  {
-    public OctagonsTrueTestVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    {
-    }
-
-
-    public override OctagonEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-
-    {
-      return data.TestTrueEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueLessEqualThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueLessThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueNotEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data;
-    }
-  }
-
-
-  class OctagonsTrueTestNotRefiningVisitor<Variable, Expression>
-  : TestTrueVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
-  {
-    public OctagonsTrueTestNotRefiningVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    {
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitAnd(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {     
-      var isLeftAVar = this.Decoder.IsVariable(left);
-      var isLeftAConst = this.Decoder.IsConstant(left);
-      var isRightAVar = this.Decoder.IsVariable(right);
-      var isRightAConst = this.Decoder.IsConstant(right);
-
-      if ((isLeftAVar && isRightAConst) || (isLeftAConst && isRightAVar))
-      {
-        //this.result = data;
-        return data;
-      }
-      else
-      {
-        var oct = (OctagonEnvironment<Variable, Expression>)data.Clone();
-
-        oct = oct.TestTrueNotRefining(left);
-        oct = oct.TestTrueNotRefining(right);
-
-        return oct;
-      }
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueEqualNotRefininingLeftArguments(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueLessEqualThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueLessThan(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueNotEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitVariable(Variable var, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data;
-    }
-  }
-
-  class OctagonsFalseTestVisitor<Variable, Expression>
-    : TestFalseVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
-  {
-    public OctagonsFalseTestVisitor(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
-      : base(decoder)
-    { }
-
-    public override OctagonEnvironment<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueNotEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data.TestTrueEqual(this.Decoder.Stripped(left), this.Decoder.Stripped(right));
-    }
-
-    public override OctagonEnvironment<Variable, Expression> VisitVariable(Variable variable, Expression original, OctagonEnvironment<Variable, Expression> data)
-    {
-      return data;
-    }
-  }
-
-  class OctagonsCheckIfHoldsVisitor<Variable, Expression>
-    : CheckIfHoldsVisitor<OctagonEnvironment<Variable, Expression>, Variable, Expression>
-  {
-    public OctagonsCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    {
-    }
-
-    public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      var resultLeft = Domain.CheckIfLessEqualThan(left, right);
-      
-      if (!resultLeft.IsBottom && !resultLeft.IsTop)
-      {
-        var resultRight = Domain.CheckIfLessEqualThan(right, left);
-
-        if (!resultRight.IsBottom && !resultRight.IsTop)
-        {
-          return resultLeft.Meet(resultRight);
-        }
-        else
-        {
-          return resultRight;
-        }
-      }
-      else
-      {
-        return resultLeft;
-      }
-    }
-
-    public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return VisitEqual(left, right, original, data);
-    }
-
-    public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return Domain.CheckIfLessEqualThan(left, right);
-    }
-
-    public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return Domain.CheckIfLessThan(left, right);
-    }
-
-    public override FlatAbstractDomain<bool> VisitVariable(Variable variable, Expression original, FlatAbstractDomain<bool> data)
-    {
-      var intv = this.Domain.BoundsFor(variable);
-
-      if (intv.IsBottom)
-        return CheckOutcome.Bottom;
-
-      if (intv.IsTop)
-        return CheckOutcome.Top;
-
-      Rational v;
-      if (intv.TryGetSingletonValue(out v))
-      {
-        return v.IsZero ? CheckOutcome.False : CheckOutcome.True;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-  }
-  #endregion
-
-  #region Visitor for Inferring Octagon Constraints
-
-
-  abstract class TryVisitAtMostTwoMonomialsOfInt<Variable, Expression, In, Data>
-  {
-    /// <summary>
-    /// We want it to be used by the subclasses, but not called from clients
-    /// </summary>
-
-    protected bool Dispatch(PolynomialOfInt<Variable, Expression> exp, ref Data result)
-    {
-      Variable x, y;
-      int a, b, k;
-
-      if(PolynomialOfIntHelper.Match_k1XLessEqualThank2(exp, out a, out x, out k))
-      { // a * x <= k
-        if (a < 0)
-        {
-          return this.VisitMinusXLessEqualThan(a, x, k, ref result);
-        }
-        else if (a > 0)
-        {
-          return this.VisitXLessEqualThan(a, x, k, ref result);
-        }
-        else // a == 0
-        {
-          return Default(ref result);
-        }
-      }
-      else if(PolynomialOfIntHelper.Match_k1XLessThank2(exp, out a, out x, out k))
-      { // "a * x < k " == "a * x  <= k-1"
-        if (a < 0)
-        {
-          return this.VisitMinusXLessEqualThan(a, x, k - 1, ref result);
-        }
-        else if (a > 0)
-        {
-          return this.VisitXLessEqualThan(a, x, k - 1, ref result);
-        }
-        else
-        {
-          return Default(ref result);
-        }
-      }
-      else if(PolynomialOfIntHelper.Match_k1XPlusk2YLessEqualThanK(exp, out a, out x, out b, out y, out k))
-      { // "a * x + b * y <= k" 
-        if (a == 1 && b == 1)
-        {
-          return VisitXYLessEqualThanK(x, y, k, ref result);
-        }
-        else if (a == 1 && b == -1)
-        {
-          return this.VisitXMinusYLessEqualThan(x, y, k, ref result);
-        }
-        else if (a == -1 && b == 1)
-        {
-          return this.VisitXMinusYLessEqualThan(y, x, k, ref result);
-        }
-        else if(a== -1 && b == -1)
-        {
-          return this.VisitMinusXMinusYLessEqualThan(x, y, k, ref result);
-        }
-        else 
-        {
-          // Todo: Do we want a visitor for other cases here?
-          return Default(ref result);
-        }
-      }
-      else if(PolynomialOfIntHelper.Match_k1XPlusk2YLessThanK(exp, out a, out x, out b, out y, out k))
-      { // "a * x + b * y < k" is "a * x + b * y <=  k-1"
-        if (a == 1 && b == 1)
-        {
-          return this.VisitXYLessEqualThanK(x, y, k - 1, ref result);
-        }
-        else if (a == 1 && b == -1)
-        {
-          return this.VisitXMinusYLessEqualThan(x, y, k - 1, ref result);
-        }
-        else if (a == -1 && b == 1)
-        {
-          return this.VisitXMinusYLessEqualThan(y, x, k - 1, ref result);
-        }
-        else if (a == -1 && b == -1)
-        {
-          return this.VisitMinusXMinusYLessEqualThan(x, y, k - 1, ref result);
-        }
-        else
-        {
-          // Todo: Do we want a visitor for other cases here?
-          return Default(ref result);
-        }
-      }
-      else
-      {
-        return Default(ref result);
-      }
-    }
-
-    abstract public bool Visit(PolynomialOfInt<Variable, Expression> exp, In input, ref Data result);
-
-    abstract protected bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, int k, ref Data result);
-
-    abstract protected bool VisitXMinusYLessEqualThan(Variable x, Variable y, int k, ref Data result);
-
-    abstract protected bool VisitXYLessEqualThanK(Variable x, Variable y, int k, ref Data result);
-
-    abstract protected bool VisitXLessEqualThan(int a, Variable x, int k, ref Data result);
-
-    abstract protected bool VisitMinusXLessEqualThan(int a, Variable x, int k, ref Data result);
-
-
-    private bool Default(ref Data result)
-    {
-      return false;
-    }
-  }
-
-
-  class InferOctagonConstraints<Variable, Expression>
-    : TryVisitAtMostTwoMonomialsOfInt<Variable, Expression, OctagonEnvironment<Variable, Expression>, Set<OctagonConstraint>>
-
-  {
-    private OctagonEnvironment<Variable, Expression> octagon;
-
-    public InferOctagonConstraints()
-    {
-      this.octagon = null;
-    }
-
-    public override bool Visit(PolynomialOfInt<Variable, Expression> exp, OctagonEnvironment<Variable, Expression> input, ref Set<OctagonConstraint> result)
-
-    {
-      this.octagon = input;
-
-      bool ok = this.Dispatch(exp, ref result);
-
-      this.octagon = null;
-
-      return ok;
-    }
-
-
-    protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, int k, ref Set<OctagonConstraint> result)
-    {
-      result.Add(new OctagonConstraintMinusXMinusY(this.octagon.DimensionForVar(x), this.octagon.DimensionForVar(y), k));
-
-      return true;
-    }
-
-
-    protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, int k, ref Set<OctagonConstraint> result)
-    {
-      result.Add(new OctagonConstraintXMinusY(this.octagon.DimensionForVar(x), this.octagon.DimensionForVar(y), k));
-
-      return true;
-    }
-
-    protected override bool VisitXYLessEqualThanK(Variable x, Variable y, int k, ref Set<OctagonConstraint> result)
-    {
-      result.Add(new OctagonConstraintXY(this.octagon.DimensionForVar(x), this.octagon.DimensionForVar(y), k));
-
-      return true;
-    }
-
-    protected override bool VisitXLessEqualThan(int a, Variable x, int k, ref Set<OctagonConstraint> result)
-    {
-      Contract.Assert(a > 0);
-
-      if (k % a == 0)
-      {
-        result.Add(new OctagonConstraintX(this.octagon.DimensionForVar(x), (k / Math.Abs(a))));
-        return true;
-      }
-
-      return false;
-    }
-
-
-    protected override bool VisitMinusXLessEqualThan(int a, Variable x, int k, ref Set<OctagonConstraint> result)
-    {
-      Contract.Assert(a < 0);
-
-      if (k % a == 0)
-      {
-        result.Add(new OctagonConstraintMinusX(this.octagon.DimensionForVar(x), (k / Math.Abs(a))));
-
-        return true;
-      }
-
-      return false;
-    }
-  }
-
-  // This class is just for sharing code, you do not want to use it or give some meaning
-
-  class CheckLessThanOrLessEqualThan<Variable, Expression>
-    : TryVisitAtMostTwoMonomialsOfInt<Variable, Expression, OctagonEnvironment<Variable, Expression>, FlatAbstractDomain<bool>>
-  {
-    private OctagonEnvironment<Variable, Expression> octagon;
-
-    public CheckLessThanOrLessEqualThan()
-    {
-      this.octagon = null;
-    }
-
-    /// <summary>
-    /// Tries to see if <code>exp</code> holds in input.
-    /// If it can figure it out a definite value (true or false), it returns true, and the value will be in <code>result</code>
-    /// </summary>
-
-    public override bool Visit(PolynomialOfInt<Variable, Expression> exp, OctagonEnvironment<Variable, Expression> input, ref FlatAbstractDomain<bool> result)
-    {
-      this.octagon = input;
-
-      if (this.octagon.IsEmpty)
-      {
-        result = CheckOutcome.Top; // In theory the client should not access this value
-        return false;
-      }
-
-      bool success = this.Dispatch(exp, ref result);
-
-      this.octagon = null;
-
-      return success;
-    }
-
-    protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, int k, ref FlatAbstractDomain<bool> result)
-    {
-      Rational val;
-      if (this.octagon.TryConstantForMinusXMinusY(x, y, out val))
-      {
-        result = val <= k ? CheckOutcome.True: CheckOutcome.Top;
-        return true;
-      }
-      else
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-    }
-
-
-    protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, int k, ref FlatAbstractDomain<bool> result)
-    {
-      Rational val;
-      if (this.octagon.TryConstantForXMinusY(x, y, out val))
-      {
-        result = val <= k ? CheckOutcome.True : CheckOutcome.Top;
-        return true;
-      }
-      else
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-    }
-
-    protected override bool VisitXYLessEqualThanK(Variable x, Variable y, int k, ref FlatAbstractDomain<bool> result)
-    {
-      Rational val;
-      if (this.octagon.TryConstantForXY(x, y, out val))
-      {
-        result = val <= k ? CheckOutcome.True : CheckOutcome.Top;
-        return true;
-      }
-      else
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-    }
-
-
-    protected override bool VisitXLessEqualThan(int a, Variable x, int k, ref FlatAbstractDomain<bool> result)
-    {
-      Rational val;
-      if (this.octagon.TryConstantForX(x, out val))
-      {
-        result = val <= (k/a) ? CheckOutcome.True : CheckOutcome.Top;
-        return true;
-      }
-      else
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-    }
-
-    protected override bool VisitMinusXLessEqualThan(int a, Variable x, int k, ref FlatAbstractDomain<bool> result)
-    {
-      Rational val;
-      if (this.octagon.TryConstantForMinusX(x, out val))
-      {
-        result = val <= -(k/a)? CheckOutcome.True : CheckOutcome.Top;
-        return true;
-      }
-      else
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-    }
-  }
-  #endregion
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Octagons/Octagons.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Octagons/Octagons.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation of Octagons. 
 // There are two classes: CoreOctagon that is the plain octagon domain and OctagonEnvironment that is the generic one for the analysis
@@ -24,7 +13,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;   
+using System.Diagnostics;
 using System.Text;
 using Microsoft.Research.DataStructures;
 using Microsoft.Research.AbstractDomains.Expressions;
@@ -33,915 +22,913 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// The Core implementation of the Octagons abstract domain 
-  /// F: I decupled the implementation of CoreOctagon from OctagonEnvironment to simplify the code, which otheriwse would have
-  /// caused a "too big" class
-  /// </summary>
-  public abstract class CoreOctagon 
-  {
-    #region Const
-    protected const string STR_FOR_DIMENSION = "d";
-    protected const int DimensionGrowthStep = 4;        // The dimensions to be added at each step in which the octagon is enlarged
-    #endregion
-
-    #region Constants used by the octagon
-    internal protected enum OctagonState { EMPTY, NORMAL, CLOSED, BOTTOM }
-    #endregion
-
-    #region Getters for Profile informations
-
-#if  TRACE_AD_PERFORMANCES
-    public static TimeSpan TimeSpentInDuplicate
-    {
-      get
-      {
-        return timeSpentInDuplicate;
-      }
-    }
-
-    public static TimeSpan TimeSpentInDoClousure
-    {
-      get
-      {
-        return timeSpentInDoClosure;
-      }
-    }
-
-    public static TimeSpan TimeSpentInDomainOperations
-    {
-      get
-      {
-        return timeSpentInDomainOperations;
-      }
-    }
-
-    public static TimeSpan TimeSpentInAssignments
-    {
-      get
-      {
-        return timeSpentInAssignments;
-      }
-    }
-
-    public static long CountDoClosureInvocations
-    {
-      get
-      {
-        return countDoClosureInvocations;
-      }
-    }
-
-    public static long CountDomainOperationsInvocations
-    {
-      get
-      {
-        return countDomainOperationsInvocations;
-      }
-    }
-
-#endif
-
-    virtual public string Statistics
-    {
-      get
-      {
-        StringBuilder output = new StringBuilder();
-#if  TRACE_AD_PERFORMANCES
-        output.AppendLine("# of closure invocations              : " + CountDoClosureInvocations);
-        output.AppendLine("# of domain operation invocations     : " + CountDomainOperationsInvocations);
-        output.AppendLine("Time spent in closing the octagon     : " + TimeSpentInDoClousure.ToString());
-        output.AppendLine("Time spent in duplicating the octagon : " + TimeSpentInDuplicate.ToString());
-        output.AppendLine("Time spent in doing the octassignment : " + timeSpentInAssignments.ToString());
-        output.AppendLine("Time spent in LessEq/Join/Widen/Meet  : " + TimeSpentInDomainOperations.ToString());
-#endif
-        return output.ToString();
-      }
-    }
-
-    [Conditional("TRACE_AD_PERFORMANCES")]
-    protected  void AddTimeElapsedFromStart(string msg, ref TimeSpan counter, TimeSpan elapsed)
-    {
-      counter += elapsed;
-
-      //Log("{0}, {1} total time", msg, timeSpentInDoClosure.ToString());
-    }
-
-    [Conditional("TRACE_AD_PERFORMANCES")]
-    protected static void Increase(ref long value)
-    {
-      value++;
-    }
-
-    #endregion
-
-    #region Private fields: CoreOctagon State Variables
-
-#if  TRACE_AD_PERFORMANCES
-    // Begin Profiling variables
-    private static TimeSpan timeSpentInDuplicate = new TimeSpan(0);				          // The time spent for duplicating an octagon
-    private static TimeSpan timeSpentInDoClosure = new TimeSpan(0);                 // The time spent for closing the octagons
-    protected static TimeSpan timeSpentInDomainOperations = new TimeSpan(0);        // The time spent for doing Join, Meet and Widenings
-    protected static TimeSpan timeSpentInAssignments = new TimeSpan(0);             // The time spent in doing the assignments in the octagon
-    private static long countDoClosureInvocations = 0;			                          // Count how many times we invoked DoClosure
-    protected static long countDomainOperationsInvocations = 0;                      // Count how many times we invoker the LessEqual/Join/Meet/Widening
-    // End Profiling variables
-#endif
-
-    private int bottomDimension = -1;                       // Helper that tell us, in the Closure, which index is bottom
-
-    protected Set<int> availableDimensions;			            // The set of unused variables
-    
-    private int dimensions;							                      // The dimensions of the octagon
-
-    internal protected OctagonState state;					          // The state of the octagon
-    
-    internal protected SparseRationalArray octagon;
-
-    // We use the optimization of allocation a vector of the size that is the double of the required one, so to reduce the overhead in adding new dimensions
-
-    #endregion
-
-    #region Protected (Must override) members
-
-    abstract protected CoreOctagon Factory(int dim);
-
-    abstract protected CoreOctagon Factory(int dim, bool allocateMatrix);
-
-    public abstract object Clone();
-
-    #endregion
-
-    #region Properties about this octagon
     /// <summary>
-    /// The number of dimensions of the octagon
+    /// The Core implementation of the Octagons abstract domain 
+    /// F: I decupled the implementation of CoreOctagon from OctagonEnvironment to simplify the code, which otheriwse would have
+    /// caused a "too big" class
     /// </summary>
-    protected int Dimensions
+    public abstract class CoreOctagon
     {
-      get
-      {
-        return this.dimensions;
-      }
-    }
+        #region Const
+        protected const string STR_FOR_DIMENSION = "d";
+        protected const int DimensionGrowthStep = 4;        // The dimensions to be added at each step in which the octagon is enlarged
+        #endregion
 
-    //^ invariant this.FreeDimensions.Count + this.AllocatedDimensions.Count == this.Dimensions;
+        #region Constants used by the octagon
+        internal protected enum OctagonState { EMPTY, NORMAL, CLOSED, BOTTOM }
+        #endregion
 
-    ///<summary>
-    /// The dimensions not allocated
-    ///</summary>
-    ///<return>A fresh set containing the dimensions that are constrained by this octagon</return>
-    public Set<int> FreeDimensions
-    {
-      get
-      {
-        return new Set<int>(this.availableDimensions);
-      }
-    }
+        #region Getters for Profile informations
 
-    /// <summary>
-    /// The allocated dimensions
-    /// </summary>
-    /// <returns>A fresh set containing the dimensions that are "free"</returns>
-    public Set<int> AllocatedDimensions
-    {
-      get
-      {
-        Set<int> result = new Set<int>();
-        for (int i = 0; i < this.Dimensions; i++)
+#if TRACE_AD_PERFORMANCES
+        public static TimeSpan TimeSpentInDuplicate
         {
-          if (!this.availableDimensions.Contains(i))
-            result.Add(i);
-        }
-        return result;
-      }
-    }
-
-    ///<summary>
-    ///The number of constraints in this octagon
-    ///</summary>
-    public int NumberOfConstraints
-    {
-      get
-      {
-        if (this.state == OctagonState.EMPTY || this.state == OctagonState.BOTTOM)
-          return 0;
-
-        int size = Matsize(this.dimensions);
-        int count = 0;
-
-        for (int i = 0; i < size; i++)
-        {
-          if (!this.octagon[i].IsInfinity)
-          {
-            count++;
-          }
-        }
-
-        return count - 2 * this.dimensions; // remove the 2*n constraints of the form x(i) - x(i) <= 0
-      }
-    }
-
-    ///<summary>
-    /// The octagon is in a closed form?
-    ///</summary>
-    public bool IsClosed
-    {
-      get
-      {
-        return this.state != OctagonState.NORMAL;
-      }
-    }
-
-    ///<summary>
-    /// The octagon is empty?
-    ///</summary>
-    public bool IsEmpty
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    #endregion
-
-    #region Constructors
-    /// <summary>
-    /// Construct an octagon of size n. 
-    /// The constraints are set to +oo, execept for those relating the variables themselves.
-    /// 
-    /// <param name="n"> The number of dimensions of the octagon </param>
-    /// <remarks>It can throw the exception <code>OutOfMemoryException</code>if n is too large</remarks>
-    /// </summary>
-    public CoreOctagon(int n)
-    {
-      this.dimensions = n;
-
-      try
-      {
-        this.octagon = SparseRationalArray.New(Matsize(n), Rational.PlusInfinity);
-      }
-      catch (OutOfMemoryException)
-      {
-        // If we cannot allocate an array of double the size, let's jsut go with the usual one
-        this.octagon = SparseRationalArray.New(Matsize(n), Rational.PlusInfinity);
-      }
-
-      this.availableDimensions = new Set<int>();
-
-      for (int i = 0; i < 2 * n; i++)
-        this.octagon[Matpos(i, i)] = Rational.For(0);
-
-      this.state = OctagonState.CLOSED;
-    }
-
-    /// <summary>
-    /// A private octagon, used by duplicate. It does not allocate space for the new matrix.
-    /// </summary>
-    /// <param name="n">The number of dimensions for the octagon</param>
-    /// <param name="allocateMatrix">Must be fals</param>
-    protected CoreOctagon(int n, bool allocateMatrix)
-    {
-      Contract.Assert(!allocateMatrix, "Error: something is wrong, not supposed to be there...");
-
-      this.dimensions = n;
-      this.state = OctagonState.EMPTY;
-      this.octagon = null;
-      this.availableDimensions = null;
-    }
-
-    ///<summary>
-    /// Creates a copy of the octagon from the parameter.
-    /// The representation of the octagon is shared
-    ///</summary>
-    /// <param name="oct">The source octagon</param>
-    protected CoreOctagon(CoreOctagon oct)
-    {
-      this.dimensions = oct.dimensions;
-      this.state = oct.state;
-      this.octagon = oct.octagon != null? oct.octagon.Duplicate() : null;  // The octagon representation may be null when it is bottom
-      this.availableDimensions = oct.availableDimensions;
-    }
-
-    protected void CloneFromThis(CoreOctagon oct)
-    {
-      this.dimensions = oct.dimensions;
-      this.state = oct.state;
-
-      Contract.Assert(oct.octagon != null || oct.state == OctagonState.BOTTOM, "The octagon should not be null there...");
-
-      this.octagon = oct.octagon;
-
-      this.availableDimensions = oct.availableDimensions;
-    }
-    #endregion
-
-    #region Conversion methods to Intervals
-    ///<summary>
-    /// Get the lower and the upper bounds for a variable
-    ///</summary>
-    ///<param name="dim"> The dimension corresponding to the variable</param>
-    ///<returns>An interval containing the lower and the upper bound for a variable in the octagon</returns>
-    public Interval BoundsFor(int dim)
-    {
-      Contract.Assert(IsAllocatedDimension(dim)); // , "Error: the dimension " + dim + " is not in the octagon");  
-
-      this.DoClosure();		// close the octagon
-
-      if (this.IsBottom)
-      {
-        return Interval.UnknownInterval;
-      }
-
-      Rational lowerBound, upperBound;
-
-      if (!this.octagon[Matpos(2 * dim, 2 * dim + 1)].IsInfinity)
-      {			// -dim <= -v , v != -oo
-        Rational tmp = this.octagon[Matpos(2 * dim, 2 * dim + 1)] / 2;
-        lowerBound = -tmp;
-      }
-      else	// -oo = dim
-      {
-        lowerBound = Rational.MinusInfinity;
-      }
-
-      if (!this.octagon[Matpos(2 * dim + 1, 2 * dim)].IsInfinity)		// dim <= v  , v != +oo
-      {
-        upperBound = this.octagon[Matpos(2 * dim + 1, 2 * dim)] / 2;
-      }
-      else	// dim = +oo
-      {
-        upperBound = Rational.PlusInfinity;
-      }
-
-      return Interval.For(lowerBound, upperBound);
-    }
-
-    #endregion
-
-    #region Implementation for IsBottom and IsTop
-    /// <returns>
-    /// True iff this octagon is empty.
-    /// We may want to override it, so we make it virtual
-    /// </returns>
-    public virtual bool IsBottom
-    {
-      get
-      {
-        return this.state == OctagonState.BOTTOM || this.IsEmpty;
-      }
-    }
-
-    /// <returns>
-    /// True iff all the constraints are +oo
-    /// We may want to override it, so we make it virtual
-    /// </returns>
-    public virtual bool IsTop
-    {
-      get
-      {
-        int n2 = this.dimensions * 2;
-
-        if (this.state == OctagonState.EMPTY)
-        {
-          return true;
-        }
-
-        if (this.state == OctagonState.BOTTOM)
-        {
-          return false;
-        }
-
-        int pos = 0;
-        for (int i = 0; i < n2; i++)
-        {
-          int ii = i | 1;
-          for (int j = 0; j <= ii; j++, pos++)
-          {
-            if (!this.octagon[pos].IsInfinity && i != j)
+            get
             {
-              return false;
+                return timeSpentInDuplicate;
             }
-          }
         }
-        return true;
-      }
-    }
 
-    #endregion
+        public static TimeSpan TimeSpentInDoClousure
+        {
+            get
+            {
+                return timeSpentInDoClosure;
+            }
+        }
 
-    #region Closure, Equivalence, duplication, etc. on octagon
+        public static TimeSpan TimeSpentInDomainOperations
+        {
+            get
+            {
+                return timeSpentInDomainOperations;
+            }
+        }
 
-    ///<summary>
-    /// Check if the given dimension is "allocated"
-    ///</summary>
-    protected bool IsAllocatedDimension(int dimension)
-    {
-      return dimension < this.Dimensions && !this.availableDimensions.Contains(dimension);
-    }
+        public static TimeSpan TimeSpentInAssignments
+        {
+            get
+            {
+                return timeSpentInAssignments;
+            }
+        }
 
-    ///<summary>
-    /// Duplicate the octagon.
-    /// It makes a lazy copy of the octagon.
-    /// The difference with Clone its a more precise return type (<code>CoreOctagon</code>)
-    ///</summary>
-    virtual public CoreOctagon Duplicate()
-    {
-      var watch = new Stopwatch();
-      watch.Start();
+        public static long CountDoClosureInvocations
+        {
+            get
+            {
+                return countDoClosureInvocations;
+            }
+        }
 
-      CoreOctagon octCopy = Factory(this.dimensions, false);
+        public static long CountDomainOperationsInvocations
+        {
+            get
+            {
+                return countDomainOperationsInvocations;
+            }
+        }
 
-      octCopy.state = this.state;
-
-      octCopy.octagon = this.state == OctagonState.BOTTOM? null : this.octagon.Duplicate();
-
-      octCopy.availableDimensions = new Set<int>(this.availableDimensions);
-#if  TRACE_AD_PERFORMANCES
-      AddTimeElapsedFromStart("Duplicate", ref timeSpentInDuplicate, watch.Elapsed);
 #endif
-      return octCopy;
-    }
 
-    ///<summary>
-    /// Close the octagon, by propagating all the constraints.
-    /// The update is in place.
-    ///</summary>
-    ///<remarks>It may set the octagon representation to NULL (when it finds a contraddiction), so, when you use it, you should check if the octagon is not bottom</remarks>
-    public void DoClosure()
-    {
-#if  TRACE_AD_PERFORMANCES
-      Increase(ref countDoClosureInvocations);
+        virtual public string Statistics
+        {
+            get
+            {
+                StringBuilder output = new StringBuilder();
+#if TRACE_AD_PERFORMANCES
+                output.AppendLine("# of closure invocations              : " + CountDoClosureInvocations);
+                output.AppendLine("# of domain operation invocations     : " + CountDomainOperationsInvocations);
+                output.AppendLine("Time spent in closing the octagon     : " + TimeSpentInDoClousure.ToString());
+                output.AppendLine("Time spent in duplicating the octagon : " + TimeSpentInDuplicate.ToString());
+                output.AppendLine("Time spent in doing the octassignment : " + timeSpentInAssignments.ToString());
+                output.AppendLine("Time spent in LessEq/Join/Widen/Meet  : " + TimeSpentInDomainOperations.ToString());
 #endif
-      if (this.state != OctagonState.NORMAL)
-      {
-        return; /* There is nothing to do */
-      }
-
-      var watch = new Stopwatch();
-      watch.Start();
-
-      var n2 = this.dimensions * 2;
-
-      var buf1 = new Rational[n2];
-      var buf2 = new Rational[n2];
-
-      for (int k = 0; k < n2; k += 2)
-      {
-        #region Ck step
-
-        Rational kk1, kk2;
-
-        kk1 = this.octagon[Matpos(k + 1, k)]; // xk + xk
-        kk2 = this.octagon[Matpos(k, k + 1)]; // -xk - xk
-
-        int i;
-        for (i = 0; i <= k; i += 2)
-        {
-          buf1[i] = this.octagon[Matpos(k + 1, i + 1)]; // -xi + xk
-          buf2[i] = this.octagon[Matpos(k, i + 1)];	 // -xi + xk
-          buf1[i + 1] = this.octagon[Matpos(k + 1, i)]; //  xi+xk 
-          buf2[i + 1] = this.octagon[Matpos(k, i)]; //  xi-xk 
+                return output.ToString();
+            }
         }
 
-        for (; i < n2; i += 2)
+        [Conditional("TRACE_AD_PERFORMANCES")]
+        protected void AddTimeElapsedFromStart(string msg, ref TimeSpan counter, TimeSpan elapsed)
         {
-          buf1[i] = this.octagon[Matpos(i, k)]; /*  xk-xi */
-          buf2[i] = this.octagon[Matpos(i, k + 1)]; /* -xk-xi */
-          buf1[i + 1] = this.octagon[Matpos(i + 1, k)]; /*  xk+xi */
-          buf2[i + 1] = this.octagon[Matpos(i + 1, k + 1)]; /* -xk+xi */
+            counter += elapsed;
+
+            //Log("{0}, {1} total time", msg, timeSpentInDoClosure.ToString());
         }
 
-        int count_d;
-        for (i = 0, count_d = 0; i < n2; i++)
+        [Conditional("TRACE_AD_PERFORMANCES")]
+        protected static void Increase(ref long value)
         {
-          var ii = i | 1;
-
-          for (int j = 0; j <= ii; j++, count_d++)
-          {
-            int jj = j ^ 1;
-            
-            var ij1 = Add(buf1[i], buf2[jj]);
-            var ij2 = Add3(buf2[i], kk1, buf2[jj]);
-            var ij3 = Add(buf2[i],buf1[jj]);
-            var ij4 = Add3(buf1[i], kk2, buf1[jj]);
-
-            ij1 = Rational.Min(Rational.Min(ij1, ij2), Rational.Min(ij3, ij4));
-
-            // this.octagon[count_d] = Rational.Min(this.octagon[count_d], ij1);
-
-            DebugSet(count_d, Rational.Min(this.octagon[count_d], ij1));
-          }
+            value++;
         }
+
         #endregion
 
-        count_d = 0;
+        #region Private fields: CoreOctagon State Variables
 
-        #region  S Step
+#if TRACE_AD_PERFORMANCES
+        // Begin Profiling variables
+        private static TimeSpan timeSpentInDuplicate = new TimeSpan(0);                       // The time spent for duplicating an octagon
+        private static TimeSpan timeSpentInDoClosure = new TimeSpan(0);                 // The time spent for closing the octagons
+        protected static TimeSpan timeSpentInDomainOperations = new TimeSpan(0);        // The time spent for doing Join, Meet and Widenings
+        protected static TimeSpan timeSpentInAssignments = new TimeSpan(0);             // The time spent in doing the assignments in the octagon
+        private static long countDoClosureInvocations = 0;                                    // Count how many times we invoked DoClosure
+        protected static long countDomainOperationsInvocations = 0;                      // Count how many times we invoker the LessEqual/Join/Meet/Widening
+                                                                                         // End Profiling variables
+#endif
 
-        for (i = 0; i < n2; i += 2)
-        {
-          buf1[i] = this.octagon[Matpos(i + 1, i)] /2 ; 	/* ( xi+xi)/2 */
-          buf1[i + 1] = this.octagon[Matpos(i, i + 1)] /2; 	/* (-xi-xi)/2 */
-        }
+        private int bottomDimension = -1;                       // Helper that tell us, in the Closure, which index is bottom
 
-        for (i = 0; i < n2; i++)
-        {
-          var ii = i | 1;
-          var ii2 = i ^ 1;
-          for (int j = 0; j <= ii; j++, count_d++)
-          {
-            var ij1 = Add(buf1[j], buf1[ii2]);
-            //this.octagon[count_d] = Rational.Min(this.octagon[count_d], ij1);
+        protected Set<int> availableDimensions;                     // The set of unused variables
 
-            DebugSet(count_d, Rational.Min(this.octagon[count_d], ij1));
-          }
-        }
+        private int dimensions;                                               // The dimensions of the octagon
+
+        internal protected OctagonState state;                            // The state of the octagon
+
+        internal protected SparseRationalArray octagon;
+
+        // We use the optimization of allocation a vector of the size that is the double of the required one, so to reduce the overhead in adding new dimensions
+
         #endregion
 
-        #region Emptyness checking
-        for (i = 0; i < n2; i += 2)
+        #region Protected (Must override) members
+
+        abstract protected CoreOctagon Factory(int dim);
+
+        abstract protected CoreOctagon Factory(int dim, bool allocateMatrix);
+
+        public abstract object Clone();
+
+        #endregion
+
+        #region Properties about this octagon
+        /// <summary>
+        /// The number of dimensions of the octagon
+        /// </summary>
+        protected int Dimensions
         {
-          if (this.octagon[Matpos(i, i)] < 0)
-          {
-            this.state = OctagonState.BOTTOM;
+            get
+            {
+                return dimensions;
+            }
+        }
+
+        //^ invariant this.FreeDimensions.Count + this.AllocatedDimensions.Count == this.Dimensions;
+
+        ///<summary>
+        /// The dimensions not allocated
+        ///</summary>
+        ///<return>A fresh set containing the dimensions that are constrained by this octagon</return>
+        public Set<int> FreeDimensions
+        {
+            get
+            {
+                return new Set<int>(this.availableDimensions);
+            }
+        }
+
+        /// <summary>
+        /// The allocated dimensions
+        /// </summary>
+        /// <returns>A fresh set containing the dimensions that are "free"</returns>
+        public Set<int> AllocatedDimensions
+        {
+            get
+            {
+                Set<int> result = new Set<int>();
+                for (int i = 0; i < this.Dimensions; i++)
+                {
+                    if (!this.availableDimensions.Contains(i))
+                        result.Add(i);
+                }
+                return result;
+            }
+        }
+
+        ///<summary>
+        ///The number of constraints in this octagon
+        ///</summary>
+        public int NumberOfConstraints
+        {
+            get
+            {
+                if (this.state == OctagonState.EMPTY || this.state == OctagonState.BOTTOM)
+                    return 0;
+
+                int size = Matsize(dimensions);
+                int count = 0;
+
+                for (int i = 0; i < size; i++)
+                {
+                    if (!this.octagon[i].IsInfinity)
+                    {
+                        count++;
+                    }
+                }
+
+                return count - 2 * dimensions; // remove the 2*n constraints of the form x(i) - x(i) <= 0
+            }
+        }
+
+        ///<summary>
+        /// The octagon is in a closed form?
+        ///</summary>
+        public bool IsClosed
+        {
+            get
+            {
+                return this.state != OctagonState.NORMAL;
+            }
+        }
+
+        ///<summary>
+        /// The octagon is empty?
+        ///</summary>
+        public bool IsEmpty
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Construct an octagon of size n. 
+        /// The constraints are set to +oo, execept for those relating the variables themselves.
+        /// 
+        /// <param name="n"> The number of dimensions of the octagon </param>
+        /// <remarks>It can throw the exception <code>OutOfMemoryException</code>if n is too large</remarks>
+        /// </summary>
+        public CoreOctagon(int n)
+        {
+            dimensions = n;
+
+            try
+            {
+                this.octagon = SparseRationalArray.New(Matsize(n), Rational.PlusInfinity);
+            }
+            catch (OutOfMemoryException)
+            {
+                // If we cannot allocate an array of double the size, let's jsut go with the usual one
+                this.octagon = SparseRationalArray.New(Matsize(n), Rational.PlusInfinity);
+            }
+
+            this.availableDimensions = new Set<int>();
+
+            for (int i = 0; i < 2 * n; i++)
+                this.octagon[Matpos(i, i)] = Rational.For(0);
+
+            this.state = OctagonState.CLOSED;
+        }
+
+        /// <summary>
+        /// A private octagon, used by duplicate. It does not allocate space for the new matrix.
+        /// </summary>
+        /// <param name="n">The number of dimensions for the octagon</param>
+        /// <param name="allocateMatrix">Must be fals</param>
+        protected CoreOctagon(int n, bool allocateMatrix)
+        {
+            Contract.Assert(!allocateMatrix, "Error: something is wrong, not supposed to be there...");
+
+            dimensions = n;
+            this.state = OctagonState.EMPTY;
             this.octagon = null;
-            this.bottomDimension = i;
-#if  TRACE_AD_PERFORMANCES
-            AddTimeElapsedFromStart("Closure", ref timeSpentInDoClosure, start);
-#endif
-            return;
-          }
+            this.availableDimensions = null;
+        }
+
+        ///<summary>
+        /// Creates a copy of the octagon from the parameter.
+        /// The representation of the octagon is shared
+        ///</summary>
+        /// <param name="oct">The source octagon</param>
+        protected CoreOctagon(CoreOctagon oct)
+        {
+            dimensions = oct.dimensions;
+            this.state = oct.state;
+            this.octagon = oct.octagon != null ? oct.octagon.Duplicate() : null;  // The octagon representation may be null when it is bottom
+            this.availableDimensions = oct.availableDimensions;
+        }
+
+        protected void CloneFromThis(CoreOctagon oct)
+        {
+            dimensions = oct.dimensions;
+            this.state = oct.state;
+
+            Contract.Assert(oct.octagon != null || oct.state == OctagonState.BOTTOM, "The octagon should not be null there...");
+
+            this.octagon = oct.octagon;
+
+            this.availableDimensions = oct.availableDimensions;
         }
         #endregion
 
-        this.state = OctagonState.CLOSED;
-      }
+        #region Conversion methods to Intervals
+        ///<summary>
+        /// Get the lower and the upper bounds for a variable
+        ///</summary>
+        ///<param name="dim"> The dimension corresponding to the variable</param>
+        ///<returns>An interval containing the lower and the upper bound for a variable in the octagon</returns>
+        public Interval BoundsFor(int dim)
+        {
+            Contract.Assert(IsAllocatedDimension(dim)); // , "Error: the dimension " + dim + " is not in the octagon");  
 
+            this.DoClosure();       // close the octagon
 
-#if  TRACE_AD_PERFORMANCES
-      AddTimeElapsedFromStart(string.Format("Closure done in {0} ({1} variables)", watch.Elapsed, this.Dimensions), ref timeSpentInDoClosure, start);
+            if (this.IsBottom)
+            {
+                return Interval.UnknownInterval;
+            }
+
+            Rational lowerBound, upperBound;
+
+            if (!this.octagon[Matpos(2 * dim, 2 * dim + 1)].IsInfinity)
+            {           // -dim <= -v , v != -oo
+                Rational tmp = this.octagon[Matpos(2 * dim, 2 * dim + 1)] / 2;
+                lowerBound = -tmp;
+            }
+            else    // -oo = dim
+            {
+                lowerBound = Rational.MinusInfinity;
+            }
+
+            if (!this.octagon[Matpos(2 * dim + 1, 2 * dim)].IsInfinity)     // dim <= v  , v != +oo
+            {
+                upperBound = this.octagon[Matpos(2 * dim + 1, 2 * dim)] / 2;
+            }
+            else    // dim = +oo
+            {
+                upperBound = Rational.PlusInfinity;
+            }
+
+            return Interval.For(lowerBound, upperBound);
+        }
+
+        #endregion
+
+        #region Implementation for IsBottom and IsTop
+        /// <returns>
+        /// True iff this octagon is empty.
+        /// We may want to override it, so we make it virtual
+        /// </returns>
+        public virtual bool IsBottom
+        {
+            get
+            {
+                return this.state == OctagonState.BOTTOM || this.IsEmpty;
+            }
+        }
+
+        /// <returns>
+        /// True iff all the constraints are +oo
+        /// We may want to override it, so we make it virtual
+        /// </returns>
+        public virtual bool IsTop
+        {
+            get
+            {
+                int n2 = dimensions * 2;
+
+                if (this.state == OctagonState.EMPTY)
+                {
+                    return true;
+                }
+
+                if (this.state == OctagonState.BOTTOM)
+                {
+                    return false;
+                }
+
+                int pos = 0;
+                for (int i = 0; i < n2; i++)
+                {
+                    int ii = i | 1;
+                    for (int j = 0; j <= ii; j++, pos++)
+                    {
+                        if (!this.octagon[pos].IsInfinity && i != j)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+
+        #endregion
+
+        #region Closure, Equivalence, duplication, etc. on octagon
+
+        ///<summary>
+        /// Check if the given dimension is "allocated"
+        ///</summary>
+        protected bool IsAllocatedDimension(int dimension)
+        {
+            return dimension < this.Dimensions && !this.availableDimensions.Contains(dimension);
+        }
+
+        ///<summary>
+        /// Duplicate the octagon.
+        /// It makes a lazy copy of the octagon.
+        /// The difference with Clone its a more precise return type (<code>CoreOctagon</code>)
+        ///</summary>
+        virtual public CoreOctagon Duplicate()
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            CoreOctagon octCopy = Factory(dimensions, false);
+
+            octCopy.state = this.state;
+
+            octCopy.octagon = this.state == OctagonState.BOTTOM ? null : this.octagon.Duplicate();
+
+            octCopy.availableDimensions = new Set<int>(this.availableDimensions);
+#if TRACE_AD_PERFORMANCES
+            AddTimeElapsedFromStart("Duplicate", ref timeSpentInDuplicate, watch.Elapsed);
 #endif
-      }
-
-    private void DebugSet(int where, Rational val)
-    {
-      this.octagon[where] = val;
-    }
-
-    /// <summary>
-    /// Debugging info: Which is the i such that this.octagon[Matpos(i, i)] \lt 0 ?
-    /// </summary>
-    public int WhyBottom
-    {
-      get
-      {
-        return this.bottomDimension;
-      }
-    }
-
-    private static Rational Add(Rational x, Rational y)
-    {
-      try
-      {
-        return x + y;
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return Rational.PlusInfinity;
-      }
-    }
-
-    private static Rational Add3(Rational x, Rational y, Rational z)
-    {
-      try
-      {
-        return x + y + z;
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return Rational.PlusInfinity;
-      }
-    }
-
-    #endregion
-
-    #region Transfer functions (projection, add a constraint, etc.)
-
-    ///<summary>
-    ///Project out a variable from the constraints (set it to top).
-    ///The resulting octagon is then closed
-    ///</summary>
-    ///<param name="k">The dimension addociated to the variable to be projected</param>
-    protected void ProjectDimension(int k)
-    {
-      Contract.Requires(k <= this.Dimensions, "Error: Trying to remove a variable not in the octagon");
-
-      int k2 = 2 * k;
-      int n2 = 2 * this.dimensions;
-
-      this.DoClosure();
-
-      if (this.state == OctagonState.BOTTOM || this.state == OctagonState.EMPTY)
-      {
-        return;
-      }
-
-      // Change the result matrix 
-      for (var i = 0; i < k2; i++)
-      {
-        this.octagon[Matpos(k2, i)] = Rational.PlusInfinity;
-        this.octagon[Matpos(k2 + 1, i)] = Rational.PlusInfinity;
-      }
-
-      for (var i = k2 + 2; i < n2; i++)
-      {
-        this.octagon[Matpos(i, k2)] = Rational.PlusInfinity;
-        this.octagon[Matpos(i, k2 + 1)] = Rational.PlusInfinity;
-      }
-
-      this.octagon[Matpos(k2, k2 + 1)] = Rational.PlusInfinity;
-      this.octagon[Matpos(k2 + 1, k2)] = Rational.PlusInfinity;
-    }
-
-    ///<summary>
-    /// Remove a variable from the octagon
-    ///</summary>
-    ///<param name="dim">The dimension addociated to the variable to be projected</param>
-    public void RemoveDimension(int dim)
-    {
-      this.ProjectDimension(dim);
-      this.availableDimensions.Add(dim);		// Remember the removed varaible
-    }
-
-    ///<summary>
-    /// Add a constraint to this octagon.
-    /// If the octagon is Bottom, it's a nop
-    ///</summary>
-    virtual public void AddConstraint(OctagonConstraint constraint)
-    {
-      Contract.Assert(this.state == OctagonState.BOTTOM || constraint.X <= this.dimensions);
-
-      if (this.state != OctagonState.BOTTOM)
-      {
-        bool hasChanged = constraint.AddToOctagon(this);
-
-        if (hasChanged)
-        {
-          this.state = OctagonState.NORMAL;
-        }
-      }
-    }
-
-    /// <summary>
-    /// Add a set of constraints to this octagon
-    /// </summary>
-    /// <param name="constraints">The constraints to add</param>
-    /// <returns>The affected dimensions </returns>
-    public IMutableSet<int> AddConstraints(IMutableSet<OctagonConstraint> constraints)
-    {
-      bool hasChanged = false;
-
-      if (this.state == OctagonState.BOTTOM)
-        return new Set<int>();
-
-      var affectedDimensions = new Set<int>();
-
-      foreach (var cons in constraints)
-      {
-        Contract.Assert(cons.X <= this.dimensions);//, "Error: Variable index greater than the dimensions of the octagon");
-
-        hasChanged = cons.AddToOctagon(this, affectedDimensions) || hasChanged;
-      }
-      // Improve: Use DoIncrementalClosure for closing the octagon if just one constraint has changed
-
-      if (hasChanged && this.state != OctagonState.BOTTOM)	// The CoreOctagon is no more in the closed form
-      {
-        this.state = OctagonState.NORMAL;
-      }
-
-      return affectedDimensions;
-    }
-
-    ///<summary>
-    /// Use this function to get a new dimension in the octagon, that can be associated with a memory address.
-    /// If no dimension is available, then the octagon is enlarged, with n new dimensions (n is specified by DimensionGrowthStep)
-    /// The returned dimensions is removed from the set of available locations
-    ///</summary>
-    ///<returns>A non-zero integer index of an available dimension, otherwise a negative number</returns>
-    public int GetAvailableDimension()
-    {
-      if (this.availableDimensions.IsEmpty)
-      {
-        // No variable is left
-        this.AddDimensions(DimensionGrowthStep);    // Add a new variable
-        return this.GetAvailableDimension(); 	      // return a fresh variable
-      }
-      else
-      {
-        // Return a "free" dimension in the octagon                
-
-        int i = this.availableDimensions.PickAnElement();
-        this.availableDimensions.Remove(i);
-
-        return i;
-      }
-    }
-
-    ///<summary>
-    /// Add new dimensions to this octagon, without any constraint. 
-    ///</summary>
-    public void AddDimensions(int newDimensions)
-    {
-      int n1 = Matsize(this.dimensions);
-      int n2 = Matsize(this.dimensions + newDimensions);
-
-      if (this.state != OctagonState.BOTTOM)
-      {
-        SparseRationalArray newOctagon; 
-
-        if (this.octagon.Length <= n2)
-        {
-          newOctagon = SparseRationalArray.New(n2 + 1, Rational.PlusInfinity);
-          newOctagon.CopyFrom(this.octagon);
-
-          // For the garbage collection
-          this.octagon = null;
-        }
-        else
-        {
-          newOctagon = this.octagon;
+            return octCopy;
         }
 
-        for (int i = this.dimensions; i < 2 * (this.dimensions + newDimensions); i++)
-          newOctagon[Matpos(i, i)] = Rational.For(0);
-
-        this.octagon = newOctagon;
-      }
-
-      // The new, added, dimensions are ready for use 
-      for (int i = this.dimensions; i < this.dimensions + newDimensions; i++)
-      {
-        this.availableDimensions.Add(i);
-      }
-      this.dimensions += newDimensions;
-    }
-
-    ///<summary>
-    /// Return the constraints in the octagon
-    ///</summary>
-    public ICollection<OctagonConstraint> ToConstraints()
-    {
-      var retValue = new List<OctagonConstraint>();
-      OctagonConstraint con;
-
-      this.DoClosure();
-
-      if (this.IsBottom)
-        return retValue;
-
-      foreach (int i in this.AllocatedDimensions)
-      {
-        if (this.octagon[Matpos(2 * i, 2 * i)].IsNotZero)
+        ///<summary>
+        /// Close the octagon, by propagating all the constraints.
+        /// The update is in place.
+        ///</summary>
+        ///<remarks>It may set the octagon representation to NULL (when it finds a contraddiction), so, when you use it, you should check if the octagon is not bottom</remarks>
+        public void DoClosure()
         {
-          con = new OctagonConstraintXMinusY(i, i, Matpos(2 * i, 2 * 1));
-          retValue.Add(con);
+#if TRACE_AD_PERFORMANCES
+            Increase(ref countDoClosureInvocations);
+#endif
+            if (this.state != OctagonState.NORMAL)
+            {
+                return; /* There is nothing to do */
+            }
+
+            var watch = new Stopwatch();
+            watch.Start();
+
+            var n2 = dimensions * 2;
+
+            var buf1 = new Rational[n2];
+            var buf2 = new Rational[n2];
+
+            for (int k = 0; k < n2; k += 2)
+            {
+                #region Ck step
+
+                Rational kk1, kk2;
+
+                kk1 = this.octagon[Matpos(k + 1, k)]; // xk + xk
+                kk2 = this.octagon[Matpos(k, k + 1)]; // -xk - xk
+
+                int i;
+                for (i = 0; i <= k; i += 2)
+                {
+                    buf1[i] = this.octagon[Matpos(k + 1, i + 1)]; // -xi + xk
+                    buf2[i] = this.octagon[Matpos(k, i + 1)];    // -xi + xk
+                    buf1[i + 1] = this.octagon[Matpos(k + 1, i)]; //  xi+xk 
+                    buf2[i + 1] = this.octagon[Matpos(k, i)]; //  xi-xk 
+                }
+
+                for (; i < n2; i += 2)
+                {
+                    buf1[i] = this.octagon[Matpos(i, k)]; /*  xk-xi */
+                    buf2[i] = this.octagon[Matpos(i, k + 1)]; /* -xk-xi */
+                    buf1[i + 1] = this.octagon[Matpos(i + 1, k)]; /*  xk+xi */
+                    buf2[i + 1] = this.octagon[Matpos(i + 1, k + 1)]; /* -xk+xi */
+                }
+
+                int count_d;
+                for (i = 0, count_d = 0; i < n2; i++)
+                {
+                    var ii = i | 1;
+
+                    for (int j = 0; j <= ii; j++, count_d++)
+                    {
+                        int jj = j ^ 1;
+
+                        var ij1 = Add(buf1[i], buf2[jj]);
+                        var ij2 = Add3(buf2[i], kk1, buf2[jj]);
+                        var ij3 = Add(buf2[i], buf1[jj]);
+                        var ij4 = Add3(buf1[i], kk2, buf1[jj]);
+
+                        ij1 = Rational.Min(Rational.Min(ij1, ij2), Rational.Min(ij3, ij4));
+
+                        // this.octagon[count_d] = Rational.Min(this.octagon[count_d], ij1);
+
+                        DebugSet(count_d, Rational.Min(this.octagon[count_d], ij1));
+                    }
+                }
+                #endregion
+
+                count_d = 0;
+
+                #region  S Step
+
+                for (i = 0; i < n2; i += 2)
+                {
+                    buf1[i] = this.octagon[Matpos(i + 1, i)] / 2;   /* ( xi+xi)/2 */
+                    buf1[i + 1] = this.octagon[Matpos(i, i + 1)] / 2;   /* (-xi-xi)/2 */
+                }
+
+                for (i = 0; i < n2; i++)
+                {
+                    var ii = i | 1;
+                    var ii2 = i ^ 1;
+                    for (int j = 0; j <= ii; j++, count_d++)
+                    {
+                        var ij1 = Add(buf1[j], buf1[ii2]);
+                        //this.octagon[count_d] = Rational.Min(this.octagon[count_d], ij1);
+
+                        DebugSet(count_d, Rational.Min(this.octagon[count_d], ij1));
+                    }
+                }
+                #endregion
+
+                #region Emptyness checking
+                for (i = 0; i < n2; i += 2)
+                {
+                    if (this.octagon[Matpos(i, i)] < 0)
+                    {
+                        this.state = OctagonState.BOTTOM;
+                        this.octagon = null;
+                        bottomDimension = i;
+#if TRACE_AD_PERFORMANCES
+                        AddTimeElapsedFromStart("Closure", ref timeSpentInDoClosure, start);
+#endif
+                        return;
+                    }
+                }
+                #endregion
+
+                this.state = OctagonState.CLOSED;
+            }
+
+#if TRACE_AD_PERFORMANCES
+            AddTimeElapsedFromStart(string.Format("Closure done in {0} ({1} variables)", watch.Elapsed, this.Dimensions), ref timeSpentInDoClosure, start);
+#endif
         }
-        if (this.octagon[Matpos(2 * i + 1, 2 * i + 1)].IsNotZero)
+
+        private void DebugSet(int where, Rational val)
         {
-          con = new OctagonConstraintXMinusY(i, i, Matpos(2 * i + 1, 2 * i + 1));
-          retValue.Add(con);
+            this.octagon[where] = val;
         }
-        if (!this.octagon[Matpos(2 * i + 1, 2 * i)].IsInfinity)
+
+        /// <summary>
+        /// Debugging info: Which is the i such that this.octagon[Matpos(i, i)] \lt 0 ?
+        /// </summary>
+        public int WhyBottom
         {
-          con = new OctagonConstraintX(i, this.octagon[Matpos(2 * i + 1, 2 * i)]/2);
-          retValue.Add(con);
+            get
+            {
+                return bottomDimension;
+            }
         }
-        if (!this.octagon[Matpos(2 * i, 2 * i + 1)].IsInfinity)
+
+        private static Rational Add(Rational x, Rational y)
         {
-          con = new OctagonConstraintMinusX(i, this.octagon[Matpos(2 * i, 2 * i + 1)]/2);
-          retValue.Add(con);
+            try
+            {
+                return x + y;
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return Rational.PlusInfinity;
+            }
         }
-      }
 
-      for (int i = 0; i < this.dimensions; i++)
-        for (int j = i + 1; j < this.dimensions; j++)
+        private static Rational Add3(Rational x, Rational y, Rational z)
         {
-          if (!this.octagon[Matpos(2 * j, 2 * i)].IsInfinity)
-          {
-            con = new OctagonConstraintXMinusY(i, j, this.octagon[Matpos(2 * j, 2 * i)]);
-            retValue.Add(con);
-          }
-          if (!this.octagon[Matpos(2 * j, 2 * i + 1)].IsInfinity)
-          {
-            con = new OctagonConstraintMinusXMinusY(i, j, this.octagon[Matpos(2 * j, 2 * i + 1)]);
-            retValue.Add(con);
-          }
-          if (!this.octagon[Matpos(2 * j + 1, 2 * i)].IsInfinity)
-          {
-            con = new OctagonConstraintXY(i, j, this.octagon[Matpos(2 * j + 1, 2 * i)]);
-            retValue.Add(con);
-          }
-          if (!this.octagon[Matpos(2 * j + 1, 2 * i + 1)].IsInfinity)
-          {
-            con = new OctagonConstraintXMinusY(j, i, this.octagon[Matpos(2 * j + 1, 2 * i + 1)]);
-            retValue.Add(con);
-          }
+            try
+            {
+                return x + y + z;
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return Rational.PlusInfinity;
+            }
         }
-      return retValue;
-    }
 
-    #endregion
+        #endregion
 
-    #region Private methods
+        #region Transfer functions (projection, add a constraint, etc.)
 
-    ///<summary>
-    /// The number of elements in a matrix with n variables
-    ///</summary>s
-    protected static int Matsize(int n)
-    {
-      return (2 * n * (n + 1));
-    }
+        ///<summary>
+        ///Project out a variable from the constraints (set it to top).
+        ///The resulting octagon is then closed
+        ///</summary>
+        ///<param name="k">The dimension addociated to the variable to be projected</param>
+        protected void ProjectDimension(int k)
+        {
+            Contract.Requires(k <= this.Dimensions, "Error: Trying to remove a variable not in the octagon");
 
-    ///<summary>
-    /// Return the position of the matrix element (<code>i</code>,<code>j</code>) in the flat representation
-    ///</summary>
-    protected static int Matpos(int i, int j)
-    {
-      return (j + ((i + 1) * (i + 1)) / 2);
-    }
+            int k2 = 2 * k;
+            int n2 = 2 * dimensions;
 
-    protected static int Matpos2(int i, int j)
-    {
-      return j > i ? Matpos((j ^ 1), (i ^ 1)) : Matpos(i, j);
-    }
+            this.DoClosure();
 
-    #endregion
+            if (this.state == OctagonState.BOTTOM || this.state == OctagonState.EMPTY)
+            {
+                return;
+            }
 
-    #region Overridden (ToString())
+            // Change the result matrix 
+            for (var i = 0; i < k2; i++)
+            {
+                this.octagon[Matpos(k2, i)] = Rational.PlusInfinity;
+                this.octagon[Matpos(k2 + 1, i)] = Rational.PlusInfinity;
+            }
 
-    override public string ToString()
-    {
-      return ToStringRaw();
-    }
+            for (var i = k2 + 2; i < n2; i++)
+            {
+                this.octagon[Matpos(i, k2)] = Rational.PlusInfinity;
+                this.octagon[Matpos(i, k2 + 1)] = Rational.PlusInfinity;
+            }
 
-    public string ToStringRaw()
-    {
+            this.octagon[Matpos(k2, k2 + 1)] = Rational.PlusInfinity;
+            this.octagon[Matpos(k2 + 1, k2)] = Rational.PlusInfinity;
+        }
 
+        ///<summary>
+        /// Remove a variable from the octagon
+        ///</summary>
+        ///<param name="dim">The dimension addociated to the variable to be projected</param>
+        public void RemoveDimension(int dim)
+        {
+            this.ProjectDimension(dim);
+            this.availableDimensions.Add(dim);      // Remember the removed varaible
+        }
+
+        ///<summary>
+        /// Add a constraint to this octagon.
+        /// If the octagon is Bottom, it's a nop
+        ///</summary>
+        virtual public void AddConstraint(OctagonConstraint constraint)
+        {
+            Contract.Assert(this.state == OctagonState.BOTTOM || constraint.X <= dimensions);
+
+            if (this.state != OctagonState.BOTTOM)
+            {
+                bool hasChanged = constraint.AddToOctagon(this);
+
+                if (hasChanged)
+                {
+                    this.state = OctagonState.NORMAL;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add a set of constraints to this octagon
+        /// </summary>
+        /// <param name="constraints">The constraints to add</param>
+        /// <returns>The affected dimensions </returns>
+        public IMutableSet<int> AddConstraints(IMutableSet<OctagonConstraint> constraints)
+        {
+            bool hasChanged = false;
+
+            if (this.state == OctagonState.BOTTOM)
+                return new Set<int>();
+
+            var affectedDimensions = new Set<int>();
+
+            foreach (var cons in constraints)
+            {
+                Contract.Assert(cons.X <= dimensions);//, "Error: Variable index greater than the dimensions of the octagon");
+
+                hasChanged = cons.AddToOctagon(this, affectedDimensions) || hasChanged;
+            }
+            // Improve: Use DoIncrementalClosure for closing the octagon if just one constraint has changed
+
+            if (hasChanged && this.state != OctagonState.BOTTOM)    // The CoreOctagon is no more in the closed form
+            {
+                this.state = OctagonState.NORMAL;
+            }
+
+            return affectedDimensions;
+        }
+
+        ///<summary>
+        /// Use this function to get a new dimension in the octagon, that can be associated with a memory address.
+        /// If no dimension is available, then the octagon is enlarged, with n new dimensions (n is specified by DimensionGrowthStep)
+        /// The returned dimensions is removed from the set of available locations
+        ///</summary>
+        ///<returns>A non-zero integer index of an available dimension, otherwise a negative number</returns>
+        public int GetAvailableDimension()
+        {
+            if (this.availableDimensions.IsEmpty)
+            {
+                // No variable is left
+                this.AddDimensions(DimensionGrowthStep);    // Add a new variable
+                return this.GetAvailableDimension();          // return a fresh variable
+            }
+            else
+            {
+                // Return a "free" dimension in the octagon                
+
+                int i = this.availableDimensions.PickAnElement();
+                this.availableDimensions.Remove(i);
+
+                return i;
+            }
+        }
+
+        ///<summary>
+        /// Add new dimensions to this octagon, without any constraint. 
+        ///</summary>
+        public void AddDimensions(int newDimensions)
+        {
+            int n1 = Matsize(dimensions);
+            int n2 = Matsize(dimensions + newDimensions);
+
+            if (this.state != OctagonState.BOTTOM)
+            {
+                SparseRationalArray newOctagon;
+
+                if (this.octagon.Length <= n2)
+                {
+                    newOctagon = SparseRationalArray.New(n2 + 1, Rational.PlusInfinity);
+                    newOctagon.CopyFrom(this.octagon);
+
+                    // For the garbage collection
+                    this.octagon = null;
+                }
+                else
+                {
+                    newOctagon = this.octagon;
+                }
+
+                for (int i = dimensions; i < 2 * (dimensions + newDimensions); i++)
+                    newOctagon[Matpos(i, i)] = Rational.For(0);
+
+                this.octagon = newOctagon;
+            }
+
+            // The new, added, dimensions are ready for use 
+            for (int i = dimensions; i < dimensions + newDimensions; i++)
+            {
+                this.availableDimensions.Add(i);
+            }
+            dimensions += newDimensions;
+        }
+
+        ///<summary>
+        /// Return the constraints in the octagon
+        ///</summary>
+        public ICollection<OctagonConstraint> ToConstraints()
+        {
+            var retValue = new List<OctagonConstraint>();
+            OctagonConstraint con;
+
+            this.DoClosure();
+
+            if (this.IsBottom)
+                return retValue;
+
+            foreach (int i in this.AllocatedDimensions)
+            {
+                if (this.octagon[Matpos(2 * i, 2 * i)].IsNotZero)
+                {
+                    con = new OctagonConstraintXMinusY(i, i, Matpos(2 * i, 2 * 1));
+                    retValue.Add(con);
+                }
+                if (this.octagon[Matpos(2 * i + 1, 2 * i + 1)].IsNotZero)
+                {
+                    con = new OctagonConstraintXMinusY(i, i, Matpos(2 * i + 1, 2 * i + 1));
+                    retValue.Add(con);
+                }
+                if (!this.octagon[Matpos(2 * i + 1, 2 * i)].IsInfinity)
+                {
+                    con = new OctagonConstraintX(i, this.octagon[Matpos(2 * i + 1, 2 * i)] / 2);
+                    retValue.Add(con);
+                }
+                if (!this.octagon[Matpos(2 * i, 2 * i + 1)].IsInfinity)
+                {
+                    con = new OctagonConstraintMinusX(i, this.octagon[Matpos(2 * i, 2 * i + 1)] / 2);
+                    retValue.Add(con);
+                }
+            }
+
+            for (int i = 0; i < dimensions; i++)
+                for (int j = i + 1; j < dimensions; j++)
+                {
+                    if (!this.octagon[Matpos(2 * j, 2 * i)].IsInfinity)
+                    {
+                        con = new OctagonConstraintXMinusY(i, j, this.octagon[Matpos(2 * j, 2 * i)]);
+                        retValue.Add(con);
+                    }
+                    if (!this.octagon[Matpos(2 * j, 2 * i + 1)].IsInfinity)
+                    {
+                        con = new OctagonConstraintMinusXMinusY(i, j, this.octagon[Matpos(2 * j, 2 * i + 1)]);
+                        retValue.Add(con);
+                    }
+                    if (!this.octagon[Matpos(2 * j + 1, 2 * i)].IsInfinity)
+                    {
+                        con = new OctagonConstraintXY(i, j, this.octagon[Matpos(2 * j + 1, 2 * i)]);
+                        retValue.Add(con);
+                    }
+                    if (!this.octagon[Matpos(2 * j + 1, 2 * i + 1)].IsInfinity)
+                    {
+                        con = new OctagonConstraintXMinusY(j, i, this.octagon[Matpos(2 * j + 1, 2 * i + 1)]);
+                        retValue.Add(con);
+                    }
+                }
+            return retValue;
+        }
+
+        #endregion
+
+        #region Private methods
+
+        ///<summary>
+        /// The number of elements in a matrix with n variables
+        ///</summary>s
+        protected static int Matsize(int n)
+        {
+            return (2 * n * (n + 1));
+        }
+
+        ///<summary>
+        /// Return the position of the matrix element (<code>i</code>,<code>j</code>) in the flat representation
+        ///</summary>
+        protected static int Matpos(int i, int j)
+        {
+            return (j + ((i + 1) * (i + 1)) / 2);
+        }
+
+        protected static int Matpos2(int i, int j)
+        {
+            return j > i ? Matpos((j ^ 1), (i ^ 1)) : Matpos(i, j);
+        }
+
+        #endregion
+
+        #region Overridden (ToString())
+
+        override public string ToString()
+        {
+            return ToStringRaw();
+        }
+
+        public string ToStringRaw()
+        {
 #if VERBOSEOUTPUT
-      string postFix = this.dimensions + "-dimensions octagon) " + Environment.NewLine;
+            string postFix = dimensions + "-dimensions octagon) " + Environment.NewLine;
 #else
-      string postFix = "octagon)";
+            string postFix = "octagon)";
 #endif
 
-      if (this.state == OctagonState.EMPTY)
-      {
-        return "(empty " + postFix;
-      }
-      else if (this.state == OctagonState.BOTTOM)
-      {
-        return "(bottom " + postFix;
-      }
+            if (this.state == OctagonState.EMPTY)
+            {
+                return "(empty " + postFix;
+            }
+            else if (this.state == OctagonState.BOTTOM)
+            {
+                return "(bottom " + postFix;
+            }
 
-      String retStr = "";
+            String retStr = "";
 
 #if VERBOSEOUTPUT
-      if (this.state == OctagonState.CLOSED)
-        retStr = "(closed " + postFix;
-      else
-        retStr = "(NOT closed " + postFix;
+            if (this.state == OctagonState.CLOSED)
+                retStr = "(closed " + postFix;
+            else
+                retStr = "(NOT closed " + postFix;
 
-      retStr += "(# of Constraints: " + this.NumberOfConstraints + ", ";
-      retStr += "length of the representation: " + this.octagon.Length + ") " + Environment.NewLine;
-      retStr += this.octagon.ToString() + Environment.NewLine;
+            retStr += "(# of Constraints: " + this.NumberOfConstraints + ", ";
+            retStr += "length of the representation: " + this.octagon.Length + ") " + Environment.NewLine;
+            retStr += this.octagon.ToString() + Environment.NewLine;
 
 #endif
 #if PRINT_PLAIN_OCTAGON     // print the octagon in the plain form
 
-      for (int i = 0; i < this.dimensions; i++)
-      {
-        if (this.octagon[Matpos(2 * i, 2 * i)] != 0)
-          retStr += STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i)] + Environment.NewLine + " ";
-        if (this.octagon[Matpos(2 * i + 1, 2 * i + 1)] != 0)
-          retStr += "-" + STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i + 1)] + Environment.NewLine + " ";
-        if (!this.octagon[Matpos(2 * i + 1, 2 * i)].IsInfinity)
-          retStr += STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i)] /2 + Environment.NewLine + " ";
-        if (!this.octagon[Matpos(2 * i, 2 * i + 1)].IsInfinity)
-          retStr += "-" + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i + 1)] /2 + Environment.NewLine + " ";
-      }
+            for (int i = 0; i < dimensions; i++)
+            {
+                if (this.octagon[Matpos(2 * i, 2 * i)] != 0)
+                    retStr += STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i)] + Environment.NewLine + " ";
+                if (this.octagon[Matpos(2 * i + 1, 2 * i + 1)] != 0)
+                    retStr += "-" + STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i + 1)] + Environment.NewLine + " ";
+                if (!this.octagon[Matpos(2 * i + 1, 2 * i)].IsInfinity)
+                    retStr += STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i)] / 2 + Environment.NewLine + " ";
+                if (!this.octagon[Matpos(2 * i, 2 * i + 1)].IsInfinity)
+                    retStr += "-" + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i + 1)] / 2 + Environment.NewLine + " ";
+            }
 
-      for (int i = 0; i < this.dimensions; i++)
-        for (int j = i + 1; j < this.dimensions; j++)
-        {
-          if (!this.octagon[Matpos(2 * j, 2 * i)].IsInfinity)
-            retStr += STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i)] + Environment.NewLine + " ";
-          if (!this.octagon[Matpos(2 * j, 2 * i + 1)].IsInfinity)
-            retStr += "-" + STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i + 1)] + Environment.NewLine + " ";
-          if (!this.octagon[Matpos(2 * j + 1, 2 * i)].IsInfinity)
-            retStr += STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i)] + Environment.NewLine + " ";
-          if (!this.octagon[Matpos(2 * j + 1, 2 * i + 1)].IsInfinity)
-            retStr += STR_FOR_DIMENSION + j + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i + 1)] + Environment.NewLine + " ";
-        }
+            for (int i = 0; i < dimensions; i++)
+                for (int j = i + 1; j < dimensions; j++)
+                {
+                    if (!this.octagon[Matpos(2 * j, 2 * i)].IsInfinity)
+                        retStr += STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i)] + Environment.NewLine + " ";
+                    if (!this.octagon[Matpos(2 * j, 2 * i + 1)].IsInfinity)
+                        retStr += "-" + STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i + 1)] + Environment.NewLine + " ";
+                    if (!this.octagon[Matpos(2 * j + 1, 2 * i)].IsInfinity)
+                        retStr += STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i)] + Environment.NewLine + " ";
+                    if (!this.octagon[Matpos(2 * j + 1, 2 * i + 1)].IsInfinity)
+                        retStr += STR_FOR_DIMENSION + j + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i + 1)] + Environment.NewLine + " ";
+                }
 
 #else               // a nicer way of printing the octagon constraints...
       if (this.IsBottom)
@@ -1015,2154 +1002,2147 @@ namespace Microsoft.Research.AbstractDomains.Numerical
       }
 #endif
 
-      return retStr;
-    }
-    #endregion
+            return retStr;
+        }
+        #endregion
 
-    protected void CheckConsistency()
+        protected void CheckConsistency()
+        {
+            // Invariant : this.octagon == null ==> this.state = Bottom
+            Contract.Assert(this.octagon != null || this.state == OctagonState.BOTTOM, "I was not expecting null here...");
+        }
+    }
+
+    /// <summary>
+    /// The implementation of an abstraction of a set of program states <code>var -> val</code>, 
+    /// where <code>var</code> is of type <code>Expression</code> and <code>val</code> is an <code>Int32</code>.
+    /// 
+    /// TODO: In the future consider to make this class generic w.r.t. the values 
+    /// </summary>
+    public sealed partial class OctagonEnvironment<Variable, Expression> :
+      CoreOctagon, INumericalAbstractDomain<Variable, Expression>
     {
-      // Invariant : this.octagon == null ==> this.state = Bottom
-      Contract.Assert(this.octagon != null || this.state == OctagonState.BOTTOM, "I was not expecting null here...");
-    }
-  }
+        #region OctagonPrecision
+        public enum OctagonPrecision { JustTests, FullPrecision } // Meaning: justTests: ignores the assignments, and handles just the Test*
+        #endregion
 
-  /// <summary>
-  /// The implementation of an abstraction of a set of program states <code>var -> val</code>, 
-  /// where <code>var</code> is of type <code>Expression</code> and <code>val</code> is an <code>Int32</code>.
-  /// 
-  /// TODO: In the future consider to make this class generic w.r.t. the values 
-  /// </summary>
-  public sealed partial class OctagonEnvironment<Variable, Expression> : 
-    CoreOctagon, INumericalAbstractDomain<Variable, Expression>
-  {
-    #region OctagonPrecision
-    public enum OctagonPrecision { JustTests, FullPrecision } // Meaning: justTests: ignores the assignments, and handles just the Test*
-    #endregion
+        #region Statics for OctagonEnvironment configuration
+        private const int DEFAULTSIZE = 8;
 
-    #region Statics for OctagonEnvironment configuration
-    private const int DEFAULTSIZE = 8;
-
-    // The thresholds are shared by all the instances of OctagonEnvironment<Variable, Expression>
-    [ThreadStatic]
-    static private IThreshold<Rational> thresholds;                    // At the beginning we assume widening thresholds [0, +oo]
+        // The thresholds are shared by all the instances of OctagonEnvironment<Variable, Expression>
+        [ThreadStatic]
+        static private IThreshold<Rational> thresholds;                    // At the beginning we assume widening thresholds [0, +oo]
 #if false // unused?
-    [ThreadStatic]
-    static private int MaxDim;      // The maximum size number of dimensions ever hold in an octagon
+        [ThreadStatic]
+        static private int MaxDim;      // The maximum size number of dimensions ever hold in an octagon
 #endif
-    
-    private static IThreshold<Rational> Thresholds // Lazy initialization because of ThreadStatic
-    {
-      get
-      {
-        if (thresholds == null)
-          thresholds = new SimpleRationalThreshold();
-        return thresholds;
-      }
-    }
-    #endregion
 
-    #region Private state
-    readonly private OctagonPrecision precision;   // The precision in octagons, by default we keep just tests
+        private static IThreshold<Rational> Thresholds // Lazy initialization because of ThreadStatic
+        {
+            get
+            {
+                if (thresholds == null)
+                    thresholds = new SimpleRationalThreshold();
+                return thresholds;
+            }
+        }
+        #endregion
 
-    readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
+        #region Private state
+        readonly private OctagonPrecision precision;   // The precision in octagons, by default we keep just tests
 
-    readonly private OctagonsTrueTestVisitor<Variable, Expression> trueTestVisitor;
-    readonly private OctagonsTrueTestNotRefiningVisitor<Variable, Expression> trueTestNotRefiningVisitor;
-    readonly private OctagonsFalseTestVisitor<Variable, Expression> falseTestVisitor;
+        readonly private ExpressionManagerWithEncoder<Variable, Expression> expManager;
 
-    readonly private IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>.EvalConstantVisitor constantVisitor;
+        readonly private OctagonsTrueTestVisitor<Variable, Expression> trueTestVisitor;
+        readonly private OctagonsTrueTestNotRefiningVisitor<Variable, Expression> trueTestNotRefiningVisitor;
+        readonly private OctagonsFalseTestVisitor<Variable, Expression> falseTestVisitor;
 
-    readonly private List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>> constraintsForAssignment;
+        readonly private IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>.EvalConstantVisitor constantVisitor;
 
-    private BijectiveMap<Variable, int> variables2dimensions;        // The conversion map between variables and dimensions in the octagon
+        readonly private List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>> constraintsForAssignment;
 
-    #endregion
+        private BijectiveMap<Variable, int> variables2dimensions;        // The conversion map between variables and dimensions in the octagon
 
-    #region Dimension for a variable
-    /// <returns>
-    /// The dimension associated with the variable, if any.
-    /// Otherwise it extends this octagon, and add the new variable
-    /// </returns>
-    internal int DimensionForVar(Variable var)
-    {
-      if (!this.variables2dimensions.ContainsKey(var))
-      {
-        this.AddVariable(var);
-      }
+        #endregion
 
-      // Should be there now!
-      return this.variables2dimensions[var];
-    }
+        #region Dimension for a variable
+        /// <returns>
+        /// The dimension associated with the variable, if any.
+        /// Otherwise it extends this octagon, and add the new variable
+        /// </returns>
+        internal int DimensionForVar(Variable var)
+        {
+            if (!variables2dimensions.ContainsKey(var))
+            {
+                this.AddVariable(var);
+            }
 
-    #endregion
+            // Should be there now!
+            return variables2dimensions[var];
+        }
 
-    #region Precision in the handling of assignments
-    
-    /// <summary>
-    /// Set or get if we have to precision we have to use for the assigment octagons
-    /// </summary>
-    public OctagonPrecision Precision
-    {
-      get { return this.precision; }
-    }
+        #endregion
 
-    #endregion
+        #region Precision in the handling of assignments
 
-    #region Constructors
+        /// <summary>
+        /// Set or get if we have to precision we have to use for the assigment octagons
+        /// </summary>
+        public OctagonPrecision Precision
+        {
+            get { return precision; }
+        }
 
-    /// <summary>
-    /// The starting point for an environment approximated by an octagon
-    /// </summary>
-    public OctagonEnvironment(ExpressionManagerWithEncoder<Variable, Expression> expManager, OctagonPrecision precision)
-      : this(DEFAULTSIZE, expManager, precision)
-    {
+        #endregion
 
-      this.state = OctagonState.EMPTY;
+        #region Constructors
 
-      Contract.Assert(this.state == OctagonState.EMPTY);
-    }
+        /// <summary>
+        /// The starting point for an environment approximated by an octagon
+        /// </summary>
+        public OctagonEnvironment(ExpressionManagerWithEncoder<Variable, Expression> expManager, OctagonPrecision precision)
+          : this(DEFAULTSIZE, expManager, precision)
+        {
+            this.state = OctagonState.EMPTY;
 
-    /// <summary>
-    /// Construct an octagon with <code>n</code> dimensions and no map between variables and dimensions in it
-    /// </summary>
-    private OctagonEnvironment(int n, ExpressionManagerWithEncoder<Variable, Expression> expManager, OctagonPrecision precision)
-      : base(n)
-    {
-      this.expManager = expManager;
+            Contract.Assert(this.state == OctagonState.EMPTY);
+        }
 
-      this.precision = precision;
+        /// <summary>
+        /// Construct an octagon with <code>n</code> dimensions and no map between variables and dimensions in it
+        /// </summary>
+        private OctagonEnvironment(int n, ExpressionManagerWithEncoder<Variable, Expression> expManager, OctagonPrecision precision)
+          : base(n)
+        {
+            this.expManager = expManager;
 
-      this.trueTestVisitor = new OctagonsTrueTestVisitor<Variable, Expression>(this.expManager.Decoder);
-      this.trueTestNotRefiningVisitor = new OctagonsTrueTestNotRefiningVisitor<Variable, Expression>(this.expManager.Decoder);
-      this.falseTestVisitor = new OctagonsFalseTestVisitor<Variable, Expression>(this.expManager.Decoder);
-      this.trueTestVisitor.FalseVisitor = this.falseTestVisitor;
-      this.trueTestNotRefiningVisitor.FalseVisitor = this.falseTestVisitor;
-      this.falseTestVisitor.TrueVisitor = this.trueTestVisitor;
+            this.precision = precision;
 
-      this.constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>()
+            trueTestVisitor = new OctagonsTrueTestVisitor<Variable, Expression>(this.expManager.Decoder);
+            trueTestNotRefiningVisitor = new OctagonsTrueTestNotRefiningVisitor<Variable, Expression>(this.expManager.Decoder);
+            falseTestVisitor = new OctagonsFalseTestVisitor<Variable, Expression>(this.expManager.Decoder);
+            trueTestVisitor.FalseVisitor = falseTestVisitor;
+            trueTestNotRefiningVisitor.FalseVisitor = falseTestVisitor;
+            falseTestVisitor.TrueVisitor = trueTestVisitor;
+
+            constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>()
       {
         new LessEqualThanConstraints<Variable, Expression>(this.expManager),
         new LessThanConstraints<Variable, Expression>(this.expManager),
         new GreaterEqualThanZeroConstraints<Variable, Expression>(this.expManager)
       };
 
-      this.constantVisitor = new IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>.EvalConstantVisitor(this.expManager.Decoder);
+            constantVisitor = new IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>.EvalConstantVisitor(this.expManager.Decoder);
 
-      this.variables2dimensions = new BijectiveMap<Variable, int>(n);
+            variables2dimensions = new BijectiveMap<Variable, int>(n);
 
-      Contract.Assert(this.availableDimensions != null);
+            Contract.Assert(this.availableDimensions != null);
 
-      for (int i = 0; i < n; i++)
-      {
-        this.availableDimensions.Add(i);
-      }
-    }
+            for (int i = 0; i < n; i++)
+            {
+                this.availableDimensions.Add(i);
+            }
+        }
 
-    /// <summary>
-    /// Copy constructor #1
-    /// </summary>
-    private OctagonEnvironment(OctagonEnvironment<Variable, Expression> oct)
-      : base(oct)
-    {
-      this.expManager = oct.expManager;
-      this.precision = oct.precision;
+        /// <summary>
+        /// Copy constructor #1
+        /// </summary>
+        private OctagonEnvironment(OctagonEnvironment<Variable, Expression> oct)
+          : base(oct)
+        {
+            expManager = oct.expManager;
+            precision = oct.precision;
 
-      this.trueTestVisitor = oct.trueTestVisitor;
-      this.trueTestNotRefiningVisitor = oct.trueTestNotRefiningVisitor;
-      this.falseTestVisitor = oct.falseTestVisitor;
+            trueTestVisitor = oct.trueTestVisitor;
+            trueTestNotRefiningVisitor = oct.trueTestNotRefiningVisitor;
+            falseTestVisitor = oct.falseTestVisitor;
 
-      this.constantVisitor = oct.constantVisitor;
+            constantVisitor = oct.constantVisitor;
 
-      this.constraintsForAssignment = oct.constraintsForAssignment;
+            constraintsForAssignment = oct.constraintsForAssignment;
 
-      this.variables2dimensions = oct.variables2dimensions;
+            variables2dimensions = oct.variables2dimensions;
 
-      // Contract.Assert(this.octagon != null, "Octagon should not be null there...");
-    }
+            // Contract.Assert(this.octagon != null, "Octagon should not be null there...");
+        }
 
-    private void CloneFromThis(OctagonEnvironment<Variable, Expression> oct)
-    {
-      base.CloneFromThis(oct);
-      this.variables2dimensions = oct.variables2dimensions;      
-    }
+        private void CloneFromThis(OctagonEnvironment<Variable, Expression> oct)
+        {
+            base.CloneFromThis(oct);
+            variables2dimensions = oct.variables2dimensions;
+        }
 
-    /// <summary>
-    /// Copy constructor #2
-    /// </summary>
-    private OctagonEnvironment(int n, bool allocateMatrix, ExpressionManagerWithEncoder<Variable, Expression> expManager, OctagonPrecision precision)
-      : base(n, allocateMatrix)
-    {
-      this.expManager = expManager;
+        /// <summary>
+        /// Copy constructor #2
+        /// </summary>
+        private OctagonEnvironment(int n, bool allocateMatrix, ExpressionManagerWithEncoder<Variable, Expression> expManager, OctagonPrecision precision)
+          : base(n, allocateMatrix)
+        {
+            this.expManager = expManager;
 
-      this.precision = precision;
+            this.precision = precision;
 
-      this.trueTestVisitor = new OctagonsTrueTestVisitor<Variable, Expression>(this.expManager.Decoder);
-      this.trueTestNotRefiningVisitor = new OctagonsTrueTestNotRefiningVisitor<Variable, Expression>(this.expManager.Decoder);
-      this.falseTestVisitor = new OctagonsFalseTestVisitor<Variable, Expression>(this.expManager.Decoder);
-      this.trueTestVisitor.FalseVisitor = this.falseTestVisitor;
-      this.trueTestNotRefiningVisitor.FalseVisitor = this.falseTestVisitor;
-      this.falseTestVisitor.TrueVisitor = this.trueTestVisitor;
+            trueTestVisitor = new OctagonsTrueTestVisitor<Variable, Expression>(this.expManager.Decoder);
+            trueTestNotRefiningVisitor = new OctagonsTrueTestNotRefiningVisitor<Variable, Expression>(this.expManager.Decoder);
+            falseTestVisitor = new OctagonsFalseTestVisitor<Variable, Expression>(this.expManager.Decoder);
+            trueTestVisitor.FalseVisitor = falseTestVisitor;
+            trueTestNotRefiningVisitor.FalseVisitor = falseTestVisitor;
+            falseTestVisitor.TrueVisitor = trueTestVisitor;
 
-      this.constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>()
+            constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>()
       {
         new LessEqualThanConstraints<Variable,Expression>(this.expManager),
         new LessThanConstraints<Variable,Expression>(this.expManager),
         new GreaterEqualThanZeroConstraints<Variable, Expression>(this.expManager)
       };
 
-      this.constantVisitor = new IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>.EvalConstantVisitor(this.expManager.Decoder);
+            constantVisitor = new IntervalEnvironment_Base<IntervalEnvironment<Variable, Expression>, Variable, Expression, Interval, Rational>.EvalConstantVisitor(this.expManager.Decoder);
 
-      this.variables2dimensions = null; // This will be set by Clone
-    }
-
-    #endregion
-
-    #region Conversion methods for Intervals
-
-    /// <summary>
-    /// Get the bounds for the variable <code>v</code>
-    /// </summary>
-    public DisInterval BoundsFor(Expression exp)
-    {
-      return this.BoundsFor(this.expManager.Decoder.UnderlyingVariable(exp));
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      if (this.state != OctagonState.EMPTY && this.state != OctagonState.BOTTOM && this.variables2dimensions.Keys.Contains(v))
-      {
-        return base.BoundsFor(this.variables2dimensions[v]).AsDisInterval;
-      }
-      else
-      {
-        return DisInterval.UnknownInterval;
-      }
-    }
-
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      CheckConsistency();
-
-      if (this.Precision == OctagonPrecision.FullPrecision)
-      {
-        if (!value.IsNormal)
-        { // TODO: for the moment we ignore the "false" interval
-          this.RemoveVariable(x);
-        }
-        else
-        {
-          if (!value.LowerBound.IsInfinity)
-          { // Add the constraint -x <= -value
-            this.AddConstraint(new OctagonConstraintMinusX(this.DimensionForVar(x), -value.LowerBound));
-          }
-
-          if (!value.UpperBound.IsInfinity)
-          { // Add the constraint x <= value
-            this.AddConstraint(new OctagonConstraintX(this.DimensionForVar(x), value.UpperBound));
-          }
-        }
-      }
-      CheckConsistency();
-    }
-
-    public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-    }
-
-    /// <summary>
-    /// Abstract an OctagonEnvironment to an IntervalEnvironment
-    /// </summary>
-    public IntervalEnvironment<Variable, Expression> ToIntervalEnvironment()
-    {
-      var result = new IntervalEnvironment<Variable, Expression>(this.expManager);
-      
-      foreach (var x in this.variables2dimensions.Keys)
-      {
-        result.AssumeInDisInterval(x, this.BoundsFor(x));
-      }
-      return result;
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members: Bottom, Top, Join, Meet, Widening 
-
-    private enum BinaryOperationType { Join, Meet, Widening };
-
-    private delegate Rational BinaryOperation(Rational left, Rational right);
-
-    private static readonly BinaryOperation pointwiseWidening = delegate(Rational current, Rational prev)
-        {
-          if (Rational.Min(current, prev) == current)
-          {   // The bound is stable
-            return prev;
-          }
-          else
-          {   // The bound is not stable, take
-            var candidate = Thresholds.GetNext(current.NextInt32);
-            return candidate < Int32.MaxValue ? candidate : Rational.PlusInfinity;  // Gets the smaller value in the thresholds that is larger than b
-          }
-        };
-
-    /// <summary>
-    /// An OctagonEnvironment is bottom when the variable map is not empty, and the octagon is
-    /// </summary>
-    public override bool IsBottom
-    {
-      get
-      {
-        #if  TRACE_AD_PERFORMANCES
-
-        countDomainOperationsInvocations++;
-
-      var watch = new Stopwatch();
-      watch.Start();
-#endif
-        
-        var result = this.state == OctagonState.BOTTOM || (this.variables2dimensions.Count != 0 && base.IsBottom);
-
-        #if  TRACE_AD_PERFORMANCES
-
-        timeSpentInDomainOperations += watch.Elapsed;
-      #endif
-  
-        return result;
-      }
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get
-      {
-        #if  TRACE_AD_PERFORMANCES
-        countDomainOperationsInvocations++;
-
-      var watch = new Stopwatch();
-      watch.Start();
-#endif
-
-        var bot = this.FactoryForOctagonEnvironment(2);
-        bot.state = OctagonState.BOTTOM;
-
-        if (this.variables2dimensions.Count > 0)
-        {
-          bot.variables2dimensions = new BijectiveMap<Variable, int>(this.variables2dimensions);
-        }
-        else
-        {
-          bot.variables2dimensions = new BijectiveMap<Variable, int>(1);
-          this.state = OctagonState.BOTTOM;
+            variables2dimensions = null; // This will be set by Clone
         }
 
-      #if  TRACE_AD_PERFORMANCES
-        timeSpentInDomainOperations += watch.Elapsed;
-      #endif
-        return bot;
-      }
-    }
+        #endregion
 
-    /// <summary>
-    /// An OctagonEnvironment is top when the variable map is empty or when the octagon has no constraints
-    /// </summary>
-    public override bool IsTop
-    {
-      get
-      {
-#if  TRACE_AD_PERFORMANCES
-        countDomainOperationsInvocations++;
+        #region Conversion methods for Intervals
 
-      var watch = new Stopwatch();
-      watch.Start();
-#endif
-        if (this.state == OctagonState.BOTTOM)
-          return false;
-
-        bool result = this.variables2dimensions.Count == 0 || base.IsTop;
-#if  TRACE_AD_PERFORMANCES
-        timeSpentInDomainOperations += watch.Elapsed;
-#endif
-        return result;
-      }
-    }
-
-    public IAbstractDomain Top
-    {
-      get
-      {
-        OctagonEnvironment<Variable, Expression> tmp = this.FactoryForOctagonEnvironment(1);
-        tmp.ProjectDimension(0);
-
-        return tmp;
-      }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain  abs)
-    {
-      return this.LessEqual((OctagonEnvironment<Variable, Expression>) abs);
-    }
-
-    public bool LessEqual(OctagonEnvironment<Variable, Expression>  right)
-    {
-      #if  TRACE_AD_PERFORMANCES
-
-      Increase(ref countDomainOperationsInvocations);
-#endif
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
-      {
-        return result;
-      }
-
-      var watch = new Stopwatch();
-      watch.Start();
-
-      result = HelperForLessEqual(right);
-      #if  TRACE_AD_PERFORMANCES
-
-      AddTimeElapsedFromStart("LessEqual", ref timeSpentInDomainOperations, watch.Elapsed);
-#endif
-      return result;
-    }
-
-    IAbstractDomain  IAbstractDomain.Join(IAbstractDomain  a)
-    {
-      return this.Join((OctagonEnvironment<Variable, Expression>)a);
-    }
-
-    public OctagonEnvironment<Variable, Expression> Join(OctagonEnvironment<Variable, Expression> right)
-    {
-      #if  TRACE_AD_PERFORMANCES
-
-      Increase(ref countDomainOperationsInvocations);
-#endif
-      OctagonEnvironment<Variable, Expression>  result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
-      {
-        return result;
-      }
-
-      var watch = new Stopwatch();
-      watch.Start();
-
-      HelperForBinaryDomainOperation(BinaryOperationType.Join, Rational.Max, right, out result);
-      #if  TRACE_AD_PERFORMANCES
-
-      AddTimeElapsedFromStart("Join", ref timeSpentInDomainOperations, watch.Elapsed); 
-#endif
-      return result;
-    }
-
-    IAbstractDomain  IAbstractDomain.Meet(IAbstractDomain  a)
-    {
-      return this.Meet((OctagonEnvironment<Variable, Expression>)a);
-    }    
-
-    public OctagonEnvironment<Variable, Expression>  Meet(OctagonEnvironment<Variable, Expression>  right)
-    {
-      #if  TRACE_AD_PERFORMANCES
-
-      Increase(ref countDomainOperationsInvocations);
-#endif
-      OctagonEnvironment<Variable, Expression> result;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, right, out result))
-      {
-        return result;
-      }
-
-      var watch = new Stopwatch();
-      watch.Start();
-      HelperForBinaryDomainOperation(BinaryOperationType.Meet, Rational.Min, right, out result);
-      #if  TRACE_AD_PERFORMANCES
-
-      AddTimeElapsedFromStart("Meet", ref timeSpentInDomainOperations, watch.Elapsed);
-#endif
-      return result;
-    }
-
-    IAbstractDomain  IAbstractDomain.Widening(IAbstractDomain  prev)
-    {
-      return this.Widening((OctagonEnvironment<Variable, Expression>)prev);
-    }
-
-    /// <summary>
-    /// Widening with thresholds.
-    /// Please note that all the instances of OctagonEnvironment shares the same thresholds for widening
-    /// </summary>
-    /// <param name="prev"></param>
-    /// <returns></returns>
-    public OctagonEnvironment<Variable, Expression>  Widening(OctagonEnvironment<Variable, Expression>  prev)
-    {
-      #if  TRACE_AD_PERFORMANCES
-
-      Increase( ref countDomainOperationsInvocations);
-#endif
-      OctagonEnvironment<Variable, Expression> result;
-
-      if(AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
-      {
-        return result;
-      }
-
-      var watch = new Stopwatch();
-      watch.Start();
-      HelperForBinaryDomainOperation(BinaryOperationType.Widening, pointwiseWidening, prev, out result);
-
-      #if  TRACE_AD_PERFORMANCES
-
-      AddTimeElapsedFromStart("Widening", ref timeSpentInDomainOperations, watch.Elapsed);
-#endif
-      return result;
-    }
-    #endregion
-
-    #region IPureExpressionAssignments Members (ProjectVariable, AddVariable, RemoveVariable, RenameVariable)
-
-    public List<Variable> Variables
-    {
-      get
-      {
-        return new List<Variable>(this.variables2dimensions.Keys);
-      }
-    }
-
-    /// <summary>
-    /// Project the value of the variable <code>var</code>.
-    /// It is as setting its value to top, or playing havoc 
-    /// </summary>
-    public void ProjectVariable(Variable  var)
-    {
-      if (this.variables2dimensions.Keys.Contains(var))
-      {
-        base.ProjectDimension(this.variables2dimensions[var]);
-      }
-      else
-      {
-        // do nothing...
-      }
-    }
-
-    /// <summary>
-    /// Add a new variable to the environment.
-    /// The variable must not be 
-    /// </summary>
-    public void AddVariable(Variable  var)
-    {
-      // If the variable is already in the Octagon, then we have nothing to do
-      if (this.variables2dimensions.ContainsKey(var))
-      {
-        return;
-      }
-      else
-      {
-        int newDim = base.GetAvailableDimension();
-        this.variables2dimensions[var] = newDim;
-
-        this.state = this.state != OctagonState.BOTTOM? OctagonState.NORMAL : OctagonState.BOTTOM;
-      }
-    }
-
-    /// <summary>
-    /// Remove the variable from the current environment.
-    /// Its values is projected, so that the relations are kept.
-    /// The variable is removed from the octagon
-    /// </summary>
-    public void RemoveVariable(Variable  var)
-    {
-      if (this.variables2dimensions.Keys.Contains(var))
-      {
-        base.RemoveDimension(this.variables2dimensions[var]);
-        this.variables2dimensions.Remove(var);
-      }
-      else
-      {
-        // do nothing..
-      }
-    }
-
-    /// <summary>
-    /// Renames the variable <code>oldName</code> to <code>newName</code>
-    /// </summary>
-    public void RenameVariable(Variable oldName, Variable newName)
-    {
-      this.variables2dimensions[newName] = this.variables2dimensions[oldName];
-      this.variables2dimensions.Remove(oldName);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignmentsWithBackward<Expression> Members
-
-    /// <summary>
-    /// Performs the backward assignment for Octagons
-    /// </summary>
-    /// <param name="x">The variable to be assigned</param>
-    /// <param name="exp">The source expression</param>
-    public void AssignBackward(Expression  x, Expression  exp)
-    {
-      throw new AbstractInterpretationTODOException();
-    }
-
-    public void AssignBackward(Expression  x, Expression  exp, IAbstractDomain  preState, out IAbstractDomain refinedPreState)
-    {
-      throw new AbstractInterpretationTODOException();
-    }
-
-    #endregion
-
-    #region IPureExpressionTest Members (TestTrue)
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    #endregion
-
-    #region Factories 
-
-    override protected CoreOctagon Factory(int dim)
-    {
-      return this.FactoryForOctagonEnvironment(dim);
-    }
-
-    private OctagonEnvironment<Variable, Expression> FactoryForOctagonEnvironment(int dim)
-    {
-      return new OctagonEnvironment<Variable, Expression>(dim, this.expManager, this.Precision);
-    }
-
-    protected override CoreOctagon Factory(int dim, bool allocateMatrix)
-    {
-      return this.FactoryForOctagonEnvironment(dim, allocateMatrix);
-    }
-
-    private OctagonEnvironment<Variable, Expression> FactoryForOctagonEnvironment(int dim, bool allocateMatrix)
-    {
-      return new OctagonEnvironment<Variable, Expression>(dim, allocateMatrix, this.expManager, this.Precision);
-    }
-
-    new public OctagonEnvironment<Variable, Expression> Duplicate()
-    {
-      OctagonEnvironment<Variable, Expression> result = base.Duplicate() as OctagonEnvironment<Variable, Expression>;
-
-      Contract.Assert(result != null, "Expecting an instance of OctagonEnvironment..."); //^ assert result != null;
-      Contract.Assert(result != this, "Duplicate must create a fresh octagon reference");
-
-      result.variables2dimensions = new BijectiveMap<Variable, int>(this.variables2dimensions);     // for this we are eager...
-
-      return result;
-    }
-
-    public override object  Clone()
-    {
-      return this.Duplicate();
-    }
-
-    public override bool Equals(object obj)
-    {
-      var that = obj as OctagonEnvironment<Variable, Expression>;
-      if (that == null) return false;
-
-      return (that.LessEqual(this) && this.LessEqual(that));
-    }
-
-    public override int GetHashCode()
-    {
-      return base.GetHashCode();
-    }
-
-    /// <summary>
-    /// Does nothing
-    /// </summary>
-    /// <param name="oracle"></param>
-    /// <returns></returns>
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return this.Duplicate();
-    }
-
-    #endregion
-
-    #region ToString
-
-
-    public T To<T>(IFactory<T> factory)
-    {
-      var result = factory.IdentityForAnd;
-
-      this.DoClosure();
-
-      if (this.IsBottom)
-      {
-        return factory.Constant(false);
-      }
-
-      if (this.IsTop)
-      {
-        return factory.Constant(true);
-      }
-
-
-      for (int i = 0; i < this.Dimensions; i++)
-      {
-        if(!this.variables2dimensions.ContainsValue(i))
+        /// <summary>
+        /// Get the bounds for the variable <code>v</code>
+        /// </summary>
+        public DisInterval BoundsFor(Expression exp)
         {
-          continue;
+            return this.BoundsFor(expManager.Decoder.UnderlyingVariable(exp));
         }
 
-        var x = this.variables2dimensions.KeyForValue(i);
-
-        if (this.octagon[Matpos(2 * i, 2 * i)] != 0)
+        public DisInterval BoundsFor(Variable v)
         {
-          // STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i)] 
-          var tmp = ToOctagonConstraint(1, x, -1, x, this.octagon[Matpos(2*i, 2*i)], factory);
-          result = factory.And(result, tmp);
-        }
-
-        if (this.octagon[Matpos(2 * i + 1, 2 * i + 1)] != 0)
-        {
-          // STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i + 1)] 
-          var tmp = ToOctagonConstraint(1, x, 1, x, this.octagon[Matpos(2 * i + 1, 2 * i + 1)], factory);
-          result = factory.And(result, tmp);
-        }
-        if (!this.octagon[Matpos(2 * i + 1, 2 * i)].IsInfinity)
-        {
-          // STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i)] + "/2" ;
-          var tmp = ToOctagonConstraint(1, x, this.octagon[Matpos(2 * i + 1, 2 * i)] / 2, factory);
-          result = factory.And(result, tmp);
-        }
-        if (!this.octagon[Matpos(2 * i, 2 * i + 1)].IsInfinity)
-        {
-          // "-" + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i + 1)] + "/2" + Environment.NewLine + " ";
-          var tmp = ToOctagonConstraint(-1, x, this.octagon[Matpos(2 * i + 1, 2 * i +1)] / 2, factory);
-          result = factory.And(result, tmp);
-        }
-      }
-
-      for (int i = 0; i < this.Dimensions; i++)
-      {
-        if (!this.variables2dimensions.ContainsValue(i))
-        {
-          continue;
-        }
-
-        var x = this.variables2dimensions.KeyForValue(i);
-
-        for (int j = i + 1; j < this.Dimensions; j++)
-        {
-          if (!this.variables2dimensions.ContainsValue(j))
-          {
-            continue;
-          }
-
-          var y = this.variables2dimensions.KeyForValue(j);
-
-          if (!this.octagon[Matpos(2 * j, 2 * i)].IsInfinity)
-          {
-            // STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i)]           
-            var tmp = ToOctagonConstraint(1, x, -1, y, this.octagon[Matpos(2 * j, 2 * i)], factory);
-            result = factory.And(result, tmp);
-          }
-          
-          if (!this.octagon[Matpos(2 * j, 2 * i + 1)].IsInfinity)
-          {
-            // "-" + STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i + 1)] 
-            var tmp = ToOctagonConstraint(-1, x, -1, y, this.octagon[Matpos(2 * j, 2 * i + 1)], factory);
-            result = factory.And(result, tmp);
-          }
-
-          if (!this.octagon[Matpos(2 * j + 1, 2 * i)].IsInfinity)
-          {  
-            // STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i)] 
-            var tmp = ToOctagonConstraint(1, x, 1, y, this.octagon[Matpos(2 * j + 1, 2 * i)], factory);
-            result = factory.And(result, tmp);
-          }
-          
-          if (!this.octagon[Matpos(2 * j + 1, 2 * i + 1)].IsInfinity)
-          {
-            // STR_FOR_DIMENSION + j + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i + 1)] 
-            var tmp = ToOctagonConstraint(1, y, -1, x, this.octagon[Matpos(2 * j + 1, 2 * i + 1)], factory);
-            result = factory.And(result, tmp);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    public T ToOctagonConstraint<T>(int a, Variable x, int b, Variable y, Rational k, IFactory<T> factory)
-    {
-      T left, right;
-
-      if(a != 0 && b !=0)
-      {
-        var m1 = factory.Mul(factory.Constant(a), factory.Variable(x));
-        var m2 = factory.Mul(factory.Constant(b), factory.Variable(y));
-
-        left = factory.Add(m1, m2); 
-      }
-      else if (a != 0)
-      { // b == 0
-        left = factory.Mul(factory.Constant(a), factory.Variable(x));
-      }
-      else if (b != 0)
-      { // a== 0
-        left = factory.Mul(factory.Constant(b), factory.Variable(y));
-      }
-      else
-      {
-        throw new AbstractInterpretationException("Impossible case");
-      }
-
-      right = factory.Constant(k);
-
-      return factory.LessEqualThan(left, right);
-    }
-
-    public T ToOctagonConstraint<T>(int a, Variable x, Rational k, IFactory<T> factory)
-    {
-      return ToOctagonConstraint<T>(a, x, 0, default(Variable), k, factory);
-    }
-
-    public override string ToString()
-    {
-      var oct = RenameDimensions(base.ToString());
-
-      var env = new StringBuilder();
-
-      foreach (var var in this.variables2dimensions.Keys)
-      {
-        env.Append("(" + var + ", " + this.variables2dimensions[var] + "),");
-      }
-      var env2str = env.ToString();
-      var indexLastComma = env2str.LastIndexOf(",");
-      env2str = indexLastComma > 0 ? env2str.Remove(indexLastComma) : env2str;
-
-      return env2str + Environment.NewLine + oct;
-    }
-
-    public string ToString(Expression exp)
-    {
-      if (this.expManager.Decoder != null)
-      {
-        return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
-      }
-      else
-      {
-        return "< missing expression decoder >";
-      }
-    }
-
-    /// <summary>
-    /// Takes the result of <code>base.ToString()</code> and rename all the occurrences of <code>vi</code> with the correct variable
-    /// </summary>
-    private string RenameDimensions(string oct)
-    {
-      // Contract.Assert(oct.CompareTo(base.ToString()) == 0, "You can invoke RenameDimensions just on the result of CoreOctagon.ToString()");
-
-      var result = new StringBuilder(oct);
-
-      foreach (var x in this.variables2dimensions.Keys)
-      {
-        Contract.Assert(x != null);
-        //^ assert x != null;
-
-        int i = this.variables2dimensions[x];
-
-        result.Replace(STR_FOR_DIMENSION + i + " ", x.ToString());  // Trick: we need to pattern match the space!
-      }
-
-      return result.ToString();
-    }
-
-    #endregion
-
-    #region Performance and debugging helpers
-    // This is just for checking the soundness of the operation
-    private Set<int> visitedIndexes = new Set<int>();
-
-    // Used only to monitor the accesses to the octagon, for debugging
-    private Rational this[int i]
-    {
-      set
-      {
-        this.octagon[i] = value;
-
-        if (this.visitedIndexes.Contains(i))
-        {
-          System.Diagnostics.Debugger.Break();
-        }
-
-        this.visitedIndexes.Add(i);
-      }
-    }
-
-    private static void UpdateMaxDim(int x, int y)
-    {
-#if false // unused?
-      MaxDim = Math.Max(MaxDim, Math.Max(x, y));
-#endif
-    }
-
-    #endregion
-
-    #region Helpers for Domain operations (LessEq, Join, Meet and Widening)
-    /// <summary>
-    /// The core method for OctagonEnvironments Join, Meet and Widening
-    /// </summary>
-    /// <param name="whichOperation">Which operation have we to apply?</param>
-    /// <param name="pointwiseOp">The operation to be applyed, pointwise, to each element</param>
-    /// <param name="right">The "right" OctagonEnvironment. It must have the SAME dimensions than this octagon</param>
-    /// <param name="result">Meaningful iff whichOperation \in { Join, Meet, Widening }</param>
-    private void HelperForBinaryDomainOperation(BinaryOperationType whichOperation, BinaryOperation pointwiseOp, OctagonEnvironment<Variable, Expression>  right, out OctagonEnvironment<Variable, Expression> result)
-    {
-      // PRECONDITION: !!!! The two octagons must have the same number of allocated variables !!!!
-
-      CheckConsistency();
-
-      OctagonEnvironment<Variable, Expression> left = this;
-
-      OctagonEnvironment<Variable, Expression> resultOctagon;
-
-      UpdateMaxDim(left.octagon.Length, right.octagon.Length);
-
-      #region 1. Close the octagon, depending on the kind of the operation...
-      if (left == right)
-      {
-        result = this;
-
-        return;
-      }
-
-      // To ensure convergence for widening we have to pay attention when to close
-      if (whichOperation == BinaryOperationType.Join || whichOperation == BinaryOperationType.Meet)
-      {
-        // for join and meet we can always close to have precision
-        left.DoClosure();
-        right.DoClosure();
-
-        if (whichOperation == BinaryOperationType.Join && AbstractDomainsHelper.TryTrivialJoin(left, right, out result))
-        {
-          return /*result*/;
-        }
-        else if (whichOperation == BinaryOperationType.Meet && AbstractDomainsHelper.TryTrivialMeet(left, right, out result))
-        {
-          return /*result*/;
-        }
-      }
-      else if (whichOperation == BinaryOperationType.Widening)
-      {
-        // For widenings we have to close just the previous iteration!
-        right.DoClosure();
-
-        if (AbstractDomainsHelper.TryTrivialJoin(left, right, out result))
-        {
-          return /*result*/;
-        }
-      }
-      else
-      {
-        Contract.Assert(false, "I do not know the operation + " + whichOperation);
-      }
-
-      #endregion
-
-      #region 2. Create the result octagon
-
-      // Compute an overapproximation of the variables in the result
-      var varsInResult = new List<Variable>();
-      switch (whichOperation)
-      {
-        case BinaryOperationType.Join:
-        case BinaryOperationType.Widening:
-          {
-            varsInResult = left.Variables.SetIntersection(right.Variables);
-          }
-          break;
-
-        case BinaryOperationType.Meet:
-          {
-            varsInResult = left.Variables.SetUnion(right.Variables);
-          }
-          break;
-
-        default:
-          throw new AbstractInterpretationException("Unknown octagon operation: " + whichOperation);
-      }
-
-      resultOctagon = new OctagonEnvironment<Variable, Expression>(varsInResult.Count, this.expManager, this.Precision);    // The new result octagon
-
-      // Now add them
-      foreach (var x in varsInResult)
-      {
-        resultOctagon.AddVariable(x);
-      }
-
-      #endregion
-
-      #region 3. Iterates over all the constraints in this OctagonEnvironment, find the corresponding in right, apply the binary operation and writes the result in the output
-      foreach (var i in left.AllocatedDimensions)
-      {
-        var var = left.variables2dimensions.KeyForValue(i);                     // Gets the variable corresponding to i
-
-        if (!varsInResult.Contains(var))
-        {
-          continue;
-        }
-
-        var dimInRight = right.DimensionForVar(var);   // Get the dimension corresponding to this variable in the right octagon
-        var dimInResult = resultOctagon.DimensionForVar(var); // Get the dimension corresponding to this variable in the result octagon
-
-        Rational thisK, rightK;
-        Rational resultOfCombination;
-
-        // We consider all the constraints for the variable var
-
-        // 1. OctagonConstraint XMinusY(i, i), this.octagon[Matpos(2 * i, 2 * i)]
-        thisK = left.ConstantForXMinusY(i, i);
-        rightK = right.ConstantForXMinusY(dimInRight, dimInRight);
-        resultOfCombination = pointwiseOp(thisK, rightK);
-        resultOctagon/*.octagon*/[Matpos2(2 * dimInResult, 2 * dimInResult)] = resultOfCombination;
-
-        // 2. OctagonConstraint MinusXY, this.octagon[Matpos(2 * i + 1, 2 * i + 1)]
-        thisK = left.ConstantForMinusXY(i, i);
-        rightK = right.ConstantForMinusXY(dimInRight, dimInRight);
-        resultOfCombination = pointwiseOp(thisK, rightK);
-        resultOctagon/*.octagon*/[Matpos2(2 * dimInResult + 1, 2 * dimInResult + 1)] = resultOfCombination;
-
-        // 3. OctagonConstraint X, this.octagon[Matpos(2 * i + 1, 2 * i)])
-        thisK = left.ConstantForX(i);
-        rightK = right.ConstantForX(dimInRight);
-        resultOfCombination = pointwiseOp(thisK, rightK);
-        resultOctagon/*.octagon*/[Matpos2(2 * dimInResult + 1, 2 * dimInResult)] = resultOfCombination;
-
-        // 4. OctagonConstraint MinusX, this.octagon[Matpos(2 * i, 2 * i + 1)]
-        thisK = left.ConstantForMinusX(i);
-        rightK = right.ConstantForMinusX(dimInRight);
-        resultOfCombination = pointwiseOp(thisK, rightK);
-        resultOctagon/*.octagon*/[Matpos2(2 * dimInResult, 2 * dimInResult + 1)] = resultOfCombination;
-      }
-
-      // I use this method, instead of two iterators, as it is faster (I do not have to visit the dimensions*dimensions cases, but just 1/2(dimensions * dimensions)
-      for (int i = 0; i < left.Dimensions; i++)
-      {
-        // If it is a dimension without a variable associated to it, then skip it
-        if (!left.variables2dimensions.ContainsValue(i))
-        {
-          continue;
-        }
-
-        var varForI = left.variables2dimensions.KeyForValue(i);     // The variable corresponding to the dimension i
-        var dimInRightForI = right.DimensionForVar(varForI);          // The dimension, in right, corresponding to the variable varForI    
-        var dimInResultForI = resultOctagon.DimensionForVar(varForI); // The dimension, in result, corresponding to the variable varForI
-
-        for (var j = i + 1; j < left.Dimensions; j++)
-        {
-          // If it is a dimension without a variable associated to it, then skip it
-          if (!left.variables2dimensions.ContainsValue(j))
-          {
-            continue;
-          }
-
-          var varForJ = left.variables2dimensions.KeyForValue(j);      // The variable corresponding to the dimension j         
-          var dimInRightForJ = right.DimensionForVar(varForJ);           // The dimension, in right, corresponding to the variable varForJ                
-          var dimInResultForJ = resultOctagon.DimensionForVar(varForJ);  // The dimension, in result, corresponding to the variable varForJ
-
-          Rational thisK, rightK;
-          Rational resultOfCombination;
-
-          // 1. OctagonConstraint XMinusY, this.octagon[Matpos(2 * j, 2 * i)])
-          thisK = left.ConstantForXMinusY(j, i);
-          rightK = right.ConstantForXMinusY(dimInRightForJ, dimInRightForI);
-          resultOfCombination = pointwiseOp(thisK, rightK);
-          resultOctagon/*.octagon*/[IndexForXMinusY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
-
-          // 2. OctagonConstraint MinusXMinusY, this.octagon[Matpos(2 * j, 2 * i + 1)])
-          thisK = left.ConstantForMinusXMinusY(j, i);
-          rightK = right.ConstantForMinusXMinusY(dimInRightForJ, dimInRightForI);
-          resultOfCombination = pointwiseOp(thisK, rightK);
-          resultOctagon/*.octagon*/[IndexForMinusXMinusY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
-
-          // 3. OctagonConstraint XY, this.octagon[Matpos(2 * j + 1, 2 * i)])                    
-          thisK = left.ConstantForXY(j, i);
-          rightK = right.ConstantForXY(dimInRightForJ, dimInRightForI);
-          resultOfCombination = pointwiseOp(thisK, rightK);
-          resultOctagon/*.octagon*/[IndexForXY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
-
-          // 4. OctagonConstraint MinusXY, this.octagon[Matpos(2 * j + 1, 2 * i + 1)]))
-          thisK = left.ConstantForMinusXY(j, i);
-          rightK = right.ConstantForMinusXY(dimInRightForJ, dimInRightForI);
-          resultOfCombination = pointwiseOp(thisK, rightK);
-          resultOctagon/*.octagon*/[IndexForMinusXY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
-        }
-      }
-
-      #endregion
-
-      result = resultOctagon;
-    }
-
-    private bool HelperForLessEqual(OctagonEnvironment<Variable, Expression>  a)
-    {
-      // PRECONDITION: !!!! The two octagons must have the same number of allocated variables !!!!
-
-      // We have to check the copies in order to avoid NON-termination when combined with widening...
-
-      var left = this.Duplicate();
-      var right = a.Duplicate();
-
-      left.DoClosure();
-      right.DoClosure();			
-
-	// we are adding those two as the truvual check done before does not enforce the closure
-
-      if (left.IsBottom)
-        return true;
-
-      if (right.IsBottom)
-        return false;
-
-      #region 1. Compute the inverse map of this Var -> dimensions
-      // TODO4: Improve perfomances with caching 
-
-      var inverseMap = new Dictionary<int, Variable>(this.variables2dimensions.Count);                      // Dimensions -> Variables
-
-      foreach (var x in this.variables2dimensions.Keys)
-      {
-        inverseMap[left.variables2dimensions[x]] = x;
-      }
-
-      #endregion
-
-      #region 2. Iterates over all the constraints in this OctagonEnvironment, find the corresponding in right, check the leq property
-      foreach (int i in left.AllocatedDimensions)
-      {
-        var var = inverseMap[i];                     // Gets the variable corresponding to i
-
-        var dimInRight = right.DimensionForVar(var);   // Get the dimension corresponding to this variable in the right octagon
-
-        Rational thisK, rightK;
-
-
-        // We consider all the constraints for the variable <code>var</var>
-
-        // 1. OctagonConstraint XMinusY(i, i), this.octagon[Matpos(2 * i, 2 * i)]
-        thisK = left.ConstantForXMinusY(i, i);
-        rightK = right.ConstantForXMinusY(dimInRight, dimInRight);
-        if (rightK < thisK)
-          return false;
-
-        // 2. OctagonConstraint MinusXY, this.octagon[Matpos(2 * i + 1, 2 * i + 1)]
-        thisK = left.ConstantForMinusXY(i, i);
-        rightK = right.ConstantForMinusXY(dimInRight, dimInRight);
-        if (rightK < thisK)
-          return false;
-
-        // 3. OctagonConstraint X, this.octagon[Matpos(2 * i + 1, 2 * i)])
-        thisK = left.ConstantForX(i);
-        rightK = right.ConstantForX(dimInRight);
-        if (rightK < thisK)
-          return false;
-
-        // 4. OctagonConstraint MinusX, this.octagon[Matpos(2 * i, 2 * i + 1)]
-        thisK = left.ConstantForMinusX(i);
-        rightK = right.ConstantForMinusX(dimInRight);
-        if (rightK < thisK)
-          return false;
-
-      }
-
-      // I use this method, instead of two iterators, as it is faster (I do not have to visit the dimensions*dimensions cases, but just 1/2(dimensions * dimensions)
-      for (int i = 0; i < left.Dimensions; i++)
-      {
-        // If it is a dimension without a variable associated to it, then skip it
-        if (!inverseMap.ContainsKey(i))
-        {
-          continue;
-        }
-
-        var varForI = inverseMap[i];                         // The variable corresponding to the dimension i
-        var dimInRightForI = right.DimensionForVar(varForI);   // The dimension, in right, corresponding to the variable varForI    
-
-        for (int j = i + 1; j < left.Dimensions; j++)
-        {
-          // If it is a dimension without a variable associated to it, then skip it
-          if (!inverseMap.ContainsKey(j))
-          {
-            continue;
-          }
-
-          var varForJ = inverseMap[j];                         // The variable corresponding to the dimension j         
-          var dimInRightForJ = right.DimensionForVar(varForJ);   // The dimension, in right, corresponding to the variable varForJ                
-
-          Rational thisK, rightK;
-
-          // 1. OctagonConstraint XMinusY, this.octagon[Matpos(2 * j, 2 * i)])
-          thisK = left.ConstantForXMinusY(j, i);
-          rightK = right.ConstantForXMinusY(dimInRightForJ, dimInRightForI);
-          if (rightK < thisK)
-            return false;
-
-          // 2. OctagonConstraint MinusXMinusY, this.octagon[Matpos(2 * j, 2 * i + 1)])
-          thisK = left.ConstantForMinusXMinusY(j, i);
-          rightK = right.ConstantForMinusXMinusY(dimInRightForJ, dimInRightForI);
-          if (rightK < thisK)
-            return false;
-
-          // 3. OctagonConstraint XY, this.octagon[Matpos(2 * j + 1, 2 * i)])                    
-          thisK = left.ConstantForXY(j, i);
-          rightK = right.ConstantForXY(dimInRightForJ, dimInRightForI);
-          if (rightK < thisK)
-            return false;
-
-          // 4. OctagonConstraint MinusXY, this.octagon[Matpos(2 * j + 1, 2 * i + 1)]))
-          thisK = left.ConstantForMinusXY(j, i);
-          rightK = right.ConstantForMinusXY(dimInRightForJ, dimInRightForI);
-          if (rightK < thisK)
-            return false;
-        }
-      }
-      #endregion
-
-      return true;
-    }
-
-    #endregion
-
-    #region Public Queries
-
-    /// <summary>
-    /// x + y \leq val
-    /// </summary>
-    /// <returns><code>true</code> if it succeeds</returns>
-    internal bool TryConstantForXY(Variable x, Variable y, out Rational val)
-    {
-      if (this.variables2dimensions.ContainsKey(x) && this.variables2dimensions.ContainsKey(y))
-      {
-        val = this.ConstantForXY(DimensionForVar(x), DimensionForVar(y));
-
-        return !val.IsInfinity;
-      }
-      else
-      {
-        val = default(Rational);
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// x - y \leq val
-    /// </summary>
-    /// <returns><code>true</code> if it succeeds</returns>
-    internal bool TryConstantForXMinusY(Variable x, Variable y, out Rational val)
-    {
-      if (this.variables2dimensions.ContainsKey(x) && this.variables2dimensions.ContainsKey(y))
-      {
-        val = this.ConstantForXMinusY(DimensionForVar(x), DimensionForVar(y));
-        return !val.IsInfinity;
-      }
-      else
-      {
-        val = default(Rational);
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// -x - y \leq val
-    /// </summary>
-    /// <returns><code>true</code> if it succeeds</returns>
-    internal bool TryConstantForMinusXMinusY(Variable x, Variable y, out Rational val)
-    {
-      if (this.variables2dimensions.ContainsKey(x) && this.variables2dimensions.ContainsKey(y))
-      {
-        val = this.ConstantForMinusXMinusY(DimensionForVar(x), DimensionForVar(y));
-        return !val.IsInfinity;
-      }
-      else
-      {
-        val = default(Rational);
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// x \leq val
-    /// </summary>
-    /// <returns><code>true</code> if it succeeds</returns>
-    internal bool TryConstantForX(Variable x, out Rational val)
-    {
-      if (this.variables2dimensions.ContainsKey(x))
-      {
-        val = this.ConstantForX(DimensionForVar(x));
-        val = val / 2;    // This is because of the octagons encoding
-
-        return !val.IsInfinity;
-      }
-      else
-      {
-        val = default(Rational);
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// -x \leq val
-    /// </summary>
-    /// <returns><code>true</code> if it succeeds</returns>
-    internal bool TryConstantForMinusX(Variable x, out Rational val)
-    {
-      if (this.variables2dimensions.ContainsKey(x))
-      {
-        val = this.ConstantForMinusX(DimensionForVar(x));
-        val = val / 2;  // This is because of the octagons encoding
-
-        return !val.IsInfinity;
-      }
-      else
-      {
-        val = default(Rational);
-        return false;
-      }
-    }
-
-    #endregion
-
-    #region Private Queries 
-
-    /// <summary>
-    /// Gets the constant (k) corresponding to the constraint X + Y \leq k
-    /// </summary>
-    private Rational ConstantForXY(int x, int y)
-    {
-      int j = 2 * x;
-      int i = 2 * y + 1;
-      return this.octagon[Matpos2(i, j)];
-    }
-
-    /// <summary>
-    /// Gets the constant (k) corresponding to the constraint X - Y \leq k
-    /// </summary>
-    private Rational ConstantForXMinusY(int x, int y)
-    {
-      int j = 2 * x;
-      int i = 2 * y;
-      return this.octagon[Matpos2(i, j)];
-    }
-
-    /// <summary>
-    /// Gets the constant (k) corresponding to the constraint - X + Y \leq k
-    /// </summary>
-    private Rational ConstantForMinusXY(int x, int y)
-    {
-      int j = 2 * x + 1;
-      int i = 2 * y + 1;
-      return this.octagon[Matpos2(i, j)];
-    }
-
-    /// <summary>
-    /// Gets the constant (k) corresponding to the constraint - X - Y \leq k
-    /// </summary>
-    private Rational ConstantForMinusXMinusY(int x, int y)
-    {
-      int j = 2 * x + 1;
-      int i = 2 * y;
-      return this.octagon[Matpos2(i, j)];
-    }
-
-    /// <summary>
-    /// Gets the constant (k) corresponding to the constraint X \leq k
-    /// </summary>
-    /// <returns>k is TWICE the real value, because of "two times" representation</returns>
-    private Rational ConstantForX(int x)
-    {
-      int j = 2 * x;
-      int i = 2 * x + 1;
-      return this.octagon[Matpos2(i, j)];
-    }
-
-    /// <summary>
-    /// Gets the constant (k) corresponding to the constraint - X \leq k
-    /// </summary>
-    /// <returns>k is TWICE the real value, because of "two times" representation</returns>
-    private Rational ConstantForMinusX(int x)
-    {
-      int j = 2 * x + 1;
-      int i = 2 * x;
-      return this.octagon[Matpos2(i, j)];
-    }
-
-    #endregion
-
-    #region Index computation
-    /// <summary>
-    /// Gets the index corresponding to the constraint X + Y \leq k
-    /// </summary>
-    static private int IndexForXY(int x, int y)
-    {
-      int j = 2 * x;
-      int i = 2 * y + 1;
-      return Matpos2(i, j);
-    }
-
-    /// <summary>
-    /// Gets the index corresponding to the constraint X - Y \leq k
-    /// </summary>
-    static private int IndexForXMinusY(int x, int y)
-    {
-      int j = 2 * x;
-      int i = 2 * y;
-      return Matpos2(i, j);
-    }
-
-    /// <summary>
-    /// Gets the index corresponding to the constraint - X + Y \leq k
-    /// </summary>
-    static private int IndexForMinusXY(int x, int y)
-    {
-      int j = 2 * x + 1;
-      int i = 2 * y + 1;
-      return Matpos2(i, j);
-    }
-
-    /// <summary>
-    /// Gets the index corresponding to the constraint - X - Y \leq k
-    /// </summary>
-    static private int IndexForMinusXMinusY(int x, int y)
-    {
-      int j = 2 * x + 1;
-      int i = 2 * y;
-      return Matpos2(i, j);
-    }
-
-    #endregion
-
-    #region TestTrue Members
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression  exp)
-    {
-      return this.TestTrueGeqZero(exp);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression  exp1, Expression  exp2)
-    {
-      return this.TestTrueLessThan(exp1, exp2);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression  exp1, Expression  exp2)
-    {
-      return this.TestTrueLessEqualThan(exp1, exp2);
-    }
-
-    public OctagonEnvironment<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      if (!this.expManager.Decoder.IsConstant(exp))
-      { // Create the constraint "exp >= 0"
-        var newConstraint = new OctagonConstraintMinusX(this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(exp)), 0);
-        this.AddConstraint(newConstraint);
-      }
-
-      return this;
-    }
-
-    public OctagonEnvironment<Variable, Expression> TestTrueLessThan(Expression e1, Expression e2)
-    {
-      // Add the direct
-
-      // e1 < e2 is equivalent to e1 - e2 <= -1
-      var intvForE1 = this.constantVisitor.Visit(e1, new IntervalEnvironment<Variable, Expression>(this.expManager));
-      var intvForE2 = this.constantVisitor.Visit(e2, new IntervalEnvironment<Variable, Expression>(this.expManager));
-
-      Rational valForE1, valForE2;
-      var b1 = intvForE1.TryGetSingletonValue(out valForE1);
-      var b2 = intvForE2.TryGetSingletonValue(out valForE2);
-
-      var e1Var = this.expManager.Decoder.UnderlyingVariable(e1);
-      var e2Var = this.expManager.Decoder.UnderlyingVariable(e2);
-
-      OctagonConstraint directConstraint = null;
-
-      // The four cases...
-      if (b1 && !b2)
-      { // k - e2 <= -1
-        if (valForE1.IsInteger)
-        {
-          directConstraint = OctagonConstraint.For(-1, this.DimensionForVar(e2Var), -1 - ((Int32)valForE1));
-        }
-      }
-      else if(!b1 && b2)
-      { // e1 - k <= -1
-        if (valForE2.IsInteger)
-        {
-          directConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1 + ((Int32)valForE2));
-        }
-      }
-      else if (b1 && b2)
-      {
-        if (!(valForE1 < valForE2))
-        {
-          return (OctagonEnvironment<Variable, Expression>)this.Bottom;
-        }
-      }
-      else
-      {
-        directConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(e2Var), Rational.For(-1));
-      }
-
-      if (directConstraint != null)
-      {
-        this.AddConstraint(directConstraint);
-      }
-
-      TestTrueLessThanSpecialCaseForPartitionAnalysis(e1, e2);
-
-      // Now go inside an simplify it
-      PolynomialOfInt<Variable, Expression> e1AsPoly, e2AsPoly, combined;
-      if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e1, this.expManager.Decoder, out e1AsPoly)
-        && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e2, this.expManager.Decoder, out e2AsPoly)
-        && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1AsPoly, e2AsPoly, out combined))
-      {
-
-        var newConstraints = new Set<OctagonConstraint>();
-        if (new InferOctagonConstraints<Variable, Expression>().Visit(combined, this, ref newConstraints))
-        {
-          this.AddConstraints(newConstraints);
-        }
-      }
-
-      return this;
-    }
-
-    /// <summary>
-    /// Special case needed for the partition analysis which wants to infer octogonal constraints on conditions in the form
-    /// slackVar \lt (exp + k), without refining exp
-    /// </summary>
-    private void TestTrueLessThanSpecialCaseForPartitionAnalysis(Expression e1, Expression e2)
-    {
-      TestTrueLessThanOrLessEqualThanCaseSpecialCaseForPartitionAnalysis(e1, e2, 1);
-    }
-
-    private void TestTrueLessEqualThanSpecialCaseForPartitionAnalysis(Expression e1, Expression e2)
-    {
-      TestTrueLessThanOrLessEqualThanCaseSpecialCaseForPartitionAnalysis(e1, e2, 0);
-    }
-
-    private void TestTrueLessThanOrLessEqualThanCaseSpecialCaseForPartitionAnalysis(Expression e1, Expression e2, int offset)
-    {
-      // case slackVar \lt exp + k
-
-      var e1Var = this.expManager.Decoder.UnderlyingVariable(e1);
-
-      if (this.expManager.Decoder.IsSlackVariable(e1Var) && this.expManager.Decoder.IsBinaryExpression(e2))
-      {
-        var op = this.expManager.Decoder.OperatorFor(e2);
-
-        var left = this.expManager.Decoder.LeftExpressionFor(e2);
-        var right = this.expManager.Decoder.RightExpressionFor(e2);
-
-        var leftIntv = this.constantVisitor.Visit(left, new IntervalEnvironment<Variable, Expression>(this.expManager));
-        var rightIntv = this.constantVisitor.Visit(right, new IntervalEnvironment<Variable, Expression>(this.expManager));
-
-        Rational v1, v2;
-
-        var b1 = leftIntv.TryGetSingletonValue(out v1);
-        var b2 = rightIntv.TryGetSingletonValue(out v2);
-
-        OctagonConstraint newConstraint = null;
-
-        switch (op)
-        {
-          case ExpressionOperator.Addition:
+            if (this.state != OctagonState.EMPTY && this.state != OctagonState.BOTTOM && variables2dimensions.Keys.Contains(v))
             {
-              if (b1 && !b2)
-              { // case x < v1 + right
-                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(right)), v1 - offset);
-              }
-              if (!b1 && b2)
-              {  // case x < left + v2
-                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(left)), v2 - offset);
-              }
+                return base.BoundsFor(variables2dimensions[v]).AsDisInterval;
             }
-            break;
-
-          case ExpressionOperator.Subtraction:
+            else
             {
-              if (b1 && !b2)
-              { // case x <= v1 - right
-                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(right)), -(v1 - offset));
-              }
-              if (!b1 && b2)
-              {  // case x <= left - v2
-                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(left)), -(v2 - offset));
-              }
+                return DisInterval.UnknownInterval;
             }
-            break;
-
-          default:
-            // do nothing.
-            return;
-            //break;
         }
-        if (newConstraint == null)
+
+        public void AssumeInDisInterval(Variable x, DisInterval value)
         {
-          return;
-        }
-        else
-        {
-          this.AddConstraint(newConstraint);
-        }
-      }
+            CheckConsistency();
 
-      // case e1 \lt slackVar
-      var e2Var = this.expManager.Decoder.UnderlyingVariable(e2);
-      if (this.expManager.Decoder.IsSlackVariable(e2Var) && this.expManager.Decoder.IsBinaryExpression(e1))
-      {
-        var op = this.expManager.Decoder.OperatorFor(e1);
-
-        var left = this.expManager.Decoder.LeftExpressionFor(e1);
-        var right = this.expManager.Decoder.RightExpressionFor(e1);
-
-        var leftIntv = this.constantVisitor.Visit(left, new IntervalEnvironment<Variable, Expression>(this.expManager));
-        var rightIntv = this.constantVisitor.Visit(right, new IntervalEnvironment<Variable, Expression>(this.expManager));
-
-        Rational v1, v2;
-
-        var b1 = leftIntv.TryGetSingletonValue(out v1);
-        var b2 = rightIntv.TryGetSingletonValue(out v2);
-
-        OctagonConstraint newConstraint = null;
-
-        switch (op)
-        {
-          case ExpressionOperator.Addition:
+            if (this.Precision == OctagonPrecision.FullPrecision)
             {
-              if (b1 && !b2)
-              { // case v1 + right < e2
-                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(right)), -1, this.DimensionForVar(e2Var), -v1 - offset);
-              }
-              if (!b1 && b2)
-              {  // case left + v2 < e2
-                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(left)), -1, this.DimensionForVar(e2Var), -v2 - offset);
-              }
-            }
-            break;
+                if (!value.IsNormal)
+                { // TODO: for the moment we ignore the "false" interval
+                    this.RemoveVariable(x);
+                }
+                else
+                {
+                    if (!value.LowerBound.IsInfinity)
+                    { // Add the constraint -x <= -value
+                        this.AddConstraint(new OctagonConstraintMinusX(this.DimensionForVar(x), -value.LowerBound));
+                    }
 
-          case ExpressionOperator.Subtraction:
+                    if (!value.UpperBound.IsInfinity)
+                    { // Add the constraint x <= value
+                        this.AddConstraint(new OctagonConstraintX(this.DimensionForVar(x), value.UpperBound));
+                    }
+                }
+            }
+            CheckConsistency();
+        }
+
+        public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+        }
+
+        /// <summary>
+        /// Abstract an OctagonEnvironment to an IntervalEnvironment
+        /// </summary>
+        public IntervalEnvironment<Variable, Expression> ToIntervalEnvironment()
+        {
+            var result = new IntervalEnvironment<Variable, Expression>(expManager);
+
+            foreach (var x in variables2dimensions.Keys)
             {
-              if (b1 && !b2)
-              { // case v1 - right < e2
-                newConstraint = OctagonConstraint.For(-1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(right)), -1, this.DimensionForVar(e2Var), -v1 - offset);
-              }
-              if (!b1 && b2)
-              {  // case left - v2 < e2
-                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(this.expManager.Decoder.UnderlyingVariable(left)), -1, this.DimensionForVar(e2Var), v2 - offset);
-              }
+                result.AssumeInDisInterval(x, this.BoundsFor(x));
             }
-            break;
-
-          default:
-            // do nothing
-            return;
-            //break;
-        }
-        if (newConstraint == null)
-        {
-          return;
-        }
-        else
-        {
-          this.AddConstraint(newConstraint);
-        }
-      }
-
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueEqual(exp1, exp2);
-    }
-
-    public OctagonEnvironment<Variable, Expression> TestTrueEqual(Expression  exp1, Expression  exp2)
-    {
-      this.CheckConsistency();
-
-      return this.TestTrueLessEqualThan(exp1, exp2).TestTrueLessEqualThan(exp2, exp1);
-    }
-
-    /// <summary>
-    /// A Special case of TestTrue that is needed for the partition analysis.
-    /// </summary>
-    public OctagonEnvironment<Variable, Expression> TestTrueEqualNotRefininingLeftArguments(Expression exp1, Expression exp2)
-    {
-      this.CheckConsistency();
-
-      var res = this.TestTrueLessEqualThan(exp1, exp2).TestTrueLessEqualThan(exp2, exp1);
-
-      return res.TestTrueEqualNotRefininingLeftArgumentsInternal(exp1, exp2);
-    }
-
-    public OctagonEnvironment<Variable, Expression> TestTrueNotEqual(Expression e1, Expression e2)
-    {
-      var e1Var = this.expManager.Decoder.UnderlyingVariable(e1);
-      var e2Var = this.expManager.Decoder.UnderlyingVariable(e2);
-
-      if (!this.variables2dimensions.ContainsKey(e1Var) || !this.variables2dimensions.ContainsKey(e2Var))
-      {
-        return this;
-      }
-     
-       Rational k;
-
-       if (this.TryConstantForXMinusY(e1Var, e2Var, out k) && k.IsZero)
-      { // It is the case that exp1 <= exp2
-        this.AddConstraint(new OctagonConstraintXMinusY(this.DimensionForVar(e1Var), this.DimensionForVar(e2Var), -1));
-      }
-       else if (this.TryConstantForXMinusY(e2Var, e1Var, out k) && k.IsZero)
-      { // It is the case that exp2 <= exp1
-        this.AddConstraint(new OctagonConstraintXMinusY(this.DimensionForVar(e2Var), this.DimensionForVar(e1Var), -1));
-      }
-
-      return this;
-    }
-
-    #endregion
-
-    #region CheckIfHolds methods
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      return new OctagonsCheckIfHoldsVisitor<Variable, Expression>(this.expManager.Decoder).Visit(exp, this);
-    }
-
-    /// <summary>
-    /// Check if the expression <code>exp</code> is greater than zero
-    /// </summary>
-    public FlatAbstractDomain<bool>  CheckIfGreaterEqualThanZero(Expression  exp)
-    {
-      var result = CommonChecks.CheckGreaterEqualThanZero(exp, this.expManager.Decoder);
-      if (!result.IsTop)
-      {
-        return result;
-      }
-      else
-      {
-        var tmp = this.Duplicate();
-        tmp.DoClosure();
-
-        if (tmp.IsBottom)
-          return CheckOutcome.Bottom;
-        else
-          return tmp.ToIntervalEnvironment().CheckIfGreaterEqualThanZero(exp);
-      }
-    }
-
-    /// <summary>
-    /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
-    /// </summary>
-    public FlatAbstractDomain<bool>  CheckIfLessThan(Expression  e1, Expression  e2)
-    {
-      var result = CommonChecks.CheckLessThan(e1, e2, this, this.expManager.Decoder);
-
-      if (result.IsTop)
-      { // Then we go deeper in the expression ...
-
-        // We need to make a clone of this to make it simpler
-        var duplicate = this.Duplicate();
-        duplicate.DoClosure();
-
-        if (duplicate.IsBottom)
-        {
-          return CheckOutcome.Bottom;
-        }
-        else
-        {
-          // Capture the cases when e1 or e2 are constants. To do it, we simply use the intervals
-          result = duplicate.ToIntervalEnvironment().CheckIfLessThan(e1, e2);
-        }
-
-        if (result.IsTop)
-        {
-          PolynomialOfInt<Variable, Expression> e1AsPoly, e2AsPoly, tmp;
-          if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e1, this.expManager.Decoder, out e1AsPoly)
-            && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e2, this.expManager.Decoder, out e2AsPoly)
-            && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1AsPoly, e2AsPoly, out tmp))
-          {
-            if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
-            {
-              return result;
-            }
-          }
-          else
-          {
-            var e1Var = this.expManager.Decoder.UnderlyingVariable(e1);
-            var e2Var = this.expManager.Decoder.UnderlyingVariable(e2);
-
-            var leftList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(e1Var), new MonomialOfInt<Variable>(-1, e2Var) };
-            var rightList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(-1) };
-
-            if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, leftList, rightList, out tmp))
-            {
-              if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
-              {
-                return result;
-              }
-            }
-          }
-        }
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool>  CheckIfLessThan(Variable v1, Variable v2)
-    {
-      return this.CheckIfLessThan(this.expManager.Encoder.VariableFor(v1), this.expManager.Encoder.VariableFor(v2));
-    }
-
-    public FlatAbstractDomain<bool>  CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    /// <summary>
-    /// Check if the expression <code>e1</code> is smaller equal than <code>e2</code>
-    /// </summary>
-    public FlatAbstractDomain<bool>  CheckIfLessEqualThan(Expression  e1, Expression  e2)
-    {
-      var result = CommonChecks.CheckLessEqualThan(e1, e2, this, this.expManager.Decoder);
-
-      if (!result.IsTop)
-      {
-        return result;
-      }
-
-      // We need to make a clone of this to make it simpler
-      var duplicate = this.Duplicate();
-      duplicate.DoClosure();
-
-      if (duplicate.IsBottom)
-      {
-        return CheckOutcome.Bottom;
-      }
-      else
-      {
-        // Capture the cases when e1 or e2 are constants. To do it, we simply use the intervals
-        result = duplicate.ToIntervalEnvironment().CheckIfLessEqualThan(e1, e2);
-      }
-
-      if (result.IsTop)
-      {
-        PolynomialOfInt<Variable, Expression> e1AsPoly, e2AsPoly, tmp;
-
-        if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e1, this.expManager.Decoder, out e1AsPoly)
-          && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e2, this.expManager.Decoder, out e2AsPoly)
-          && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1AsPoly, e2AsPoly, out tmp))
-        {
-          if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
-          {
             return result;
-          }
         }
-        else
-        {
-          var e1Var = this.expManager.Decoder.UnderlyingVariable(e1);
-          var e2Var = this.expManager.Decoder.UnderlyingVariable(e2);
 
-          var leftList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(e1Var), new MonomialOfInt<Variable>(-1, e2Var) };
-          var rightList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(0) };
+        #endregion
 
-          if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, leftList, rightList, out tmp))
-          {
-            if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
+        #region IAbstractDomain Members: Bottom, Top, Join, Meet, Widening 
+
+        private enum BinaryOperationType { Join, Meet, Widening };
+
+        private delegate Rational BinaryOperation(Rational left, Rational right);
+
+        private static readonly BinaryOperation pointwiseWidening = delegate (Rational current, Rational prev)
             {
-              return result;
+                if (Rational.Min(current, prev) == current)
+                {   // The bound is stable
+                    return prev;
+                }
+                else
+                {   // The bound is not stable, take
+                    var candidate = Thresholds.GetNext(current.NextInt32);
+                    return candidate < Int32.MaxValue ? candidate : Rational.PlusInfinity;  // Gets the smaller value in the thresholds that is larger than b
+                }
+            };
+
+        /// <summary>
+        /// An OctagonEnvironment is bottom when the variable map is not empty, and the octagon is
+        /// </summary>
+        public override bool IsBottom
+        {
+            get
+            {
+#if TRACE_AD_PERFORMANCES
+
+                countDomainOperationsInvocations++;
+
+                var watch = new Stopwatch();
+                watch.Start();
+#endif
+
+                var result = this.state == OctagonState.BOTTOM || (variables2dimensions.Count != 0 && base.IsBottom);
+
+#if TRACE_AD_PERFORMANCES
+
+                timeSpentInDomainOperations += watch.Elapsed;
+#endif
+
+                return result;
             }
-          }
         }
 
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool>  CheckIfLessThanIncomplete(Expression  e1, Expression  e2)
-    {
-      // TODO: provide a faster implementation
-      return this.CheckIfLessThan(e1, e2);
-    }
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessEqualThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> c1, c2;
-      if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
-      {
-        return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfEqual(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool>  CheckIfLessEqualThan(Variable v1, Variable v2)
-    {
-      return this.CheckIfLessEqualThan(this.expManager.Encoder.VariableFor(v1), this.expManager.Encoder.VariableFor(v2));
-    }
-
-    /// <summary>
-    /// Check if <code>e != 0</code>
-    /// </summary>
-    public FlatAbstractDomain<bool>  CheckIfNonZero(Expression  e)
-    {
-      // We need to make a clone of this to make it simpler
-      OctagonEnvironment<Variable, Expression> duplicate = this.Duplicate();
-      duplicate.DoClosure();
-
-      if (duplicate.IsBottom)
-      {
-        return CheckOutcome.Bottom;
-      }
-      else
-      {
-        return duplicate.ToIntervalEnvironment().CheckIfNonZero(e);
-      }
-    }
-    #endregion
-
-    #region INumericalAbstractDomain<int,Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      this.CheckConsistency();
-
-      if (this.IsBottom)
-      {
-        return;
-      }
-
-      var tmp = new OctagonEnvironment<Variable, Expression>(this);
-      
-      var rewrittenVariables = new Set<Variable>();
-
-      tmp.CheckConsistency();
-
-      foreach (var x in this.Variables)
-      {
-        if (!sourcesToTargets.ContainsKey(x))
+        public IAbstractDomain Bottom
         {
-          if (rewrittenVariables.Contains(x))
-          {
-            continue;
-          }
+            get
+            {
+#if TRACE_AD_PERFORMANCES
+                countDomainOperationsInvocations++;
 
-          tmp.RemoveVariable(x);
+                var watch = new Stopwatch();
+                watch.Start();
+#endif
 
-          tmp.CheckConsistency();
+                var bot = this.FactoryForOctagonEnvironment(2);
+                bot.state = OctagonState.BOTTOM;
 
-          continue;
+                if (variables2dimensions.Count > 0)
+                {
+                    bot.variables2dimensions = new BijectiveMap<Variable, int>(variables2dimensions);
+                }
+                else
+                {
+                    bot.variables2dimensions = new BijectiveMap<Variable, int>(1);
+                    this.state = OctagonState.BOTTOM;
+                }
+
+#if TRACE_AD_PERFORMANCES
+                timeSpentInDomainOperations += watch.Elapsed;
+#endif
+                return bot;
+            }
         }
 
-        // Chose the canonical element
-        var target = (sourcesToTargets[x].Length() > 1 && x.Equals(sourcesToTargets[x].Head)) 
-          ? sourcesToTargets[x].Tail.Head 
-          : sourcesToTargets[x].Head; 
-
-        if (x.Equals(target))
-        { 
-          // If it is the identity there is nothing to do...
-          continue;
-        }
-
-        if (tmp.variables2dimensions.ContainsKey(target))
+        /// <summary>
+        /// An OctagonEnvironment is top when the variable map is empty or when the octagon has no constraints
+        /// </summary>
+        public override bool IsTop
         {
-          tmp.RemoveVariable(target);
+            get
+            {
+#if TRACE_AD_PERFORMANCES
+                countDomainOperationsInvocations++;
 
-          rewrittenVariables.Add(target);
+                var watch = new Stopwatch();
+                watch.Start();
+#endif
+                if (this.state == OctagonState.BOTTOM)
+                    return false;
 
-          tmp.CheckConsistency();
+                bool result = variables2dimensions.Count == 0 || base.IsTop;
+#if TRACE_AD_PERFORMANCES
+                timeSpentInDomainOperations += watch.Elapsed;
+#endif
+                return result;
+            }
         }
 
-        int dimX = tmp.variables2dimensions[x];
-
-        tmp.variables2dimensions.Remove(x);
-
-        tmp.variables2dimensions[target] = dimX;
-
-        this.CheckConsistency();
-        tmp.CheckConsistency();
-      }
-
-      // Add the equalities between the same source
-      foreach (var source in sourcesToTargets.Keys)
-      {
-        if (sourcesToTargets[source].Length() <= 1)
+        public IAbstractDomain Top
         {
-          continue;
+            get
+            {
+                OctagonEnvironment<Variable, Expression> tmp = this.FactoryForOctagonEnvironment(1);
+                tmp.ProjectDimension(0);
+
+                return tmp;
+            }
         }
 
-        var target = source.Equals(sourcesToTargets[source].Head) 
-          ? sourcesToTargets[source].Tail.Head 
-          : sourcesToTargets[source].Head;
-
-        foreach (var otherTarget in sourcesToTargets[source].GetEnumerable())
+        bool IAbstractDomain.LessEqual(IAbstractDomain abs)
         {
-          tmp.CheckConsistency();
-          tmp = tmp.TestTrueEqual(convert(target), convert(otherTarget));
-          tmp.CheckConsistency();
+            return this.LessEqual((OctagonEnvironment<Variable, Expression>)abs);
         }
-      }
 
-      tmp.CheckConsistency();
-
-      // We change the state of this, using tmp
-      CloneFromThis(tmp);
-
-      this.CheckConsistency();
-
-    }
-
-    public Set<Expression> EqualsTo(Expression x)
-    {
-      var result = new Set<Expression>();
-      
-      if(this.expManager.Encoder == null)
-      {
-        return result;
-      }
-
-      var xVar = this.expManager.Decoder.UnderlyingVariable(x);
-
-      int varDim;
-      if (this.variables2dimensions.TryGetValue(xVar, out varDim))
-      {
-        // 0. clone it before closing
-
-        var dup = this.Duplicate();
-        dup.DoClosure();
-
-        // 1. try to get a constant
-        var intvX = dup.BoundsFor(x);
-        Rational val;
-        if (intvX.TryGetSingletonValue(out val))
+        public bool LessEqual(OctagonEnvironment<Variable, Expression> right)
         {
-          //var eq = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, x, val.ToExpression(this.encoder));
-          var eq = val.ToExpression(this.expManager.Encoder);
-          result.Add(eq);
+#if TRACE_AD_PERFORMANCES
+
+            Increase(ref countDomainOperationsInvocations);
+#endif
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
+            {
+                return result;
+            }
+
+            var watch = new Stopwatch();
+            watch.Start();
+
+            result = HelperForLessEqual(right);
+#if TRACE_AD_PERFORMANCES
+
+            AddTimeElapsedFromStart("LessEqual", ref timeSpentInDomainOperations, watch.Elapsed);
+#endif
+            return result;
         }
 
-        // 2. try to get a relation betwee x and y
-        foreach (var y in dup.variables2dimensions.Keys)
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
         {
-          if (x.Equals(y))
-          {
-            continue;
-          }
-
-          var dimY = dup.variables2dimensions[y];
-
-          // 2.1 try x - y == k
-          Rational r1, r2;
-          var b1 = dup.TryConstantForXMinusY(xVar, y, out r1);    // x - y <= r1
-          var b2 = dup.TryConstantForXMinusY(y, xVar, out r2);   // y - x <= r2 is -(x - y) <= r2 is -r2 <= (x - y) 
-
-          if (b1 && b2 && r1 == -r2)
-          {
-            var eq = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Int32, 
-              ExpressionOperator.Addition, this.expManager.Encoder.VariableFor(y), r1.ToExpression(this.expManager.Encoder));
-
-            result.Add(eq);
-          }
-
-          // 2.2 try x + y = k
-
-          b1 = dup.TryConstantForXY(xVar, y, out r1);              // x + y <= r1
-          b2 = dup.TryConstantForMinusXMinusY(xVar, y, out r2);    // -(x +y) <= r2 is -r2 <= x + y
-          if (b1 && b2 && r1 == -r2)
-          {
-            var eq = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Int32, 
-              ExpressionOperator.Subtraction, r1.ToExpression(this.expManager.Encoder), this.expManager.Encoder.VariableFor(y));
-
-            result.Add(eq);
-          }
+            return this.Join((OctagonEnvironment<Variable, Expression>)a);
         }
-      }
 
-      return result;
+        public OctagonEnvironment<Variable, Expression> Join(OctagonEnvironment<Variable, Expression> right)
+        {
+#if TRACE_AD_PERFORMANCES
+
+            Increase(ref countDomainOperationsInvocations);
+#endif
+            OctagonEnvironment<Variable, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
+            {
+                return result;
+            }
+
+            var watch = new Stopwatch();
+            watch.Start();
+
+            HelperForBinaryDomainOperation(BinaryOperationType.Join, Rational.Max, right, out result);
+#if TRACE_AD_PERFORMANCES
+
+            AddTimeElapsedFromStart("Join", ref timeSpentInDomainOperations, watch.Elapsed);
+#endif
+            return result;
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            return this.Meet((OctagonEnvironment<Variable, Expression>)a);
+        }
+
+        public OctagonEnvironment<Variable, Expression> Meet(OctagonEnvironment<Variable, Expression> right)
+        {
+#if TRACE_AD_PERFORMANCES
+
+            Increase(ref countDomainOperationsInvocations);
+#endif
+            OctagonEnvironment<Variable, Expression> result;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, right, out result))
+            {
+                return result;
+            }
+
+            var watch = new Stopwatch();
+            watch.Start();
+            HelperForBinaryDomainOperation(BinaryOperationType.Meet, Rational.Min, right, out result);
+#if TRACE_AD_PERFORMANCES
+
+            AddTimeElapsedFromStart("Meet", ref timeSpentInDomainOperations, watch.Elapsed);
+#endif
+            return result;
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            return this.Widening((OctagonEnvironment<Variable, Expression>)prev);
+        }
+
+        /// <summary>
+        /// Widening with thresholds.
+        /// Please note that all the instances of OctagonEnvironment shares the same thresholds for widening
+        /// </summary>
+        /// <param name="prev"></param>
+        /// <returns></returns>
+        public OctagonEnvironment<Variable, Expression> Widening(OctagonEnvironment<Variable, Expression> prev)
+        {
+#if TRACE_AD_PERFORMANCES
+
+            Increase(ref countDomainOperationsInvocations);
+#endif
+            OctagonEnvironment<Variable, Expression> result;
+
+            if (AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
+            {
+                return result;
+            }
+
+            var watch = new Stopwatch();
+            watch.Start();
+            HelperForBinaryDomainOperation(BinaryOperationType.Widening, pointwiseWidening, prev, out result);
+
+#if TRACE_AD_PERFORMANCES
+
+            AddTimeElapsedFromStart("Widening", ref timeSpentInDomainOperations, watch.Elapsed);
+#endif
+            return result;
+        }
+        #endregion
+
+        #region IPureExpressionAssignments Members (ProjectVariable, AddVariable, RemoveVariable, RenameVariable)
+
+        public List<Variable> Variables
+        {
+            get
+            {
+                return new List<Variable>(variables2dimensions.Keys);
+            }
+        }
+
+        /// <summary>
+        /// Project the value of the variable <code>var</code>.
+        /// It is as setting its value to top, or playing havoc 
+        /// </summary>
+        public void ProjectVariable(Variable var)
+        {
+            if (variables2dimensions.Keys.Contains(var))
+            {
+                base.ProjectDimension(variables2dimensions[var]);
+            }
+            else
+            {
+                // do nothing...
+            }
+        }
+
+        /// <summary>
+        /// Add a new variable to the environment.
+        /// The variable must not be 
+        /// </summary>
+        public void AddVariable(Variable var)
+        {
+            // If the variable is already in the Octagon, then we have nothing to do
+            if (variables2dimensions.ContainsKey(var))
+            {
+                return;
+            }
+            else
+            {
+                int newDim = base.GetAvailableDimension();
+                variables2dimensions[var] = newDim;
+
+                this.state = this.state != OctagonState.BOTTOM ? OctagonState.NORMAL : OctagonState.BOTTOM;
+            }
+        }
+
+        /// <summary>
+        /// Remove the variable from the current environment.
+        /// Its values is projected, so that the relations are kept.
+        /// The variable is removed from the octagon
+        /// </summary>
+        public void RemoveVariable(Variable var)
+        {
+            if (variables2dimensions.Keys.Contains(var))
+            {
+                base.RemoveDimension(variables2dimensions[var]);
+                variables2dimensions.Remove(var);
+            }
+            else
+            {
+                // do nothing..
+            }
+        }
+
+        /// <summary>
+        /// Renames the variable <code>oldName</code> to <code>newName</code>
+        /// </summary>
+        public void RenameVariable(Variable oldName, Variable newName)
+        {
+            variables2dimensions[newName] = variables2dimensions[oldName];
+            variables2dimensions.Remove(oldName);
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignmentsWithBackward<Expression> Members
+
+        /// <summary>
+        /// Performs the backward assignment for Octagons
+        /// </summary>
+        /// <param name="x">The variable to be assigned</param>
+        /// <param name="exp">The source expression</param>
+        public void AssignBackward(Expression x, Expression exp)
+        {
+            throw new AbstractInterpretationTODOException();
+        }
+
+        public void AssignBackward(Expression x, Expression exp, IAbstractDomain preState, out IAbstractDomain refinedPreState)
+        {
+            throw new AbstractInterpretationTODOException();
+        }
+
+        #endregion
+
+        #region IPureExpressionTest Members (TestTrue)
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        #endregion
+
+        #region Factories 
+
+        override protected CoreOctagon Factory(int dim)
+        {
+            return this.FactoryForOctagonEnvironment(dim);
+        }
+
+        private OctagonEnvironment<Variable, Expression> FactoryForOctagonEnvironment(int dim)
+        {
+            return new OctagonEnvironment<Variable, Expression>(dim, expManager, this.Precision);
+        }
+
+        protected override CoreOctagon Factory(int dim, bool allocateMatrix)
+        {
+            return this.FactoryForOctagonEnvironment(dim, allocateMatrix);
+        }
+
+        private OctagonEnvironment<Variable, Expression> FactoryForOctagonEnvironment(int dim, bool allocateMatrix)
+        {
+            return new OctagonEnvironment<Variable, Expression>(dim, allocateMatrix, expManager, this.Precision);
+        }
+
+        new public OctagonEnvironment<Variable, Expression> Duplicate()
+        {
+            OctagonEnvironment<Variable, Expression> result = base.Duplicate() as OctagonEnvironment<Variable, Expression>;
+
+            Contract.Assert(result != null, "Expecting an instance of OctagonEnvironment..."); //^ assert result != null;
+            Contract.Assert(result != this, "Duplicate must create a fresh octagon reference");
+
+            result.variables2dimensions = new BijectiveMap<Variable, int>(variables2dimensions);     // for this we are eager...
+
+            return result;
+        }
+
+        public override object Clone()
+        {
+            return this.Duplicate();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var that = obj as OctagonEnvironment<Variable, Expression>;
+            if (that == null) return false;
+
+            return (that.LessEqual(this) && this.LessEqual(that));
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        /// <summary>
+        /// Does nothing
+        /// </summary>
+        /// <param name="oracle"></param>
+        /// <returns></returns>
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return this.Duplicate();
+        }
+
+        #endregion
+
+        #region ToString
+
+
+        public T To<T>(IFactory<T> factory)
+        {
+            var result = factory.IdentityForAnd;
+
+            this.DoClosure();
+
+            if (this.IsBottom)
+            {
+                return factory.Constant(false);
+            }
+
+            if (this.IsTop)
+            {
+                return factory.Constant(true);
+            }
+
+
+            for (int i = 0; i < this.Dimensions; i++)
+            {
+                if (!variables2dimensions.ContainsValue(i))
+                {
+                    continue;
+                }
+
+                var x = variables2dimensions.KeyForValue(i);
+
+                if (this.octagon[Matpos(2 * i, 2 * i)] != 0)
+                {
+                    // STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i)] 
+                    var tmp = ToOctagonConstraint(1, x, -1, x, this.octagon[Matpos(2 * i, 2 * i)], factory);
+                    result = factory.And(result, tmp);
+                }
+
+                if (this.octagon[Matpos(2 * i + 1, 2 * i + 1)] != 0)
+                {
+                    // STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i + 1)] 
+                    var tmp = ToOctagonConstraint(1, x, 1, x, this.octagon[Matpos(2 * i + 1, 2 * i + 1)], factory);
+                    result = factory.And(result, tmp);
+                }
+                if (!this.octagon[Matpos(2 * i + 1, 2 * i)].IsInfinity)
+                {
+                    // STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i + 1, 2 * i)] + "/2" ;
+                    var tmp = ToOctagonConstraint(1, x, this.octagon[Matpos(2 * i + 1, 2 * i)] / 2, factory);
+                    result = factory.And(result, tmp);
+                }
+                if (!this.octagon[Matpos(2 * i, 2 * i + 1)].IsInfinity)
+                {
+                    // "-" + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * i, 2 * i + 1)] + "/2" + Environment.NewLine + " ";
+                    var tmp = ToOctagonConstraint(-1, x, this.octagon[Matpos(2 * i + 1, 2 * i + 1)] / 2, factory);
+                    result = factory.And(result, tmp);
+                }
+            }
+
+            for (int i = 0; i < this.Dimensions; i++)
+            {
+                if (!variables2dimensions.ContainsValue(i))
+                {
+                    continue;
+                }
+
+                var x = variables2dimensions.KeyForValue(i);
+
+                for (int j = i + 1; j < this.Dimensions; j++)
+                {
+                    if (!variables2dimensions.ContainsValue(j))
+                    {
+                        continue;
+                    }
+
+                    var y = variables2dimensions.KeyForValue(j);
+
+                    if (!this.octagon[Matpos(2 * j, 2 * i)].IsInfinity)
+                    {
+                        // STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i)]           
+                        var tmp = ToOctagonConstraint(1, x, -1, y, this.octagon[Matpos(2 * j, 2 * i)], factory);
+                        result = factory.And(result, tmp);
+                    }
+
+                    if (!this.octagon[Matpos(2 * j, 2 * i + 1)].IsInfinity)
+                    {
+                        // "-" + STR_FOR_DIMENSION + i + " - " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j, 2 * i + 1)] 
+                        var tmp = ToOctagonConstraint(-1, x, -1, y, this.octagon[Matpos(2 * j, 2 * i + 1)], factory);
+                        result = factory.And(result, tmp);
+                    }
+
+                    if (!this.octagon[Matpos(2 * j + 1, 2 * i)].IsInfinity)
+                    {
+                        // STR_FOR_DIMENSION + i + " + " + STR_FOR_DIMENSION + j + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i)] 
+                        var tmp = ToOctagonConstraint(1, x, 1, y, this.octagon[Matpos(2 * j + 1, 2 * i)], factory);
+                        result = factory.And(result, tmp);
+                    }
+
+                    if (!this.octagon[Matpos(2 * j + 1, 2 * i + 1)].IsInfinity)
+                    {
+                        // STR_FOR_DIMENSION + j + " - " + STR_FOR_DIMENSION + i + " <= " + this.octagon[Matpos(2 * j + 1, 2 * i + 1)] 
+                        var tmp = ToOctagonConstraint(1, y, -1, x, this.octagon[Matpos(2 * j + 1, 2 * i + 1)], factory);
+                        result = factory.And(result, tmp);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public T ToOctagonConstraint<T>(int a, Variable x, int b, Variable y, Rational k, IFactory<T> factory)
+        {
+            T left, right;
+
+            if (a != 0 && b != 0)
+            {
+                var m1 = factory.Mul(factory.Constant(a), factory.Variable(x));
+                var m2 = factory.Mul(factory.Constant(b), factory.Variable(y));
+
+                left = factory.Add(m1, m2);
+            }
+            else if (a != 0)
+            { // b == 0
+                left = factory.Mul(factory.Constant(a), factory.Variable(x));
+            }
+            else if (b != 0)
+            { // a== 0
+                left = factory.Mul(factory.Constant(b), factory.Variable(y));
+            }
+            else
+            {
+                throw new AbstractInterpretationException("Impossible case");
+            }
+
+            right = factory.Constant(k);
+
+            return factory.LessEqualThan(left, right);
+        }
+
+        public T ToOctagonConstraint<T>(int a, Variable x, Rational k, IFactory<T> factory)
+        {
+            return ToOctagonConstraint<T>(a, x, 0, default(Variable), k, factory);
+        }
+
+        public override string ToString()
+        {
+            var oct = RenameDimensions(base.ToString());
+
+            var env = new StringBuilder();
+
+            foreach (var var in variables2dimensions.Keys)
+            {
+                env.Append("(" + var + ", " + variables2dimensions[var] + "),");
+            }
+            var env2str = env.ToString();
+            var indexLastComma = env2str.LastIndexOf(",");
+            env2str = indexLastComma > 0 ? env2str.Remove(indexLastComma) : env2str;
+
+            return env2str + Environment.NewLine + oct;
+        }
+
+        public string ToString(Expression exp)
+        {
+            if (expManager.Decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, expManager.Decoder);
+            }
+            else
+            {
+                return "< missing expression decoder >";
+            }
+        }
+
+        /// <summary>
+        /// Takes the result of <code>base.ToString()</code> and rename all the occurrences of <code>vi</code> with the correct variable
+        /// </summary>
+        private string RenameDimensions(string oct)
+        {
+            // Contract.Assert(oct.CompareTo(base.ToString()) == 0, "You can invoke RenameDimensions just on the result of CoreOctagon.ToString()");
+
+            var result = new StringBuilder(oct);
+
+            foreach (var x in variables2dimensions.Keys)
+            {
+                Contract.Assert(x != null);
+                //^ assert x != null;
+
+                int i = variables2dimensions[x];
+
+                result.Replace(STR_FOR_DIMENSION + i + " ", x.ToString());  // Trick: we need to pattern match the space!
+            }
+
+            return result.ToString();
+        }
+
+        #endregion
+
+        #region Performance and debugging helpers
+        // This is just for checking the soundness of the operation
+        private Set<int> visitedIndexes = new Set<int>();
+
+        // Used only to monitor the accesses to the octagon, for debugging
+        private Rational this[int i]
+        {
+            set
+            {
+                this.octagon[i] = value;
+
+                if (visitedIndexes.Contains(i))
+                {
+                    System.Diagnostics.Debugger.Break();
+                }
+
+                visitedIndexes.Add(i);
+            }
+        }
+
+        private static void UpdateMaxDim(int x, int y)
+        {
+#if false // unused?
+            MaxDim = Math.Max(MaxDim, Math.Max(x, y));
+#endif
+        }
+
+        #endregion
+
+        #region Helpers for Domain operations (LessEq, Join, Meet and Widening)
+        /// <summary>
+        /// The core method for OctagonEnvironments Join, Meet and Widening
+        /// </summary>
+        /// <param name="whichOperation">Which operation have we to apply?</param>
+        /// <param name="pointwiseOp">The operation to be applyed, pointwise, to each element</param>
+        /// <param name="right">The "right" OctagonEnvironment. It must have the SAME dimensions than this octagon</param>
+        /// <param name="result">Meaningful iff whichOperation \in { Join, Meet, Widening }</param>
+        private void HelperForBinaryDomainOperation(BinaryOperationType whichOperation, BinaryOperation pointwiseOp, OctagonEnvironment<Variable, Expression> right, out OctagonEnvironment<Variable, Expression> result)
+        {
+            // PRECONDITION: !!!! The two octagons must have the same number of allocated variables !!!!
+
+            CheckConsistency();
+
+            OctagonEnvironment<Variable, Expression> left = this;
+
+            OctagonEnvironment<Variable, Expression> resultOctagon;
+
+            UpdateMaxDim(left.octagon.Length, right.octagon.Length);
+
+            #region 1. Close the octagon, depending on the kind of the operation...
+            if (left == right)
+            {
+                result = this;
+
+                return;
+            }
+
+            // To ensure convergence for widening we have to pay attention when to close
+            if (whichOperation == BinaryOperationType.Join || whichOperation == BinaryOperationType.Meet)
+            {
+                // for join and meet we can always close to have precision
+                left.DoClosure();
+                right.DoClosure();
+
+                if (whichOperation == BinaryOperationType.Join && AbstractDomainsHelper.TryTrivialJoin(left, right, out result))
+                {
+                    return /*result*/;
+                }
+                else if (whichOperation == BinaryOperationType.Meet && AbstractDomainsHelper.TryTrivialMeet(left, right, out result))
+                {
+                    return /*result*/;
+                }
+            }
+            else if (whichOperation == BinaryOperationType.Widening)
+            {
+                // For widenings we have to close just the previous iteration!
+                right.DoClosure();
+
+                if (AbstractDomainsHelper.TryTrivialJoin(left, right, out result))
+                {
+                    return /*result*/;
+                }
+            }
+            else
+            {
+                Contract.Assert(false, "I do not know the operation + " + whichOperation);
+            }
+
+            #endregion
+
+            #region 2. Create the result octagon
+
+            // Compute an overapproximation of the variables in the result
+            var varsInResult = new List<Variable>();
+            switch (whichOperation)
+            {
+                case BinaryOperationType.Join:
+                case BinaryOperationType.Widening:
+                    {
+                        varsInResult = left.Variables.SetIntersection(right.Variables);
+                    }
+                    break;
+
+                case BinaryOperationType.Meet:
+                    {
+                        varsInResult = left.Variables.SetUnion(right.Variables);
+                    }
+                    break;
+
+                default:
+                    throw new AbstractInterpretationException("Unknown octagon operation: " + whichOperation);
+            }
+
+            resultOctagon = new OctagonEnvironment<Variable, Expression>(varsInResult.Count, expManager, this.Precision);    // The new result octagon
+
+            // Now add them
+            foreach (var x in varsInResult)
+            {
+                resultOctagon.AddVariable(x);
+            }
+
+            #endregion
+
+            #region 3. Iterates over all the constraints in this OctagonEnvironment, find the corresponding in right, apply the binary operation and writes the result in the output
+            foreach (var i in left.AllocatedDimensions)
+            {
+                var var = left.variables2dimensions.KeyForValue(i);                     // Gets the variable corresponding to i
+
+                if (!varsInResult.Contains(var))
+                {
+                    continue;
+                }
+
+                var dimInRight = right.DimensionForVar(var);   // Get the dimension corresponding to this variable in the right octagon
+                var dimInResult = resultOctagon.DimensionForVar(var); // Get the dimension corresponding to this variable in the result octagon
+
+                Rational thisK, rightK;
+                Rational resultOfCombination;
+
+                // We consider all the constraints for the variable var
+
+                // 1. OctagonConstraint XMinusY(i, i), this.octagon[Matpos(2 * i, 2 * i)]
+                thisK = left.ConstantForXMinusY(i, i);
+                rightK = right.ConstantForXMinusY(dimInRight, dimInRight);
+                resultOfCombination = pointwiseOp(thisK, rightK);
+                resultOctagon/*.octagon*/[Matpos2(2 * dimInResult, 2 * dimInResult)] = resultOfCombination;
+
+                // 2. OctagonConstraint MinusXY, this.octagon[Matpos(2 * i + 1, 2 * i + 1)]
+                thisK = left.ConstantForMinusXY(i, i);
+                rightK = right.ConstantForMinusXY(dimInRight, dimInRight);
+                resultOfCombination = pointwiseOp(thisK, rightK);
+                resultOctagon/*.octagon*/[Matpos2(2 * dimInResult + 1, 2 * dimInResult + 1)] = resultOfCombination;
+
+                // 3. OctagonConstraint X, this.octagon[Matpos(2 * i + 1, 2 * i)])
+                thisK = left.ConstantForX(i);
+                rightK = right.ConstantForX(dimInRight);
+                resultOfCombination = pointwiseOp(thisK, rightK);
+                resultOctagon/*.octagon*/[Matpos2(2 * dimInResult + 1, 2 * dimInResult)] = resultOfCombination;
+
+                // 4. OctagonConstraint MinusX, this.octagon[Matpos(2 * i, 2 * i + 1)]
+                thisK = left.ConstantForMinusX(i);
+                rightK = right.ConstantForMinusX(dimInRight);
+                resultOfCombination = pointwiseOp(thisK, rightK);
+                resultOctagon/*.octagon*/[Matpos2(2 * dimInResult, 2 * dimInResult + 1)] = resultOfCombination;
+            }
+
+            // I use this method, instead of two iterators, as it is faster (I do not have to visit the dimensions*dimensions cases, but just 1/2(dimensions * dimensions)
+            for (int i = 0; i < left.Dimensions; i++)
+            {
+                // If it is a dimension without a variable associated to it, then skip it
+                if (!left.variables2dimensions.ContainsValue(i))
+                {
+                    continue;
+                }
+
+                var varForI = left.variables2dimensions.KeyForValue(i);     // The variable corresponding to the dimension i
+                var dimInRightForI = right.DimensionForVar(varForI);          // The dimension, in right, corresponding to the variable varForI    
+                var dimInResultForI = resultOctagon.DimensionForVar(varForI); // The dimension, in result, corresponding to the variable varForI
+
+                for (var j = i + 1; j < left.Dimensions; j++)
+                {
+                    // If it is a dimension without a variable associated to it, then skip it
+                    if (!left.variables2dimensions.ContainsValue(j))
+                    {
+                        continue;
+                    }
+
+                    var varForJ = left.variables2dimensions.KeyForValue(j);      // The variable corresponding to the dimension j         
+                    var dimInRightForJ = right.DimensionForVar(varForJ);           // The dimension, in right, corresponding to the variable varForJ                
+                    var dimInResultForJ = resultOctagon.DimensionForVar(varForJ);  // The dimension, in result, corresponding to the variable varForJ
+
+                    Rational thisK, rightK;
+                    Rational resultOfCombination;
+
+                    // 1. OctagonConstraint XMinusY, this.octagon[Matpos(2 * j, 2 * i)])
+                    thisK = left.ConstantForXMinusY(j, i);
+                    rightK = right.ConstantForXMinusY(dimInRightForJ, dimInRightForI);
+                    resultOfCombination = pointwiseOp(thisK, rightK);
+                    resultOctagon/*.octagon*/[IndexForXMinusY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
+
+                    // 2. OctagonConstraint MinusXMinusY, this.octagon[Matpos(2 * j, 2 * i + 1)])
+                    thisK = left.ConstantForMinusXMinusY(j, i);
+                    rightK = right.ConstantForMinusXMinusY(dimInRightForJ, dimInRightForI);
+                    resultOfCombination = pointwiseOp(thisK, rightK);
+                    resultOctagon/*.octagon*/[IndexForMinusXMinusY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
+
+                    // 3. OctagonConstraint XY, this.octagon[Matpos(2 * j + 1, 2 * i)])                    
+                    thisK = left.ConstantForXY(j, i);
+                    rightK = right.ConstantForXY(dimInRightForJ, dimInRightForI);
+                    resultOfCombination = pointwiseOp(thisK, rightK);
+                    resultOctagon/*.octagon*/[IndexForXY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
+
+                    // 4. OctagonConstraint MinusXY, this.octagon[Matpos(2 * j + 1, 2 * i + 1)]))
+                    thisK = left.ConstantForMinusXY(j, i);
+                    rightK = right.ConstantForMinusXY(dimInRightForJ, dimInRightForI);
+                    resultOfCombination = pointwiseOp(thisK, rightK);
+                    resultOctagon/*.octagon*/[IndexForMinusXY(dimInResultForJ, dimInResultForI)] = resultOfCombination;
+                }
+            }
+
+            #endregion
+
+            result = resultOctagon;
+        }
+
+        private bool HelperForLessEqual(OctagonEnvironment<Variable, Expression> a)
+        {
+            // PRECONDITION: !!!! The two octagons must have the same number of allocated variables !!!!
+
+            // We have to check the copies in order to avoid NON-termination when combined with widening...
+
+            var left = this.Duplicate();
+            var right = a.Duplicate();
+
+            left.DoClosure();
+            right.DoClosure();
+
+            // we are adding those two as the truvual check done before does not enforce the closure
+
+            if (left.IsBottom)
+                return true;
+
+            if (right.IsBottom)
+                return false;
+
+            #region 1. Compute the inverse map of this Var -> dimensions
+            // TODO4: Improve perfomances with caching 
+
+            var inverseMap = new Dictionary<int, Variable>(variables2dimensions.Count);                      // Dimensions -> Variables
+
+            foreach (var x in variables2dimensions.Keys)
+            {
+                inverseMap[left.variables2dimensions[x]] = x;
+            }
+
+            #endregion
+
+            #region 2. Iterates over all the constraints in this OctagonEnvironment, find the corresponding in right, check the leq property
+            foreach (int i in left.AllocatedDimensions)
+            {
+                var var = inverseMap[i];                     // Gets the variable corresponding to i
+
+                var dimInRight = right.DimensionForVar(var);   // Get the dimension corresponding to this variable in the right octagon
+
+                Rational thisK, rightK;
+
+
+                // We consider all the constraints for the variable <code>var</var>
+
+                // 1. OctagonConstraint XMinusY(i, i), this.octagon[Matpos(2 * i, 2 * i)]
+                thisK = left.ConstantForXMinusY(i, i);
+                rightK = right.ConstantForXMinusY(dimInRight, dimInRight);
+                if (rightK < thisK)
+                    return false;
+
+                // 2. OctagonConstraint MinusXY, this.octagon[Matpos(2 * i + 1, 2 * i + 1)]
+                thisK = left.ConstantForMinusXY(i, i);
+                rightK = right.ConstantForMinusXY(dimInRight, dimInRight);
+                if (rightK < thisK)
+                    return false;
+
+                // 3. OctagonConstraint X, this.octagon[Matpos(2 * i + 1, 2 * i)])
+                thisK = left.ConstantForX(i);
+                rightK = right.ConstantForX(dimInRight);
+                if (rightK < thisK)
+                    return false;
+
+                // 4. OctagonConstraint MinusX, this.octagon[Matpos(2 * i, 2 * i + 1)]
+                thisK = left.ConstantForMinusX(i);
+                rightK = right.ConstantForMinusX(dimInRight);
+                if (rightK < thisK)
+                    return false;
+            }
+
+            // I use this method, instead of two iterators, as it is faster (I do not have to visit the dimensions*dimensions cases, but just 1/2(dimensions * dimensions)
+            for (int i = 0; i < left.Dimensions; i++)
+            {
+                // If it is a dimension without a variable associated to it, then skip it
+                if (!inverseMap.ContainsKey(i))
+                {
+                    continue;
+                }
+
+                var varForI = inverseMap[i];                         // The variable corresponding to the dimension i
+                var dimInRightForI = right.DimensionForVar(varForI);   // The dimension, in right, corresponding to the variable varForI    
+
+                for (int j = i + 1; j < left.Dimensions; j++)
+                {
+                    // If it is a dimension without a variable associated to it, then skip it
+                    if (!inverseMap.ContainsKey(j))
+                    {
+                        continue;
+                    }
+
+                    var varForJ = inverseMap[j];                         // The variable corresponding to the dimension j         
+                    var dimInRightForJ = right.DimensionForVar(varForJ);   // The dimension, in right, corresponding to the variable varForJ                
+
+                    Rational thisK, rightK;
+
+                    // 1. OctagonConstraint XMinusY, this.octagon[Matpos(2 * j, 2 * i)])
+                    thisK = left.ConstantForXMinusY(j, i);
+                    rightK = right.ConstantForXMinusY(dimInRightForJ, dimInRightForI);
+                    if (rightK < thisK)
+                        return false;
+
+                    // 2. OctagonConstraint MinusXMinusY, this.octagon[Matpos(2 * j, 2 * i + 1)])
+                    thisK = left.ConstantForMinusXMinusY(j, i);
+                    rightK = right.ConstantForMinusXMinusY(dimInRightForJ, dimInRightForI);
+                    if (rightK < thisK)
+                        return false;
+
+                    // 3. OctagonConstraint XY, this.octagon[Matpos(2 * j + 1, 2 * i)])                    
+                    thisK = left.ConstantForXY(j, i);
+                    rightK = right.ConstantForXY(dimInRightForJ, dimInRightForI);
+                    if (rightK < thisK)
+                        return false;
+
+                    // 4. OctagonConstraint MinusXY, this.octagon[Matpos(2 * j + 1, 2 * i + 1)]))
+                    thisK = left.ConstantForMinusXY(j, i);
+                    rightK = right.ConstantForMinusXY(dimInRightForJ, dimInRightForI);
+                    if (rightK < thisK)
+                        return false;
+                }
+            }
+            #endregion
+
+            return true;
+        }
+
+        #endregion
+
+        #region Public Queries
+
+        /// <summary>
+        /// x + y \leq val
+        /// </summary>
+        /// <returns><code>true</code> if it succeeds</returns>
+        internal bool TryConstantForXY(Variable x, Variable y, out Rational val)
+        {
+            if (variables2dimensions.ContainsKey(x) && variables2dimensions.ContainsKey(y))
+            {
+                val = this.ConstantForXY(DimensionForVar(x), DimensionForVar(y));
+
+                return !val.IsInfinity;
+            }
+            else
+            {
+                val = default(Rational);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// x - y \leq val
+        /// </summary>
+        /// <returns><code>true</code> if it succeeds</returns>
+        internal bool TryConstantForXMinusY(Variable x, Variable y, out Rational val)
+        {
+            if (variables2dimensions.ContainsKey(x) && variables2dimensions.ContainsKey(y))
+            {
+                val = this.ConstantForXMinusY(DimensionForVar(x), DimensionForVar(y));
+                return !val.IsInfinity;
+            }
+            else
+            {
+                val = default(Rational);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// -x - y \leq val
+        /// </summary>
+        /// <returns><code>true</code> if it succeeds</returns>
+        internal bool TryConstantForMinusXMinusY(Variable x, Variable y, out Rational val)
+        {
+            if (variables2dimensions.ContainsKey(x) && variables2dimensions.ContainsKey(y))
+            {
+                val = this.ConstantForMinusXMinusY(DimensionForVar(x), DimensionForVar(y));
+                return !val.IsInfinity;
+            }
+            else
+            {
+                val = default(Rational);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// x \leq val
+        /// </summary>
+        /// <returns><code>true</code> if it succeeds</returns>
+        internal bool TryConstantForX(Variable x, out Rational val)
+        {
+            if (variables2dimensions.ContainsKey(x))
+            {
+                val = this.ConstantForX(DimensionForVar(x));
+                val = val / 2;    // This is because of the octagons encoding
+
+                return !val.IsInfinity;
+            }
+            else
+            {
+                val = default(Rational);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// -x \leq val
+        /// </summary>
+        /// <returns><code>true</code> if it succeeds</returns>
+        internal bool TryConstantForMinusX(Variable x, out Rational val)
+        {
+            if (variables2dimensions.ContainsKey(x))
+            {
+                val = this.ConstantForMinusX(DimensionForVar(x));
+                val = val / 2;  // This is because of the octagons encoding
+
+                return !val.IsInfinity;
+            }
+            else
+            {
+                val = default(Rational);
+                return false;
+            }
+        }
+
+        #endregion
+
+        #region Private Queries 
+
+        /// <summary>
+        /// Gets the constant (k) corresponding to the constraint X + Y \leq k
+        /// </summary>
+        private Rational ConstantForXY(int x, int y)
+        {
+            int j = 2 * x;
+            int i = 2 * y + 1;
+            return this.octagon[Matpos2(i, j)];
+        }
+
+        /// <summary>
+        /// Gets the constant (k) corresponding to the constraint X - Y \leq k
+        /// </summary>
+        private Rational ConstantForXMinusY(int x, int y)
+        {
+            int j = 2 * x;
+            int i = 2 * y;
+            return this.octagon[Matpos2(i, j)];
+        }
+
+        /// <summary>
+        /// Gets the constant (k) corresponding to the constraint - X + Y \leq k
+        /// </summary>
+        private Rational ConstantForMinusXY(int x, int y)
+        {
+            int j = 2 * x + 1;
+            int i = 2 * y + 1;
+            return this.octagon[Matpos2(i, j)];
+        }
+
+        /// <summary>
+        /// Gets the constant (k) corresponding to the constraint - X - Y \leq k
+        /// </summary>
+        private Rational ConstantForMinusXMinusY(int x, int y)
+        {
+            int j = 2 * x + 1;
+            int i = 2 * y;
+            return this.octagon[Matpos2(i, j)];
+        }
+
+        /// <summary>
+        /// Gets the constant (k) corresponding to the constraint X \leq k
+        /// </summary>
+        /// <returns>k is TWICE the real value, because of "two times" representation</returns>
+        private Rational ConstantForX(int x)
+        {
+            int j = 2 * x;
+            int i = 2 * x + 1;
+            return this.octagon[Matpos2(i, j)];
+        }
+
+        /// <summary>
+        /// Gets the constant (k) corresponding to the constraint - X \leq k
+        /// </summary>
+        /// <returns>k is TWICE the real value, because of "two times" representation</returns>
+        private Rational ConstantForMinusX(int x)
+        {
+            int j = 2 * x + 1;
+            int i = 2 * x;
+            return this.octagon[Matpos2(i, j)];
+        }
+
+        #endregion
+
+        #region Index computation
+        /// <summary>
+        /// Gets the index corresponding to the constraint X + Y \leq k
+        /// </summary>
+        static private int IndexForXY(int x, int y)
+        {
+            int j = 2 * x;
+            int i = 2 * y + 1;
+            return Matpos2(i, j);
+        }
+
+        /// <summary>
+        /// Gets the index corresponding to the constraint X - Y \leq k
+        /// </summary>
+        static private int IndexForXMinusY(int x, int y)
+        {
+            int j = 2 * x;
+            int i = 2 * y;
+            return Matpos2(i, j);
+        }
+
+        /// <summary>
+        /// Gets the index corresponding to the constraint - X + Y \leq k
+        /// </summary>
+        static private int IndexForMinusXY(int x, int y)
+        {
+            int j = 2 * x + 1;
+            int i = 2 * y + 1;
+            return Matpos2(i, j);
+        }
+
+        /// <summary>
+        /// Gets the index corresponding to the constraint - X - Y \leq k
+        /// </summary>
+        static private int IndexForMinusXMinusY(int x, int y)
+        {
+            int j = 2 * x + 1;
+            int i = 2 * y;
+            return Matpos2(i, j);
+        }
+
+        #endregion
+
+        #region TestTrue Members
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression exp)
+        {
+            return this.TestTrueGeqZero(exp);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessThan(exp1, exp2);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessEqualThan(exp1, exp2);
+        }
+
+        public OctagonEnvironment<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            if (!expManager.Decoder.IsConstant(exp))
+            { // Create the constraint "exp >= 0"
+                var newConstraint = new OctagonConstraintMinusX(this.DimensionForVar(expManager.Decoder.UnderlyingVariable(exp)), 0);
+                this.AddConstraint(newConstraint);
+            }
+
+            return this;
+        }
+
+        public OctagonEnvironment<Variable, Expression> TestTrueLessThan(Expression e1, Expression e2)
+        {
+            // Add the direct
+
+            // e1 < e2 is equivalent to e1 - e2 <= -1
+            var intvForE1 = constantVisitor.Visit(e1, new IntervalEnvironment<Variable, Expression>(expManager));
+            var intvForE2 = constantVisitor.Visit(e2, new IntervalEnvironment<Variable, Expression>(expManager));
+
+            Rational valForE1, valForE2;
+            var b1 = intvForE1.TryGetSingletonValue(out valForE1);
+            var b2 = intvForE2.TryGetSingletonValue(out valForE2);
+
+            var e1Var = expManager.Decoder.UnderlyingVariable(e1);
+            var e2Var = expManager.Decoder.UnderlyingVariable(e2);
+
+            OctagonConstraint directConstraint = null;
+
+            // The four cases...
+            if (b1 && !b2)
+            { // k - e2 <= -1
+                if (valForE1.IsInteger)
+                {
+                    directConstraint = OctagonConstraint.For(-1, this.DimensionForVar(e2Var), -1 - ((Int32)valForE1));
+                }
+            }
+            else if (!b1 && b2)
+            { // e1 - k <= -1
+                if (valForE2.IsInteger)
+                {
+                    directConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1 + ((Int32)valForE2));
+                }
+            }
+            else if (b1 && b2)
+            {
+                if (!(valForE1 < valForE2))
+                {
+                    return (OctagonEnvironment<Variable, Expression>)this.Bottom;
+                }
+            }
+            else
+            {
+                directConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(e2Var), Rational.For(-1));
+            }
+
+            if (directConstraint != null)
+            {
+                this.AddConstraint(directConstraint);
+            }
+
+            TestTrueLessThanSpecialCaseForPartitionAnalysis(e1, e2);
+
+            // Now go inside an simplify it
+            PolynomialOfInt<Variable, Expression> e1AsPoly, e2AsPoly, combined;
+            if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e1, expManager.Decoder, out e1AsPoly)
+              && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e2, expManager.Decoder, out e2AsPoly)
+              && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1AsPoly, e2AsPoly, out combined))
+            {
+                var newConstraints = new Set<OctagonConstraint>();
+                if (new InferOctagonConstraints<Variable, Expression>().Visit(combined, this, ref newConstraints))
+                {
+                    this.AddConstraints(newConstraints);
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Special case needed for the partition analysis which wants to infer octogonal constraints on conditions in the form
+        /// slackVar \lt (exp + k), without refining exp
+        /// </summary>
+        private void TestTrueLessThanSpecialCaseForPartitionAnalysis(Expression e1, Expression e2)
+        {
+            TestTrueLessThanOrLessEqualThanCaseSpecialCaseForPartitionAnalysis(e1, e2, 1);
+        }
+
+        private void TestTrueLessEqualThanSpecialCaseForPartitionAnalysis(Expression e1, Expression e2)
+        {
+            TestTrueLessThanOrLessEqualThanCaseSpecialCaseForPartitionAnalysis(e1, e2, 0);
+        }
+
+        private void TestTrueLessThanOrLessEqualThanCaseSpecialCaseForPartitionAnalysis(Expression e1, Expression e2, int offset)
+        {
+            // case slackVar \lt exp + k
+
+            var e1Var = expManager.Decoder.UnderlyingVariable(e1);
+
+            if (expManager.Decoder.IsSlackVariable(e1Var) && expManager.Decoder.IsBinaryExpression(e2))
+            {
+                var op = expManager.Decoder.OperatorFor(e2);
+
+                var left = expManager.Decoder.LeftExpressionFor(e2);
+                var right = expManager.Decoder.RightExpressionFor(e2);
+
+                var leftIntv = constantVisitor.Visit(left, new IntervalEnvironment<Variable, Expression>(expManager));
+                var rightIntv = constantVisitor.Visit(right, new IntervalEnvironment<Variable, Expression>(expManager));
+
+                Rational v1, v2;
+
+                var b1 = leftIntv.TryGetSingletonValue(out v1);
+                var b2 = rightIntv.TryGetSingletonValue(out v2);
+
+                OctagonConstraint newConstraint = null;
+
+                switch (op)
+                {
+                    case ExpressionOperator.Addition:
+                        {
+                            if (b1 && !b2)
+                            { // case x < v1 + right
+                                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(right)), v1 - offset);
+                            }
+                            if (!b1 && b2)
+                            {  // case x < left + v2
+                                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(left)), v2 - offset);
+                            }
+                        }
+                        break;
+
+                    case ExpressionOperator.Subtraction:
+                        {
+                            if (b1 && !b2)
+                            { // case x <= v1 - right
+                                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(right)), -(v1 - offset));
+                            }
+                            if (!b1 && b2)
+                            {  // case x <= left - v2
+                                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(e1Var), -1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(left)), -(v2 - offset));
+                            }
+                        }
+                        break;
+
+                    default:
+                        // do nothing.
+                        return;
+                        //break;
+                }
+                if (newConstraint == null)
+                {
+                    return;
+                }
+                else
+                {
+                    this.AddConstraint(newConstraint);
+                }
+            }
+
+            // case e1 \lt slackVar
+            var e2Var = expManager.Decoder.UnderlyingVariable(e2);
+            if (expManager.Decoder.IsSlackVariable(e2Var) && expManager.Decoder.IsBinaryExpression(e1))
+            {
+                var op = expManager.Decoder.OperatorFor(e1);
+
+                var left = expManager.Decoder.LeftExpressionFor(e1);
+                var right = expManager.Decoder.RightExpressionFor(e1);
+
+                var leftIntv = constantVisitor.Visit(left, new IntervalEnvironment<Variable, Expression>(expManager));
+                var rightIntv = constantVisitor.Visit(right, new IntervalEnvironment<Variable, Expression>(expManager));
+
+                Rational v1, v2;
+
+                var b1 = leftIntv.TryGetSingletonValue(out v1);
+                var b2 = rightIntv.TryGetSingletonValue(out v2);
+
+                OctagonConstraint newConstraint = null;
+
+                switch (op)
+                {
+                    case ExpressionOperator.Addition:
+                        {
+                            if (b1 && !b2)
+                            { // case v1 + right < e2
+                                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(right)), -1, this.DimensionForVar(e2Var), -v1 - offset);
+                            }
+                            if (!b1 && b2)
+                            {  // case left + v2 < e2
+                                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(left)), -1, this.DimensionForVar(e2Var), -v2 - offset);
+                            }
+                        }
+                        break;
+
+                    case ExpressionOperator.Subtraction:
+                        {
+                            if (b1 && !b2)
+                            { // case v1 - right < e2
+                                newConstraint = OctagonConstraint.For(-1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(right)), -1, this.DimensionForVar(e2Var), -v1 - offset);
+                            }
+                            if (!b1 && b2)
+                            {  // case left - v2 < e2
+                                newConstraint = OctagonConstraint.For(1, this.DimensionForVar(expManager.Decoder.UnderlyingVariable(left)), -1, this.DimensionForVar(e2Var), v2 - offset);
+                            }
+                        }
+                        break;
+
+                    default:
+                        // do nothing
+                        return;
+                        //break;
+                }
+                if (newConstraint == null)
+                {
+                    return;
+                }
+                else
+                {
+                    this.AddConstraint(newConstraint);
+                }
+            }
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueEqual(exp1, exp2);
+        }
+
+        public OctagonEnvironment<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            this.CheckConsistency();
+
+            return this.TestTrueLessEqualThan(exp1, exp2).TestTrueLessEqualThan(exp2, exp1);
+        }
+
+        /// <summary>
+        /// A Special case of TestTrue that is needed for the partition analysis.
+        /// </summary>
+        public OctagonEnvironment<Variable, Expression> TestTrueEqualNotRefininingLeftArguments(Expression exp1, Expression exp2)
+        {
+            this.CheckConsistency();
+
+            var res = this.TestTrueLessEqualThan(exp1, exp2).TestTrueLessEqualThan(exp2, exp1);
+
+            return res.TestTrueEqualNotRefininingLeftArgumentsInternal(exp1, exp2);
+        }
+
+        public OctagonEnvironment<Variable, Expression> TestTrueNotEqual(Expression e1, Expression e2)
+        {
+            var e1Var = expManager.Decoder.UnderlyingVariable(e1);
+            var e2Var = expManager.Decoder.UnderlyingVariable(e2);
+
+            if (!variables2dimensions.ContainsKey(e1Var) || !variables2dimensions.ContainsKey(e2Var))
+            {
+                return this;
+            }
+
+            Rational k;
+
+            if (this.TryConstantForXMinusY(e1Var, e2Var, out k) && k.IsZero)
+            { // It is the case that exp1 <= exp2
+                this.AddConstraint(new OctagonConstraintXMinusY(this.DimensionForVar(e1Var), this.DimensionForVar(e2Var), -1));
+            }
+            else if (this.TryConstantForXMinusY(e2Var, e1Var, out k) && k.IsZero)
+            { // It is the case that exp2 <= exp1
+                this.AddConstraint(new OctagonConstraintXMinusY(this.DimensionForVar(e2Var), this.DimensionForVar(e1Var), -1));
+            }
+
+            return this;
+        }
+
+        #endregion
+
+        #region CheckIfHolds methods
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return new OctagonsCheckIfHoldsVisitor<Variable, Expression>(expManager.Decoder).Visit(exp, this);
+        }
+
+        /// <summary>
+        /// Check if the expression <code>exp</code> is greater than zero
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            var result = CommonChecks.CheckGreaterEqualThanZero(exp, expManager.Decoder);
+            if (!result.IsTop)
+            {
+                return result;
+            }
+            else
+            {
+                var tmp = this.Duplicate();
+                tmp.DoClosure();
+
+                if (tmp.IsBottom)
+                    return CheckOutcome.Bottom;
+                else
+                    return tmp.ToIntervalEnvironment().CheckIfGreaterEqualThanZero(exp);
+            }
+        }
+
+        /// <summary>
+        /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            var result = CommonChecks.CheckLessThan(e1, e2, this, expManager.Decoder);
+
+            if (result.IsTop)
+            { // Then we go deeper in the expression ...
+              // We need to make a clone of this to make it simpler
+                var duplicate = this.Duplicate();
+                duplicate.DoClosure();
+
+                if (duplicate.IsBottom)
+                {
+                    return CheckOutcome.Bottom;
+                }
+                else
+                {
+                    // Capture the cases when e1 or e2 are constants. To do it, we simply use the intervals
+                    result = duplicate.ToIntervalEnvironment().CheckIfLessThan(e1, e2);
+                }
+
+                if (result.IsTop)
+                {
+                    PolynomialOfInt<Variable, Expression> e1AsPoly, e2AsPoly, tmp;
+                    if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e1, expManager.Decoder, out e1AsPoly)
+                      && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e2, expManager.Decoder, out e2AsPoly)
+                      && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1AsPoly, e2AsPoly, out tmp))
+                    {
+                        if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
+                        {
+                            return result;
+                        }
+                    }
+                    else
+                    {
+                        var e1Var = expManager.Decoder.UnderlyingVariable(e1);
+                        var e2Var = expManager.Decoder.UnderlyingVariable(e2);
+
+                        var leftList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(e1Var), new MonomialOfInt<Variable>(-1, e2Var) };
+                        var rightList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(-1) };
+
+                        if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, leftList, rightList, out tmp))
+                        {
+                            if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
+                            {
+                                return result;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
+        {
+            return this.CheckIfLessThan(expManager.Encoder.VariableFor(v1), expManager.Encoder.VariableFor(v2));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
+
+        /// <summary>
+        /// Check if the expression <code>e1</code> is smaller equal than <code>e2</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            var result = CommonChecks.CheckLessEqualThan(e1, e2, this, expManager.Decoder);
+
+            if (!result.IsTop)
+            {
+                return result;
+            }
+
+            // We need to make a clone of this to make it simpler
+            var duplicate = this.Duplicate();
+            duplicate.DoClosure();
+
+            if (duplicate.IsBottom)
+            {
+                return CheckOutcome.Bottom;
+            }
+            else
+            {
+                // Capture the cases when e1 or e2 are constants. To do it, we simply use the intervals
+                result = duplicate.ToIntervalEnvironment().CheckIfLessEqualThan(e1, e2);
+            }
+
+            if (result.IsTop)
+            {
+                PolynomialOfInt<Variable, Expression> e1AsPoly, e2AsPoly, tmp;
+
+                if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e1, expManager.Decoder, out e1AsPoly)
+                  && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(e2, expManager.Decoder, out e2AsPoly)
+                  && PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1AsPoly, e2AsPoly, out tmp))
+                {
+                    if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
+                    {
+                        return result;
+                    }
+                }
+                else
+                {
+                    var e1Var = expManager.Decoder.UnderlyingVariable(e1);
+                    var e2Var = expManager.Decoder.UnderlyingVariable(e2);
+
+                    var leftList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(e1Var), new MonomialOfInt<Variable>(-1, e2Var) };
+                    var rightList = new List<MonomialOfInt<Variable>>() { new MonomialOfInt<Variable>(0) };
+
+                    if (PolynomialOfInt<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, leftList, rightList, out tmp))
+                    {
+                        if (new CheckLessThanOrLessEqualThan<Variable, Expression>().Visit(tmp, duplicate, ref result))
+                        {
+                            return result;
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            // TODO: provide a faster implementation
+            return this.CheckIfLessThan(e1, e2);
+        }
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessEqualThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> c1, c2;
+            if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
+            {
+                return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfEqual(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
+        {
+            return this.CheckIfLessEqualThan(expManager.Encoder.VariableFor(v1), expManager.Encoder.VariableFor(v2));
+        }
+
+        /// <summary>
+        /// Check if <code>e != 0</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
+        {
+            // We need to make a clone of this to make it simpler
+            OctagonEnvironment<Variable, Expression> duplicate = this.Duplicate();
+            duplicate.DoClosure();
+
+            if (duplicate.IsBottom)
+            {
+                return CheckOutcome.Bottom;
+            }
+            else
+            {
+                return duplicate.ToIntervalEnvironment().CheckIfNonZero(e);
+            }
+        }
+        #endregion
+
+        #region INumericalAbstractDomain<int,Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            this.CheckConsistency();
+
+            if (this.IsBottom)
+            {
+                return;
+            }
+
+            var tmp = new OctagonEnvironment<Variable, Expression>(this);
+
+            var rewrittenVariables = new Set<Variable>();
+
+            tmp.CheckConsistency();
+
+            foreach (var x in this.Variables)
+            {
+                if (!sourcesToTargets.ContainsKey(x))
+                {
+                    if (rewrittenVariables.Contains(x))
+                    {
+                        continue;
+                    }
+
+                    tmp.RemoveVariable(x);
+
+                    tmp.CheckConsistency();
+
+                    continue;
+                }
+
+                // Chose the canonical element
+                var target = (sourcesToTargets[x].Length() > 1 && x.Equals(sourcesToTargets[x].Head))
+                  ? sourcesToTargets[x].Tail.Head
+                  : sourcesToTargets[x].Head;
+
+                if (x.Equals(target))
+                {
+                    // If it is the identity there is nothing to do...
+                    continue;
+                }
+
+                if (tmp.variables2dimensions.ContainsKey(target))
+                {
+                    tmp.RemoveVariable(target);
+
+                    rewrittenVariables.Add(target);
+
+                    tmp.CheckConsistency();
+                }
+
+                int dimX = tmp.variables2dimensions[x];
+
+                tmp.variables2dimensions.Remove(x);
+
+                tmp.variables2dimensions[target] = dimX;
+
+                this.CheckConsistency();
+                tmp.CheckConsistency();
+            }
+
+            // Add the equalities between the same source
+            foreach (var source in sourcesToTargets.Keys)
+            {
+                if (sourcesToTargets[source].Length() <= 1)
+                {
+                    continue;
+                }
+
+                var target = source.Equals(sourcesToTargets[source].Head)
+                  ? sourcesToTargets[source].Tail.Head
+                  : sourcesToTargets[source].Head;
+
+                foreach (var otherTarget in sourcesToTargets[source].GetEnumerable())
+                {
+                    tmp.CheckConsistency();
+                    tmp = tmp.TestTrueEqual(convert(target), convert(otherTarget));
+                    tmp.CheckConsistency();
+                }
+            }
+
+            tmp.CheckConsistency();
+
+            // We change the state of this, using tmp
+            CloneFromThis(tmp);
+
+            this.CheckConsistency();
+        }
+
+        public Set<Expression> EqualsTo(Expression x)
+        {
+            var result = new Set<Expression>();
+
+            if (expManager.Encoder == null)
+            {
+                return result;
+            }
+
+            var xVar = expManager.Decoder.UnderlyingVariable(x);
+
+            int varDim;
+            if (variables2dimensions.TryGetValue(xVar, out varDim))
+            {
+                // 0. clone it before closing
+
+                var dup = this.Duplicate();
+                dup.DoClosure();
+
+                // 1. try to get a constant
+                var intvX = dup.BoundsFor(x);
+                Rational val;
+                if (intvX.TryGetSingletonValue(out val))
+                {
+                    //var eq = this.expManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, x, val.ToExpression(this.encoder));
+                    var eq = val.ToExpression(expManager.Encoder);
+                    result.Add(eq);
+                }
+
+                // 2. try to get a relation betwee x and y
+                foreach (var y in dup.variables2dimensions.Keys)
+                {
+                    if (x.Equals(y))
+                    {
+                        continue;
+                    }
+
+                    var dimY = dup.variables2dimensions[y];
+
+                    // 2.1 try x - y == k
+                    Rational r1, r2;
+                    var b1 = dup.TryConstantForXMinusY(xVar, y, out r1);    // x - y <= r1
+                    var b2 = dup.TryConstantForXMinusY(y, xVar, out r2);   // y - x <= r2 is -(x - y) <= r2 is -r2 <= (x - y) 
+
+                    if (b1 && b2 && r1 == -r2)
+                    {
+                        var eq = expManager.Encoder.CompoundExpressionFor(ExpressionType.Int32,
+                          ExpressionOperator.Addition, expManager.Encoder.VariableFor(y), r1.ToExpression(expManager.Encoder));
+
+                        result.Add(eq);
+                    }
+
+                    // 2.2 try x + y = k
+
+                    b1 = dup.TryConstantForXY(xVar, y, out r1);              // x + y <= r1
+                    b2 = dup.TryConstantForMinusXMinusY(xVar, y, out r2);    // -(x +y) <= r2 is -r2 <= x + y
+                    if (b1 && b2 && r1 == -r2)
+                    {
+                        var eq = expManager.Encoder.CompoundExpressionFor(ExpressionType.Int32,
+                          ExpressionOperator.Subtraction, r1.ToExpression(expManager.Encoder), expManager.Encoder.VariableFor(y));
+
+                        result.Add(eq);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                // TODO
+                return new List<Pair<Variable, Int32>>();
+            }
+        }
+
+        /// <summary>
+        /// Not implemented
+        /// </summary>
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            // TODO
+            return new Set<Expression>(); // not implemented
+        }
+
+        /// <summary>
+        /// Not implemented
+        /// </summary>
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            // TODO
+            return new Set<Expression>(); // not implemented
+        }
+
+
+        /// <summary>
+        /// Not implemented
+        /// </summary>
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            // TODO
+            return new Set<Expression>(); // not implemented
+        }
+
+        /// <summary>
+        /// Not implemented
+        /// </summary>
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            // TODO
+            return new Set<Expression>(); // not implemented
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            // TODO
+            return new Set<Variable>();
+        }
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
     }
 
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        // TODO
-        return new List<Pair<Variable, Int32>>();
-      }
-    }
-
-    /// <summary>
-    /// Not implemented
-    /// </summary>
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      // TODO
-      return new Set<Expression>(); // not implemented
-    }
-
-    /// <summary>
-    /// Not implemented
-    /// </summary>
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      // TODO
-      return new Set<Expression>(); // not implemented
-    }
-
-
-    /// <summary>
-    /// Not implemented
-    /// </summary>
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      // TODO
-      return new Set<Expression>(); // not implemented
-    }
-
-    /// <summary>
-    /// Not implemented
-    /// </summary>
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      // TODO
-      return new Set<Expression>(); // not implemented
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      // TODO
-      return new Set<Variable>();
-    }
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-  }
-
-  // public class ClosedOctagonEnvironment<Expression>
+    // public class ClosedOctagonEnvironment<Expression>
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/Pentagons.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/Pentagons.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The implementation for the reduced product of intervals and symbolic weak upper bounds
 // This has got the official name of "Pentagons"
@@ -33,665 +22,664 @@ using System.Linq;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-
-  /// <summary> 
-  /// The main class for intervals (of rationals) with symbolic upper bounds
-  /// </summary>
-  [ContractVerification(true)]
-  public class Pentagons<Variable, Expression>
-    :  ReducedCartesianAbstractDomain<IIntervalAbstraction<Variable, Expression>, WeakUpperBounds<Variable, Expression>>,
-      INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Invariant
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    /// <summary> 
+    /// The main class for intervals (of rationals) with symbolic upper bounds
+    /// </summary>
+    [ContractVerification(true)]
+    public class Pentagons<Variable, Expression>
+      : ReducedCartesianAbstractDomain<IIntervalAbstraction<Variable, Expression>, WeakUpperBounds<Variable, Expression>>,
+        INumericalAbstractDomain<Variable, Expression>
     {
-      Contract.Invariant(this.expManager!= null);
-    }
+        #region Invariant
 
-    #endregion
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(expManager != null);
+        }
 
-    #region Statistics
-    static public string Statistics
-    {
-      get
-      {
+        #endregion
+
+        #region Statistics
+        static public string Statistics
+        {
+            get
+            {
 #if TRACE_PERFORMANCE
-        string maxSizeforFunctionalDomain = MaxSizesAnalysisFrom(IntervalEnvironment<Variable, Expression>.MaxSizes);
-        return maxSizeforFunctionalDomain.ToString();
+                string maxSizeforFunctionalDomain = MaxSizesAnalysisFrom(IntervalEnvironment<Variable, Expression>.MaxSizes);
+                return maxSizeforFunctionalDomain.ToString();
 #else
-        return "Performance tracing is off";
+                return "Performance tracing is off";
 #endif
-      }
-    }
-
-    private static string MaxSizesAnalysisFrom(IDictionary<int, int> iDictionary)
-    {
-      if (iDictionary == null)
-        return "";
-
-      int max = Int32.MinValue;
-      int sum = 0;
-      var occurrences = new Dictionary<int, int>();
-
-      foreach (int o in iDictionary.Keys)
-      {
-        if (iDictionary[o] > max)
-        {
-          max = iDictionary[o];
+            }
         }
 
-        sum += iDictionary[o];
-
-        // Update the occurrences count
-        if (occurrences.ContainsKey(iDictionary[o]))
+        private static string MaxSizesAnalysisFrom(IDictionary<int, int> iDictionary)
         {
-          occurrences[iDictionary[o]]++;
+            if (iDictionary == null)
+                return "";
+
+            int max = Int32.MinValue;
+            int sum = 0;
+            var occurrences = new Dictionary<int, int>();
+
+            foreach (int o in iDictionary.Keys)
+            {
+                if (iDictionary[o] > max)
+                {
+                    max = iDictionary[o];
+                }
+
+                sum += iDictionary[o];
+
+                // Update the occurrences count
+                if (occurrences.ContainsKey(iDictionary[o]))
+                {
+                    occurrences[iDictionary[o]]++;
+                }
+                else
+                {
+                    occurrences[iDictionary[o]] = 1;
+                }
+            }
+
+            var averageSize = iDictionary.Count != 0 ? ((double)sum) / iDictionary.Count : Double.PositiveInfinity;
+
+            return "Max size : " + max + Environment.NewLine + "Average size: " + averageSize;
         }
-        else
+
+        #endregion
+
+        #region Private state
+
+        private readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
+
+        #endregion
+
+        #region (private) Constructor
+        /// <summary>
+        /// Please note that the decoder MUST be already be set for the <code>left</code> and <code>right</code> abstract domains
+        /// </summary>
+        public Pentagons(
+          IIntervalAbstraction<Variable, Expression> left,
+          WeakUpperBounds<Variable, Expression> right,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(left, right)
         {
-          occurrences[iDictionary[o]] = 1;
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Requires(expManager != null);
+
+            this.expManager = expManager;
         }
-      }
+        #endregion
 
-      var averageSize = iDictionary.Count != 0? ((double)sum) / iDictionary.Count : Double.PositiveInfinity;
-
-      return "Max size : " + max + Environment.NewLine + "Average size: " + averageSize;
-    }
-
-    #endregion
-
-    #region Private state
-
-    private readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
-    
-    #endregion
-
-    #region (private) Constructor
-    /// <summary>
-    /// Please note that the decoder MUST be already be set for the <code>left</code> and <code>right</code> abstract domains
-    /// </summary>
-    public Pentagons(
-      IIntervalAbstraction<Variable, Expression> left, 
-      WeakUpperBounds<Variable, Expression> right,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(left, right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Requires(expManager != null);
-
-      this.expManager = expManager;
-    }
-    #endregion
-
-    #region (protected) Getters
-    protected ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<ExpressionManagerWithEncoder<Variable, Expression>>() != null);
-
-        return this.expManager;
-      }
-    }
-    #endregion
-
-    #region Factories
-    
-    [Pure]
-    override protected ReducedCartesianAbstractDomain<IIntervalAbstraction<Variable, Expression>, WeakUpperBounds<Variable, Expression>>
-      Factory(IIntervalAbstraction<Variable, Expression> left, WeakUpperBounds<Variable, Expression> right)
-    {
-      return this.FactoryOfPentagons(left, right);
-    }
-
-    [Pure]
-    private Pentagons<Variable, Expression> FactoryOfPentagons(
-      IIntervalAbstraction<Variable, Expression> left, WeakUpperBounds<Variable, Expression> right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);      
-
-      return new Pentagons<Variable, Expression>(left, right, this.expManager); 
-    }
-
-    /// <summary>
-    /// This reduction considers the pairs (x, y)  of intervals and add to the weak upper bounds all those such that x &lt; y
-    /// </summary>
-    [Pure]
-    public override ReducedCartesianAbstractDomain<IIntervalAbstraction<Variable, Expression>, WeakUpperBounds<Variable, Expression>>
-      Reduce(IIntervalAbstraction<Variable, Expression> left, WeakUpperBounds<Variable, Expression> right)
-    {
-      return this.Factory(left, right);
-    }
-
-    #endregion
-
-    #region Implementation of the abstract methods
-
-    override public bool LessEqual(IAbstractDomain a)
-    {
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
-      {
-        return result;
-      }
-
-      var r = a as Pentagons<Variable, Expression>;
-
-      Contract.Assume(r != null);
-
-      if (!this.Left.LessEqual(r.Left))
-      {
-        return false;
-      }
-
-      return this.Right.LessEqual(r.Right);
-    }
-
-    /// <summary>
-    /// This is a version of the join which causes a partial propagation of the information from Intervals to Symbolic upper bounds
-    /// </summary>
-    /// <param name="a">The other element</param>
-    sealed public override IAbstractDomain Join(IAbstractDomain a)
-    {
-      if (this.IsBottom)
-        return a;
-      if (a.IsBottom)
-        return this;
-      if (this.IsTop)
-        return this;
-      if (a.IsTop)
-        return a;
-
-      var r = a as Pentagons<Variable, Expression>;
-
-      Contract.Assume(r != null);
-
-      // These two lines have a weak notion of closure, which essentially avoids dropping "x < y" if it is implied by the intervals abstract domain                
-      // It seems that it is as precise as the expensive join
-
-      var joinRightPart = this.Right.Join(r.Right, this.Left, r.Left);
-      var joinLeftPart = this.Left.Join(r.Left);
-
-      return this.Factory(joinLeftPart, joinRightPart);
-    }
-
-    /// <summary>
-    /// The pairwise widening
-    /// </summary>
-    public override IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      if (this.IsBottom)
-        return prev;
-      if (prev.IsBottom)
-        return this;
-
-      var asIntWSUB = prev as Pentagons<Variable, Expression>;
-      Contract.Assume(asIntWSUB != null);
-
-      var widenLeft = this.Left.Widening(asIntWSUB.Left);
-      var widenRight = this.Right.Widening(asIntWSUB.Right);
-
-      return this.Factory(widenLeft, widenRight);     
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression>Members
-
-    /// <summary>
-    /// Dispatch the assigment to the underlying abstract domains
-    /// </summary>
-    /// <param name="sourcesToTargets"></param>
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      // NOTE NOTE that we first assign in the right (so to assign in the pre-state!!!) and then on the left
-      this.Right.AssignInParallel(sourcesToTargets, convert, this.Left);
-
-      this.Left.AssignInParallel(sourcesToTargets, convert);
-    }
-
-    /// <returns>
-    /// An interval that contains the upper bounds for <code>v</code>
-    /// </returns>
-    public DisInterval BoundsFor(Expression v)
-    {
-      return this.Left.BoundsFor(v);
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      return this.Left.BoundsFor(v);
-    }
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return this.Left.IntConstants;
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      return this.Right.EqualitiesFor(v);
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      return this.Left.CheckIfGreaterEqualThanZero(exp).Meet(Right.CheckIfGreaterEqualThanZero(exp));
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      var checkOnLeft = this.Left.CheckIfLessThan(e1, e2);      
-      var checkOnRight = this.Right.CheckIfLessThan(e1, e2, this.Left);
-
-      return checkOnLeft.Meet(checkOnRight);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      var checkOnLeft = this.Left.CheckIfLessThan_Un(e1, e2);
-      var checkOnRight = this.Right.CheckIfLessThan_Un(e1, e2);
-
-      return checkOnLeft.Meet(checkOnRight);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
-    {
-      var checkOnLeft = this.Left.CheckIfLessThan(v1, v2);
-      var checkOnRight = this.Right.CheckIfLessThan(v1, v2);
-
-      return checkOnLeft.Meet(checkOnRight);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      var checkOnLeft = this.Left.CheckIfLessEqualThan(e1, e2);
-      var checkOnRight = this.Right.CheckIfLessEqualThan(e1, e2, this.Left);
-
-      return checkOnLeft.Meet(checkOnRight);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      var checkOnLeft = this.Left.CheckIfLessEqualThan_Un(e1, e2);
-      var checkOnRight = this.Right.CheckIfLessEqualThan_Un(e1, e2);
-
-      return checkOnLeft.Meet(checkOnRight);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable  v2)
-    {
-      var checkOnLeft = this.Left.CheckIfLessEqualThan(v1, v2);
-      var checkOnRight = this.Right.CheckIfLessEqualThan(v1, v2);
-
-      return checkOnLeft.Meet(checkOnRight);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      var c1 = CheckIfLessEqualThan(e1, e2);
-      var c2 = CheckIfLessEqualThan(e2, e1);
-
-      if (c1.IsNormal())
-      {
-        if (c2.IsNormal())
+        #region (protected) Getters
+        protected ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager
         {
-          return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
+            get
+            {
+                Contract.Ensures(Contract.Result<ExpressionManagerWithEncoder<Variable, Expression>>() != null);
+
+                return expManager;
+            }
         }
-        else
+        #endregion
+
+        #region Factories
+
+        [Pure]
+        override protected ReducedCartesianAbstractDomain<IIntervalAbstraction<Variable, Expression>, WeakUpperBounds<Variable, Expression>>
+          Factory(IIntervalAbstraction<Variable, Expression> left, WeakUpperBounds<Variable, Expression> right)
         {
-          var lt = CheckIfLessThan(e1, e2);
-          if (lt.IsTrue())  // e1 < e2
-          {
-            return CheckOutcome.False;
-          }
-          else if (lt.IsFalse()) // e1 <= e2 & !(e1 < e2) 
-          {
-            return CheckOutcome.True;
-          }
+            return this.FactoryOfPentagons(left, right);
         }
-      }
-      else if (c2.IsNormal())
-      {
-        var gt = CheckIfLessThan(e2, e1);
-        if (gt.IsTrue())    // e1 > e2
+
+        [Pure]
+        private Pentagons<Variable, Expression> FactoryOfPentagons(
+          IIntervalAbstraction<Variable, Expression> left, WeakUpperBounds<Variable, Expression> right)
         {
-          return CheckOutcome.False;
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+
+            return new Pentagons<Variable, Expression>(left, right, expManager);
         }
-        else if (gt.IsFalse())  // e1 >= e2 & !(e1 > e2)
+
+        /// <summary>
+        /// This reduction considers the pairs (x, y)  of intervals and add to the weak upper bounds all those such that x &lt; y
+        /// </summary>
+        [Pure]
+        public override ReducedCartesianAbstractDomain<IIntervalAbstraction<Variable, Expression>, WeakUpperBounds<Variable, Expression>>
+          Reduce(IIntervalAbstraction<Variable, Expression> left, WeakUpperBounds<Variable, Expression> right)
         {
-          return CheckOutcome.True;
+            return this.Factory(left, right);
         }
-      }
 
-      return CheckOutcome.Top;
+        #endregion
+
+        #region Implementation of the abstract methods
+
+        override public bool LessEqual(IAbstractDomain a)
+        {
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out result))
+            {
+                return result;
+            }
+
+            var r = a as Pentagons<Variable, Expression>;
+
+            Contract.Assume(r != null);
+
+            if (!this.Left.LessEqual(r.Left))
+            {
+                return false;
+            }
+
+            return this.Right.LessEqual(r.Right);
+        }
+
+        /// <summary>
+        /// This is a version of the join which causes a partial propagation of the information from Intervals to Symbolic upper bounds
+        /// </summary>
+        /// <param name="a">The other element</param>
+        sealed public override IAbstractDomain Join(IAbstractDomain a)
+        {
+            if (this.IsBottom)
+                return a;
+            if (a.IsBottom)
+                return this;
+            if (this.IsTop)
+                return this;
+            if (a.IsTop)
+                return a;
+
+            var r = a as Pentagons<Variable, Expression>;
+
+            Contract.Assume(r != null);
+
+            // These two lines have a weak notion of closure, which essentially avoids dropping "x < y" if it is implied by the intervals abstract domain                
+            // It seems that it is as precise as the expensive join
+
+            var joinRightPart = this.Right.Join(r.Right, this.Left, r.Left);
+            var joinLeftPart = this.Left.Join(r.Left);
+
+            return this.Factory(joinLeftPart, joinRightPart);
+        }
+
+        /// <summary>
+        /// The pairwise widening
+        /// </summary>
+        public override IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            if (this.IsBottom)
+                return prev;
+            if (prev.IsBottom)
+                return this;
+
+            var asIntWSUB = prev as Pentagons<Variable, Expression>;
+            Contract.Assume(asIntWSUB != null);
+
+            var widenLeft = this.Left.Widening(asIntWSUB.Left);
+            var widenRight = this.Right.Widening(asIntWSUB.Right);
+
+            return this.Factory(widenLeft, widenRight);
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression>Members
+
+        /// <summary>
+        /// Dispatch the assigment to the underlying abstract domains
+        /// </summary>
+        /// <param name="sourcesToTargets"></param>
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            // NOTE NOTE that we first assign in the right (so to assign in the pre-state!!!) and then on the left
+            this.Right.AssignInParallel(sourcesToTargets, convert, this.Left);
+
+            this.Left.AssignInParallel(sourcesToTargets, convert);
+        }
+
+        /// <returns>
+        /// An interval that contains the upper bounds for <code>v</code>
+        /// </returns>
+        public DisInterval BoundsFor(Expression v)
+        {
+            return this.Left.BoundsFor(v);
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            return this.Left.BoundsFor(v);
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                return this.Left.IntConstants;
+            }
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            return this.Right.EqualitiesFor(v);
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            return this.Right.LowerBoundsFor(v, strict).Union(this.Left.LowerBoundsFor(v, strict));
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            return this.Right.UpperBoundsFor(v, strict).Union(this.Left.UpperBoundsFor(v, strict));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            return this.Left.CheckIfGreaterEqualThanZero(exp).Meet(Right.CheckIfGreaterEqualThanZero(exp));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            var checkOnLeft = this.Left.CheckIfLessThan(e1, e2);
+            var checkOnRight = this.Right.CheckIfLessThan(e1, e2, this.Left);
+
+            return checkOnLeft.Meet(checkOnRight);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            var checkOnLeft = this.Left.CheckIfLessThan_Un(e1, e2);
+            var checkOnRight = this.Right.CheckIfLessThan_Un(e1, e2);
+
+            return checkOnLeft.Meet(checkOnRight);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
+        {
+            var checkOnLeft = this.Left.CheckIfLessThan(v1, v2);
+            var checkOnRight = this.Right.CheckIfLessThan(v1, v2);
+
+            return checkOnLeft.Meet(checkOnRight);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            var checkOnLeft = this.Left.CheckIfLessEqualThan(e1, e2);
+            var checkOnRight = this.Right.CheckIfLessEqualThan(e1, e2, this.Left);
+
+            return checkOnLeft.Meet(checkOnRight);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            var checkOnLeft = this.Left.CheckIfLessEqualThan_Un(e1, e2);
+            var checkOnRight = this.Right.CheckIfLessEqualThan_Un(e1, e2);
+
+            return checkOnLeft.Meet(checkOnRight);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
+        {
+            var checkOnLeft = this.Left.CheckIfLessEqualThan(v1, v2);
+            var checkOnRight = this.Right.CheckIfLessEqualThan(v1, v2);
+
+            return checkOnLeft.Meet(checkOnRight);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            var c1 = CheckIfLessEqualThan(e1, e2);
+            var c2 = CheckIfLessEqualThan(e2, e1);
+
+            if (c1.IsNormal())
+            {
+                if (c2.IsNormal())
+                {
+                    return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
+                }
+                else
+                {
+                    var lt = CheckIfLessThan(e1, e2);
+                    if (lt.IsTrue())  // e1 < e2
+                    {
+                        return CheckOutcome.False;
+                    }
+                    else if (lt.IsFalse()) // e1 <= e2 & !(e1 < e2) 
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
+            }
+            else if (c2.IsNormal())
+            {
+                var gt = CheckIfLessThan(e2, e1);
+                if (gt.IsTrue())    // e1 > e2
+                {
+                    return CheckOutcome.False;
+                }
+                else if (gt.IsFalse())  // e1 >= e2 & !(e1 > e2)
+                {
+                    return CheckOutcome.True;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfEqual(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
+        {
+            var checkOnLeft = this.Left.CheckIfNonZero(e);
+            var checkOnRight = this.Right.CheckIfNonZero(e);
+
+            return checkOnLeft.Meet(checkOnRight);
+        }
+
+        public Variable ToVariable(Expression exp)
+        {
+            return this.ExpressionManager.Decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignmentsWithForward<Expression> Members
+
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            this.Left.AssumeInDisInterval(x, value);
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+            if (x == null || exp == null)
+                return;
+
+            this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
+
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            // Infer some x >= 0 invariants which requires the information from the two domains
+            // The information should be inferred in the pre-state
+            List<Expression> geqZero;
+            // if (this.ExpressionManager.Encoder!= null)
+            {
+                geqZero = new GreaterEqualThanZeroConstraints<Variable, Expression>(this.ExpressionManager).InferConstraints(x, exp, preState);
+                Contract.Assert(Contract.ForAll(geqZero, condition => condition != null));
+            }
+            /*      else
+                  {
+                    geqZero = new List<Expression>();
+                    // F: we do not decompile ForAll in the case below
+                    Contract.Assume(Contract.ForAll(geqZero, condition => condition != null));
+                  }
+            */
+            Contract.Assert(Contract.ForAll(geqZero, condition => condition != null));
+
+            this.Right.Assign(x, exp, preState);
+            this.Left.Assign(x, exp, preState);
+
+            // The information is assumed in the post-state...
+            foreach (var condition in geqZero)
+            {
+                this.TestTrue(condition);
+            }
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        public List<Variable> Variables
+        {
+            get
+            {
+                return this.Left.Variables.SetUnion(this.Right.Variables);
+            }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            this.Left.AddVariable(var);
+            this.Right.AddVariable(var);
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            this.Left.ProjectVariable(var);
+            this.Right.ProjectVariable(var);
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            this.Left.RemoveVariable(var);
+            this.Right.RemoveVariable(var);
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            this.Left.RenameVariable(OldName, NewName);
+            this.Right.RenameVariable(OldName, NewName);
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            return this.TestTrue(guard);
+        }
+
+        public Pentagons<Variable, Expression> TestTrue(Expression guard)
+        {
+            Contract.Requires(guard != null);
+
+            Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+
+            var resultLeft = this.Left.TestTrue(guard);
+            var resultRight = this.Right.TestTrue(guard);
+
+            return this.FactoryOfPentagons(resultLeft, resultRight);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            return this.TestFalse(guard);
+        }
+
+        public Pentagons<Variable, Expression> TestFalse(Expression guard)
+        {
+            Contract.Requires(guard != null);
+
+            Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+
+            var resultLeft = this.Left.TestFalse(guard);
+            var resultRight = this.Right.TestFalse(guard);
+
+            return this.FactoryOfPentagons(resultLeft, resultRight);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression exp)
+        {
+            return this.TestTrueGeqZero(exp);
+        }
+
+        public Pentagons<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            Contract.Requires(exp != null);
+
+            var newLeft = this.Left.TestTrueGeqZero(exp);
+            var newRight = this.Right; // We abstract them away
+
+            return this.FactoryOfPentagons(newLeft, newRight);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessThan(exp1, exp2);
+        }
+
+        public Pentagons<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+            Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+
+            var newLeft = this.Left.TestTrueLessThan(exp1, exp2);
+            var newRight = this.Right.TestTrueLessThan(exp1, exp2);
+
+            return this.FactoryOfPentagons(newLeft, newRight);
+        }
+
+        public Pentagons<Variable, Expression> TestTrueLessThan(Variable v1, Variable v2)
+        {
+            var newLeft = this.Left.TestTrueLessThan(v1, v2);
+            var newRight = this.Right.TestTrueLessThan(v1, v2);
+
+            return this.FactoryOfPentagons(newLeft, newRight);
+        }
+
+
+        public Pentagons<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2,
+          WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+            Contract.Requires(oracleDomain != null);
+
+            Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+
+
+            var newLeft = this.Left.TestTrueLessThan(exp1, exp2);
+            var newRight = this.Right.TestTrueLessThan(exp1, exp2, oracleDomain);
+
+            return this.FactoryOfPentagons(newLeft, newRight);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessEqualThan(exp1, exp2);
+        }
+
+        public Pentagons<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            Contract.Requires(exp1 != null);
+            Contract.Requires(exp2 != null);
+
+            Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+
+            var newLeft = this.Left.TestTrueLessEqualThan(exp1, exp2);
+            var newRight = this.Right.TestTrueLessEqualThan(exp1, exp2);
+
+            return this.FactoryOfPentagons(newLeft, newRight);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueEqual(exp1, exp2);
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            Contract.Assume(exp1 != null);
+            Contract.Assume(exp2 != null);
+
+            var resultLeft = this.Left.TestTrueEqual(exp1, exp2);
+            var resultRight = this.Right.TestTrueEqual(exp1, exp2);
+
+            return this.FactoryOfPentagons(resultLeft, resultRight);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            if (CommonChecks.CheckTrivialEquality(exp, this.ExpressionManager.Decoder))
+            {
+                return CheckOutcome.True;
+            }
+
+            var checkLeft = this.Left.CheckIfHolds(exp);
+            var checkRight = this.Right.CheckIfHolds(exp, null);
+
+            return checkLeft.Meet(checkRight);
+        }
+        #endregion
+
+        #region Remove redundancies
+        public Pentagons<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            Contract.Requires(oracle != null);
+
+            var left = this.Left.RemoveRedundanciesWith(oracle);
+            var right = this.Right.RemoveRedundanciesWith(this.Right).RemoveRedundanciesWith(oracle);
+
+            return this.FactoryOfPentagons(left, right);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return this.RemoveRedundanciesWith(oracle);
+        }
+
+        #endregion
+
+        #region ToString
+        public string ToString(Expression exp)
+        {
+            //      if (this.expManager.Decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, expManager.Decoder);
+            }
+            /*    else
+                {
+                  return "< missing expression decoder >";
+                }*/
+        }
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
     }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfEqual(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
-    {
-      var checkOnLeft = this.Left.CheckIfNonZero(e);
-      var checkOnRight = this.Right.CheckIfNonZero(e);
-
-      return checkOnLeft.Meet(checkOnRight);
-    }
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.ExpressionManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignmentsWithForward<Expression> Members
-
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      this.Left.AssumeInDisInterval(x, value);
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      if(x == null || exp == null)
-        return;
-
-      this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      // Infer some x >= 0 invariants which requires the information from the two domains
-      // The information should be inferred in the pre-state
-      List<Expression> geqZero;
-      // if (this.ExpressionManager.Encoder!= null)
-      {
-        geqZero = new GreaterEqualThanZeroConstraints<Variable, Expression>(this.ExpressionManager).InferConstraints(x, exp, preState);
-        Contract.Assert(Contract.ForAll(geqZero, condition => condition != null));
-      }
-/*      else
-      {
-        geqZero = new List<Expression>();
-        // F: we do not decompile ForAll in the case below
-        Contract.Assume(Contract.ForAll(geqZero, condition => condition != null));
-      }
-*/
-      Contract.Assert(Contract.ForAll(geqZero, condition => condition != null));
-
-      this.Right.Assign(x, exp, preState);
-      this.Left.Assign(x, exp, preState);
-
-      // The information is assumed in the post-state...
-      foreach (var condition in geqZero)
-      {
-        this.TestTrue(condition);
-      }
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get
-      {
-        return this.Left.Variables.SetUnion(this.Right.Variables);
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      this.Left.AddVariable(var);
-      this.Right.AddVariable(var);
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      this.Left.ProjectVariable(var);
-      this.Right.ProjectVariable(var);
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      this.Left.RemoveVariable(var);
-      this.Right.RemoveVariable(var);
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      this.Left.RenameVariable(OldName, NewName);
-      this.Right.RenameVariable(OldName, NewName);
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression  guard)
-    {
-      return this.TestTrue(guard);
-    }
-
-    public Pentagons<Variable, Expression> TestTrue(Expression guard)
-    {
-      Contract.Requires(guard != null);
-      
-      Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
-
-      var resultLeft = this.Left.TestTrue(guard);
-      var resultRight = this.Right.TestTrue(guard);
-
-      return this.FactoryOfPentagons(resultLeft, resultRight);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression  guard)
-    {
-      return this.TestFalse(guard);
-    }
-
-    public Pentagons<Variable, Expression> TestFalse(Expression guard)
-    {
-      Contract.Requires(guard != null);
-
-      Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
-
-      var resultLeft = this.Left.TestFalse(guard);
-      var resultRight = this.Right.TestFalse(guard);
-
-      return this.FactoryOfPentagons(resultLeft, resultRight);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueGeqZero(Expression  exp)
-    {
-      return this.TestTrueGeqZero(exp);
-    }
-    
-    public Pentagons<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      Contract.Requires(exp != null);
-
-      var newLeft = this.Left.TestTrueGeqZero(exp);
-      var newRight = this.Right; // We abstract them away
-
-      return this.FactoryOfPentagons(newLeft, newRight);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression  exp1, Expression  exp2)
-    {
-      return this.TestTrueLessThan(exp1, exp2);
-    }
-
-    public Pentagons<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-      Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
-
-      var newLeft = this.Left.TestTrueLessThan(exp1, exp2);
-      var newRight = this.Right.TestTrueLessThan(exp1, exp2);
-
-      return this.FactoryOfPentagons(newLeft, newRight);  
-    }
-
-    public Pentagons<Variable, Expression> TestTrueLessThan(Variable v1, Variable v2)
-    {
-      var newLeft = this.Left.TestTrueLessThan(v1, v2);
-      var newRight = this.Right.TestTrueLessThan(v1, v2);
-
-      return this.FactoryOfPentagons(newLeft, newRight);
-    }
-
-
-    public Pentagons<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2, 
-      WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-      Contract.Requires(oracleDomain != null);
-
-      Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
-
-
-      var newLeft = this.Left.TestTrueLessThan(exp1, exp2);
-      var newRight = this.Right.TestTrueLessThan(exp1, exp2, oracleDomain);
-
-      return this.FactoryOfPentagons(newLeft, newRight);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueLessEqualThan(exp1, exp2);
-    }
-      
-    public Pentagons<Variable, Expression> TestTrueLessEqualThan(Expression  exp1, Expression  exp2)
-    {
-      Contract.Requires(exp1 != null);
-      Contract.Requires(exp2 != null);
-
-      Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
-
-      var newLeft = this.Left.TestTrueLessEqualThan(exp1, exp2);
-      var newRight = this.Right.TestTrueLessEqualThan(exp1, exp2);
-
-      return this.FactoryOfPentagons(newLeft, newRight);  
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueEqual(exp1, exp2);
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      Contract.Assume(exp1 != null);
-      Contract.Assume(exp2 != null);
-
-      var resultLeft = this.Left.TestTrueEqual(exp1, exp2);
-      var resultRight = this.Right.TestTrueEqual(exp1, exp2);
-
-      return this.FactoryOfPentagons(resultLeft, resultRight);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      if (CommonChecks.CheckTrivialEquality(exp, this.ExpressionManager.Decoder))
-      {
-        return CheckOutcome.True;
-      }
-
-      var checkLeft = this.Left.CheckIfHolds(exp);
-      var checkRight = this.Right.CheckIfHolds(exp, null);
-
-      return checkLeft.Meet(checkRight);
-    }
-    #endregion
-
-    #region Remove redundancies
-    public Pentagons<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      Contract.Requires(oracle != null);
-
-      var left = this.Left.RemoveRedundanciesWith(oracle);
-      var right = this.Right.RemoveRedundanciesWith(this.Right).RemoveRedundanciesWith(oracle);
-
-      return this.FactoryOfPentagons(left, right);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return this.RemoveRedundanciesWith(oracle);
-    }
-
-    #endregion
-    
-    #region ToString
-    public string ToString(Expression exp)
-    {
-//      if (this.expManager.Decoder != null)
-      {
-        return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
-      }
-  /*    else
-      {
-        return "< missing expression decoder >";
-      }*/
-    }
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/PentagonsPlus.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/PentagonsPlus.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -23,657 +12,657 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  [ContractVerification(true)]
-  public class PentagonsPlus<Variable, Expression>
-    : ReducedNumericalDomains<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>, Variable, Expression>
-  {
-    #region Constructor
-
-    public PentagonsPlus(
-      WeakUpperBoundsEqual<Variable, Expression> left, Pentagons<Variable, Expression> right,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(left, right, expManager)
+    [ContractVerification(true)]
+    public class PentagonsPlus<Variable, Expression>
+      : ReducedNumericalDomains<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>, Variable, Expression>
     {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Requires(expManager != null);
-    }
+        #region Constructor
 
-    #endregion
-
-    #region Assign
-
-    public override void Assign(Expression x, Expression exp)
-    {
-      // F: I am lazy...
-      Contract.Assume(x != null);
-      Contract.Assume(exp != null);
-
-      // Infer some x >= 0 invariants which requires the information from the two domains
-      // The information should be inferred in the pre-state
-      var geqZero = new GreaterEqualThanZeroConstraints<Variable, Expression>(this.ExpressionManager).InferConstraints(x, exp, this);
-
-      this.Left.Assign(x, exp, this);
-      this.Right.Assign(x, exp);
-
-      // The information is assumed in the post-state...
-      foreach (var condition in geqZero)
-      {
-        this.TestTrue(condition);
-      }
-    }
-
-    public override void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      var right = this.Right;
-
-      this.AssignInParallel(this.Left, right.Right, sourcesToTargets, right.Left as INumericalAbstractDomain<Variable, Expression>);
-
-      right.Left.AssignInParallel(sourcesToTargets, convert);
-    }
-
-    private void AssignInParallel
-      (WeakUpperBoundsEqual<Variable, Expression> wubeq, WeakUpperBounds<Variable, Expression> wub, 
-      Dictionary<Variable, FList<Variable>> sourcesToTargets, INumericalAbstractDomain<Variable,Expression> oracleDomain)
-    {
-      Contract.Requires(wubeq != null);
-      Contract.Requires(wub != null);
-
-      // adding the domain-generated variables to the map as identity
-      var oldToNewMap = new Dictionary<Variable, FList<Variable>>(sourcesToTargets);
-
-      if (!wubeq.IsTop)
-      {
-        foreach (var e in wubeq.SlackVariables)
+        public PentagonsPlus(
+          WeakUpperBoundsEqual<Variable, Expression> left, Pentagons<Variable, Expression> right,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(left, right, expManager)
         {
-            oldToNewMap[e] = FList<Variable>.Cons(e, FList<Variable>.Empty);
-        }
-      }
-
-      if (!wub.IsTop)
-      {
-        foreach (var e in wub.SlackVariables)
-        {
-            oldToNewMap[e] = FList<Variable>.Cons(e, FList<Variable>.Empty);
-        }
-      }
-
-      // when x has several targets including itself, the canonical element shouldn't be itself
-      foreach (var sourceToTargets in sourcesToTargets)
-      {
-        var source = sourceToTargets.Key;
-        var targets = sourceToTargets.Value;
-
-        Contract.Assume(targets != null);
-
-        if (targets.Length() > 1 && targets.Head.Equals(source))
-        {
-          var tail = targets.Tail;
-          Contract.Assert(tail != null);
-
-          var newTargets = FList<Variable>.Cons(tail.Head, FList<Variable>.Cons(source, tail.Tail));
-          oldToNewMap[source] = newTargets;
-        }
-      }
-
-        AssignInParallelWUBSpecific(wub, oldToNewMap);
-        AssignInParallelWUBEQSpecific(wubeq, sourcesToTargets, oldToNewMap);
-    }
-
-    private void AssignInParallelWUBSpecific(WeakUpperBounds<Variable, Expression> wub, Dictionary<Variable, FList<Variable>> oldToNewMap)
-    {
-      Contract.Requires(wub != null);
-      Contract.Requires(oldToNewMap != null);
-
-      var newMappings = new Dictionary<Variable, List<Variable>>(wub.Count);
- 
-      foreach (var oldLeft_pair in wub.Elements)
-      {
-        if (!oldToNewMap.ContainsKey(oldLeft_pair.Key))
-        {
-          continue;
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Requires(expManager != null);
         }
 
-        var target = oldToNewMap[oldLeft_pair.Key];
-        Contract.Assume(target != null);
+        #endregion
 
-        var newLeft = target.Head; // our canonical element
+        #region Assign
 
-        var oldBounds = oldLeft_pair.Value;
-        if (!oldBounds.IsNormal())
+        public override void Assign(Expression x, Expression exp)
         {
-          continue;
-        }
+            // F: I am lazy...
+            Contract.Assume(x != null);
+            Contract.Assume(exp != null);
 
-        foreach (var oldRight in oldBounds.Values)
-        {
-          FList<Variable> olds;
+            // Infer some x >= 0 invariants which requires the information from the two domains
+            // The information should be inferred in the pre-state
+            var geqZero = new GreaterEqualThanZeroConstraints<Variable, Expression>(this.ExpressionManager).InferConstraints(x, exp, this);
 
-          if (oldToNewMap.TryGetValue(oldRight, out olds))
-          {
-            Contract.Assume(olds != null);
-            // This case is so so common that we want to specialize it
-            if (olds.Length() == 1)
+            this.Left.Assign(x, exp, this);
+            this.Right.Assign(x, exp);
+
+            // The information is assumed in the post-state...
+            foreach (var condition in geqZero)
             {
-              var newRight = olds.Head; // our canonical element
-              AddUpperBound(newLeft, newRight, newMappings);
+                this.TestTrue(condition);
             }
-            else
+        }
+
+        public override void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            var right = this.Right;
+
+            this.AssignInParallel(this.Left, right.Right, sourcesToTargets, right.Left as INumericalAbstractDomain<Variable, Expression>);
+
+            right.Left.AssignInParallel(sourcesToTargets, convert);
+        }
+
+        private void AssignInParallel
+          (WeakUpperBoundsEqual<Variable, Expression> wubeq, WeakUpperBounds<Variable, Expression> wub,
+          Dictionary<Variable, FList<Variable>> sourcesToTargets, INumericalAbstractDomain<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(wubeq != null);
+            Contract.Requires(wub != null);
+
+            // adding the domain-generated variables to the map as identity
+            var oldToNewMap = new Dictionary<Variable, FList<Variable>>(sourcesToTargets);
+
+            if (!wubeq.IsTop)
             {
-              foreach (var newRight in olds.GetEnumerable())
-              {
-                AddUpperBound(newLeft, newRight, newMappings);
-              }
+                foreach (var e in wubeq.SlackVariables)
+                {
+                    oldToNewMap[e] = FList<Variable>.Cons(e, FList<Variable>.Empty);
+                }
             }
-          }
-        }
 
-        // There are some more elements
-        for (var list = oldToNewMap[oldLeft_pair.Key].Tail; list != null; list = list.Tail)
-        {
-          List<Variable> targets;
-          if (newMappings.TryGetValue(newLeft, out targets))
-          {
-            Contract.Assume(targets != null);
-            foreach (var con in targets)
+            if (!wub.IsTop)
             {
-              AddUpperBound(list.Head, con, newMappings);
+                foreach (var e in wub.SlackVariables)
+                {
+                    oldToNewMap[e] = FList<Variable>.Cons(e, FList<Variable>.Empty);
+                }
             }
-          }
-        }
-      }
 
-      // Update
-      var newConstraints = new Dictionary<Variable, SetOfConstraints<Variable>>(wub.Count);
-
-      foreach (var pair in newMappings)
-      {
-        Contract.Assume(pair.Value != null);
-        newConstraints.Add(pair.Key, new SetOfConstraints<Variable>(pair.Value));
-      }
-
-      wub.SetElements(newConstraints);
-    }
-
-    private void AssignInParallelWUBEQSpecific(
-      WeakUpperBoundsEqual<Variable, Expression> wubeq, Dictionary<Variable, FList<Variable>> sourcesToTargets, 
-      Dictionary<Variable, FList<Variable>> oldToNewMap)
-    {
-      Contract.Requires(wubeq != null);
-      Contract.Requires(sourcesToTargets != null);
-      Contract.Requires(oldToNewMap != null);
-
-      var newMappings = new Dictionary<Variable, List<Variable>>(wubeq.Count);
-
-      foreach (var oldLeft_Pair in wubeq.Elements)
-      {
-        FList<Variable> targets;
-        if (oldToNewMap.TryGetValue(oldLeft_Pair.Key, out targets))
-        {
-          Contract.Assume(targets != null);
-
-          var oldBounds = oldLeft_Pair.Value;
-          if (!oldBounds.IsNormal())
-          {
-            continue;
-          }
-
-          var newLeft = targets.Head; // our canonical element
-
-          foreach (var oldRight in oldBounds.Values)
-          {
-            FList<Variable> olds;
-            if (oldToNewMap.TryGetValue(oldRight, out olds))
+            // when x has several targets including itself, the canonical element shouldn't be itself
+            foreach (var sourceToTargets in sourcesToTargets)
             {
-              Contract.Assume(olds != null);
+                var source = sourceToTargets.Key;
+                var targets = sourceToTargets.Value;
 
-              var newRight = olds.Head; // our canonical element
-              AddUpperBound(newLeft, newRight, newMappings);
+                Contract.Assume(targets != null);
+
+                if (targets.Length() > 1 && targets.Head.Equals(source))
+                {
+                    var tail = targets.Tail;
+                    Contract.Assert(tail != null);
+
+                    var newTargets = FList<Variable>.Cons(tail.Head, FList<Variable>.Cons(source, tail.Tail));
+                    oldToNewMap[source] = newTargets;
+                }
             }
-          }
+
+            AssignInParallelWUBSpecific(wub, oldToNewMap);
+            AssignInParallelWUBEQSpecific(wubeq, sourcesToTargets, oldToNewMap);
         }
-      }
 
-      // Precision improvements:
-      //
-      // Consider:
-      //   if (x < y) x = y;
-      //   Debug.Assert(x >= y);
-      //
-      // This is an example where at the end of the then branch, we have a single old variable being assigned to new new variables:
-      //   x := y'  and y := y'
-      // Since in this branch, we obviously have y' => y', the new renamed state should have y => x and x => y. That way, at the join,
-      // the constraint x >= y is retained.
-      // 
-      foreach (var pair in sourcesToTargets)
-      {
-        var targets = pair.Value;
-        Contract.Assume(targets != null);
-
-        var newCanonical = targets.Head;
-        targets = targets.Tail;
-
-        while (targets != null)
+        private void AssignInParallelWUBSpecific(WeakUpperBounds<Variable, Expression> wub, Dictionary<Variable, FList<Variable>> oldToNewMap)
         {
-          // make all other targets equal to canonical (rather than n^2 combinations)
-          AddUpperBound(newCanonical, targets.Head, newMappings);
-          AddUpperBound(targets.Head, newCanonical, newMappings);
-          targets = targets.Tail;
-        }
-      }
-      
-      var result = new List<Pair<Variable, SetOfConstraints<Variable>>>();
+            Contract.Requires(wub != null);
+            Contract.Requires(oldToNewMap != null);
 
-      // now add the new mappings
-      foreach (var pair in newMappings)
-      {
-        var bounds = pair.Value;
-        Contract.Assume(bounds != null);
-        if (bounds.Count == 0)
-        {
-          continue;
-        }
+            var newMappings = new Dictionary<Variable, List<Variable>>(wub.Count);
 
-        var newBoundsFromClosure = new Set<Variable>(bounds);
-
-        foreach (var upp in bounds)
-        {
-          List<Variable> values;
-          if (!upp.Equals(pair.Key) && newMappings.TryGetValue(upp, out values))
-          {
-            Contract.Assume(values != null);
-            newBoundsFromClosure.AddRange(values);
-          }
-        }
-
-        result.Add(pair.Key, new SetOfConstraints<Variable>(newBoundsFromClosure, false));
-      }
-
-      wubeq.SetElements(result);
-    }
-
-
-    static internal void AddUpperBound(Variable key, Variable upperBound,
-      Dictionary<Variable, List<Variable>> map)
-    {
-      Contract.Requires(map != null);
-
-      List<Variable> bounds;
-      if (!map.TryGetValue(key, out bounds))
-      {
-        bounds = new List<Variable>();
-        map.Add(key, bounds);
-      }
-      Contract.Assume(bounds != null); // If we have it in the dictionary, then it is != null
-
-      bounds.Add(upperBound);
-    }
-
-    #endregion
-
-    #region Abstract domain operations 
-
-    public override IAbstractDomain Join(IAbstractDomain a)
-    {
-      if (this.IsBottom)
-        return a;
-      if (a.IsBottom)
-        return this;
-      if (this.IsTop)
-        return this;
-      if (a.IsTop)
-        return a;
-
-      var r = a as PentagonsPlus<Variable, Expression>;
-
-      Contract.Assume(r != null, "Error cannot compare a cartesian abstract element with a " + a.GetType());
-
-      // These two lines have a weak notion of closure, which essentially avoids dropping "x <= y" if it is implied by the intervals abstract domain            
-      // It seems that it is as precise as the expensive join
-
-      var joinLeftPart = this.Left.Join(r.Left, this.Right.Left, r.Right.Left);
-      Contract.Assert(joinLeftPart != null);
-      var joinRightPart = this.Right.Join(r.Right) as Pentagons<Variable, Expression>;
-      Contract.Assume(joinRightPart != null);
-
-      return new PentagonsPlus<Variable, Expression>(joinLeftPart, joinRightPart, this.ExpressionManager);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      var left = this.Left.CheckIfGreaterEqualThanZero(exp);
-      if(!left.IsTop)
-      {
-        return left;
-      }
-
-      return this.Right.CheckIfGreaterEqualThanZero(exp);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      var left = Left.CheckIfLessThan(e1, e2, Right);
-
-      if (!left.IsTop)
-      {
-        return left;
-      }
-
-      return Right.CheckIfLessThan(e1, e2);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      var left = Left.CheckIfLessThan_Un(e1, e2);
-
-      if (!left.IsTop)
-      {
-        return left;
-      } 
-
-      return Right.CheckIfLessThan_Un(e1, e2);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      var left = Left.CheckIfLessEqualThan(e1, e2);
-
-      if (!left.IsTop)
-      {
-        return left;
-      }
-
-      return Right.CheckIfLessEqualThan(e1, e2);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      var left =Left.CheckIfLessEqualThan_Un(e1, e2);
-      if (!left.IsTop)
-      {
-        return left;
-      } 
-      
-      return Right.CheckIfLessEqualThan_Un(e1, e2);
-    }
-
-    public override IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      Expression e1, e2;
-
-      var newLeft = this.Left;
-      var newRight = this.Right;
-
-      if (this.IsLessThanPositive(guard, out e1, out e2))
-      {
-        // We have e1 < e2. If we already know that e1 >= e2. then we have a contraddiction
-        if (this.CheckIfLessEqualThan(e2, e1).IsTrue())
-        {
-          var bott = this.Bottom as PentagonsPlus<Variable, Expression>;
-          Contract.Assume(bott != null);
-
-          return bott;
-        }
-
-        var decoder = this.ExpressionManager.Decoder; 
-        var e1Var = decoder.UnderlyingVariable(e1);
-        var e2Var = decoder.UnderlyingVariable(e2);
-
-        SetOfConstraints<Variable> upperBounds;
-        if (this.Left.TryGetValue(e2Var, out upperBounds))
-        { // if guard == "e1 < e2" and we know that "e2 <= e3", then we also have "e1 < e3"
-          if (upperBounds.IsNormal())
-          {
-            foreach (var e3 in upperBounds.Values)
+            foreach (var oldLeft_pair in wub.Elements)
             {
-              newRight = newRight.TestTrueLessThan(e1Var, e3);
+                if (!oldToNewMap.ContainsKey(oldLeft_pair.Key))
+                {
+                    continue;
+                }
+
+                var target = oldToNewMap[oldLeft_pair.Key];
+                Contract.Assume(target != null);
+
+                var newLeft = target.Head; // our canonical element
+
+                var oldBounds = oldLeft_pair.Value;
+                if (!oldBounds.IsNormal())
+                {
+                    continue;
+                }
+
+                foreach (var oldRight in oldBounds.Values)
+                {
+                    FList<Variable> olds;
+
+                    if (oldToNewMap.TryGetValue(oldRight, out olds))
+                    {
+                        Contract.Assume(olds != null);
+                        // This case is so so common that we want to specialize it
+                        if (olds.Length() == 1)
+                        {
+                            var newRight = olds.Head; // our canonical element
+                            AddUpperBound(newLeft, newRight, newMappings);
+                        }
+                        else
+                        {
+                            foreach (var newRight in olds.GetEnumerable())
+                            {
+                                AddUpperBound(newLeft, newRight, newMappings);
+                            }
+                        }
+                    }
+                }
+
+                // There are some more elements
+                for (var list = oldToNewMap[oldLeft_pair.Key].Tail; list != null; list = list.Tail)
+                {
+                    List<Variable> targets;
+                    if (newMappings.TryGetValue(newLeft, out targets))
+                    {
+                        Contract.Assume(targets != null);
+                        foreach (var con in targets)
+                        {
+                            AddUpperBound(list.Head, con, newMappings);
+                        }
+                    }
+                }
             }
-          }
+
+            // Update
+            var newConstraints = new Dictionary<Variable, SetOfConstraints<Variable>>(wub.Count);
+
+            foreach (var pair in newMappings)
+            {
+                Contract.Assume(pair.Value != null);
+                newConstraints.Add(pair.Key, new SetOfConstraints<Variable>(pair.Value));
+            }
+
+            wub.SetElements(newConstraints);
         }
-      }
-      else if (this.TryMatchNotEqualTo(guard, out e1, out e2))
-      {
-        newRight = HelperForTestTrueNotEqual(e1, e2, newRight);
-      }
 
-      newLeft = newLeft.TestTrue(guard);
-      newRight = newRight.TestTrue(guard);
-      
-      return new PentagonsPlus<Variable, Expression>(newLeft, newRight, this.ExpressionManager);
-    }
+        private void AssignInParallelWUBEQSpecific(
+          WeakUpperBoundsEqual<Variable, Expression> wubeq, Dictionary<Variable, FList<Variable>> sourcesToTargets,
+          Dictionary<Variable, FList<Variable>> oldToNewMap)
+        {
+            Contract.Requires(wubeq != null);
+            Contract.Requires(sourcesToTargets != null);
+            Contract.Requires(oldToNewMap != null);
 
-    public override IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      Expression e1, e2;
+            var newMappings = new Dictionary<Variable, List<Variable>>(wubeq.Count);
 
-      var newLeft = this.Left;
-      var newRight = this.Right;
+            foreach (var oldLeft_Pair in wubeq.Elements)
+            {
+                FList<Variable> targets;
+                if (oldToNewMap.TryGetValue(oldLeft_Pair.Key, out targets))
+                {
+                    Contract.Assume(targets != null);
 
-      if (this.TryMatchEqualTo(guard, out e1, out e2))
-      { // if "e1 != e2", then we can restrain "e1 <= e2" (resp "e2 <= e1") to "e1 < e2" (resp "e2 < e1")
-        newRight = HelperForTestTrueNotEqual(e1, e2, newRight);
-      }
+                    var oldBounds = oldLeft_Pair.Value;
+                    if (!oldBounds.IsNormal())
+                    {
+                        continue;
+                    }
 
-      newLeft = newLeft.TestFalse(guard);
-      newRight = newRight.TestFalse(guard);
+                    var newLeft = targets.Head; // our canonical element
 
-      return new PentagonsPlus<Variable, Expression>(newLeft, newRight, this.ExpressionManager);
-    }
+                    foreach (var oldRight in oldBounds.Values)
+                    {
+                        FList<Variable> olds;
+                        if (oldToNewMap.TryGetValue(oldRight, out olds))
+                        {
+                            Contract.Assume(olds != null);
 
-    public override INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      var withPentagons = this as PentagonsPlus<Variable, Expression>;
-      var newLeft = this.Left;
+                            var newRight = olds.Head; // our canonical element
+                            AddUpperBound(newLeft, newRight, newMappings);
+                        }
+                    }
+                }
+            }
 
-      var newRight = withPentagons.Right.TestTrueLessThan(exp1, exp2, this.Left);
-      newLeft = newLeft.TestTrueLessThan(exp1, exp2);
+            // Precision improvements:
+            //
+            // Consider:
+            //   if (x < y) x = y;
+            //   Debug.Assert(x >= y);
+            //
+            // This is an example where at the end of the then branch, we have a single old variable being assigned to new new variables:
+            //   x := y'  and y := y'
+            // Since in this branch, we obviously have y' => y', the new renamed state should have y => x and x => y. That way, at the join,
+            // the constraint x >= y is retained.
+            // 
+            foreach (var pair in sourcesToTargets)
+            {
+                var targets = pair.Value;
+                Contract.Assume(targets != null);
 
-      Contract.Assert(withPentagons.ExpressionManager.Encoder != null);
-      return new PentagonsPlus<Variable, Expression>(newLeft, newRight, withPentagons.ExpressionManager);
-    }
+                var newCanonical = targets.Head;
+                targets = targets.Tail;
 
-    [Pure]
-    public override ReducedCartesianAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>>
-      Reduce(WeakUpperBoundsEqual<Variable, Expression> left, Pentagons<Variable, Expression> right)
-    {
-      return this.Factory(left, right);
-    }
+                while (targets != null)
+                {
+                    // make all other targets equal to canonical (rather than n^2 combinations)
+                    AddUpperBound(newCanonical, targets.Head, newMappings);
+                    AddUpperBound(targets.Head, newCanonical, newMappings);
+                    targets = targets.Tail;
+                }
+            }
 
-    [Pure]
-    protected override ReducedCartesianAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>>
-      Factory(WeakUpperBoundsEqual<Variable, Expression> left, Pentagons<Variable, Expression> right)
-    {
-      Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>>>() != null);
+            var result = new List<Pair<Variable, SetOfConstraints<Variable>>>();
 
-      return new PentagonsPlus<Variable, Expression>(left, right, this.ExpressionManager);
-    }
+            // now add the new mappings
+            foreach (var pair in newMappings)
+            {
+                var bounds = pair.Value;
+                Contract.Assume(bounds != null);
+                if (bounds.Count == 0)
+                {
+                    continue;
+                }
 
-    #endregion
+                var newBoundsFromClosure = new Set<Variable>(bounds);
 
-    #region Private methods
+                foreach (var upp in bounds)
+                {
+                    List<Variable> values;
+                    if (!upp.Equals(pair.Key) && newMappings.TryGetValue(upp, out values))
+                    {
+                        Contract.Assume(values != null);
+                        newBoundsFromClosure.AddRange(values);
+                    }
+                }
 
-    private Pentagons<Variable, Expression> HelperForTestTrueNotEqual(Expression e1, Expression e2, Pentagons<Variable, Expression> newRight)
-    {
-      Contract.Requires(newRight != null);
-      Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+                result.Add(pair.Key, new SetOfConstraints<Variable>(newBoundsFromClosure, false));
+            }
 
-      var decoder = this.ExpressionManager.Decoder;
-
-      // Get rid of the conversion operators
-      e1 = decoder.Stripped(e1);
-      e2 = decoder.Stripped(e2);
-
-      var e1Var = decoder.UnderlyingVariable(e1);
-      var e2Var = decoder.UnderlyingVariable(e2);
-
-      SetOfConstraints<Variable> upperBounds;
-      if (this.Left.TryGetValue(e1Var, out upperBounds))
-      {
-        if (upperBounds.IsNormal() && upperBounds.Contains(e2Var))
-        { // if "e1 <= e2" then "e2 < e1"
-          newRight = newRight.TestTrueLessThan(e1, e2);
+            wubeq.SetElements(result);
         }
-      }
 
-      if (this.Left.TryGetValue(e2Var, out upperBounds))
-      {
-        if (upperBounds.IsNormal() && upperBounds.Contains(e1Var))
-        { // if "e2 <= e1" then "e2 < e1"
-          newRight = newRight.TestTrueLessThan(e2, e1);
+
+        static internal void AddUpperBound(Variable key, Variable upperBound,
+          Dictionary<Variable, List<Variable>> map)
+        {
+            Contract.Requires(map != null);
+
+            List<Variable> bounds;
+            if (!map.TryGetValue(key, out bounds))
+            {
+                bounds = new List<Variable>();
+                map.Add(key, bounds);
+            }
+            Contract.Assume(bounds != null); // If we have it in the dictionary, then it is != null
+
+            bounds.Add(upperBound);
         }
-      }
 
-      return newRight;
-    }
+        #endregion
 
-    private bool IsLessThanPositive(Expression guard, out Expression e1, out Expression e2)
-    {
-      ExpressionOperator op;
-      e1 = default(Expression);
-      e2 = default(Expression);
+        #region Abstract domain operations 
 
-      var decoder = this.ExpressionManager.Decoder;
+        public override IAbstractDomain Join(IAbstractDomain a)
+        {
+            if (this.IsBottom)
+                return a;
+            if (a.IsBottom)
+                return this;
+            if (this.IsTop)
+                return this;
+            if (a.IsTop)
+                return a;
 
-      switch (decoder.OperatorFor(guard))
-      {
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          if (decoder.Match_E1relopE2eq0(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard), out op, out e1, out e2))
-          { // here guard is "(e1 op e2) == 0"
-            return this.IsLessThanNegative(decoder.LeftExpressionFor(guard), out e1, out e2);
-          }
-          else
-          {
-            return false;
-          }
+            var r = a as PentagonsPlus<Variable, Expression>;
 
-        case ExpressionOperator.GreaterThan:
-          {
-            e1 = decoder.RightExpressionFor(guard);
-            e2 = decoder.LeftExpressionFor(guard);
+            Contract.Assume(r != null, "Error cannot compare a cartesian abstract element with a " + a.GetType());
 
-            return true;
-          }
-        case ExpressionOperator.LessThan:
-          {
-            e1 = decoder.LeftExpressionFor(guard);
-            e2 = decoder.RightExpressionFor(guard);
-            return true;
-          }
+            // These two lines have a weak notion of closure, which essentially avoids dropping "x <= y" if it is implied by the intervals abstract domain            
+            // It seems that it is as precise as the expensive join
 
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.LessThan_Un:
-        default:
-          {
-            return false;
-          }
-      }
-    }
+            var joinLeftPart = this.Left.Join(r.Left, this.Right.Left, r.Right.Left);
+            Contract.Assert(joinLeftPart != null);
+            var joinRightPart = this.Right.Join(r.Right) as Pentagons<Variable, Expression>;
+            Contract.Assume(joinRightPart != null);
 
-    private bool IsLessThanNegative(Expression guard, out Expression e1, out Expression e2)
-    {
-      ExpressionOperator op;
-      e1 = default(Expression);
-      e2 = default(Expression);
+            return new PentagonsPlus<Variable, Expression>(joinLeftPart, joinRightPart, this.ExpressionManager);
+        }
 
-      var decoder = this.ExpressionManager.Decoder;
+        public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            var left = this.Left.CheckIfGreaterEqualThanZero(exp);
+            if (!left.IsTop)
+            {
+                return left;
+            }
 
-      switch (decoder.OperatorFor(guard))
-      {
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          if (decoder.Match_E1relopE2eq0(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard), out op, out e1, out e2))
-          { // the guard is "(e1 op e2) == 0"
-            return this.IsLessThanPositive(decoder.LeftExpressionFor(guard), out e1, out e2);
-          }
-          else
-          {
-            return false;
-          }
+            return this.Right.CheckIfGreaterEqualThanZero(exp);
+        }
 
-        case ExpressionOperator.GreaterEqualThan:
-          {          // !(a >= b) == (a < b)
-            e1 = decoder.LeftExpressionFor(guard);
-            e2 = decoder.RightExpressionFor(guard);
+        public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            var left = Left.CheckIfLessThan(e1, e2, Right);
 
-            return true;
-          }
+            if (!left.IsTop)
+            {
+                return left;
+            }
 
-        case ExpressionOperator.LessEqualThan:
-          {
-            // !(a <= b) == (a > b) == (b < a)
-            e1 = decoder.RightExpressionFor(guard);
-            e2 = decoder.LeftExpressionFor(guard);
-            
-            return true;
-          }
+            return Right.CheckIfLessThan(e1, e2);
+        }
 
-        default:
-          {
-            return false;
-          }
-      }
-    }
+        public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            var left = Left.CheckIfLessThan_Un(e1, e2);
 
-    private bool TryMatchEqualTo(Expression guard, out Expression e1, out Expression e2)
-    {
-      var decoder = this.ExpressionManager.Decoder;
+            if (!left.IsTop)
+            {
+                return left;
+            }
 
-      switch (decoder.OperatorFor(guard))
-      {
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          {
-            e1 = decoder.Stripped(this.ExpressionManager.Decoder.LeftExpressionFor(guard));
-            e2 = decoder.Stripped(this.ExpressionManager.Decoder.RightExpressionFor(guard));
-            return true;
-          }
+            return Right.CheckIfLessThan_Un(e1, e2);
+        }
 
-        default:
-          {
-            e1 = e2 = default(Expression);
-            return false;
-          }
-      }
-    }
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            var left = Left.CheckIfLessEqualThan(e1, e2);
 
-    private bool TryMatchNotEqualTo(Expression guard, out Expression e1, out Expression e2)
-    {
-      var decoder = this.ExpressionManager.Decoder;
+            if (!left.IsTop)
+            {
+                return left;
+            }
 
-      var op_guard = decoder.OperatorFor(guard);
-      switch (op_guard)
-      {
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          {
+            return Right.CheckIfLessEqualThan(e1, e2);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            var left = Left.CheckIfLessEqualThan_Un(e1, e2);
+            if (!left.IsTop)
+            {
+                return left;
+            }
+
+            return Right.CheckIfLessEqualThan_Un(e1, e2);
+        }
+
+        public override IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            Expression e1, e2;
+
+            var newLeft = this.Left;
+            var newRight = this.Right;
+
+            if (this.IsLessThanPositive(guard, out e1, out e2))
+            {
+                // We have e1 < e2. If we already know that e1 >= e2. then we have a contraddiction
+                if (this.CheckIfLessEqualThan(e2, e1).IsTrue())
+                {
+                    var bott = this.Bottom as PentagonsPlus<Variable, Expression>;
+                    Contract.Assume(bott != null);
+
+                    return bott;
+                }
+
+                var decoder = this.ExpressionManager.Decoder;
+                var e1Var = decoder.UnderlyingVariable(e1);
+                var e2Var = decoder.UnderlyingVariable(e2);
+
+                SetOfConstraints<Variable> upperBounds;
+                if (this.Left.TryGetValue(e2Var, out upperBounds))
+                { // if guard == "e1 < e2" and we know that "e2 <= e3", then we also have "e1 < e3"
+                    if (upperBounds.IsNormal())
+                    {
+                        foreach (var e3 in upperBounds.Values)
+                        {
+                            newRight = newRight.TestTrueLessThan(e1Var, e3);
+                        }
+                    }
+                }
+            }
+            else if (this.TryMatchNotEqualTo(guard, out e1, out e2))
+            {
+                newRight = HelperForTestTrueNotEqual(e1, e2, newRight);
+            }
+
+            newLeft = newLeft.TestTrue(guard);
+            newRight = newRight.TestTrue(guard);
+
+            return new PentagonsPlus<Variable, Expression>(newLeft, newRight, this.ExpressionManager);
+        }
+
+        public override IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            Expression e1, e2;
+
+            var newLeft = this.Left;
+            var newRight = this.Right;
+
+            if (this.TryMatchEqualTo(guard, out e1, out e2))
+            { // if "e1 != e2", then we can restrain "e1 <= e2" (resp "e2 <= e1") to "e1 < e2" (resp "e2 < e1")
+                newRight = HelperForTestTrueNotEqual(e1, e2, newRight);
+            }
+
+            newLeft = newLeft.TestFalse(guard);
+            newRight = newRight.TestFalse(guard);
+
+            return new PentagonsPlus<Variable, Expression>(newLeft, newRight, this.ExpressionManager);
+        }
+
+        public override INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            var withPentagons = this as PentagonsPlus<Variable, Expression>;
+            var newLeft = this.Left;
+
+            var newRight = withPentagons.Right.TestTrueLessThan(exp1, exp2, this.Left);
+            newLeft = newLeft.TestTrueLessThan(exp1, exp2);
+
+            Contract.Assert(withPentagons.ExpressionManager.Encoder != null);
+            return new PentagonsPlus<Variable, Expression>(newLeft, newRight, withPentagons.ExpressionManager);
+        }
+
+        [Pure]
+        public override ReducedCartesianAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>>
+          Reduce(WeakUpperBoundsEqual<Variable, Expression> left, Pentagons<Variable, Expression> right)
+        {
+            return this.Factory(left, right);
+        }
+
+        [Pure]
+        protected override ReducedCartesianAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>>
+          Factory(WeakUpperBoundsEqual<Variable, Expression> left, Pentagons<Variable, Expression> right)
+        {
+            Contract.Ensures(Contract.Result<ReducedCartesianAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Pentagons<Variable, Expression>>>() != null);
+
+            return new PentagonsPlus<Variable, Expression>(left, right, this.ExpressionManager);
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private Pentagons<Variable, Expression> HelperForTestTrueNotEqual(Expression e1, Expression e2, Pentagons<Variable, Expression> newRight)
+        {
+            Contract.Requires(newRight != null);
+            Contract.Ensures(Contract.Result<Pentagons<Variable, Expression>>() != null);
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            // Get rid of the conversion operators
+            e1 = decoder.Stripped(e1);
+            e2 = decoder.Stripped(e2);
+
+            var e1Var = decoder.UnderlyingVariable(e1);
+            var e2Var = decoder.UnderlyingVariable(e2);
+
+            SetOfConstraints<Variable> upperBounds;
+            if (this.Left.TryGetValue(e1Var, out upperBounds))
+            {
+                if (upperBounds.IsNormal() && upperBounds.Contains(e2Var))
+                { // if "e1 <= e2" then "e2 < e1"
+                    newRight = newRight.TestTrueLessThan(e1, e2);
+                }
+            }
+
+            if (this.Left.TryGetValue(e2Var, out upperBounds))
+            {
+                if (upperBounds.IsNormal() && upperBounds.Contains(e1Var))
+                { // if "e2 <= e1" then "e2 < e1"
+                    newRight = newRight.TestTrueLessThan(e2, e1);
+                }
+            }
+
+            return newRight;
+        }
+
+        private bool IsLessThanPositive(Expression guard, out Expression e1, out Expression e2)
+        {
             ExpressionOperator op;
-            if (decoder.Match_E1relopE2eq0(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard), out op, out e1, out e2))
+            e1 = default(Expression);
+            e2 = default(Expression);
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            switch (decoder.OperatorFor(guard))
             {
-              if (op == op_guard)
-              {
-                return true;
-              }
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    if (decoder.Match_E1relopE2eq0(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard), out op, out e1, out e2))
+                    { // here guard is "(e1 op e2) == 0"
+                        return this.IsLessThanNegative(decoder.LeftExpressionFor(guard), out e1, out e2);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+
+                case ExpressionOperator.GreaterThan:
+                    {
+                        e1 = decoder.RightExpressionFor(guard);
+                        e2 = decoder.LeftExpressionFor(guard);
+
+                        return true;
+                    }
+                case ExpressionOperator.LessThan:
+                    {
+                        e1 = decoder.LeftExpressionFor(guard);
+                        e2 = decoder.RightExpressionFor(guard);
+                        return true;
+                    }
+
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.LessThan_Un:
+                default:
+                    {
+                        return false;
+                    }
             }
-            goto default;
-          }
+        }
 
-        case ExpressionOperator.NotEqual:
-          {
-            e1 = decoder.LeftExpressionFor(guard);
-            e2 = decoder.RightExpressionFor(guard);
- 
-            return true;
-          }
+        private bool IsLessThanNegative(Expression guard, out Expression e1, out Expression e2)
+        {
+            ExpressionOperator op;
+            e1 = default(Expression);
+            e2 = default(Expression);
 
-        default:
-          {
-            e1 = e2 = default(Expression);
-            return false;
-          }
-      }
+            var decoder = this.ExpressionManager.Decoder;
+
+            switch (decoder.OperatorFor(guard))
+            {
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    if (decoder.Match_E1relopE2eq0(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard), out op, out e1, out e2))
+                    { // the guard is "(e1 op e2) == 0"
+                        return this.IsLessThanPositive(decoder.LeftExpressionFor(guard), out e1, out e2);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+
+                case ExpressionOperator.GreaterEqualThan:
+                    {          // !(a >= b) == (a < b)
+                        e1 = decoder.LeftExpressionFor(guard);
+                        e2 = decoder.RightExpressionFor(guard);
+
+                        return true;
+                    }
+
+                case ExpressionOperator.LessEqualThan:
+                    {
+                        // !(a <= b) == (a > b) == (b < a)
+                        e1 = decoder.RightExpressionFor(guard);
+                        e2 = decoder.LeftExpressionFor(guard);
+
+                        return true;
+                    }
+
+                default:
+                    {
+                        return false;
+                    }
+            }
+        }
+
+        private bool TryMatchEqualTo(Expression guard, out Expression e1, out Expression e2)
+        {
+            var decoder = this.ExpressionManager.Decoder;
+
+            switch (decoder.OperatorFor(guard))
+            {
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    {
+                        e1 = decoder.Stripped(this.ExpressionManager.Decoder.LeftExpressionFor(guard));
+                        e2 = decoder.Stripped(this.ExpressionManager.Decoder.RightExpressionFor(guard));
+                        return true;
+                    }
+
+                default:
+                    {
+                        e1 = e2 = default(Expression);
+                        return false;
+                    }
+            }
+        }
+
+        private bool TryMatchNotEqualTo(Expression guard, out Expression e1, out Expression e2)
+        {
+            var decoder = this.ExpressionManager.Decoder;
+
+            var op_guard = decoder.OperatorFor(guard);
+            switch (op_guard)
+            {
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    {
+                        ExpressionOperator op;
+                        if (decoder.Match_E1relopE2eq0(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard), out op, out e1, out e2))
+                        {
+                            if (op == op_guard)
+                            {
+                                return true;
+                            }
+                        }
+                        goto default;
+                    }
+
+                case ExpressionOperator.NotEqual:
+                    {
+                        e1 = decoder.LeftExpressionFor(guard);
+                        e2 = decoder.RightExpressionFor(guard);
+
+                        return true;
+                    }
+
+                default:
+                    {
+                        e1 = e2 = default(Expression);
+                        return false;
+                    }
+            }
+        }
+
+        #endregion
     }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/WeakUpperBounds.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/WeakUpperBounds.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -25,2304 +14,2301 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// The abstract domain to keep track of relations in the form of "x &lt; y".
-  /// It does not (always) close, so it is less precise than octagons
-  /// </summary>
-  [ContractVerification(true)]
-  public class WeakUpperBounds<Variable, Expression> :
-      FunctionalAbstractDomain<WeakUpperBounds<Variable, Expression>, Variable, SetOfConstraints<Variable>>,
-        INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    /// <summary>
+    /// The abstract domain to keep track of relations in the form of "x &lt; y".
+    /// It does not (always) close, so it is less precise than octagons
+    /// </summary>
+    [ContractVerification(true)]
+    public class WeakUpperBounds<Variable, Expression> :
+        FunctionalAbstractDomain<WeakUpperBounds<Variable, Expression>, Variable, SetOfConstraints<Variable>>,
+          INumericalAbstractDomain<Variable, Expression>
     {
-      Contract.Invariant(this.expManager != null);
-      Contract.Invariant(constraintsForAssignment != null);
-    }
+        #region Invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.expManager != null);
+            Contract.Invariant(constraintsForAssignment != null);
+        }
 
-    #endregion
+        #endregion
 
-    #region Private state
+        #region Private state
 
-    readonly protected ExpressionManagerWithEncoder<Variable, Expression> expManager;
-    readonly private List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>> constraintsForAssignment;
-    
-    #endregion
-   
-    #region Constructor
+        readonly protected ExpressionManagerWithEncoder<Variable, Expression> expManager;
+        readonly private List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>> constraintsForAssignment;
 
-    public WeakUpperBounds(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
+        #endregion
 
-      this.expManager = expManager;
-      
-      this.constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>() 
-      { 
-        new LessThanConstraints<Variable, Expression>(expManager) 
+        #region Constructor
+
+        public WeakUpperBounds(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
+
+            this.expManager = expManager;
+
+            constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>()
+      {
+        new LessThanConstraints<Variable, Expression>(expManager)
       };
-    }
-
-    private WeakUpperBounds(WeakUpperBounds<Variable, Expression> other)
-      : base(other)
-    {
-      Contract.Requires(other != null);
-
-      Contract.Assume(other.constraintsForAssignment != null);
-      Contract.Assume(other.expManager != null);
-
-      this.expManager = other.expManager;
-      this.constraintsForAssignment = other.constraintsForAssignment;
-    }
-
-    #endregion
-
-    #region Cloning
-
-    override public object Clone()
-    {
-      return this.DuplicateMe();
-    }
-
-    private WeakUpperBounds<Variable, Expression> DuplicateMe()
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);      
-      
-      return new WeakUpperBounds<Variable, Expression>(this);
-    }
-
-    /// <summary>
-    /// Do the assignment, improving the precision using the oracle domain, which gives informations on the pre-state
-    /// </summary>
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain)
-    {
-     var LTConstraints = new List<Expression>();
-
-      // Discover new constraints
-      foreach (var constraintsFetcher in this.constraintsForAssignment)
-      {
-        Contract.Assume(constraintsFetcher != null);
-
-        var constrs = constraintsFetcher.InferConstraints(x, exp, oracleDomain);
-        LTConstraints.AddRange(constrs);
-      }
-
-      // Assume them
-      foreach (var newConstraint in LTConstraints)
-      {
-        this.TestTrue(newConstraint);
-      }
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      Contract.Assume(x != null);
-      Contract.Assume(exp != null);
-
-      this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    /// <summary>
-    /// As we keep no information on bounds, the only thing to do is to return the top interval
-    /// </summary>
-    public DisInterval BoundsFor(Expression v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);      
-
-      return CheckIfHolds(exp, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp, INumericalAbstractDomain<Variable, Expression> oracleDomain)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      Contract.Assume(exp != null);
-
-      return new WUBCheckIfHoldsVisitor(this.expManager.Decoder).Visit(exp, this);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      Polynomial<Variable, Expression> pol;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.expManager.Decoder, out pol))
-      {
-        Variable x, y;
-        Rational k;
-
-        if (pol.TryMatch_XMinusYPlusK(out x, out y, out k))
-        {
-          var lt = this.CheckIfLessThan(y, x);
-
-          if (lt.IsNormal() && lt.BoxedElement && k >= -1)
-          { // if we have to check x - y + k >= 0, and we know that k >= -1 and x - y > 0, then this is true
-            return lt;    
-          }
-        }
-      }
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-      
-      // TODO
-      return CheckOutcome.Top;
-    }
-
-    /// <summary>
-    /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      SetOfConstraints<Variable> bounds;
-      if (this.TryGetValue(e1, out bounds))
-      {
-        if (bounds.IsBottom)
-        {
-          return CheckOutcome.True;
-        }
-        else if (bounds.Contains(e2))
-        {
-          return CheckOutcome.True;
         }
 
-        if (bounds.IsNormal())
+        private WeakUpperBounds(WeakUpperBounds<Variable, Expression> other)
+          : base(other)
         {
-          foreach (var other in bounds.Values)
-          {
-            SetOfConstraints<Variable> otherBounds;
-            if (this.TryGetValue(other, out otherBounds))
-            {             
-              if (otherBounds.IsNormal() && otherBounds.Contains(e2))
-              { // e1 < other , other < e2 => e1 < e2
-                return CheckOutcome.True;
-              }
-            }
-          }
+            Contract.Requires(other != null);
+
+            Contract.Assume(other.constraintsForAssignment != null);
+            Contract.Assume(other.expManager != null);
+
+            this.expManager = other.expManager;
+            constraintsForAssignment = other.constraintsForAssignment;
         }
-      }
-      else if (this.TryGetValue(e2, out bounds))
-      {
-        if (bounds.IsBottom)
+
+        #endregion
+
+        #region Cloning
+
+        override public object Clone()
         {
-          return CheckOutcome.True;
+            return this.DuplicateMe();
         }
-        else if (bounds.Contains(e1))
+
+        private WeakUpperBounds<Variable, Expression> DuplicateMe()
         {
-          return CheckOutcome.False;
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            return new WeakUpperBounds<Variable, Expression>(this);
         }
-      }
 
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      if (e1 == null || e2 == null)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var decoder = this.expManager.Decoder;
-
-      e1 = decoder.Stripped(e1);
-      e2 = decoder.Stripped(e2);
-
-      var e1Var = decoder.UnderlyingVariable(e1);
-      var e2Var = decoder.UnderlyingVariable(e2);
-
-      var result = this.CheckIfLessThan(e1Var, e2Var);
-
-      if (result.IsNormal())
-      {
-        return result;
-      }
-
-      Polynomial<Variable, Expression> e1LTe2;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1, e2, decoder, out e1LTe2))
-      {
-        Contract.Assume(e1LTe2.Relation == ExpressionOperator.LessThan, "Exprecting a LT");
-
-        if (e1LTe2.Left.Length == 2 && e1LTe2.IsOctagonForm)
+        /// <summary>
+        /// Do the assignment, improving the precision using the oracle domain, which gives informations on the pre-state
+        /// </summary>
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain)
         {
-          Contract.Assume(e1LTe2.Degree == 1); // We know it has 2 variables, and unary coefficients, hence the polynomial degree is 1
+            var LTConstraints = new List<Expression>();
 
-          Contract.Assert(e1LTe2.Right != null); // Adding the assertion as the backward visit does not go far enough
-
-          Contract.Assume(e1LTe2.Right.Length > 0);
-
-          var monomial0 = e1LTe2.Left[0];
-          var monomial1 = e1LTe2.Left[1];
-
-          Contract.Assume(monomial0.Degree == 1);
-          Contract.Assume(monomial1.Degree == 1);
-
-          var k1 = monomial0.K;
-          var x1 = monomial0.VariableAt(0);
-
-          var k2 = monomial1.K;
-          var x2 = monomial1.VariableAt(0);
-
-          var k = e1LTe2.Right[0].K;
-
-          bool isImplied = false;
-
-          if (k >= 0)
-          {
-            if (k1 == 1 && k2 == -1)  // x1 - x2 < 1, that is x1 < x2 + 1 
+            // Discover new constraints
+            foreach (var constraintsFetcher in constraintsForAssignment)
             {
-              isImplied = Check(x1, x2);
-            }
-            else if (k1 == -1 && k2 == 1) // -x1 + x2 < 1, that is x2 < x1 + 1
-            {
-              isImplied = Check(x2, x1);
-            }
-          }
+                Contract.Assume(constraintsFetcher != null);
 
-          if (isImplied)
-          {
-            return CheckOutcome.True;
-          }
+                var constrs = constraintsFetcher.InferConstraints(x, exp, oracleDomain);
+                LTConstraints.AddRange(constrs);
+            }
+
+            // Assume them
+            foreach (var newConstraint in LTConstraints)
+            {
+                this.TestTrue(newConstraint);
+            }
         }
-        else
+
+        public void Assign(Expression x, Expression exp)
         {
-          Polynomial<Variable, Expression> e1AsPolynomial;
-          // Try to see if e1 == "a1 x1 + a2 x2 + ... " is such that each xi < e2, and 0<= sum ai <= 1 and \forall i. ai > 0
-          if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, decoder, out e1AsPolynomial) && e1AsPolynomial.Degree == 1)
-          {
-            var sum = Rational.For(0);
+            Contract.Assume(x != null);
+            Contract.Assume(exp != null);
 
-            // Checks two things: 
-            //  1. All the x are < e2
-            //  2. \forall ai. ai >= 0 && 0<= a1 + a2 + ... + an <= 1
-            foreach (var m in e1AsPolynomial.Left)
+            this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
+
+        /// <summary>
+        /// As we keep no information on bounds, the only thing to do is to return the top interval
+        /// </summary>
+        public DisInterval BoundsFor(Expression v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            return CheckIfHolds(exp, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp, INumericalAbstractDomain<Variable, Expression> oracleDomain)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            Contract.Assume(exp != null);
+
+            return new WUBCheckIfHoldsVisitor(this.expManager.Decoder).Visit(exp, this);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            Polynomial<Variable, Expression> pol;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.expManager.Decoder, out pol))
             {
-              if (!m.IsConstant)
-              {
-                var x = m.VariableAt(0);
+                Variable x, y;
+                Rational k;
 
-                // Checks that x < e2
-                SetOfConstraints<Variable> values;
-                if (!(this.TryGetValue(x, out values) && values.IsNormal() && values.Contains(e2Var)))
+                if (pol.TryMatch_XMinusYPlusK(out x, out y, out k))
                 {
-                  return CheckOutcome.Top;
-                }
-              }
+                    var lt = this.CheckIfLessThan(y, x);
 
-              if (m.K <= 0)
-              {
+                    if (lt.IsNormal() && lt.BoxedElement && k >= -1)
+                    { // if we have to check x - y + k >= 0, and we know that k >= -1 and x - y > 0, then this is true
+                        return lt;
+                    }
+                }
+            }
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            // TODO
+            return CheckOutcome.Top;
+        }
+
+        /// <summary>
+        /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable e1, Variable e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            SetOfConstraints<Variable> bounds;
+            if (this.TryGetValue(e1, out bounds))
+            {
+                if (bounds.IsBottom)
+                {
+                    return CheckOutcome.True;
+                }
+                else if (bounds.Contains(e2))
+                {
+                    return CheckOutcome.True;
+                }
+
+                if (bounds.IsNormal())
+                {
+                    foreach (var other in bounds.Values)
+                    {
+                        SetOfConstraints<Variable> otherBounds;
+                        if (this.TryGetValue(other, out otherBounds))
+                        {
+                            if (otherBounds.IsNormal() && otherBounds.Contains(e2))
+                            { // e1 < other , other < e2 => e1 < e2
+                                return CheckOutcome.True;
+                            }
+                        }
+                    }
+                }
+            }
+            else if (this.TryGetValue(e2, out bounds))
+            {
+                if (bounds.IsBottom)
+                {
+                    return CheckOutcome.True;
+                }
+                else if (bounds.Contains(e1))
+                {
+                    return CheckOutcome.False;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            if (e1 == null || e2 == null)
+            {
                 return CheckOutcome.Top;
-              }
-              else
-              {
-                try
-                {
-                  sum += m.K;
-                }
-                catch (ArithmeticExceptionRational)
-                {
-                  return CheckOutcome.Top;
-                }
-              }
             }
 
-            if (sum <= 1)
-            {
-              Contract.Assume(sum >= 0, "At this point the sum of the values must be positive");
-              return CheckOutcome.True;
-            }
-          }
-        }
-      }
- 
-      return CheckOutcome.Top;
-    }
+            var decoder = this.expManager.Decoder;
 
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
+            e1 = decoder.Stripped(e1);
+            e2 = decoder.Stripped(e2);
 
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);      
-
-      return this.CheckIfLessEqualThan(e1, e2);
-    }
-
-    /// <summary>
-    /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code> using, 
-    /// if needed the abstract domain <code>oracleDomain</code> to refine the information
-    /// </summary>
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2,
-      IIntervalAbstraction<Variable, Expression> oracleDomain)
-    {
-      Contract.Requires(oracleDomain != null);
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      if (e1 == null || e2 == null)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var decoder = this.expManager.Decoder;
-
-      e1 = decoder.Stripped(e1);
-      e2 = decoder.Stripped(e2);
-
-      var directTry = CheckIfLessThan(e1, e2);
-      if (!directTry.IsTop)
-      {
-        return directTry;
-      }
-
-      var result = CommonChecks.CheckLessThan(e1, e2, oracleDomain, decoder);
-
-      if (!result.IsTop)
-      {
-        return result;
-      }
-
-      switch (this.expManager.Decoder.OperatorFor(e1))
-      {
-        case ExpressionOperator.Modulus:
-          {
-            // It is " (e1Left % e1Right) < e2 "
-            var e1Left = decoder.LeftExpressionFor(e1);
-            var e1Right = decoder.RightExpressionFor(e1);
-            var e1RightStripped = decoder.Stripped(e1Right);
-
-            if (e2.Equals(e1RightStripped))
-            {
-              var valFore1Left = oracleDomain.BoundsFor(e1Left);
-
-              if (valFore1Left.LowerBound >= 0 || oracleDomain.BoundsFor(e2).LowerBound >= 0)
-              {
-                return CheckOutcome.True;
-              }
-            }
-          }
-          break;
-
-        case ExpressionOperator.ShiftRight:
-          {
-            // It is "(e1Left >> e2Left) < e2" 
-            var e1Left = decoder.LeftExpressionFor(e1);
-            var e1Right = decoder.RightExpressionFor(e1);
-
-            if (oracleDomain.BoundsFor(e1Left).LowerBound >= 0)
-            {
-              return this.CheckIfLessThan(e1Left, e2, oracleDomain);   // check if e1Left < e2
-            }
-          }
-          break;
-
-        case ExpressionOperator.Addition:
-          {
-            // it is (e1Left + e1right) < e2
-            var e1Left = decoder.LeftExpressionFor(e1);
-            var e1Right = decoder.RightExpressionFor(e1);
-
-            int k;
-            // Try the transitive closure of length 1 (see the check k == 1 !!!)
-            // this is useful to speed up checks in the array analysis
-            if (decoder.IsConstantInt(e1Right, out k) && k == 1)
-            {
-              // it is (e1Left + 1) < e2
-              foreach (var upp in this.UpperBoundsFor(e1Left, true))
-              {
-                if (this.UpperBoundsFor(upp, true).Contains(e2))
-                  return CheckOutcome.True;
-              }
-            }
-          }
-          break;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return new List<Pair<Variable, Int32>>();
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      return LowerBoundsFor(this.expManager.Decoder.UnderlyingVariable(v), strict);
-    }
-
-     public IEnumerable<Expression> LowerBoundsFor(Variable vVar, bool strict)
-     {
-       foreach (var exp_pair in this.Elements)
-       {
-         var valueSet = exp_pair.Value;
-         Contract.Assume(valueSet != null);
-      
-         if (!valueSet.IsTop && valueSet.Contains(vVar))
-         {
-           yield return this.expManager.Encoder.VariableFor(exp_pair.Key);
-         }
-       }
-     }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      return UpperBoundsFor(this.expManager.Decoder.UnderlyingVariable(v), strict);
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable vVar, bool strict)
-    {
-      SetOfConstraints<Variable> bounds;
-      if (this.TryGetValue(vVar, out bounds) && !bounds.IsTop)
-      {
-        foreach (var upp in bounds.Values)
-        {
-          yield return this.expManager.Encoder.VariableFor(upp);
-        }
-      }
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      return new Set<Variable>();
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);      
-
-      e1 = this.expManager.Decoder.Stripped(e1);
-      e2 = this.expManager.Decoder.Stripped(e2);
-
-      var result = this.HelperForCheckLessEqualThan(e1, e2);
-      if (result.IsTop)
-      {
-        Polynomial<Variable, Expression> tmp;
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1, e2, this.expManager.Decoder, out tmp))
-        {
-          if (new VisitorForCheckLessEqualThan().Visit(tmp, this, ref result))
-          {
-            return result;
-          }
-        }
-      }
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessEqualThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> c1, c2;
-
-      if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
-      {
-        return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfEqual(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
-    {
-      SetOfConstraints<Variable> upp;
-      if (this.TryGetValue(e1, out upp))
-      {
-        if (upp.IsNormal() && upp.Contains(e2))
-        {
-          return CheckOutcome.True;
-        }
-      }
-
-      return CheckOutcome.Top;
-    }
-
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2, 
-      IIntervalAbstraction<Variable, Expression> oracleDomain)
-    {
-      Contract.Requires(oracleDomain != null);
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      if (e1 == null || e2 == null)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var decoder = this.expManager.Decoder;
-
-      e1 = decoder.Stripped(e1);
-      e2 = decoder.Stripped(e2);
-
-      var res = this.CheckIfLessThan(e1, e2, oracleDomain);
-
-      if (!res.IsNormal())
-      {
-        Polynomial<Variable, Expression> pol;
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, decoder, out pol))
-        {
-          Variable x;
-          Rational k;
-          if (pol.TryMatch_YPlusK(out x, out k) && k == 1)
-          {
-            var e2Exp = decoder.UnderlyingVariable(e2);
-
-            res = this.CheckIfLessThan(x, e2Exp);
-            if (!res.IsBottom)
-              return res;
-            else // if (res.BoxedElement == false)
-              return CheckOutcome.Top;
-          }
-        }
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(e2, decoder, out pol))
-        {
-          Variable x;
-          Rational k;
-          if (pol.TryMatch_YMinusK(out x, out k) && k == -1)
-          {
-            var e1Exp = decoder.UnderlyingVariable(e1);
-              res = this.CheckIfLessThan(e1Exp, x);
-              if (!res.IsBottom)
-                return res;
-              else // if (res.BoxedElement == false)
-                return CheckOutcome.Top;
-          }
-        }
-        return res;
-      }
-      else if (res.IsTrue())
-      {
-        return res;
-      }
-      else
-      {
-        Contract.Assume(res.IsFalse());
-        // we know e1 >= e2, let us check if e1 > e2
-        if (this.CheckIfLessThan(e2, e1).IsTrue())
-        {
-          return CheckOutcome.False;
-        }
-
-        return CheckOutcome.Top;
-      }
-
-    }
-
-    [ContractVerification(false)] // Turning off verification of this method, as it is not more really interesting: it is never called in actual runs of CLousot (only in some regression)
-      public void AssignInParallel(
-      Dictionary<Variable, FList<Variable>> sourcesToTargets,
-      Converter<Variable, Expression> convert, IIntervalAbstraction<Variable, Expression> oracleDomain)
-    {
-      // Recall that we are solving the following problem. We have a new alphabet of variables V and an old alphabet of variables V'.
-      // The current state holds constraints over old variables v'1 <= v'2.
-      //
-      // The sourcesToTargets map represents assignments from old variables to new variables. An entry
-      //   v' -> v1, v2, ... vn represents the assignments v1 := v', v2 := v', ... vn := v'
-      //
-      // Thus, if the current state holds  v'1 <= v'2, and we have
-      //   v'1 -> v11, v12, ..., v1n
-      //   v'2 -> v21, v22, ..., v2m
-      //
-      // Then "all" information about v'1 <= v'2 expressed in the new state would be the conjunction of constraints
-      //   v1i <= v2j, for i=1..n and j=1..m
-      //
-      // Clearly, we don't generally want to produce this quadratic number of constraints (although in practice it is rare
-      // to see more than 1 new variable assigned the same old variable).
-      //
-      // Thus, in practice, we might pick a "canonical" new name for an old variable, say the first in the list (v11 and v21).
-      // This would then give us a single new constraint for v'1 <= v'2, namely  v11 <= v21.
-      //
-      // To compute this, we use the sourcesToTargets map as our canonical map M from old to new, by simply using the first in the list
-      // as the canonical new variable.
-
-      // Then it is simple to produce the new state: iterate over all constraints v'1 <= v'2 in the old state, and simply put
-      //   M(v'1) <= M(v'2) into the new state.
-
-      // The fact that we have to do this computation "in-place" is annoying. It would be simpler to produce a new state.
-      // Thus, we will compute the new mappings on the side, then clear the current state, then add the new mappings back.
-
-      // adding the domain-generated variables to the map as identity
-      var oldToNewMap = new Dictionary<Variable, FList<Variable>>(sourcesToTargets);
-      if (!this.IsTop)
-      {
-        var decoder = this.expManager.Decoder;
-
-        foreach (var v in this.Variables)
-        {
-          if (decoder.IsSlackVariable(v))
-          {
-            oldToNewMap.Add(v, FList<Variable>.Cons(v, FList<Variable>.Empty));
-          }
-        }
-      }
-
-      // when x has several targets including itself, the canonical element shouldn't be itself
-      foreach (var sourceToTargets in sourcesToTargets)
-      {
-        var source = sourceToTargets.Key;
-        var targets = sourceToTargets.Value;
-        if (targets.Length() > 1 && targets.Head.Equals(source))
-        {
-          var newTargets = FList<Variable>.Cons(targets.Tail.Head, FList<Variable>.Cons(source, targets.Tail.Tail));
-          oldToNewMap[source] = newTargets;
-        }
-      }
-
-      // The invariant is \forall x. newConstraints[x].EmbeddedValues_Unsafe == newMappings[x]
-      var newMappings = new Dictionary<Variable, Set<Variable>>(this.Count);
-      var newConstraints = new Dictionary<Variable, SetOfConstraints<Variable>>(this.Count);
-
-      foreach (var oldLeft_pair in this.Elements)
-      {
-        if (!oldToNewMap.ContainsKey(oldLeft_pair.Key))
-        {
-          continue;
-        }
-
-        Variable newLeft = oldToNewMap[oldLeft_pair.Key].Head; // our canonical element
-
-        var oldBounds = oldLeft_pair.Value;
-        if (!oldBounds.IsNormal())
-        {
-          continue;
-        }
-
-        foreach (var oldRight in oldBounds.Values)
-        {
-          if (!oldToNewMap.ContainsKey(oldRight))
-          {
-            continue;
-          }
-
-          // This case is so so common that we want to specialize it
-          if (oldToNewMap[oldRight].Length() == 1)
-          {
-            var newRight = oldToNewMap[oldRight].Head; // our canonical element
-            AddUpperBound(newLeft, newRight, newMappings, newConstraints);
-          }
-          else
-          {
-            foreach (var newRight in oldToNewMap[oldRight].GetEnumerable())
-            {
-              AddUpperBound(newLeft, newRight, newMappings, newConstraints);
-            }
-          }
-        }
-
-        // There are some more elements
-        for (var list = oldToNewMap[oldLeft_pair.Key].Tail; list != null; list = list.Tail)
-        {
-          if (newConstraints.ContainsKey(newLeft))
-          {
-            foreach (var con in newConstraints[newLeft].Values)
-            {
-              AddUpperBound(list.Head, con, newMappings, newConstraints);
-            }
-          }
-        }
-      }
-
-      // Update
-      this.SetElements(newConstraints);
-    }
-
-    /// <summary>
-    /// Add or materialize the map entry and add the value
-    /// </summary>
-    static internal void AddUpperBound(Variable key, Variable upperBound, 
-      Dictionary<Variable, Set<Variable>> map, Dictionary<Variable, SetOfConstraints<Variable>> newCostraints)
-    {
-      Contract.Requires(map != null);
-      Contract.Requires(newCostraints != null);
-
-      Set<Variable> bounds;
-      if (!map.TryGetValue(key, out bounds))
-      {
-        bounds = new Set<Variable>();
-        map.Add(key, bounds);
-      }
-      Contract.Assume(bounds != null);
-
-      bounds.Add(upperBound);
-      newCostraints[key] = new SetOfConstraints<Variable>(bounds, false);
-    }
-
-    protected override WeakUpperBounds<Variable, Expression> Factory()
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);      
-
-      return new WeakUpperBounds<Variable, Expression>(this.expManager);
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression>Members
-
-    /// <summary>
-    /// The assignment in parallel.
-    /// It does not use any knowledge on the value of the expressions
-    /// </summary>
-    /// <param name="sourcesToTargets"></param>
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      this.AssignInParallel(sourcesToTargets, convert, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.expManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-
-    #region Particular cases for IAbstractDomain
-
-    override public WeakUpperBounds<Variable, Expression> Join(WeakUpperBounds<Variable, Expression> right)
-    {
-      // Here we do not have trivial joins as we want to join maps of different cardinality
-      if (this.IsBottom)
-        return right;
-      if (right.IsBottom)
-        return this;
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
-      {
-        SetOfConstraints<Variable> right_x;
-        if (right.TryGetValue(pair.Key, out right_x))
-        {
-          Contract.Assume(pair.Value != null);
-
-          var intersection = pair.Value.Join(right_x);
-
-          if (intersection.IsNormal())
-          {
-            // We keep in the map only the elements that are != top and != bottom
-
-            result[pair.Key] = intersection;
-          }
-        }
-      }
-
-      return result;
-    }
-
-    public WeakUpperBounds<Variable, Expression> Join(WeakUpperBounds<Variable, Expression> right,
-      IIntervalAbstraction<Variable, Expression> intervalsForThis, IIntervalAbstraction<Variable, Expression> intervalsForRight)
-    {
-      Contract.Requires(right != null);
-      Contract.Requires(intervalsForThis != null);
-      Contract.Requires(intervalsForRight != null);
-
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      // Here we do not have trivial joins as we want to join maps of different cardinality
-      if (this.IsBottom)
-        return right;
-      if (right.IsBottom)
-        return this;
-
-      var result = this.Factory();
-
-      foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
-      {
-        var newValues = new Set<Variable>();
-
-        SetOfConstraints<Variable> otherBounds;
-        if (right.TryGetValue(pair.Key, out otherBounds))
-        {
-          Contract.Assume(pair.Value != null);
-
-          var intersection = pair.Value.Join(otherBounds);
-          if (!intersection.IsTop)
-          {
-            newValues.AddRange(intersection.Values);
-          }
-
-          // Foreach x < y
-          if (otherBounds.IsNormal())
-          {
-            foreach (var y in otherBounds.Values)
-            {
-              if (newValues.Contains(y))
-              {
-                continue;
-              }
-
-              var res = intervalsForThis.CheckIfLessThan(pair.Key, y);
-
-              if (!res.IsNormal())
-              {
-                continue;
-              }
-
-              if (res.BoxedElement)    // If the intervals imply this relation, just keep it
-              {
-                newValues.Add(y);   // Add x < y
-              }
-            }
-          }
-        }
-
-        // Foreach x < y
-        if (pair.Value.IsNormal())
-        {
-          foreach (var y in pair.Value.Values)
-          {
-            if (newValues.Contains(y))
-            {
-              continue;
-            }
-
-            var res = intervalsForRight.CheckIfLessThan(pair.Key, y);
-
-            if (!res.IsNormal())
-            {
-              continue;
-            }
-
-            if (res.BoxedElement)    // If the intervals imply this relation, just keep it
-            {
-              newValues.Add(y);   // Add x < y everywhere
-              right.TestTrueLessThan(pair.Key, y);
-            }
-          }
-        }
-        if (!newValues.IsEmpty)
-        {
-          result[pair.Key] = new SetOfConstraints<Variable>(newValues, false);
-        }
-      }
-
-      foreach (var pair in right.Elements)
-      {
-        if (this.ContainsKey(pair.Key))
-        {
-          // Case already handled
-          continue;
-        }
-
-        var newValues = new Set<Variable>();
-
-        // Foreach x < y
-        if (pair.Value.IsNormal())
-        {
-          foreach (var y in pair.Value.Values)
-          {
-            var res = intervalsForThis.CheckIfLessThan(pair.Key, y);
-
-            if (!res.IsNormal())
-            {
-              continue;
-            }
-
-            if (res.BoxedElement)    // If the intervals imply this relation, just keep it
-            {
-              newValues.Add(y);   // Add x < y
-              this.TestTrueLessThan(pair.Key, y);
-            }
-          }
-
-          if (!newValues.IsEmpty)
-          {
-            result[pair.Key] = new SetOfConstraints<Variable>(newValues, false);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignmentsWithForward<Expression> Members
-
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      if (this.ContainsKey(x))
-        this.RemoveVariable(x);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get 
-      {
-        var result = new List<Variable>();
-        var uppBounds = new Set<Variable>();
-
-        foreach (var x in this.Elements)
-        {
-          Contract.Assume(x.Value != null);
-
-          result.Add(x.Key);
-          if (!x.Value.IsTop)
-          {
-            uppBounds.AddRange(x.Value.Values);
-          }
-        }
-
-        result.AddRange(uppBounds);
-
-        return result;
-      }
-    }
-
-    public IEnumerable<Variable> SlackVariables
-    {
-      get
-      {
-        var decoder = this.expManager.Decoder;
-
-        var seen = new Set<Variable>();
-
-        foreach (var x_pair in this.Elements)
-        {
-          if (decoder.IsSlackVariable(x_pair.Key))
-          {
-            seen.Add(x_pair.Key);
-            yield return x_pair.Key;
-          }
-
-          if (!x_pair.Value.IsTop)
-          {
-            foreach (var y in x_pair.Value.Values)
-            {
-              if (decoder.IsSlackVariable(y) && !seen.Contains(y))
-              {
-                seen.Add(y);
-                yield return y;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      // Does nothing, as we assume variables initialized to top
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      this.RemoveElement(var);
-
-      var toUpdate = new List<Pair<Variable, SetOfConstraints<Variable>>>();
-
-      foreach (var pair in this.Elements)
-      {
-        if (pair.Value.IsNormal() && pair.Value.Contains(var))
-        {
-          var s = new Set<Variable>(pair.Value.Values);
-          s.Remove(var);
-          toUpdate.Add(pair.Key, new SetOfConstraints<Variable>(s, false));
-        }
-      }
-
-      foreach (var pair in toUpdate)
-      {
-        this[pair.One] = pair.Two;
-      }
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      this.ProjectVariable(var);
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-
-        if (!pair.Value.IsTop)
-        {
-          var oldVal = pair.Value;
-          if(oldVal.Contains(OldName))
-          {
-            var newVal = new Set<Variable>(oldVal.Values);
-            newVal.Remove(OldName);
-            newVal.Add(NewName);
-            this[pair.Key] = new SetOfConstraints<Variable>(newVal, false);
-          }
-        }
-      }
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-      return this.TestTrue(guard);
-    }
-
-    public WeakUpperBounds<Variable, Expression> TestTrue(Expression guard)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      return ProcessTestTrue(guard);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      return this.TestFalse(guard);
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    public WeakUpperBounds<Variable, Expression> TestFalse(Expression guard)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-      
-     var encoder = this.expManager.Encoder;
-//      if (encoder != null)
-      {
-        var notGuard = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Not, guard);
-        return TestTrue(notGuard);
-      }
-  /*    else
-      {
-        return ProcessTestFalse(guard);
-      }
-   */ 
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return this.RemoveRedundanciesWith(oracle);
-    }
-
-    public WeakUpperBounds<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      Contract.Requires(oracle != null);
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);      
-
-      var result = this.DuplicateMe();
-//      if (this.expManager.Encoder != null)
-      {
-        foreach (var pair in this.Elements)
-        {
-          if (!pair.Value.IsNormal())
-          {
-            result[pair.Key] = pair.Value;
-          }
-          else
-          {
-            var newExp = new List<Variable>();
-            foreach (var exp in pair.Value.Values)
-            {
-              // x <= exp
-              var lt = oracle.CheckIfLessThan(pair.Key, exp);
-
-              if (!lt.IsNormal() || !lt.BoxedElement)
-              { // Then it is not implied by oracle
-                newExp.Add(exp);
-              }
-            }
-            if (newExp.Count > 0)
-            {
-              result[pair.Key] = new SetOfConstraints<Variable>(newExp);
-            }
-          }
-        }
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region WeakUpperBounds-Specific Methods
-
-    public INumericalAbstractDomain<Variable, Expression>TestTrueGeqZero(Expression exp)
-    {
-      return this;
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression  exp1, Expression  exp2)
-    {
-      return this.TestTrueLessThan(exp1, exp2);
-    }
-
-    public WeakUpperBounds<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);      
-
-      return this.TestTrueLessThan(exp1, exp2, new WeakUpperBoundsEqual<Variable, Expression>(this.expManager));
-    }
-
-    public WeakUpperBounds<Variable, Expression> TestTrueLessThan(Variable v1, Variable v2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);      
-
-      SetOfConstraints<Variable> upp;
-      if(this.TryGetValue(v1, out upp) && upp.IsNormal())
-      {
-        var newElements = new Set<Variable>(upp.Values);
-        newElements.Add(v2);
-        upp = new SetOfConstraints<Variable>(newElements, false);
-        newElements = null; // F: just want to make sure that we do not reuse it, as we passed the ownership
-      }
-      else
-      {
-        upp = new SetOfConstraints<Variable>(v2);
-      }
-
-      this[v1] = upp;
-
-      return this;
-    }
-
-    public WeakUpperBounds<Variable, Expression> TestTrueLessThan(Expression e1, Expression e2, 
-      WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
-    {
-      Contract.Requires(oracleDomain != null);
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      var decoder = this.expManager.Decoder; 
-      
-      var e1Var = decoder.UnderlyingVariable(e1);
-      var e2Var = decoder.UnderlyingVariable(e2);
-      var e2Stripped = decoder.Stripped(e2);
-      var e2StrippedVar = decoder.UnderlyingVariable(e2Stripped);
-
-      if (decoder.IsVariable(e1))
-      {      // If e1 is a variable, then we add transitively all the constraints of e2
-        AddAssumptionsTestTrueLessThanVariable(e1Var, e2, e2Var, e2StrippedVar, oracleDomain);
-      }
-      else
-      {
-        AddAssumptionsTestTrueLessThanNonVariableCase(e1, e2, e1Var, e2Var, e2StrippedVar);
-      }
-
-      if (this[e1Var].IsNormal())
-      {
-        var toBeUpdated = new List<Pair<Variable, SetOfConstraints<Variable>>>();
-
-        // "e1 < e2", so we search all the variables to see if "e0 < e1"
-        foreach (var pair in this.Elements)
-        {
-          if (pair.Value.IsNormal())
-          {
-            if (pair.Value.Contains(e1Var))
-            {
-              var values = new Set<Variable>(pair.Value.Values);
-              values.AddRange(this[e1Var].Values);
-
-              toBeUpdated.Add(pair.Key, new SetOfConstraints<Variable>(values, false));
-            }
-          }
-        }
-
-        if (toBeUpdated.Count > 0)
-        {
-          foreach (var pair in toBeUpdated)
-          {
-            this[pair.One] = pair.Two;
-          }
-        }
-      }
-
-      return this;
-    }
-
-    /// <summary>
-    /// We add the assumptions e1Var \lt e2Var, e2StripperVar
-    /// </summary>
-    private void AddAssumptionsTestTrueLessThanVariable(
-      Variable e1Var, Expression e2, Variable e2Var, Variable e2StrippedVar, 
-      WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
-    {
-      Contract.Requires(oracleDomain != null);
-    
-      var newValues = new Set<Variable>();
-
-      newValues.Add(e2Var);  // e1 < e2 
-      newValues.Add(e2StrippedVar);   // Add "e1 < e2'", if e2 was in the form "(int32) e2'" or similar 
-
-      SetOfConstraints<Variable> this_e1;
-      if (this.TryGetValue(e1Var, out this_e1) && !this_e1.IsTop)
-      {                   // e1 < "all the values before"
-        newValues.AddRange(this_e1.Values);
-      }
-
-      SetOfConstraints<Variable> this_e2;
-      if (this.TryGetValue(e2Var, out this_e2) && !this_e2.IsTop)
-      {                   // e1 < "all the values e2 is smaller than"
-        newValues.AddRange(this_e2.Values);
-      }
-
-      SetOfConstraints<Variable> oracleDomain_e2;
-      if (oracleDomain.TryGetValue(e2Var, out oracleDomain_e2) && !oracleDomain_e2.IsTop)
-      {                   // e1 < "all the values e2 is smaller than or equal to"
-        newValues.AddRange(oracleDomain_e2.Values);
-      }
-
-      var decoder = this.expManager.Decoder;
-      // e1 < x - y
-      if (decoder.IsBinaryExpression(e2) && decoder.OperatorFor(e2) == ExpressionOperator.Subtraction)
-      {
-        var left = decoder.LeftExpressionFor(e2);
-        var right = decoder.RightExpressionFor(e2);
-
-        int v;
-        if (decoder.IsConstantInt(right, out v) && v > 0)
-        {
-          newValues.Add(decoder.UnderlyingVariable(left));
-          newValues.Add(decoder.UnderlyingVariable(decoder.Stripped(left)));
-        }
-      }
-
-      this[e1Var] = new SetOfConstraints<Variable>(newValues, false);
-    }
-
-    /// <summary>
-    /// e1 is not a variable, We try to construct a polynomial out of it and then infer new relations in the form x lt y
-    /// </summary>
-    private void AddAssumptionsTestTrueLessThanNonVariableCase(Expression e1, Expression e2, Variable e1Var, Variable e2Var, Variable e2StrippedVar)
-    {
-      Contract.Requires(!this.expManager.Decoder.IsVariable(e1));
-
-      // e1Var < e2Var and e2StrippedVar
-      if (!this.ContainsKey(e1Var))
-      {
-        var tmp = new Set<Variable>() { e2Var, e2StrippedVar };
-
-        this[e1Var] = new SetOfConstraints<Variable>(tmp, false);
-      }
-
-      // Infer constraints from a more concrete form (polynomial)
-      Polynomial<Variable, Expression> e1LTe2;
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1, e2, this.expManager.Decoder, out e1LTe2))
-      {
-        Rational k1, k2, k;
-        Variable x1, x2;
-
-        if (e1LTe2.TryMatch_k1XPlusk2YLessThanK(out k1, out x1, out k2, out x2, out k))
-        {
-          if (k <= 0)
-          {
-            if (k1 == 1 && k2 == -1)   // x1 - x2 < k <= 0 => x1 < x2
-            {
-              this.UpdateConstraintsFor(x1, x2);
-            }
-            else if (k1 == -1 && k2 == 1) // -x1 + x2 < k <= 0 => x2 < x1
-            {
-              this.UpdateConstraintsFor(x2, x1);
-            }
-          }
-        }
-      }
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueLessEqualThan(exp1, exp2);
-    }
-
-    public WeakUpperBounds<Variable, Expression> TestTrueLessEqualThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      Polynomial<Variable, Expression> p1, p2;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, this.expManager.Decoder, out p1)
-        && Polynomial<Variable, Expression>.TryToPolynomialForm(e2, this.expManager.Decoder, out p2))
-      {
-        Variable x, y;
-        Rational k;
-
-        var decoder = this.expManager.Decoder;
-
-        // Consider the case "e1 <= y - k"
-        if (p2.TryMatch_YMinusK(out y, out k))
-        {
-          // Assume e1 < y
-          var e1Var = decoder.UnderlyingVariable(e1);
-          var result = this.HelperForLessThan(e1Var, y);
-
-          var e1StrippedVar = decoder.UnderlyingVariable(decoder.Stripped(e1));
-          result = this.HelperForLessThan(e1StrippedVar, y);
-
-          return result;
-        }
-        // Consider the case "x + k <= e2"
-        if (p1.TryMatch_YPlusK(out x, out k))
-        {
-          if (k > 0)
-          {
+            var e1Var = decoder.UnderlyingVariable(e1);
             var e2Var = decoder.UnderlyingVariable(e2);
 
-            return this.HelperForLessThan(x, e2Var);
-          }
-        }
+            var result = this.CheckIfLessThan(e1Var, e2Var);
 
-        // Consider the case "e1 <= y"
-        if (p2.TryMatch_Y(out y))
-        {
-          SetOfConstraints<Variable> value;
-          // If we know that "y < z", then also "e1 < z"
-          if (this.TryGetValue(y, out value) && value.IsNormal())
-          {
-            var e1Var = decoder.UnderlyingVariable(e1);
-            this[e1Var] = value;
-
-            return this;
-          }
-        }
-
-        Rational k1, k2;
-        Variable x1, x2;
-        Polynomial<Variable, Expression> combined;
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, p1, p2, out combined) && combined.TryMatch_k1XPlusk2YLessThanK(out k1, out x1, out k2, out x2, out k))
-        { // k1 x1 + k2 x2 < k
-
-          if (k1 < 0 && k2 > 0)
-          {
-            var tmp = k1;
-            k1 = k2;
-            k2 = tmp;
-
-            var tmpExp = x1;
-            x1 = x2;
-            x2 = tmpExp;
-          }
-
-          if (k1 == 1 && k2 == -1 && k <= 0)
-          {
-            // "x1 - x2 < k <= 0" that is "x1 < x2" 
-            return this.HelperForLessThan(x1, x2);
-          }
-        }
-      }
-
-      return this;
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression  exp1, Expression  exp2)
-    {
-      return this.TestTrueEqual(exp1, exp2);
-    }
-
-    public WeakUpperBounds<Variable, Expression> TestTrueEqual(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      Polynomial<Variable, Expression> p1, p2;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, this.expManager.Decoder, out p1)
-        && Polynomial<Variable, Expression>.TryToPolynomialForm(e2, this.expManager.Decoder, out p2))
-      {
-        // match p1 with " x + 1 ", and p2 with " y "
-        if (p1.IsLinearOctagon && p2.IsLinearOctagon)
-        {
-          if (p1.Left.Length == 1 && p2.Left.Length == 2)
-          {
-            var tmp = p1; p1 = p2; p2 = tmp;
-          }
-
-          // Here we want p1.Left.Count == 2. If this is not the case, we just drop this info
-          if (p1.Left.Length == 2 && p1.Left[0].Degree == 1 && p1.Left[1].IsConstant
-            && p2.Left.Length == 1 && p2.Left[0].Degree == 1)
-          {
-            var x = p1.Left[0].VariableAt(0);
-            var k = p1.Left[1].K;
-            var y = p2.Left[0].VariableAt(0);
-
-            if (k > 0)
-            { // Then we know that " x + k = y, k > 0 " implies " x < y "  
-              return this.HelperForLessThan(x, y);
-            }
-          }
-        }
-      }
-
-      return this;
-    }
-
-    #endregion
-
-    #region Protected methods
-
-    private bool Check(Variable x1, Variable x2)
-    {
-      SetOfConstraints<Variable> value;
-
-      if (this.TryGetValue(x1, out value))
-      {
-        if (value.IsBottom)
-        {
-          return true;
-        }
-        else if (!value.IsTop)
-        {
-          return value.Contains(x2);
-        }
-      }
-
-      return false;
-    }
-
-    virtual protected WeakUpperBounds<Variable, Expression> ProcessTestTrue(Expression guard)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      var decoder = this.expManager.Decoder;
-
-      switch (decoder.OperatorFor(guard))
-      {
-        #region all the cases
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          {
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            var leftVar = decoder.UnderlyingVariable(left);
-            var rightVar = decoder.UnderlyingVariable(right);
-
-            SetOfConstraints<Variable> v1, v2;
-            var b1 = this.TryGetValue(leftVar, out v1);
-            var b2 =this.TryGetValue(rightVar, out v2); 
-            if (b1 && b2)
+            if (result.IsNormal())
             {
-              var intersection = v1.Meet(v2);
-              if (v1.IsBottom)
-              {
-                return this.Bottom;
-              }
-              else
-              {
-                this[leftVar] = intersection;
-                this[rightVar] = intersection;
-
-                return this;
-              }
+                return result;
             }
-            else if (b1 && v1.IsNormal())
-            {
-              this[rightVar] = v1;
 
-              return this;
+            Polynomial<Variable, Expression> e1LTe2;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1, e2, decoder, out e1LTe2))
+            {
+                Contract.Assume(e1LTe2.Relation == ExpressionOperator.LessThan, "Exprecting a LT");
+
+                if (e1LTe2.Left.Length == 2 && e1LTe2.IsOctagonForm)
+                {
+                    Contract.Assume(e1LTe2.Degree == 1); // We know it has 2 variables, and unary coefficients, hence the polynomial degree is 1
+
+                    Contract.Assert(e1LTe2.Right != null); // Adding the assertion as the backward visit does not go far enough
+
+                    Contract.Assume(e1LTe2.Right.Length > 0);
+
+                    var monomial0 = e1LTe2.Left[0];
+                    var monomial1 = e1LTe2.Left[1];
+
+                    Contract.Assume(monomial0.Degree == 1);
+                    Contract.Assume(monomial1.Degree == 1);
+
+                    var k1 = monomial0.K;
+                    var x1 = monomial0.VariableAt(0);
+
+                    var k2 = monomial1.K;
+                    var x2 = monomial1.VariableAt(0);
+
+                    var k = e1LTe2.Right[0].K;
+
+                    bool isImplied = false;
+
+                    if (k >= 0)
+                    {
+                        if (k1 == 1 && k2 == -1)  // x1 - x2 < 1, that is x1 < x2 + 1 
+                        {
+                            isImplied = Check(x1, x2);
+                        }
+                        else if (k1 == -1 && k2 == 1) // -x1 + x2 < 1, that is x2 < x1 + 1
+                        {
+                            isImplied = Check(x2, x1);
+                        }
+                    }
+
+                    if (isImplied)
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
+                else
+                {
+                    Polynomial<Variable, Expression> e1AsPolynomial;
+                    // Try to see if e1 == "a1 x1 + a2 x2 + ... " is such that each xi < e2, and 0<= sum ai <= 1 and \forall i. ai > 0
+                    if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, decoder, out e1AsPolynomial) && e1AsPolynomial.Degree == 1)
+                    {
+                        var sum = Rational.For(0);
+
+                        // Checks two things: 
+                        //  1. All the x are < e2
+                        //  2. \forall ai. ai >= 0 && 0<= a1 + a2 + ... + an <= 1
+                        foreach (var m in e1AsPolynomial.Left)
+                        {
+                            if (!m.IsConstant)
+                            {
+                                var x = m.VariableAt(0);
+
+                                // Checks that x < e2
+                                SetOfConstraints<Variable> values;
+                                if (!(this.TryGetValue(x, out values) && values.IsNormal() && values.Contains(e2Var)))
+                                {
+                                    return CheckOutcome.Top;
+                                }
+                            }
+
+                            if (m.K <= 0)
+                            {
+                                return CheckOutcome.Top;
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    sum += m.K;
+                                }
+                                catch (ArithmeticExceptionRational)
+                                {
+                                    return CheckOutcome.Top;
+                                }
+                            }
+                        }
+
+                        if (sum <= 1)
+                        {
+                            Contract.Assume(sum >= 0, "At this point the sum of the values must be positive");
+                            return CheckOutcome.True;
+                        }
+                    }
+                }
             }
-            else if (b2 && v2.IsNormal())
-            {
-              this[leftVar] = v2;
 
-              return this;
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            return this.CheckIfLessEqualThan(e1, e2);
+        }
+
+        /// <summary>
+        /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code> using, 
+        /// if needed the abstract domain <code>oracleDomain</code> to refine the information
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2,
+          IIntervalAbstraction<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(oracleDomain != null);
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            if (e1 == null || e2 == null)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var decoder = this.expManager.Decoder;
+
+            e1 = decoder.Stripped(e1);
+            e2 = decoder.Stripped(e2);
+
+            var directTry = CheckIfLessThan(e1, e2);
+            if (!directTry.IsTop)
+            {
+                return directTry;
+            }
+
+            var result = CommonChecks.CheckLessThan(e1, e2, oracleDomain, decoder);
+
+            if (!result.IsTop)
+            {
+                return result;
+            }
+
+            switch (this.expManager.Decoder.OperatorFor(e1))
+            {
+                case ExpressionOperator.Modulus:
+                    {
+                        // It is " (e1Left % e1Right) < e2 "
+                        var e1Left = decoder.LeftExpressionFor(e1);
+                        var e1Right = decoder.RightExpressionFor(e1);
+                        var e1RightStripped = decoder.Stripped(e1Right);
+
+                        if (e2.Equals(e1RightStripped))
+                        {
+                            var valFore1Left = oracleDomain.BoundsFor(e1Left);
+
+                            if (valFore1Left.LowerBound >= 0 || oracleDomain.BoundsFor(e2).LowerBound >= 0)
+                            {
+                                return CheckOutcome.True;
+                            }
+                        }
+                    }
+                    break;
+
+                case ExpressionOperator.ShiftRight:
+                    {
+                        // It is "(e1Left >> e2Left) < e2" 
+                        var e1Left = decoder.LeftExpressionFor(e1);
+                        var e1Right = decoder.RightExpressionFor(e1);
+
+                        if (oracleDomain.BoundsFor(e1Left).LowerBound >= 0)
+                        {
+                            return this.CheckIfLessThan(e1Left, e2, oracleDomain);   // check if e1Left < e2
+                        }
+                    }
+                    break;
+
+                case ExpressionOperator.Addition:
+                    {
+                        // it is (e1Left + e1right) < e2
+                        var e1Left = decoder.LeftExpressionFor(e1);
+                        var e1Right = decoder.RightExpressionFor(e1);
+
+                        int k;
+                        // Try the transitive closure of length 1 (see the check k == 1 !!!)
+                        // this is useful to speed up checks in the array analysis
+                        if (decoder.IsConstantInt(e1Right, out k) && k == 1)
+                        {
+                            // it is (e1Left + 1) < e2
+                            foreach (var upp in this.UpperBoundsFor(e1Left, true))
+                            {
+                                if (this.UpperBoundsFor(upp, true).Contains(e2))
+                                    return CheckOutcome.True;
+                            }
+                        }
+                    }
+                    break;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                return new List<Pair<Variable, Int32>>();
+            }
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            return LowerBoundsFor(this.expManager.Decoder.UnderlyingVariable(v), strict);
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable vVar, bool strict)
+        {
+            foreach (var exp_pair in this.Elements)
+            {
+                var valueSet = exp_pair.Value;
+                Contract.Assume(valueSet != null);
+
+                if (!valueSet.IsTop && valueSet.Contains(vVar))
+                {
+                    yield return this.expManager.Encoder.VariableFor(exp_pair.Key);
+                }
+            }
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            return UpperBoundsFor(this.expManager.Decoder.UnderlyingVariable(v), strict);
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable vVar, bool strict)
+        {
+            SetOfConstraints<Variable> bounds;
+            if (this.TryGetValue(vVar, out bounds) && !bounds.IsTop)
+            {
+                foreach (var upp in bounds.Values)
+                {
+                    yield return this.expManager.Encoder.VariableFor(upp);
+                }
+            }
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            return new Set<Variable>();
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            e1 = this.expManager.Decoder.Stripped(e1);
+            e2 = this.expManager.Decoder.Stripped(e2);
+
+            var result = this.HelperForCheckLessEqualThan(e1, e2);
+            if (result.IsTop)
+            {
+                Polynomial<Variable, Expression> tmp;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1, e2, this.expManager.Decoder, out tmp))
+                {
+                    if (new VisitorForCheckLessEqualThan().Visit(tmp, this, ref result))
+                    {
+                        return result;
+                    }
+                }
+            }
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessEqualThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> c1, c2;
+
+            if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
+            {
+                return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfEqual(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable e1, Variable e2)
+        {
+            SetOfConstraints<Variable> upp;
+            if (this.TryGetValue(e1, out upp))
+            {
+                if (upp.IsNormal() && upp.Contains(e2))
+                {
+                    return CheckOutcome.True;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2,
+          IIntervalAbstraction<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(oracleDomain != null);
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            if (e1 == null || e2 == null)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var decoder = this.expManager.Decoder;
+
+            e1 = decoder.Stripped(e1);
+            e2 = decoder.Stripped(e2);
+
+            var res = this.CheckIfLessThan(e1, e2, oracleDomain);
+
+            if (!res.IsNormal())
+            {
+                Polynomial<Variable, Expression> pol;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, decoder, out pol))
+                {
+                    Variable x;
+                    Rational k;
+                    if (pol.TryMatch_YPlusK(out x, out k) && k == 1)
+                    {
+                        var e2Exp = decoder.UnderlyingVariable(e2);
+
+                        res = this.CheckIfLessThan(x, e2Exp);
+                        if (!res.IsBottom)
+                            return res;
+                        else // if (res.BoxedElement == false)
+                            return CheckOutcome.Top;
+                    }
+                }
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(e2, decoder, out pol))
+                {
+                    Variable x;
+                    Rational k;
+                    if (pol.TryMatch_YMinusK(out x, out k) && k == -1)
+                    {
+                        var e1Exp = decoder.UnderlyingVariable(e1);
+                        res = this.CheckIfLessThan(e1Exp, x);
+                        if (!res.IsBottom)
+                            return res;
+                        else // if (res.BoxedElement == false)
+                            return CheckOutcome.Top;
+                    }
+                }
+                return res;
+            }
+            else if (res.IsTrue())
+            {
+                return res;
             }
             else
             {
-              // Try to figure out if it is in the form of (e11 rel e12) == 0
-              Expression e11, e12;
-              ExpressionOperator op;
-              if (decoder.Match_E1relopE2eq0(left, right, out op, out e11, out e12))
-              {
-                return ProcessTestFalse(left);
-              }
+                Contract.Assume(res.IsFalse());
+                // we know e1 >= e2, let us check if e1 > e2
+                if (this.CheckIfLessThan(e2, e1).IsTrue())
+                {
+                    return CheckOutcome.False;
+                }
+
+                return CheckOutcome.Top;
             }
+        }
 
-            return this;
-          }
-
-        case ExpressionOperator.GreaterEqualThan:
-          // Does nothing ...
-          return this;
-
-        case ExpressionOperator.GreaterThan:
-          {
-            // "left > right", so we add the constraint
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return this.TestTrueLessThan(right, left);
-          }
-
-        case ExpressionOperator.LessEqualThan:
-          {
-            // "left <= right"
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return this.TestTrueLessEqualThan(left, right);
-          }
-
-        case ExpressionOperator.LessThan:
-          // "left < right"
-          {
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            
-            return this.TestTrueLessThan(left, right);
-          }
-
-        // We abstract away the symbolic reasoning for unsigned as it may be incorrect
-        // Example "sv1 CLT_Un sv2" and sv2 is -1, so it should be understood as sv1 CLT_Un UInt.MaxValue - this reasoning is done by intervals
-        case ExpressionOperator.LessThan_Un:
-        case ExpressionOperator.LessEqualThan_Un:
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.GreaterEqualThan_Un:
-          {
-            return this;
-          }
-
-        case ExpressionOperator.LogicalAnd:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
-
-            leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
-            rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
-
-            return leftDomain.Meet(rightDomain);
-          }
-
-        case ExpressionOperator.LogicalOr:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
-
-            leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
-            rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
-
-            return leftDomain.Join(rightDomain);
-          }
-
-        case ExpressionOperator.Not:
-          {
-            return this.ProcessTestFalse(this.expManager.Decoder.LeftExpressionFor(guard));
-          }
-
-        case ExpressionOperator.Addition:
-        case ExpressionOperator.Constant:
-        case ExpressionOperator.ConvertToInt32:
-        case ExpressionOperator.ConvertToUInt8:
-        case ExpressionOperator.ConvertToUInt16:
-        case ExpressionOperator.ConvertToUInt32:
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToFloat64:
-        case ExpressionOperator.Division:
-        case ExpressionOperator.And:
-        case ExpressionOperator.Or:
-        case ExpressionOperator.Modulus:
-        case ExpressionOperator.ShiftLeft:
-        case ExpressionOperator.ShiftRight:
-        case ExpressionOperator.SizeOf:
-        case ExpressionOperator.Multiplication:
-        case ExpressionOperator.NotEqual:
-        case ExpressionOperator.Subtraction:
-        case ExpressionOperator.UnaryMinus:
-        case ExpressionOperator.Xor:
-        case ExpressionOperator.Unknown:
-        case ExpressionOperator.Variable:
-          return this;
-
-        default:
-          return this;
-        #endregion
-      }
-    }
-
-    virtual protected WeakUpperBounds<Variable, Expression> ProcessTestFalse(Expression guard)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      var decoder = this.expManager.Decoder;
-
-      switch (decoder.OperatorFor(guard))
-      {
-        #region all the cases
-
-        case ExpressionOperator.LogicalAnd:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
-
-            leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard));
-            rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard));
-
-            return leftDomain.Join(rightDomain);
-          }
-
-        case ExpressionOperator.And:
-        case ExpressionOperator.Addition:
-        case ExpressionOperator.Constant:
-        case ExpressionOperator.ConvertToInt32:
-        case ExpressionOperator.ConvertToUInt8:
-        case ExpressionOperator.ConvertToUInt16:
-        case ExpressionOperator.ConvertToUInt32:
-        case ExpressionOperator.ConvertToFloat32:
-        case ExpressionOperator.ConvertToFloat64:
-        case ExpressionOperator.Division:
-        case ExpressionOperator.Modulus:
-        case ExpressionOperator.Multiplication:
-        case ExpressionOperator.NotEqual:
-        case ExpressionOperator.Or:
-        case ExpressionOperator.ShiftLeft:
-        case ExpressionOperator.ShiftRight:
-        case ExpressionOperator.SizeOf:
-        case ExpressionOperator.Subtraction:
-        case ExpressionOperator.UnaryMinus:
-        case ExpressionOperator.Unknown:
-        case ExpressionOperator.Xor:
-        case ExpressionOperator.Variable:
-          return this;
-
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          return TestTrueNotEqual(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard));
-
-        case ExpressionOperator.GreaterEqualThan:
-          {
-            // !(left >= right) is equivalent to (left < right)
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            
-            return this.TestTrueLessThan(left, right);
-          }
-
-        case ExpressionOperator.GreaterThan:
-          {
-            // !(left > right) is equivalent to left <= right
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-
-            return this.TestTrueLessEqualThan(left, right);
-          }
-
-        case ExpressionOperator.LessEqualThan:
-          {
-            // !(left <= right) is equivalent to (left > right)
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            
-            return this.TestTrueLessThan(right, left);
-          }
-
-        case ExpressionOperator.LessThan:
-          {
-            // !(left < right) is (left >= right) which is (right <= left)
-            var left = this.expManager.Decoder.LeftExpressionFor(guard);
-            var right = this.expManager.Decoder.RightExpressionFor(guard);
-
-            return this.TestTrueLessEqualThan(right, left);
-          }
-
-        // We abstract away the symbolic reasoning for unsigned as it may be incorrect
-        // Example "sv1 CLT_Un sv2" and sv2 is -1, so it should be understood as sv1 CLT_Un UInt.MaxValue - this reasoning is done by intervals
-        case ExpressionOperator.LessThan_Un:
-        case ExpressionOperator.LessEqualThan_Un:
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.GreaterEqualThan_Un:
-          {
-            return this;
-          }
-
-        case ExpressionOperator.LogicalOr:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
-
-            leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard));
-            rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard));
-
-            return leftDomain.Meet(rightDomain);
-          }
-
-        case ExpressionOperator.Not:
-          {
-            return this.ProcessTestTrue(decoder.LeftExpressionFor(guard));
-          }
-        default:
-          return this;
-        #endregion
-      }
-    }
-     
-    private WeakUpperBounds<Variable, Expression> HelperForLessThan(Variable v1, Variable v2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-      
-      return this.HelperForLessThan(v1, v2, new WeakUpperBoundsEqual<Variable, Expression>(this.expManager));
-    }
-
-    private WeakUpperBounds<Variable, Expression> HelperForLessThan(Variable v1, Variable v2, WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
-    {
-      Contract.Requires(oracleDomain != null);
-      Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
-
-      var newValues = new Set<Variable>();
-
-      newValues.Add(v2);  // v1 < v2 
-
-      SetOfConstraints<Variable> this_e1;
-      if (this.TryGetValue(v1, out this_e1) && !this_e1.IsTop)
-      {                   // e1 < "all the values before"
-        newValues.AddRange(this_e1.Values);
-      }
-
-      SetOfConstraints<Variable> this_e2;
-      if (this.TryGetValue(v2, out this_e2) && !this_e2.IsTop)
-      {                   // e1 < "all the values e2 is smaller than"
-        newValues.AddRange(this_e2.Values);
-      }
-
-      SetOfConstraints<Variable> oracleDomain_e2;
-      if (oracleDomain.TryGetValue(v2, out oracleDomain_e2) && !oracleDomain_e2.IsTop)
-      {                   // e1 < "all the values e2 is smaller than or equal to"
-        newValues.AddRange(oracleDomain_e2.Values);
-      }
-
-      var newConstraintsForV1 = new SetOfConstraints<Variable>(newValues, false);
-      this[v1] = newConstraintsForV1;
-
-      if (newConstraintsForV1.IsNormal())
-      {
-        var toBeUpdated = new List<Pair<Variable, SetOfConstraints<Variable>>>();
-
-        // "e1 < e2", so we search all the variables to see if "e0 < e1"
-        foreach (var pair in this.Elements)
+        [ContractVerification(false)] // Turning off verification of this method, as it is not more really interesting: it is never called in actual runs of CLousot (only in some regression)
+        public void AssignInParallel(
+          Dictionary<Variable, FList<Variable>> sourcesToTargets,
+          Converter<Variable, Expression> convert, IIntervalAbstraction<Variable, Expression> oracleDomain)
         {
-          if (pair.Value.IsNormal())
-          {
-            if (pair.Value.Contains(v1))
+            // Recall that we are solving the following problem. We have a new alphabet of variables V and an old alphabet of variables V'.
+            // The current state holds constraints over old variables v'1 <= v'2.
+            //
+            // The sourcesToTargets map represents assignments from old variables to new variables. An entry
+            //   v' -> v1, v2, ... vn represents the assignments v1 := v', v2 := v', ... vn := v'
+            //
+            // Thus, if the current state holds  v'1 <= v'2, and we have
+            //   v'1 -> v11, v12, ..., v1n
+            //   v'2 -> v21, v22, ..., v2m
+            //
+            // Then "all" information about v'1 <= v'2 expressed in the new state would be the conjunction of constraints
+            //   v1i <= v2j, for i=1..n and j=1..m
+            //
+            // Clearly, we don't generally want to produce this quadratic number of constraints (although in practice it is rare
+            // to see more than 1 new variable assigned the same old variable).
+            //
+            // Thus, in practice, we might pick a "canonical" new name for an old variable, say the first in the list (v11 and v21).
+            // This would then give us a single new constraint for v'1 <= v'2, namely  v11 <= v21.
+            //
+            // To compute this, we use the sourcesToTargets map as our canonical map M from old to new, by simply using the first in the list
+            // as the canonical new variable.
+
+            // Then it is simple to produce the new state: iterate over all constraints v'1 <= v'2 in the old state, and simply put
+            //   M(v'1) <= M(v'2) into the new state.
+
+            // The fact that we have to do this computation "in-place" is annoying. It would be simpler to produce a new state.
+            // Thus, we will compute the new mappings on the side, then clear the current state, then add the new mappings back.
+
+            // adding the domain-generated variables to the map as identity
+            var oldToNewMap = new Dictionary<Variable, FList<Variable>>(sourcesToTargets);
+            if (!this.IsTop)
             {
-              var values = new Set<Variable>(pair.Value.Values);
-              values.AddRange(newConstraintsForV1.Values);
+                var decoder = this.expManager.Decoder;
 
-              toBeUpdated.Add(pair.Key, new SetOfConstraints<Variable>(values, false));
+                foreach (var v in this.Variables)
+                {
+                    if (decoder.IsSlackVariable(v))
+                    {
+                        oldToNewMap.Add(v, FList<Variable>.Cons(v, FList<Variable>.Empty));
+                    }
+                }
             }
-          }
+
+            // when x has several targets including itself, the canonical element shouldn't be itself
+            foreach (var sourceToTargets in sourcesToTargets)
+            {
+                var source = sourceToTargets.Key;
+                var targets = sourceToTargets.Value;
+                if (targets.Length() > 1 && targets.Head.Equals(source))
+                {
+                    var newTargets = FList<Variable>.Cons(targets.Tail.Head, FList<Variable>.Cons(source, targets.Tail.Tail));
+                    oldToNewMap[source] = newTargets;
+                }
+            }
+
+            // The invariant is \forall x. newConstraints[x].EmbeddedValues_Unsafe == newMappings[x]
+            var newMappings = new Dictionary<Variable, Set<Variable>>(this.Count);
+            var newConstraints = new Dictionary<Variable, SetOfConstraints<Variable>>(this.Count);
+
+            foreach (var oldLeft_pair in this.Elements)
+            {
+                if (!oldToNewMap.ContainsKey(oldLeft_pair.Key))
+                {
+                    continue;
+                }
+
+                Variable newLeft = oldToNewMap[oldLeft_pair.Key].Head; // our canonical element
+
+                var oldBounds = oldLeft_pair.Value;
+                if (!oldBounds.IsNormal())
+                {
+                    continue;
+                }
+
+                foreach (var oldRight in oldBounds.Values)
+                {
+                    if (!oldToNewMap.ContainsKey(oldRight))
+                    {
+                        continue;
+                    }
+
+                    // This case is so so common that we want to specialize it
+                    if (oldToNewMap[oldRight].Length() == 1)
+                    {
+                        var newRight = oldToNewMap[oldRight].Head; // our canonical element
+                        AddUpperBound(newLeft, newRight, newMappings, newConstraints);
+                    }
+                    else
+                    {
+                        foreach (var newRight in oldToNewMap[oldRight].GetEnumerable())
+                        {
+                            AddUpperBound(newLeft, newRight, newMappings, newConstraints);
+                        }
+                    }
+                }
+
+                // There are some more elements
+                for (var list = oldToNewMap[oldLeft_pair.Key].Tail; list != null; list = list.Tail)
+                {
+                    if (newConstraints.ContainsKey(newLeft))
+                    {
+                        foreach (var con in newConstraints[newLeft].Values)
+                        {
+                            AddUpperBound(list.Head, con, newMappings, newConstraints);
+                        }
+                    }
+                }
+            }
+
+            // Update
+            this.SetElements(newConstraints);
         }
 
-        if (toBeUpdated.Count > 0)
+        /// <summary>
+        /// Add or materialize the map entry and add the value
+        /// </summary>
+        static internal void AddUpperBound(Variable key, Variable upperBound,
+          Dictionary<Variable, Set<Variable>> map, Dictionary<Variable, SetOfConstraints<Variable>> newCostraints)
         {
-          foreach (var pair in toBeUpdated)
-          {
-            this[pair.One] = pair.Two;
-          }
+            Contract.Requires(map != null);
+            Contract.Requires(newCostraints != null);
+
+            Set<Variable> bounds;
+            if (!map.TryGetValue(key, out bounds))
+            {
+                bounds = new Set<Variable>();
+                map.Add(key, bounds);
+            }
+            Contract.Assume(bounds != null);
+
+            bounds.Add(upperBound);
+            newCostraints[key] = new SetOfConstraints<Variable>(bounds, false);
         }
-      }
 
-      return this;
-    }
-  
-    public WeakUpperBounds<Variable, Expression> TestTrueNotEqual(Expression e1, Expression e2)
-    {     
-      // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant 
-      if (this.expManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.expManager.Decoder.IsConstant(e2))
-      {
-        int v;
-
-        if (this.expManager.Decoder.IsConstantInt(e2, out v))
+        protected override WeakUpperBounds<Variable, Expression> Factory()
         {
-          if (v == 0)
-          { // that is !!(e1)
-            return this.TestTrue(e1);
-          }
-          else if (v == 1)
-          { // that is !e1
-            return this.TestFalse(e1);
-          }
-        }
-      }
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
 
-      return this;
+            return new WeakUpperBounds<Variable, Expression>(this.expManager);
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression>Members
+
+        /// <summary>
+        /// The assignment in parallel.
+        /// It does not use any knowledge on the value of the expressions
+        /// </summary>
+        /// <param name="sourcesToTargets"></param>
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            this.AssignInParallel(sourcesToTargets, convert, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        public Variable ToVariable(Expression exp)
+        {
+            return this.expManager.Decoder.UnderlyingVariable(exp);
+        }
+
+        #endregion
+
+        #region Particular cases for IAbstractDomain
+
+        override public WeakUpperBounds<Variable, Expression> Join(WeakUpperBounds<Variable, Expression> right)
+        {
+            // Here we do not have trivial joins as we want to join maps of different cardinality
+            if (this.IsBottom)
+                return right;
+            if (right.IsBottom)
+                return this;
+
+            var result = Factory();
+
+            foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
+            {
+                SetOfConstraints<Variable> right_x;
+                if (right.TryGetValue(pair.Key, out right_x))
+                {
+                    Contract.Assume(pair.Value != null);
+
+                    var intersection = pair.Value.Join(right_x);
+
+                    if (intersection.IsNormal())
+                    {
+                        // We keep in the map only the elements that are != top and != bottom
+
+                        result[pair.Key] = intersection;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public WeakUpperBounds<Variable, Expression> Join(WeakUpperBounds<Variable, Expression> right,
+          IIntervalAbstraction<Variable, Expression> intervalsForThis, IIntervalAbstraction<Variable, Expression> intervalsForRight)
+        {
+            Contract.Requires(right != null);
+            Contract.Requires(intervalsForThis != null);
+            Contract.Requires(intervalsForRight != null);
+
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            // Here we do not have trivial joins as we want to join maps of different cardinality
+            if (this.IsBottom)
+                return right;
+            if (right.IsBottom)
+                return this;
+
+            var result = this.Factory();
+
+            foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
+            {
+                var newValues = new Set<Variable>();
+
+                SetOfConstraints<Variable> otherBounds;
+                if (right.TryGetValue(pair.Key, out otherBounds))
+                {
+                    Contract.Assume(pair.Value != null);
+
+                    var intersection = pair.Value.Join(otherBounds);
+                    if (!intersection.IsTop)
+                    {
+                        newValues.AddRange(intersection.Values);
+                    }
+
+                    // Foreach x < y
+                    if (otherBounds.IsNormal())
+                    {
+                        foreach (var y in otherBounds.Values)
+                        {
+                            if (newValues.Contains(y))
+                            {
+                                continue;
+                            }
+
+                            var res = intervalsForThis.CheckIfLessThan(pair.Key, y);
+
+                            if (!res.IsNormal())
+                            {
+                                continue;
+                            }
+
+                            if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+                            {
+                                newValues.Add(y);   // Add x < y
+                            }
+                        }
+                    }
+                }
+
+                // Foreach x < y
+                if (pair.Value.IsNormal())
+                {
+                    foreach (var y in pair.Value.Values)
+                    {
+                        if (newValues.Contains(y))
+                        {
+                            continue;
+                        }
+
+                        var res = intervalsForRight.CheckIfLessThan(pair.Key, y);
+
+                        if (!res.IsNormal())
+                        {
+                            continue;
+                        }
+
+                        if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+                        {
+                            newValues.Add(y);   // Add x < y everywhere
+                            right.TestTrueLessThan(pair.Key, y);
+                        }
+                    }
+                }
+                if (!newValues.IsEmpty)
+                {
+                    result[pair.Key] = new SetOfConstraints<Variable>(newValues, false);
+                }
+            }
+
+            foreach (var pair in right.Elements)
+            {
+                if (this.ContainsKey(pair.Key))
+                {
+                    // Case already handled
+                    continue;
+                }
+
+                var newValues = new Set<Variable>();
+
+                // Foreach x < y
+                if (pair.Value.IsNormal())
+                {
+                    foreach (var y in pair.Value.Values)
+                    {
+                        var res = intervalsForThis.CheckIfLessThan(pair.Key, y);
+
+                        if (!res.IsNormal())
+                        {
+                            continue;
+                        }
+
+                        if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+                        {
+                            newValues.Add(y);   // Add x < y
+                            this.TestTrueLessThan(pair.Key, y);
+                        }
+                    }
+
+                    if (!newValues.IsEmpty)
+                    {
+                        result[pair.Key] = new SetOfConstraints<Variable>(newValues, false);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignmentsWithForward<Expression> Members
+
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            if (this.ContainsKey(x))
+                this.RemoveVariable(x);
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        public List<Variable> Variables
+        {
+            get
+            {
+                var result = new List<Variable>();
+                var uppBounds = new Set<Variable>();
+
+                foreach (var x in this.Elements)
+                {
+                    Contract.Assume(x.Value != null);
+
+                    result.Add(x.Key);
+                    if (!x.Value.IsTop)
+                    {
+                        uppBounds.AddRange(x.Value.Values);
+                    }
+                }
+
+                result.AddRange(uppBounds);
+
+                return result;
+            }
+        }
+
+        public IEnumerable<Variable> SlackVariables
+        {
+            get
+            {
+                var decoder = this.expManager.Decoder;
+
+                var seen = new Set<Variable>();
+
+                foreach (var x_pair in this.Elements)
+                {
+                    if (decoder.IsSlackVariable(x_pair.Key))
+                    {
+                        seen.Add(x_pair.Key);
+                        yield return x_pair.Key;
+                    }
+
+                    if (!x_pair.Value.IsTop)
+                    {
+                        foreach (var y in x_pair.Value.Values)
+                        {
+                            if (decoder.IsSlackVariable(y) && !seen.Contains(y))
+                            {
+                                seen.Add(y);
+                                yield return y;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            // Does nothing, as we assume variables initialized to top
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            this.RemoveElement(var);
+
+            var toUpdate = new List<Pair<Variable, SetOfConstraints<Variable>>>();
+
+            foreach (var pair in this.Elements)
+            {
+                if (pair.Value.IsNormal() && pair.Value.Contains(var))
+                {
+                    var s = new Set<Variable>(pair.Value.Values);
+                    s.Remove(var);
+                    toUpdate.Add(pair.Key, new SetOfConstraints<Variable>(s, false));
+                }
+            }
+
+            foreach (var pair in toUpdate)
+            {
+                this[pair.One] = pair.Two;
+            }
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            this.ProjectVariable(var);
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+
+                if (!pair.Value.IsTop)
+                {
+                    var oldVal = pair.Value;
+                    if (oldVal.Contains(OldName))
+                    {
+                        var newVal = new Set<Variable>(oldVal.Values);
+                        newVal.Remove(OldName);
+                        newVal.Add(NewName);
+                        this[pair.Key] = new SetOfConstraints<Variable>(newVal, false);
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            return this.TestTrue(guard);
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestTrue(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            return ProcessTestTrue(guard);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            return this.TestFalse(guard);
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestFalse(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            var encoder = this.expManager.Encoder;
+            //      if (encoder != null)
+            {
+                var notGuard = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Not, guard);
+                return TestTrue(notGuard);
+            }
+            /*    else
+                {
+                  return ProcessTestFalse(guard);
+                }
+             */
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return this.RemoveRedundanciesWith(oracle);
+        }
+
+        public WeakUpperBounds<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            Contract.Requires(oracle != null);
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            var result = this.DuplicateMe();
+            //      if (this.expManager.Encoder != null)
+            {
+                foreach (var pair in this.Elements)
+                {
+                    if (!pair.Value.IsNormal())
+                    {
+                        result[pair.Key] = pair.Value;
+                    }
+                    else
+                    {
+                        var newExp = new List<Variable>();
+                        foreach (var exp in pair.Value.Values)
+                        {
+                            // x <= exp
+                            var lt = oracle.CheckIfLessThan(pair.Key, exp);
+
+                            if (!lt.IsNormal() || !lt.BoxedElement)
+                            { // Then it is not implied by oracle
+                                newExp.Add(exp);
+                            }
+                        }
+                        if (newExp.Count > 0)
+                        {
+                            result[pair.Key] = new SetOfConstraints<Variable>(newExp);
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region WeakUpperBounds-Specific Methods
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            return this;
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessThan(exp1, exp2);
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            return this.TestTrueLessThan(exp1, exp2, new WeakUpperBoundsEqual<Variable, Expression>(this.expManager));
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestTrueLessThan(Variable v1, Variable v2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            SetOfConstraints<Variable> upp;
+            if (this.TryGetValue(v1, out upp) && upp.IsNormal())
+            {
+                var newElements = new Set<Variable>(upp.Values);
+                newElements.Add(v2);
+                upp = new SetOfConstraints<Variable>(newElements, false);
+                newElements = null; // F: just want to make sure that we do not reuse it, as we passed the ownership
+            }
+            else
+            {
+                upp = new SetOfConstraints<Variable>(v2);
+            }
+
+            this[v1] = upp;
+
+            return this;
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestTrueLessThan(Expression e1, Expression e2,
+          WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(oracleDomain != null);
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            var decoder = this.expManager.Decoder;
+
+            var e1Var = decoder.UnderlyingVariable(e1);
+            var e2Var = decoder.UnderlyingVariable(e2);
+            var e2Stripped = decoder.Stripped(e2);
+            var e2StrippedVar = decoder.UnderlyingVariable(e2Stripped);
+
+            if (decoder.IsVariable(e1))
+            {      // If e1 is a variable, then we add transitively all the constraints of e2
+                AddAssumptionsTestTrueLessThanVariable(e1Var, e2, e2Var, e2StrippedVar, oracleDomain);
+            }
+            else
+            {
+                AddAssumptionsTestTrueLessThanNonVariableCase(e1, e2, e1Var, e2Var, e2StrippedVar);
+            }
+
+            if (this[e1Var].IsNormal())
+            {
+                var toBeUpdated = new List<Pair<Variable, SetOfConstraints<Variable>>>();
+
+                // "e1 < e2", so we search all the variables to see if "e0 < e1"
+                foreach (var pair in this.Elements)
+                {
+                    if (pair.Value.IsNormal())
+                    {
+                        if (pair.Value.Contains(e1Var))
+                        {
+                            var values = new Set<Variable>(pair.Value.Values);
+                            values.AddRange(this[e1Var].Values);
+
+                            toBeUpdated.Add(pair.Key, new SetOfConstraints<Variable>(values, false));
+                        }
+                    }
+                }
+
+                if (toBeUpdated.Count > 0)
+                {
+                    foreach (var pair in toBeUpdated)
+                    {
+                        this[pair.One] = pair.Two;
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// We add the assumptions e1Var \lt e2Var, e2StripperVar
+        /// </summary>
+        private void AddAssumptionsTestTrueLessThanVariable(
+          Variable e1Var, Expression e2, Variable e2Var, Variable e2StrippedVar,
+          WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(oracleDomain != null);
+
+            var newValues = new Set<Variable>();
+
+            newValues.Add(e2Var);  // e1 < e2 
+            newValues.Add(e2StrippedVar);   // Add "e1 < e2'", if e2 was in the form "(int32) e2'" or similar 
+
+            SetOfConstraints<Variable> this_e1;
+            if (this.TryGetValue(e1Var, out this_e1) && !this_e1.IsTop)
+            {                   // e1 < "all the values before"
+                newValues.AddRange(this_e1.Values);
+            }
+
+            SetOfConstraints<Variable> this_e2;
+            if (this.TryGetValue(e2Var, out this_e2) && !this_e2.IsTop)
+            {                   // e1 < "all the values e2 is smaller than"
+                newValues.AddRange(this_e2.Values);
+            }
+
+            SetOfConstraints<Variable> oracleDomain_e2;
+            if (oracleDomain.TryGetValue(e2Var, out oracleDomain_e2) && !oracleDomain_e2.IsTop)
+            {                   // e1 < "all the values e2 is smaller than or equal to"
+                newValues.AddRange(oracleDomain_e2.Values);
+            }
+
+            var decoder = this.expManager.Decoder;
+            // e1 < x - y
+            if (decoder.IsBinaryExpression(e2) && decoder.OperatorFor(e2) == ExpressionOperator.Subtraction)
+            {
+                var left = decoder.LeftExpressionFor(e2);
+                var right = decoder.RightExpressionFor(e2);
+
+                int v;
+                if (decoder.IsConstantInt(right, out v) && v > 0)
+                {
+                    newValues.Add(decoder.UnderlyingVariable(left));
+                    newValues.Add(decoder.UnderlyingVariable(decoder.Stripped(left)));
+                }
+            }
+
+            this[e1Var] = new SetOfConstraints<Variable>(newValues, false);
+        }
+
+        /// <summary>
+        /// e1 is not a variable, We try to construct a polynomial out of it and then infer new relations in the form x lt y
+        /// </summary>
+        private void AddAssumptionsTestTrueLessThanNonVariableCase(Expression e1, Expression e2, Variable e1Var, Variable e2Var, Variable e2StrippedVar)
+        {
+            Contract.Requires(!this.expManager.Decoder.IsVariable(e1));
+
+            // e1Var < e2Var and e2StrippedVar
+            if (!this.ContainsKey(e1Var))
+            {
+                var tmp = new Set<Variable>() { e2Var, e2StrippedVar };
+
+                this[e1Var] = new SetOfConstraints<Variable>(tmp, false);
+            }
+
+            // Infer constraints from a more concrete form (polynomial)
+            Polynomial<Variable, Expression> e1LTe2;
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1, e2, this.expManager.Decoder, out e1LTe2))
+            {
+                Rational k1, k2, k;
+                Variable x1, x2;
+
+                if (e1LTe2.TryMatch_k1XPlusk2YLessThanK(out k1, out x1, out k2, out x2, out k))
+                {
+                    if (k <= 0)
+                    {
+                        if (k1 == 1 && k2 == -1)   // x1 - x2 < k <= 0 => x1 < x2
+                        {
+                            this.UpdateConstraintsFor(x1, x2);
+                        }
+                        else if (k1 == -1 && k2 == 1) // -x1 + x2 < k <= 0 => x2 < x1
+                        {
+                            this.UpdateConstraintsFor(x2, x1);
+                        }
+                    }
+                }
+            }
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueLessEqualThan(exp1, exp2);
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestTrueLessEqualThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            Polynomial<Variable, Expression> p1, p2;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, this.expManager.Decoder, out p1)
+              && Polynomial<Variable, Expression>.TryToPolynomialForm(e2, this.expManager.Decoder, out p2))
+            {
+                Variable x, y;
+                Rational k;
+
+                var decoder = this.expManager.Decoder;
+
+                // Consider the case "e1 <= y - k"
+                if (p2.TryMatch_YMinusK(out y, out k))
+                {
+                    // Assume e1 < y
+                    var e1Var = decoder.UnderlyingVariable(e1);
+                    var result = this.HelperForLessThan(e1Var, y);
+
+                    var e1StrippedVar = decoder.UnderlyingVariable(decoder.Stripped(e1));
+                    result = this.HelperForLessThan(e1StrippedVar, y);
+
+                    return result;
+                }
+                // Consider the case "x + k <= e2"
+                if (p1.TryMatch_YPlusK(out x, out k))
+                {
+                    if (k > 0)
+                    {
+                        var e2Var = decoder.UnderlyingVariable(e2);
+
+                        return this.HelperForLessThan(x, e2Var);
+                    }
+                }
+
+                // Consider the case "e1 <= y"
+                if (p2.TryMatch_Y(out y))
+                {
+                    SetOfConstraints<Variable> value;
+                    // If we know that "y < z", then also "e1 < z"
+                    if (this.TryGetValue(y, out value) && value.IsNormal())
+                    {
+                        var e1Var = decoder.UnderlyingVariable(e1);
+                        this[e1Var] = value;
+
+                        return this;
+                    }
+                }
+
+                Rational k1, k2;
+                Variable x1, x2;
+                Polynomial<Variable, Expression> combined;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, p1, p2, out combined) && combined.TryMatch_k1XPlusk2YLessThanK(out k1, out x1, out k2, out x2, out k))
+                { // k1 x1 + k2 x2 < k
+                    if (k1 < 0 && k2 > 0)
+                    {
+                        var tmp = k1;
+                        k1 = k2;
+                        k2 = tmp;
+
+                        var tmpExp = x1;
+                        x1 = x2;
+                        x2 = tmpExp;
+                    }
+
+                    if (k1 == 1 && k2 == -1 && k <= 0)
+                    {
+                        // "x1 - x2 < k <= 0" that is "x1 < x2" 
+                        return this.HelperForLessThan(x1, x2);
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueEqual(exp1, exp2);
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestTrueEqual(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            Polynomial<Variable, Expression> p1, p2;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, this.expManager.Decoder, out p1)
+              && Polynomial<Variable, Expression>.TryToPolynomialForm(e2, this.expManager.Decoder, out p2))
+            {
+                // match p1 with " x + 1 ", and p2 with " y "
+                if (p1.IsLinearOctagon && p2.IsLinearOctagon)
+                {
+                    if (p1.Left.Length == 1 && p2.Left.Length == 2)
+                    {
+                        var tmp = p1; p1 = p2; p2 = tmp;
+                    }
+
+                    // Here we want p1.Left.Count == 2. If this is not the case, we just drop this info
+                    if (p1.Left.Length == 2 && p1.Left[0].Degree == 1 && p1.Left[1].IsConstant
+                      && p2.Left.Length == 1 && p2.Left[0].Degree == 1)
+                    {
+                        var x = p1.Left[0].VariableAt(0);
+                        var k = p1.Left[1].K;
+                        var y = p2.Left[0].VariableAt(0);
+
+                        if (k > 0)
+                        { // Then we know that " x + k = y, k > 0 " implies " x < y "  
+                            return this.HelperForLessThan(x, y);
+                        }
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        #endregion
+
+        #region Protected methods
+
+        private bool Check(Variable x1, Variable x2)
+        {
+            SetOfConstraints<Variable> value;
+
+            if (this.TryGetValue(x1, out value))
+            {
+                if (value.IsBottom)
+                {
+                    return true;
+                }
+                else if (!value.IsTop)
+                {
+                    return value.Contains(x2);
+                }
+            }
+
+            return false;
+        }
+
+        virtual protected WeakUpperBounds<Variable, Expression> ProcessTestTrue(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            var decoder = this.expManager.Decoder;
+
+            switch (decoder.OperatorFor(guard))
+            {
+                #region all the cases
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    {
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        var leftVar = decoder.UnderlyingVariable(left);
+                        var rightVar = decoder.UnderlyingVariable(right);
+
+                        SetOfConstraints<Variable> v1, v2;
+                        var b1 = this.TryGetValue(leftVar, out v1);
+                        var b2 = this.TryGetValue(rightVar, out v2);
+                        if (b1 && b2)
+                        {
+                            var intersection = v1.Meet(v2);
+                            if (v1.IsBottom)
+                            {
+                                return this.Bottom;
+                            }
+                            else
+                            {
+                                this[leftVar] = intersection;
+                                this[rightVar] = intersection;
+
+                                return this;
+                            }
+                        }
+                        else if (b1 && v1.IsNormal())
+                        {
+                            this[rightVar] = v1;
+
+                            return this;
+                        }
+                        else if (b2 && v2.IsNormal())
+                        {
+                            this[leftVar] = v2;
+
+                            return this;
+                        }
+                        else
+                        {
+                            // Try to figure out if it is in the form of (e11 rel e12) == 0
+                            Expression e11, e12;
+                            ExpressionOperator op;
+                            if (decoder.Match_E1relopE2eq0(left, right, out op, out e11, out e12))
+                            {
+                                return ProcessTestFalse(left);
+                            }
+                        }
+
+                        return this;
+                    }
+
+                case ExpressionOperator.GreaterEqualThan:
+                    // Does nothing ...
+                    return this;
+
+                case ExpressionOperator.GreaterThan:
+                    {
+                        // "left > right", so we add the constraint
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return this.TestTrueLessThan(right, left);
+                    }
+
+                case ExpressionOperator.LessEqualThan:
+                    {
+                        // "left <= right"
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return this.TestTrueLessEqualThan(left, right);
+                    }
+
+                case ExpressionOperator.LessThan:
+                    // "left < right"
+                    {
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+
+                        return this.TestTrueLessThan(left, right);
+                    }
+
+                // We abstract away the symbolic reasoning for unsigned as it may be incorrect
+                // Example "sv1 CLT_Un sv2" and sv2 is -1, so it should be understood as sv1 CLT_Un UInt.MaxValue - this reasoning is done by intervals
+                case ExpressionOperator.LessThan_Un:
+                case ExpressionOperator.LessEqualThan_Un:
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    {
+                        return this;
+                    }
+
+                case ExpressionOperator.LogicalAnd:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
+                        rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
+
+                        return leftDomain.Meet(rightDomain);
+                    }
+
+                case ExpressionOperator.LogicalOr:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
+                        rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
+
+                        return leftDomain.Join(rightDomain);
+                    }
+
+                case ExpressionOperator.Not:
+                    {
+                        return this.ProcessTestFalse(this.expManager.Decoder.LeftExpressionFor(guard));
+                    }
+
+                case ExpressionOperator.Addition:
+                case ExpressionOperator.Constant:
+                case ExpressionOperator.ConvertToInt32:
+                case ExpressionOperator.ConvertToUInt8:
+                case ExpressionOperator.ConvertToUInt16:
+                case ExpressionOperator.ConvertToUInt32:
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToFloat64:
+                case ExpressionOperator.Division:
+                case ExpressionOperator.And:
+                case ExpressionOperator.Or:
+                case ExpressionOperator.Modulus:
+                case ExpressionOperator.ShiftLeft:
+                case ExpressionOperator.ShiftRight:
+                case ExpressionOperator.SizeOf:
+                case ExpressionOperator.Multiplication:
+                case ExpressionOperator.NotEqual:
+                case ExpressionOperator.Subtraction:
+                case ExpressionOperator.UnaryMinus:
+                case ExpressionOperator.Xor:
+                case ExpressionOperator.Unknown:
+                case ExpressionOperator.Variable:
+                    return this;
+
+                default:
+                    return this;
+                    #endregion
+            }
+        }
+
+        virtual protected WeakUpperBounds<Variable, Expression> ProcessTestFalse(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            var decoder = this.expManager.Decoder;
+
+            switch (decoder.OperatorFor(guard))
+            {
+                #region all the cases
+
+                case ExpressionOperator.LogicalAnd:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard));
+                        rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard));
+
+                        return leftDomain.Join(rightDomain);
+                    }
+
+                case ExpressionOperator.And:
+                case ExpressionOperator.Addition:
+                case ExpressionOperator.Constant:
+                case ExpressionOperator.ConvertToInt32:
+                case ExpressionOperator.ConvertToUInt8:
+                case ExpressionOperator.ConvertToUInt16:
+                case ExpressionOperator.ConvertToUInt32:
+                case ExpressionOperator.ConvertToFloat32:
+                case ExpressionOperator.ConvertToFloat64:
+                case ExpressionOperator.Division:
+                case ExpressionOperator.Modulus:
+                case ExpressionOperator.Multiplication:
+                case ExpressionOperator.NotEqual:
+                case ExpressionOperator.Or:
+                case ExpressionOperator.ShiftLeft:
+                case ExpressionOperator.ShiftRight:
+                case ExpressionOperator.SizeOf:
+                case ExpressionOperator.Subtraction:
+                case ExpressionOperator.UnaryMinus:
+                case ExpressionOperator.Unknown:
+                case ExpressionOperator.Xor:
+                case ExpressionOperator.Variable:
+                    return this;
+
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    return TestTrueNotEqual(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard));
+
+                case ExpressionOperator.GreaterEqualThan:
+                    {
+                        // !(left >= right) is equivalent to (left < right)
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+
+                        return this.TestTrueLessThan(left, right);
+                    }
+
+                case ExpressionOperator.GreaterThan:
+                    {
+                        // !(left > right) is equivalent to left <= right
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+
+                        return this.TestTrueLessEqualThan(left, right);
+                    }
+
+                case ExpressionOperator.LessEqualThan:
+                    {
+                        // !(left <= right) is equivalent to (left > right)
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+
+                        return this.TestTrueLessThan(right, left);
+                    }
+
+                case ExpressionOperator.LessThan:
+                    {
+                        // !(left < right) is (left >= right) which is (right <= left)
+                        var left = this.expManager.Decoder.LeftExpressionFor(guard);
+                        var right = this.expManager.Decoder.RightExpressionFor(guard);
+
+                        return this.TestTrueLessEqualThan(right, left);
+                    }
+
+                // We abstract away the symbolic reasoning for unsigned as it may be incorrect
+                // Example "sv1 CLT_Un sv2" and sv2 is -1, so it should be understood as sv1 CLT_Un UInt.MaxValue - this reasoning is done by intervals
+                case ExpressionOperator.LessThan_Un:
+                case ExpressionOperator.LessEqualThan_Un:
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    {
+                        return this;
+                    }
+
+                case ExpressionOperator.LogicalOr:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard));
+                        rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard));
+
+                        return leftDomain.Meet(rightDomain);
+                    }
+
+                case ExpressionOperator.Not:
+                    {
+                        return this.ProcessTestTrue(decoder.LeftExpressionFor(guard));
+                    }
+                default:
+                    return this;
+                    #endregion
+            }
+        }
+
+        private WeakUpperBounds<Variable, Expression> HelperForLessThan(Variable v1, Variable v2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            return this.HelperForLessThan(v1, v2, new WeakUpperBoundsEqual<Variable, Expression>(this.expManager));
+        }
+
+        private WeakUpperBounds<Variable, Expression> HelperForLessThan(Variable v1, Variable v2, WeakUpperBoundsEqual<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(oracleDomain != null);
+            Contract.Ensures(Contract.Result<WeakUpperBounds<Variable, Expression>>() != null);
+
+            var newValues = new Set<Variable>();
+
+            newValues.Add(v2);  // v1 < v2 
+
+            SetOfConstraints<Variable> this_e1;
+            if (this.TryGetValue(v1, out this_e1) && !this_e1.IsTop)
+            {                   // e1 < "all the values before"
+                newValues.AddRange(this_e1.Values);
+            }
+
+            SetOfConstraints<Variable> this_e2;
+            if (this.TryGetValue(v2, out this_e2) && !this_e2.IsTop)
+            {                   // e1 < "all the values e2 is smaller than"
+                newValues.AddRange(this_e2.Values);
+            }
+
+            SetOfConstraints<Variable> oracleDomain_e2;
+            if (oracleDomain.TryGetValue(v2, out oracleDomain_e2) && !oracleDomain_e2.IsTop)
+            {                   // e1 < "all the values e2 is smaller than or equal to"
+                newValues.AddRange(oracleDomain_e2.Values);
+            }
+
+            var newConstraintsForV1 = new SetOfConstraints<Variable>(newValues, false);
+            this[v1] = newConstraintsForV1;
+
+            if (newConstraintsForV1.IsNormal())
+            {
+                var toBeUpdated = new List<Pair<Variable, SetOfConstraints<Variable>>>();
+
+                // "e1 < e2", so we search all the variables to see if "e0 < e1"
+                foreach (var pair in this.Elements)
+                {
+                    if (pair.Value.IsNormal())
+                    {
+                        if (pair.Value.Contains(v1))
+                        {
+                            var values = new Set<Variable>(pair.Value.Values);
+                            values.AddRange(newConstraintsForV1.Values);
+
+                            toBeUpdated.Add(pair.Key, new SetOfConstraints<Variable>(values, false));
+                        }
+                    }
+                }
+
+                if (toBeUpdated.Count > 0)
+                {
+                    foreach (var pair in toBeUpdated)
+                    {
+                        this[pair.One] = pair.Two;
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        public WeakUpperBounds<Variable, Expression> TestTrueNotEqual(Expression e1, Expression e2)
+        {
+            // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant 
+            if (this.expManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.expManager.Decoder.IsConstant(e2))
+            {
+                int v;
+
+                if (this.expManager.Decoder.IsConstantInt(e2, out v))
+                {
+                    if (v == 0)
+                    { // that is !!(e1)
+                        return this.TestTrue(e1);
+                    }
+                    else if (v == 1)
+                    { // that is !e1
+                        return this.TestFalse(e1);
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        #endregion
+
+        #region Private and Protected methods
+
+        /// <summary>
+        /// Add the constraint <code>x &lt; y ></code>to this environment.
+        /// If <code>x</code> already has some constraints related to him, we make the union of constraints (but we do not propagate)
+        /// </summary>
+        private void UpdateConstraintsFor(Variable x, Variable y)
+        {
+            var newValues = new Set<Variable>();
+
+            SetOfConstraints<Variable> this_x;
+            if (this.TryGetValue(x, out this_x) && !this_x.IsTop)
+            {
+                newValues.AddRange(this_x.Values);
+            }
+            newValues.Add(y);
+
+            this[x] = new SetOfConstraints<Variable>(newValues, false);  // Do the update
+        }
+
+        #endregion
+
+        #region ToString
+        protected override string ToLogicalFormula(Variable d, SetOfConstraints<Variable> c)
+        {
+            if (!c.IsNormal())
+            {
+                return null;
+            }
+
+            var result = new List<string>();
+
+            var niceD = ExpressionPrinter.ToString(d, this.expManager.Decoder);
+            foreach (var y in c.Values)
+            {
+                string niceY = ExpressionPrinter.ToString(y, this.expManager.Decoder);
+                result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessThan, niceD, niceY));
+            }
+
+            return ExpressionPrinter.ToLogicalFormula(ExpressionOperator.LogicalAnd, result);
+        }
+
+        [ContractVerification(false)]
+        protected override T To<T>(Variable d, SetOfConstraints<Variable> c, IFactory<T> factory)
+        {
+            if (c.IsTop)
+                return factory.Constant(true);
+            if (c.IsBottom)
+                return factory.Constant(false);
+
+            var result = factory.IdentityForAnd;
+            var x = factory.Variable(d);
+
+            // We know the constraints are x < y
+            foreach (var y in c.Values)
+            {
+                T atom = factory.LessThan(x, factory.Variable(y));
+                result = factory.And(result, atom);
+            }
+
+            return result;
+        }
+
+        public override string ToString()
+        {
+            if (this.IsTop)
+                return "Top";
+
+            if (this.IsBottom)
+                return "Bottom";
+
+            var result = new StringBuilder();
+            result.AppendLine("WUB:");
+            foreach (var x_pair in this.Elements)
+            {
+                Contract.Assume(x_pair.Value != null);
+
+                if (!x_pair.Value.IsTop)
+                {
+                    var niceX = ExpressionPrinter.ToString(x_pair.Key, this.expManager.Decoder);
+                    var niceVal = ToString(x_pair.Value.Values, x_pair.Value.Count);
+                    result.AppendLine(niceX + " < " + niceVal + " ");
+                }
+            }
+
+            return result.ToString();
+        }
+
+        private string ToString(IEnumerable<Variable> set, int count)
+        {
+            Contract.Requires(set != null);
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            var result = new StringBuilder();
+            result.Append("{");
+            int c = 0;
+
+            foreach (var x in set)
+            {
+                var xAsString = ExpressionPrinter.ToString(x, this.expManager.Decoder);
+
+                result.Append(xAsString);
+
+                if (c < count - 1)
+                {
+                    result.Append(" ,  ");
+                }
+
+                c++;
+            }
+
+            result.Append("}");
+
+            return result.ToString();
+        }
+
+        public string ToString(Expression exp)
+        {
+            //if (this.expManager.Decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
+            }
+            //      else
+            //     {
+            //      return "< missing expression decoder >";
+            //     }
+        }
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
+
+        private class VisitorForCheckLessEqualThan
+          : TryVisitAtMostTwoMonomials<Variable, Expression, WeakUpperBounds<Variable, Expression>, FlatAbstractDomain<bool>>
+        {
+            private WeakUpperBounds<Variable, Expression> leq;
+
+            public VisitorForCheckLessEqualThan()
+            {
+                leq = null;
+            }
+
+            sealed public override bool Visit(Polynomial<Variable, Expression> exp, WeakUpperBounds<Variable, Expression> input, ref FlatAbstractDomain<bool> result)
+            {
+                Contract.Ensures(result != null);
+
+                leq = input;
+                result = CheckOutcome.Top;
+
+                if (leq.IsTop)
+                {
+                    return false;
+                }
+
+                bool success = this.Dispatch(exp, ref result);
+
+                leq = null;
+
+                // F: this seems a bug: the postcondition for Dispatch is not taken into account here, and we can prove it
+                // However, the postcondition result != null is not proven!
+                Contract.Assert(result != null);
+
+                return success;
+            }
+
+            protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref FlatAbstractDomain<bool> result)
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+
+            protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref FlatAbstractDomain<bool> result)
+            {
+                if (leq == null)
+                {
+                    return false;
+                }
+                if (k.IsZero)
+                {
+                    result = leq.CheckIfLessThan(x, y);
+                    return true;
+                }
+                else if (k == -1)
+                {
+                    result = leq.CheckIfLessThan(x, y);
+                    return true;
+                }
+                else
+                {
+                    result = CheckOutcome.Top;
+                    return false;
+                }
+            }
+
+            protected override bool VisitXYLessEqualThanK(Variable x, Variable y, Rational k, ref FlatAbstractDomain<bool> result)
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+
+            protected override bool VisitXLessEqualThan(Rational a, Variable x, Rational k, ref FlatAbstractDomain<bool> result)
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+
+            protected override bool VisitMinusXLessEqualThan(Rational a, Variable x, Rational k, ref FlatAbstractDomain<bool> result)
+            {
+                result = CheckOutcome.Top;
+                return false;
+            }
+        }
+
+        private class WUBCheckIfHoldsVisitor
+          : CheckIfHoldsVisitor<WeakUpperBounds<Variable, Expression>, Variable, Expression>
+        {
+            public WUBCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                var resultLeft = Domain.CheckIfLessEqualThan(left, right);
+
+                if (resultLeft.IsNormal())
+                {
+                    var resultRight = Domain.CheckIfLessEqualThan(right, left);
+
+                    if (resultRight.IsNormal())
+                    {
+                        return resultLeft.Join(resultRight);
+                    }
+
+                    return resultRight;
+                }
+
+                return resultLeft;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return VisitEqual(left, right, original, data);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessEqualThan(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessThan(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                var check1 = this.VisitLessThan(left, right, original, data);
+                if (check1.IsNormal())
+                {
+                    return new FlatAbstractDomain<bool>(true);
+                }
+
+                var check2 = this.VisitLessThan(right, left, original, data);
+                if (check2.IsNormal())
+                {
+                    return new FlatAbstractDomain<bool>(true);
+                }
+
+                return Default(data);
+            }
+        }
     }
 
+    [ContractClass(typeof(TryVisitAtMostTwoMonomialsContracts<,,,>))]
+    internal abstract class TryVisitAtMostTwoMonomials<Variable, Expression, In, Data>
+    {
+        /// <summary>
+        /// We want it to be used by the subclasses, but not called from clients
+        /// </summary>
+        protected bool Dispatch(Polynomial<Variable, Expression> exp, ref Data result)
+        {
+            Contract.Ensures(result != null);
+
+            Variable x, y;
+            Rational a, b, k;
+
+            if (exp.TryMatch_k1XLessEqualThank2(out a, out x, out k))
+            { // a * x <= k
+                if (a < 0)
+                {
+                    return this.VisitMinusXLessEqualThan(a, x, k, ref result);
+                }
+                else if (a > 0)
+                {
+                    return this.VisitXLessEqualThan(a, x, k, ref result);
+                }
+                else // a == 0
+                {
+                    return Default(ref result);
+                }
+            }
+            else if (exp.TryMatch_k1XLessThank2(out a, out x, out k))
+            { // "a * x < k " == "a * x  <= k-1"
+                if (a < 0)
+                {
+                    return this.VisitMinusXLessEqualThan(a, x, k - 1, ref result);
+                }
+                else if (a > 0)
+                {
+                    return this.VisitXLessEqualThan(a, x, k - 1, ref result);
+                }
+                else
+                {
+                    return Default(ref result);
+                }
+            }
+            else if (exp.TryMatch_k1XPlusk2YLessEqualThanK(out a, out x, out b, out y, out k))
+            { // "a * x + b * y <= k" 
+                if (a == 1 && b == 1)
+                {
+                    return VisitXYLessEqualThanK(x, y, k, ref result);
+                }
+                else if (a == 1 && b == -1)
+                {
+                    return this.VisitXMinusYLessEqualThan(x, y, k, ref result);
+                }
+                else if (a == -1 && b == 1)
+                {
+                    return this.VisitXMinusYLessEqualThan(y, x, k, ref result);
+                }
+                else if (a == -1 && b == -1)
+                {
+                    return this.VisitMinusXMinusYLessEqualThan(x, y, k, ref result);
+                }
+                else
+                {
+                    // Todo: Do we want a visitor for other cases here?
+                    return Default(ref result);
+                }
+            }
+            else if (exp.TryMatch_k1XPlusk2YLessThanK(out a, out x, out b, out y, out k))
+            { // "a * x + b * y < k" is "a * x + b * y <=  k-1"
+                if (a == 1 && b == 1)
+                {
+                    return this.VisitXYLessEqualThanK(x, y, k - 1, ref result);
+                }
+                else if (a == 1 && b == -1)
+                {
+                    return this.VisitXMinusYLessEqualThan(x, y, k - 1, ref result);
+                }
+                else if (a == -1 && b == 1)
+                {
+                    return this.VisitXMinusYLessEqualThan(y, x, k - 1, ref result);
+                }
+                else if (a == -1 && b == -1)
+                {
+                    return this.VisitMinusXMinusYLessEqualThan(x, y, k - 1, ref result);
+                }
+                else
+                {
+                    // Todo: Do we want a visitor for other cases here?
+                    return Default(ref result);
+                }
+            }
+            else
+            {
+                return Default(ref result);
+            }
+        }
+
+        abstract public bool Visit(Polynomial<Variable, Expression> exp, In input, ref Data result);
+
+        abstract protected bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result);
+
+        abstract protected bool VisitXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result);
+
+        abstract protected bool VisitXYLessEqualThanK(Variable x, Variable y, Rational k, ref Data result);
+
+        abstract protected bool VisitXLessEqualThan(Rational a, Variable x, Rational k, ref Data result);
+
+        abstract protected bool VisitMinusXLessEqualThan(Rational a, Variable x, Rational k, ref Data result);
+
+        private bool Default(ref Data result)
+        {
+            return false;
+        }
+    }
+
+    #region Contracts
+    [ContractClassFor(typeof(TryVisitAtMostTwoMonomials<,,,>))]
+    internal abstract class TryVisitAtMostTwoMonomialsContracts<Variable, Expression, In, Data> : TryVisitAtMostTwoMonomials<Variable, Expression, In, Data>
+    {
+        public override bool Visit(Polynomial<Variable, Expression> exp, In input, ref Data result)
+        {
+            Contract.Requires(input != null);
+            Contract.Ensures(result != null);
+
+            throw new NotImplementedException();
+        }
+
+        protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result)
+        {
+            Contract.Requires(!object.Equals(k, null));
+
+            throw new NotImplementedException();
+        }
+
+        protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result)
+        {
+            Contract.Requires(!object.Equals(k, null));
+
+            throw new NotImplementedException();
+        }
+
+        protected override bool VisitXYLessEqualThanK(Variable x, Variable y, Rational k, ref Data result)
+        {
+            Contract.Requires(!object.Equals(k, null));
+
+            throw new NotImplementedException();
+        }
+
+        protected override bool VisitXLessEqualThan(Rational a, Variable x, Rational k, ref Data result)
+        {
+            Contract.Requires(!object.Equals(k, null));
+
+            throw new NotImplementedException();
+        }
+
+        protected override bool VisitMinusXLessEqualThan(Rational a, Variable x, Rational k, ref Data result)
+        {
+            Contract.Requires(!object.Equals(k, null));
+
+            throw new NotImplementedException();
+        }
+    }
     #endregion
-
-    #region Private and Protected methods
-
-    /// <summary>
-    /// Add the constraint <code>x &lt; y ></code>to this environment.
-    /// If <code>x</code> already has some constraints related to him, we make the union of constraints (but we do not propagate)
-    /// </summary>
-    private void UpdateConstraintsFor(Variable x, Variable y)
-    {
-      var newValues = new Set<Variable>();
-
-      SetOfConstraints<Variable> this_x;
-      if (this.TryGetValue(x, out this_x)  && !this_x.IsTop)
-      {
-        newValues.AddRange(this_x.Values);
-      }
-      newValues.Add(y);
-
-      this[x] = new SetOfConstraints<Variable>(newValues, false);  // Do the update
-    }
-
-    #endregion
-
-    #region ToString
-    protected override string ToLogicalFormula(Variable d, SetOfConstraints<Variable> c)
-    {
-      if (!c.IsNormal())
-      {
-        return null;
-      }
-
-      var result = new List<string>();
-
-      var niceD = ExpressionPrinter.ToString(d, this.expManager.Decoder);
-      foreach (var y in c.Values)
-      {
-        string niceY = ExpressionPrinter.ToString(y, this.expManager.Decoder);
-        result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessThan, niceD, niceY));
-      }
-
-      return ExpressionPrinter.ToLogicalFormula(ExpressionOperator.LogicalAnd, result);
-    }
-
-    [ContractVerification(false)]
-    protected override T To<T>(Variable d, SetOfConstraints<Variable> c, IFactory<T> factory)
-    {
-      if (c.IsTop)
-        return factory.Constant(true);
-      if (c.IsBottom)
-        return factory.Constant(false);
-
-      var result = factory.IdentityForAnd;
-      var x = factory.Variable(d);
-
-      // We know the constraints are x < y
-      foreach (var y in c.Values)
-      {
-        T atom = factory.LessThan(x, factory.Variable(y));
-        result = factory.And(result, atom);
-      }
-
-      return result;
-    }
-
-    public override string ToString()
-    {
-      if (this.IsTop)
-        return "Top";
-
-      if (this.IsBottom)
-        return "Bottom";
-
-      var result = new StringBuilder();
-      result.AppendLine("WUB:");
-      foreach (var x_pair in this.Elements)
-      {
-        Contract.Assume(x_pair.Value != null);
-
-        if (!x_pair.Value.IsTop)
-        {
-          var niceX = ExpressionPrinter.ToString(x_pair.Key, this.expManager.Decoder);
-          var niceVal = ToString(x_pair.Value.Values, x_pair.Value.Count);
-          result.AppendLine(niceX + " < " + niceVal + " ");
-        }
-      }
-
-      return result.ToString();
-    }
-
-    private string ToString(IEnumerable<Variable> set, int count)
-    {
-      Contract.Requires(set != null);
-      Contract.Ensures(Contract.Result<string>() != null);      
-
-      var result = new StringBuilder();
-      result.Append("{");
-      int c = 0;
-
-      foreach (var x in set)
-      {
-        var xAsString = ExpressionPrinter.ToString(x, this.expManager.Decoder);
-
-        result.Append(xAsString);
-        
-        if (c < count-1)
-        {
-          result.Append(" ,  ");
-        }
-
-        c++;
-      }
-
-      result.Append("}");
-
-      return result.ToString();
-    }
-
-    public string ToString(Expression exp)
-    {
-      //if (this.expManager.Decoder != null)
-      {
-        return ExpressionPrinter.ToString(exp, this.expManager.Decoder);
-      }
-//      else
- //     {
-  //      return "< missing expression decoder >";
- //     }
-    }
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-
-    class VisitorForCheckLessEqualThan 
-      : TryVisitAtMostTwoMonomials<Variable, Expression, WeakUpperBounds<Variable, Expression>, FlatAbstractDomain<bool>>
-    {
-      private WeakUpperBounds<Variable, Expression> leq;
-
-      public VisitorForCheckLessEqualThan()
-      {
-        this.leq = null;
-      }
-
-      sealed public override bool Visit(Polynomial<Variable, Expression> exp, WeakUpperBounds<Variable, Expression> input, ref FlatAbstractDomain<bool> result)
-      {
-        Contract.Ensures(result != null);
-
-        this.leq = input;
-        result = CheckOutcome.Top; 
-
-        if (this.leq.IsTop)
-        {
-          return false;
-        }
-
-        bool success = this.Dispatch(exp, ref result);
-
-        this.leq = null;
-
-        // F: this seems a bug: the postcondition for Dispatch is not taken into account here, and we can prove it
-        // However, the postcondition result != null is not proven!
-        Contract.Assert(result != null); 
-
-        return success;
-      }
-
-      protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref FlatAbstractDomain<bool> result)
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-
-      protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref FlatAbstractDomain<bool> result)
-      {
-        if (this.leq == null)
-        {
-          return false;
-        }
-        if (k.IsZero)
-        {
-          result = this.leq.CheckIfLessThan(x, y);
-          return true;
-        }
-        else if (k == -1)
-        {
-          result = this.leq.CheckIfLessThan(x, y);
-          return true;
-        }
-        else
-        {
-          result = CheckOutcome.Top;
-          return false;
-        }
-      }
-
-      protected override bool VisitXYLessEqualThanK(Variable x, Variable y, Rational k, ref FlatAbstractDomain<bool> result)
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-
-      protected override bool VisitXLessEqualThan(Rational a, Variable x, Rational k, ref FlatAbstractDomain<bool> result)
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-
-      protected override bool VisitMinusXLessEqualThan(Rational a, Variable x, Rational k, ref FlatAbstractDomain<bool> result)
-      {
-        result = CheckOutcome.Top;
-        return false;
-      }
-    }
-
-    class WUBCheckIfHoldsVisitor
-      : CheckIfHoldsVisitor<WeakUpperBounds<Variable, Expression>, Variable, Expression>
-    {
-      public WUBCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        var resultLeft = Domain.CheckIfLessEqualThan(left, right);
-
-        if (resultLeft.IsNormal())
-        {
-          var resultRight = Domain.CheckIfLessEqualThan(right, left);
-
-          if (resultRight.IsNormal())
-          {
-            return resultLeft.Join(resultRight);
-          }
-
-          return resultRight;
-        }
-
-        return resultLeft;
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return VisitEqual(left, right, original, data);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessEqualThan(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessThan(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        var check1 = this.VisitLessThan(left, right, original, data);
-        if (check1.IsNormal())
-        {
-          return new FlatAbstractDomain<bool>(true);
-        }
-
-        var check2 = this.VisitLessThan(right, left, original, data);
-        if (check2.IsNormal())
-        {
-          return new FlatAbstractDomain<bool>(true);
-        }
-
-        return Default(data);
-      }
-    }
-  }
-
-  [ContractClass(typeof(TryVisitAtMostTwoMonomialsContracts<,,,>))]
-  abstract class TryVisitAtMostTwoMonomials<Variable, Expression, In, Data>
-  {
-    /// <summary>
-    /// We want it to be used by the subclasses, but not called from clients
-    /// </summary>
-    protected bool Dispatch(Polynomial<Variable, Expression> exp, ref Data result)
-    {
-      Contract.Ensures(result != null);
-
-      Variable x, y;
-      Rational a, b, k;
-
-      if (exp.TryMatch_k1XLessEqualThank2(out a, out x, out k))
-      { // a * x <= k
-        if (a < 0)
-        {
-          return this.VisitMinusXLessEqualThan(a, x, k, ref result);
-        }
-        else if (a > 0)
-        {
-          return this.VisitXLessEqualThan(a, x, k, ref result);
-        }
-        else // a == 0
-        {
-          return Default(ref result);
-        }
-      }
-      else if (exp.TryMatch_k1XLessThank2(out a, out x, out k))
-      { // "a * x < k " == "a * x  <= k-1"
-        if (a < 0)
-        {
-          return this.VisitMinusXLessEqualThan(a, x, k - 1, ref result);
-        }
-        else if (a > 0)
-        {
-          return this.VisitXLessEqualThan(a, x, k - 1, ref result);
-        }
-        else
-        {
-          return Default(ref result);
-        }
-      }
-      else if (exp.TryMatch_k1XPlusk2YLessEqualThanK(out a, out x, out b, out y, out k))
-      { // "a * x + b * y <= k" 
-        if (a == 1 && b == 1)
-        {
-          return VisitXYLessEqualThanK(x, y, k, ref result);
-        }
-        else if (a == 1 && b == -1)
-        {
-          return this.VisitXMinusYLessEqualThan(x, y, k, ref result);
-        }
-        else if (a == -1 && b == 1)
-        {
-          return this.VisitXMinusYLessEqualThan(y, x, k, ref result);
-        }
-        else if (a == -1 && b == -1)
-        {
-          return this.VisitMinusXMinusYLessEqualThan(x, y, k, ref result);
-        }
-        else
-        {
-          // Todo: Do we want a visitor for other cases here?
-          return Default(ref result);
-        }
-      }
-      else if (exp.TryMatch_k1XPlusk2YLessThanK(out a, out x, out b, out y, out k))
-      { // "a * x + b * y < k" is "a * x + b * y <=  k-1"
-        if (a == 1 && b == 1)
-        {
-          return this.VisitXYLessEqualThanK(x, y, k - 1, ref result);
-        }
-        else if (a == 1 && b == -1)
-        {
-          return this.VisitXMinusYLessEqualThan(x, y, k - 1, ref result);
-        }
-        else if (a == -1 && b == 1)
-        {
-          return this.VisitXMinusYLessEqualThan(y, x, k - 1, ref result);
-        }
-        else if (a == -1 && b == -1)
-        {
-          return this.VisitMinusXMinusYLessEqualThan(x, y, k - 1, ref result);
-        }
-        else
-        {
-          // Todo: Do we want a visitor for other cases here?
-          return Default(ref result);
-        }
-      }
-      else
-      {
-        return Default(ref result);
-      }
-    }
-
-    abstract public bool Visit(Polynomial<Variable, Expression> exp, In input, ref Data result);
-
-    abstract protected bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result);
-
-    abstract protected bool VisitXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result);
-
-    abstract protected bool VisitXYLessEqualThanK(Variable x, Variable y, Rational k, ref Data result);
-
-    abstract protected bool VisitXLessEqualThan(Rational a, Variable x, Rational k, ref Data result);
-
-    abstract protected bool VisitMinusXLessEqualThan(Rational a, Variable x, Rational k, ref Data result);
-
-    private bool Default(ref Data result)
-    {
-      return false;
-    }
-  }
-
-  #region Contracts
-  [ContractClassFor(typeof(TryVisitAtMostTwoMonomials<,,,>))]
-  abstract class TryVisitAtMostTwoMonomialsContracts<Variable, Expression, In, Data> : TryVisitAtMostTwoMonomials<Variable, Expression, In, Data>
-  {
-    public override bool Visit(Polynomial<Variable, Expression> exp, In input, ref Data result)
-    {
-      Contract.Requires(input != null);
-      Contract.Ensures(result != null);
-
-      throw new NotImplementedException();
-    }
-
-    protected override bool VisitMinusXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result)
-    {
-      Contract.Requires(!object.Equals(k, null));
-
-      throw new NotImplementedException();
-    }
-
-    protected override bool VisitXMinusYLessEqualThan(Variable x, Variable y, Rational k, ref Data result)
-    {
-      Contract.Requires(!object.Equals(k, null));
-      
-      throw new NotImplementedException();
-    }
-
-    protected override bool VisitXYLessEqualThanK(Variable x, Variable y, Rational k, ref Data result)
-    {
-      Contract.Requires(!object.Equals(k, null));
-
-      throw new NotImplementedException();
-    }
-
-    protected override bool VisitXLessEqualThan(Rational a, Variable x, Rational k, ref Data result)
-    {
-      Contract.Requires(!object.Equals(k, null));
-
-      throw new NotImplementedException();
-    }
-
-    protected override bool VisitMinusXLessEqualThan(Rational a, Variable x, Rational k, ref Data result)
-    {
-      Contract.Requires(!object.Equals(k, null));
-
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
 }
-

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/WeakUpperBoundsEqual.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Pentagons/WeakUpperBoundsEqual.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -24,1801 +13,1797 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// The abstract domain to keep track of relations in the form of "x \leq y".
-  /// It does not (always) close, so it is less precise than octagons
-  /// </summary>
-  [ContractVerification(true)]
-  public class WeakUpperBoundsEqual<Variable, Expression> :
-      FunctionalAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Variable, SetOfConstraints<Variable>>,
-        INumericalAbstractDomain<Variable, Expression>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    /// <summary>
+    /// The abstract domain to keep track of relations in the form of "x \leq y".
+    /// It does not (always) close, so it is less precise than octagons
+    /// </summary>
+    [ContractVerification(true)]
+    public class WeakUpperBoundsEqual<Variable, Expression> :
+        FunctionalAbstractDomain<WeakUpperBoundsEqual<Variable, Expression>, Variable, SetOfConstraints<Variable>>,
+          INumericalAbstractDomain<Variable, Expression>
     {
-      Contract.Invariant(this.constraintsForAssignment != null);
-      Contract.Invariant(this.ExpressionManager != null);
-    }
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(constraintsForAssignment != null);
+            Contract.Invariant(this.ExpressionManager != null);
+        }
 
 
-    #region Private state
+        #region Private state
 
-    readonly protected ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
+        readonly protected ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
 
-    private int closureSteps;
-    [ThreadStatic]
-    private static int defaultClosureSteps;
-    public static int DefaultClosureSteps
-    {
-      get { return defaultClosureSteps; }
-      set { defaultClosureSteps = value; }
-    }
+        private int closureSteps;
+        [ThreadStatic]
+        private static int defaultClosureSteps;
+        public static int DefaultClosureSteps
+        {
+            get { return defaultClosureSteps; }
+            set { defaultClosureSteps = value; }
+        }
 
-    readonly private List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>> constraintsForAssignment;
+        readonly private List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>> constraintsForAssignment;
 
-    #endregion
+        #endregion
 
-    #region Constructor
+        #region Constructor
 
-    public WeakUpperBoundsEqual(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
+        public WeakUpperBoundsEqual(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
 
-      this.ExpressionManager = expManager;
+            this.ExpressionManager = expManager;
 
-      this.constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>()
+            constraintsForAssignment = new List<IConstraintsForAssignment<Variable, Expression, INumericalAbstractDomainQuery<Variable, Expression>>>()
       {
         new LessEqualThanConstraints<Variable, Expression>(this.ExpressionManager),
         new LessThanConstraints<Variable, Expression>(this.ExpressionManager),
         new GreaterEqualThanZeroConstraints<Variable, Expression>(this.ExpressionManager)
       };
-    }
+        }
 
-    private WeakUpperBoundsEqual(WeakUpperBoundsEqual<Variable, Expression> other)
-      : base(other)
-    {
-      Contract.Requires(other != null);
-
-      // F: We do not assume the object invariant for now
-
-      Contract.Assume(other.ExpressionManager != null);
-      Contract.Assume(other.constraintsForAssignment != null);
-
-      this.ExpressionManager = other.ExpressionManager;
-      this.constraintsForAssignment = other.constraintsForAssignment;
-    }
-
-    #endregion
-
-    public override object Clone()
-    {
-      return this.DuplicateMe();
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression> DuplicateMe()
-    {
-      return new WeakUpperBoundsEqual<Variable, Expression>(this);
-    }
-
-    #region IPureExpressionAssignmentsWithForward<Expression> Members
-    /// <summary>
-    /// Do the assignment, improving the precision using the oracle domain
-    /// </summary>
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain)
-    {
-      var LEQConstraints = new Set<Expression>();
-
-      // Discover new constraints
-      foreach (var constraintsFetcher in this.constraintsForAssignment)
-      {
-        Contract.Assume(constraintsFetcher != null);
-
-        LEQConstraints.AddRange(constraintsFetcher.InferConstraints(x, exp, oracleDomain));
-      }
-
-      // Assume them
-      foreach (var newConstraint in LEQConstraints)
-      {
-        this.TestTrue(newConstraint);
-      }
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      Contract.Assume(x != null);
-      Contract.Assume(exp != null);
-
-      Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton); 
-    }
-
-    #endregion
-
-    #region Easy ones
-
-    public DisInterval BoundsFor(Expression exp)
-    {
-      Expression left, right;
-
-      switch (this.ExpressionManager.Decoder.OperatorFor(exp))
-      {
-        case ExpressionOperator.Subtraction:
-          left = this.ExpressionManager.Decoder.LeftExpressionFor(exp);
-          right = this.ExpressionManager.Decoder.RightExpressionFor(exp);
-
-          var isPositive = this.CheckIfLessEqualThan(right, left); // right <= left
-
-          if (isPositive.IsNormal())
-          {
-            return isPositive.BoxedElement ? DisInterval.Positive : DisInterval.Negative;
-          }
-          else
-          {
-            return DisInterval.UnknownInterval;
-          }
-
-        default:
-          return DisInterval.UnknownInterval;
-      }
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      return this.BoundsFor(this.ExpressionManager.Encoder.VariableFor(v));
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression  exp)
-    {
-      return this.CheckIfHolds(exp, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    public FlatAbstractDomain<bool>  CheckIfHolds(Expression exp, INumericalAbstractDomain<Variable, Expression> oracleDomain)
-    {
-      var operatorForExp = this.ExpressionManager.Decoder.OperatorFor(exp);
-
-      if (operatorForExp.IsBinary() && operatorForExp.IsRelationalOperator())
-      {
-        Expression left, right;
-
-        left = this.ExpressionManager.Decoder.LeftExpressionFor(exp);
-        right = this.ExpressionManager.Decoder.RightExpressionFor(exp);
-
-        switch (operatorForExp)
+        private WeakUpperBoundsEqual(WeakUpperBoundsEqual<Variable, Expression> other)
+          : base(other)
         {
-          case ExpressionOperator.Equal:
-          case ExpressionOperator.Equal_Obj:
-            ExpressionOperator op;
-            Expression e11, e12;
-            if (this.ExpressionManager.Decoder.Match_E1relopE2eq0(left, right, out op, out e11, out e12))
+            Contract.Requires(other != null);
+
+            // F: We do not assume the object invariant for now
+
+            Contract.Assume(other.ExpressionManager != null);
+            Contract.Assume(other.constraintsForAssignment != null);
+
+            this.ExpressionManager = other.ExpressionManager;
+            constraintsForAssignment = other.constraintsForAssignment;
+        }
+
+        #endregion
+
+        public override object Clone()
+        {
+            return this.DuplicateMe();
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> DuplicateMe()
+        {
+            return new WeakUpperBoundsEqual<Variable, Expression>(this);
+        }
+
+        #region IPureExpressionAssignmentsWithForward<Expression> Members
+        /// <summary>
+        /// Do the assignment, improving the precision using the oracle domain
+        /// </summary>
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain)
+        {
+            var LEQConstraints = new Set<Expression>();
+
+            // Discover new constraints
+            foreach (var constraintsFetcher in constraintsForAssignment)
             {
-              return ChechIfHoldsNegative(op, e11, e12);
+                Contract.Assume(constraintsFetcher != null);
+
+                LEQConstraints.AddRange(constraintsFetcher.InferConstraints(x, exp, oracleDomain));
             }
-            break;
 
-          case ExpressionOperator.GreaterThan:
-          case ExpressionOperator.GreaterThan_Un:
-            return CheckIfLessThan(right, left);
+            // Assume them
+            foreach (var newConstraint in LEQConstraints)
+            {
+                this.TestTrue(newConstraint);
+            }
+        }
 
-          case ExpressionOperator.LessThan:
-          case ExpressionOperator.LessThan_Un:
-            return CheckIfLessThan(left, right);
+        public void Assign(Expression x, Expression exp)
+        {
+            Contract.Assume(x != null);
+            Contract.Assume(exp != null);
 
-          case ExpressionOperator.LessEqualThan:
-          case ExpressionOperator.LessEqualThan_Un:
-            return CheckIfLessEqualThan(left, right);
+            Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
 
-          case ExpressionOperator.GreaterEqualThan:
-          case ExpressionOperator.GreaterEqualThan_Un:
-            return CheckIfLessEqualThan(right, left);
+        #endregion
 
-          default:
+        #region Easy ones
+
+        public DisInterval BoundsFor(Expression exp)
+        {
+            Expression left, right;
+
+            switch (this.ExpressionManager.Decoder.OperatorFor(exp))
+            {
+                case ExpressionOperator.Subtraction:
+                    left = this.ExpressionManager.Decoder.LeftExpressionFor(exp);
+                    right = this.ExpressionManager.Decoder.RightExpressionFor(exp);
+
+                    var isPositive = this.CheckIfLessEqualThan(right, left); // right <= left
+
+                    if (isPositive.IsNormal())
+                    {
+                        return isPositive.BoxedElement ? DisInterval.Positive : DisInterval.Negative;
+                    }
+                    else
+                    {
+                        return DisInterval.UnknownInterval;
+                    }
+
+                default:
+                    return DisInterval.UnknownInterval;
+            }
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            return this.BoundsFor(this.ExpressionManager.Encoder.VariableFor(v));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return this.CheckIfHolds(exp, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp, INumericalAbstractDomain<Variable, Expression> oracleDomain)
+        {
+            var operatorForExp = this.ExpressionManager.Decoder.OperatorFor(exp);
+
+            if (operatorForExp.IsBinary() && operatorForExp.IsRelationalOperator())
+            {
+                Expression left, right;
+
+                left = this.ExpressionManager.Decoder.LeftExpressionFor(exp);
+                right = this.ExpressionManager.Decoder.RightExpressionFor(exp);
+
+                switch (operatorForExp)
+                {
+                    case ExpressionOperator.Equal:
+                    case ExpressionOperator.Equal_Obj:
+                        ExpressionOperator op;
+                        Expression e11, e12;
+                        if (this.ExpressionManager.Decoder.Match_E1relopE2eq0(left, right, out op, out e11, out e12))
+                        {
+                            return ChechIfHoldsNegative(op, e11, e12);
+                        }
+                        break;
+
+                    case ExpressionOperator.GreaterThan:
+                    case ExpressionOperator.GreaterThan_Un:
+                        return CheckIfLessThan(right, left);
+
+                    case ExpressionOperator.LessThan:
+                    case ExpressionOperator.LessThan_Un:
+                        return CheckIfLessThan(left, right);
+
+                    case ExpressionOperator.LessEqualThan:
+                    case ExpressionOperator.LessEqualThan_Un:
+                        return CheckIfLessEqualThan(left, right);
+
+                    case ExpressionOperator.GreaterEqualThan:
+                    case ExpressionOperator.GreaterEqualThan_Un:
+                        return CheckIfLessEqualThan(right, left);
+
+                    default:
+                        return CheckOutcome.Top;
+                }
+            }
+
             return CheckOutcome.Top;
         }
-      }
 
-      return CheckOutcome.Top;
-    }
-
-    private FlatAbstractDomain<bool> ChechIfHoldsNegative(ExpressionOperator op, Expression a, Expression b)
-    {
-      switch (op)
-      {
-        case ExpressionOperator.GreaterEqualThan:
-        case ExpressionOperator.GreaterEqualThan_Un:
-          // !(a >= b) == a < b
-          return CheckIfLessThan(a, b);
-
-        case ExpressionOperator.GreaterThan:
-        case ExpressionOperator.GreaterThan_Un:
-          // !(a > b) == a <= b
-          return CheckIfLessEqualThan(a, b);
-
-        case ExpressionOperator.LessEqualThan:
-        case ExpressionOperator.LessEqualThan_Un:
-          // !(a <= b) == a > b =+ b < a
-          return CheckIfLessThan(b, a);
-
-        case ExpressionOperator.LessThan:
-        case ExpressionOperator.LessThan_Un:
-          // !(a < b) =+ a >= b == b <= a 
-          return CheckIfLessEqualThan(b, a);
-
-        default:
-          return CheckOutcome.Top;
-      }
-    }
-
-    /// <summary>
-    /// Add or materialize the map entry and add the value
-    /// </summary>
-    static internal void AddUpperBound(Variable key, Variable upperBound, Dictionary<Variable, Set<Variable>> map)
-    {
-      Contract.Requires(map != null);
-
-      Set<Variable> bounds;
-      if (!map.TryGetValue(key, out bounds))
-      {
-        bounds = new Set<Variable>();
-        map[key] = bounds;
-      }
-      Contract.Assume(bounds != null);
-
-      bounds.Add(upperBound);
-    }
-
-    public FlatAbstractDomain<bool>  CheckIfNonZero(Expression  exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      Polynomial<Variable, Expression> pol;
-      Variable x, y;
-      Rational k;
-
-      if (/*this.ExpressionManager.Encoder != null && */
-        Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.ExpressionManager.Decoder, out pol)
-        && pol.TryMatch_XMinusYPlusK(out x, out y, out k))
-      {
-        var xExp = this.ExpressionManager.Encoder.VariableFor(x);
-        var yExp = this.ExpressionManager.Encoder.VariableFor(y);
-
-        var lt = this.CheckIfLessEqualThan(yExp, xExp);
-
-        if (lt.IsNormal() && lt.BoxedElement == true && k >= -1)
-        { // if we have to check x - y + k >= 0, and we know that k >= -1 and x - y > 0, then this is true
-          return lt;    // that is true
-        }
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2, INumericalAbstractDomain<Variable, Expression> oracleDomain)
-    {
-      Contract.Requires(oracleDomain != null);
-
-      if (this.IsTop)
-      {
-        return CheckOutcome.Top;
-      }
-
-      Polynomial<Variable, Expression> pol;
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, this.ExpressionManager.Decoder, out pol))
-      {
-        Variable x, y;
-        Rational k;
-        if (pol.TryMatch_XMinusYPlusK(out x, out y, out k))
+        private FlatAbstractDomain<bool> ChechIfHoldsNegative(ExpressionOperator op, Expression a, Expression b)
         {
-          var xExp = this.ExpressionManager.Encoder.VariableFor(x);
-
-          if (this.CheckIfLessEqualThan(xExp, e2).IsTrue() && oracleDomain.BoundsFor(y).LowerBound > k)
-          {
-            return CheckOutcome.True;
-          }
-        }
-        else if (pol.TryMatch_YMinusK(out x, out k))
-        {
-          var xExp = this.ExpressionManager.Encoder.VariableFor(x);
-
-          if (this.CheckIfLessEqualThan(xExp, e2).IsTrue())
-          {
-            return CheckOutcome.True;
-          }
-        }
-      }
-
-      switch(this.ExpressionManager.Decoder.OperatorFor(e2))
-      {
-        case ExpressionOperator.Addition:
-          {
-            // try to match the case e1 < e2 + k, with k > 0. In this case we can check if e1 <= e2
-            var e2Left = this.ExpressionManager.Decoder.LeftExpressionFor(e2);
-            var e2Right = this.ExpressionManager.Decoder.RightExpressionFor(e2);
-            int k;
-            if (this.ExpressionManager.Decoder.IsConstantInt(e2Right, out k) && k > 0)
+            switch (op)
             {
-              if (this.CheckIfLessEqualThan(e1, e2Left).IsTrue())
-              {
-                return CheckOutcome.True;
-              }              
-              // if the check if false, we cannot say
-            }
-          }
-          break;
+                case ExpressionOperator.GreaterEqualThan:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    // !(a >= b) == a < b
+                    return CheckIfLessThan(a, b);
 
-      }
+                case ExpressionOperator.GreaterThan:
+                case ExpressionOperator.GreaterThan_Un:
+                    // !(a > b) == a <= b
+                    return CheckIfLessEqualThan(a, b);
 
-      return CheckOutcome.Top;
-    }
-    
-    /// <summary>
-    /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code> using, 
-    /// if needed the abstract domain <code>oracleDomain</code> to refine the information
-    /// </summary>
-    public FlatAbstractDomain<bool>  CheckIfLessEqualThan(Expression  e1, Expression  e2, INumericalAbstractDomain<Variable, Expression> oracleDomain)
-    {
-      // First we try it without the oracle domain
-      var directTry = CheckIfLessEqualThan(e1, e2);
+                case ExpressionOperator.LessEqualThan:
+                case ExpressionOperator.LessEqualThan_Un:
+                    // !(a <= b) == a > b =+ b < a
+                    return CheckIfLessThan(b, a);
 
-      if (directTry.IsTop)
-      {
-        return CommonChecks.CheckLessEqualThan(e1, e2, oracleDomain, this.ExpressionManager.Decoder);
-      }
+                case ExpressionOperator.LessThan:
+                case ExpressionOperator.LessThan_Un:
+                    // !(a < b) =+ a >= b == b <= a 
+                    return CheckIfLessEqualThan(b, a);
 
-      return directTry;
-    }
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return new List<Pair<Variable, Int32>>();
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression  v, bool strict)
-    {
-      return this.LowerBoundsFor(this.ExpressionManager.Decoder.UnderlyingVariable(v), strict);
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      var result = new Set<Expression>();
-
-      if (strict)
-      {
-        return result;
-      }
-
-      foreach (var pair in this.Elements)
-      {
-        var valueSet = pair.Value;
-        if (valueSet.IsNormal() && valueSet.Contains(v))
-        {
-          result.Add(this.ExpressionManager.Encoder.VariableFor(pair.Key));
-        }
-      }
-
-      return result;
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression  v, bool strict)
-    {
-      return UpperBoundsFor(this.ExpressionManager.Decoder.UnderlyingVariable(v), strict);
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      var result = new Set<Expression>();
-
-      SetOfConstraints<Variable> value;
-      if (!strict && this.TryGetValue(v, out value) && value.IsNormal())
-      {
-        foreach (var x in value.Values)
-        {
-          result.Add(this.ExpressionManager.Encoder.VariableFor(x));
-        }
-      }
-
-      return result;
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      var result = new Set<Variable>();
-
-      SetOfConstraints<Variable> upperBounds;
-      if (this.TryGetValue(v, out upperBounds) && upperBounds.IsNormal())
-      {
-        foreach (var x in upperBounds.Values)
-        {
-          SetOfConstraints<Variable> other;
-          if (!x.Equals(v) && this.TryGetValue(x, out other) && other.IsNormal() && other.Contains(v))
-          {
-            result.Add(x);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    ///<summary>By default, it does nothing</summary>
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      // does nothing
-    }
-   
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      return CheckIfLessThan(e1, e2, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
-    {
-      return this.CheckIfLessThan(this.ExpressionManager.Encoder.VariableFor(v1), this.ExpressionManager.Encoder.VariableFor(v2));
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      if (this.IsTop)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var decoder = this.ExpressionManager.Decoder;
-
-      var stripped1Var = decoder.UnderlyingVariable(decoder.Stripped(e1));
-
-      SetOfConstraints<Variable> value;
-      if (this.TryGetValue(stripped1Var, out value) && value.IsNormal())
-      {
-        if (value.Contains(decoder.UnderlyingVariable(e2)))
-        {
-          return CheckOutcome.True;
-        }
-
-        if (value.Contains(decoder.UnderlyingVariable(decoder.Stripped(e2))))
-        {
-          return CheckOutcome.True;
-        }
-
-        foreach (var eTmp in value.Values)
-        {
-          SetOfConstraints<Variable> bounds;
-          if (this.TryGetValue(eTmp, out bounds) &&
-            (bounds.Contains(decoder.UnderlyingVariable(e2)) || bounds.Contains(decoder.UnderlyingVariable(decoder.Stripped(e2)))))
-            { // e1 <= eTmp , eTmp <= e2 => e1 <= e2
-              return CheckOutcome.True;
+                default:
+                    return CheckOutcome.Top;
             }
         }
-      }
 
-      if (this.TryGetValue(decoder.UnderlyingVariable(e2), out value) && value.IsNormal())
-      {
-        if (this.CheckIfLessThan(e2, decoder.Stripped(e1), TopNumericalDomain<Variable, Expression>.Singleton) == CheckOutcome.True)
+        /// <summary>
+        /// Add or materialize the map entry and add the value
+        /// </summary>
+        static internal void AddUpperBound(Variable key, Variable upperBound, Dictionary<Variable, Set<Variable>> map)
         {
-          return CheckOutcome.False;
-        }
-      }
+            Contract.Requires(map != null);
 
-      // This is a useful case when the underlying framework has not assigned a value to the variable
-      Variable v1, v2;
-      int k1, k2;
-      if (decoder.TryMatchVarPlusConst(e1, out v1, out k1) && decoder.TryMatchVarPlusConst(e2, out v2, out k2)  && k1 == k2)
-      {
-        return this.CheckIfLessEqualThan(v1, v2);
-      }
-
-      switch (decoder.OperatorFor(e2))
-      {
-        case ExpressionOperator.Addition:
-          {
-            // try to match e1 <= e21 + k, k > 0
-            var e2Left = decoder.LeftExpressionFor(e2);
-            var e2Right = decoder.RightExpressionFor(e2);
-            int k;
-            if (decoder.IsConstantInt(e2Right, out k) && k > 0)
+            Set<Variable> bounds;
+            if (!map.TryGetValue(key, out bounds))
             {
-              if (this.CheckIfLessEqualThan(e1, e2Left).IsTrue())
-              {
-                return CheckOutcome.True;
-              }
+                bounds = new Set<Variable>();
+                map[key] = bounds;
             }
-          }
-          break;
-      }
+            Contract.Assume(bounds != null);
 
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
-    {
-      return this.CheckIfLessEqualThan(this.ExpressionManager.Encoder.VariableFor(v1), this.ExpressionManager.Encoder.VariableFor(v2));
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessEqualThan(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThanIncomplete(Expression e1, Expression e2)
-    {
-      if (this.IsTop)
-      {
-        return CheckOutcome.Top;
-      }
-
-      var decoder = this.ExpressionManager.Decoder;
-
-      var stripped1Var = decoder.UnderlyingVariable(decoder.Stripped(e1));
-
-      SetOfConstraints<Variable> value;
-      if (this.TryGetValue(stripped1Var, out value) && value.IsNormal())
-      {
-        if (value.Contains(decoder.UnderlyingVariable(e2)))
-        {
-          return CheckOutcome.True;
+            bounds.Add(upperBound);
         }
 
-        if (value.Contains(decoder.UnderlyingVariable(decoder.Stripped(e2))))
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
         {
-          return CheckOutcome.True;
+            return CheckOutcome.Top;
         }
-      }
 
-      if (this.TryGetValue(decoder.UnderlyingVariable(e2), out value) && value.IsNormal())
-      {
-        if (this.CheckIfLessThan(e2, decoder.Stripped(e1), TopNumericalDomain<Variable, Expression>.Singleton) == CheckOutcome.True)
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
         {
-          return CheckOutcome.False;
-        }
-      }
+            Polynomial<Variable, Expression> pol;
+            Variable x, y;
+            Rational k;
 
-      switch (decoder.OperatorFor(e2))
-      {
-        case ExpressionOperator.Addition:
-          {
-            // try to match e1 <= e21 + k, k > 0
-            var e2Left = decoder.LeftExpressionFor(e2);
-            var e2Right = decoder.RightExpressionFor(e2);
-            int k;
-            if (decoder.IsConstantInt(e2Right, out k) && k > 0)
+            if (/*this.ExpressionManager.Encoder != null && */
+              Polynomial<Variable, Expression>.TryToPolynomialForm(exp, this.ExpressionManager.Decoder, out pol)
+              && pol.TryMatch_XMinusYPlusK(out x, out y, out k))
             {
-              if (this.CheckIfLessEqualThanIncomplete(e1, e2Left).IsTrue())
-              {
-                return CheckOutcome.True;
-              }
-            }
-          }
-          break;
-      }
+                var xExp = this.ExpressionManager.Encoder.VariableFor(x);
+                var yExp = this.ExpressionManager.Encoder.VariableFor(y);
 
-      return CheckOutcome.Top;
+                var lt = this.CheckIfLessEqualThan(yExp, xExp);
 
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> c1, c2;
-
-      if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
-      {
-        return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> c1, c2;
-
-      if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
-      {
-        return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    override protected WeakUpperBoundsEqual<Variable, Expression> Factory()
-    {
-      return new WeakUpperBoundsEqual<Variable, Expression>(this.ExpressionManager);
-    }
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression> Members
-
-
-    /// <summary>
-    /// Perform the parallel assignment, and improved the precision using the information from the oracle domain
-    /// </summary>
-    /// <param name="sourcesToTargets"></param>
-    [SuppressMessage("Microsoft.Contracts", "Assert-1-0")]
-    public  void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      Debug.Assert(false); // Should not be called in the current Clousot setting
-
-      // Recall that we are solving the following problem. We have a new alphabet of variables V and an old alphabet of variables V'.
-      // The current state holds constraints over old variables v'1 <= v'2.
-      //
-      // The sourcesToTargets map represents assignments from old variables to new variables. An entry
-      //   v' -> v1, v2, ... vn represents the assignments v1 := v', v2 := v', ... vn := v'
-      //
-      // Thus, if the current state holds  v'1 <= v'2, and we have
-      //   v'1 -> v11, v12, ..., v1n
-      //   v'2 -> v21, v22, ..., v2m
-      //
-      // Then "all" information about v'1 <= v'2 expressed in the new state would be the conjunction of constraints
-      //   v1i <= v2j, for i=1..n and j=1..m
-      //
-      // Clearly, we don't generally want to produce this quadratic number of constraints (although in practice it is rare
-      // to see more than 1 new variable assigned the same old variable).
-      //
-      // Thus, in practice, we might pick a "canonical" new name for an old variable, say the first in the list (v11 and v21).
-      // This would then give us a single new constraint for v'1 <= v'2, namely  v11 <= v21.
-      //
-      // To compute this, we use the sourcesToTargets map as our canonical map M from old to new, by simply using the first in the list
-      // as the canonical new variable.
-
-      // Then it is simple to produce the new state: iterate over all constraints v'1 <= v'2 in the old state, and simply put
-      //   M(v'1) <= M(v'2) into the new state.
-      //
-
-
-      // The fact that we have to do this computation "in-place" is annoying. It would be simpler to produce a new state.
-      // Thus, we will compute the new mappings on the side, then clear the current state, then add the new mappings back.
-
-      // adding the domain-generated variables to the map as identity
-      var oldToNewMap = new Dictionary<Variable, FList<Variable>>(sourcesToTargets);
-      if (!this.IsTop)
-      {
-        foreach (var e in this.Variables)
-        {
-          if (this.ExpressionManager.Decoder.IsSlackVariable(e))
-            oldToNewMap.Add(e, FList<Variable>.Cons(e, FList<Variable>.Empty));
-        }
-      }
-
-      // when x has several targets including itself, the canonical element shouldn't be itself
-      foreach (var sourceToTargets in sourcesToTargets)
-      {
-        var source = sourceToTargets.Key;
-        var targets = sourceToTargets.Value;
-        if (targets.Length() > 1 && targets.Head.Equals(source))
-        {
-          var newTargets = FList<Variable>.Cons(targets.Tail.Head, FList<Variable>.Cons(source, targets.Tail.Tail));
-          oldToNewMap[source] = newTargets;
-        }
-      }
-
-      var newMappings = new Dictionary<Variable, Set<Variable>>(this.Count);
-
-      foreach (var oldLeft_Pair in this.Elements)
-      {
-        if (!oldToNewMap.ContainsKey(oldLeft_Pair.Key)) 
-        { 
-          continue; 
-        }
-
-        var targets = oldToNewMap[oldLeft_Pair.Key];
-        var newLeft = targets.Head; // our canonical element
-
-        var oldBounds = oldLeft_Pair.Value;
-        if (!oldBounds.IsNormal()) 
-        { 
-          continue; 
-        }
-
-        foreach (var oldRight in oldBounds.Values)
-        {
-          if (!oldToNewMap.ContainsKey(oldRight))
-          {
-            continue;
-          }
-
-          var newRight = oldToNewMap[oldRight].Head; // our canonical element
-          AddUpperBound(newLeft, newRight, newMappings);
-        }
-
-      }
-
-      // Precision improvements:
-      //
-      // Consider:
-      //   if (x < y) x = y;
-      //   Debug.Assert(x >= y);
-      //
-      // This is an example where at the end of the then branch, we have a single old variable being assigned to new new variables:
-      //   x := y'  and y := y'
-      // Since in this branch, we obviously have y' => y', the new renamed state should have y => x and x => y. That way, at the join,
-      // the constraint x >= y is retained.
-      // 
-      foreach (var pair in sourcesToTargets)
-      {
-        var targets = pair.Value;
-        var newCanonical = targets.Head;
-        targets = targets.Tail;
-        while (targets != null)
-        {
-          // make all other targets equal to canonical (rather than n^2 combinations)
-          AddUpperBound(newCanonical, targets.Head, newMappings);
-          AddUpperBound(targets.Head, newCanonical, newMappings);
-          targets = targets.Tail;
-        }
-      }
-
-      // now clear the current state
-      this.ClearElements();
-
-      // now add the new mappings
-      foreach (var key in newMappings.Keys)
-      {
-        var bounds = newMappings[key];
-        
-        if (bounds.Count == 0) 
-          continue;
-
-        var newBoundsFromClosure = new Set<Variable>();
-
-        foreach (var upp in bounds)
-        {
-          if (!upp.Equals(key) && newMappings.ContainsKey(upp))
-          {
-            newBoundsFromClosure.AddRange(newMappings[upp]);
-          }
-        }
-
-        bounds.AddRange(newBoundsFromClosure);
-
-        this.AddElement(key, new SetOfConstraints<Variable>(bounds, false));
-      }
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      var result = this.DuplicateMe();
-
-      // if (this.ExpressionManager.Encoder != null)
-      {
-        foreach (var pair in this.Elements)
-        {
-          if (pair.Value.IsNormal())
-          {
-            result.AddElement(pair.Key, pair.Value);
-          }
-          else
-          {
-            var newExp = new Set<Variable>();
-            foreach (var val in pair.Value.Values)
-            {
-              // x <= x 
-              if (pair.Value.Equals(val))
-              {
-                continue;
-              }
-
-              // x <= exp
-              var leq = oracle.CheckIfLessEqualThan(pair.Key, val);
-
-              if (!leq.IsNormal() || !leq.BoxedElement)
-              { // Then it is not implied by oracle
-                newExp.Add(val);
-              }
-            }
-            if (newExp.Count > 0)
-            {
-              result.AddElement(pair.Key, new SetOfConstraints<Variable>(newExp, false));
-            }
-          }
-        }
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public Variable ToVariable(Expression exp)
-    {
-      return this.ExpressionManager.Decoder.UnderlyingVariable(exp);
-    }
-
-    #endregion
-
-    #region Particular cases for IAbstractDomain
-
-    public override WeakUpperBoundsEqual<Variable, Expression> Join(WeakUpperBoundsEqual<Variable, Expression>  right)
-    {
-      // Here we do not have trivial joins as we want to join maps of different cardinality
-      if (this.IsBottom)
-        return right;
-      if (right.IsBottom)
-        return this;
-
-      var result = Factory();
-
-      foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
-      {
-        SetOfConstraints<Variable> intersection;
-
-        SetOfConstraints<Variable> right_x;
-        if (right.TryGetValue(pair.Key, out right_x))
-        {
-          // Implementation of transitive closure using the steps option
-          closureSteps = DefaultClosureSteps;
-
-          Contract.Assume(pair.Value != null);
-
-          var closedleft = new Set<Variable>(pair.Value.Values);
-          var closedright = new Set<Variable>(right_x.Values);
-
-          while (closureSteps > 0)
-          {
-            // here we do a transitive closure step
-            var templeft = new Set<Variable>(closedleft);
-            var tempright = new Set<Variable>(closedright);
-
-            foreach (var e in closedleft)
-            {
-              SetOfConstraints<Variable> this_e;
-              if (this.TryGetValue(e, out this_e) && !this_e.IsTop)
-              {
-                var tempSet = new Set<Variable>(this_e.Values);
-                tempSet.Remove(pair.Key);
-                templeft.AddRange(tempSet);
-              }
+                if (lt.IsNormal() && lt.BoxedElement == true && k >= -1)
+                { // if we have to check x - y + k >= 0, and we know that k >= -1 and x - y > 0, then this is true
+                    return lt;    // that is true
+                }
             }
 
-            foreach (var e in closedright)
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2, INumericalAbstractDomain<Variable, Expression> oracleDomain)
+        {
+            Contract.Requires(oracleDomain != null);
+
+            if (this.IsTop)
             {
-              SetOfConstraints<Variable> right_e;
-              if (right.TryGetValue(e, out right_e) && !right_e.IsTop)
-              {
-                var tempSet = new Set<Variable>(right_e.Values);
-                tempSet.Remove(pair.Key);
-                tempright.AddRange(tempSet);
-              }
+                return CheckOutcome.Top;
             }
 
-            closedleft = templeft;
-            closedright = tempright;
-
-            closureSteps--;
-          }
-
-          intersection = new SetOfConstraints<Variable>(closedleft.Intersection(closedright), false);
-
-          if (intersection.IsNormal())
-          {
-            // We keep in the map only the elements that are != top and != bottom
-            result[pair.Key] = intersection;
-          }
-        }
-      }
-
-      return result;
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression>  Join(WeakUpperBoundsEqual<Variable, Expression>  right,
-       IIntervalAbstraction<Variable, Expression> intervalsForThis, IIntervalAbstraction<Variable, Expression> intervalsForRight)
-    {
-      Contract.Requires(right != null);
-      Contract.Requires(intervalsForThis != null);
-      Contract.Requires(intervalsForRight != null);
-
-      // Here we do not have trivial joins as we want to join maps of different cardinality
-      if (this.IsBottom)
-        return right;
-      if (right.IsBottom)
-        return this;
-
-      var result = this.Factory();
-
-      foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
-      {
-        var intersection = new SetOfConstraints<Variable>(new Set<Variable>(), false);
-        var newValues = new Set<Variable>();
-
-        SetOfConstraints<Variable> right_x;
-        if (right.TryGetValue(pair.Key, out right_x))
-        {
-          Contract.Assume(pair.Value != null);
-
-          intersection = pair.Value.Join(right_x);
-          if (!intersection.IsTop)
-          {
-            newValues.AddRange(intersection.Values);
-          }
-
-          // Foreach x <= y
-          if (right_x.IsNormal())
-          {
-            foreach (var y in right_x.Values)
+            Polynomial<Variable, Expression> pol;
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(e1, this.ExpressionManager.Decoder, out pol))
             {
-              if (newValues.Contains(y))
-              {
-                continue;
-              }
+                Variable x, y;
+                Rational k;
+                if (pol.TryMatch_XMinusYPlusK(out x, out y, out k))
+                {
+                    var xExp = this.ExpressionManager.Encoder.VariableFor(x);
 
-              var res = intervalsForThis.CheckIfLessEqualThan(pair.Key, y);
+                    if (this.CheckIfLessEqualThan(xExp, e2).IsTrue() && oracleDomain.BoundsFor(y).LowerBound > k)
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
+                else if (pol.TryMatch_YMinusK(out x, out k))
+                {
+                    var xExp = this.ExpressionManager.Encoder.VariableFor(x);
 
-              if (!res.IsNormal())
-              {
-                continue;
-              }
-
-              if (res.BoxedElement)    // If the intervals imply this relation, just keep it
-              {
-                newValues.Add(y);   // Add x <= y
-              }
-            }
-          }
-        }
-
-        // Foreach x <= y
-        if (pair.Value.IsNormal() )
-        {
-          foreach (var y in pair.Value.Values)
-          {
-            if (newValues.Contains(y))
-            {
-              continue;
+                    if (this.CheckIfLessEqualThan(xExp, e2).IsTrue())
+                    {
+                        return CheckOutcome.True;
+                    }
+                }
             }
 
-            var res = intervalsForRight.CheckIfLessEqualThan(pair.Key, y);
-
-            if (!res.IsNormal())
+            switch (this.ExpressionManager.Decoder.OperatorFor(e2))
             {
-              continue;
+                case ExpressionOperator.Addition:
+                    {
+                        // try to match the case e1 < e2 + k, with k > 0. In this case we can check if e1 <= e2
+                        var e2Left = this.ExpressionManager.Decoder.LeftExpressionFor(e2);
+                        var e2Right = this.ExpressionManager.Decoder.RightExpressionFor(e2);
+                        int k;
+                        if (this.ExpressionManager.Decoder.IsConstantInt(e2Right, out k) && k > 0)
+                        {
+                            if (this.CheckIfLessEqualThan(e1, e2Left).IsTrue())
+                            {
+                                return CheckOutcome.True;
+                            }
+                            // if the check if false, we cannot say
+                        }
+                    }
+                    break;
             }
 
-            if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+            return CheckOutcome.Top;
+        }
+
+        /// <summary>
+        /// Check if the expression <code>e1</code> is strictly smaller than <code>e2</code> using, 
+        /// if needed the abstract domain <code>oracleDomain</code> to refine the information
+        /// </summary>
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2, INumericalAbstractDomain<Variable, Expression> oracleDomain)
+        {
+            // First we try it without the oracle domain
+            var directTry = CheckIfLessEqualThan(e1, e2);
+
+            if (directTry.IsTop)
             {
-              newValues.Add(y);   // Add x <= y everywhere
-              right.TestTrueLessEqualThan(pair.Key, y);
-            }
-          }
-        }
-
-        if (!newValues.IsEmpty)
-        {
-          result[pair.Key] = new SetOfConstraints<Variable>(newValues, false);
-        }
-      }
-
-      foreach (var x_pair in right.Elements)
-      {
-        if (this.ContainsKey(x_pair.Key))
-        {
-          // Case already handled
-          continue;
-        }
-
-        var newValues = new Set<Variable>();
-
-        // Foreach x <= y
-        if (x_pair.Value.IsNormal())
-        {
-          foreach (var y in x_pair.Value.Values)
-          {
-           var res = intervalsForThis.CheckIfLessEqualThan(x_pair.Key, y);
-
-            if (!res.IsNormal())
-            {
-              continue;
+                return CommonChecks.CheckLessEqualThan(e1, e2, oracleDomain, this.ExpressionManager.Decoder);
             }
 
-            if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+            return directTry;
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
             {
-              newValues.Add(y);   // Add x <= y
-              this.TestTrueLessEqualThan(x_pair.Key, y);
+                return new List<Pair<Variable, Int32>>();
             }
-          }
-
-          if (!newValues.IsEmpty)
-          {
-            result[x_pair.Key] = new SetOfConstraints<Variable>(newValues, false);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get
-      {
-        var result = new List<Variable>();
-
-        var inside = new Set<Variable>();
-
-        foreach (var x_pair in this.Elements)
-        {
-          result.Add(x_pair.Key);
-
-          Contract.Assume(x_pair.Value != null);
-
-          if (!x_pair.Value.IsTop)
-          {
-            inside.AddRange(x_pair.Value.Values);
-          }
         }
 
-        result.AddRange(inside);
-
-        return result;
-      }
-    }
-
-    public IEnumerable<Variable> SlackVariables
-    {
-      get
-      {
-        var seen = new Set<Variable>();
-        var decoder = this.ExpressionManager.Decoder;
-
-        foreach (var x_pair in this.Elements)
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
         {
-          if (decoder.IsSlackVariable(x_pair.Key))
-          {
-            seen.Add(x_pair.Key);
-            yield return x_pair.Key;
-          }
+            return this.LowerBoundsFor(this.ExpressionManager.Decoder.UnderlyingVariable(v), strict);
+        }
 
-          if (!x_pair.Value.IsTop)
-          {
-            foreach (var y in x_pair.Value.Values)
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            var result = new Set<Expression>();
+
+            if (strict)
             {
-              if (decoder.IsSlackVariable(y) && !seen.Contains(y))
-              {
-                seen.Add(y);
-                yield return y;
-              }
-            }            
-          }
-        }
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      // Does nothing, as we assume variables initialized to top
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      this.RemoveElement(var);
-
-      var toUpdate = new List<Pair<Variable, SetOfConstraints<Variable>>>();
-
-      foreach (var pair in this.Elements)
-      {
-        if (pair.Value.IsNormal() && pair.Value.Contains(var))
-        {
-          var s = new Set<Variable>(pair.Value.Values);
-          s.Remove(var);
-          toUpdate.Add(pair.Key, new SetOfConstraints<Variable>(s, false));
-        }
-      }
-
-      foreach (var pair in toUpdate)
-      {
-        this[pair.One] = pair.Two;
-      }
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      var toUpdate = new Dictionary<Variable, SetOfConstraints<Variable>>(this.Count);
-
-      var forVar = new Set<Variable>();
-
-      SetOfConstraints<Variable> value;
-      if (this.TryGetValue(var, out value) && value.IsNormal())
-      {
-        forVar = new Set<Variable>(value.Values);
-      }
-
-      foreach (var x_Pair in this.Elements)
-      {
-        var constraints = x_Pair.Value;
-
-        if (!constraints.IsNormal() || !constraints.Contains(var))
-        {
-          continue;
-        }
-
-        var newConstraints = new Set<Variable>(constraints.Values);
-        newConstraints.AddRange(forVar);
-        newConstraints.Remove(var);
-        
-        toUpdate[x_Pair.Key] = new SetOfConstraints<Variable>(newConstraints);
-      }
-
-      foreach (var x_pair in toUpdate)
-      {
-        this[x_pair.Key] = x_pair.Value;
-      }
-
-      this.RemoveElement(var);
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      foreach (var x_pair in this.Elements)
-      {
-        if (x_pair.Value.IsNormal())
-        {
-          var oldVal = x_pair.Value;
-          if (oldVal.Contains(OldName))
-          {
-            var newVal = new Set<Variable>(oldVal.Values);
-            newVal.Remove(OldName);
-            newVal.Add(NewName);
-            this[x_pair.Key] = new SetOfConstraints<Variable>(newVal, false);
-          }
-        }
-      }
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
-    {
-       return this.TestTrue(guard);
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression> TestTrue(Expression guard)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);  
-
-      return ProcessTestTrue(guard);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
-    {
-      return this.TestFalse(guard);
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression> TestFalse(Expression guard)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);  
-
-//      if (this.ExpressionManager.Encoder != null)
-      {
-        var notGuard = this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Not, guard);
-        return TestTrue(notGuard);
-      }
-  /*
-      else
-      {
-        return ProcessTestFalse(guard);
-      }
-   */ 
-    }
-
-    /// <summary>
-    /// Does nothing
-    /// </summary>
-    public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression  exp)
-    {
-      return this;
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      return this.TestTrueEqual(exp1, exp2);
-    }
-
-    #endregion
-
-    #region WeakUpperBounds-Specific Methods
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression  e1, Expression  e2)
-    {
-      return this.HelperForLessThan(e1, e2);
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression> TestTrueLessThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);  
-
-      return this.HelperForLessThan(e1, e2);
-    }
-
-    INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression e1, Expression e2)
-    {
-      return this.TestTrueLessEqualThan(e1, e2);
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression> TestTrueLessEqualThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);  
-
-      return this.HelperForLessEqualThan(e1, e2);
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression> TestTrueLessEqualThan(Variable e1, Variable e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);  
-
-      return this.TestTrueLessEqualThan(this.ExpressionManager.Encoder.VariableFor(e1), this.ExpressionManager.Encoder.VariableFor(e2));
-    }
-
-    public WeakUpperBoundsEqual<Variable, Expression> TestTrueEqual(Expression e1, Expression e2)
-    {
-      return this.HelperForEqual(e1, e2);
-    }
-
-    #endregion
-
-    #region Protected methods
-
-    protected  WeakUpperBoundsEqual<Variable, Expression> ProcessTestTrue(Expression  guard)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
-
-      var decoder = this.ExpressionManager.Decoder;
-
-      switch (decoder.OperatorFor(guard))
-      {
-        #region all the cases
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          {
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-
-            var leftVar = decoder.UnderlyingVariable(left);
-            var rightVar = decoder.UnderlyingVariable(right);
-
-            SetOfConstraints<Variable> v1, v2;
-            if (this.TryGetValue(leftVar, out v1) && this.TryGetValue(rightVar, out v2))
-            {
-              var intersection = v1.Meet(v2);
-              if (v1.IsBottom)
-              {
-                return this.Bottom;
-              }
-              else
-              {
-                this[leftVar] = intersection;
-                this[rightVar] = intersection;
-
-                return this;
-              }
+                return result;
             }
-            else
+
+            foreach (var pair in this.Elements)
             {
-              // Try to figure out if it is in the form of (e11 rel e12) == 0
-              Expression e11, e12;
-              ExpressionOperator op;
-              if (decoder.Match_E1relopE2eq0(left, right, out op, out e11, out e12))
-              {
-                return ProcessTestFalse(left);
-              }
-              else
-              {
-                // F: We do not want this domain to track arbitrary equalities (because of performances), 
-                // so if we do not understand the equality, we abstract it
-                return this;
-              }
+                var valueSet = pair.Value;
+                if (valueSet.IsNormal() && valueSet.Contains(v))
+                {
+                    result.Add(this.ExpressionManager.Encoder.VariableFor(pair.Key));
+                }
             }
-          }
- 
-        case ExpressionOperator.GreaterEqualThan:
-          {
-            // left >= right, so we want to add right <= left
-            var left = this.ExpressionManager.Decoder.LeftExpressionFor(guard);
-            var right = this.ExpressionManager.Decoder.RightExpressionFor(guard);
-            return this.TestTrueLessEqualThan(right, left);
-          }
 
-        case ExpressionOperator.GreaterThan:
-          {
-            // "left > right", so we add the constraint
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return HelperForLessThan(right, left);
-          }
+            return result;
+        }
 
-        case ExpressionOperator.LessEqualThan:
-          {
-            // "left <= right"
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return HelperForLessEqualThan(left, right);
-          }
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            return UpperBoundsFor(this.ExpressionManager.Decoder.UnderlyingVariable(v), strict);
+        }
 
-        case ExpressionOperator.LessThan:
-          {
-            // "left < right"
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return HelperForLessThan(left, right);
-          }
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            var result = new Set<Expression>();
 
-          // We abstract away the symbolic reasoning for unsigned as it may be incorrect
-          // Example "sv1 CLT_Un sv2" and sv2 is -1, so it should be understood as sv1 CLT_Un UInt.MaxValue - this reasoning is done by intervals
-        case ExpressionOperator.LessThan_Un:
-        case ExpressionOperator.LessEqualThan_Un:
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.GreaterEqualThan_Un:
-          {
-            return this;
-          }
+            SetOfConstraints<Variable> value;
+            if (!strict && this.TryGetValue(v, out value) && value.IsNormal())
+            {
+                foreach (var x in value.Values)
+                {
+                    result.Add(this.ExpressionManager.Encoder.VariableFor(x));
+                }
+            }
 
-        case ExpressionOperator.LogicalAnd:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
+            return result;
+        }
 
-            leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
-            rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            var result = new Set<Variable>();
 
-            return leftDomain.Meet(rightDomain);
-          }
+            SetOfConstraints<Variable> upperBounds;
+            if (this.TryGetValue(v, out upperBounds) && upperBounds.IsNormal())
+            {
+                foreach (var x in upperBounds.Values)
+                {
+                    SetOfConstraints<Variable> other;
+                    if (!x.Equals(v) && this.TryGetValue(x, out other) && other.IsNormal() && other.Contains(v))
+                    {
+                        result.Add(x);
+                    }
+                }
+            }
 
-        case ExpressionOperator.LogicalOr:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
+            return result;
+        }
 
-            leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
-            rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
+        ///<summary>By default, it does nothing</summary>
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            // does nothing
+        }
 
-            return leftDomain.Join(rightDomain);
-          }
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            return CheckIfLessThan(e1, e2, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
 
-        case ExpressionOperator.Not:
-          {
-            return this.ProcessTestFalse(decoder.LeftExpressionFor(guard));
-          }
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
 
-        default:
-          {
-            return this;
-          }
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
+        {
+            return this.CheckIfLessThan(this.ExpressionManager.Encoder.VariableFor(v1), this.ExpressionManager.Encoder.VariableFor(v2));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            if (this.IsTop)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            var stripped1Var = decoder.UnderlyingVariable(decoder.Stripped(e1));
+
+            SetOfConstraints<Variable> value;
+            if (this.TryGetValue(stripped1Var, out value) && value.IsNormal())
+            {
+                if (value.Contains(decoder.UnderlyingVariable(e2)))
+                {
+                    return CheckOutcome.True;
+                }
+
+                if (value.Contains(decoder.UnderlyingVariable(decoder.Stripped(e2))))
+                {
+                    return CheckOutcome.True;
+                }
+
+                foreach (var eTmp in value.Values)
+                {
+                    SetOfConstraints<Variable> bounds;
+                    if (this.TryGetValue(eTmp, out bounds) &&
+                      (bounds.Contains(decoder.UnderlyingVariable(e2)) || bounds.Contains(decoder.UnderlyingVariable(decoder.Stripped(e2)))))
+                    { // e1 <= eTmp , eTmp <= e2 => e1 <= e2
+                        return CheckOutcome.True;
+                    }
+                }
+            }
+
+            if (this.TryGetValue(decoder.UnderlyingVariable(e2), out value) && value.IsNormal())
+            {
+                if (this.CheckIfLessThan(e2, decoder.Stripped(e1), TopNumericalDomain<Variable, Expression>.Singleton) == CheckOutcome.True)
+                {
+                    return CheckOutcome.False;
+                }
+            }
+
+            // This is a useful case when the underlying framework has not assigned a value to the variable
+            Variable v1, v2;
+            int k1, k2;
+            if (decoder.TryMatchVarPlusConst(e1, out v1, out k1) && decoder.TryMatchVarPlusConst(e2, out v2, out k2) && k1 == k2)
+            {
+                return this.CheckIfLessEqualThan(v1, v2);
+            }
+
+            switch (decoder.OperatorFor(e2))
+            {
+                case ExpressionOperator.Addition:
+                    {
+                        // try to match e1 <= e21 + k, k > 0
+                        var e2Left = decoder.LeftExpressionFor(e2);
+                        var e2Right = decoder.RightExpressionFor(e2);
+                        int k;
+                        if (decoder.IsConstantInt(e2Right, out k) && k > 0)
+                        {
+                            if (this.CheckIfLessEqualThan(e1, e2Left).IsTrue())
+                            {
+                                return CheckOutcome.True;
+                            }
+                        }
+                    }
+                    break;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
+        {
+            return this.CheckIfLessEqualThan(this.ExpressionManager.Encoder.VariableFor(v1), this.ExpressionManager.Encoder.VariableFor(v2));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessEqualThan(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThanIncomplete(Expression e1, Expression e2)
+        {
+            if (this.IsTop)
+            {
+                return CheckOutcome.Top;
+            }
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            var stripped1Var = decoder.UnderlyingVariable(decoder.Stripped(e1));
+
+            SetOfConstraints<Variable> value;
+            if (this.TryGetValue(stripped1Var, out value) && value.IsNormal())
+            {
+                if (value.Contains(decoder.UnderlyingVariable(e2)))
+                {
+                    return CheckOutcome.True;
+                }
+
+                if (value.Contains(decoder.UnderlyingVariable(decoder.Stripped(e2))))
+                {
+                    return CheckOutcome.True;
+                }
+            }
+
+            if (this.TryGetValue(decoder.UnderlyingVariable(e2), out value) && value.IsNormal())
+            {
+                if (this.CheckIfLessThan(e2, decoder.Stripped(e1), TopNumericalDomain<Variable, Expression>.Singleton) == CheckOutcome.True)
+                {
+                    return CheckOutcome.False;
+                }
+            }
+
+            switch (decoder.OperatorFor(e2))
+            {
+                case ExpressionOperator.Addition:
+                    {
+                        // try to match e1 <= e21 + k, k > 0
+                        var e2Left = decoder.LeftExpressionFor(e2);
+                        var e2Right = decoder.RightExpressionFor(e2);
+                        int k;
+                        if (decoder.IsConstantInt(e2Right, out k) && k > 0)
+                        {
+                            if (this.CheckIfLessEqualThanIncomplete(e1, e2Left).IsTrue())
+                            {
+                                return CheckOutcome.True;
+                            }
+                        }
+                    }
+                    break;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> c1, c2;
+
+            if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
+            {
+                return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> c1, c2;
+
+            if ((c1 = CheckIfLessEqualThan(e1, e2)).IsNormal() && (c2 = CheckIfLessEqualThan(e2, e1)).IsNormal())
+            {
+                return new FlatAbstractDomain<bool>(c1.BoxedElement && c2.BoxedElement);
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        override protected WeakUpperBoundsEqual<Variable, Expression> Factory()
+        {
+            return new WeakUpperBoundsEqual<Variable, Expression>(this.ExpressionManager);
+        }
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression> Members
+
+
+        /// <summary>
+        /// Perform the parallel assignment, and improved the precision using the information from the oracle domain
+        /// </summary>
+        /// <param name="sourcesToTargets"></param>
+        [SuppressMessage("Microsoft.Contracts", "Assert-1-0")]
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            Debug.Assert(false); // Should not be called in the current Clousot setting
+
+            // Recall that we are solving the following problem. We have a new alphabet of variables V and an old alphabet of variables V'.
+            // The current state holds constraints over old variables v'1 <= v'2.
+            //
+            // The sourcesToTargets map represents assignments from old variables to new variables. An entry
+            //   v' -> v1, v2, ... vn represents the assignments v1 := v', v2 := v', ... vn := v'
+            //
+            // Thus, if the current state holds  v'1 <= v'2, and we have
+            //   v'1 -> v11, v12, ..., v1n
+            //   v'2 -> v21, v22, ..., v2m
+            //
+            // Then "all" information about v'1 <= v'2 expressed in the new state would be the conjunction of constraints
+            //   v1i <= v2j, for i=1..n and j=1..m
+            //
+            // Clearly, we don't generally want to produce this quadratic number of constraints (although in practice it is rare
+            // to see more than 1 new variable assigned the same old variable).
+            //
+            // Thus, in practice, we might pick a "canonical" new name for an old variable, say the first in the list (v11 and v21).
+            // This would then give us a single new constraint for v'1 <= v'2, namely  v11 <= v21.
+            //
+            // To compute this, we use the sourcesToTargets map as our canonical map M from old to new, by simply using the first in the list
+            // as the canonical new variable.
+
+            // Then it is simple to produce the new state: iterate over all constraints v'1 <= v'2 in the old state, and simply put
+            //   M(v'1) <= M(v'2) into the new state.
+            //
+
+
+            // The fact that we have to do this computation "in-place" is annoying. It would be simpler to produce a new state.
+            // Thus, we will compute the new mappings on the side, then clear the current state, then add the new mappings back.
+
+            // adding the domain-generated variables to the map as identity
+            var oldToNewMap = new Dictionary<Variable, FList<Variable>>(sourcesToTargets);
+            if (!this.IsTop)
+            {
+                foreach (var e in this.Variables)
+                {
+                    if (this.ExpressionManager.Decoder.IsSlackVariable(e))
+                        oldToNewMap.Add(e, FList<Variable>.Cons(e, FList<Variable>.Empty));
+                }
+            }
+
+            // when x has several targets including itself, the canonical element shouldn't be itself
+            foreach (var sourceToTargets in sourcesToTargets)
+            {
+                var source = sourceToTargets.Key;
+                var targets = sourceToTargets.Value;
+                if (targets.Length() > 1 && targets.Head.Equals(source))
+                {
+                    var newTargets = FList<Variable>.Cons(targets.Tail.Head, FList<Variable>.Cons(source, targets.Tail.Tail));
+                    oldToNewMap[source] = newTargets;
+                }
+            }
+
+            var newMappings = new Dictionary<Variable, Set<Variable>>(this.Count);
+
+            foreach (var oldLeft_Pair in this.Elements)
+            {
+                if (!oldToNewMap.ContainsKey(oldLeft_Pair.Key))
+                {
+                    continue;
+                }
+
+                var targets = oldToNewMap[oldLeft_Pair.Key];
+                var newLeft = targets.Head; // our canonical element
+
+                var oldBounds = oldLeft_Pair.Value;
+                if (!oldBounds.IsNormal())
+                {
+                    continue;
+                }
+
+                foreach (var oldRight in oldBounds.Values)
+                {
+                    if (!oldToNewMap.ContainsKey(oldRight))
+                    {
+                        continue;
+                    }
+
+                    var newRight = oldToNewMap[oldRight].Head; // our canonical element
+                    AddUpperBound(newLeft, newRight, newMappings);
+                }
+            }
+
+            // Precision improvements:
+            //
+            // Consider:
+            //   if (x < y) x = y;
+            //   Debug.Assert(x >= y);
+            //
+            // This is an example where at the end of the then branch, we have a single old variable being assigned to new new variables:
+            //   x := y'  and y := y'
+            // Since in this branch, we obviously have y' => y', the new renamed state should have y => x and x => y. That way, at the join,
+            // the constraint x >= y is retained.
+            // 
+            foreach (var pair in sourcesToTargets)
+            {
+                var targets = pair.Value;
+                var newCanonical = targets.Head;
+                targets = targets.Tail;
+                while (targets != null)
+                {
+                    // make all other targets equal to canonical (rather than n^2 combinations)
+                    AddUpperBound(newCanonical, targets.Head, newMappings);
+                    AddUpperBound(targets.Head, newCanonical, newMappings);
+                    targets = targets.Tail;
+                }
+            }
+
+            // now clear the current state
+            this.ClearElements();
+
+            // now add the new mappings
+            foreach (var key in newMappings.Keys)
+            {
+                var bounds = newMappings[key];
+
+                if (bounds.Count == 0)
+                    continue;
+
+                var newBoundsFromClosure = new Set<Variable>();
+
+                foreach (var upp in bounds)
+                {
+                    if (!upp.Equals(key) && newMappings.ContainsKey(upp))
+                    {
+                        newBoundsFromClosure.AddRange(newMappings[upp]);
+                    }
+                }
+
+                bounds.AddRange(newBoundsFromClosure);
+
+                this.AddElement(key, new SetOfConstraints<Variable>(bounds, false));
+            }
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            var result = this.DuplicateMe();
+
+            // if (this.ExpressionManager.Encoder != null)
+            {
+                foreach (var pair in this.Elements)
+                {
+                    if (pair.Value.IsNormal())
+                    {
+                        result.AddElement(pair.Key, pair.Value);
+                    }
+                    else
+                    {
+                        var newExp = new Set<Variable>();
+                        foreach (var val in pair.Value.Values)
+                        {
+                            // x <= x 
+                            if (pair.Value.Equals(val))
+                            {
+                                continue;
+                            }
+
+                            // x <= exp
+                            var leq = oracle.CheckIfLessEqualThan(pair.Key, val);
+
+                            if (!leq.IsNormal() || !leq.BoxedElement)
+                            { // Then it is not implied by oracle
+                                newExp.Add(val);
+                            }
+                        }
+                        if (newExp.Count > 0)
+                        {
+                            result.AddElement(pair.Key, new SetOfConstraints<Variable>(newExp, false));
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
 
         #endregion
-      }
-    }
 
-    protected  WeakUpperBoundsEqual<Variable, Expression>  ProcessTestFalse(Expression  guard)
-    {
-      Contract.Ensures(Contract.Result< WeakUpperBoundsEqual<Variable, Expression>>() != null);
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
 
-      var decoder = this.ExpressionManager.Decoder;
-
-      switch (this.ExpressionManager.Decoder.OperatorFor(guard))
-      {
-        #region all the cases
-
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          return HelperForNotEqual(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard));
-
-        case ExpressionOperator.GreaterEqualThan:
-          {
-            // !(left >= right) is equivalent to (left < right)
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return HelperForLessThan(left, right);
-          }
-
-        case ExpressionOperator.GreaterThan:
-          {
-            // !(left > right) is equivalent to left <= right
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return HelperForLessEqualThan(left, right);
-          }
-
-        case ExpressionOperator.LessEqualThan:
-          {
-            // !(left <= right) is equivalent to (left > right)
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return HelperForLessThan(right, left);
-          }
-
-        case ExpressionOperator.LessThan:
-          {
-            // !(left < right) is equivalent to (left >= right) that is (right <= left)
-            var left = decoder.LeftExpressionFor(guard);
-            var right = decoder.RightExpressionFor(guard);
-            return this.HelperForLessEqualThan(right, left);
-          }
-
-        case ExpressionOperator.GreaterThan_Un:
-        case ExpressionOperator.LessThan_Un:
-        case ExpressionOperator.LessEqualThan_Un:
-        case ExpressionOperator.GreaterEqualThan_Un:
-          {
-            return this;
-          }
-
-        case ExpressionOperator.LogicalAnd:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
-
-            leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard));
-            rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard));
-
-            return leftDomain.Join(rightDomain);
-          }
-          
-        case ExpressionOperator.LogicalOr:
-          {
-            var leftDomain = this.DuplicateMe();
-            var rightDomain = this.DuplicateMe();
-
-            leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard)) as WeakUpperBoundsEqual<Variable, Expression>;
-            rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard)) as WeakUpperBoundsEqual<Variable, Expression>;
-
-            return leftDomain.Meet(rightDomain);
-          }
-
-        case ExpressionOperator.Not:
-          {
-            var left = this.ExpressionManager.Decoder.LeftExpressionFor(guard);
-            return this.ProcessTestTrue(left);
-          }
-
-        default:
-          return this;
+        public Variable ToVariable(Expression exp)
+        {
+            return this.ExpressionManager.Decoder.UnderlyingVariable(exp);
+        }
 
         #endregion
-      }
-    }
 
-    /// <summary>
-    /// Handle the case <code>e1 &lt; e2</code> as it was <code>e1 &lt;= e2</code>
-    /// </summary>
-    private WeakUpperBoundsEqual<Variable, Expression> HelperForLessThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+        #region Particular cases for IAbstractDomain
 
-      var decoder = this.ExpressionManager.Decoder;
-
-      if (decoder.IsBinaryExpression(e2) && decoder.OperatorFor(e2) == ExpressionOperator.Addition)
-      {
-        var exp = decoder.RightExpressionFor(e2);
-        int value;
-        if (decoder.IsConstantInt(exp, out value) && value == 1)
+        public override WeakUpperBoundsEqual<Variable, Expression> Join(WeakUpperBoundsEqual<Variable, Expression> right)
         {
-          return HelperForLessEqualThan(e1, decoder.LeftExpressionFor(e2));
-        }
-      }
+            // Here we do not have trivial joins as we want to join maps of different cardinality
+            if (this.IsBottom)
+                return right;
+            if (right.IsBottom)
+                return this;
 
-      if (decoder.IsBinaryExpression(e1) && decoder.OperatorFor(e1) == ExpressionOperator.Subtraction)
-      {
-        var exp = decoder.RightExpressionFor(e1);
-        int value;
-        if (decoder.IsConstantInt(exp, out value) && value == 1)
+            var result = Factory();
+
+            foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
+            {
+                SetOfConstraints<Variable> intersection;
+
+                SetOfConstraints<Variable> right_x;
+                if (right.TryGetValue(pair.Key, out right_x))
+                {
+                    // Implementation of transitive closure using the steps option
+                    closureSteps = DefaultClosureSteps;
+
+                    Contract.Assume(pair.Value != null);
+
+                    var closedleft = new Set<Variable>(pair.Value.Values);
+                    var closedright = new Set<Variable>(right_x.Values);
+
+                    while (closureSteps > 0)
+                    {
+                        // here we do a transitive closure step
+                        var templeft = new Set<Variable>(closedleft);
+                        var tempright = new Set<Variable>(closedright);
+
+                        foreach (var e in closedleft)
+                        {
+                            SetOfConstraints<Variable> this_e;
+                            if (this.TryGetValue(e, out this_e) && !this_e.IsTop)
+                            {
+                                var tempSet = new Set<Variable>(this_e.Values);
+                                tempSet.Remove(pair.Key);
+                                templeft.AddRange(tempSet);
+                            }
+                        }
+
+                        foreach (var e in closedright)
+                        {
+                            SetOfConstraints<Variable> right_e;
+                            if (right.TryGetValue(e, out right_e) && !right_e.IsTop)
+                            {
+                                var tempSet = new Set<Variable>(right_e.Values);
+                                tempSet.Remove(pair.Key);
+                                tempright.AddRange(tempSet);
+                            }
+                        }
+
+                        closedleft = templeft;
+                        closedright = tempright;
+
+                        closureSteps--;
+                    }
+
+                    intersection = new SetOfConstraints<Variable>(closedleft.Intersection(closedright), false);
+
+                    if (intersection.IsNormal())
+                    {
+                        // We keep in the map only the elements that are != top and != bottom
+                        result[pair.Key] = intersection;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> Join(WeakUpperBoundsEqual<Variable, Expression> right,
+           IIntervalAbstraction<Variable, Expression> intervalsForThis, IIntervalAbstraction<Variable, Expression> intervalsForRight)
         {
-          return HelperForLessEqualThan(decoder.LeftExpressionFor(e1), e2);
+            Contract.Requires(right != null);
+            Contract.Requires(intervalsForThis != null);
+            Contract.Requires(intervalsForRight != null);
+
+            // Here we do not have trivial joins as we want to join maps of different cardinality
+            if (this.IsBottom)
+                return right;
+            if (right.IsBottom)
+                return this;
+
+            var result = this.Factory();
+
+            foreach (var pair in this.Elements)       // For all the elements in the intersection do the point-wise join
+            {
+                var intersection = new SetOfConstraints<Variable>(new Set<Variable>(), false);
+                var newValues = new Set<Variable>();
+
+                SetOfConstraints<Variable> right_x;
+                if (right.TryGetValue(pair.Key, out right_x))
+                {
+                    Contract.Assume(pair.Value != null);
+
+                    intersection = pair.Value.Join(right_x);
+                    if (!intersection.IsTop)
+                    {
+                        newValues.AddRange(intersection.Values);
+                    }
+
+                    // Foreach x <= y
+                    if (right_x.IsNormal())
+                    {
+                        foreach (var y in right_x.Values)
+                        {
+                            if (newValues.Contains(y))
+                            {
+                                continue;
+                            }
+
+                            var res = intervalsForThis.CheckIfLessEqualThan(pair.Key, y);
+
+                            if (!res.IsNormal())
+                            {
+                                continue;
+                            }
+
+                            if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+                            {
+                                newValues.Add(y);   // Add x <= y
+                            }
+                        }
+                    }
+                }
+
+                // Foreach x <= y
+                if (pair.Value.IsNormal())
+                {
+                    foreach (var y in pair.Value.Values)
+                    {
+                        if (newValues.Contains(y))
+                        {
+                            continue;
+                        }
+
+                        var res = intervalsForRight.CheckIfLessEqualThan(pair.Key, y);
+
+                        if (!res.IsNormal())
+                        {
+                            continue;
+                        }
+
+                        if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+                        {
+                            newValues.Add(y);   // Add x <= y everywhere
+                            right.TestTrueLessEqualThan(pair.Key, y);
+                        }
+                    }
+                }
+
+                if (!newValues.IsEmpty)
+                {
+                    result[pair.Key] = new SetOfConstraints<Variable>(newValues, false);
+                }
+            }
+
+            foreach (var x_pair in right.Elements)
+            {
+                if (this.ContainsKey(x_pair.Key))
+                {
+                    // Case already handled
+                    continue;
+                }
+
+                var newValues = new Set<Variable>();
+
+                // Foreach x <= y
+                if (x_pair.Value.IsNormal())
+                {
+                    foreach (var y in x_pair.Value.Values)
+                    {
+                        var res = intervalsForThis.CheckIfLessEqualThan(x_pair.Key, y);
+
+                        if (!res.IsNormal())
+                        {
+                            continue;
+                        }
+
+                        if (res.BoxedElement)    // If the intervals imply this relation, just keep it
+                        {
+                            newValues.Add(y);   // Add x <= y
+                            this.TestTrueLessEqualThan(x_pair.Key, y);
+                        }
+                    }
+
+                    if (!newValues.IsEmpty)
+                    {
+                        result[x_pair.Key] = new SetOfConstraints<Variable>(newValues, false);
+                    }
+                }
+            }
+
+            return result;
         }
-      }
 
-      return HelperForLessEqualThan(e1, e2);
-    }
+        #endregion
 
-    private WeakUpperBoundsEqual<Variable, Expression> HelperForLessEqualThan(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+        #region IPureExpressionAssignments<Expression> Members
 
-      var decoder = this.ExpressionManager.Decoder;
-
-      var e1Var = decoder.UnderlyingVariable(e1);
-      var e2Var = decoder.UnderlyingVariable(e2);
-
-      if (!decoder.IsSlackOrFrameworkVariable(e1Var) || !decoder.IsSlackOrFrameworkVariable(e2Var))
-      {
-        return this;
-      }
-
-      SetOfConstraints<Variable> this_e1;
-      if (this.TryGetValue(e1Var, out this_e1) && !this_e1.IsTop)
-      {
-        var newConstraints = new Set<Variable>(this_e1.Values);
-        newConstraints.Add(e2Var);
-
-        this[e1Var] = new SetOfConstraints<Variable>(newConstraints, false);
-      }
-
-      var newValues = new Set<Variable>();
-
-      var stripped = decoder.Stripped(e1);
-      var strippedVar = decoder.UnderlyingVariable(stripped);
-
-      if (decoder.IsVariable(stripped) || decoder.IsConstant(stripped))
-      {
-        newValues.Add(e2Var);  // e1 <= e2
-        newValues.Add(decoder.UnderlyingVariable(decoder.Stripped(e2)));   // Add "e1 <= e2'", if e2 was in the form "(int32) e2'" or similar 
-
-        SetOfConstraints<Variable> this_stripped;
-        if (this.TryGetValue(strippedVar, out this_stripped) && !this_stripped.IsTop)
-        {                   // e1 <= "all the values before"
-          newValues.AddRange(this_stripped.Values);
-        }
-
-        SetOfConstraints<Variable> this_e2;
-        if (this.TryGetValue(e2Var, out this_e2) && !this_e2.IsTop)
-        {                   // e1 <= "all the values e2 is smaller than"
-          newValues.AddRange(this_e2.Values);
-        }
-
-        this[strippedVar] = new SetOfConstraints<Variable>(newValues, false);
-      }
-      else if (!this.ContainsKey(strippedVar))
-      {
-        var tmp = new Set<Variable>() { e2Var, decoder.UnderlyingVariable(decoder.Stripped(e2)) };
-      
-        this[strippedVar] = new SetOfConstraints<Variable>(tmp, false);
-      }
-
-      Polynomial<Variable, Expression> e1LEQe2;
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1, e2, decoder, out e1LEQe2))
-      {
-        Rational k1, k2, k;
-        Variable x1, x2;
-
-        if (e1LEQe2.TryMatch_k1XPlusk2YLessThanK(out k1, out x1, out k2, out x2, out k))
+        public List<Variable> Variables
         {
-          if (k <= 0)
-          {
-            if (k1 == 1 && k2 == -1)   // x1 - x2 <= k <= 0 => x1 < x2
+            get
             {
-              this.UpdateConstraintsFor(x1, x2);
-            }
-            else if (k1 == -1 && k2 == 1) // -x1 + x2 <= k <= 0 => x2 < x1
-            {
-              this.UpdateConstraintsFor(x2, x1);
-            }
-          }
+                var result = new List<Variable>();
 
-          if (k == 1)
-          {
-            if (k1 == 1 && k2 == -1)   // x1 - x2 < 1  => x1 < x2 +1 => x1 <= x2 
-            {
-              this.UpdateConstraintsFor(x1, x2);
+                var inside = new Set<Variable>();
+
+                foreach (var x_pair in this.Elements)
+                {
+                    result.Add(x_pair.Key);
+
+                    Contract.Assume(x_pair.Value != null);
+
+                    if (!x_pair.Value.IsTop)
+                    {
+                        inside.AddRange(x_pair.Value.Values);
+                    }
+                }
+
+                result.AddRange(inside);
+
+                return result;
             }
-            else if (k1 == -1 && k2 == 1)
-            {
-              this.UpdateConstraintsFor(x2, x1);
-            }
-          }
         }
-      }
 
-        var valuesOfStripped = this[strippedVar];
-        if (valuesOfStripped.IsNormal())
+        public IEnumerable<Variable> SlackVariables
         {
-          var toBeUpdated = new List<Pair<Variable, SetOfConstraints<Variable>>>();
-
-          // "e1 <= e2", so we search all the variables to see if "e0 <= e1"
-          foreach (var e0_pair in this.Elements)
-          {
-            if (e0_pair.Value.IsNormal())
+            get
             {
-              if (e0_pair.Value.Contains(strippedVar))
-              {
-                var values = new Set<Variable>(e0_pair.Value.Values);
-                values.AddRange(valuesOfStripped.Values);
+                var seen = new Set<Variable>();
+                var decoder = this.ExpressionManager.Decoder;
 
-                toBeUpdated.Add(e0_pair.Key, new SetOfConstraints<Variable>(values, false));
-              }
+                foreach (var x_pair in this.Elements)
+                {
+                    if (decoder.IsSlackVariable(x_pair.Key))
+                    {
+                        seen.Add(x_pair.Key);
+                        yield return x_pair.Key;
+                    }
+
+                    if (!x_pair.Value.IsTop)
+                    {
+                        foreach (var y in x_pair.Value.Values)
+                        {
+                            if (decoder.IsSlackVariable(y) && !seen.Contains(y))
+                            {
+                                seen.Add(y);
+                                yield return y;
+                            }
+                        }
+                    }
+                }
             }
-          }
-
-          if (toBeUpdated.Count > 0)
-          {
-            foreach (var pair in toBeUpdated)
-            {
-              this[pair.One] = pair.Two;
-            }
-          }
         }
 
-      return this;
-    }
-
-    private WeakUpperBoundsEqual<Variable, Expression> HelperForNotEqual(Expression e1, Expression e2)
-    {
-      Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);  
-
-      int value;
-      // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant 
-      if (this.ExpressionManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.ExpressionManager.Decoder.IsConstantInt(e2, out value))
-      {
-        if (value == 0)
-        { // that is !!(e1)
-          return this.TestTrue(e1);
-        }
-        
-        if (value == 1)
-        { // that is !e1
-          return this.TestFalse(e1);
-        }
-      }
-
-      return this;
-    }
-
-    private WeakUpperBoundsEqual<Variable, Expression> HelperForEqual(Expression e1, Expression e2)
-    {
-      var result = this.HelperForLessEqualThan(e1, e2).HelperForLessEqualThan(e2, e1);
-      
-      // The code below is to share the constraints between e1 and e2
-      var e1Var = this.ExpressionManager.Decoder.UnderlyingVariable(e1);
-      var e2Var = this.ExpressionManager.Decoder.UnderlyingVariable(e2);
-
-      SetOfConstraints<Variable> e1Leq, e2Leq;
-      if (result.TryGetValue(e1Var, out e1Leq) && result.TryGetValue(e2Var, out e2Leq))
-      {
-        var meet = e1Leq.Meet(e2Leq);
-
-        result[e1Var] = meet;
-        result[e2Var] = meet;
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region Private and Protected methods
-
-    /// <summary>
-    /// Add the constraint <code>x &lt; y ></code>to this environment.
-    /// If <code>x</code> already has some constraints related to him, we make the union of constraints (but we do not propagate)
-    /// </summary>
-    private void UpdateConstraintsFor(Variable x, Variable y)
-    {
-      var newValues = new Set<Variable>();
-
-      SetOfConstraints<Variable> bounds;
-      if (this.TryGetValue(x, out bounds) && !bounds.IsTop)
-      {
-        newValues.AddRange(bounds.Values);
-      }
-      newValues.Add(y);
-
-      this[x] = new SetOfConstraints<Variable>(newValues, false);  // Do the update
-    }
-
-    #endregion
-
-    #region ToLogicalFormula
-    protected override string ToLogicalFormula(Variable d, SetOfConstraints<Variable> c)
-    {
-      if (!c.IsNormal())
-      {
-        return null;
-      }
-
-      var result = new List<string>();
-
-      var niceD = ExpressionPrinter.ToString(d, this.ExpressionManager.Decoder);
-      foreach (var y in c.Values)
-      {
-        var niceY = ExpressionPrinter.ToString(y, this.ExpressionManager.Decoder);
-        result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessEqualThan, niceD, niceY)); 
-      }
-
-      return ExpressionPrinter.ToLogicalFormula(ExpressionOperator.LogicalAnd, result);
-    }
-
-    protected override T To<T>(Variable d, SetOfConstraints<Variable> c, IFactory<T> factory)
-    {
-      // F: this are preconditions, but I am lazy...
-      Contract.Assume(c != null);
-
-      if (c.IsTop)
-        return factory.Constant(true);
-      if (c.IsBottom)
-        return factory.Constant(false);
-
-      var result = factory.IdentityForAnd;
-
-      var x = factory.Variable(d);
-
-      // We know the constraints are x <= y
-      foreach (var y in c.Values)
-      {
-        T atom = factory.LessEqualThan(x, factory.Variable(y));
-        result = factory.And(result, atom);
-      }
-
-      return result;
-    }
-    #endregion
-
-    #region ToString
-
-    public override string ToString()
-    {
-      if (this.IsTop)
-        return "Top";
-
-      if (this.IsBottom)
-        return "Bottom";
-
-      var result = new StringBuilder();
-      result.AppendLine("WUB=:");
-
-      foreach (var pair in this.Elements)
-      {
-        Contract.Assume(pair.Value != null);
-
-        if (!pair.Value.IsTop)
+        public void AddVariable(Variable var)
         {
-          var niceX = ExpressionPrinter.ToString(pair.Key, this.ExpressionManager.Decoder);
-          var niceVal = pair.Value.ToString();
-          result.AppendLine(niceX + " <= " + niceVal + " ");
+            // Does nothing, as we assume variables initialized to top
         }
-      }
 
-      return result.ToString();
+        public void ProjectVariable(Variable var)
+        {
+            this.RemoveElement(var);
+
+            var toUpdate = new List<Pair<Variable, SetOfConstraints<Variable>>>();
+
+            foreach (var pair in this.Elements)
+            {
+                if (pair.Value.IsNormal() && pair.Value.Contains(var))
+                {
+                    var s = new Set<Variable>(pair.Value.Values);
+                    s.Remove(var);
+                    toUpdate.Add(pair.Key, new SetOfConstraints<Variable>(s, false));
+                }
+            }
+
+            foreach (var pair in toUpdate)
+            {
+                this[pair.One] = pair.Two;
+            }
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            var toUpdate = new Dictionary<Variable, SetOfConstraints<Variable>>(this.Count);
+
+            var forVar = new Set<Variable>();
+
+            SetOfConstraints<Variable> value;
+            if (this.TryGetValue(var, out value) && value.IsNormal())
+            {
+                forVar = new Set<Variable>(value.Values);
+            }
+
+            foreach (var x_Pair in this.Elements)
+            {
+                var constraints = x_Pair.Value;
+
+                if (!constraints.IsNormal() || !constraints.Contains(var))
+                {
+                    continue;
+                }
+
+                var newConstraints = new Set<Variable>(constraints.Values);
+                newConstraints.AddRange(forVar);
+                newConstraints.Remove(var);
+
+                toUpdate[x_Pair.Key] = new SetOfConstraints<Variable>(newConstraints);
+            }
+
+            foreach (var x_pair in toUpdate)
+            {
+                this[x_pair.Key] = x_pair.Value;
+            }
+
+            this.RemoveElement(var);
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            foreach (var x_pair in this.Elements)
+            {
+                if (x_pair.Value.IsNormal())
+                {
+                    var oldVal = x_pair.Value;
+                    if (oldVal.Contains(OldName))
+                    {
+                        var newVal = new Set<Variable>(oldVal.Values);
+                        newVal.Remove(OldName);
+                        newVal.Add(NewName);
+                        this[x_pair.Key] = new SetOfConstraints<Variable>(newVal, false);
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestTrue(Expression guard)
+        {
+            return this.TestTrue(guard);
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> TestTrue(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            return ProcessTestTrue(guard);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Variable, Expression>.TestFalse(Expression guard)
+        {
+            return this.TestFalse(guard);
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> TestFalse(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            //      if (this.ExpressionManager.Encoder != null)
+            {
+                var notGuard = this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Not, guard);
+                return TestTrue(notGuard);
+            }
+            /*
+                else
+                {
+                  return ProcessTestFalse(guard);
+                }
+             */
+        }
+
+        /// <summary>
+        /// Does nothing
+        /// </summary>
+        public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            return this;
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return this.TestTrueEqual(exp1, exp2);
+        }
+
+        #endregion
+
+        #region WeakUpperBounds-Specific Methods
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessThan(Expression e1, Expression e2)
+        {
+            return this.HelperForLessThan(e1, e2);
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> TestTrueLessThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            return this.HelperForLessThan(e1, e2);
+        }
+
+        INumericalAbstractDomain<Variable, Expression> INumericalAbstractDomain<Variable, Expression>.TestTrueLessEqualThan(Expression e1, Expression e2)
+        {
+            return this.TestTrueLessEqualThan(e1, e2);
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> TestTrueLessEqualThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            return this.HelperForLessEqualThan(e1, e2);
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> TestTrueLessEqualThan(Variable e1, Variable e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            return this.TestTrueLessEqualThan(this.ExpressionManager.Encoder.VariableFor(e1), this.ExpressionManager.Encoder.VariableFor(e2));
+        }
+
+        public WeakUpperBoundsEqual<Variable, Expression> TestTrueEqual(Expression e1, Expression e2)
+        {
+            return this.HelperForEqual(e1, e2);
+        }
+
+        #endregion
+
+        #region Protected methods
+
+        protected WeakUpperBoundsEqual<Variable, Expression> ProcessTestTrue(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            switch (decoder.OperatorFor(guard))
+            {
+                #region all the cases
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    {
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+
+                        var leftVar = decoder.UnderlyingVariable(left);
+                        var rightVar = decoder.UnderlyingVariable(right);
+
+                        SetOfConstraints<Variable> v1, v2;
+                        if (this.TryGetValue(leftVar, out v1) && this.TryGetValue(rightVar, out v2))
+                        {
+                            var intersection = v1.Meet(v2);
+                            if (v1.IsBottom)
+                            {
+                                return this.Bottom;
+                            }
+                            else
+                            {
+                                this[leftVar] = intersection;
+                                this[rightVar] = intersection;
+
+                                return this;
+                            }
+                        }
+                        else
+                        {
+                            // Try to figure out if it is in the form of (e11 rel e12) == 0
+                            Expression e11, e12;
+                            ExpressionOperator op;
+                            if (decoder.Match_E1relopE2eq0(left, right, out op, out e11, out e12))
+                            {
+                                return ProcessTestFalse(left);
+                            }
+                            else
+                            {
+                                // F: We do not want this domain to track arbitrary equalities (because of performances), 
+                                // so if we do not understand the equality, we abstract it
+                                return this;
+                            }
+                        }
+                    }
+
+                case ExpressionOperator.GreaterEqualThan:
+                    {
+                        // left >= right, so we want to add right <= left
+                        var left = this.ExpressionManager.Decoder.LeftExpressionFor(guard);
+                        var right = this.ExpressionManager.Decoder.RightExpressionFor(guard);
+                        return this.TestTrueLessEqualThan(right, left);
+                    }
+
+                case ExpressionOperator.GreaterThan:
+                    {
+                        // "left > right", so we add the constraint
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return HelperForLessThan(right, left);
+                    }
+
+                case ExpressionOperator.LessEqualThan:
+                    {
+                        // "left <= right"
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return HelperForLessEqualThan(left, right);
+                    }
+
+                case ExpressionOperator.LessThan:
+                    {
+                        // "left < right"
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return HelperForLessThan(left, right);
+                    }
+
+                // We abstract away the symbolic reasoning for unsigned as it may be incorrect
+                // Example "sv1 CLT_Un sv2" and sv2 is -1, so it should be understood as sv1 CLT_Un UInt.MaxValue - this reasoning is done by intervals
+                case ExpressionOperator.LessThan_Un:
+                case ExpressionOperator.LessEqualThan_Un:
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    {
+                        return this;
+                    }
+
+                case ExpressionOperator.LogicalAnd:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
+                        rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
+
+                        return leftDomain.Meet(rightDomain);
+                    }
+
+                case ExpressionOperator.LogicalOr:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestTrue(decoder.LeftExpressionFor(guard));
+                        rightDomain = rightDomain.ProcessTestTrue(decoder.RightExpressionFor(guard));
+
+                        return leftDomain.Join(rightDomain);
+                    }
+
+                case ExpressionOperator.Not:
+                    {
+                        return this.ProcessTestFalse(decoder.LeftExpressionFor(guard));
+                    }
+
+                default:
+                    {
+                        return this;
+                    }
+
+                    #endregion
+            }
+        }
+
+        protected WeakUpperBoundsEqual<Variable, Expression> ProcessTestFalse(Expression guard)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            switch (this.ExpressionManager.Decoder.OperatorFor(guard))
+            {
+                #region all the cases
+
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    return HelperForNotEqual(decoder.LeftExpressionFor(guard), decoder.RightExpressionFor(guard));
+
+                case ExpressionOperator.GreaterEqualThan:
+                    {
+                        // !(left >= right) is equivalent to (left < right)
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return HelperForLessThan(left, right);
+                    }
+
+                case ExpressionOperator.GreaterThan:
+                    {
+                        // !(left > right) is equivalent to left <= right
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return HelperForLessEqualThan(left, right);
+                    }
+
+                case ExpressionOperator.LessEqualThan:
+                    {
+                        // !(left <= right) is equivalent to (left > right)
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return HelperForLessThan(right, left);
+                    }
+
+                case ExpressionOperator.LessThan:
+                    {
+                        // !(left < right) is equivalent to (left >= right) that is (right <= left)
+                        var left = decoder.LeftExpressionFor(guard);
+                        var right = decoder.RightExpressionFor(guard);
+                        return this.HelperForLessEqualThan(right, left);
+                    }
+
+                case ExpressionOperator.GreaterThan_Un:
+                case ExpressionOperator.LessThan_Un:
+                case ExpressionOperator.LessEqualThan_Un:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    {
+                        return this;
+                    }
+
+                case ExpressionOperator.LogicalAnd:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard));
+                        rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard));
+
+                        return leftDomain.Join(rightDomain);
+                    }
+
+                case ExpressionOperator.LogicalOr:
+                    {
+                        var leftDomain = this.DuplicateMe();
+                        var rightDomain = this.DuplicateMe();
+
+                        leftDomain = leftDomain.ProcessTestFalse(decoder.LeftExpressionFor(guard)) as WeakUpperBoundsEqual<Variable, Expression>;
+                        rightDomain = rightDomain.ProcessTestFalse(decoder.RightExpressionFor(guard)) as WeakUpperBoundsEqual<Variable, Expression>;
+
+                        return leftDomain.Meet(rightDomain);
+                    }
+
+                case ExpressionOperator.Not:
+                    {
+                        var left = this.ExpressionManager.Decoder.LeftExpressionFor(guard);
+                        return this.ProcessTestTrue(left);
+                    }
+
+                default:
+                    return this;
+
+                    #endregion
+            }
+        }
+
+        /// <summary>
+        /// Handle the case <code>e1 &lt; e2</code> as it was <code>e1 &lt;= e2</code>
+        /// </summary>
+        private WeakUpperBoundsEqual<Variable, Expression> HelperForLessThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            if (decoder.IsBinaryExpression(e2) && decoder.OperatorFor(e2) == ExpressionOperator.Addition)
+            {
+                var exp = decoder.RightExpressionFor(e2);
+                int value;
+                if (decoder.IsConstantInt(exp, out value) && value == 1)
+                {
+                    return HelperForLessEqualThan(e1, decoder.LeftExpressionFor(e2));
+                }
+            }
+
+            if (decoder.IsBinaryExpression(e1) && decoder.OperatorFor(e1) == ExpressionOperator.Subtraction)
+            {
+                var exp = decoder.RightExpressionFor(e1);
+                int value;
+                if (decoder.IsConstantInt(exp, out value) && value == 1)
+                {
+                    return HelperForLessEqualThan(decoder.LeftExpressionFor(e1), e2);
+                }
+            }
+
+            return HelperForLessEqualThan(e1, e2);
+        }
+
+        private WeakUpperBoundsEqual<Variable, Expression> HelperForLessEqualThan(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            var decoder = this.ExpressionManager.Decoder;
+
+            var e1Var = decoder.UnderlyingVariable(e1);
+            var e2Var = decoder.UnderlyingVariable(e2);
+
+            if (!decoder.IsSlackOrFrameworkVariable(e1Var) || !decoder.IsSlackOrFrameworkVariable(e2Var))
+            {
+                return this;
+            }
+
+            SetOfConstraints<Variable> this_e1;
+            if (this.TryGetValue(e1Var, out this_e1) && !this_e1.IsTop)
+            {
+                var newConstraints = new Set<Variable>(this_e1.Values);
+                newConstraints.Add(e2Var);
+
+                this[e1Var] = new SetOfConstraints<Variable>(newConstraints, false);
+            }
+
+            var newValues = new Set<Variable>();
+
+            var stripped = decoder.Stripped(e1);
+            var strippedVar = decoder.UnderlyingVariable(stripped);
+
+            if (decoder.IsVariable(stripped) || decoder.IsConstant(stripped))
+            {
+                newValues.Add(e2Var);  // e1 <= e2
+                newValues.Add(decoder.UnderlyingVariable(decoder.Stripped(e2)));   // Add "e1 <= e2'", if e2 was in the form "(int32) e2'" or similar 
+
+                SetOfConstraints<Variable> this_stripped;
+                if (this.TryGetValue(strippedVar, out this_stripped) && !this_stripped.IsTop)
+                {                   // e1 <= "all the values before"
+                    newValues.AddRange(this_stripped.Values);
+                }
+
+                SetOfConstraints<Variable> this_e2;
+                if (this.TryGetValue(e2Var, out this_e2) && !this_e2.IsTop)
+                {                   // e1 <= "all the values e2 is smaller than"
+                    newValues.AddRange(this_e2.Values);
+                }
+
+                this[strippedVar] = new SetOfConstraints<Variable>(newValues, false);
+            }
+            else if (!this.ContainsKey(strippedVar))
+            {
+                var tmp = new Set<Variable>() { e2Var, decoder.UnderlyingVariable(decoder.Stripped(e2)) };
+
+                this[strippedVar] = new SetOfConstraints<Variable>(tmp, false);
+            }
+
+            Polynomial<Variable, Expression> e1LEQe2;
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1, e2, decoder, out e1LEQe2))
+            {
+                Rational k1, k2, k;
+                Variable x1, x2;
+
+                if (e1LEQe2.TryMatch_k1XPlusk2YLessThanK(out k1, out x1, out k2, out x2, out k))
+                {
+                    if (k <= 0)
+                    {
+                        if (k1 == 1 && k2 == -1)   // x1 - x2 <= k <= 0 => x1 < x2
+                        {
+                            this.UpdateConstraintsFor(x1, x2);
+                        }
+                        else if (k1 == -1 && k2 == 1) // -x1 + x2 <= k <= 0 => x2 < x1
+                        {
+                            this.UpdateConstraintsFor(x2, x1);
+                        }
+                    }
+
+                    if (k == 1)
+                    {
+                        if (k1 == 1 && k2 == -1)   // x1 - x2 < 1  => x1 < x2 +1 => x1 <= x2 
+                        {
+                            this.UpdateConstraintsFor(x1, x2);
+                        }
+                        else if (k1 == -1 && k2 == 1)
+                        {
+                            this.UpdateConstraintsFor(x2, x1);
+                        }
+                    }
+                }
+            }
+
+            var valuesOfStripped = this[strippedVar];
+            if (valuesOfStripped.IsNormal())
+            {
+                var toBeUpdated = new List<Pair<Variable, SetOfConstraints<Variable>>>();
+
+                // "e1 <= e2", so we search all the variables to see if "e0 <= e1"
+                foreach (var e0_pair in this.Elements)
+                {
+                    if (e0_pair.Value.IsNormal())
+                    {
+                        if (e0_pair.Value.Contains(strippedVar))
+                        {
+                            var values = new Set<Variable>(e0_pair.Value.Values);
+                            values.AddRange(valuesOfStripped.Values);
+
+                            toBeUpdated.Add(e0_pair.Key, new SetOfConstraints<Variable>(values, false));
+                        }
+                    }
+                }
+
+                if (toBeUpdated.Count > 0)
+                {
+                    foreach (var pair in toBeUpdated)
+                    {
+                        this[pair.One] = pair.Two;
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        private WeakUpperBoundsEqual<Variable, Expression> HelperForNotEqual(Expression e1, Expression e2)
+        {
+            Contract.Ensures(Contract.Result<WeakUpperBoundsEqual<Variable, Expression>>() != null);
+
+            int value;
+            // If it is in the for "op(e11, e12) relSym k" where relSym is a relational symbol, and k a constant 
+            if (this.ExpressionManager.Decoder.OperatorFor(e1).IsRelationalOperator() && this.ExpressionManager.Decoder.IsConstantInt(e2, out value))
+            {
+                if (value == 0)
+                { // that is !!(e1)
+                    return this.TestTrue(e1);
+                }
+
+                if (value == 1)
+                { // that is !e1
+                    return this.TestFalse(e1);
+                }
+            }
+
+            return this;
+        }
+
+        private WeakUpperBoundsEqual<Variable, Expression> HelperForEqual(Expression e1, Expression e2)
+        {
+            var result = this.HelperForLessEqualThan(e1, e2).HelperForLessEqualThan(e2, e1);
+
+            // The code below is to share the constraints between e1 and e2
+            var e1Var = this.ExpressionManager.Decoder.UnderlyingVariable(e1);
+            var e2Var = this.ExpressionManager.Decoder.UnderlyingVariable(e2);
+
+            SetOfConstraints<Variable> e1Leq, e2Leq;
+            if (result.TryGetValue(e1Var, out e1Leq) && result.TryGetValue(e2Var, out e2Leq))
+            {
+                var meet = e1Leq.Meet(e2Leq);
+
+                result[e1Var] = meet;
+                result[e2Var] = meet;
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region Private and Protected methods
+
+        /// <summary>
+        /// Add the constraint <code>x &lt; y ></code>to this environment.
+        /// If <code>x</code> already has some constraints related to him, we make the union of constraints (but we do not propagate)
+        /// </summary>
+        private void UpdateConstraintsFor(Variable x, Variable y)
+        {
+            var newValues = new Set<Variable>();
+
+            SetOfConstraints<Variable> bounds;
+            if (this.TryGetValue(x, out bounds) && !bounds.IsTop)
+            {
+                newValues.AddRange(bounds.Values);
+            }
+            newValues.Add(y);
+
+            this[x] = new SetOfConstraints<Variable>(newValues, false);  // Do the update
+        }
+
+        #endregion
+
+        #region ToLogicalFormula
+        protected override string ToLogicalFormula(Variable d, SetOfConstraints<Variable> c)
+        {
+            if (!c.IsNormal())
+            {
+                return null;
+            }
+
+            var result = new List<string>();
+
+            var niceD = ExpressionPrinter.ToString(d, this.ExpressionManager.Decoder);
+            foreach (var y in c.Values)
+            {
+                var niceY = ExpressionPrinter.ToString(y, this.ExpressionManager.Decoder);
+                result.Add(ExpressionPrinter.ToStringBinary(ExpressionOperator.LessEqualThan, niceD, niceY));
+            }
+
+            return ExpressionPrinter.ToLogicalFormula(ExpressionOperator.LogicalAnd, result);
+        }
+
+        protected override T To<T>(Variable d, SetOfConstraints<Variable> c, IFactory<T> factory)
+        {
+            // F: this are preconditions, but I am lazy...
+            Contract.Assume(c != null);
+
+            if (c.IsTop)
+                return factory.Constant(true);
+            if (c.IsBottom)
+                return factory.Constant(false);
+
+            var result = factory.IdentityForAnd;
+
+            var x = factory.Variable(d);
+
+            // We know the constraints are x <= y
+            foreach (var y in c.Values)
+            {
+                T atom = factory.LessEqualThan(x, factory.Variable(y));
+                result = factory.And(result, atom);
+            }
+
+            return result;
+        }
+        #endregion
+
+        #region ToString
+
+        public override string ToString()
+        {
+            if (this.IsTop)
+                return "Top";
+
+            if (this.IsBottom)
+                return "Bottom";
+
+            var result = new StringBuilder();
+            result.AppendLine("WUB=:");
+
+            foreach (var pair in this.Elements)
+            {
+                Contract.Assume(pair.Value != null);
+
+                if (!pair.Value.IsTop)
+                {
+                    var niceX = ExpressionPrinter.ToString(pair.Key, this.ExpressionManager.Decoder);
+                    var niceVal = pair.Value.ToString();
+                    result.AppendLine(niceX + " <= " + niceVal + " ");
+                }
+            }
+
+            return result.ToString();
+        }
+
+        public string ToString(Expression exp)
+        {
+            // if (this.ExpressionManager.Decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, this.ExpressionManager.Decoder);
+            }
+
+            /*else
+            {
+              return "< missing expression decoder >";
+            }*/
+        }
+
+        #endregion
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
     }
-
-    public string ToString(Expression exp)
-    {
-      // if (this.ExpressionManager.Decoder != null)
-      {
-        return ExpressionPrinter.ToString(exp, this.ExpressionManager.Decoder);
-      }
-
-      /*else
-      {
-        return "< missing expression decoder >";
-      }*/
-    }
-
-    #endregion
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-  }
-
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Polyhedra.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Polyhedra.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if POLYHEDRA
 using System;
@@ -25,1029 +14,1029 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  class UnknownType : AI.AIType
-  {
-    public UnknownType()
-    { }
-  }
-
-  static class UnknownFunctionSymbol
-  {
-    private static AI.FunctionSymbol value;
-    static UnknownFunctionSymbol()
+    class UnknownType : AI.AIType
     {
-      value = new AI.FunctionSymbol(new UnknownType());
+        public UnknownType()
+        { }
     }
 
-    static public AI.FunctionSymbol Value
+    static class UnknownFunctionSymbol
     {
-      get
-      {
-        return value;
-      }
-    }
-  }
-
-  class Converter
-  {
-    static public Exp<E> Box<E>(E exp, IExpressionDecoder<E> decoder)
-    {
-      if (decoder.IsVariable(exp))
-        return new Var<E>(exp, decoder);
-      else
-      {
-        switch (decoder.OperatorFor(exp))
+        private static AI.FunctionSymbol value;
+        static UnknownFunctionSymbol()
         {
-          case ExpressionOperator.ConvertToInt32:
-          case ExpressionOperator.ConvertToUInt16:
-          case ExpressionOperator.ConvertToUInt32:
-          case ExpressionOperator.ConvertToUInt8:
-            return Box(decoder.LeftExpressionFor(exp), decoder);
-        }
-        return new Exp<E>(exp, decoder);
-      }
-    }
-
-    static public Var<E> BoxAsVariable<E>(E exp, IExpressionDecoder<E> decoder)
-    {
-      return new Var<E>(exp, decoder);
-    }
-
-    static public E Unbox<E>(AI.IExpr boxed)
-    {
-      return ((Exp<E>)boxed).InExp;
-    }
-  }
-
-  class Exp<Expression> : AI.IFunApp
-  {
-    protected IExpressionDecoder<Variable, Expression> decoder;
-    protected Expression exp;
-
-    internal Expression InExp
-    {
-      get
-      {
-        return this.exp;
-      }
-    }
-
-    public Exp(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      this.exp = exp;
-      this.decoder = decoder;
-    }
-
-    #region IFunApp Members
-
-    public IList/*<AI.IExpr>*/ Arguments
-    {
-      get 
-      {
-        IList result = new ArrayList();
-        if (this.decoder.IsUnaryExpression(exp))
-        {
-          result.Add(Converter.Box(this.decoder.LeftExpressionFor(exp), this.decoder));
-        }
-        else if(this.decoder.IsBinaryExpression(exp))
-        {
-          result.Add(Converter.Box(this.decoder.LeftExpressionFor(exp), this.decoder));
-          result.Add(Converter.Box(this.decoder.RightExpressionFor(exp), this.decoder));
+            value = new AI.FunctionSymbol(new UnknownType());
         }
 
-        return result;
-      }
-    }
-
-    public AI.IFunApp CloneWithArguments(System.Collections.IList args)
-    {
-      return this;
-    }
-
-    public AI.IFunctionSymbol FunctionSymbol
-    {
-      get 
-      {
-        if (this.decoder.IsConstant(this.exp))
+        static public AI.FunctionSymbol Value
         {
-          int val; 
-          if (this.decoder.TryValueOf<int>(this.exp, ExpressionType.Int32, out val))
-          {
-            return AI.Int.Const(val);
-          }
-          else
-          {
-            return UnknownFunctionSymbol.Value;
-          }
+            get
+            {
+                return value;
+            }
+        }
+    }
+
+    class Converter
+    {
+        static public Exp<E> Box<E>(E exp, IExpressionDecoder<E> decoder)
+        {
+            if (decoder.IsVariable(exp))
+                return new Var<E>(exp, decoder);
+            else
+            {
+                switch (decoder.OperatorFor(exp))
+                {
+                    case ExpressionOperator.ConvertToInt32:
+                    case ExpressionOperator.ConvertToUInt16:
+                    case ExpressionOperator.ConvertToUInt32:
+                    case ExpressionOperator.ConvertToUInt8:
+                        return Box(decoder.LeftExpressionFor(exp), decoder);
+                }
+                return new Exp<E>(exp, decoder);
+            }
         }
 
-        switch (this.decoder.OperatorFor(exp))
+        static public Var<E> BoxAsVariable<E>(E exp, IExpressionDecoder<E> decoder)
         {
-          case ExpressionOperator.Addition:
-            return AI.Int.Add;
-
-          case ExpressionOperator.And:
-            return AI.Prop.And;
-
-          case ExpressionOperator.Constant:
-            return UnknownFunctionSymbol.Value;
-
-          case ExpressionOperator.ConvertToInt32:
-          case ExpressionOperator.ConvertToUInt16:
-          case ExpressionOperator.ConvertToUInt32:
-          case ExpressionOperator.ConvertToUInt8:
-            return Converter.Box(this.decoder.LeftExpressionFor(exp), this.decoder).FunctionSymbol;
-
-          case ExpressionOperator.Division:
-            return AI.Int.Div;
-
-          case ExpressionOperator.Equal:
-case ExpressionOperator.Equal_obj:
-            return AI.Int.Eq;
-
-          case ExpressionOperator.GreaterEqualThan_Un:
-          case ExpressionOperator.GreaterEqualThan:
-            return AI.Int.AtLeast;
-
-          case ExpressionOperator.GreaterThan_Un:
-          case ExpressionOperator.GreaterThan:
-            return AI.Int.Greater;
-
-          case ExpressionOperator.LessEqualThan_Un:
-          case ExpressionOperator.LessEqualThan:
-            return AI.Int.AtMost;
-
-          case ExpressionOperator.LessThan_Un:
-          case ExpressionOperator.LessThan:
-            return AI.Int.Less;
-
-          case ExpressionOperator.Modulus:
-            return AI.Int.Mod;
-
-          case ExpressionOperator.Multiplication:
-            return AI.Int.Mul;
-
-          case ExpressionOperator.Not:
-            return AI.Prop.Not;
-
-          case ExpressionOperator.NotEqual:
-            return AI.Int.Neq;
-
-          case ExpressionOperator.Or:
-            return AI.Prop.Or;
-
-          case ExpressionOperator.ShiftLeft:
-            return UnknownFunctionSymbol.Value;
-
-          case ExpressionOperator.ShiftRight:
-            return UnknownFunctionSymbol.Value;
-
-          case ExpressionOperator.SizeOf:
-            return UnknownFunctionSymbol.Value;
-
-          case ExpressionOperator.Subtraction:
-            return AI.Int.Sub;
-
-          case ExpressionOperator.UnaryMinus:
-            return AI.Int.Negate;
-
-          case ExpressionOperator.Unknown:
-            return UnknownFunctionSymbol.Value;
-
-          case ExpressionOperator.Variable:
-            return new AI.NamedSymbol(ExpressionPrinter.ToString(this.exp, this.decoder), AI.Int.Type);
-
-          case ExpressionOperator.WritableBytes: // to improve???
-            return UnknownFunctionSymbol.Value;
-
-          default:
-            return UnknownFunctionSymbol.Value;
-        }
-      }
-    }
-
-    #endregion
-
-    #region IExpr Members
-
-    public object DoVisit(AI.ExprVisitor visitor)
-    {
-      if (this.decoder.IsVariable(this.exp))
-      {
-        return visitor.VisitVariable(Converter.BoxAsVariable(this.exp, this.decoder));
-      }
-      else 
-      {
-        return visitor.VisitFunApp(Converter.Box(this.exp, this.decoder));
-      }
-    }
-
-    #endregion
-
-    public override string ToString()
-    {
-      return ExpressionPrinter.ToString(this.exp, this.decoder);
-
-    }
-  }
-
-  class Var<Expression> : Exp<Expression>, AI.IVariable
-  {
-
-    public Var(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
-     : base(exp, decoder)
-    {
-    }
-
-    #region IVariable Members
-
-    public string Name
-    {
-      get
-      {
-        return ExpressionPrinter.ToString(this.exp, this.decoder);
-      }
-    }
-
-    #endregion
-  }
-
-  class UninterestingFunctions : AI.IFunApp
-  {
-    #region IFunApp Members
-
-    public IList Arguments
-    {
-      get { return new ArrayList(); }
-    }
-
-    public AI.IFunApp CloneWithArguments(IList args)
-    {
-      return this;
-    }
-
-    public AI.IFunctionSymbol FunctionSymbol
-    {
-      get { return UnknownFunctionSymbol.Value; }
-    }
-
-    #endregion
-
-    #region IExpr Members
-
-    public object DoVisit(AI.ExprVisitor visitor)
-    {
-      return visitor.Default(this);
-    }
-
-    #endregion
-  }
-
-  class PropFactory<Expression> : AI.IQuantPropExprFactory
-  {
-    internal static AI.IFunApp t = null;
-    internal static AI.IFunApp f = null;
-
-    IExpressionDecoder<Variable, Expression> decoder;
-    IExpressionEncoder<Variable, Expression> encoder;
-
-    public PropFactory(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
-    {
-      this.decoder = decoder;
-      this.encoder = encoder;
-    }
-
-    #region IQuantPropExprFactory Members
-
-    public AI.IFunApp Exists(AI.AIType paramType, AI.FunctionBody body)
-    {
-      return new UninterestingFunctions();
-    }
-
-    public AI.IFunApp Exists(AI.IFunction p)
-    {
-      return new UninterestingFunctions();
-    }
-
-    public AI.IFunApp Forall(AI.AIType paramType, AI.FunctionBody body)
-    {
-      return new UninterestingFunctions();
-    }
-
-    public AI.IFunApp Forall(AI.IFunction p)
-    {
-      return new UninterestingFunctions();
-    }
-
-    #endregion
-
-    #region IPropExprFactory Members
-
-    public AI.IFunApp And(AI.IExpr p, AI.IExpr q)
-    {
-      Expression e1 = Converter.Unbox<Expression>(p);
-      Expression e2 = Converter.Unbox<Expression>(q);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.And, e1, e2), this.decoder);
-    }
-
-    public AI.IFunApp False
-    {
-      get 
-      {
-        if (f == null)
-        {
-          Expression f1 = this.encoder.ConstantFor(false);
-          f = Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Constant, f1), this.decoder);
-        }
-        return f;
-      }
-    }
-
-    public AI.IFunApp Implies(AI.IExpr p, AI.IExpr q)
-    {
-      return new UninterestingFunctions();
-    }
-
-    public AI.IFunApp Not(AI.IExpr p)
-    {
-      Expression e = Converter.Unbox<Expression>(p);
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Not, e), this.decoder);
-    }
-
-    public AI.IFunApp Or(AI.IExpr p, AI.IExpr q)
-    {
-      Expression e1 = Converter.Unbox<Expression>(p);
-      Expression e2 = Converter.Unbox<Expression>(q);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Or, e1, e2), this.decoder);
-    }
-
-    public AI.IFunApp True
-    {
-      get 
-      {
-        if (t == null)
-        {
-          Expression t1 = this.encoder.ConstantFor(true);
-          t = Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Constant, t1), this.decoder);
-        }
-        return t;
-      }
-    }
-
-    #endregion
-  }
-
-  class LinearExpFactory<Expression> : AI.ILinearExprFactory
-  {
-    IExpressionDecoder<Variable, Expression> decoder;
-    IExpressionEncoder<Variable, Expression> encoder;
-   
-    public LinearExpFactory(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
-    {
-      this.decoder = decoder;
-      this.encoder = encoder;
-    }
-
-    #region ILinearExprFactory Members
-
-    public AI.IFunApp Add(AI.IExpr p, AI.IExpr q)
-    {
-      Expression e1 = Converter.Unbox<Expression>(p);
-      Expression e2 = Converter.Unbox<Expression>(q);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, e1, e2), this.decoder);
-    }
-
-    public AI.IFunApp And(AI.IExpr p, AI.IExpr q)
-    {
-      Expression e1 = Converter.Unbox<Expression>(p);
-      Expression e2 = Converter.Unbox<Expression>(q);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.And, e1, e2), this.decoder);
-    }
-
-    public AI.IFunApp AtMost(AI.IExpr p, AI.IExpr q)
-    {
-      Expression e1 = Converter.Unbox<Expression>(p);
-      Expression e2 = Converter.Unbox<Expression>(q);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, e1, e2), this.decoder);
-    }
-
-    public AI.IFunApp False
-    {
-      get 
-      {
-        if (PropFactory<Expression>.f == null)
-        {
-          Expression f1 = this.encoder.ConstantFor(false);
-          PropFactory<Expression>.f = Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Constant, f1), this.decoder);
-        }
-        return PropFactory<Expression>.f;
-      }
-    }
-
-    public AI.IExpr Term(AI.Rational r, AI.IVariable var)
-    {
-      long up = r.Numerator;
-      long down = r.Denominator;
-
-      Expression upAsExp = this.encoder.ConstantFor(up);
-      Expression downAsExp = this.encoder.ConstantFor(down);
-
-      Expression asFrac = this.encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Division, upAsExp, downAsExp);
-
-      // We assume AI.IVariable being a Var<Exp>
-      Var<Expression> v = var as Var<Expression>;
-
-      if(v == null)
-        throw new AbstractInterpretationException();
-
-      Expression newVar = Converter.Unbox<Expression>(v);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, asFrac, newVar), this.decoder); 
-    }
-
-    public AI.IFunApp True
-    {
-      get
-      {
-        if (PropFactory<Expression>.t == null)
-        {
-          Expression t1 = this.encoder.ConstantFor(false);
-          PropFactory<Expression>.t = Converter.Box(t1, this.decoder);
-        }
-        return PropFactory<Expression>.t;
-      }
-    }
-
-    #endregion
-
-    #region IIntExprFactory Members
-
-    public AI.IFunApp Const(int i)
-    {
-      return Converter.Box(this.encoder.ConstantFor(i), this.decoder);
-    }
-
-    #endregion
-
-    #region IValueExprFactory Members
-
-    public AI.IFunApp Eq(AI.IExpr p, AI.IExpr q)
-    {
-      Expression e1 = Converter.Unbox<Expression>(p);
-      Expression e2 = Converter.Unbox<Expression>(q);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, e1, e2), this.decoder);
-    }
-
-    public AI.IFunApp Neq(AI.IExpr p, AI.IExpr q)
-    {
-      Expression e1 = Converter.Unbox<Expression>(p);
-      Expression e2 = Converter.Unbox<Expression>(q);
-
-      return Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, e1, e2), this.decoder);
-    }
-
-    #endregion
-  }
-
-  public class PolyhedraEnvironment<Expression> : INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Statics
-    static private AI.Lattice UnderlyingPolyhedra;
-    static private LinearExpFactory<Expression> linearfactory;
-    static private PropFactory<Expression> propfactory;
-
-    public static void Init(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
-    {
-      linearfactory = new LinearExpFactory<Expression>(decoder, encoder);
-      propfactory = new PropFactory<Expression>(decoder, encoder);
-      UnderlyingPolyhedra = new AI.PolyhedraLattice(linearfactory, propfactory);
-
-      UnderlyingPolyhedra.Validate();
-    }
-    #endregion
-
-    #region Private State
-    private AI.PolyhedraLattice.Element embedded;
-    private IntervalEnvironment<Variable, Expression> intv;
-
-    private IExpressionDecoder<Variable, Expression> decoder;
-    private IExpressionEncoder<Variable, Expression> encoder;
-
-    private PolyhedraTestTrueVisitor testTrueVisitor;
-    private PolyhedraTestFalseVisitor testFalseVisitor;
-    #endregion
-
-    public PolyhedraEnvironment(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
-    {
-      this.decoder = decoder;
-      this.encoder = encoder;
-      this.embedded = UnderlyingPolyhedra.Top;
-      this.intv = new IntervalEnvironment<Variable, Expression>(decoder, encoder);
-
-      this.testTrueVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestTrueVisitor(decoder);
-      this.testFalseVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestFalseVisitor(decoder);
-      this.testTrueVisitor.FalseVisitor = this.testFalseVisitor;
-      this.testFalseVisitor.TrueVisitor = this.testTrueVisitor;
-    }
-
-    private PolyhedraEnvironment(PolyhedraEnvironment<Expression> pe, AI.PolyhedraLattice.Element value, IntervalEnvironment<Variable, Expression> intv)
-      : this(pe.decoder, pe.encoder, value, intv)
-    {
-      this.testTrueVisitor = pe.testTrueVisitor;
-      this.testFalseVisitor = pe.testFalseVisitor;
-    }
-
-    private PolyhedraEnvironment(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder, AI.PolyhedraLattice.Element value, IntervalEnvironment<Variable, Expression> intv)
-    {
-      this.decoder = decoder;
-      this.encoder = encoder;
-      this.embedded = value;
-      this.intv = intv;
-
-      this.testTrueVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestTrueVisitor(decoder);
-      this.testFalseVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestFalseVisitor(decoder);
-      this.testTrueVisitor.FalseVisitor = this.testFalseVisitor;
-      this.testFalseVisitor.TrueVisitor = this.testTrueVisitor;
-    }
-
-    #region INumericalAbstractDomain<Rational,Expression> Members
-
-    /// <summary>
-    /// Return top
-    /// </summary>
-    public Interval BoundsFor(Expression v)
-    {
-      return this.intv.BoundsFor(v); 
-    }
-
-    // Does nothing for the moment
-    public void AssignInterval(Expression x, Interval value)
-    {
-      this.AssignIntervalJustInPolyhedra(x, value);
-      this.intv.AssignInterval(x, value);
-    }
-
-    private void AssignIntervalJustInPolyhedra(Expression x, Interval value)
-    {
-      if (!value.IsBottom)
-      {
-        if (!value.LowerBound.IsInfinity)
-        {
-          AI.IExpr lowerBound = linearfactory.AtMost(linearfactory.Const((Int32)value.LowerBound.PreviousInteger), Converter.BoxAsVariable(x, this.decoder));
-          this.embedded = UnderlyingPolyhedra.Constrain(this.embedded, lowerBound);
-        }
-        if (!value.UpperBound.IsInfinity)
-        {
-          AI.IExpr upperBound = linearfactory.AtMost(Converter.BoxAsVariable(x, this.decoder), linearfactory.Const((Int32)value.UpperBound.NextInteger));
-          this.embedded = UnderlyingPolyhedra.Constrain(this.embedded, upperBound);
-        }
-      }
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      // 0 <= exp
-      AI.IExpr toAssume = linearfactory.AtMost(linearfactory.Const(0), Converter.Box<Expression>(exp, this.decoder));
-
-      return Factory(UnderlyingPolyhedra.Constrain(this.embedded, toAssume), this.intv.TestTrueGeqZero(exp));
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      // exp1 <= exp2 -1
-      AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(exp1, this.decoder), linearfactory.Add(Converter.Box(exp2, this.decoder), linearfactory.Const(-1)));
-
-      return Factory(UnderlyingPolyhedra.Constrain(this.embedded, toAssume), this.intv.TestTrueLessThan(exp1, exp2));
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      // exp1 <= exp2 
-      AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(exp1, this.decoder), Converter.Box(exp2, this.decoder));
-
-      return Factory(UnderlyingPolyhedra.Constrain(this.embedded, toAssume), this.intv.TestTrueLessEqualThan(exp1, exp2));
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      // exp >= 0 ?
-      AI.IExpr toCheck = linearfactory.AtMost(linearfactory.Const(0), Converter.Box<Expression>(exp, this.decoder));
-
-      return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(this.embedded, toCheck)).Meet(this.intv.CheckIfGreaterEqualThanZero(exp));
-    }
-    
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      // exp1 <= exp2 -1 ?
-
-      AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(e1, this.decoder), linearfactory.Add(Converter.Box(e2, this.decoder), linearfactory.Const(-1)));
-
-      return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(this.embedded, toAssume)).Meet(this.intv.CheckIfLessThan(e1, e2));
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-     // exp1 <= exp2 ?
-      AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(e1, this.decoder), Converter.Box(e2, this.decoder));
-
-      return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(this.embedded, toAssume)).Meet(this.intv.CheckIfLessEqualThan(e1, e2));
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get 
-      {
-        return UnderlyingPolyhedra.IsBottom(this.embedded) || this.intv.IsBottom;
-      }
-    }
-
-    public bool IsTop
-    {
-      get 
-      {
-        return UnderlyingPolyhedra.IsTop(this.embedded) && this.intv.IsTop;
-      }
-    }
-
-    bool IAbstractDomain.LessEqual(IAbstractDomain a)
-    {
-      return this.LessEqual((PolyhedraEnvironment<Expression>)a);
-    }
-
-    public bool LessEqual(PolyhedraEnvironment<Expression> right)
-    {
-      bool result;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
-      {
-        return result;
-      }
-      else
-      {
-        return UnderlyingPolyhedra.LowerThan(this.embedded, right.embedded) && this.intv.LessEqual(right.intv);
-      }
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get 
-      {
-        return Factory(UnderlyingPolyhedra.Bottom, (INumericalAbstractDomain<Variable, Expression>) this.intv.Bottom);
-      }
-    }
-
-    public IAbstractDomain Top
-    {
-      get 
-      {
-        return Factory(UnderlyingPolyhedra.Top, (INumericalAbstractDomain<Variable, Expression>)this.intv.Top);
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
-    {
-      return this.Join((PolyhedraEnvironment<Expression>)a); 
-    }
-
-    public PolyhedraEnvironment<Expression> Join(PolyhedraEnvironment<Expression> right)
-    {
-      PolyhedraEnvironment<Expression> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
-      {
-        return result;
-      }
-      else
-      {
-        return Factory(UnderlyingPolyhedra.Join(this.embedded, right.embedded), this.intv.Join(right.intv));
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
-    {
-      return this.Meet((PolyhedraEnvironment<Expression>)a);
-    }
-
-    public PolyhedraEnvironment<Expression> Meet(PolyhedraEnvironment<Expression> right)
-    {
-      PolyhedraEnvironment<Expression> result;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, right, out result))
-      {
-        return result;
-      }
-      else
-      {
-        return Factory(UnderlyingPolyhedra.Meet(this.embedded, right.embedded), this.intv.Meet(right.intv));
-      }
-    }
-
-    IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
-    {
-      return this.Widening((PolyhedraEnvironment<Expression>)prev);
-    }
-
-    public PolyhedraEnvironment<Expression> Widening(PolyhedraEnvironment<Expression> prev)
-    {
-      PolyhedraEnvironment<Expression> result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
-      {
-        return result;
-      }
-      else
-      {
-        // Boogie's polyhedra has it in the other order
-        return Factory(UnderlyingPolyhedra.Widen(prev.embedded, this.embedded), this.intv.Widening(prev.intv));
-      }
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      return factory.Constant(true);
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      return Factory((AI.PolyhedraLattice.Element) this.embedded.Clone(), (IAbstractDomain) this.intv.Clone());
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public Set<Expression> Variables
-    {
-      get 
-      {
-        Set<Expression> result = new Set<Expression>();
-
-        foreach (AI.IVariable var in this.embedded.FreeVariables())
-        {
-          Exp<Expression> asExp = var as Exp<Expression>;
-          result.Add(asExp.InExp);
+            return new Var<E>(exp, decoder);
         }
 
-        return result.Union(this.intv.Variables);
-      }
-    }
-
-    public void AddVariable(Expression var)
-    {
-      // Does nothing
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
-    }
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      this.embedded = UnderlyingPolyhedra.Constrain(this.embedded, Converter.Box(this.encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, x, exp), this.decoder));
-    }
-
-    public void ProjectVariable(Expression var)
-    {
-      this.embedded = UnderlyingPolyhedra.Eliminate(this.embedded, Converter.BoxAsVariable<Expression>(var, this.decoder));
-      this.intv.ProjectVariable(var);
-    }
-
-    public void RemoveVariable(Expression var)
-    {
-      this.embedded = UnderlyingPolyhedra.Eliminate(this.embedded, Converter.BoxAsVariable<Expression>(var, this.decoder));
-      this.intv.RemoveVariable(var);
-    }
-
-    public void RenameVariable(Expression OldName, Expression NewName)
-    {
-      this.embedded = UnderlyingPolyhedra.Rename(this.embedded, Converter.BoxAsVariable<Expression>(OldName, this.decoder), Converter.BoxAsVariable<Expression>(NewName, this.decoder));
-      this.intv.RenameVariable(OldName, NewName);
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Expression>.TestTrue(Expression guard)
-    {
-      return this.TestTrue(guard);
-    }
-
-    PolyhedraEnvironment<Expression> TestTrue(Expression guard)
-    {
-      return this.testTrueVisitor.Visit(guard, this);
-    }
-
-    IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Expression>.TestFalse(Expression guard)
-    {
-      return this.TestFalse(guard);
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      return this.testFalseVisitor.Visit(guard, this);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
-    {
-      return new FlatAbstractDomain<bool>(false).Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      // exp ?
-      return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(this.embedded, Converter.Box(exp, this.decoder))).Meet(this.intv.CheckIfHolds(exp));
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Expression> Members
-
-    public void AssignInParallel(IDictionary<Expression, Microsoft.Research.DataStructures.FList<Expression>> sourcesToTargets)
-    {
-      this.intv.AssignInParallel(sourcesToTargets);
-
-      // Do the renamings
-      foreach (Expression source in sourcesToTargets.Keys)
-      {
+        static public E Unbox<E>(AI.IExpr boxed)
         {
-          if (sourcesToTargets[source].Length() == 1)
-          { // we want to just follow the renamings, all the rest is not interesting and we discard it
-            Expression target = sourcesToTargets[source].Head;
-            // source -> target ,  i.e. the new name for "source" is "target"
-
-            ALog.Message(StringClosure.For("Renaming {0} to {1}", ExpressionPrinter.ToStringClosure(source, decoder), ExpressionPrinter.ToStringClosure(target, decoder)));
-
-              this.embedded = UnderlyingPolyhedra.Rename(this.embedded,Converter.BoxAsVariable(source, this.decoder), Converter.BoxAsVariable(target, this.decoder));
-          }
+            return ((Exp<E>)boxed).InExp;
         }
-      }
+    }
+
+    class Exp<Expression> : AI.IFunApp
+    {
+        protected IExpressionDecoder<Variable, Expression> decoder;
+        protected Expression exp;
+
+        internal Expression InExp
+        {
+            get
+            {
+                return this.exp;
+            }
+        }
+
+        public Exp(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            this.exp = exp;
+            this.decoder = decoder;
+        }
+
+#region IFunApp Members
+
+        public IList/*<AI.IExpr>*/ Arguments
+        {
+            get
+            {
+                IList result = new ArrayList();
+                if (this.decoder.IsUnaryExpression(exp))
+                {
+                    result.Add(Converter.Box(this.decoder.LeftExpressionFor(exp), this.decoder));
+                }
+                else if (this.decoder.IsBinaryExpression(exp))
+                {
+                    result.Add(Converter.Box(this.decoder.LeftExpressionFor(exp), this.decoder));
+                    result.Add(Converter.Box(this.decoder.RightExpressionFor(exp), this.decoder));
+                }
+
+                return result;
+            }
+        }
+
+        public AI.IFunApp CloneWithArguments(System.Collections.IList args)
+        {
+            return this;
+        }
+
+        public AI.IFunctionSymbol FunctionSymbol
+        {
+            get
+            {
+                if (this.decoder.IsConstant(this.exp))
+                {
+                    int val;
+                    if (this.decoder.TryValueOf<int>(this.exp, ExpressionType.Int32, out val))
+                    {
+                        return AI.Int.Const(val);
+                    }
+                    else
+                    {
+                        return UnknownFunctionSymbol.Value;
+                    }
+                }
+
+                switch (this.decoder.OperatorFor(exp))
+                {
+                    case ExpressionOperator.Addition:
+                        return AI.Int.Add;
+
+                    case ExpressionOperator.And:
+                        return AI.Prop.And;
+
+                    case ExpressionOperator.Constant:
+                        return UnknownFunctionSymbol.Value;
+
+                    case ExpressionOperator.ConvertToInt32:
+                    case ExpressionOperator.ConvertToUInt16:
+                    case ExpressionOperator.ConvertToUInt32:
+                    case ExpressionOperator.ConvertToUInt8:
+                        return Converter.Box(this.decoder.LeftExpressionFor(exp), this.decoder).FunctionSymbol;
+
+                    case ExpressionOperator.Division:
+                        return AI.Int.Div;
+
+                    case ExpressionOperator.Equal:
+                    case ExpressionOperator.Equal_obj:
+                        return AI.Int.Eq;
+
+                    case ExpressionOperator.GreaterEqualThan_Un:
+                    case ExpressionOperator.GreaterEqualThan:
+                        return AI.Int.AtLeast;
+
+                    case ExpressionOperator.GreaterThan_Un:
+                    case ExpressionOperator.GreaterThan:
+                        return AI.Int.Greater;
+
+                    case ExpressionOperator.LessEqualThan_Un:
+                    case ExpressionOperator.LessEqualThan:
+                        return AI.Int.AtMost;
+
+                    case ExpressionOperator.LessThan_Un:
+                    case ExpressionOperator.LessThan:
+                        return AI.Int.Less;
+
+                    case ExpressionOperator.Modulus:
+                        return AI.Int.Mod;
+
+                    case ExpressionOperator.Multiplication:
+                        return AI.Int.Mul;
+
+                    case ExpressionOperator.Not:
+                        return AI.Prop.Not;
+
+                    case ExpressionOperator.NotEqual:
+                        return AI.Int.Neq;
+
+                    case ExpressionOperator.Or:
+                        return AI.Prop.Or;
+
+                    case ExpressionOperator.ShiftLeft:
+                        return UnknownFunctionSymbol.Value;
+
+                    case ExpressionOperator.ShiftRight:
+                        return UnknownFunctionSymbol.Value;
+
+                    case ExpressionOperator.SizeOf:
+                        return UnknownFunctionSymbol.Value;
+
+                    case ExpressionOperator.Subtraction:
+                        return AI.Int.Sub;
+
+                    case ExpressionOperator.UnaryMinus:
+                        return AI.Int.Negate;
+
+                    case ExpressionOperator.Unknown:
+                        return UnknownFunctionSymbol.Value;
+
+                    case ExpressionOperator.Variable:
+                        return new AI.NamedSymbol(ExpressionPrinter.ToString(this.exp, this.decoder), AI.Int.Type);
+
+                    case ExpressionOperator.WritableBytes: // to improve???
+                        return UnknownFunctionSymbol.Value;
+
+                    default:
+                        return UnknownFunctionSymbol.Value;
+                }
+            }
+        }
+
+#endregion
+
+#region IExpr Members
+
+        public object DoVisit(AI.ExprVisitor visitor)
+        {
+            if (this.decoder.IsVariable(this.exp))
+            {
+                return visitor.VisitVariable(Converter.BoxAsVariable(this.exp, this.decoder));
+            }
+            else
+            {
+                return visitor.VisitFunApp(Converter.Box(this.exp, this.decoder));
+            }
+        }
+
+#endregion
+
+        public override string ToString()
+        {
+            return ExpressionPrinter.ToString(this.exp, this.decoder);
+
+        }
+    }
+
+    class Var<Expression> : Exp<Expression>, AI.IVariable
+    {
+
+        public Var(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
+         : base(exp, decoder)
+        {
+        }
+
+#region IVariable Members
+
+        public string Name
+        {
+            get
+            {
+                return ExpressionPrinter.ToString(this.exp, this.decoder);
+            }
+        }
+
+#endregion
+    }
+
+    class UninterestingFunctions : AI.IFunApp
+    {
+#region IFunApp Members
+
+        public IList Arguments
+        {
+            get { return new ArrayList(); }
+        }
+
+        public AI.IFunApp CloneWithArguments(IList args)
+        {
+            return this;
+        }
+
+        public AI.IFunctionSymbol FunctionSymbol
+        {
+            get { return UnknownFunctionSymbol.Value; }
+        }
+
+#endregion
+
+#region IExpr Members
+
+        public object DoVisit(AI.ExprVisitor visitor)
+        {
+            return visitor.Default(this);
+        }
+
+#endregion
+    }
+
+    class PropFactory<Expression> : AI.IQuantPropExprFactory
+    {
+        internal static AI.IFunApp t = null;
+        internal static AI.IFunApp f = null;
+
+        IExpressionDecoder<Variable, Expression> decoder;
+        IExpressionEncoder<Variable, Expression> encoder;
+
+        public PropFactory(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
+        {
+            this.decoder = decoder;
+            this.encoder = encoder;
+        }
+
+#region IQuantPropExprFactory Members
+
+        public AI.IFunApp Exists(AI.AIType paramType, AI.FunctionBody body)
+        {
+            return new UninterestingFunctions();
+        }
+
+        public AI.IFunApp Exists(AI.IFunction p)
+        {
+            return new UninterestingFunctions();
+        }
+
+        public AI.IFunApp Forall(AI.AIType paramType, AI.FunctionBody body)
+        {
+            return new UninterestingFunctions();
+        }
+
+        public AI.IFunApp Forall(AI.IFunction p)
+        {
+            return new UninterestingFunctions();
+        }
+
+#endregion
+
+#region IPropExprFactory Members
+
+        public AI.IFunApp And(AI.IExpr p, AI.IExpr q)
+        {
+            Expression e1 = Converter.Unbox<Expression>(p);
+            Expression e2 = Converter.Unbox<Expression>(q);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.And, e1, e2), decoder);
+        }
+
+        public AI.IFunApp False
+        {
+            get
+            {
+                if (f == null)
+                {
+                    Expression f1 = encoder.ConstantFor(false);
+                    f = Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Constant, f1), decoder);
+                }
+                return f;
+            }
+        }
+
+        public AI.IFunApp Implies(AI.IExpr p, AI.IExpr q)
+        {
+            return new UninterestingFunctions();
+        }
+
+        public AI.IFunApp Not(AI.IExpr p)
+        {
+            Expression e = Converter.Unbox<Expression>(p);
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Not, e), decoder);
+        }
+
+        public AI.IFunApp Or(AI.IExpr p, AI.IExpr q)
+        {
+            Expression e1 = Converter.Unbox<Expression>(p);
+            Expression e2 = Converter.Unbox<Expression>(q);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Or, e1, e2), decoder);
+        }
+
+        public AI.IFunApp True
+        {
+            get
+            {
+                if (t == null)
+                {
+                    Expression t1 = encoder.ConstantFor(true);
+                    t = Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Constant, t1), decoder);
+                }
+                return t;
+            }
+        }
+
+#endregion
+    }
+
+    class LinearExpFactory<Expression> : AI.ILinearExprFactory
+    {
+        IExpressionDecoder<Variable, Expression> decoder;
+        IExpressionEncoder<Variable, Expression> encoder;
+
+        public LinearExpFactory(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
+        {
+            this.decoder = decoder;
+            this.encoder = encoder;
+        }
+
+#region ILinearExprFactory Members
+
+        public AI.IFunApp Add(AI.IExpr p, AI.IExpr q)
+        {
+            Expression e1 = Converter.Unbox<Expression>(p);
+            Expression e2 = Converter.Unbox<Expression>(q);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, e1, e2), decoder);
+        }
+
+        public AI.IFunApp And(AI.IExpr p, AI.IExpr q)
+        {
+            Expression e1 = Converter.Unbox<Expression>(p);
+            Expression e2 = Converter.Unbox<Expression>(q);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.And, e1, e2), decoder);
+        }
+
+        public AI.IFunApp AtMost(AI.IExpr p, AI.IExpr q)
+        {
+            Expression e1 = Converter.Unbox<Expression>(p);
+            Expression e2 = Converter.Unbox<Expression>(q);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, e1, e2), decoder);
+        }
+
+        public AI.IFunApp False
+        {
+            get
+            {
+                if (PropFactory<Expression>.f == null)
+                {
+                    Expression f1 = encoder.ConstantFor(false);
+                    PropFactory<Expression>.f = Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Constant, f1), decoder);
+                }
+                return PropFactory<Expression>.f;
+            }
+        }
+
+        public AI.IExpr Term(AI.Rational r, AI.IVariable var)
+        {
+            long up = r.Numerator;
+            long down = r.Denominator;
+
+            Expression upAsExp = encoder.ConstantFor(up);
+            Expression downAsExp = encoder.ConstantFor(down);
+
+            Expression asFrac = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Division, upAsExp, downAsExp);
+
+            // We assume AI.IVariable being a Var<Exp>
+            Var<Expression> v = var as Var<Expression>;
+
+            if (v == null)
+                throw new AbstractInterpretationException();
+
+            Expression newVar = Converter.Unbox<Expression>(v);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, asFrac, newVar), decoder);
+        }
+
+        public AI.IFunApp True
+        {
+            get
+            {
+                if (PropFactory<Expression>.t == null)
+                {
+                    Expression t1 = encoder.ConstantFor(false);
+                    PropFactory<Expression>.t = Converter.Box(t1, decoder);
+                }
+                return PropFactory<Expression>.t;
+            }
+        }
+
+#endregion
+
+#region IIntExprFactory Members
+
+        public AI.IFunApp Const(int i)
+        {
+            return Converter.Box(encoder.ConstantFor(i), decoder);
+        }
+
+#endregion
+
+#region IValueExprFactory Members
+
+        public AI.IFunApp Eq(AI.IExpr p, AI.IExpr q)
+        {
+            Expression e1 = Converter.Unbox<Expression>(p);
+            Expression e2 = Converter.Unbox<Expression>(q);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, e1, e2), decoder);
+        }
+
+        public AI.IFunApp Neq(AI.IExpr p, AI.IExpr q)
+        {
+            Expression e1 = Converter.Unbox<Expression>(p);
+            Expression e2 = Converter.Unbox<Expression>(q);
+
+            return Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, e1, e2), decoder);
+        }
+
+#endregion
+    }
+
+    public class PolyhedraEnvironment<Expression> : INumericalAbstractDomain<Variable, Expression>
+    {
+#region Statics
+        static private AI.Lattice UnderlyingPolyhedra;
+        static private LinearExpFactory<Expression> linearfactory;
+        static private PropFactory<Expression> propfactory;
+
+        public static void Init(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
+        {
+            linearfactory = new LinearExpFactory<Expression>(decoder, encoder);
+            propfactory = new PropFactory<Expression>(decoder, encoder);
+            UnderlyingPolyhedra = new AI.PolyhedraLattice(linearfactory, propfactory);
+
+            UnderlyingPolyhedra.Validate();
+        }
+#endregion
+
+#region Private State
+        private AI.PolyhedraLattice.Element embedded;
+        private IntervalEnvironment<Variable, Expression> intv;
+
+        private IExpressionDecoder<Variable, Expression> decoder;
+        private IExpressionEncoder<Variable, Expression> encoder;
+
+        private PolyhedraTestTrueVisitor testTrueVisitor;
+        private PolyhedraTestFalseVisitor testFalseVisitor;
+#endregion
+
+        public PolyhedraEnvironment(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder)
+        {
+            this.decoder = decoder;
+            this.encoder = encoder;
+            embedded = UnderlyingPolyhedra.Top;
+            intv = new IntervalEnvironment<Variable, Expression>(decoder, encoder);
+
+            testTrueVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestTrueVisitor(decoder);
+            testFalseVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestFalseVisitor(decoder);
+            testTrueVisitor.FalseVisitor = testFalseVisitor;
+            testFalseVisitor.TrueVisitor = testTrueVisitor;
+        }
+
+        private PolyhedraEnvironment(PolyhedraEnvironment<Expression> pe, AI.PolyhedraLattice.Element value, IntervalEnvironment<Variable, Expression> intv)
+          : this(pe.decoder, pe.encoder, value, intv)
+        {
+            testTrueVisitor = pe.testTrueVisitor;
+            testFalseVisitor = pe.testFalseVisitor;
+        }
+
+        private PolyhedraEnvironment(IExpressionDecoder<Variable, Expression> decoder, IExpressionEncoder<Variable, Expression> encoder, AI.PolyhedraLattice.Element value, IntervalEnvironment<Variable, Expression> intv)
+        {
+            this.decoder = decoder;
+            this.encoder = encoder;
+            embedded = value;
+            this.intv = intv;
+
+            testTrueVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestTrueVisitor(decoder);
+            testFalseVisitor = new PolyhedraEnvironment<Expression>.PolyhedraTestFalseVisitor(decoder);
+            testTrueVisitor.FalseVisitor = testFalseVisitor;
+            testFalseVisitor.TrueVisitor = testTrueVisitor;
+        }
+
+#region INumericalAbstractDomain<Rational,Expression> Members
+
+        /// <summary>
+        /// Return top
+        /// </summary>
+        public Interval BoundsFor(Expression v)
+        {
+            return intv.BoundsFor(v);
+        }
+
+        // Does nothing for the moment
+        public void AssignInterval(Expression x, Interval value)
+        {
+            this.AssignIntervalJustInPolyhedra(x, value);
+            intv.AssignInterval(x, value);
+        }
+
+        private void AssignIntervalJustInPolyhedra(Expression x, Interval value)
+        {
+            if (!value.IsBottom)
+            {
+                if (!value.LowerBound.IsInfinity)
+                {
+                    AI.IExpr lowerBound = linearfactory.AtMost(linearfactory.Const((Int32)value.LowerBound.PreviousInteger), Converter.BoxAsVariable(x, decoder));
+                    embedded = UnderlyingPolyhedra.Constrain(embedded, lowerBound);
+                }
+                if (!value.UpperBound.IsInfinity)
+                {
+                    AI.IExpr upperBound = linearfactory.AtMost(Converter.BoxAsVariable(x, decoder), linearfactory.Const((Int32)value.UpperBound.NextInteger));
+                    embedded = UnderlyingPolyhedra.Constrain(embedded, upperBound);
+                }
+            }
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            // 0 <= exp
+            AI.IExpr toAssume = linearfactory.AtMost(linearfactory.Const(0), Converter.Box<Expression>(exp, decoder));
+
+            return Factory(UnderlyingPolyhedra.Constrain(embedded, toAssume), intv.TestTrueGeqZero(exp));
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            // exp1 <= exp2 -1
+            AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(exp1, decoder), linearfactory.Add(Converter.Box(exp2, decoder), linearfactory.Const(-1)));
+
+            return Factory(UnderlyingPolyhedra.Constrain(embedded, toAssume), intv.TestTrueLessThan(exp1, exp2));
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            // exp1 <= exp2 
+            AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(exp1, decoder), Converter.Box(exp2, decoder));
+
+            return Factory(UnderlyingPolyhedra.Constrain(embedded, toAssume), intv.TestTrueLessEqualThan(exp1, exp2));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            // exp >= 0 ?
+            AI.IExpr toCheck = linearfactory.AtMost(linearfactory.Const(0), Converter.Box<Expression>(exp, decoder));
+
+            return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(embedded, toCheck)).Meet(intv.CheckIfGreaterEqualThanZero(exp));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            // exp1 <= exp2 -1 ?
+
+            AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(e1, decoder), linearfactory.Add(Converter.Box(e2, decoder), linearfactory.Const(-1)));
+
+            return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(embedded, toAssume)).Meet(intv.CheckIfLessThan(e1, e2));
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            // exp1 <= exp2 ?
+            AI.IExpr toAssume = linearfactory.AtMost(Converter.Box(e1, decoder), Converter.Box(e2, decoder));
+
+            return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(embedded, toAssume)).Meet(intv.CheckIfLessEqualThan(e1, e2));
+        }
+
+#endregion
+
+#region IAbstractDomain Members
+
+        public bool IsBottom
+        {
+            get
+            {
+                return UnderlyingPolyhedra.IsBottom(embedded) || intv.IsBottom;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return UnderlyingPolyhedra.IsTop(embedded) && intv.IsTop;
+            }
+        }
+
+        bool IAbstractDomain.LessEqual(IAbstractDomain a)
+        {
+            return this.LessEqual((PolyhedraEnvironment<Expression>)a);
+        }
+
+        public bool LessEqual(PolyhedraEnvironment<Expression> right)
+        {
+            bool result;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, right, out result))
+            {
+                return result;
+            }
+            else
+            {
+                return UnderlyingPolyhedra.LowerThan(embedded, right.embedded) && intv.LessEqual(right.intv);
+            }
+        }
+
+        public IAbstractDomain Bottom
+        {
+            get
+            {
+                return Factory(UnderlyingPolyhedra.Bottom, (INumericalAbstractDomain<Variable, Expression>)intv.Bottom);
+            }
+        }
+
+        public IAbstractDomain Top
+        {
+            get
+            {
+                return Factory(UnderlyingPolyhedra.Top, (INumericalAbstractDomain<Variable, Expression>)intv.Top);
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Join(IAbstractDomain a)
+        {
+            return this.Join((PolyhedraEnvironment<Expression>)a);
+        }
+
+        public PolyhedraEnvironment<Expression> Join(PolyhedraEnvironment<Expression> right)
+        {
+            PolyhedraEnvironment<Expression> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, right, out result))
+            {
+                return result;
+            }
+            else
+            {
+                return Factory(UnderlyingPolyhedra.Join(embedded, right.embedded), intv.Join(right.intv));
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Meet(IAbstractDomain a)
+        {
+            return this.Meet((PolyhedraEnvironment<Expression>)a);
+        }
+
+        public PolyhedraEnvironment<Expression> Meet(PolyhedraEnvironment<Expression> right)
+        {
+            PolyhedraEnvironment<Expression> result;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, right, out result))
+            {
+                return result;
+            }
+            else
+            {
+                return Factory(UnderlyingPolyhedra.Meet(embedded, right.embedded), intv.Meet(right.intv));
+            }
+        }
+
+        IAbstractDomain IAbstractDomain.Widening(IAbstractDomain prev)
+        {
+            return this.Widening((PolyhedraEnvironment<Expression>)prev);
+        }
+
+        public PolyhedraEnvironment<Expression> Widening(PolyhedraEnvironment<Expression> prev)
+        {
+            PolyhedraEnvironment<Expression> result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
+            {
+                return result;
+            }
+            else
+            {
+                // Boogie's polyhedra has it in the other order
+                return Factory(UnderlyingPolyhedra.Widen(prev.embedded, embedded), intv.Widening(prev.intv));
+            }
+        }
+
+        public T To<T>(IFactory<T> factory)
+        {
+            return factory.Constant(true);
+        }
+
+#endregion
+
+#region ICloneable Members
+
+        public object Clone()
+        {
+            return Factory((AI.PolyhedraLattice.Element)embedded.Clone(), (IAbstractDomain)intv.Clone());
+        }
+
+#endregion
+
+#region IPureExpressionAssignments<Expression> Members
+
+        public Set<Expression> Variables
+        {
+            get
+            {
+                Set<Expression> result = new Set<Expression>();
+
+                foreach (AI.IVariable var in embedded.FreeVariables())
+                {
+                    Exp<Expression> asExp = var as Exp<Expression>;
+                    result.Add(asExp.InExp);
+                }
+
+                return result.Union(intv.Variables);
+            }
+        }
+
+        public void AddVariable(Expression var)
+        {
+            // Does nothing
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+            this.Assign(x, exp, TopNumericalDomain<Variable, Expression>.Singleton);
+        }
+
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            embedded = UnderlyingPolyhedra.Constrain(embedded, Converter.Box(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, x, exp), decoder));
+        }
+
+        public void ProjectVariable(Expression var)
+        {
+            embedded = UnderlyingPolyhedra.Eliminate(embedded, Converter.BoxAsVariable<Expression>(var, decoder));
+            intv.ProjectVariable(var);
+        }
+
+        public void RemoveVariable(Expression var)
+        {
+            embedded = UnderlyingPolyhedra.Eliminate(embedded, Converter.BoxAsVariable<Expression>(var, decoder));
+            intv.RemoveVariable(var);
+        }
+
+        public void RenameVariable(Expression OldName, Expression NewName)
+        {
+            embedded = UnderlyingPolyhedra.Rename(embedded, Converter.BoxAsVariable<Expression>(OldName, decoder), Converter.BoxAsVariable<Expression>(NewName, decoder));
+            intv.RenameVariable(OldName, NewName);
+        }
+
+#endregion
+
+#region IPureExpressionTest<Expression> Members
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Expression>.TestTrue(Expression guard)
+        {
+            return this.TestTrue(guard);
+        }
+
+        PolyhedraEnvironment<Expression> TestTrue(Expression guard)
+        {
+            return testTrueVisitor.Visit(guard, this);
+        }
+
+        IAbstractDomainForEnvironments<Variable, Expression> IPureExpressionTest<Expression>.TestFalse(Expression guard)
+        {
+            return this.TestFalse(guard);
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            return testFalseVisitor.Visit(guard, this);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
+        {
+            return new FlatAbstractDomain<bool>(false).Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            // exp ?
+            return ToFlatAbstractDomain(UnderlyingPolyhedra.CheckPredicate(embedded, Converter.Box(exp, decoder))).Meet(intv.CheckIfHolds(exp));
+        }
+
+#endregion
+
+#region IAssignInParallel<Expression> Members
+
+        public void AssignInParallel(IDictionary<Expression, Microsoft.Research.DataStructures.FList<Expression>> sourcesToTargets)
+        {
+            intv.AssignInParallel(sourcesToTargets);
+
+            // Do the renamings
+            foreach (Expression source in sourcesToTargets.Keys)
+            {
+                {
+                    if (sourcesToTargets[source].Length() == 1)
+                    { // we want to just follow the renamings, all the rest is not interesting and we discard it
+                        Expression target = sourcesToTargets[source].Head;
+                        // source -> target ,  i.e. the new name for "source" is "target"
+
+                        ALog.Message(StringClosure.For("Renaming {0} to {1}", ExpressionPrinter.ToStringClosure(source, decoder), ExpressionPrinter.ToStringClosure(target, decoder)));
+
+                        embedded = UnderlyingPolyhedra.Rename(embedded, Converter.BoxAsVariable(source, decoder), Converter.BoxAsVariable(target, decoder));
+                    }
+                }
+            }
 #if true || MOREPRECISE
-        // else we want to keep track of constants
+            // else we want to keep track of constants
 
-      foreach (Expression x in this.intv.Variables)
-      {
-        Interval value = this.intv.BoundsFor(x);
-        {
-          this.AssignIntervalJustInPolyhedra(x, value);
-        }
-      }
+            foreach (Expression x in intv.Variables)
+            {
+                Interval value = intv.BoundsFor(x);
+                {
+                    this.AssignIntervalJustInPolyhedra(x, value);
+                }
+            }
 
 #endif
+        }
+
+
+#endregion
+
+#region Private Methods
+        private PolyhedraEnvironment<Expression> Factory(AI.PolyhedraLattice.Element element, IAbstractDomain intv)
+        {
+            return new PolyhedraEnvironment<Expression>(decoder, encoder, element, (IntervalEnvironment<Variable, Expression>)intv);
+        }
+
+        private FlatAbstractDomain<bool> ToFlatAbstractDomain(AI.Answer answer)
+        {
+            switch (answer)
+            {
+                case AI.Answer.Maybe:
+                    return new FlatAbstractDomain<bool>(false).Top;
+
+                case AI.Answer.No:
+                    return new FlatAbstractDomain<bool>(false);
+
+                case AI.Answer.Yes:
+                    return new FlatAbstractDomain<bool>(true);
+            }
+
+            return null; // Should be unreachable
+        }
+
+
+#endregion
+
+        public override string ToString()
+        {
+            return embedded.ToString();
+        }
+        public string ToString(Expression exp)
+        {
+            if (decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, decoder);
+            }
+            else
+            {
+                return "< missing expression decoder >";
+            }
+        }
+
+
+        class PolyhedraTestTrueVisitor : TestTrueVisitor<PolyhedraEnvironment<Expression>, Expression>
+        {
+            public PolyhedraTestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            public override PolyhedraEnvironment<Expression> VisitEqual(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
+            {
+                // left == right
+                AI.IExpr notEq = linearfactory.Eq(Converter.Box(left, this.Decoder), Converter.Box(right, this.Decoder));
+
+                return data.Factory(UnderlyingPolyhedra.Constrain(data.embedded, notEq), data.intv);
+            }
+
+            public override PolyhedraEnvironment<Expression> VisitLessEqualThan(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
+            {
+                return (PolyhedraEnvironment<Expression>)data.TestTrueLessEqualThan(left, right);
+            }
+
+            public override PolyhedraEnvironment<Expression> VisitLessThan(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
+            {
+                return (PolyhedraEnvironment<Expression>)data.TestTrueLessThan(left, right);
+            }
+
+            public override PolyhedraEnvironment<Expression> VisitNotEqual(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
+            {
+                // left != right
+                AI.IExpr notEq = linearfactory.Neq(Converter.Box(left, this.Decoder), Converter.Box(right, this.Decoder));
+
+                return data.Factory(UnderlyingPolyhedra.Constrain(data.embedded, notEq), data.intv);
+            }
+
+            public override PolyhedraEnvironment<Expression> VisitVariable(Expression exp, object variable, PolyhedraEnvironment<Expression> data)
+            {
+                return data;
+            }
+
+        }
+
+        class PolyhedraTestFalseVisitor : TestFalseVisitor<PolyhedraEnvironment<Expression>, Expression>
+        {
+            public PolyhedraTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            public override PolyhedraEnvironment<Expression> VisitVariable(Expression left, object variable, PolyhedraEnvironment<Expression> data)
+            {
+                return data;
+            }
+        }
+
+
+#region INumericalAbstractDomain<Rational,Expression> Members
+
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return (INumericalAbstractDomain<Variable, Expression>)this.Clone();
+        }
+
+        /// <returns>
+        /// The empty set
+        /// </returns>
+        public IEnumerable<Expression> LowerBoundsFor(Expression v)
+        {
+            return new Set<Expression>();
+        }
+
+#endregion
+
+#region INumericalAbstractDomain<Rational,Expression> Members
+
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            return new Set<Expression>();
+        }
+
+#endregion
+
+#region INumericalAbstractDomain<Rational,Expression> Members
+
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            return new Set<Expression>();
+        }
+
+#endregion
     }
 
-
-    #endregion
-
-    #region Private Methods
-    private PolyhedraEnvironment<Expression> Factory(AI.PolyhedraLattice.Element element, IAbstractDomain intv)
+    public class PolyhedraException : Exception
     {
-      return new PolyhedraEnvironment<Expression>(this.decoder, this.encoder, element, (IntervalEnvironment<Variable, Expression>) intv);
     }
 
-    private FlatAbstractDomain<bool> ToFlatAbstractDomain(AI.Answer answer)
-    {
-      switch (answer)
-      {
-        case AI.Answer.Maybe:
-          return new FlatAbstractDomain<bool>(false).Top;
-
-        case AI.Answer.No:
-          return new FlatAbstractDomain<bool>(false);
-
-        case AI.Answer.Yes:
-          return new FlatAbstractDomain<bool>(true);
-      }
-
-      return null; // Should be unreachable
-    }
-
-
-    #endregion
-
-    public override string ToString()
-    {
-      return this.embedded.ToString();
-    }
-    public string ToString(Expression exp)
-    {
-      if (this.decoder != null)
-      {
-        return ExpressionPrinter.ToString(exp, this.decoder);
-      }
-      else
-      {
-        return "< missing expression decoder >";
-      }
-    }
-
-
-    class PolyhedraTestTrueVisitor : TestTrueVisitor<PolyhedraEnvironment<Expression>, Expression>
-    {
-      public PolyhedraTestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      public override PolyhedraEnvironment<Expression> VisitEqual(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
-      {
-        // left == right
-        AI.IExpr notEq = linearfactory.Eq(Converter.Box(left, this.Decoder), Converter.Box(right, this.Decoder));
-
-        return data.Factory(UnderlyingPolyhedra.Constrain(data.embedded, notEq), data.intv); 
-      }
-
-      public override PolyhedraEnvironment<Expression> VisitLessEqualThan(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
-      {
-        return (PolyhedraEnvironment<Expression>) data.TestTrueLessEqualThan(left, right);
-      }
-
-      public override PolyhedraEnvironment<Expression> VisitLessThan(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
-      {
-        return (PolyhedraEnvironment <Expression> ) data.TestTrueLessThan(left, right);
-      }
-
-      public override PolyhedraEnvironment<Expression> VisitNotEqual(Expression left, Expression right, PolyhedraEnvironment<Expression> data)
-      {
-        // left != right
-        AI.IExpr notEq = linearfactory.Neq(Converter.Box(left, this.Decoder), Converter.Box(right, this.Decoder));
-
-        return data.Factory(UnderlyingPolyhedra.Constrain(data.embedded, notEq), data.intv); 
-      }
-
-      public override PolyhedraEnvironment<Expression> VisitVariable(Expression exp, object variable, PolyhedraEnvironment<Expression> data)
-      {
-        return data;
-      }
-
-    }
-
-    class PolyhedraTestFalseVisitor : TestFalseVisitor<PolyhedraEnvironment<Expression>, Expression>
-    {
-      public PolyhedraTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      public override PolyhedraEnvironment<Expression> VisitVariable(Expression left, object variable, PolyhedraEnvironment<Expression> data)
-      {
-        return data;
-      }
-    }
-
-
-    #region INumericalAbstractDomain<Rational,Expression> Members
-
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return (INumericalAbstractDomain<Variable, Expression>) this.Clone();
-    }
-
-    /// <returns>
-    /// The empty set
-    /// </returns>
-    public IEnumerable<Expression> LowerBoundsFor(Expression v)
-    {
-      return new Set<Expression>();
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Rational,Expression> Members
-
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      return new Set<Expression>();
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Rational,Expression> Members
-
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      return new Set<Expression>();
-    }
-
-    #endregion
-  }
-
-  public class PolyhedraException : Exception
-  {
-  }
-  
 }
 #endif

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Rational.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Rational.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This file contains an implementation for rational numbers
 
@@ -30,2127 +19,2125 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// A class for rational numbers.
-  /// </summary>
+    /// <summary>
+    /// A class for rational numbers.
+    /// </summary>
 
-  public
+    public
 #if !STRUCTRATIONALS
-  sealed class
+    sealed class
 #else
-     struct 
+    struct
 #endif
     Rational
-  {
-    #region State
-    enum Kind { Normal, PlusInfinty, MinusInfinity }
-  
-    #endregion
-
-    #region Statics
-    // Cached values, as they are used very often!
-    static private readonly Rational Zero = new Rational((long)0);
-    static private readonly Rational One = new Rational(1);
-    static private readonly Rational MinusOne = new Rational(-1);
-
-    static private readonly Rational plusInfinity = new Rational(Kind.PlusInfinty);
-    static private readonly Rational minusInfinity = new Rational(Kind.MinusInfinity);
-
-    static private readonly Rational maxValue = new Rational(long.MaxValue);
-    static private readonly Rational minValue = new Rational(long.MinValue);
-
-    static private readonly Rational[] cachedPowersOfTwo;
-
-    [ThreadStatic]
-    static private ulong allocated; // How many Rational we allocated?
-    #endregion
-
-    #region
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
     {
-      Contract.Invariant(this.kind != Kind.Normal || this.down != 0);
-      Contract.Invariant(this.kind == Kind.Normal || this.down == 0);
-    }
-    #endregion
+        #region State
+        private enum Kind { Normal, PlusInfinty, MinusInfinity }
 
-    #region Privates
-    private readonly Kind kind;
+        #endregion
 
-    private readonly Int64 up;
-    private readonly Int64 down;
+        #region Statics
+        // Cached values, as they are used very often!
+        static private readonly Rational Zero = new Rational((long)0);
+        static private readonly Rational One = new Rational(1);
+        static private readonly Rational MinusOne = new Rational(-1);
 
-    #endregion
+        static private readonly Rational plusInfinity = new Rational(Kind.PlusInfinty);
+        static private readonly Rational minusInfinity = new Rational(Kind.MinusInfinity);
 
-    #region Static getters
-    static public Rational PlusInfinity
-    {
-      get
-      {
-        Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+        static private readonly Rational maxValue = new Rational(long.MaxValue);
+        static private readonly Rational minValue = new Rational(long.MinValue);
 
-        return plusInfinity;
-      }
-    }
+        static private readonly Rational[] cachedPowersOfTwo;
 
-    static public Rational MinusInfinity
-    {
-      get
-      {
-        Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+        [ThreadStatic]
+        static private ulong allocated; // How many Rational we allocated?
+        #endregion
 
-        return minusInfinity;
-      }
-    }
+        #region
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(kind != Kind.Normal || down != 0);
+            Contract.Invariant(kind == Kind.Normal || down == 0);
+        }
+        #endregion
 
-    static public Rational MaxValue
-    {
-      get
-      {
-        Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+        #region Privates
+        private readonly Kind kind;
 
-        return maxValue;
-      }
-    }
+        private readonly Int64 up;
+        private readonly Int64 down;
 
-    static public Rational MinValue
-    {
-      get
-      {
-        Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+        #endregion
 
-        return minValue;
-      }
-    }
-
-    static public int MaxBits
-    {
-      get
-      {
-        return 64;
-      }
-    }
-
-    internal static ulong Allocated
-    {
-      get
-      {
-        return allocated;
-      }
-    }
-
-    #endregion
-
-    #region Static constructor
-    static Rational()
-    {
-      allocated = 0;
-
-      #region Initialize the array with the powers of two
-      cachedPowersOfTwo = new Rational[Rational.MaxBits - 1];
-
-      var soFar = new Rational(1);
-      var two = new Rational(2);
-
-      // We unroll the loop, as the naif way of writing it causes a Aithmetic overflow at the last iteration
-      cachedPowersOfTwo[0] = soFar;
-      for (int i = 1; i < Rational.MaxBits - 1; i++)
-      {
-        soFar *= two;
-        cachedPowersOfTwo[i] = soFar;
-      }
-
-      #endregion
-    }
-    #endregion
-
-    #region Constructor
-
-    private Rational(Kind kind)
-    {
-      Contract.Requires(kind != Kind.Normal);
-
-      this.kind = kind;
-      this.up = 0;
-      this.down = 0;
-    }
-
-    /// <summary>
-    /// Construct the rational number <code>numerator</code> / <code>denominator</code>
-    /// </summary>
-    private Rational(Int64 numerator, Int64 denominator)
-    {
-      Contract.Requires(!(numerator == 0 && denominator == 0), "Cannot build the rational 0/0 !!!");
-
-      allocated++;
-
-      // k / 0
-      if (denominator == 0)
-      {
-        this.kind = numerator > 0 ? Kind.PlusInfinty : Kind.MinusInfinity;
-
-        this.up = 0;
-        this.down = 0;
-
-        return;
-      }
-
-      Contract.Assert(denominator != 0);
-
-      // 0 / k
-      if (numerator == 0)
-      {
-        this.kind = Kind.Normal;
-
-        this.up = 0;
-        this.down = 1;
-
-        IncreaseCount("0");
-
-        return;
-      }
-
-      // The sign of the result
-
-      var sign = Math.Sign(numerator) * Math.Sign(denominator);
-
-      Contract.Assume(sign != 0);
-
-      // Normalize
-      if(numerator != Int64.MinValue)
-      {
-        numerator = sign * Math.Abs(numerator);
-      }
-      else
-      {
-        // Should be unreached 
-        numerator = sign >= 0 ? Int64.MaxValue : Int64.MinValue;
-      }
-
-      if(denominator != Int64.MinValue)
-      {
-        denominator = Math.Abs(denominator);
-        Contract.Assume(denominator > 0); // f: too weak postcondition on Abs. We need "x != 0 ==> result > 0"
-      }
-      else
-      {
-        numerator = 0;
-        denominator = 1;
-      }
-
-      Contract.Assert(denominator > 0); // We want the invariant the sign is kept by the numerator
-
-      this.kind = Kind.Normal;
-
-      if (numerator % denominator == 0)
-      {
-        this.up = numerator / denominator;
-        this.down = 1;
-      }
-      else
-      {
-        Int64 gcd =
-          numerator != 0 && denominator != 0 &&
-          numerator != Int64.MaxValue && numerator != Int64.MinValue && denominator != Int64.MaxValue
-          ? GCD(Math.Abs(numerator), Math.Abs(denominator)) : 1;
-
-
-        this.up = (Int64)(numerator / gcd);
-        this.down = (Int64)(denominator / gcd);
-      }
-
-      IncreaseCount(this.ToString());
-    }
-
-    private Rational(Int64 numerator)
-    {
-      allocated++;
-
-      this.kind = Kind.Normal;
-
-      this.up = numerator;
-      this.down = 1;
-
-      IncreaseCount(this.ToString());
-    }
-
-    #endregion
-
-    #region Factory for rationals
-
-    private static SimpleHashtable<Int64, Rational> cache = new SimpleHashtable<Int64, Rational>();
-
-    /// <returns>A normal rational representing <code>i</code></returns>
-    static public Rational For(Int64 i)
-    {
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      switch (i)
-      {
-        case 0:
-          return Zero;
-        case 1:
-          return One;
-        case -1:
-          return MinusOne;
-        default:
-          {
-            Rational result;
-
-            if (cache.TryGetValue(i, out result))
+        #region Static getters
+        static public Rational PlusInfinity
+        {
+            get
             {
-              Contract.Assume(((object)result) != null);      // F: need array
-              return result;
+                Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+
+                return plusInfinity;
+            }
+        }
+
+        static public Rational MinusInfinity
+        {
+            get
+            {
+                Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+
+                return minusInfinity;
+            }
+        }
+
+        static public Rational MaxValue
+        {
+            get
+            {
+                Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+
+                return maxValue;
+            }
+        }
+
+        static public Rational MinValue
+        {
+            get
+            {
+                Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+
+                return minValue;
+            }
+        }
+
+        static public int MaxBits
+        {
+            get
+            {
+                return 64;
+            }
+        }
+
+        internal static ulong Allocated
+        {
+            get
+            {
+                return allocated;
+            }
+        }
+
+        #endregion
+
+        #region Static constructor
+        static Rational()
+        {
+            allocated = 0;
+
+            #region Initialize the array with the powers of two
+            cachedPowersOfTwo = new Rational[Rational.MaxBits - 1];
+
+            var soFar = new Rational(1);
+            var two = new Rational(2);
+
+            // We unroll the loop, as the naif way of writing it causes a Aithmetic overflow at the last iteration
+            cachedPowersOfTwo[0] = soFar;
+            for (int i = 1; i < Rational.MaxBits - 1; i++)
+            {
+                soFar *= two;
+                cachedPowersOfTwo[i] = soFar;
             }
 
-            result = new Rational(i);
-            cache[i] = result;
+            #endregion
+        }
+        #endregion
+
+        #region Constructor
+
+        private Rational(Kind kind)
+        {
+            Contract.Requires(kind != Kind.Normal);
+
+            this.kind = kind;
+            up = 0;
+            down = 0;
+        }
+
+        /// <summary>
+        /// Construct the rational number <code>numerator</code> / <code>denominator</code>
+        /// </summary>
+        private Rational(Int64 numerator, Int64 denominator)
+        {
+            Contract.Requires(!(numerator == 0 && denominator == 0), "Cannot build the rational 0/0 !!!");
+
+            allocated++;
+
+            // k / 0
+            if (denominator == 0)
+            {
+                kind = numerator > 0 ? Kind.PlusInfinty : Kind.MinusInfinity;
+
+                up = 0;
+                down = 0;
+
+                return;
+            }
+
+            Contract.Assert(denominator != 0);
+
+            // 0 / k
+            if (numerator == 0)
+            {
+                kind = Kind.Normal;
+
+                up = 0;
+                down = 1;
+
+                IncreaseCount("0");
+
+                return;
+            }
+
+            // The sign of the result
+
+            var sign = Math.Sign(numerator) * Math.Sign(denominator);
+
+            Contract.Assume(sign != 0);
+
+            // Normalize
+            if (numerator != Int64.MinValue)
+            {
+                numerator = sign * Math.Abs(numerator);
+            }
+            else
+            {
+                // Should be unreached 
+                numerator = sign >= 0 ? Int64.MaxValue : Int64.MinValue;
+            }
+
+            if (denominator != Int64.MinValue)
+            {
+                denominator = Math.Abs(denominator);
+                Contract.Assume(denominator > 0); // f: too weak postcondition on Abs. We need "x != 0 ==> result > 0"
+            }
+            else
+            {
+                numerator = 0;
+                denominator = 1;
+            }
+
+            Contract.Assert(denominator > 0); // We want the invariant the sign is kept by the numerator
+
+            kind = Kind.Normal;
+
+            if (numerator % denominator == 0)
+            {
+                up = numerator / denominator;
+                down = 1;
+            }
+            else
+            {
+                Int64 gcd =
+                  numerator != 0 && denominator != 0 &&
+                  numerator != Int64.MaxValue && numerator != Int64.MinValue && denominator != Int64.MaxValue
+                  ? GCD(Math.Abs(numerator), Math.Abs(denominator)) : 1;
+
+
+                up = (Int64)(numerator / gcd);
+                down = (Int64)(denominator / gcd);
+            }
+
+            IncreaseCount(this.ToString());
+        }
+
+        private Rational(Int64 numerator)
+        {
+            allocated++;
+
+            kind = Kind.Normal;
+
+            up = numerator;
+            down = 1;
+
+            IncreaseCount(this.ToString());
+        }
+
+        #endregion
+
+        #region Factory for rationals
+
+        private static SimpleHashtable<Int64, Rational> cache = new SimpleHashtable<Int64, Rational>();
+
+        /// <returns>A normal rational representing <code>i</code></returns>
+        static public Rational For(Int64 i)
+        {
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            switch (i)
+            {
+                case 0:
+                    return Zero;
+                case 1:
+                    return One;
+                case -1:
+                    return MinusOne;
+                default:
+                    {
+                        Rational result;
+
+                        if (cache.TryGetValue(i, out result))
+                        {
+                            Contract.Assume(((object)result) != null);      // F: need array
+                            return result;
+                        }
+
+                        result = new Rational(i);
+                        cache[i] = result;
+
+                        return result;
+                    }
+            }
+        }
+
+        /// <returns>
+        /// A rational representing <code>numerator / denominator</code>.
+        /// If denominator == 0, an exception is thrown
+        /// </returns>
+        static internal Rational For(Int64 numerator, Int64 denominator)
+        {
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            switch (denominator)
+            {
+                case 0:
+                    throw new ArithmeticExceptionRational();
+                case 1:
+                    return Rational.For(numerator);
+                default:
+                    return new Rational(numerator, denominator);
+            }
+        }
+
+        static public Rational For(Byte b)
+        {
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            return Rational.For((Int64)b);
+        }
+
+        static public Rational For(UInt16 u16)
+        {
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            return Rational.For((Int64)u16);
+        }
+
+        static public Rational For(UInt32 u32)
+        {
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            return Rational.For((Int64)u32);
+        }
+
+        static public Rational For(Double f64)
+        {
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            // return Rational.For((Int32)Math.Truncate(f32));
+            return Rational.For((Int64)Math.Truncate(f64));
+        }
+        #endregion
+
+        #region Common Arithmetic functions (abs, min, max)
+
+        /// <returns>
+        /// The absolute value for <code>value</code>
+        /// </returns>
+        public static Rational Abs(Rational value)
+        {
+            Contract.Requires((object)value != null);
+            Contract.Requires(!value.IsMinValue);
+
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            if (value.IsPlusInfinity)
+                return MinusInfinity;
+
+            if (value.IsMinusInfinity)
+                return PlusInfinity;
+
+            if (value.IsZero || value > 0)
+                return value;
+
+            return -value;
+        }
+
+        /// <returns>
+        /// The smallest value between <code>x</code> and <code>y</code>
+        /// </returns>
+        public static Rational Min(Rational x, Rational y)
+        {
+            Contract.Requires(((object)x) != null);
+            Contract.Requires(((object)y) != null);
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            return x < y ? x : y;
+        }
+
+        /// <returns>
+        /// The largest value between <code>x</code> and <code>y</code>
+        /// </returns>
+        public static Rational Max(Rational x, Rational y)
+        {
+            Contract.Requires(((object)x) != null);
+            Contract.Requires(((object)y) != null);
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            return x < y ? y : x;
+        }
+
+        /// <summary>
+        /// Computes <code>2 ^ k</code>
+        /// </summary>
+        /// <param name="k">Should be positive</param>
+        public static Rational ToThePowerOfTwo(int k)
+        {
+            Contract.Requires(k >= 0);
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            if (k >= Rational.MaxBits - 1)
+            {
+                throw new ArithmeticExceptionRational();
+            }
+
+            var result = Rational.cachedPowersOfTwo[k];
+
+            Contract.Assume(((object)result) != null);    // F: We need arrays here
 
             return result;
-          }
-      }
-    }
-
-    /// <returns>
-    /// A rational representing <code>numerator / denominator</code>.
-    /// If denominator == 0, an exception is thrown
-    /// </returns>
-    static internal Rational For(Int64 numerator, Int64 denominator)
-    {
-      Contract.Ensures((object) Contract.Result<Rational>() != null);
-
-      switch (denominator)
-      {
-        case 0:
-          throw new ArithmeticExceptionRational();
-        case 1:
-          return Rational.For(numerator);
-        default:
-          return new Rational(numerator, denominator);
-      }
-    }
-
-    static public Rational For(Byte b)
-    {
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      return Rational.For((Int64)b);
-    }
-
-    static public Rational For(UInt16 u16)
-    {
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      return Rational.For((Int64)u16);
-    }
-
-    static public Rational For(UInt32 u32)
-    {
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      return Rational.For((Int64)u32);
-    }
-
-    static public Rational For(Double f64)
-    {
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      // return Rational.For((Int32)Math.Truncate(f32));
-      return Rational.For((Int64)Math.Truncate(f64));
-    }
-    #endregion
-
-    #region Common Arithmetic functions (abs, min, max)
-
-    /// <returns>
-    /// The absolute value for <code>value</code>
-    /// </returns>
-    public static Rational Abs(Rational value)
-    {
-      Contract.Requires((object)value != null);
-      Contract.Requires(!value.IsMinValue);
-      
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      if (value.IsPlusInfinity)
-        return MinusInfinity;
-
-      if (value.IsMinusInfinity)
-        return PlusInfinity;
-
-      if (value.IsZero || value > 0)
-        return value;
-
-      return -value;
-    }
-
-    /// <returns>
-    /// The smallest value between <code>x</code> and <code>y</code>
-    /// </returns>
-    public static Rational Min(Rational x, Rational y)
-    {
-      Contract.Requires(((object)x) != null);
-      Contract.Requires(((object)y) != null);
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-      
-      return x < y ? x : y;
-    }
-
-    /// <returns>
-    /// The largest value between <code>x</code> and <code>y</code>
-    /// </returns>
-    public static Rational Max(Rational x, Rational y)
-    {
-      Contract.Requires(((object)x) != null);
-      Contract.Requires(((object)y) != null);
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-      
-      return x < y ? y : x;
-    }
-
-    /// <summary>
-    /// Computes <code>2 ^ k</code>
-    /// </summary>
-    /// <param name="k">Should be positive</param>
-    public static Rational ToThePowerOfTwo(int k)
-    {
-      Contract.Requires(k >= 0);
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      if (k >= Rational.MaxBits - 1)
-      {
-        throw new ArithmeticExceptionRational();
-      }
-
-      var result =  Rational.cachedPowersOfTwo[k];
-
-      Contract.Assume(((object)result) != null);    // F: We need arrays here
-
-      return result;
-    }
-
-    public static bool CanRepresentExactly(float value)
-    {
-      if (Single.IsInfinity(value) || Single.IsNaN(value))
-        return false;
-
-      // It's an integral value?
-      if (Math.Truncate(value).Equals(value))
-      {
-        return true;
-      }
-
-      return false;
-    }
-
-    public static bool CanRepresentExactly(Double value)
-    {
-      if (Double.IsInfinity(value) || Double.IsNaN(value))
-        return false;
-
-      // It's an integral value?
-      if (Math.Truncate(value).Equals(value))
-        return Int64.MinValue < value && value < Int64.MaxValue;
-
-      return false;
-    }
-
-    #endregion
-
-    #region Checking methods, NextInt32, PrevInt32, PlusInfinity, MinusInfinity
-
-    /// <summary>
-    /// A rational is Infinity if it is PlusInfinity or MinusInfinity
-    /// </summary>
-    public bool IsInfinity
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<bool>() || this.down != 0);
-
-        return this.IsPlusInfinity || this.IsMinusInfinity;
-      }
-    }
-
-
-
-    #endregion
-
-    #region Implementation of the superclass abstract methods
-
-    /// <summary>
-    /// The sign of this Rational (can be +1 or -1)
-    /// </summary>
-    public int Sign
-    {
-      get
-      {
-        if (this.IsPlusInfinity)
-          return 1;
-        else if (this.IsMinusInfinity)
-          return -1;
-        else
-          return Math.Sign(this.down) * Math.Sign(this.up);
-      }
-    }
-
-    /// <summary>
-    /// Is true iff this rational is an integer number 
-    /// </summary>
-    public bool IsInteger
-    {
-      get
-      {
-        if (this.IsInfinity)
-        {
-          return false;
-        }
-        Contract.Assert(this.down != 0);
-
-        return (this.up % this.down) == 0;          
-      }
-    }
-
-
-    public bool IsInt32
-    {
-      get
-      {
-        if (!this.IsInteger)
-          return false;
-
-        var value = this.up / this.down;
-        return Int32.MinValue <= value && value <= Int32.MaxValue;
-      }
-    }
-
-    /// <summary>
-    /// Return the smallest <code>Int32</code> greater than this rational
-    /// </summary>
-    public Rational NextInt32
-    {
-      get
-      {
-        Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-        if (this.IsInfinity)
-          return this;
-
-        var next = (Int64)Math.Ceiling((double)this);
-
-        return next < Int32.MaxValue ? Rational.For(next) : Rational.For((Int64)Int32.MaxValue);
-      }
-    }
-
-    public Rational NextInt64
-    {
-      get
-      {
-        Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-        if (this.IsInfinity)
-          return this;
-
-        var next = Math.Ceiling((double)this);
-
-        return next < Int64.MaxValue ? Rational.For(next) : Rational.For(Int64.MaxValue);
-      }
-    }
-
-
-    /// <summary>
-    /// Return the smallest <code>Int32</code> smaller than this rational
-    /// </summary>
-    public Rational PreviousInt32
-    {
-      get
-      {
-        Contract.Ensures(((object)Contract.Result<Rational>()) != null);        
-
-        if (this.IsInfinity)
-          return this;
-
-        if (this.down == 1)
-        {
-          return this;
         }
 
-        var prev = (Int64)Math.Floor((double)this);
-
-        return prev > Int32.MinValue ? Rational.For(prev) : Rational.For((Int64)Int32.MinValue);
-      }
-    }
-
-    public Rational PreviousInt64
-    {
-      get
-      {
-        Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-        if (this.IsInfinity)
-          return this;
-
-        if (this.down == 1)
+        public static bool CanRepresentExactly(float value)
         {
-          return this;
-        }
+            if (Single.IsInfinity(value) || Single.IsNaN(value))
+                return false;
 
-        var prev = Math.Floor((double)this);
+            // It's an integral value?
+            if (Math.Truncate(value).Equals(value))
+            {
+                return true;
+            }
 
-        return prev > Int64.MinValue ? Rational.For(prev) : Rational.For(Int64.MinValue);
-      }
-    }
-
-
-    public double Ceiling
-    {
-      get
-      {
-        if (this.IsMinusInfinity)
-          return Double.NegativeInfinity;
-        if (this.IsPlusInfinity)
-          return Double.PositiveInfinity;
-        if (this.IsZero)
-          return +0.0;
-
-        return Math.Ceiling(FloatingPointExtensions.Div_Up(this.up, this.down));
-      }
-    }
-
-    public double Floor
-    {
-      get
-      {
-        if (this.IsMinusInfinity)
-          return Double.NegativeInfinity;
-        if (this.IsPlusInfinity)
-          return Double.PositiveInfinity;
-        if (this.IsZero)
-          return +0.0;
-
-        return Math.Floor(FloatingPointExtensions.Div_Low(this.up, this.down));
-      }
-    }
-
-    public bool IsZero
-    {
-      get
-      {
-        return this.kind == Kind.Normal && this.up == 0;
-      }
-    }
-
-    public bool IsNotZero
-    {
-      get
-      {
-        return this.kind == Kind.Normal && this.up != 0;
-      }
-    }
-
-    /// <summary>
-    /// A rational is +oo when one of the two:
-    ///  1. the denominator is 0 and the numerator is > 0
-    ///  2. the denominator is 1 and the numerator is Int32.MaxValue
-    /// </summary>
-    public bool IsPlusInfinity
-    {
-      get
-      {
-        Contract.Ensures(!Contract.Result<bool>() || this.down == 0);
-        Contract.Ensures(Contract.Result<bool>() == (this.kind == Kind.PlusInfinty));
-
-        return this.kind == Kind.PlusInfinty;
-      }
-    }
-
-    /// <summary>
-    /// A rational is -oo when one of the two:
-    ///  1. the denominator is 0 and the numerator is \less 0
-    ///  2. the denominator is 1 and the numerator is Int32.MinValue
-    /// </summary>
-    public bool IsMinusInfinity
-    {
-      get
-      {
-        Contract.Ensures(!Contract.Result<bool>() || this.down == 0);
-        Contract.Ensures(Contract.Result<bool>() == (this.kind == Kind.MinusInfinity));
-
-        return this.kind == Kind.MinusInfinity;
-      }
-    }
-
-    public bool IsMaxValue
-    {
-      get
-      {
-        return this.kind == Kind.Normal && this.up == long.MaxValue && this.down == 1;
-      }
-    }
-
-    public bool IsMinValue
-    {
-      get
-      {
-        return this.kind == Kind.Normal && this.up == long.MinValue && this.down == 1;
-      }
-    }
-
-    public Int64 Up
-    {
-      get
-      {
-        if (this.kind != Kind.Normal)
-        {
-          throw new InvalidOperationException();
-        }
-        return this.up;
-      }
-    }
-
-    public Int64 Down
-    {
-      get
-      {
-        if (this.kind != Kind.Normal)
-        {
-          throw new InvalidOperationException();
-        }
-        return this.down;
-      }
-    }
-
-
-    public Expression ToExpression<Variable, Expression>(IExpressionEncoder<Variable, Expression> encoder)
-    {
-      Contract.Requires(encoder != null);
-      Contract.Ensures(Contract.Result<Expression>() != null);
-
-      if (this.IsInteger)
-      {
-        return encoder.ConstantFor((long)this);
-      }
-      if (this.IsPlusInfinity)
-      {
-        return encoder.CompoundExpressionFor(ExpressionType.Int64, ExpressionOperator.Division, encoder.ConstantFor(1), encoder.ConstantFor(0));
-      }
-      if (this.IsMinusInfinity)
-      {
-        return encoder.CompoundExpressionFor(ExpressionType.Int64, ExpressionOperator.Division, encoder.ConstantFor(-1), encoder.ConstantFor(0));
-      }
-      else
-      {
-        var upAsExp = encoder.ConstantFor(this.up);
-        var downAsExp = encoder.ConstantFor(this.down);
-
-        return encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Division, upAsExp, downAsExp);
-      }
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsInteger)
-      {
-        var asInt64 = this.NextInt64;
-        if (Int32.MinValue <= asInt64 && asInt64 <= Int32.MaxValue)
-        {
-          return factory.Constant((Int32)asInt64);
-        }
-        else
-        {
-          return factory.Constant((Int64)asInt64);
-        }
-      }
-      else
-      {
-        T upConst = factory.Constant(this.up);
-        T downConst = factory.Constant(this.down);
-
-        return factory.Div(upConst, downConst);
-      }
-    }
-
-    #endregion
-
-    #region Try* version of arithmetic operators
-
-    #region TryAdd*
-    public static bool TryAdd(Rational r1, Rational r2, out Rational result)
-    {
-      Contract.Requires(!object.ReferenceEquals(r1, null));
-      Contract.Requires(!object.ReferenceEquals(r2, null));
-
-      Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
-
-      // Special cases (Using IsZero, as it is faster than operator ==)
-      // 0 + r2 = r2
-      if (r1.IsZero)
-      {
-        result = r2;
-        return true;
-      }
-
-      // r1 + 0 = r1
-      if (r2.IsZero)
-      {
-        result = r1;
-        return true;
-      }
-
-      // oo + r2 = oo
-      if (r1.IsInfinity)
-      {
-        result = r1;
-        return true;
-      }
-
-      // r1 + oo = oo
-      if (r2.IsInfinity)
-      {
-        result = r2;
-        return true;
-      }
-      // maxval + pos = infinity
-      if ((r1.IsMaxValue && r2 > 0) || (r2.IsMaxValue && r1 > 0))
-      {
-        result = Rational.PlusInfinity;
-        return true;
-      }
-
-      // minval + neg = -infinity
-      if ((r1.IsMinValue && r2 < 0) || (r2.IsMinValue && r1 < 0))
-      {
-        result = Rational.MinusInfinity;
-        return true;
-      }
-
-      Int64 returnUp;
-      Int64 returnDown;
-
-      try
-      {
-        if (r1.down == r2.down)
-        { 
-          // Special case for (a/b + a/b) = (a / (b/2)
-          if (r1.up == r2.up && r1.down % 2 == 0)
-          {
-            returnUp = r1.up;
-            returnDown = checked(r1.down / 2);
-          }
-          else
-          {
-            returnUp = checked(r1.up + r2.up);
-            returnDown = checked(r1.down);
-          }
-        }
-        else
-        {
-          var tmp1 = checked(r1.up * r2.down);
-          var tmp2 = checked(r2.up * r1.down);
-          returnUp = checked(tmp1 + tmp2);
-
-          returnDown = checked(r1.down * r2.down);
-        }
-      }
-      catch (ArithmeticException)
-      {        
-        {
-          try
-          {
-            long gcd = GCD(r1.down, r2.down);
-
-            long tmp1 = checked(r1.up * (r2.down / gcd));
-            long tmp2 = checked(r2.up * (r1.down / gcd));
-
-            returnUp = checked(tmp1 + tmp2);
-            returnDown = checked(r1.down * r2.down);
-          }
-          catch (ArithmeticException)
-          {
-            result = default(Rational);
             return false;
-          }
         }
-      }
 
-      // Small inlining, as operator+ is called so many times
-      result = returnDown == 1 ? Rational.For(returnUp) : Rational.For(returnUp, returnDown);
-
-      return true;
-    }
-
-    public static bool TryAdd(Rational r1, Int64 i, out Rational result)
-    {
-      Contract.Requires(!object.ReferenceEquals(r1, null));
-
-      Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
-
-      if (r1.kind == Kind.Normal && r1.down == 1)
-      {
-        try
+        public static bool CanRepresentExactly(Double value)
         {
-          result = Rational.For(checked(r1.up + i));
+            if (Double.IsInfinity(value) || Double.IsNaN(value))
+                return false;
+
+            // It's an integral value?
+            if (Math.Truncate(value).Equals(value))
+                return Int64.MinValue < value && value < Int64.MaxValue;
+
+            return false;
         }
-        catch (ArithmeticException)
-        { // slow path
-          return TryAdd(r1, Rational.For(i), out result);
-        }
 
-        return true;
-      }
-      else
-      {
-        return TryAdd(r1, Rational.For(i), out result);
-      }
-    }
+        #endregion
 
-    public static bool TryAdd(Int64 i, Rational r2, out Rational result)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || ((object)Contract.ValueAtReturn(out result)) != null);
+        #region Checking methods, NextInt32, PrevInt32, PlusInfinity, MinusInfinity
 
-      return TryAdd(r2, i, out result);
-    }
-    #endregion
-    
-    public static bool TrySub(Rational r1, Rational r2, out Rational result)
-    {
-      Contract.Requires(!object.ReferenceEquals(r1, null));
-      Contract.Requires(!object.ReferenceEquals(r2, null));
-
-      Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
-
-      Int64 returnUp;
-      Int64 returnDown;
-
-      // r1 - 0 = r1
-      if (r2.IsZero)
-      {
-        result = r1;
-        return true;
-      }
-      
-      // 0 - r2 = -r2
-      if (r1.IsZero)
-      {
-        result = -r2;
-        return true;
-      }
-      
-      // r1 - r1 = 0
-      if (r1 == r2)
-      {
-        result = Zero;
-        return true;
-      }
-      
-      // r1 - (-r2) = r1 + r2
-      if (r2 < 0 && !r2.IsMinValue)
-      {
-        // result = r1 + Rational.Abs(r2);
-        return TryAdd(r1, Rational.Abs(r2), out result);
-      }
-
-      // oo - r2 = oo
-      if (r1.IsInfinity)
-      {
-        result = r1;
-        return true;
-      }
-
-      // r1 - oo = -oo
-      if (r2.IsInfinity)
-      {
-        result = -r2;
-        return true;
-      }
-
-      if (r1.IsMinValue && r2 > 0)
-      {
-        result = Rational.MinusInfinity;
-        return true;
-      }
-
-      try
-      {
-        // This optimization is to avoid the creation of large numbers (and also to save 3 multiplications)
-        if (r1.down == r2.down)
+        /// <summary>
+        /// A rational is Infinity if it is PlusInfinity or MinusInfinity
+        /// </summary>
+        public bool IsInfinity
         {
-          returnUp = checked(r1.up - r2.up);
-          returnDown = r1.down;
+            get
+            {
+                Contract.Ensures(Contract.Result<bool>() || down != 0);
+
+                return this.IsPlusInfinity || this.IsMinusInfinity;
+            }
         }
-        else
+
+
+
+        #endregion
+
+        #region Implementation of the superclass abstract methods
+
+        /// <summary>
+        /// The sign of this Rational (can be +1 or -1)
+        /// </summary>
+        public int Sign
         {
-          long tmp1 = checked(r1.up * r2.down);
-          long tmp2 = checked(r2.up * r1.down);
-          returnUp = checked(tmp1 - tmp2);
-
-          returnDown = checked(r1.down * r2.down);
+            get
+            {
+                if (this.IsPlusInfinity)
+                    return 1;
+                else if (this.IsMinusInfinity)
+                    return -1;
+                else
+                    return Math.Sign(down) * Math.Sign(up);
+            }
         }
-      }
-      catch (ArithmeticException)
-      {
-          result = default(Rational);
-          return false;
-      }
 
-      result = Rational.For(returnUp, returnDown);
-      return true;
-    }
-
-    // This is always going to succeed (because of our representation of Rationals), but to make the code easier to read, I made it a Try*
-    public static bool TryUnaryMinus(Rational r, out Rational result)
-    {
-      Contract.Requires(!object.ReferenceEquals(r, null));
-
-      Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
-
-      // -0 = 0
-      if (r.IsZero)
-      {
-        result = r;
-        return true;
-      }
-
-      // - (-oo) = oo
-      if (r.IsMinusInfinity)
-      {
-        result = Rational.PlusInfinity;
-        return true;
-      }
-
-      // - (+ oo) = -oo
-      if (r.IsPlusInfinity)
-      {
-        result = Rational.MinusInfinity;
-        return true;
-      }
-
-      if (r.IsMinValue)
-      {
-        result = Rational.MaxValue;
-        return true;
-      }
-
-      if (r.IsMaxValue)
-      {
-        result = Rational.MinValue;
-        return true;
-      }
-      if (r.down == 1)
-      {
-        result = Rational.For(-r.up);
-        return true;
-      }
-      else
-      {
-        result = Rational.For(-r.up, r.down);
-        return true;
-      }
-    }
-
-    public static bool TryMul(Rational r1, Rational r2, out Rational result)
-    {
-      Contract.Requires(!object.ReferenceEquals(r1, null));
-      Contract.Requires(!object.ReferenceEquals(r2, null));
-
-      Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
-
-      // 0 * r2 = r1 * 0 = 0
-      if (r1.IsZero || r2.IsZero)
-      {
-        result = Zero;
-        return true;
-      }
-
-      // 1 * r2 = r2
-      if (r1 == 1)
-      {
-        result = r2;
-        return true;
-      }
-
-      // r1 * 1 = r1
-      if (r2 == 1)
-      {
-        result = r1;
-        return true;
-      }
-
-      if (r1.IsPlusInfinity)
-      {
-        if (r2.IsPlusInfinity)
+        /// <summary>
+        /// Is true iff this rational is an integer number 
+        /// </summary>
+        public bool IsInteger
         {
-          result = Rational.PlusInfinity;
+            get
+            {
+                if (this.IsInfinity)
+                {
+                    return false;
+                }
+                Contract.Assert(down != 0);
+
+                return (up % down) == 0;
+            }
         }
-        else if (r2.IsMinusInfinity)
+
+
+        public bool IsInt32
         {
-          result = Rational.MinusInfinity;
+            get
+            {
+                if (!this.IsInteger)
+                    return false;
+
+                var value = up / down;
+                return Int32.MinValue <= value && value <= Int32.MaxValue;
+            }
         }
-        else
+
+        /// <summary>
+        /// Return the smallest <code>Int32</code> greater than this rational
+        /// </summary>
+        public Rational NextInt32
         {
-          result = r2.Sign > 0 ? Rational.PlusInfinity : (r2.Sign < 0 ? Rational.MinusInfinity : Zero);
-        }
-        return true;
-      }
+            get
+            {
+                Contract.Ensures(((object)Contract.Result<Rational>()) != null);
 
-      if (r1.IsMinusInfinity)
-      {
-        if (r2.IsPlusInfinity)
+                if (this.IsInfinity)
+                    return this;
+
+                var next = (Int64)Math.Ceiling((double)this);
+
+                return next < Int32.MaxValue ? Rational.For(next) : Rational.For((Int64)Int32.MaxValue);
+            }
+        }
+
+        public Rational NextInt64
         {
-          result = Rational.MinusInfinity;
+            get
+            {
+                Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+                if (this.IsInfinity)
+                    return this;
+
+                var next = Math.Ceiling((double)this);
+
+                return next < Int64.MaxValue ? Rational.For(next) : Rational.For(Int64.MaxValue);
+            }
         }
-        else if (r2.IsMinusInfinity)
+
+
+        /// <summary>
+        /// Return the smallest <code>Int32</code> smaller than this rational
+        /// </summary>
+        public Rational PreviousInt32
         {
-          result = Rational.PlusInfinity;
+            get
+            {
+                Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+                if (this.IsInfinity)
+                    return this;
+
+                if (down == 1)
+                {
+                    return this;
+                }
+
+                var prev = (Int64)Math.Floor((double)this);
+
+                return prev > Int32.MinValue ? Rational.For(prev) : Rational.For((Int64)Int32.MinValue);
+            }
         }
-        else
+
+        public Rational PreviousInt64
         {
-          result = r2.Sign > 0 ? Rational.MinusInfinity : (r2.Sign < 0 ? Rational.PlusInfinity : Zero);
+            get
+            {
+                Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+                if (this.IsInfinity)
+                    return this;
+
+                if (down == 1)
+                {
+                    return this;
+                }
+
+                var prev = Math.Floor((double)this);
+
+                return prev > Int64.MinValue ? Rational.For(prev) : Rational.For(Int64.MinValue);
+            }
         }
-        return true;
-      }
-      if (r2.IsPlusInfinity)
-      {
-        Contract.Assume(!r1.IsInfinity);
-        result = r1.Sign > 0 ? Rational.PlusInfinity : (r1.Sign < 0 ? Rational.MinusInfinity : Zero);
-        return true;
-      }
 
-      if (r2.IsMinusInfinity)
-      {
-        Contract.Assume(!r1.IsInfinity);
-        result = r1.Sign > 0 ? Rational.MinusInfinity : (r1.Sign < 0 ? Rational.PlusInfinity : Zero);
-        return true;
-      }
 
-      // To do : add the entries with MaxValue
-
-      Int64 returnUp;
-      Int64 returnDown;
-
-      try
-      {
-        // If we want to compute a/b * c/d we make the rational smaller by computing a/d * c/b
-        var crossRational1 = Rational.For(r1.up, r2.down);
-        var crossRational2 = Rational.For(r2.up, r1.down);
-
-        returnUp = checked(crossRational1.up * crossRational2.up);
-        returnDown = checked(crossRational1.down * crossRational2.down);
-      }
-      catch (ArithmeticException)
-      {
-        result = default(Rational);
-        return false;
-      }
-
-      result = Rational.For(returnUp, returnDown);
-      return true;
-    }
-
-    public static bool TryDiv(Rational r1, Rational r2, out Rational result)
-    {
-      Contract.Requires(!object.ReferenceEquals(r1, null));
-      Contract.Requires(!object.ReferenceEquals(r2, null));
-
-      Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
-
-      Int64 returnUp;
-      Int64 returnDown;
-
-      // r1 / 1 = r1 
-      if (r2 == 1)
-      {
-        result = r1;
-        return true;
-      }
-      // r2 / 0 = "overflow"
-      if (r2.IsZero)
-      {
-        result = default(Rational);
-        return false;
-      }
-
-      // 0 / r1 =0
-      if (r1.IsZero)
-      {
-        result = Zero;
-        return true;
-      }
-
-      // Note: At this point we know that r2 != 0;
-
-      // + oo / k = sign(k) * oo
-      if (r1.IsPlusInfinity && !r2.IsInfinity)
-      {
-        result = r2.Sign >= 0 ? Rational.PlusInfinity : Rational.MinusInfinity;
-        return true;
-      }
-
-      // - oo / k = -1 * sign(k) * oo 
-      if (r1.IsMinusInfinity && !r2.IsInfinity)
-      {
-        result = r2.Sign >= 0 ? Rational.MinusInfinity : Rational.PlusInfinity;
-        return true;
-      }
-      // Note: At this point we know that r1 != 0 (and 1)
-
-      // k / oo = 0
-      if (r2.IsInfinity)
-      {
-        result = Zero;
-        return true;
-      }
-
-      if (r1.up == r2.up)
-      { // (a /b) / (a / c) = c / b
-        returnUp = r2.down;
-        returnDown = r1.down;
-      }
-      else if (r1.down == r2.down)
-      { // (a / b) / (c / b) = a / c
-        returnUp = r1.up;
-        returnDown = r2.up;
-      }
-      else
-      {
-        try
+        public double Ceiling
         {
-          returnUp = checked(r1.up * r2.down);
-          returnDown = checked(r1.down * r2.up);
+            get
+            {
+                if (this.IsMinusInfinity)
+                    return Double.NegativeInfinity;
+                if (this.IsPlusInfinity)
+                    return Double.PositiveInfinity;
+                if (this.IsZero)
+                    return +0.0;
+
+                return Math.Ceiling(FloatingPointExtensions.Div_Up(up, down));
+            }
         }
-        catch (ArithmeticException)
+
+        public double Floor
         {
-          result = default(Rational);
-          return false;
+            get
+            {
+                if (this.IsMinusInfinity)
+                    return Double.NegativeInfinity;
+                if (this.IsPlusInfinity)
+                    return Double.PositiveInfinity;
+                if (this.IsZero)
+                    return +0.0;
+
+                return Math.Floor(FloatingPointExtensions.Div_Low(up, down));
+            }
         }
-      }
 
-      result = Rational.For(returnUp, returnDown);
-      return true;
-    }
-
-    #endregion
-
-    #region Arithmetic operations
-
-    public static Rational operator +(Rational r1, Rational r2)
-    {
-      Contract.Requires(!object.ReferenceEquals(r1, null));
-      Contract.Requires(!object.ReferenceEquals(r2, null));
-
-      Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));  
-
-      Rational result;
-      if (TryAdd(r1, r2, out result))
-      {
-        return result;
-      }
-      else
-      {
-        throw new ArithmeticExceptionRational();
-      }
-    }
-
-    public static Rational operator -(Rational r1, Rational r2)
-    {
-      Contract.Requires(!object.ReferenceEquals(r1, null));
-      Contract.Requires(!object.ReferenceEquals(r2, null));
-
-      Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));   
-
-      Rational result;
-      if (TrySub(r1, r2, out result))
-      {
-        return result;
-      }
-      else
-      {
-        throw new ArithmeticExceptionRational();
-      }
-    }
-
-    public static Rational operator -(Rational r)
-    {
-      Contract.Requires(!object.ReferenceEquals(r, null));
-
-      Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));
-
-      Rational result;
-      if (TryUnaryMinus(r, out result))
-      {
-        return result;
-      }
-      else
-      {
-        throw new ArithmeticExceptionRational();
-      }
-    }
-
-    public static Rational operator *(Rational r1, Rational r2)
-    {
-      Contract.Requires((object)r1 != null);
-      Contract.Requires((object)r2 != null);
-
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      Rational result;
-      if (TryMul(r1, r2, out result))
-      {
-        return result;
-      }
-      else
-      {
-        throw new ArithmeticExceptionRational();
-      }
-    }
-
-    public static Rational MultiplyWithDefault(Rational r1, Rational r2, Rational def)
-    {
-      Contract.Requires((object)r1 != null);
-      Contract.Requires((object)r2 != null);
-      Contract.Requires((object)def != null);
-
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      try
-      {
-        return r1 * r2;
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return def;
-      }
-    }
-
-
-    public static Rational operator /(Rational r1, Rational r2)
-    {
-      Contract.Requires((object)r1 != null);
-      Contract.Requires((object)r2 != null);
-
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      Rational result;
-
-      if (r2.IsZero)
-      {
-        throw new DivideByZeroException();
-      }
-
-      if(TryDiv(r1, r2, out result))
-      {
-        return result;
-      }
-      else
-      {
-        throw new ArithmeticExceptionRational();
-      }
-    }
-
-    public static Rational DivideWithDefault(Rational r1, Rational r2, Rational def)
-    {
-      Contract.Requires((object)r1 != null);
-      Contract.Requires((object)r2 != null);
-      Contract.Requires((object)def != null);
-
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      try
-      {
-        return r1 / r2;
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return def;
-      }
-    }
-
-    #endregion
-
-    #region Specialized arithmetic operations
-    public static Rational operator +(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      Rational result;
-      if (TryAdd(r, i, out result))
-      {
-        return result;
-      }
-      else
-      {
-        throw new ArithmeticExceptionRational();
-      }
-    }
-
-    public static Rational operator +(Int64 i, Rational r)
-    {
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-      
-      return r + i;
-    }
-
-    public static Rational operator -(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures((object)Contract.Result<Rational>() != null);
-
-      if (r.kind == Kind.Normal && r.down == 1)
-      {
-        try
+        public bool IsZero
         {
-          return Rational.For(checked(r.up - i));
+            get
+            {
+                return kind == Kind.Normal && up == 0;
+            }
         }
-        catch (ArithmeticException)
-        { // Slow path
-          return r - Rational.For(i);
-        }
-      }
-      else
-      {
-        return r - Rational.For(i);
-      }
-    }
-    
-    public static Rational operator -(Int64 i, Rational r)
-    {
-      Contract.Requires((object)r != null);
 
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      if (r.kind == Kind.Normal && r.down == 1)
-      {
-        try
+        public bool IsNotZero
         {
-          return Rational.For(checked(i - r.up));
+            get
+            {
+                return kind == Kind.Normal && up != 0;
+            }
         }
-        catch (ArithmeticException)
-        { // Slow path
-          return Rational.For(i) - r ;
-        }
-      }
-      else
-      {
-        return Rational.For(i) - r;
-      }
-    }
 
-    static public Rational operator *(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      if (r.kind == Kind.Normal)
-      {
-        try
+        /// <summary>
+        /// A rational is +oo when one of the two:
+        ///  1. the denominator is 0 and the numerator is > 0
+        ///  2. the denominator is 1 and the numerator is Int32.MaxValue
+        /// </summary>
+        public bool IsPlusInfinity
         {
-          return Rational.For(checked(r.up) * i, r.down);
+            get
+            {
+                Contract.Ensures(!Contract.Result<bool>() || down == 0);
+                Contract.Ensures(Contract.Result<bool>() == (kind == Kind.PlusInfinty));
+
+                return kind == Kind.PlusInfinty;
+            }
         }
-        catch (ArithmeticException)
+
+        /// <summary>
+        /// A rational is -oo when one of the two:
+        ///  1. the denominator is 0 and the numerator is \less 0
+        ///  2. the denominator is 1 and the numerator is Int32.MinValue
+        /// </summary>
+        public bool IsMinusInfinity
         {
-          return r * Rational.For(i);
+            get
+            {
+                Contract.Ensures(!Contract.Result<bool>() || down == 0);
+                Contract.Ensures(Contract.Result<bool>() == (kind == Kind.MinusInfinity));
+
+                return kind == Kind.MinusInfinity;
+            }
         }
-      }
-      else
-      {
-        return r * Rational.For(i);
-      }
-    }
 
-    static public Rational operator *(Int64 i, Rational r)
-    {
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      return r * i;
-    }
-
-    static public Rational operator /(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      if (r.kind == Kind.Normal)
-      {
-        try
+        public bool IsMaxValue
         {
-          return Rational.For(r.up, checked(r.down * i));
+            get
+            {
+                return kind == Kind.Normal && up == long.MaxValue && down == 1;
+            }
         }
-        catch (ArithmeticException)
+
+        public bool IsMinValue
         {
-          return r / Rational.For(i);
+            get
+            {
+                return kind == Kind.Normal && up == long.MinValue && down == 1;
+            }
         }
-      }
-      else
-      {
-        return r / Rational.For(i);
-      }
-    }
 
-    #endregion  
-
-    #region Comparison operators
-    public static bool operator ==(Rational r1, Rational r2)
-    {
-      Contract.Requires(!object.Equals(r1, null));
-      Contract.Requires(!object.Equals(r2, null));
-
-      // Some very common checks
-      if (object.ReferenceEquals(r1, r2))
-        return true;
-
-      if (r1.IsZero)
-        return r2.IsZero;
-
-      if (r2.IsZero)
-        return false;
-
-      if (r1.IsPlusInfinity)
-        return r2.IsPlusInfinity;
-
-      if (r2.IsPlusInfinity)
-        return false;
-
-      if (r1.IsMinusInfinity)
-        return r2.IsMinusInfinity;
-
-      if (r2.IsMinusInfinity)
-        return false;
-
-      // Special case for syntactical equality 
-      if (r1.up == r2.up && r1.down == r2.down)
-        return true;
-
-      // General case...
-      try
-      {
-        return checked(r1.up * r2.down == r1.down * r2.up);
-      }
-      catch (ArithmeticException)
-      {
-        return ((decimal)r1.up / (decimal)r1.down) == ((decimal)r2.up / (decimal)r2.down);
-      }
-    }
-
-    public static bool operator !=(Rational r1, Rational r2)
-    {
-      Contract.Requires(!object.Equals(r1, null));
-      Contract.Requires(!object.Equals(r2, null));
-
-      // Some very common checks
-      if (object.ReferenceEquals(r1, r2))
-        return false;
-
-      if (r1.IsZero)
-        return !r2.IsZero;
-
-      if (r2.IsZero)
-        return true;
-
-      return !(r1 == r2);
-    }
-
-    public static bool operator <=(Rational r1, Rational r2)
-    {
-      if (object.ReferenceEquals(r1, r2))
-      {
-        return true;
-      }
-
-      if (r1.IsMinusInfinity || r2.IsPlusInfinity)
-      {
-        return true;
-      }
-
-      if (r1.IsPlusInfinity || r2.IsMinusInfinity)
-      {
-        return false;
-      }
-
-      try
-      {
-        if (r1.down == r2.down)
-          return r1.up <= r2.up;
-
-        return checked(r1.up * r2.down <= r1.down * r2.up);
-      }
-      catch (ArithmeticException)
-      {
-        return ((decimal)r1.up) / ((decimal)r1.down) <= ((decimal)r2.up) / ((decimal)r2.down);
-      }
-
-    }
-
-    public static bool operator >=(Rational r1, Rational r2)
-    {
-      return r2 <= r1;
-    }
-
-    public static bool operator <(Rational r1, Rational r2)
-    {
-      if (object.ReferenceEquals(r1, r2))
-        return false;
-
-      if (r1.IsMinusInfinity && !r2.IsMinusInfinity)
-        return true;
-
-      if (r2.IsPlusInfinity && !r1.IsPlusInfinity)
-        return true;
-
-      if (r1.IsPlusInfinity || r2.IsMinusInfinity)
-        return false;
-
-      else
-      {
-        // Special cases to make it faster?  (avoid the multiplications)
-        if (r1.down == r2.down)
-          return r1.up < r2.up;
-
-        if (r1.up <= 0 && r2.up > 0)
-          return true;
-
-        if (r1.up < 0 && r2.up == 0)
-          return true;
-
-        try
+        public Int64 Up
         {
-          // else
-          {
-            return checked((Int64)r1.up * (Int64)r2.down < (Int64)r1.down * (Int64)r2.up);
-          }
+            get
+            {
+                if (kind != Kind.Normal)
+                {
+                    throw new InvalidOperationException();
+                }
+                return up;
+            }
         }
-        catch (ArithmeticException)
+
+        public Int64 Down
         {
-          return ((decimal)r1.up / (decimal)r1.down) < ((decimal)r2.up) / ((decimal)r2.down);
+            get
+            {
+                if (kind != Kind.Normal)
+                {
+                    throw new InvalidOperationException();
+                }
+                return down;
+            }
         }
-      }
-    }
 
-    public static bool operator >(Rational r1, Rational r2)
-    {
-      return r2 < r1;
-    }
 
-    #endregion
-
-    #region Specialized comparison operators
-    public static bool operator ==(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      switch (r.kind)
-      {
-        case Kind.MinusInfinity:
-        case Kind.PlusInfinty:
-          return false;
-
-        case Kind.Normal:
-        default:
-          try
-          {
-            return checked(r.up == i * r.down);
-          }
-          catch (ArithmeticException)
-          {
-            return checked((decimal) r.up /(decimal) r.down == i);
-          }
-      }
-
-    }
-
-    public static bool operator==(Int64 i, Rational r)
-    {
-      Contract.Requires(((object) r) != null);
-
-      return r == i;
-    }
-
-    public static bool operator !=(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      switch (r.kind)
-      {
-        case Kind.MinusInfinity:
-        case Kind.PlusInfinty:
-          return false;
-
-        case Kind.Normal:
-        default:
-          try
-          {
-            return checked(r.up != i * r.down);
-          }
-          catch (ArithmeticException)
-          {
-            return checked((decimal)r.up / (decimal)r.down != i);
-          }
-      }
-    }
-
-    public static bool operator !=(Int64 i, Rational r)
-    {
-      Contract.Requires((object)r != null);
-      return r != i;
-    }
-
-    public static bool operator <=(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      switch (r.kind)
-      {
-        case Kind.MinusInfinity:
-          return true;
-
-        case Kind.PlusInfinty:
-          return false;
-
-        case Kind.Normal:
-        default:
-          try
-          {
-            return checked(r.up <= r.down * i);
-          }
-          catch (ArithmeticException)
-          {
-            return checked((decimal)r.up / (decimal)r.down <= i);
-          }
-      }
-    }
-
-    public static bool operator <=(Int64 i, Rational r)
-    {
-      Contract.Requires((object)r != null);
-
-      switch (r.kind)
-      {
-        case Kind.MinusInfinity:
-          return false;
-
-        case Kind.PlusInfinty:
-          return true;
-
-        case Kind.Normal:
-        default:
-          try
-          {
-            return checked(i * r.down <= r.up);
-          }
-          catch (ArithmeticException)
-          {
-            return checked((i <= (decimal)r.up / (decimal)r.down));
-          }
-      }
-    }
-
-    public static bool operator >=(Rational r, Int64 i)
-    {
-      Contract.Requires((object)r != null);
-
-      return i <= r;
-    }
-
-    public static bool operator >=(Int64 i, Rational r)
-    {
-      Contract.Requires((object)r != null);
-
-      return r <= i;
-    }
-
-    public static bool operator <(Int64 i, Rational r)
-    {
-      switch (r.kind)
-      {
-        case Kind.MinusInfinity:
-          return false;
-
-        case Kind.PlusInfinty:
-          return true;
-
-        case Kind.Normal:
-        default:
-          try
-          {
-            return checked(i * r.down < r.up);
-          }
-          catch
-          {
-            return checked(i < (decimal)r.up / (decimal)r.down);
-          }
-      }
-    }
-
-    public static bool operator <(Rational r, Int64 i)
-    {
-      switch (r.kind)
-      {
-        case Kind.MinusInfinity:
-          return true;
-
-        case Kind.PlusInfinty:
-          return false;
-
-        case Kind.Normal:
-        default:
-          try
-          {
-            return checked(r.up < i * r.down);
-          }
-          catch(ArithmeticException)
-          {
-            return checked(((decimal)r.up / (decimal)r.down) < i); 
-          }
-      }
-    }
-
-    public static bool operator >(Rational r, Int64 i)
-    {
-      return i < r;
-    }
-
-    public static bool operator >(Int64 i, Rational r)
-    {
-      return r < i;
-    }
-    #endregion
-
-    #region InRange
-    public bool IsInRange(Rational low, Rational upp)
-    {
-      return low <= this && this <= upp;
-    }
-
-    public bool IsInRange(Int32 low, Int32 upp)
-    {
-      return low <= this && this<= upp;
-    }
-
-    public bool IsInRange(Int64 low, Int64 upp)
-    {
-      return low <= this && this <= upp;
-    }
-
-    public bool IsInRange(UInt32 low, UInt32 upp)
-    {
-      return low <= this && this <= upp;
-    }    
-  
-    #endregion
-
-    #region Conversion Operators (casts to and from Int32 and double)
-
-    static Dictionary<object, ulong> conversions; 
-
-    // This method is quite resource demanding, and we are using it just to profile the allocation of new Rationals
-    [Conditional("PROFILE_RATIONALS")]
-    public static void IncreaseCount(object o)
-    {
-      if (conversions == null)
-      {
-        conversions = new Dictionary<object, ulong>();
-      }
-      
-      if (conversions.ContainsKey(o))
-      {
-        conversions[o] = conversions[o] + 1;
-      }
-      else
-      {
-        conversions[o] = 1;
-      }
-    }
-
-    /// <summary>
-    /// Some performance statistics on rationals
-    /// </summary>
-    public static string Statistics
-    {
-      get
-      {
-        var result = new StringBuilder();
-
-        result.AppendFormat("# of allocated rationals : {0}" + Environment.NewLine, Rational.Allocated);
-        result.AppendFormat("# of thrown exceptions : {0}" + Environment.NewLine, ArithmeticExceptionRational.ThrownExceptions);
-
-        if (conversions != null)
+        public Expression ToExpression<Variable, Expression>(IExpressionEncoder<Variable, Expression> encoder)
         {
-          var array = new KeyValuePair<object, ulong>[conversions.Count];
+            Contract.Requires(encoder != null);
+            Contract.Ensures(Contract.Result<Expression>() != null);
 
-          var count = 0;
-          foreach (var pair in conversions)
-          {
-            array[count++] = pair; 
-          }
+            if (this.IsInteger)
+            {
+                return encoder.ConstantFor((long)this);
+            }
+            if (this.IsPlusInfinity)
+            {
+                return encoder.CompoundExpressionFor(ExpressionType.Int64, ExpressionOperator.Division, encoder.ConstantFor(1), encoder.ConstantFor(0));
+            }
+            if (this.IsMinusInfinity)
+            {
+                return encoder.CompoundExpressionFor(ExpressionType.Int64, ExpressionOperator.Division, encoder.ConstantFor(-1), encoder.ConstantFor(0));
+            }
+            else
+            {
+                var upAsExp = encoder.ConstantFor(up);
+                var downAsExp = encoder.ConstantFor(down);
 
-          Array.Sort(array, delegate(KeyValuePair<object, ulong> x, KeyValuePair<object, ulong> y) { return x.Value > y.Value ? -1 : 1; });
-
-          ulong sum = 0;
-          foreach (var pair in array)
-          {
-            result.AppendFormat("{0} -> {1}\n", pair.Key.ToString(), pair.Value.ToString());
-            sum += pair.Value;
-          }
-          result.AppendFormat("(sum of the above: {0})", sum);
+                return encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Division, upAsExp, downAsExp);
+            }
         }
 
-        return result.ToString();
-      }
-    }
-
-     ///<summary>
-     ///By default does the rounding to the closest Int32 value
-    ///</summary>
-    public static explicit operator Int32(Rational r)
-    {
-      if (r.down == 0)
-        return r.up < 0 ? Int32.MaxValue : Int32.MinValue;
-
-      else
-        return (Int32)Math.Round((double)r.up / (double)r.down);
-    }
-
-
-    public static explicit operator Int64(Rational r)
-    {
-      if (r.down == 0)
-        return r.up < 0 ? Int64.MaxValue : Int64.MinValue;
-      else
-        return r.IsInteger ? r.up : (Int64)Math.Round((double)r.up / (double)r.down);
-    }
-
-    public bool TryInt64(out Int64 value)
-    {
-      if (this.IsInfinity)
-      {
-        value = default(Int64);
-        return false;
-      }
-
-      value = this.IsInteger ? this.up : (Int64)Math.Round((double)this.up / (double)this.down);
-      return true;
-    }
-
-    public static explicit operator Double(Rational r)
-    {
-      if (r.IsPlusInfinity)
-        return Double.PositiveInfinity;
-      if (r.IsMinusInfinity)
-        return Double.NegativeInfinity;
-
-      return (double)r.up / (double)r.down;
-    }
-
-    public static Interval ConvertFromDouble(Double d)
-    {
-      Contract.Ensures(Contract.Result<Interval>() != null);
-
-      if (d.Equals(Double.NaN))
-      {
-        return Interval.UnknownInterval;
-      }
-
-      long l = (long)d;
-      if (d == (Double)l)
-      {
-        return Interval.For(Rational.For(l, 1));
-      }
-      else
-      {
-        Interval candidate;
-        if (d > 0)
+        public T To<T>(IFactory<T> factory)
         {
-          candidate = Interval.For(Rational.For(l, 1), Rational.For(l + 1, 1));
+            if (this.IsInteger)
+            {
+                var asInt64 = this.NextInt64;
+                if (Int32.MinValue <= asInt64 && asInt64 <= Int32.MaxValue)
+                {
+                    return factory.Constant((Int32)asInt64);
+                }
+                else
+                {
+                    return factory.Constant((Int64)asInt64);
+                }
+            }
+            else
+            {
+                T upConst = factory.Constant(up);
+                T downConst = factory.Constant(down);
+
+                return factory.Div(upConst, downConst);
+            }
         }
-        else
+
+        #endregion
+
+        #region Try* version of arithmetic operators
+
+        #region TryAdd*
+        public static bool TryAdd(Rational r1, Rational r2, out Rational result)
         {
-          candidate = Interval.For(Rational.For(l - 1, 1), Rational.For(l, 1));
+            Contract.Requires(!object.ReferenceEquals(r1, null));
+            Contract.Requires(!object.ReferenceEquals(r2, null));
+
+            Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
+
+            // Special cases (Using IsZero, as it is faster than operator ==)
+            // 0 + r2 = r2
+            if (r1.IsZero)
+            {
+                result = r2;
+                return true;
+            }
+
+            // r1 + 0 = r1
+            if (r2.IsZero)
+            {
+                result = r1;
+                return true;
+            }
+
+            // oo + r2 = oo
+            if (r1.IsInfinity)
+            {
+                result = r1;
+                return true;
+            }
+
+            // r1 + oo = oo
+            if (r2.IsInfinity)
+            {
+                result = r2;
+                return true;
+            }
+            // maxval + pos = infinity
+            if ((r1.IsMaxValue && r2 > 0) || (r2.IsMaxValue && r1 > 0))
+            {
+                result = Rational.PlusInfinity;
+                return true;
+            }
+
+            // minval + neg = -infinity
+            if ((r1.IsMinValue && r2 < 0) || (r2.IsMinValue && r1 < 0))
+            {
+                result = Rational.MinusInfinity;
+                return true;
+            }
+
+            Int64 returnUp;
+            Int64 returnDown;
+
+            try
+            {
+                if (r1.down == r2.down)
+                {
+                    // Special case for (a/b + a/b) = (a / (b/2)
+                    if (r1.up == r2.up && r1.down % 2 == 0)
+                    {
+                        returnUp = r1.up;
+                        returnDown = checked(r1.down / 2);
+                    }
+                    else
+                    {
+                        returnUp = checked(r1.up + r2.up);
+                        returnDown = checked(r1.down);
+                    }
+                }
+                else
+                {
+                    var tmp1 = checked(r1.up * r2.down);
+                    var tmp2 = checked(r2.up * r1.down);
+                    returnUp = checked(tmp1 + tmp2);
+
+                    returnDown = checked(r1.down * r2.down);
+                }
+            }
+            catch (ArithmeticException)
+            {
+                {
+                    try
+                    {
+                        long gcd = GCD(r1.down, r2.down);
+
+                        long tmp1 = checked(r1.up * (r2.down / gcd));
+                        long tmp2 = checked(r2.up * (r1.down / gcd));
+
+                        returnUp = checked(tmp1 + tmp2);
+                        returnDown = checked(r1.down * r2.down);
+                    }
+                    catch (ArithmeticException)
+                    {
+                        result = default(Rational);
+                        return false;
+                    }
+                }
+            }
+
+            // Small inlining, as operator+ is called so many times
+            result = returnDown == 1 ? Rational.For(returnUp) : Rational.For(returnUp, returnDown);
+
+            return true;
         }
 
-        // Check for conversion errors
-        if (candidate.LowerBound.Ceiling > d || candidate.UpperBound.Floor < d)
+        public static bool TryAdd(Rational r1, Int64 i, out Rational result)
         {
-          return Interval.UnknownInterval;
+            Contract.Requires(!object.ReferenceEquals(r1, null));
+
+            Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
+
+            if (r1.kind == Kind.Normal && r1.down == 1)
+            {
+                try
+                {
+                    result = Rational.For(checked(r1.up + i));
+                }
+                catch (ArithmeticException)
+                { // slow path
+                    return TryAdd(r1, Rational.For(i), out result);
+                }
+
+                return true;
+            }
+            else
+            {
+                return TryAdd(r1, Rational.For(i), out result);
+            }
         }
 
-        return candidate;
-      }
-    }
+        public static bool TryAdd(Int64 i, Rational r2, out Rational result)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || ((object)Contract.ValueAtReturn(out result)) != null);
 
-    #endregion
+            return TryAdd(r2, i, out result);
+        }
+        #endregion
 
-    #region Overridden methods
+        public static bool TrySub(Rational r1, Rational r2, out Rational result)
+        {
+            Contract.Requires(!object.ReferenceEquals(r1, null));
+            Contract.Requires(!object.ReferenceEquals(r2, null));
 
-    public override bool Equals(object obj)
-    {
+            Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
+
+            Int64 returnUp;
+            Int64 returnDown;
+
+            // r1 - 0 = r1
+            if (r2.IsZero)
+            {
+                result = r1;
+                return true;
+            }
+
+            // 0 - r2 = -r2
+            if (r1.IsZero)
+            {
+                result = -r2;
+                return true;
+            }
+
+            // r1 - r1 = 0
+            if (r1 == r2)
+            {
+                result = Zero;
+                return true;
+            }
+
+            // r1 - (-r2) = r1 + r2
+            if (r2 < 0 && !r2.IsMinValue)
+            {
+                // result = r1 + Rational.Abs(r2);
+                return TryAdd(r1, Rational.Abs(r2), out result);
+            }
+
+            // oo - r2 = oo
+            if (r1.IsInfinity)
+            {
+                result = r1;
+                return true;
+            }
+
+            // r1 - oo = -oo
+            if (r2.IsInfinity)
+            {
+                result = -r2;
+                return true;
+            }
+
+            if (r1.IsMinValue && r2 > 0)
+            {
+                result = Rational.MinusInfinity;
+                return true;
+            }
+
+            try
+            {
+                // This optimization is to avoid the creation of large numbers (and also to save 3 multiplications)
+                if (r1.down == r2.down)
+                {
+                    returnUp = checked(r1.up - r2.up);
+                    returnDown = r1.down;
+                }
+                else
+                {
+                    long tmp1 = checked(r1.up * r2.down);
+                    long tmp2 = checked(r2.up * r1.down);
+                    returnUp = checked(tmp1 - tmp2);
+
+                    returnDown = checked(r1.down * r2.down);
+                }
+            }
+            catch (ArithmeticException)
+            {
+                result = default(Rational);
+                return false;
+            }
+
+            result = Rational.For(returnUp, returnDown);
+            return true;
+        }
+
+        // This is always going to succeed (because of our representation of Rationals), but to make the code easier to read, I made it a Try*
+        public static bool TryUnaryMinus(Rational r, out Rational result)
+        {
+            Contract.Requires(!object.ReferenceEquals(r, null));
+
+            Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
+
+            // -0 = 0
+            if (r.IsZero)
+            {
+                result = r;
+                return true;
+            }
+
+            // - (-oo) = oo
+            if (r.IsMinusInfinity)
+            {
+                result = Rational.PlusInfinity;
+                return true;
+            }
+
+            // - (+ oo) = -oo
+            if (r.IsPlusInfinity)
+            {
+                result = Rational.MinusInfinity;
+                return true;
+            }
+
+            if (r.IsMinValue)
+            {
+                result = Rational.MaxValue;
+                return true;
+            }
+
+            if (r.IsMaxValue)
+            {
+                result = Rational.MinValue;
+                return true;
+            }
+            if (r.down == 1)
+            {
+                result = Rational.For(-r.up);
+                return true;
+            }
+            else
+            {
+                result = Rational.For(-r.up, r.down);
+                return true;
+            }
+        }
+
+        public static bool TryMul(Rational r1, Rational r2, out Rational result)
+        {
+            Contract.Requires(!object.ReferenceEquals(r1, null));
+            Contract.Requires(!object.ReferenceEquals(r2, null));
+
+            Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
+
+            // 0 * r2 = r1 * 0 = 0
+            if (r1.IsZero || r2.IsZero)
+            {
+                result = Zero;
+                return true;
+            }
+
+            // 1 * r2 = r2
+            if (r1 == 1)
+            {
+                result = r2;
+                return true;
+            }
+
+            // r1 * 1 = r1
+            if (r2 == 1)
+            {
+                result = r1;
+                return true;
+            }
+
+            if (r1.IsPlusInfinity)
+            {
+                if (r2.IsPlusInfinity)
+                {
+                    result = Rational.PlusInfinity;
+                }
+                else if (r2.IsMinusInfinity)
+                {
+                    result = Rational.MinusInfinity;
+                }
+                else
+                {
+                    result = r2.Sign > 0 ? Rational.PlusInfinity : (r2.Sign < 0 ? Rational.MinusInfinity : Zero);
+                }
+                return true;
+            }
+
+            if (r1.IsMinusInfinity)
+            {
+                if (r2.IsPlusInfinity)
+                {
+                    result = Rational.MinusInfinity;
+                }
+                else if (r2.IsMinusInfinity)
+                {
+                    result = Rational.PlusInfinity;
+                }
+                else
+                {
+                    result = r2.Sign > 0 ? Rational.MinusInfinity : (r2.Sign < 0 ? Rational.PlusInfinity : Zero);
+                }
+                return true;
+            }
+            if (r2.IsPlusInfinity)
+            {
+                Contract.Assume(!r1.IsInfinity);
+                result = r1.Sign > 0 ? Rational.PlusInfinity : (r1.Sign < 0 ? Rational.MinusInfinity : Zero);
+                return true;
+            }
+
+            if (r2.IsMinusInfinity)
+            {
+                Contract.Assume(!r1.IsInfinity);
+                result = r1.Sign > 0 ? Rational.MinusInfinity : (r1.Sign < 0 ? Rational.PlusInfinity : Zero);
+                return true;
+            }
+
+            // To do : add the entries with MaxValue
+
+            Int64 returnUp;
+            Int64 returnDown;
+
+            try
+            {
+                // If we want to compute a/b * c/d we make the rational smaller by computing a/d * c/b
+                var crossRational1 = Rational.For(r1.up, r2.down);
+                var crossRational2 = Rational.For(r2.up, r1.down);
+
+                returnUp = checked(crossRational1.up * crossRational2.up);
+                returnDown = checked(crossRational1.down * crossRational2.down);
+            }
+            catch (ArithmeticException)
+            {
+                result = default(Rational);
+                return false;
+            }
+
+            result = Rational.For(returnUp, returnDown);
+            return true;
+        }
+
+        public static bool TryDiv(Rational r1, Rational r2, out Rational result)
+        {
+            Contract.Requires(!object.ReferenceEquals(r1, null));
+            Contract.Requires(!object.ReferenceEquals(r2, null));
+
+            Contract.Ensures(!Contract.Result<bool>() || (!(object.ReferenceEquals(Contract.ValueAtReturn(out result), null))));
+
+            Int64 returnUp;
+            Int64 returnDown;
+
+            // r1 / 1 = r1 
+            if (r2 == 1)
+            {
+                result = r1;
+                return true;
+            }
+            // r2 / 0 = "overflow"
+            if (r2.IsZero)
+            {
+                result = default(Rational);
+                return false;
+            }
+
+            // 0 / r1 =0
+            if (r1.IsZero)
+            {
+                result = Zero;
+                return true;
+            }
+
+            // Note: At this point we know that r2 != 0;
+
+            // + oo / k = sign(k) * oo
+            if (r1.IsPlusInfinity && !r2.IsInfinity)
+            {
+                result = r2.Sign >= 0 ? Rational.PlusInfinity : Rational.MinusInfinity;
+                return true;
+            }
+
+            // - oo / k = -1 * sign(k) * oo 
+            if (r1.IsMinusInfinity && !r2.IsInfinity)
+            {
+                result = r2.Sign >= 0 ? Rational.MinusInfinity : Rational.PlusInfinity;
+                return true;
+            }
+            // Note: At this point we know that r1 != 0 (and 1)
+
+            // k / oo = 0
+            if (r2.IsInfinity)
+            {
+                result = Zero;
+                return true;
+            }
+
+            if (r1.up == r2.up)
+            { // (a /b) / (a / c) = c / b
+                returnUp = r2.down;
+                returnDown = r1.down;
+            }
+            else if (r1.down == r2.down)
+            { // (a / b) / (c / b) = a / c
+                returnUp = r1.up;
+                returnDown = r2.up;
+            }
+            else
+            {
+                try
+                {
+                    returnUp = checked(r1.up * r2.down);
+                    returnDown = checked(r1.down * r2.up);
+                }
+                catch (ArithmeticException)
+                {
+                    result = default(Rational);
+                    return false;
+                }
+            }
+
+            result = Rational.For(returnUp, returnDown);
+            return true;
+        }
+
+        #endregion
+
+        #region Arithmetic operations
+
+        public static Rational operator +(Rational r1, Rational r2)
+        {
+            Contract.Requires(!object.ReferenceEquals(r1, null));
+            Contract.Requires(!object.ReferenceEquals(r2, null));
+
+            Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));
+
+            Rational result;
+            if (TryAdd(r1, r2, out result))
+            {
+                return result;
+            }
+            else
+            {
+                throw new ArithmeticExceptionRational();
+            }
+        }
+
+        public static Rational operator -(Rational r1, Rational r2)
+        {
+            Contract.Requires(!object.ReferenceEquals(r1, null));
+            Contract.Requires(!object.ReferenceEquals(r2, null));
+
+            Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));
+
+            Rational result;
+            if (TrySub(r1, r2, out result))
+            {
+                return result;
+            }
+            else
+            {
+                throw new ArithmeticExceptionRational();
+            }
+        }
+
+        public static Rational operator -(Rational r)
+        {
+            Contract.Requires(!object.ReferenceEquals(r, null));
+
+            Contract.Ensures(!object.ReferenceEquals(Contract.Result<Rational>(), null));
+
+            Rational result;
+            if (TryUnaryMinus(r, out result))
+            {
+                return result;
+            }
+            else
+            {
+                throw new ArithmeticExceptionRational();
+            }
+        }
+
+        public static Rational operator *(Rational r1, Rational r2)
+        {
+            Contract.Requires((object)r1 != null);
+            Contract.Requires((object)r2 != null);
+
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            Rational result;
+            if (TryMul(r1, r2, out result))
+            {
+                return result;
+            }
+            else
+            {
+                throw new ArithmeticExceptionRational();
+            }
+        }
+
+        public static Rational MultiplyWithDefault(Rational r1, Rational r2, Rational def)
+        {
+            Contract.Requires((object)r1 != null);
+            Contract.Requires((object)r2 != null);
+            Contract.Requires((object)def != null);
+
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            try
+            {
+                return r1 * r2;
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return def;
+            }
+        }
+
+
+        public static Rational operator /(Rational r1, Rational r2)
+        {
+            Contract.Requires((object)r1 != null);
+            Contract.Requires((object)r2 != null);
+
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            Rational result;
+
+            if (r2.IsZero)
+            {
+                throw new DivideByZeroException();
+            }
+
+            if (TryDiv(r1, r2, out result))
+            {
+                return result;
+            }
+            else
+            {
+                throw new ArithmeticExceptionRational();
+            }
+        }
+
+        public static Rational DivideWithDefault(Rational r1, Rational r2, Rational def)
+        {
+            Contract.Requires((object)r1 != null);
+            Contract.Requires((object)r2 != null);
+            Contract.Requires((object)def != null);
+
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            try
+            {
+                return r1 / r2;
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return def;
+            }
+        }
+
+        #endregion
+
+        #region Specialized arithmetic operations
+        public static Rational operator +(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            Rational result;
+            if (TryAdd(r, i, out result))
+            {
+                return result;
+            }
+            else
+            {
+                throw new ArithmeticExceptionRational();
+            }
+        }
+
+        public static Rational operator +(Int64 i, Rational r)
+        {
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            return r + i;
+        }
+
+        public static Rational operator -(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures((object)Contract.Result<Rational>() != null);
+
+            if (r.kind == Kind.Normal && r.down == 1)
+            {
+                try
+                {
+                    return Rational.For(checked(r.up - i));
+                }
+                catch (ArithmeticException)
+                { // Slow path
+                    return r - Rational.For(i);
+                }
+            }
+            else
+            {
+                return r - Rational.For(i);
+            }
+        }
+
+        public static Rational operator -(Int64 i, Rational r)
+        {
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            if (r.kind == Kind.Normal && r.down == 1)
+            {
+                try
+                {
+                    return Rational.For(checked(i - r.up));
+                }
+                catch (ArithmeticException)
+                { // Slow path
+                    return Rational.For(i) - r;
+                }
+            }
+            else
+            {
+                return Rational.For(i) - r;
+            }
+        }
+
+        static public Rational operator *(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            if (r.kind == Kind.Normal)
+            {
+                try
+                {
+                    return Rational.For(checked(r.up) * i, r.down);
+                }
+                catch (ArithmeticException)
+                {
+                    return r * Rational.For(i);
+                }
+            }
+            else
+            {
+                return r * Rational.For(i);
+            }
+        }
+
+        static public Rational operator *(Int64 i, Rational r)
+        {
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            return r * i;
+        }
+
+        static public Rational operator /(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            if (r.kind == Kind.Normal)
+            {
+                try
+                {
+                    return Rational.For(r.up, checked(r.down * i));
+                }
+                catch (ArithmeticException)
+                {
+                    return r / Rational.For(i);
+                }
+            }
+            else
+            {
+                return r / Rational.For(i);
+            }
+        }
+
+        #endregion
+
+        #region Comparison operators
+        public static bool operator ==(Rational r1, Rational r2)
+        {
+            Contract.Requires(!object.Equals(r1, null));
+            Contract.Requires(!object.Equals(r2, null));
+
+            // Some very common checks
+            if (object.ReferenceEquals(r1, r2))
+                return true;
+
+            if (r1.IsZero)
+                return r2.IsZero;
+
+            if (r2.IsZero)
+                return false;
+
+            if (r1.IsPlusInfinity)
+                return r2.IsPlusInfinity;
+
+            if (r2.IsPlusInfinity)
+                return false;
+
+            if (r1.IsMinusInfinity)
+                return r2.IsMinusInfinity;
+
+            if (r2.IsMinusInfinity)
+                return false;
+
+            // Special case for syntactical equality 
+            if (r1.up == r2.up && r1.down == r2.down)
+                return true;
+
+            // General case...
+            try
+            {
+                return checked(r1.up * r2.down == r1.down * r2.up);
+            }
+            catch (ArithmeticException)
+            {
+                return ((decimal)r1.up / (decimal)r1.down) == ((decimal)r2.up / (decimal)r2.down);
+            }
+        }
+
+        public static bool operator !=(Rational r1, Rational r2)
+        {
+            Contract.Requires(!object.Equals(r1, null));
+            Contract.Requires(!object.Equals(r2, null));
+
+            // Some very common checks
+            if (object.ReferenceEquals(r1, r2))
+                return false;
+
+            if (r1.IsZero)
+                return !r2.IsZero;
+
+            if (r2.IsZero)
+                return true;
+
+            return !(r1 == r2);
+        }
+
+        public static bool operator <=(Rational r1, Rational r2)
+        {
+            if (object.ReferenceEquals(r1, r2))
+            {
+                return true;
+            }
+
+            if (r1.IsMinusInfinity || r2.IsPlusInfinity)
+            {
+                return true;
+            }
+
+            if (r1.IsPlusInfinity || r2.IsMinusInfinity)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (r1.down == r2.down)
+                    return r1.up <= r2.up;
+
+                return checked(r1.up * r2.down <= r1.down * r2.up);
+            }
+            catch (ArithmeticException)
+            {
+                return ((decimal)r1.up) / ((decimal)r1.down) <= ((decimal)r2.up) / ((decimal)r2.down);
+            }
+        }
+
+        public static bool operator >=(Rational r1, Rational r2)
+        {
+            return r2 <= r1;
+        }
+
+        public static bool operator <(Rational r1, Rational r2)
+        {
+            if (object.ReferenceEquals(r1, r2))
+                return false;
+
+            if (r1.IsMinusInfinity && !r2.IsMinusInfinity)
+                return true;
+
+            if (r2.IsPlusInfinity && !r1.IsPlusInfinity)
+                return true;
+
+            if (r1.IsPlusInfinity || r2.IsMinusInfinity)
+                return false;
+
+            else
+            {
+                // Special cases to make it faster?  (avoid the multiplications)
+                if (r1.down == r2.down)
+                    return r1.up < r2.up;
+
+                if (r1.up <= 0 && r2.up > 0)
+                    return true;
+
+                if (r1.up < 0 && r2.up == 0)
+                    return true;
+
+                try
+                {
+                    // else
+                    {
+                        return checked((Int64)r1.up * (Int64)r2.down < (Int64)r1.down * (Int64)r2.up);
+                    }
+                }
+                catch (ArithmeticException)
+                {
+                    return ((decimal)r1.up / (decimal)r1.down) < ((decimal)r2.up) / ((decimal)r2.down);
+                }
+            }
+        }
+
+        public static bool operator >(Rational r1, Rational r2)
+        {
+            return r2 < r1;
+        }
+
+        #endregion
+
+        #region Specialized comparison operators
+        public static bool operator ==(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            switch (r.kind)
+            {
+                case Kind.MinusInfinity:
+                case Kind.PlusInfinty:
+                    return false;
+
+                case Kind.Normal:
+                default:
+                    try
+                    {
+                        return checked(r.up == i * r.down);
+                    }
+                    catch (ArithmeticException)
+                    {
+                        return checked((decimal)r.up / (decimal)r.down == i);
+                    }
+            }
+        }
+
+        public static bool operator ==(Int64 i, Rational r)
+        {
+            Contract.Requires(((object)r) != null);
+
+            return r == i;
+        }
+
+        public static bool operator !=(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            switch (r.kind)
+            {
+                case Kind.MinusInfinity:
+                case Kind.PlusInfinty:
+                    return false;
+
+                case Kind.Normal:
+                default:
+                    try
+                    {
+                        return checked(r.up != i * r.down);
+                    }
+                    catch (ArithmeticException)
+                    {
+                        return checked((decimal)r.up / (decimal)r.down != i);
+                    }
+            }
+        }
+
+        public static bool operator !=(Int64 i, Rational r)
+        {
+            Contract.Requires((object)r != null);
+            return r != i;
+        }
+
+        public static bool operator <=(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            switch (r.kind)
+            {
+                case Kind.MinusInfinity:
+                    return true;
+
+                case Kind.PlusInfinty:
+                    return false;
+
+                case Kind.Normal:
+                default:
+                    try
+                    {
+                        return checked(r.up <= r.down * i);
+                    }
+                    catch (ArithmeticException)
+                    {
+                        return checked((decimal)r.up / (decimal)r.down <= i);
+                    }
+            }
+        }
+
+        public static bool operator <=(Int64 i, Rational r)
+        {
+            Contract.Requires((object)r != null);
+
+            switch (r.kind)
+            {
+                case Kind.MinusInfinity:
+                    return false;
+
+                case Kind.PlusInfinty:
+                    return true;
+
+                case Kind.Normal:
+                default:
+                    try
+                    {
+                        return checked(i * r.down <= r.up);
+                    }
+                    catch (ArithmeticException)
+                    {
+                        return checked((i <= (decimal)r.up / (decimal)r.down));
+                    }
+            }
+        }
+
+        public static bool operator >=(Rational r, Int64 i)
+        {
+            Contract.Requires((object)r != null);
+
+            return i <= r;
+        }
+
+        public static bool operator >=(Int64 i, Rational r)
+        {
+            Contract.Requires((object)r != null);
+
+            return r <= i;
+        }
+
+        public static bool operator <(Int64 i, Rational r)
+        {
+            switch (r.kind)
+            {
+                case Kind.MinusInfinity:
+                    return false;
+
+                case Kind.PlusInfinty:
+                    return true;
+
+                case Kind.Normal:
+                default:
+                    try
+                    {
+                        return checked(i * r.down < r.up);
+                    }
+                    catch
+                    {
+                        return checked(i < (decimal)r.up / (decimal)r.down);
+                    }
+            }
+        }
+
+        public static bool operator <(Rational r, Int64 i)
+        {
+            switch (r.kind)
+            {
+                case Kind.MinusInfinity:
+                    return true;
+
+                case Kind.PlusInfinty:
+                    return false;
+
+                case Kind.Normal:
+                default:
+                    try
+                    {
+                        return checked(r.up < i * r.down);
+                    }
+                    catch (ArithmeticException)
+                    {
+                        return checked(((decimal)r.up / (decimal)r.down) < i);
+                    }
+            }
+        }
+
+        public static bool operator >(Rational r, Int64 i)
+        {
+            return i < r;
+        }
+
+        public static bool operator >(Int64 i, Rational r)
+        {
+            return r < i;
+        }
+        #endregion
+
+        #region InRange
+        public bool IsInRange(Rational low, Rational upp)
+        {
+            return low <= this && this <= upp;
+        }
+
+        public bool IsInRange(Int32 low, Int32 upp)
+        {
+            return low <= this && this <= upp;
+        }
+
+        public bool IsInRange(Int64 low, Int64 upp)
+        {
+            return low <= this && this <= upp;
+        }
+
+        public bool IsInRange(UInt32 low, UInt32 upp)
+        {
+            return low <= this && this <= upp;
+        }
+
+        #endregion
+
+        #region Conversion Operators (casts to and from Int32 and double)
+
+        private static Dictionary<object, ulong> conversions;
+
+        // This method is quite resource demanding, and we are using it just to profile the allocation of new Rationals
+        [Conditional("PROFILE_RATIONALS")]
+        public static void IncreaseCount(object o)
+        {
+            if (conversions == null)
+            {
+                conversions = new Dictionary<object, ulong>();
+            }
+
+            if (conversions.ContainsKey(o))
+            {
+                conversions[o] = conversions[o] + 1;
+            }
+            else
+            {
+                conversions[o] = 1;
+            }
+        }
+
+        /// <summary>
+        /// Some performance statistics on rationals
+        /// </summary>
+        public static string Statistics
+        {
+            get
+            {
+                var result = new StringBuilder();
+
+                result.AppendFormat("# of allocated rationals : {0}" + Environment.NewLine, Rational.Allocated);
+                result.AppendFormat("# of thrown exceptions : {0}" + Environment.NewLine, ArithmeticExceptionRational.ThrownExceptions);
+
+                if (conversions != null)
+                {
+                    var array = new KeyValuePair<object, ulong>[conversions.Count];
+
+                    var count = 0;
+                    foreach (var pair in conversions)
+                    {
+                        array[count++] = pair;
+                    }
+
+                    Array.Sort(array, delegate (KeyValuePair<object, ulong> x, KeyValuePair<object, ulong> y) { return x.Value > y.Value ? -1 : 1; });
+
+                    ulong sum = 0;
+                    foreach (var pair in array)
+                    {
+                        result.AppendFormat("{0} -> {1}\n", pair.Key.ToString(), pair.Value.ToString());
+                        sum += pair.Value;
+                    }
+                    result.AppendFormat("(sum of the above: {0})", sum);
+                }
+
+                return result.ToString();
+            }
+        }
+
+        ///<summary>
+        ///By default does the rounding to the closest Int32 value
+        ///</summary>
+        public static explicit operator Int32(Rational r)
+        {
+            if (r.down == 0)
+                return r.up < 0 ? Int32.MaxValue : Int32.MinValue;
+
+            else
+                return (Int32)Math.Round((double)r.up / (double)r.down);
+        }
+
+
+        public static explicit operator Int64(Rational r)
+        {
+            if (r.down == 0)
+                return r.up < 0 ? Int64.MaxValue : Int64.MinValue;
+            else
+                return r.IsInteger ? r.up : (Int64)Math.Round((double)r.up / (double)r.down);
+        }
+
+        public bool TryInt64(out Int64 value)
+        {
+            if (this.IsInfinity)
+            {
+                value = default(Int64);
+                return false;
+            }
+
+            value = this.IsInteger ? up : (Int64)Math.Round((double)up / (double)down);
+            return true;
+        }
+
+        public static explicit operator Double(Rational r)
+        {
+            if (r.IsPlusInfinity)
+                return Double.PositiveInfinity;
+            if (r.IsMinusInfinity)
+                return Double.NegativeInfinity;
+
+            return (double)r.up / (double)r.down;
+        }
+
+        public static Interval ConvertFromDouble(Double d)
+        {
+            Contract.Ensures(Contract.Result<Interval>() != null);
+
+            if (d.Equals(Double.NaN))
+            {
+                return Interval.UnknownInterval;
+            }
+
+            long l = (long)d;
+            if (d == (Double)l)
+            {
+                return Interval.For(Rational.For(l, 1));
+            }
+            else
+            {
+                Interval candidate;
+                if (d > 0)
+                {
+                    candidate = Interval.For(Rational.For(l, 1), Rational.For(l + 1, 1));
+                }
+                else
+                {
+                    candidate = Interval.For(Rational.For(l - 1, 1), Rational.For(l, 1));
+                }
+
+                // Check for conversion errors
+                if (candidate.LowerBound.Ceiling > d || candidate.UpperBound.Floor < d)
+                {
+                    return Interval.UnknownInterval;
+                }
+
+                return candidate;
+            }
+        }
+
+        #endregion
+
+        #region Overridden methods
+
+        public override bool Equals(object obj)
+        {
 #if STRUCTRATIONALS
-      if (!(obj is Rational))
-        return false;
+            if (!(obj is Rational))
+                return false;
 
-      return this == (Rational)obj;
+            return this == (Rational)obj;
 #else
-      Rational r2 = obj as Rational;
-      if ((object)r2 != (object)null) return this == r2;
-      return false;
+            Rational r2 = obj as Rational;
+            if ((object)r2 != (object)null) return this == r2;
+            return false;
 #endif
-    }
-
-    public override int GetHashCode()
-    {
-      return (int)(this.down + this.up);
-    }
-
-    #endregion
-
-    #region The Euclide's algorithm
-    //private static Int64 GCD_Internal(Int64 x, Int64 y)
-    //{
-    //  Contract.Requires(x > 0);
-    //  Contract.Requires(y > 0);
-
-    //  Contract.Ensures(Contract.Result<Int64>() > 0);
-
-    //  while (true)
-    //  {
-    //    if (x < y)
-    //    {
-    //      y %= x;
-    //      if (y == 0)
-    //      {
-    //        return x;
-    //      }
-    //    }
-    //    else
-    //    {
-    //      x %= y;
-    //      if (x == 0)
-    //      {
-    //        return y;
-    //      }
-    //    }
-    //  }
-    //}
-
-    public static Int64 GCD(Int64 x, Int64 y)
-    {
-      Contract.Requires(x > 0);
-      Contract.Requires(y > 0);
-
-      Contract.Ensures(Contract.Result<Int64>() > 0);
-
-      var u = (UInt64)x;
-      var v = (UInt64)y;
-
-      int shift;
-
-      for (shift = 0; ((u | v) & 1) == 0; shift++)
-      {
-        u >>= 1;
-        v >>= 1;
-      }
-
-      while ((u & 1) == 0)
-      {
-        u >>= 1;
-      }
-
-      do
-      {
-        while((v & 1) == 0)
-        {
-          v >>=1;
         }
 
-        if(u < v)
+        public override int GetHashCode()
         {
-          v -= u;
+            return (int)(down + up);
         }
-        else
+
+        #endregion
+
+        #region The Euclide's algorithm
+        //private static Int64 GCD_Internal(Int64 x, Int64 y)
+        //{
+        //  Contract.Requires(x > 0);
+        //  Contract.Requires(y > 0);
+
+        //  Contract.Ensures(Contract.Result<Int64>() > 0);
+
+        //  while (true)
+        //  {
+        //    if (x < y)
+        //    {
+        //      y %= x;
+        //      if (y == 0)
+        //      {
+        //        return x;
+        //      }
+        //    }
+        //    else
+        //    {
+        //      x %= y;
+        //      if (x == 0)
+        //      {
+        //        return y;
+        //      }
+        //    }
+        //  }
+        //}
+
+        public static Int64 GCD(Int64 x, Int64 y)
         {
-          var diff = u-v;
-          u = v;
-          v = diff;
+            Contract.Requires(x > 0);
+            Contract.Requires(y > 0);
+
+            Contract.Ensures(Contract.Result<Int64>() > 0);
+
+            var u = (UInt64)x;
+            var v = (UInt64)y;
+
+            int shift;
+
+            for (shift = 0; ((u | v) & 1) == 0; shift++)
+            {
+                u >>= 1;
+                v >>= 1;
+            }
+
+            while ((u & 1) == 0)
+            {
+                u >>= 1;
+            }
+
+            do
+            {
+                while ((v & 1) == 0)
+                {
+                    v >>= 1;
+                }
+
+                if (u < v)
+                {
+                    v -= u;
+                }
+                else
+                {
+                    var diff = u - v;
+                    u = v;
+                    v = diff;
+                }
+                v >>= 1;
+            } while (v != 0);
+
+            var r1 = (Int64)u << shift;
+
+
+            Contract.Assume(r1 > 0); // F: the reason for that are quite complicated arithmetical properties
+            return r1;
         }
-        v >>=1;
-      } while(v != 0);
 
-      var r1 = (Int64) u << shift;
+        #endregion
+
+        #region Private methods
+
+        private static Int64 Abs(Int64 value)
+        {
+            if (value >= 0)
+                return value;
+            else if (value == Int64.MinValue)
+                return Int64.MaxValue;
+            else
+                return -value;
+        }
 
 
-      Contract.Assume(r1 > 0); // F: the reason for that are quite complicated arithmetical properties
-      return r1;
+
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            if (this.IsMinusInfinity)
+                return "-oo" + ((up != -1 && down != 0) ? string.Format("({0} / {1})", up, down) : "");
+            else if (this.IsPlusInfinity)
+                return "+oo" + ((up != 1 && down != 0) ? string.Format("({0} / {1})", up, down) : "");
+            else if (this.IsInteger)
+                return (up).ToString();
+            else
+                return up + "/" + down;
+        }
+        #endregion
     }
 
-    #endregion
-
-    #region Private methods
-
-    private static Int64 Abs(Int64 value)
+    [Serializable]
+    public class ArithmeticExceptionRational
+      : ArithmeticException
     {
-      if (value >= 0)
-        return value;
-      else if (value == Int64.MinValue)
-        return Int64.MaxValue;
-      else
-        return -value;
+        #region Private state
+        [ThreadStatic]
+        private static uint exceptions;
+        #endregion
+
+        #region Constructor
+        public ArithmeticExceptionRational()
+        {
+            exceptions++;
+        }
+        #endregion
+
+        #region Getters
+        /// <summary>
+        /// The number of Rational exceptions thrown so far
+        /// </summary>
+        static public uint ThrownExceptions
+        {
+            get
+            {
+                return exceptions;
+            }
+        }
+        #endregion
+
     }
-
-
-
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      if (this.IsMinusInfinity)
-        return "-oo" + ((this.up != -1 && this.down != 0) ? string.Format("({0} / {1})", this.up, this.down) : "");
-      else if (this.IsPlusInfinity)
-        return "+oo" + ((this.up != 1 && this.down != 0) ? string.Format("({0} / {1})", this.up, this.down) : "");
-      else if (this.IsInteger)
-        return (this.up).ToString();
-      else
-        return this.up + "/" + this.down;
-    }
-    #endregion
-  }
-
-  [Serializable]
-  public class ArithmeticExceptionRational
-    : ArithmeticException
-  {
-    #region Private state
-    [ThreadStatic]
-    private static uint exceptions;
-    #endregion
-
-    #region Constructor
-    public ArithmeticExceptionRational()
-    {
-      exceptions++;
-    }
-    #endregion
-
-    #region Getters
-    /// <summary>
-    /// The number of Rational exceptions thrown so far
-    /// </summary>
-    static public uint ThrownExceptions
-    {
-      get
-      {
-        return exceptions;
-      }
-    }
-    #endregion
-
-  }
 }
 

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/RefinementsForNumericalDomains.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/RefinementsForNumericalDomains.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Contains refinements for Pentagons, namely:
 // + A generic abstract domain, parameterized by a numerical abstract domain, which keeps track of (linear) equalities
@@ -29,1267 +18,1261 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// The reduced product Karr x NumericalDomain
-  /// </summary>
-  public class NumericalDomainWithKarr<Variable, Expression>
-    : ReducedNumericalDomains<LinearEqualitiesEnvironment<Variable, Expression>, INumericalAbstractDomain<Variable, Expression>, Variable, Expression>
-  {
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(trueTestVisitor != null);
-      Contract.Invariant(falseTestVisitor != null);
-      Contract.Invariant(checkIfHoldsVisitor != null);   
-    }
-
-    private const int MinStepsToEnableLessEqualThanClosure = -1; 
-    private const int MinStepsToEnableLessThanClosure = 0;
-
-    private int closureSteps;
-    [ThreadStatic]
-    private static int defaultClosureSteps;
-    public static int DefaultClosureSteps
-    {
-      get
-      {
-        return defaultClosureSteps;
-      }
-      set
-      {
-        defaultClosureSteps = value;
-      }
-    }
-
-    [ThreadStatic]
-    private static int maxPairwiseEqualitiesInClosure;
-    public static int MaxPairWiseEqualitiesInClosure
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-
-        Contract.Assume(maxPairwiseEqualitiesInClosure >= 0);
-
-        return maxPairwiseEqualitiesInClosure;
-      }
-      set
-      {
-        maxPairwiseEqualitiesInClosure = Math.Max(value, 0);
-      }
-    }
-
-    private bool inRecursion = false;
-
-
-    private RefinedTestTrueVisitor trueTestVisitor;
-    private RefinedTestFalseVisitor falseTestVisitor;
-    private RefinedCheckIfHoldsVisitor checkIfHoldsVisitor;
-
-    #region Constructors
-
-    public NumericalDomainWithKarr(
-      LinearEqualitiesEnvironment<Variable, Expression> left, INumericalAbstractDomain<Variable, Expression> right,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(left, right, expManager)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Requires(expManager != null);
-      
-      closureSteps = defaultClosureSteps;
-
-      this.trueTestVisitor = new RefinedTestTrueVisitor(expManager);
-      this.falseTestVisitor = new RefinedTestFalseVisitor(expManager.Decoder);
-      this.checkIfHoldsVisitor = new RefinedCheckIfHoldsVisitor(expManager.Decoder);
-      this.trueTestVisitor.FalseVisitor = this.falseTestVisitor;
-      this.falseTestVisitor.TrueVisitor = this.trueTestVisitor;
-    }
-
-    #endregion
-
-    #region Implementations of the abstract domain operations
-
-    public override IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.LowerBoundsFor(v, strict);
-    }
-
-    public override IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.UpperBoundsFor(v, strict);
-    }
-
-    public override IAbstractDomain Join(IAbstractDomain a)
-    {
-      var other = a as NumericalDomainWithKarr<Variable, Expression>;
-
-      Contract.Assume(other != null);
-      return this.Join(other);
-    }
-
-    public IAbstractDomain Join(NumericalDomainWithKarr<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
-
-      NumericalDomainWithKarr<Variable, Expression> adom;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, other, out adom))
-      {
-        return adom;
-      }
-
-      // Propagate the equalities that we have in Karr
-      var thisClosedRight = this.CloseRight();
-      var otherClosedRight = other.CloseRight();
-
-      var resultLeft = this.Left.Join(other.Left);
-      var resultRight = thisClosedRight.Join(otherClosedRight) as INumericalAbstractDomain<Variable, Expression>;
-
-      Contract.Assume(resultRight != null);
-
-      return this.Factory(resultLeft, resultRight);
-    }
-
-    public override IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      var aDomain = base.TestTrue(guard) as NumericalDomainWithKarr<Variable, Expression>;
-      return this.trueTestVisitor.Visit(guard, aDomain);
-    }
-
-    public override IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      var aDomain = base.TestFalse(guard) as NumericalDomainWithKarr<Variable, Expression>;
-      return this.falseTestVisitor.Visit(guard, aDomain);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      var results = new FlatAbstractDomain<bool>[this.arr.Length];
-
-      for (var i = 0; i < arr.Length; i++)
-      {
-        results[i] = this.arr[i].CheckIfGreaterEqualThanZero(exp);
-      }
-
-      return results[0].Meet(results[1]);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      return this.checkIfHoldsVisitor.Visit(exp, this);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      var results = new FlatAbstractDomain<bool>[this.arr.Length];
-
-      for(var i = 0; i < arr.Length; i++)
-      {
-        results[i] = this.arr[i].CheckIfLessThan(e1, e2);
-      }
-
-      var result = results[0].Meet(results[1]);
-
-      if (!result.IsTop)
-      {
-        return result;
-      }
-
-      return CheckIfLessWithClosure(e1, e2, result, ref inRecursion);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      // Skip Karr
-      return this.arr[1].CheckIfLessThanIncomplete(e1, e2);
-
-      /*
-      var results = new FlatAbstractDomain<bool>[this.arr.Length];
-
-      for (var i = 0; i < arr.Length; i++)
-      {
-        results[i] = this.arr[i].CheckIfLessThan(e1, e2);
-      }
-
-      return results[0].Meet(results[1]);
-       */
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return Left.CheckIfLessThan_Un(e1, e2).Meet(Right.CheckIfLessThan_Un(e1, e2));
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      var results = new FlatAbstractDomain<bool>[this.arr.Length];
-
-      for(var i = 0; i < arr.Length; i++)
-      {
-        results[i] = this.arr[i].CheckIfLessEqualThan(e1, e2);
-      }
-
-      var result = results[0].Meet(results[1]);
-
-      if (!result.IsTop)
-      {
-        return result;
-      }
-
-      return CheckIfLessEqualThanWithClosure(e1, e2);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return Left.CheckIfLessEqualThan_Un(e1, e2).Meet(Right.CheckIfLessEqualThan_Un(e1, e2));
-    }
-
-    public override ReducedCartesianAbstractDomain<LinearEqualitiesEnvironment<Variable, Expression>, INumericalAbstractDomain<Variable, Expression>> Reduce(LinearEqualitiesEnvironment<Variable, Expression> left, INumericalAbstractDomain<Variable, Expression> right)
-    {
-      return this.Factory(left, right);
-    }
-
-    protected override ReducedCartesianAbstractDomain<LinearEqualitiesEnvironment<Variable, Expression>, INumericalAbstractDomain<Variable, Expression>> Factory(LinearEqualitiesEnvironment<Variable, Expression> left, INumericalAbstractDomain<Variable, Expression> right)
-    {
-      return new NumericalDomainWithKarr<Variable, Expression>(left, right, this.ExpressionManager);
-    } 
-
-    #endregion
-
-    #region Private methods 
-
-    private INumericalAbstractDomain<Variable, Expression> CloseRight()
-    {
-      var closedRight = this.Right;
-
-      var count = 0;
-
-      foreach (var eq in this.Left.PairWiseEqualities(MaxPairWiseEqualitiesInClosure))
-      {
-        Contract.Assume(eq.One != null);
-        Contract.Assume(eq.Two != null);
-
-        closedRight = closedRight.TestTrueEqual(eq.One, eq.Two);
-
-        count++;
-      }
-
-      return closedRight;
-    }
-
-
     /// <summary>
-    /// Heuristic to determine if an expression is complex enough.
-    /// At the moment, returns true iff e is in the form Bop(e, k) or Bop(k, e) and k > 1
+    /// The reduced product Karr x NumericalDomain
     /// </summary>
-    private bool IsComplexEnoughExpression(Expression e)
+    public class NumericalDomainWithKarr<Variable, Expression>
+      : ReducedNumericalDomains<LinearEqualitiesEnvironment<Variable, Expression>, INumericalAbstractDomain<Variable, Expression>, Variable, Expression>
     {
-      var decoder = this.ExpressionManager.Decoder;
-
-      int k;
-      return decoder.IsBinaryExpression(e) &&
-        ((decoder.IsConstantInt(decoder.LeftExpressionFor(e), out k) && k > 1)
-        ||
-        (decoder.IsConstantInt(decoder.RightExpressionFor(e), out k) && k > 1))
-        ;
-    }
-
-
-    private FlatAbstractDomain<bool> CheckIfLessWithClosure(Expression e1, Expression e2, FlatAbstractDomain<bool> result, ref bool inRecursion)
-    {
-      var decoder = this.ExpressionManager.Decoder;
-      var encoder = this.ExpressionManager.Encoder;
-
-      #region Equalities
-      if (closureSteps >= 0)
-      {
-        // If we got no answer, we refine the expressions if we can
-
-        // Get all the variables defined in the two expressions
-        var vars = decoder.VariablesIn(e1);
-        vars.AddRange(decoder.VariablesIn(e2));
-
-        foreach (var equality in this.Left.PairWiseEqualities(Int32.MaxValue))
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          Expression e1Prime, e2Prime;
-
-          if (vars.Contains(decoder.UnderlyingVariable(equality.One)))
-          {
-            e1Prime = encoder.Substitute(e1, equality.One, equality.Two);
-            e2Prime = encoder.Substitute(e2, equality.One, equality.Two);
-          }
-          else if (vars.Contains(this.ExpressionManager.Decoder.UnderlyingVariable(equality.Two)))
-          {
-            e1Prime = encoder.Substitute(e1, equality.Two, equality.One);
-            e2Prime = encoder.Substitute(e2, equality.Two, equality.One);
-          }
-          else
-          {
-            continue; // we skip it 
-          }
-          closureSteps--;
-          var pair = Simplify(e1Prime, e2Prime, ExpressionOperator.LessThan);
-          result = this.CheckIfLessThan(pair.One, pair.Two);
-          closureSteps++;
-
-          if (!result.IsTop)
-          {
-            return result;  // We found some answer
-          }
+            Contract.Invariant(trueTestVisitor != null);
+            Contract.Invariant(falseTestVisitor != null);
+            Contract.Invariant(checkIfHoldsVisitor != null);
         }
-      }
-      #endregion
 
-      #region Transitive closure
-      // This code below is very expensive, a main slowdown in Clousot.
-      // By default we try not to execute it, and we force the execution either if it is indicated from the command line or if we have reason to believe that the inequality can be decided only using it
-      //
-      if (closureSteps > MinStepsToEnableLessThanClosure || (!inRecursion && (IsComplexEnoughExpression(e1) || IsComplexEnoughExpression(e2))))
-      {
-        // try to check against a lower bound for e2
+        private const int MinStepsToEnableLessEqualThanClosure = -1;
+        private const int MinStepsToEnableLessThanClosure = 0;
 
-        Polynomial<Variable, Expression> poly;
-        var leftExp = e1;
-        var rightExp = e2;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(
-          ExpressionOperator.LessEqualThan, e1, e2, this.ExpressionManager.Decoder, out poly))
+        private int closureSteps;
+        [ThreadStatic]
+        private static int defaultClosureSteps;
+        public static int DefaultClosureSteps
         {
-          Variable x, y, z;
-          Rational k;
-          if (poly.TryMatch_XPlusYLess_Equal_ThanZPlusK(out x, out y, out z, out k))
-          {
-            var xExp = encoder.VariableFor(x);
-            var yExp = encoder.VariableFor(y);
-            var zExp = encoder.VariableFor(z);
-
-            leftExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, xExp, yExp);
-            if (k.IsZero)
+            get
             {
-              rightExp = zExp;
+                return defaultClosureSteps;
             }
-            else
+            set
             {
-              rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder));
+                defaultClosureSteps = value;
             }
-          }
+        }
 
-          if (poly.TryMatch_XLess_Equal_ThanYPlusZPlusK(out x, out y, out z, out k))
-          {
-            var xExp = encoder.VariableFor(x);
-            var yExp = encoder.VariableFor(y);
-            var zExp = encoder.VariableFor(z);
-
-            leftExp = xExp;
-            if (k.IsZero)
+        [ThreadStatic]
+        private static int maxPairwiseEqualitiesInClosure;
+        public static int MaxPairWiseEqualitiesInClosure
+        {
+            get
             {
-              rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, yExp, zExp);
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                Contract.Assume(maxPairwiseEqualitiesInClosure >= 0);
+
+                return maxPairwiseEqualitiesInClosure;
             }
-            else
+            set
             {
-              rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32,
-                ExpressionOperator.Addition, yExp,
-                encoder.CompoundExpressionFor(ExpressionType.Int32,
-                ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder)));
+                maxPairwiseEqualitiesInClosure = Math.Max(value, 0);
             }
-          }
         }
 
-        inRecursion = true;
-        closureSteps--;
+        private bool inRecursion = false;
 
-        foreach (var e in this.LowerBoundsFor(rightExp, true))
+
+        private RefinedTestTrueVisitor trueTestVisitor;
+        private RefinedTestFalseVisitor falseTestVisitor;
+        private RefinedCheckIfHoldsVisitor checkIfHoldsVisitor;
+
+        #region Constructors
+
+        public NumericalDomainWithKarr(
+          LinearEqualitiesEnvironment<Variable, Expression> left, INumericalAbstractDomain<Variable, Expression> right,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(left, right, expManager)
         {
-          if (e.Equals(rightExp) || (this.LowerBoundsFor(e, true).Contains(rightExp)))
-          {
-            inRecursion = false;
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
 
-            closureSteps++;
-            return result.Top;
-          }
-          result = CheckIfLessEqualThan(leftExp, e);
-          if (result.IsTrue())
-          {
-            inRecursion = false;
-            closureSteps++;
-            return result;
-          }
+            Contract.Requires(expManager != null);
+
+            closureSteps = defaultClosureSteps;
+
+            trueTestVisitor = new RefinedTestTrueVisitor(expManager);
+            falseTestVisitor = new RefinedTestFalseVisitor(expManager.Decoder);
+            checkIfHoldsVisitor = new RefinedCheckIfHoldsVisitor(expManager.Decoder);
+            trueTestVisitor.FalseVisitor = falseTestVisitor;
+            falseTestVisitor.TrueVisitor = trueTestVisitor;
         }
 
-        foreach (var e in this.LowerBoundsFor(rightExp, false))
+        #endregion
+
+        #region Implementations of the abstract domain operations
+
+        public override IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
         {
-          result = CheckIfLessThan(leftExp, e);
-          if (result.IsTrue())
-          {
-            inRecursion = false;
-
-            closureSteps++;
-            return result;
-          }
+            return this.Right.LowerBoundsFor(v, strict);
         }
 
-        foreach (var e in this.UpperBoundsFor(leftExp, true))
+        public override IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
         {
-          if (e.Equals(leftExp) || (this.UpperBoundsFor(e, true).Contains(leftExp)))
-          {
-            inRecursion = false;
-
-            closureSteps++;
-            return result.Top;
-          }
-          result = CheckIfLessThan(e, rightExp);
-          if (result.IsTrue())
-          {
-            inRecursion = false;
-
-            closureSteps++;
-            return result;
-          }
+            return this.Right.UpperBoundsFor(v, strict);
         }
 
-        foreach (var e in this.UpperBoundsFor(leftExp, false))
+        public override IAbstractDomain Join(IAbstractDomain a)
         {
-          result = CheckIfLessThan(e, rightExp);
-          if (result.IsTrue())
-          {
-            closureSteps++;
-            return result;
-          }
+            var other = a as NumericalDomainWithKarr<Variable, Expression>;
+
+            Contract.Assume(other != null);
+            return this.Join(other);
         }
 
-        inRecursion = false;
+        public IAbstractDomain Join(NumericalDomainWithKarr<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            Contract.Ensures(Contract.Result<IAbstractDomain>() != null);
 
-        closureSteps++;
-      }
-      #endregion
+            NumericalDomainWithKarr<Variable, Expression> adom;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, other, out adom))
+            {
+                return adom;
+            }
 
-      #region Special combinations
+            // Propagate the equalities that we have in Karr
+            var thisClosedRight = this.CloseRight();
+            var otherClosedRight = other.CloseRight();
 
-      switch (decoder.OperatorFor(e1))
-      {
-        case ExpressionOperator.Division:
-          {
-            var up = decoder.LeftExpressionFor(e1);
-            var down = decoder.RightExpressionFor(e1);
+            var resultLeft = this.Left.Join(other.Left);
+            var resultRight = thisClosedRight.Join(otherClosedRight) as INumericalAbstractDomain<Variable, Expression>;
+
+            Contract.Assume(resultRight != null);
+
+            return this.Factory(resultLeft, resultRight);
+        }
+
+        public override IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            var aDomain = base.TestTrue(guard) as NumericalDomainWithKarr<Variable, Expression>;
+            return trueTestVisitor.Visit(guard, aDomain);
+        }
+
+        public override IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            var aDomain = base.TestFalse(guard) as NumericalDomainWithKarr<Variable, Expression>;
+            return falseTestVisitor.Visit(guard, aDomain);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            var results = new FlatAbstractDomain<bool>[this.arr.Length];
+
+            for (var i = 0; i < arr.Length; i++)
+            {
+                results[i] = this.arr[i].CheckIfGreaterEqualThanZero(exp);
+            }
+
+            return results[0].Meet(results[1]);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return checkIfHoldsVisitor.Visit(exp, this);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            var results = new FlatAbstractDomain<bool>[this.arr.Length];
+
+            for (var i = 0; i < arr.Length; i++)
+            {
+                results[i] = this.arr[i].CheckIfLessThan(e1, e2);
+            }
+
+            var result = results[0].Meet(results[1]);
+
+            if (!result.IsTop)
+            {
+                return result;
+            }
+
+            return CheckIfLessWithClosure(e1, e2, result, ref inRecursion);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            // Skip Karr
+            return this.arr[1].CheckIfLessThanIncomplete(e1, e2);
+
+            /*
+            var results = new FlatAbstractDomain<bool>[this.arr.Length];
+
+            for (var i = 0; i < arr.Length; i++)
+            {
+              results[i] = this.arr[i].CheckIfLessThan(e1, e2);
+            }
+
+            return results[0].Meet(results[1]);
+             */
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return Left.CheckIfLessThan_Un(e1, e2).Meet(Right.CheckIfLessThan_Un(e1, e2));
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            var results = new FlatAbstractDomain<bool>[this.arr.Length];
+
+            for (var i = 0; i < arr.Length; i++)
+            {
+                results[i] = this.arr[i].CheckIfLessEqualThan(e1, e2);
+            }
+
+            var result = results[0].Meet(results[1]);
+
+            if (!result.IsTop)
+            {
+                return result;
+            }
+
+            return CheckIfLessEqualThanWithClosure(e1, e2);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return Left.CheckIfLessEqualThan_Un(e1, e2).Meet(Right.CheckIfLessEqualThan_Un(e1, e2));
+        }
+
+        public override ReducedCartesianAbstractDomain<LinearEqualitiesEnvironment<Variable, Expression>, INumericalAbstractDomain<Variable, Expression>> Reduce(LinearEqualitiesEnvironment<Variable, Expression> left, INumericalAbstractDomain<Variable, Expression> right)
+        {
+            return this.Factory(left, right);
+        }
+
+        protected override ReducedCartesianAbstractDomain<LinearEqualitiesEnvironment<Variable, Expression>, INumericalAbstractDomain<Variable, Expression>> Factory(LinearEqualitiesEnvironment<Variable, Expression> left, INumericalAbstractDomain<Variable, Expression> right)
+        {
+            return new NumericalDomainWithKarr<Variable, Expression>(left, right, this.ExpressionManager);
+        }
+
+        #endregion
+
+        #region Private methods 
+
+        private INumericalAbstractDomain<Variable, Expression> CloseRight()
+        {
+            var closedRight = this.Right;
+
+            var count = 0;
+
+            foreach (var eq in this.Left.PairWiseEqualities(MaxPairWiseEqualitiesInClosure))
+            {
+                Contract.Assume(eq.One != null);
+                Contract.Assume(eq.Two != null);
+
+                closedRight = closedRight.TestTrueEqual(eq.One, eq.Two);
+
+                count++;
+            }
+
+            return closedRight;
+        }
+
+
+        /// <summary>
+        /// Heuristic to determine if an expression is complex enough.
+        /// At the moment, returns true iff e is in the form Bop(e, k) or Bop(k, e) and k > 1
+        /// </summary>
+        private bool IsComplexEnoughExpression(Expression e)
+        {
+            var decoder = this.ExpressionManager.Decoder;
+
             int k;
-            // (a + b) / k, k > 1
-            if (decoder.IsConstantInt(down, out k) && k > 1 && decoder.OperatorFor(up) == ExpressionOperator.Addition)
+            return decoder.IsBinaryExpression(e) &&
+              ((decoder.IsConstantInt(decoder.LeftExpressionFor(e), out k) && k > 1)
+              ||
+              (decoder.IsConstantInt(decoder.RightExpressionFor(e), out k) && k > 1))
+              ;
+        }
+
+
+        private FlatAbstractDomain<bool> CheckIfLessWithClosure(Expression e1, Expression e2, FlatAbstractDomain<bool> result, ref bool inRecursion)
+        {
+            var decoder = this.ExpressionManager.Decoder;
+            var encoder = this.ExpressionManager.Encoder;
+
+            #region Equalities
+            if (closureSteps >= 0)
             {
-              var a = decoder.LeftExpressionFor(up);
-              var b = decoder.RightExpressionFor(up);
+                // If we got no answer, we refine the expressions if we can
 
-              if (this.CheckIfGreaterEqualThanZero(a).IsTrue() && this.CheckIfGreaterEqualThanZero(b).IsTrue())
-              {
-                // if a <= e2 and b < a then a + b / k < e2
-                if ((this.CheckIfLessEqualThan(a, e2).IsTrue() && this.CheckIfLessThan(b, a).IsTrue()) ||
-                  (this.CheckIfLessEqualThan(b, e2).IsTrue()) && this.CheckIfLessThan(a, b).IsTrue())
+                // Get all the variables defined in the two expressions
+                var vars = decoder.VariablesIn(e1);
+                vars.AddRange(decoder.VariablesIn(e2));
+
+                foreach (var equality in this.Left.PairWiseEqualities(Int32.MaxValue))
                 {
-                  return CheckOutcome.True;
+                    Expression e1Prime, e2Prime;
+
+                    if (vars.Contains(decoder.UnderlyingVariable(equality.One)))
+                    {
+                        e1Prime = encoder.Substitute(e1, equality.One, equality.Two);
+                        e2Prime = encoder.Substitute(e2, equality.One, equality.Two);
+                    }
+                    else if (vars.Contains(this.ExpressionManager.Decoder.UnderlyingVariable(equality.Two)))
+                    {
+                        e1Prime = encoder.Substitute(e1, equality.Two, equality.One);
+                        e2Prime = encoder.Substitute(e2, equality.Two, equality.One);
+                    }
+                    else
+                    {
+                        continue; // we skip it 
+                    }
+                    closureSteps--;
+                    var pair = Simplify(e1Prime, e2Prime, ExpressionOperator.LessThan);
+                    result = this.CheckIfLessThan(pair.One, pair.Two);
+                    closureSteps++;
+
+                    if (!result.IsTop)
+                    {
+                        return result;  // We found some answer
+                    }
                 }
-              }
             }
-          }
-          break;
+            #endregion
 
-        default:
-          {
-            break;
-          }
-      }
+            #region Transitive closure
+            // This code below is very expensive, a main slowdown in Clousot.
+            // By default we try not to execute it, and we force the execution either if it is indicated from the command line or if we have reason to believe that the inequality can be decided only using it
+            //
+            if (closureSteps > MinStepsToEnableLessThanClosure || (!inRecursion && (IsComplexEnoughExpression(e1) || IsComplexEnoughExpression(e2))))
+            {
+                // try to check against a lower bound for e2
 
-      #endregion
+                Polynomial<Variable, Expression> poly;
+                var leftExp = e1;
+                var rightExp = e2;
 
-      return CheckOutcome.Top;
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(
+                  ExpressionOperator.LessEqualThan, e1, e2, this.ExpressionManager.Decoder, out poly))
+                {
+                    Variable x, y, z;
+                    Rational k;
+                    if (poly.TryMatch_XPlusYLess_Equal_ThanZPlusK(out x, out y, out z, out k))
+                    {
+                        var xExp = encoder.VariableFor(x);
+                        var yExp = encoder.VariableFor(y);
+                        var zExp = encoder.VariableFor(z);
+
+                        leftExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, xExp, yExp);
+                        if (k.IsZero)
+                        {
+                            rightExp = zExp;
+                        }
+                        else
+                        {
+                            rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder));
+                        }
+                    }
+
+                    if (poly.TryMatch_XLess_Equal_ThanYPlusZPlusK(out x, out y, out z, out k))
+                    {
+                        var xExp = encoder.VariableFor(x);
+                        var yExp = encoder.VariableFor(y);
+                        var zExp = encoder.VariableFor(z);
+
+                        leftExp = xExp;
+                        if (k.IsZero)
+                        {
+                            rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, yExp, zExp);
+                        }
+                        else
+                        {
+                            rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32,
+                              ExpressionOperator.Addition, yExp,
+                              encoder.CompoundExpressionFor(ExpressionType.Int32,
+                              ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder)));
+                        }
+                    }
+                }
+
+                inRecursion = true;
+                closureSteps--;
+
+                foreach (var e in this.LowerBoundsFor(rightExp, true))
+                {
+                    if (e.Equals(rightExp) || (this.LowerBoundsFor(e, true).Contains(rightExp)))
+                    {
+                        inRecursion = false;
+
+                        closureSteps++;
+                        return result.Top;
+                    }
+                    result = CheckIfLessEqualThan(leftExp, e);
+                    if (result.IsTrue())
+                    {
+                        inRecursion = false;
+                        closureSteps++;
+                        return result;
+                    }
+                }
+
+                foreach (var e in this.LowerBoundsFor(rightExp, false))
+                {
+                    result = CheckIfLessThan(leftExp, e);
+                    if (result.IsTrue())
+                    {
+                        inRecursion = false;
+
+                        closureSteps++;
+                        return result;
+                    }
+                }
+
+                foreach (var e in this.UpperBoundsFor(leftExp, true))
+                {
+                    if (e.Equals(leftExp) || (this.UpperBoundsFor(e, true).Contains(leftExp)))
+                    {
+                        inRecursion = false;
+
+                        closureSteps++;
+                        return result.Top;
+                    }
+                    result = CheckIfLessThan(e, rightExp);
+                    if (result.IsTrue())
+                    {
+                        inRecursion = false;
+
+                        closureSteps++;
+                        return result;
+                    }
+                }
+
+                foreach (var e in this.UpperBoundsFor(leftExp, false))
+                {
+                    result = CheckIfLessThan(e, rightExp);
+                    if (result.IsTrue())
+                    {
+                        closureSteps++;
+                        return result;
+                    }
+                }
+
+                inRecursion = false;
+
+                closureSteps++;
+            }
+            #endregion
+
+            #region Special combinations
+
+            switch (decoder.OperatorFor(e1))
+            {
+                case ExpressionOperator.Division:
+                    {
+                        var up = decoder.LeftExpressionFor(e1);
+                        var down = decoder.RightExpressionFor(e1);
+                        int k;
+                        // (a + b) / k, k > 1
+                        if (decoder.IsConstantInt(down, out k) && k > 1 && decoder.OperatorFor(up) == ExpressionOperator.Addition)
+                        {
+                            var a = decoder.LeftExpressionFor(up);
+                            var b = decoder.RightExpressionFor(up);
+
+                            if (this.CheckIfGreaterEqualThanZero(a).IsTrue() && this.CheckIfGreaterEqualThanZero(b).IsTrue())
+                            {
+                                // if a <= e2 and b < a then a + b / k < e2
+                                if ((this.CheckIfLessEqualThan(a, e2).IsTrue() && this.CheckIfLessThan(b, a).IsTrue()) ||
+                                  (this.CheckIfLessEqualThan(b, e2).IsTrue()) && this.CheckIfLessThan(a, b).IsTrue())
+                                {
+                                    return CheckOutcome.True;
+                                }
+                            }
+                        }
+                    }
+                    break;
+
+                default:
+                    {
+                        break;
+                    }
+            }
+
+            #endregion
+
+            return CheckOutcome.Top;
+        }
+
+        private FlatAbstractDomain<bool> CheckIfLessEqualThanWithClosure(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> result;
+
+            var decoder = this.ExpressionManager.Decoder;
+            var encoder = this.ExpressionManager.Encoder;
+
+            #region Domain Combination
+            switch (decoder.OperatorFor(e2))
+            {
+                case ExpressionOperator.Multiplication:
+                    {
+                        // try to match e1 <= e21 * k, k > 0
+                        var e2Right = decoder.RightExpressionFor(e2);
+                        int k;
+                        if (decoder.IsConstantInt(e2Right, out k) && k > 0)
+                        {
+                            if (this.CheckIfGreaterEqualThanZero(e2Right).IsTrue())
+                            {
+                                var e2Left = decoder.LeftExpressionFor(e2);
+                                if (this.CheckIfLessEqualThan(e1, e2Left).IsTrue())
+                                {
+                                    return CheckOutcome.True;
+                                }
+                            }
+                        }
+                    }
+                    break;
+            }
+            #endregion
+
+            #region Equalities
+            if (closureSteps > MinStepsToEnableLessEqualThanClosure)
+            { // If we got no answer, we refine the expressions if we can
+              // Get all the variables defined in the two expressions
+                var vars = decoder.VariablesIn(e1);
+                vars.AddRange(decoder.VariablesIn(e2));
+
+                foreach (var equality in this.Left.PairWiseEqualities(Int32.MaxValue))
+                {
+                    Expression e1Prime, e2Prime;
+
+                    if (vars.Contains(decoder.UnderlyingVariable(equality.One)))
+                    {
+                        e1Prime = encoder.Substitute(e1, equality.One, equality.Two);
+                        e2Prime = encoder.Substitute(e2, equality.One, equality.Two);
+                    }
+                    else if (vars.Contains(decoder.UnderlyingVariable(equality.Two)))
+                    {
+                        e1Prime = encoder.Substitute(e1, equality.Two, equality.One);
+                        e2Prime = encoder.Substitute(e2, equality.Two, equality.One);
+                    }
+                    else
+                    {
+                        continue; // we skip it 
+                    }
+                    closureSteps--;
+
+                    var pair = Simplify(e1Prime, e2Prime, ExpressionOperator.LessEqualThan);
+                    result = this.CheckIfLessEqualThan(pair.One, pair.Two);
+
+                    closureSteps++;
+
+                    if (!result.IsTop)
+                    {
+                        return result;  // We found some answer
+                    }
+                }
+            }
+            #endregion
+
+            #region Closure
+            if (closureSteps > MinStepsToEnableLessEqualThanClosure)
+            { // put it into tractable form then try to check against a lower bound for e2 or an upper bound for e1
+                Polynomial<Variable, Expression> poly;
+                var leftExp = e1;
+                var rightExp = e2;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(
+                  ExpressionOperator.LessEqualThan, e1, e2, decoder, out poly))
+                {
+                    Variable x, y, z;
+                    Rational k;
+                    if (poly.TryMatch_XPlusYLess_Equal_ThanZPlusK(out x, out y, out z, out k))
+                    {
+                        var xExp = encoder.VariableFor(x);
+                        var yExp = encoder.VariableFor(y);
+                        var zExp = encoder.VariableFor(z);
+
+                        leftExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, xExp, yExp);
+                        if (k.IsZero)
+                        {
+                            rightExp = zExp;
+                        }
+                        else
+                        {
+                            rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder));
+                        }
+                    }
+                    if (poly.TryMatch_XLess_Equal_ThanYPlusZPlusK(out x, out y, out z, out k))
+                    {
+                        var xExp = encoder.VariableFor(x);
+                        var yExp = encoder.VariableFor(y);
+                        var zExp = encoder.VariableFor(z);
+
+                        leftExp = xExp;
+                        if (k.IsZero)
+                        {
+                            rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32,
+                              ExpressionOperator.Addition, yExp, zExp);
+                        }
+                        else
+                        {
+                            rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32,
+                              ExpressionOperator.Addition,
+                              yExp,
+                             encoder.CompoundExpressionFor(ExpressionType.Int32,
+                              ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder)));
+                        }
+                    }
+                }
+
+                closureSteps--;
+
+                var lowerBounds = this.LowerBoundsFor(rightExp, false);
+
+                foreach (var e in lowerBounds)
+                {
+                    result = CheckIfLessEqualThan(leftExp, e);
+                    if (result.IsTrue())
+                    {
+                        closureSteps++;
+                        return result;
+                    }
+                }
+
+                var upperBounds = this.UpperBoundsFor(leftExp, false);
+
+                foreach (var e in upperBounds)
+                {
+                    result = CheckIfLessEqualThan(e, rightExp);
+                    if (result.IsTrue())
+                    {
+                        closureSteps++;
+                        return result;
+                    }
+                }
+                result = CheckOutcome.Top;
+                closureSteps++;
+            }
+            #endregion
+
+            return CheckOutcome.Top;
+        }
+
+        private Pair<Expression, Expression> Simplify(Expression e1, Expression e2, ExpressionOperator op)
+        {
+            Contract.Requires(op.IsBinary());
+
+            var decoder = this.ExpressionManager.Decoder;
+            var encoder = this.ExpressionManager.Encoder;
+
+            var vars1 = decoder.VariablesIn(e1);
+            var vars2 = decoder.VariablesIn(e2);
+
+            var intersection = vars1.Intersection(vars2);
+
+            if (intersection.IsEmpty)
+            {
+                return new Pair<Expression, Expression>(e1, e2);
+            }
+
+            Polynomial<Variable, Expression> pol;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(op, e1, e2, decoder, out pol))
+            {
+                Variable x, y;
+                Rational k1, k2, k;
+                if (op == ExpressionOperator.LessEqualThan && pol.TryMatch_k1XLessEqualThank2(out k1, out x, out k2))
+                {
+                    var xExp = encoder.VariableFor(x);
+
+                    if (k1 == -1 && k2.IsInteger)
+                    {
+                        return new Pair<Expression, Expression>(encoder.ConstantFor((int)-k2), xExp);
+                    }
+                    if (k1 == 1 && k2.IsInteger)
+                    {
+                        return new Pair<Expression, Expression>(xExp, encoder.ConstantFor((int)k2));
+                    }
+                }
+                else if (op.IsLessThan() && pol.TryMatch_k1XLessThank2(out k1, out x, out k2))
+                {
+                    var xExp = encoder.VariableFor(x);
+
+                    if (k1 == -1 && k2.IsInteger)
+                    {
+                        return new Pair<Expression, Expression>(encoder.ConstantFor((int)-k2), xExp);
+                    }
+                    if (k1 == 1 && k2.IsInteger)
+                    {
+                        return new Pair<Expression, Expression>(xExp, encoder.ConstantFor((int)k2));
+                    }
+                }
+                else if (op.IsLessEqualThan() && pol.TryMatch_k1XPlusk2YLessEqualThanK(out k1, out x, out k2, out y, out k) && k.IsZero)
+                {
+                    var xExp = encoder.VariableFor(x);
+                    var yExp = encoder.VariableFor(y);
+
+                    if (k1 == -1 && k2 == 1)
+                    {
+                        return new Pair<Expression, Expression>(yExp, xExp);
+                    }
+                    if (k1 == 1 && k2 == -1)
+                    {
+                        return new Pair<Expression, Expression>(xExp, yExp);
+                    }
+                }
+                else if (op.IsLessThan() && pol.TryMatch_k1XPlusk2YLessThanK(out k1, out x, out k2, out y, out k) && k.IsZero)
+                {
+                    var xExp = encoder.VariableFor(x);
+                    var yExp = encoder.VariableFor(y);
+
+                    if (k1 == -1 && k2 == 1)
+                    {
+                        return new Pair<Expression, Expression>(yExp, xExp);
+                    }
+                    if (k1 == 1 && k2 == -1)
+                    {
+                        return new Pair<Expression, Expression>(xExp, yExp);
+                    }
+                }
+            }
+            return new Pair<Expression, Expression>(e1, e2);
+        }
+
+        #endregion
+
+        #region Visitors for the expressions
+
+        private class RefinedCheckIfHoldsVisitor
+          : CheckIfHoldsVisitor<NumericalDomainWithKarr<Variable, Expression>, Variable, Expression>
+        {
+            public RefinedCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                var direct = base.VisitEqual(left, right, original, data);
+
+                if (direct.IsNormal())
+                {
+                    return direct;
+                }
+
+                var resultLeft = Domain.CheckIfLessEqualThan(left, right);
+
+                // left <= right
+                if (resultLeft.IsTrue())
+                {
+                    var resultRight = Domain.CheckIfLessEqualThan(right, left);
+
+                    // left >= right
+                    if (resultLeft.IsTrue())
+                    {
+                        return resultRight;
+                    }
+                }
+
+                var notEq = this.VisitNotEqual(left, right, original, data);
+                if (notEq.IsNormal() && notEq.IsTrue())
+                {
+                    return CheckOutcome.False;
+                }
+
+                return resultLeft.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return VisitEqual(left, right, original, data);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessEqualThan(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessEqualThan_Un(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessThan(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return Domain.CheckIfLessThan_Un(left, right);
+            }
+
+            public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                int value;
+                if (this.Decoder.IsNull(right) || (this.Decoder.TryValueOf<Int32>(right, ExpressionType.Int32, out value) && value == 0))
+                { // "left != 0" means that left should hold
+                    var outcome = Domain.CheckIfHolds(left);
+
+                    if (!outcome.IsTop)
+                    {
+                        return outcome;
+                    }
+                }
+
+                var exp = this.Domain.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, left, right);
+
+                // Shortcut: as the checking in Karr may be quite expensive, we first try to validate it in cheaper domains, and only if we cannot conclude, we try Karr
+                var tryRight = Domain.Right.CheckIfHolds(exp);
+                if (tryRight.IsTop)
+                {
+                    return Domain.Left.CheckIfHolds(exp);
+                }
+                else
+                {
+                    return tryRight;
+                }
+            }
+
+            public override FlatAbstractDomain<bool> VisitVariable(Variable var, Expression original, FlatAbstractDomain<bool> data)
+            {
+                // Is there a domain out there that can prove that original != null?
+                var directCheck = this.Domain.CheckIfNonZero(original);
+
+                if (directCheck.IsNormal())
+                {
+                    return directCheck;
+                }
+
+                // If not, let's collect a collective bound for the whole domain and see if it is != 0
+                var valueForVar = this.Domain.BoundsFor(original);
+
+                if (valueForVar.IsNormal())
+                {
+                    if (valueForVar.LowerBound > 0 || valueForVar.UpperBound < 0)
+                    { // It is true...
+                        return CheckOutcome.True;
+                    }
+                    else if (valueForVar.IsSingleton && valueForVar.LowerBound.IsZero)
+                    { // It is false
+                        return CheckOutcome.False;
+                    }
+                }
+                return Default(data);
+            }
+        }
+
+        private class RefinedTestTrueVisitor
+          : TestTrueVisitor<NumericalDomainWithKarr<Variable, Expression>, Variable, Expression>
+        {
+            #region invariant
+
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(expManager != null);
+            }
+
+            #endregion
+
+            #region Private state
+
+            private readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
+
+            #endregion
+
+            public RefinedTestTrueVisitor(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+              : base(expManager.Decoder)
+            {
+                Contract.Requires(expManager != null);
+
+                this.expManager = expManager;
+            }
+
+            public override NumericalDomainWithKarr<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
+            {
+                return data.TestTrueEqual(left, right) as NumericalDomainWithKarr<Variable, Expression>;
+            }
+
+            public override NumericalDomainWithKarr<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
+            {
+                Polynomial<Variable, Expression> pol;
+
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, left, right, expManager.Decoder, out pol))
+                {
+                    return data;
+                }
+
+
+                var encoder = expManager.Encoder;
+
+                var eq = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, left, right);
+                var isEq = data.CheckIfHolds(eq);
+                if (isEq.IsNormal() && isEq.BoxedElement)
+                {
+                    // We know Karr works with side effects
+                    /*data.Left = */
+                    data.Left.TestTrue(eq);
+                }
+
+                Variable v1, v2, v3;
+                Rational k;
+                if (pol.TryMatch_XPlusYLess_Equal_ThanZPlusK(out v1, out v2, out v3, out k))
+                {
+                    var freshExpression = encoder.FreshVariable<Expression>();
+                    var freshExpressionExp = encoder.VariableFor(freshExpression);
+
+                    var v1Exp = encoder.VariableFor(v1);
+                    var v2Exp = encoder.VariableFor(v2);
+                    var v3Exp = encoder.VariableFor(v3);
+
+                    var leftEnv =
+                      data.Left.TestTrueEqual(
+                        encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction,
+                        encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, v1Exp, v2Exp),
+                        encoder.ConstantFor((Int32)k)), freshExpressionExp);
+
+                    var rightEnv = data.Right.TestTrueLessEqualThan(freshExpressionExp, v3Exp);
+
+                    // it may be necessary to update the betaDep map
+
+                    return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+                }
+                if (pol.TryMatch_XLess_Equal_ThanYPlusZPlusK(out v1, out v2, out v3, out k))
+                {
+                    var freshExpression = encoder.FreshVariable<Expression>();
+                    var freshExpressionExp = encoder.VariableFor(freshExpression);
+
+                    var v1Exp = encoder.VariableFor(v1);
+                    var v2Exp = encoder.VariableFor(v2);
+                    var v3Exp = encoder.VariableFor(v3);
+
+                    var leftEnv = data.Left.TestTrueEqual(encoder.CompoundExpressionFor(ExpressionType.Int32,
+                      ExpressionOperator.Addition,
+                        encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, v2Exp, v3Exp),
+                        encoder.ConstantFor((Int32)k)), freshExpressionExp);
+
+                    var rightEnv = data.Right.TestTrueLessEqualThan(v1Exp, freshExpressionExp);
+
+                    // it may be necessary to update the betaDep map
+                    return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+                }
+                return data;
+            }
+
+            public override NumericalDomainWithKarr<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original,
+              NumericalDomainWithKarr<Variable, Expression> data)
+            {
+                Polynomial<Variable, Expression> pol;
+
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, left, right, expManager.Decoder, out pol))
+                {
+                    return data;
+                }
+
+                var encoder = expManager.Encoder;
+
+                Variable v1, v2, v3;
+                Rational k;
+                if (pol.TryMatch_XPlusYLess_Equal_ThanZPlusK(out v1, out v2, out v3, out k))
+                {
+                    var freshExpression = encoder.FreshVariable<Expression>();
+                    var freshExpressionExp = encoder.VariableFor(freshExpression);
+
+                    var v1Exp = encoder.VariableFor(v1);
+                    var v2Exp = encoder.VariableFor(v2);
+                    var v3Exp = encoder.VariableFor(v3);
+
+                    var leftEnv = data.Left.TestTrueEqual(
+                        encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction,
+                            encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition,
+                            v1Exp, v2Exp),
+                            encoder.ConstantFor((Int32)k)),
+                          freshExpressionExp);
+
+                    var rightEnv = data.Right.TestTrueLessThan(freshExpressionExp, v3Exp);
+
+                    // it may be necessary to update the betaDep map
+
+                    return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+                }
+
+                if (pol.TryMatch_XLess_Equal_ThanYPlusZPlusK(out v1, out v2, out v3, out k))
+                {
+                    var freshExpression = encoder.FreshVariable<Expression>();
+                    var freshExpressionExp = encoder.VariableFor(freshExpression);
+
+                    var v1Exp = encoder.VariableFor(v1);
+                    var v2Exp = encoder.VariableFor(v2);
+                    var v3Exp = encoder.VariableFor(v3);
+
+                    var leftEnv =
+                      data.Left.TestTrueEqual(encoder.CompoundExpressionFor(ExpressionType.Int32,
+                        ExpressionOperator.Addition, encoder.CompoundExpressionFor(ExpressionType.Int32,
+                        ExpressionOperator.Addition, v2Exp, v3Exp), encoder.ConstantFor((Int32)k)), freshExpressionExp);
+
+                    var rightEnv = data.Right.TestTrueLessThan(v1Exp, freshExpressionExp);
+
+                    // it may be necessary to update the betaDep map
+                    return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+                }
+                return data;
+            }
+
+            public override NumericalDomainWithKarr<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
+            {
+                return data;
+            }
+
+            public override NumericalDomainWithKarr<Variable, Expression> VisitVariable(Variable var, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
+            {
+                return data;
+            }
+        }
+
+        private class RefinedTestFalseVisitor : TestFalseVisitor<NumericalDomainWithKarr<Variable, Expression>, Variable, Expression>
+        {
+            public RefinedTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+                Contract.Requires(decoder != null);
+            }
+
+            public override NumericalDomainWithKarr<Variable, Expression> VisitVariable(Variable var, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
+            {
+                return data;
+            }
+        }
+
+        #endregion
     }
 
-    private FlatAbstractDomain<bool> CheckIfLessEqualThanWithClosure(Expression e1, Expression e2)
+    public class RefinedWithOctagons<RightDomain, Variable, Expression>
+      : ReducedNumericalDomains<OctagonEnvironment<Variable, Expression>, RightDomain, Variable, Expression>
+      where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
     {
-      FlatAbstractDomain<bool> result;
-
-      var decoder = this.ExpressionManager.Decoder;
-      var encoder = this.ExpressionManager.Encoder;
-
-      #region Domain Combination
-      switch (decoder.OperatorFor(e2))
-      {
-        case ExpressionOperator.Multiplication:
-          {
-            // try to match e1 <= e21 * k, k > 0
-            var e2Right = decoder.RightExpressionFor(e2);
-            int k;
-            if (decoder.IsConstantInt(e2Right, out k) && k > 0)
-            {
-              if (this.CheckIfGreaterEqualThanZero(e2Right).IsTrue())
-              {
-                var e2Left = decoder.LeftExpressionFor(e2);
-                if (this.CheckIfLessEqualThan(e1, e2Left).IsTrue())
-                {
-                  return CheckOutcome.True;
-                }
-              }
-            }
-          }
-          break;
-      }
-      #endregion
-
-      #region Equalities
-      if (closureSteps > MinStepsToEnableLessEqualThanClosure)
-      { // If we got no answer, we refine the expressions if we can
-
-        // Get all the variables defined in the two expressions
-        var vars = decoder.VariablesIn(e1);
-        vars.AddRange(decoder.VariablesIn(e2));
-
-        foreach (var equality in this.Left.PairWiseEqualities(Int32.MaxValue))
+        public RefinedWithOctagons(OctagonEnvironment<Variable, Expression> octagon, RightDomain otherDomain,
+        ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(octagon, otherDomain, expManager)
         {
-          Expression e1Prime, e2Prime;
-
-          if (vars.Contains(decoder.UnderlyingVariable(equality.One)))
-          {
-            e1Prime = encoder.Substitute(e1, equality.One, equality.Two);
-            e2Prime = encoder.Substitute(e2, equality.One, equality.Two);
-          }
-          else if (vars.Contains(decoder.UnderlyingVariable(equality.Two)))
-          {
-            e1Prime = encoder.Substitute(e1, equality.Two, equality.One);
-            e2Prime = encoder.Substitute(e2, equality.Two, equality.One);
-          }
-          else
-          {
-            continue; // we skip it 
-          }
-          closureSteps--;
-
-          var pair = Simplify(e1Prime, e2Prime, ExpressionOperator.LessEqualThan);
-          result = this.CheckIfLessEqualThan(pair.One, pair.Two);
-
-          closureSteps++;
-
-          if (!result.IsTop)
-          {
-            return result;  // We found some answer
-          }
         }
-      }
-      #endregion
 
-      #region Closure
-      if (closureSteps > MinStepsToEnableLessEqualThanClosure)
-      { // put it into tractable form then try to check against a lower bound for e2 or an upper bound for e1
-
-        Polynomial<Variable, Expression> poly;
-        var leftExp = e1;
-        var rightExp = e2;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(
-          ExpressionOperator.LessEqualThan, e1, e2, decoder, out poly))
+        public override IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
         {
-          Variable x, y, z;
-          Rational k;
-          if (poly.TryMatch_XPlusYLess_Equal_ThanZPlusK(out x, out y, out z, out k))
-          {
-            var xExp = encoder.VariableFor(x);
-            var yExp = encoder.VariableFor(y);
-            var zExp = encoder.VariableFor(z);
+            return this.Right.LowerBoundsFor(v, strict); // not implemented for octagons
+        }
 
-            leftExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, xExp, yExp);
-            if (k.IsZero)
+        public override IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            return this.Right.UpperBoundsFor(v, strict); // not implemented for octagons
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            var tryOctagons = this.Left.CheckIfGreaterEqualThanZero(exp);
+
+            if (tryOctagons.IsTop)
             {
-              rightExp = zExp;
+                return this.Right.CheckIfGreaterEqualThanZero(exp);
             }
             else
             {
-              rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder));
+                return tryOctagons;
             }
-          }
-          if (poly.TryMatch_XLess_Equal_ThanYPlusZPlusK(out x, out y, out z, out k))
-          {
-            var xExp = encoder.VariableFor(x);
-            var yExp = encoder.VariableFor(y);
-            var zExp = encoder.VariableFor(z);
+        }
 
-            leftExp = xExp;
-            if (k.IsZero)
+        public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            var tryOctagons = this.Left.CheckIfLessThan(e1, e2);
+
+            if (tryOctagons.IsTop)
             {
-              rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32,
-                ExpressionOperator.Addition, yExp, zExp);
+                return this.Right.CheckIfLessThan(e1, e2);
             }
             else
             {
-              rightExp = encoder.CompoundExpressionFor(ExpressionType.Int32,
-                ExpressionOperator.Addition,
-                yExp,
-               encoder.CompoundExpressionFor(ExpressionType.Int32,
-                ExpressionOperator.Addition, zExp, k.ToExpression<Variable, Expression>(encoder)));
+                return tryOctagons;
             }
-          }
         }
-
-        closureSteps--;
-
-        var lowerBounds = this.LowerBoundsFor(rightExp, false);
-
-        foreach (var e in lowerBounds)
+        public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
         {
-          result = CheckIfLessEqualThan(leftExp, e);
-          if (result.IsTrue())
-          {
-            closureSteps++;
-            return result;
-          }
+            return this.Left.CheckIfLessThan_Un(e1, e2).Meet(this.Right.CheckIfLessThan_Un(e1, e2));
         }
 
-        var upperBounds = this.UpperBoundsFor(leftExp, false);
-
-        foreach (var e in upperBounds)
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
         {
-          result = CheckIfLessEqualThan(e, rightExp);
-          if (result.IsTrue())
-          {
-            closureSteps++;
-            return result;
-          }
+            var tryOctagons = this.Left.CheckIfLessEqualThan(e1, e2);
+
+            if (tryOctagons.IsTop)
+            {
+                return this.Right.CheckIfLessEqualThan(e1, e2);
+            }
+            else
+            {
+                return tryOctagons;
+            }
         }
-        result = CheckOutcome.Top;
-        closureSteps++;
-      }
-      #endregion
 
-      return CheckOutcome.Top;
-    }
-
-    private Pair<Expression, Expression> Simplify(Expression e1, Expression e2, ExpressionOperator op)
-    {
-      Contract.Requires(op.IsBinary());
-
-      var decoder = this.ExpressionManager.Decoder;
-      var encoder = this.ExpressionManager.Encoder;
-
-      var vars1 = decoder.VariablesIn(e1);
-      var vars2 = decoder.VariablesIn(e2);
-      
-      var intersection = vars1.Intersection(vars2);
-
-      if (intersection.IsEmpty)
-      {
-        return new Pair<Expression, Expression>(e1, e2);
-      }
-
-      Polynomial<Variable, Expression> pol;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(op, e1, e2, decoder, out pol))
-      {
-        Variable x, y;
-        Rational k1, k2, k;
-        if (op == ExpressionOperator.LessEqualThan && pol.TryMatch_k1XLessEqualThank2(out k1, out x, out k2))
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
         {
-          var xExp = encoder.VariableFor(x);
-
-          if (k1 == -1 && k2.IsInteger)
-          {
-            return new Pair<Expression, Expression>(encoder.ConstantFor((int)-k2), xExp);
-          }
-          if (k1 == 1 && k2.IsInteger)
-          {
-            return new Pair<Expression, Expression>(xExp, encoder.ConstantFor((int)k2));
-          }
+            return this.Left.CheckIfLessEqualThan_Un(e1, e2).Meet(this.Right.CheckIfLessEqualThan_Un(e1, e2));
         }
-        else if (op.IsLessThan() && pol.TryMatch_k1XLessThank2(out k1, out x, out k2))
+
+        public override ReducedCartesianAbstractDomain<OctagonEnvironment<Variable, Expression>, RightDomain> Reduce(OctagonEnvironment<Variable, Expression> left, RightDomain right)
         {
-          var xExp = encoder.VariableFor(x);
-
-          if (k1 == -1 && k2.IsInteger)
-          {
-            return new Pair<Expression, Expression>(encoder.ConstantFor((int)-k2), xExp);
-          }
-          if (k1 == 1 && k2.IsInteger)
-          {
-            return new Pair<Expression, Expression>(xExp, encoder.ConstantFor((int)k2));
-          }
+            return this.Factory(left, right);
         }
-        else if (op.IsLessEqualThan() && pol.TryMatch_k1XPlusk2YLessEqualThanK(out k1, out x, out k2, out y, out k) && k.IsZero)
+
+        protected override ReducedCartesianAbstractDomain<OctagonEnvironment<Variable, Expression>, RightDomain> Factory(OctagonEnvironment<Variable, Expression> left, RightDomain right)
         {
-          var xExp = encoder.VariableFor(x);
-          var yExp = encoder.VariableFor(y);
-
-          if (k1 == -1 && k2 == 1)
-          {
-            return new Pair<Expression, Expression>(yExp, xExp);
-          }
-          if (k1 == 1 && k2 == -1)
-          {
-            return new Pair<Expression, Expression>(xExp, yExp);
-          }
+            return new RefinedWithOctagons<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
         }
-        else if (op.IsLessThan() && pol.TryMatch_k1XPlusk2YLessThanK(out k1, out x, out k2, out y, out k) && k.IsZero)
+    }
+
+    public class RefinedGeneric<LeftDomain, RightDomain, Variable, Expression>
+      : ReducedNumericalDomains<LeftDomain, RightDomain, Variable, Expression>
+      where LeftDomain : class, INumericalAbstractDomain<Variable, Expression>
+      where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
+    {
+        #region Constructor
+
+        public RefinedGeneric(LeftDomain left, RightDomain right,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(left, right, expManager)
+        { }
+        #endregion
+
+        #region Implementation of AssignInterval
+
+        // In the base we did not had any type for the Left argument (N1), so we could not propagate the assignment. 
+        // But here we know its type, so we can propagate the information
+        public override void AssumeInDisInterval(Variable x, DisInterval value)
         {
-          var xExp = encoder.VariableFor(x);
-          var yExp = encoder.VariableFor(y);
-          
-          if (k1 == -1 && k2 == 1)
-          {
-            return new Pair<Expression, Expression>(yExp, xExp);
-          }
-          if (k1 == 1 && k2 == -1)
-          {
-            return new Pair<Expression, Expression>(xExp, yExp);
-          }
+            Left.AssumeInDisInterval(x, value);
+            Right.AssumeInDisInterval(x, value);
         }
-      }
-      return new Pair<Expression, Expression>(e1, e2);
-    }
+        #endregion
 
-    #endregion
+        #region Override for To<T>
 
-    #region Visitors for the expressions
-
-    private class RefinedCheckIfHoldsVisitor 
-      : CheckIfHoldsVisitor<NumericalDomainWithKarr<Variable, Expression>, Variable, Expression>
-    {
-      public RefinedCheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        var direct = base.VisitEqual(left, right, original, data);
-
-        if (direct.IsNormal())
+        public override T To<T>(IFactory<T> factory)
         {
-          return direct;
+            var leftRefined = (LeftDomain)this.Left.RemoveRedundanciesWith(this.Right);
+
+            var left = leftRefined.To(factory);
+            var right = this.Right.To(factory);
+
+            return factory.And(left, right);
         }
+        #endregion
 
-        var resultLeft = Domain.CheckIfLessEqualThan(left, right);
+        #region Implementation of abstract methods
 
-        // left <= right
-        if (resultLeft.IsTrue())
+        public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
         {
-          var resultRight = Domain.CheckIfLessEqualThan(right, left);
-
-          // left >= right
-          if (resultLeft.IsTrue())
-          {
-            return resultRight;
-          }
+            return this.Left.CheckIfGreaterEqualThanZero(exp).Meet(this.Right.CheckIfGreaterEqualThanZero(exp));
         }
 
-        var notEq = this.VisitNotEqual(left, right, original, data);
-        if (notEq.IsNormal() && notEq.IsTrue())
+        public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
         {
-          return CheckOutcome.False;
+            return this.Left.CheckIfLessThan(e1, e2).Meet(this.Right.CheckIfLessThan(e1, e2));
         }
 
-        return resultLeft.Top;
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return VisitEqual(left, right, original, data);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessEqualThan(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessEqualThan_Un(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessThan(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return Domain.CheckIfLessThan_Un(left, right);
-      }
-
-      public override FlatAbstractDomain<bool> VisitNotEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        int value;
-        if (this.Decoder.IsNull(right) || (this.Decoder.TryValueOf<Int32>(right, ExpressionType.Int32, out value) && value == 0))
-        { // "left != 0" means that left should hold
-          var outcome = Domain.CheckIfHolds(left);
-
-          if (!outcome.IsTop)
-          {
-            return outcome;
-          }
-        }
-
-        var exp = this.Domain.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, left, right);
-
-        // Shortcut: as the checking in Karr may be quite expensive, we first try to validate it in cheaper domains, and only if we cannot conclude, we try Karr
-        var tryRight = Domain.Right.CheckIfHolds(exp);
-        if (tryRight.IsTop)
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
         {
-          return Domain.Left.CheckIfHolds(exp);
+            return this.Left.CheckIfLessEqualThan(e1, e2).Meet(this.Right.CheckIfLessEqualThan(e1, e2));
         }
-        else
+
+        public override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Reduce(LeftDomain left, RightDomain right)
         {
-          return tryRight;
+            return new RefinedGeneric<LeftDomain, RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
         }
-      }
 
-      public override FlatAbstractDomain<bool> VisitVariable(Variable var, Expression original, FlatAbstractDomain<bool> data)
-      {
-        // Is there a domain out there that can prove that original != null?
-        var directCheck = this.Domain.CheckIfNonZero(original);
-
-        if (directCheck.IsNormal())
+        protected override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Factory(LeftDomain left, RightDomain right)
         {
-          return directCheck;
+            return new RefinedGeneric<LeftDomain, RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
         }
 
-        // If not, let's collect a collective bound for the whole domain and see if it is != 0
-        var valueForVar = this.Domain.BoundsFor(original);
+        #endregion
+    }
 
-        if (valueForVar.IsNormal())
+    public class RefinedWithIntervalsIEEE<RightDomain, Variable, Expression>
+      : ReducedNumericalDomains<IntervalEnvironment_IEEE754<Variable, Expression>, RightDomain, Variable, Expression>
+      where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
+    {
+        public RefinedWithIntervalsIEEE(IntervalEnvironment_IEEE754<Variable, Expression> left, RightDomain right,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(left, right, expManager)
         {
-          if (valueForVar.LowerBound > 0 || valueForVar.UpperBound < 0)
-          { // It is true...
-            return CheckOutcome.True;
-          }
-          else if (valueForVar.IsSingleton && valueForVar.LowerBound.IsZero)
-          { // It is false
-            return CheckOutcome.False;
-          }
         }
-        return Default(data);
-      }
-    }
 
-    private class RefinedTestTrueVisitor
-      : TestTrueVisitor<NumericalDomainWithKarr<Variable, Expression>, Variable, Expression>
-    {
-      #region invariant
-
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.expManager != null);
-      }
-      
-      #endregion
-
-      #region Private state
-
-      private readonly ExpressionManagerWithEncoder<Variable, Expression> expManager;
-
-      #endregion
-
-      public RefinedTestTrueVisitor(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-        : base(expManager.Decoder)
-      {
-        Contract.Requires(expManager != null);
-
-        this.expManager = expManager;
-      }
-
-      public override NumericalDomainWithKarr<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
-      {
-        return data.TestTrueEqual(left, right) as NumericalDomainWithKarr<Variable, Expression>;
-      }
-
-      public override NumericalDomainWithKarr<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
-      {
-        Polynomial<Variable, Expression>  pol;
-
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, left, right, this.expManager.Decoder, out pol))
+        public override void AssumeInDisInterval(Variable x, DisInterval value)
         {
-          return data;
+            this.Left.AssumeInDisInterval(x, value);
+            this.Right.AssumeInDisInterval(x, value);
         }
 
-
-        var encoder = this.expManager.Encoder;
-
-        var eq = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, left, right);
-        var isEq = data.CheckIfHolds(eq);
-        if (isEq.IsNormal() && isEq.BoxedElement)
+        public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
         {
-          // We know Karr works with side effects
-          /*data.Left = */ data.Left.TestTrue(eq);
+            if (this.Left.CheckIfGreaterEqualThanZero(exp).IsTrue())
+                return CheckOutcome.True;
+
+            return this.Right.CheckIfGreaterEqualThanZero(exp);
         }
 
-        Variable v1, v2, v3;
-        Rational k;
-        if (pol.TryMatch_XPlusYLess_Equal_ThanZPlusK(out v1, out v2, out v3, out k))
+        public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
         {
-          var freshExpression = encoder.FreshVariable<Expression>();
-          var freshExpressionExp = encoder.VariableFor(freshExpression);
+            if (this.Left.CheckIfLessThan(e1, e2).IsTrue())
+                return CheckOutcome.True;
 
-          var v1Exp = encoder.VariableFor(v1);
-          var v2Exp = encoder.VariableFor(v2);
-          var v3Exp = encoder.VariableFor(v3);
-
-          var leftEnv =
-            data.Left.TestTrueEqual(
-              encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction,
-              encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, v1Exp, v2Exp),
-              encoder.ConstantFor((Int32)k)), freshExpressionExp);
-          
-          var rightEnv = data.Right.TestTrueLessEqualThan(freshExpressionExp, v3Exp); 
-                      
-          // it may be necessary to update the betaDep map
-
-          return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+            return this.Right.CheckIfLessThan(e1, e2);
         }
-        if (pol.TryMatch_XLess_Equal_ThanYPlusZPlusK(out v1, out v2, out v3, out k))
+
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
         {
+            if (this.Left.CheckIfLessEqualThan(e1, e2).IsTrue())
+                return CheckOutcome.True;
 
-          var freshExpression = encoder.FreshVariable<Expression>();
-          var freshExpressionExp = encoder.VariableFor(freshExpression);
-
-          var v1Exp = encoder.VariableFor(v1);
-          var v2Exp = encoder.VariableFor(v2);
-          var v3Exp = encoder.VariableFor(v3);
-
-          var leftEnv = data.Left.TestTrueEqual(encoder.CompoundExpressionFor(ExpressionType.Int32,
-            ExpressionOperator.Addition,
-              encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, v2Exp, v3Exp),
-              encoder.ConstantFor((Int32)k)), freshExpressionExp);
-         
-          var rightEnv = data.Right.TestTrueLessEqualThan(v1Exp, freshExpressionExp);
-
-          // it may be necessary to update the betaDep map
-          return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+            return this.Right.CheckIfLessEqualThan(e1, e2);
         }
-        return data;
-      }
 
-      public override NumericalDomainWithKarr<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, 
-        NumericalDomainWithKarr<Variable, Expression> data)
-      {
-        Polynomial<Variable, Expression> pol;
-
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, left, right, this.expManager.Decoder, out pol))
+        public override ReducedCartesianAbstractDomain<IntervalEnvironment_IEEE754<Variable, Expression>, RightDomain>
+          Reduce(IntervalEnvironment_IEEE754<Variable, Expression> left, RightDomain right)
         {
-          return data;
+            return new RefinedWithIntervalsIEEE<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
         }
 
-        var encoder = this.expManager.Encoder;
-
-        Variable v1, v2, v3;
-        Rational k;
-        if (pol.TryMatch_XPlusYLess_Equal_ThanZPlusK(out v1, out v2, out v3, out k))
+        protected override ReducedCartesianAbstractDomain<IntervalEnvironment_IEEE754<Variable, Expression>, RightDomain> Factory(IntervalEnvironment_IEEE754<Variable, Expression> left, RightDomain right)
         {
-          var freshExpression = encoder.FreshVariable<Expression>();
-          var freshExpressionExp = encoder.VariableFor(freshExpression);
-
-          var v1Exp = encoder.VariableFor(v1);
-          var v2Exp = encoder.VariableFor(v2);
-          var v3Exp = encoder.VariableFor(v3);
-
-          var leftEnv = data.Left.TestTrueEqual(
-              encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction,
-                  encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, 
-                  v1Exp, v2Exp), 
-                  encoder.ConstantFor((Int32)k)), 
-                freshExpressionExp);
-
-          var rightEnv = data.Right.TestTrueLessThan(freshExpressionExp, v3Exp);
-
-          // it may be necessary to update the betaDep map
-
-          return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+            return new RefinedWithIntervalsIEEE<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
         }
+    }
 
-        if (pol.TryMatch_XLess_Equal_ThanYPlusZPlusK(out v1, out v2, out v3, out k))
+    public class RefinedWithFloatTypes<RightDomain, Variable, Expression>
+      : ReducedNumericalDomains<FloatTypes<Variable, Expression>, RightDomain, Variable, Expression>
+      where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
+    {
+        public RefinedWithFloatTypes(FloatTypes<Variable, Expression> left, RightDomain right,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(left, right, expManager)
         {
-          var freshExpression = encoder.FreshVariable<Expression>();
-          var freshExpressionExp = encoder.VariableFor(freshExpression);
-
-          var v1Exp = encoder.VariableFor(v1);
-          var v2Exp = encoder.VariableFor(v2);
-          var v3Exp = encoder.VariableFor(v3);
-
-          var leftEnv =
-            data.Left.TestTrueEqual(encoder.CompoundExpressionFor(ExpressionType.Int32,
-              ExpressionOperator.Addition, encoder.CompoundExpressionFor(ExpressionType.Int32,
-              ExpressionOperator.Addition, v2Exp, v3Exp), encoder.ConstantFor((Int32)k)), freshExpressionExp);
-
-          var rightEnv = data.Right.TestTrueLessThan(v1Exp, freshExpressionExp);
-
-          // it may be necessary to update the betaDep map
-          return new NumericalDomainWithKarr<Variable, Expression>(leftEnv, rightEnv, data.ExpressionManager);
+            Contract.Requires(expManager != null);
         }
-        return data;
-      }
 
-      public override NumericalDomainWithKarr<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
-      {
-        return data;
-      }
+        public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            return this.Left.CheckIfGreaterEqualThanZero(exp).Meet(this.Right.CheckIfGreaterEqualThanZero(exp));
+        }
 
-      public override NumericalDomainWithKarr<Variable, Expression> VisitVariable(Variable var, Expression original,  NumericalDomainWithKarr<Variable, Expression> data)
-      {
-        return data;
-      }
+        public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            return this.Left.CheckIfLessThan(e1, e2).Meet(this.Right.CheckIfLessThan(e1, e2));
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            return this.Left.CheckIfLessEqualThan(e1, e2).Meet(this.Right.CheckIfLessEqualThan(e1, e2));
+        }
+
+        public override ReducedCartesianAbstractDomain<FloatTypes<Variable, Expression>, RightDomain> Reduce(FloatTypes<Variable, Expression> left, RightDomain right)
+        {
+            return this.Factory(left, right);
+        }
+
+        protected override ReducedCartesianAbstractDomain<FloatTypes<Variable, Expression>, RightDomain> Factory(FloatTypes<Variable, Expression> left, RightDomain right)
+        {
+            return new RefinedWithFloatTypes<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
+        }
     }
-
-    private class RefinedTestFalseVisitor : TestFalseVisitor< NumericalDomainWithKarr<Variable, Expression>, Variable, Expression>
-    {
-      public RefinedTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-        Contract.Requires(decoder != null);
-      }
-
-      public override NumericalDomainWithKarr<Variable, Expression> VisitVariable(Variable var, Expression original, NumericalDomainWithKarr<Variable, Expression> data)
-      {
-        return data;
-      }
-    }
-
-    #endregion
-  }
-
-  public class RefinedWithOctagons<RightDomain, Variable, Expression>
-    : ReducedNumericalDomains<OctagonEnvironment<Variable, Expression>, RightDomain, Variable, Expression>
-    where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
-  {
-    public RefinedWithOctagons(OctagonEnvironment<Variable, Expression> octagon, RightDomain otherDomain,
-    ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(octagon, otherDomain, expManager)
-    {
-    }
-
-    public override IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.LowerBoundsFor(v, strict); // not implemented for octagons
-    }
-
-    public override IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      return this.Right.UpperBoundsFor(v, strict); // not implemented for octagons
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      var tryOctagons = this.Left.CheckIfGreaterEqualThanZero(exp);
-
-      if (tryOctagons.IsTop)
-      {
-        return this.Right.CheckIfGreaterEqualThanZero(exp);
-      }
-      else
-      {
-        return tryOctagons;
-      }
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      var tryOctagons = this.Left.CheckIfLessThan(e1, e2);
-
-      if (tryOctagons.IsTop)
-      {
-        return this.Right.CheckIfLessThan(e1, e2);
-      }
-      else
-      {
-        return tryOctagons;
-      }
-    }
-    public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return this.Left.CheckIfLessThan_Un(e1, e2).Meet(this.Right.CheckIfLessThan_Un(e1, e2));
-    }   
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      var tryOctagons = this.Left.CheckIfLessEqualThan(e1, e2);
-
-      if (tryOctagons.IsTop)
-      {
-        return this.Right.CheckIfLessEqualThan(e1, e2);
-      }
-      else
-      {
-        return tryOctagons;
-      }
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return this.Left.CheckIfLessEqualThan_Un(e1, e2).Meet(this.Right.CheckIfLessEqualThan_Un(e1, e2));
-    }
-
-    public override ReducedCartesianAbstractDomain<OctagonEnvironment<Variable, Expression>, RightDomain> Reduce(OctagonEnvironment<Variable, Expression> left, RightDomain right)
-    {
-      return this.Factory(left, right);
-    }
-
-    protected override ReducedCartesianAbstractDomain<OctagonEnvironment<Variable, Expression>, RightDomain> Factory(OctagonEnvironment<Variable, Expression> left, RightDomain right)
-    {
-      return new RefinedWithOctagons<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
-    }
-  }
-
-  public class RefinedGeneric<LeftDomain, RightDomain, Variable, Expression>
-    : ReducedNumericalDomains<LeftDomain, RightDomain, Variable, Expression>
-    where LeftDomain : class, INumericalAbstractDomain<Variable, Expression>
-    where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Constructor
-
-    public RefinedGeneric(LeftDomain left, RightDomain right,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(left, right, expManager)
-    { }
-    #endregion
-
-    #region Implementation of AssignInterval
-
-    // In the base we did not had any type for the Left argument (N1), so we could not propagate the assignment. 
-    // But here we know its type, so we can propagate the information
-    public override void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      Left.AssumeInDisInterval(x, value);
-      Right.AssumeInDisInterval(x, value);
-    }
-    #endregion
-
-    #region Override for To<T>
-
-    public override T To<T>(IFactory<T> factory)
-    {
-      var leftRefined = (LeftDomain)this.Left.RemoveRedundanciesWith(this.Right);
-
-      var left = leftRefined.To(factory);
-      var right = this.Right.To(factory);
-
-      return factory.And(left, right);
-
-    }
-    #endregion
-
-    #region Implementation of abstract methods
-
-    public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      return this.Left.CheckIfGreaterEqualThanZero(exp).Meet(this.Right.CheckIfGreaterEqualThanZero(exp));
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      return this.Left.CheckIfLessThan(e1, e2).Meet(this.Right.CheckIfLessThan(e1, e2));
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      return this.Left.CheckIfLessEqualThan(e1, e2).Meet(this.Right.CheckIfLessEqualThan(e1, e2));
-    }
-
-    public override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Reduce(LeftDomain left, RightDomain right)
-    {
-      return new RefinedGeneric<LeftDomain, RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
-    }
-
-    protected override ReducedCartesianAbstractDomain<LeftDomain, RightDomain> Factory(LeftDomain left, RightDomain right)
-    {
-      return new RefinedGeneric<LeftDomain, RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
-    }
-
-    #endregion
-  }
-
-  public class RefinedWithIntervalsIEEE<RightDomain, Variable, Expression>
-    : ReducedNumericalDomains<IntervalEnvironment_IEEE754<Variable, Expression>, RightDomain, Variable, Expression>
-    where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
-  {
-
-    public RefinedWithIntervalsIEEE(IntervalEnvironment_IEEE754<Variable, Expression> left, RightDomain right,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(left, right, expManager)
-    {
-    }
-
-    public override void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      this.Left.AssumeInDisInterval(x, value);
-      this.Right.AssumeInDisInterval(x, value);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      if (this.Left.CheckIfGreaterEqualThanZero(exp).IsTrue())
-        return CheckOutcome.True;
-
-      return this.Right.CheckIfGreaterEqualThanZero(exp);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      if (this.Left.CheckIfLessThan(e1, e2).IsTrue())
-        return CheckOutcome.True;
-
-      return this.Right.CheckIfLessThan(e1, e2);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      if (this.Left.CheckIfLessEqualThan(e1, e2).IsTrue())
-        return CheckOutcome.True;
-
-      return this.Right.CheckIfLessEqualThan(e1, e2);
-    }
-
-    public override ReducedCartesianAbstractDomain<IntervalEnvironment_IEEE754<Variable, Expression>, RightDomain> 
-      Reduce(IntervalEnvironment_IEEE754<Variable, Expression> left, RightDomain right)
-    {
-      return new RefinedWithIntervalsIEEE<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
-    }
-
-    protected override ReducedCartesianAbstractDomain<IntervalEnvironment_IEEE754<Variable, Expression>, RightDomain> Factory(IntervalEnvironment_IEEE754<Variable, Expression> left, RightDomain right)
-    {
-      return new RefinedWithIntervalsIEEE<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
-    }
-  }
-
-  public class RefinedWithFloatTypes<RightDomain, Variable, Expression>
-    : ReducedNumericalDomains<FloatTypes<Variable, Expression>, RightDomain, Variable, Expression>
-    where RightDomain : class, INumericalAbstractDomain<Variable, Expression>
-  {
-
-    public RefinedWithFloatTypes(FloatTypes<Variable, Expression> left, RightDomain right, 
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(left, right, expManager)
-    {
-      Contract.Requires(expManager != null);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      return this.Left.CheckIfGreaterEqualThanZero(exp).Meet(this.Right.CheckIfGreaterEqualThanZero(exp));
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      return this.Left.CheckIfLessThan(e1, e2).Meet(this.Right.CheckIfLessThan(e1, e2));
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      return this.Left.CheckIfLessEqualThan(e1, e2).Meet(this.Right.CheckIfLessEqualThan(e1, e2));
-    }
-
-    public override ReducedCartesianAbstractDomain<FloatTypes<Variable, Expression>, RightDomain> Reduce(FloatTypes<Variable, Expression> left, RightDomain right)
-    {
-      return this.Factory(left, right);
-    }
-
-    protected override ReducedCartesianAbstractDomain<FloatTypes<Variable, Expression>, RightDomain> Factory(FloatTypes<Variable, Expression> left, RightDomain right)
-    {
-      return new RefinedWithFloatTypes<RightDomain, Variable, Expression>(left, right, this.ExpressionManager);
-    }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SparseArray.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SparseArray.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //An implementation for a sparse array, to optimize
 
@@ -27,2859 +16,2853 @@ using System.Collections;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// Sparse representation for a map int -> Rational
-  /// </summary>
-  [ContractVerification(true)]
-  [ContractClass(typeof(SparseRationalArrayContracts))]
-  abstract public class SparseRationalArray
-  {
-    public enum Representation { Dictionary, HashTable, HashTableWithBuckets, SimpleHashTable, List, Array }
-
-    [ThreadStatic]
-    private static Representation internalRepresentation;
-
     /// <summary>
-    /// The representation for the sparse array
+    /// Sparse representation for a map int -> Rational
     /// </summary>
-    public static Representation InternalRepresentation
+    [ContractVerification(true)]
+    [ContractClass(typeof(SparseRationalArrayContracts))]
+    abstract public class SparseRationalArray
     {
-      set
-      {
-        internalRepresentation = value;
-      }
-    }
+        public enum Representation { Dictionary, HashTable, HashTableWithBuckets, SimpleHashTable, List, Array }
 
-    static SparseRationalArray()
-    {
-      //internalRepresentation = Representation.Dictionary;
-      internalRepresentation = Representation.SimpleHashTable;
-    }
+        [ThreadStatic]
+        private static Representation internalRepresentation;
 
-    static public SparseRationalArray New(int length, Int32 defaultElement)
-    {
-      Contract.Requires(length >= 0);
-
-      return New(length, Rational.For(defaultElement));
-    }
-
-    /// <summary>
-    /// A fresh sparse array
-    /// </summary>
-    static public SparseRationalArray New(int length, Rational defaultElement)
-    {
-      Contract.Requires(length >= 0);
-      Contract.Requires(!object.Equals(defaultElement, null));
-
-      switch (internalRepresentation)
-      {
-        case Representation.Dictionary:
-          return new SparseRationalArray_Dictionary(length, defaultElement);
-
-        case Representation.HashTable:
-          return new SparseRationalArray_Hashtable(length, defaultElement);
-
-        case Representation.HashTableWithBuckets:
-          return new SparseRationalArray_HashtableWithBuckets(length, defaultElement);
-
-        case Representation.SimpleHashTable:
-          return new SparseRationalArray_SimpleHashtable(length, defaultElement);
-
-        case Representation.List:
-          return new SparseRationalArray_List(length, defaultElement);
-
-        case Representation.Array:
-          return new SparseRationalArray_Array(length, defaultElement);
-
-        default:
-          throw new AbstractInterpretationException("Unknown sparse array representation " + internalRepresentation);
-      }
-    }
-
-    public static String Statistics
-    {
-      get
-      {
-        switch (internalRepresentation)
+        /// <summary>
+        /// The representation for the sparse array
+        /// </summary>
+        public static Representation InternalRepresentation
         {
-          case Representation.Dictionary:
-            return SparseRationalArray_Dictionary.Statistics;
-
-          case Representation.HashTable:
-            return SparseRationalArray_Hashtable.Statistics;
-
-          case Representation.HashTableWithBuckets:
-            return SparseRationalArray_HashtableWithBuckets.Statistics;
-
-          case Representation.SimpleHashTable:
-            return SparseRationalArray_SimpleHashtable.Statistics;
-
-          case Representation.List:
-            return SparseRationalArray_List.Statistics;
-
-          default:
-            throw new AbstractInterpretationException("Unknown sparse array representation " + internalRepresentation);
-        }
-      }
-    }
-
-    protected int nonDefaultElementsCount = 0;
-
-    virtual public int NonDefaultElementsCount
-    {
-      get
-      {
-        return this.nonDefaultElementsCount;
-      }
-    }
-
-    abstract public void ExpandBy(int additionalRows);
-    abstract public bool ForEachKey(Predicate<int> pred);
-    abstract public IEnumerable<KeyValuePair<int, Rational>> GetElements();
-    abstract public IEnumerable<int> IndexesOfNonDefaultElements { get; }
-    abstract public bool IsIndexOfNonDefaultElement(int key);
-    abstract public bool IsIndexOfNonDefaultElement(int key, out Rational value);
-    abstract public int Length { get; }
-    abstract public void ResetToDefaultElement(int index);
-    abstract public void ShrinkTo(int index);
-    abstract public int SmallestIndexOfNonDefaultElement { get; }
-    abstract public Rational this[int index] { get; set; }
-    abstract public int Count { get; }
-    abstract public void Swap(int x, int y);
-
-    abstract public void CopyFrom(SparseRationalArray original);
-    abstract public void CopyFrom(SparseRationalArray original, int len);
-    abstract public SparseRationalArray Duplicate();
-
-  }
-
-  #region Contracts for SparseRationalArray
-
-  [ContractClassFor(typeof(SparseRationalArray))]
-  abstract class SparseRationalArrayContracts : SparseRationalArray
-  {
-    public override void ExpandBy(int additionalRows)
-    {
-      Contract.Requires(additionalRows >= 0);
-
-      throw new NotImplementedException();
-    }
-
-    public override bool ForEachKey(Predicate<int> pred)
-    {
-      Contract.Requires(pred != null);
-      
-      throw new NotImplementedException();
-    }
-
-    public override IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<int, Rational>>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public override IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get {
-        Contract.Ensures(Contract.Result<IEnumerable<int>>() != null);
-  
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public override bool IsIndexOfNonDefaultElement(int key)
-    {
-      Contract.Requires(key >= 0);
-
-      throw new NotImplementedException();
-    }
-
-    public override bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      Contract.Requires(key >= 0);
-      Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out value), null));
-
-      throw new NotImplementedException();
-    }
-
-    public override int Length
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override void ResetToDefaultElement(int index)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override void ShrinkTo(int index)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SmallestIndexOfNonDefaultElement
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override Rational this[int index]
-    {
-      get
-      {
-        Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
-
-        return default(Rational);
-      }
-      set
-      {
-        Contract.Requires(!object.Equals(value, null));
-      }
-    }
-
-    public override int Count
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override void Swap(int x, int y)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override void CopyFrom(SparseRationalArray original)
-    {
-      Contract.Requires(original != null);
-
-      throw new NotImplementedException();
-    }
-
-    public override void CopyFrom(SparseRationalArray original, int len)
-    {
-      Contract.Requires(original != null);
-      Contract.Requires(len >= 0);
-
-      throw new NotImplementedException();
-    }
-
-    public override SparseRationalArray Duplicate()
-    {
-      Contract.Ensures(Contract.Result<SparseRationalArray>() != null);
-
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
-
-  [ContractVerification(true)]
-  [ContractClass(typeof(SparseRationalArrayContracts<>))]
-  abstract public class SparseRationalArray<T>
-    : SparseRationalArray
-    where T : SparseRationalArray
-  {
-    abstract public void CopyFrom(T original);
-    abstract public void CopyFrom(T original, int len);
-    abstract public T DuplicateMe();
-
-    override public void CopyFrom(SparseRationalArray original)
-    {
-      this.CopyFrom((T)original);
-    }
-
-    override public void CopyFrom(SparseRationalArray original, int len)
-    {
-      this.CopyFrom((T)original, len);
-    }
-
-    override public SparseRationalArray Duplicate()
-    {
-      return this.DuplicateMe();
-    }
-
-    public override bool Equals(object obj)
-    {
-      var right = obj as SparseRationalArray<T>;
-
-      if (right == null)
-        return false;
-
-      if (this.Count != right.Count)
-        return false;
-
-      foreach (var pair in this.GetElements())
-      {
-        Contract.Assume(!object.Equals(pair.Value, null));
-
-        if (right[pair.Key] != pair.Value)
-          return false;
-      }
-
-      return true;
-    }
-
-    public override int GetHashCode()
-    {
-      return this.Count + this.Length;
-    }
-  }
-
-  #region Contracts for  SparseRationalArray<T>
-
-  [ContractClassFor(typeof(SparseRationalArray<>))]
-  abstract class SparseRationalArrayContracts<T> : SparseRationalArray<T>
-    where T : SparseRationalArray
-  {
-    public override void CopyFrom(T original)
-    {
-      Contract.Requires(original != null);
-
-      throw new NotImplementedException();
-    }
-
-    public override void CopyFrom(T original, int len)
-    {
-      Contract.Requires(original != null);
-
-      throw new NotImplementedException();
-    }
-
-    public override T DuplicateMe()
-    {
-      Contract.Ensures(Contract.Result<T>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public override void ExpandBy(int additionalRows)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override bool ForEachKey(Predicate<int> pred)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-      throw new NotImplementedException();
-    }
-
-    public override IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override bool IsIndexOfNonDefaultElement(int key)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int Length
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override void ResetToDefaultElement(int index)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override void ShrinkTo(int index)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SmallestIndexOfNonDefaultElement
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override Rational this[int index]
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public override int Count
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override void Swap(int x, int y)
-    {
-      throw new NotImplementedException();
-    }
-  }
-
-  #endregion
-
-  [ContractVerification(false)]
-  sealed class SparseRationalArray_SimpleHashtable
-  : SparseRationalArray<SparseRationalArray_SimpleHashtable>
-  {
-    #region Performance counters
-#if TRACE_PERFORMANCE
-    [ThreadStatic]
-    static private int MaxLength;
-    [ThreadStatic]
-    static private double MaxNonDefaultElements;
-#endif
-    #endregion
-
-    #region Private state
-
-    private int length;                                   // The length of the array
-    private SimpleHashtable<int, Rational> data;          // The data in the array
-
-    readonly private Rational defaultElement;             // The default element
-
-    #endregion
-
-    #region Constructor
-    public SparseRationalArray_SimpleHashtable(int length, Rational defaultElement)
-    {
-      Contract.Requires(length >= 0);
-
-      UpdateMaxLength(length);
-
-      this.length = length;
-      this.data = new SimpleHashtable<int, Rational>();
-      this.defaultElement = defaultElement;
-    }
-
-    private SparseRationalArray_SimpleHashtable(SparseRationalArray_SimpleHashtable original)
-    {
-      this.length = original.length;
-      this.data = new SimpleHashtable<int, Rational>(original.data);    // TODO: share it
-      this.defaultElement = original.defaultElement;
-    }
-
-    #endregion
-
-    override public Rational this[int index]
-    {
-      get
-      {
-        CheckBounds(index);
-
-        Rational value;
-        if (this.data.TryGetValue(index, out value))
-          return value;
-        else
-          return defaultElement;
-      }
-      set
-      {
-        CheckBounds(index);
-
-        // We do not store the default element explicitly
-        if (value == defaultElement)
-        {
-          if (this.data.ContainsKey(index))
-          {
-            this.data.Remove(index);
-            this.nonDefaultElementsCount--;
-          }
-        }
-        else
-        {
-          this.data[index] = value;
-          this.nonDefaultElementsCount++;
-
-          UpdateMaxNonDefaultElements();
-        }
-      }
-    }
-
-    [Conditional("TRACE_PERFORMANCE")]
-    private static void UpdateMaxNonDefaultElements()
-    {
-#if TRACE_PERFORMANCE
-      MaxNonDefaultElements = Math.Max(MaxNonDefaultElements, this.data.Count);
-#endif
-    }
-
-    [Conditional("TRACE_PERFORMANCE")]
-    private static void UpdateMaxLength(int length)
-    {
-#if TRACE_PERFORMANCE
-      MaxLength = Math.Max(length, MaxLength);
-#endif
-    }
-
-    override public int Length
-    {
-      get
-      {
-        return this.length;
-      }
-    }
-
-    /// <summary>
-    /// The number of non "default" elements in the sparse array
-    /// </summary>
-    override public int Count
-    {
-      get
-      {
-        return this.data.Count;
-      }
-    }
-
-    override public void ExpandBy(int additionalRows)
-    {
-      //Contract.Requires(additionalRows >= 0);
-
-      this.length += additionalRows;
-    }
-
-    override public void ShrinkTo(int index)
-    {
-      //Contract.Requires(index >= 0);
-      //Contract.Requires(index <= this.Length);
-
-      if (index == this.Length)
-        return;
-
-      for (int i = index; i < this.length; i++)
-      {
-        this.data.Remove(i);
-      }
-
-      this.length = index;
-    }
-
-    override public void ResetToDefaultElement(int index)
-    {
-      this.data.Remove(index);
-    }
-
-
-    override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-     return this.data.Elements;
-    }
-
-    override public IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get
-      {
-        return data.Keys;
-      }
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key)
-    {
-      return this.data.ContainsKey(key);
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      if (this.data.TryGetValue(key, out value))
-      {
-        return true;
-      }
-      else
-      {
-        value = this.defaultElement;
-        return false;
-      }
-    }
-
-    override public bool ForEachKey(Predicate<int> pred)
-    {
-      foreach (int key in this.data.Keys)
-      {
-        if (!pred(key))
-          return false;
-      }
-
-      return true;
-    }
-
-    override public int SmallestIndexOfNonDefaultElement
-    {
-      get
-      {
-        int min = Int32.MaxValue;
-
-        foreach (int key in this.data.Keys)
-        {
-          if (key < min)
-            min = key;
-        }
-
-        return min == Int32.MaxValue ? -1 : min;
-      }
-    }
-
-    override public void CopyFrom(SparseRationalArray_SimpleHashtable original)
-    {
-      foreach (var pair in original.data.Elements)
-      {
-        this[pair.Key] = pair.Value;
-      }
-    }
-
-    override public void Swap(int x, int y)
-    {
-      Rational xval, yval;
-      bool xb = this.data.TryGetValue(x, out xval);
-      bool yb = this.data.TryGetValue(y, out yval);
-
-      Debug.Assert(xb ? xval != defaultElement : true);
-      Debug.Assert(yb ? yval != defaultElement : true);
-
-      if (xb)
-      {
-        if (yb)
-        { // we can swap x with y
-          this.data[x] = yval;
-          this.data[y] = xval;
-        }
-        else
-        { // y has a default value
-          this.ResetToDefaultElement(x);
-          this.data[y] = xval;
-        }
-      }
-      else if (yb)
-      { // x has the default value
-        this.data[x] = yval;
-        this.ResetToDefaultElement(y);
-      }
-      else
-      { // both have the default value
-
-      }
-    }
-
-    /// <summary>
-    /// Copies just the elements of index [0, ... len-1]
-    /// </summary>
-    override public void CopyFrom(SparseRationalArray_SimpleHashtable original, int len)
-    {
-      foreach (var index_pair in original.data.Elements)
-      {
-        if (index_pair.Key < len)
-        {
-          this[index_pair.Key] = index_pair.Value;
-        }
-      }
-    }
-
-    // Idea: here we can share the internal representation?
-    override public SparseRationalArray_SimpleHashtable DuplicateMe()
-    {
-      return new SparseRationalArray_SimpleHashtable(this);
-    }
-
-    public object/*!*/ Clone()
-    {
-      return this.Duplicate();
-    }
-
-    new static internal String Statistics
-    {
-      get
-      {
-#if TRACE_PERFORMANCE
-        string s1 = string.Format("Max length of a sparse array : {0}", MaxLength);
-        string s2 = string.Format("Max # of non-default elements: {0}", MaxNonDefaultElements);
-
-        return s1 + Environment.NewLine + s2;
-#else
-        return "Performance tracing is off";
-#endif
-      }
-    }
-
-    [Conditional("DEBUG")]
-    private void CheckBounds(int i)
-    {
-      if (i < 0 || i >= length)
-      {
-        System.Diagnostics.Debugger.Break();
-       // throw new ArgumentOutOfRangeException();
-      }
-    }
-
-    public override string ToString()
-    {
-      StringBuilder str = new StringBuilder();
-
-      foreach (var pair in this.data.Elements)
-      {
-        str.AppendFormat("({0},{1})", pair.Key, pair.Value);
-      }
-
-      return str.ToString();
-    }
-  }
-
-  [ContractVerification(false)]
-  sealed class SparseRationalArray_Dictionary 
-    : SparseRationalArray<SparseRationalArray_Dictionary>
-  {
-    #region Performance counters
-
-    #if TRACE_PERFORMACE
-    [ThreadStatic]
-    static private int MaxLength;
-    [ThreadStatic]
-    static private double MaxNonDefaultElements;
-    #endif
-
-    #endregion
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.length >= 0);
-      Contract.Invariant(this.data != null);
-      Contract.Invariant(this.map != null);
-      Contract.Invariant(!object.Equals(defaultElement, null));
-      Contract.Invariant(this.length == this.map.Length);
-#if CHECKINVARIANTS
-      Contract.Invariant(Contract.ForAll(0, this.map.Length, i => this.map[i] == this.data.ContainsKey(i)));
-#endif
-    }
-
-    #region Private state
-
-    private int length;                                   // The length of the array
-    private Dictionary<int, Rational> data;               // The data in the array
-    private BitArray map;
-
-    readonly private Rational defaultElement;             // The default element
-
-    #endregion
-
-    #region Constructor
-    public SparseRationalArray_Dictionary(int length, Rational defaultElement)
-    {
-      Contract.Requires(length >= 0);
-      Contract.Requires(!object.Equals(defaultElement, null));
-
-      UpdateMaxLength(length);
-
-      this.length = length;
-      this.data = new Dictionary<int, Rational>(3);
-      this.map = new BitArray(length);
-      this.defaultElement = defaultElement;
-    }
-
-    private SparseRationalArray_Dictionary(SparseRationalArray_Dictionary original)
-    {
-      Contract.Requires(original != null);
-
-      Contract.Assume(original.length >= 0);
-      Contract.Assume(!object.Equals(original.defaultElement, null));
-
-      this.length = original.length;
-      this.data = new Dictionary<int, Rational>(original.data);    // TODO: share it
-      this.map = new BitArray(original.map);
-      this.defaultElement = original.defaultElement;
-    }
-
-    #endregion
-
-    public override int NonDefaultElementsCount
-    {
-      get
-      {
-        return this.data.Count;
-      }
-    }
-
-    override public Rational this[int index]
-    {
-      get
-      {
-        CheckBounds(index);
-
-        Rational value;
-        if(this.map[index] && this.data.TryGetValue(index, out value))
-        {
-          Contract.Assume(!object.Equals(value, null));
-          return value;
-        }
-        else
-        {
-          return defaultElement;
-        }
-      }
-      set
-      {
-        CheckBounds(index);
-
-        // We do not store the default element explicitly
-        if (value == defaultElement)
-        {
-          if (this.data.ContainsKey(index))
-          {
-            this.map[index] = false;
-            this.data.Remove(index);
-          }
-        }
-        else
-        {
-          this.map[index] = true;
-          this.data[index] = value;
-
-          UpdateMaxNonDefaultElements();
-        }
-      }
-    }
-
-    [Conditional("TRACE_PERFORMANCE")]
-    private void UpdateMaxNonDefaultElements()
-    {
-#if TRACE_PERFORMANCE
-      MaxNonDefaultElements = Math.Max(MaxNonDefaultElements, this.data.Count);
-#endif
-    }
-
-    [Conditional("TRACE_PERFORMANCE")]
-    private static void UpdateMaxLength(int length)
-    {
-#if TRACE_PERFORMANCE
-      MaxLength = Math.Max(length, MaxLength);
-#endif
-    }
-
-    override public int Length
-    {
-      get
-      {
-        return this.length;
-      }
-    }
-
-    /// <summary>
-    /// The number of non "default" elements in the sparse array
-    /// </summary>
-    override public int Count
-    {
-      get
-      {
-        return this.data.Count;
-      }
-    }
-
-    override public void ExpandBy(int additionalRows)
-    {
-      this.length += additionalRows;
-
-      this.map.Length = this.length;
-    }
-
-    override public void ShrinkTo(int index)
-    {
-      if (index == this.Length || index < 0)
-      {
-        return;
-      }
-
-      for (int i = index; i < this.length; i++)
-      {
-        this.data.Remove(i);
-      }
-
-      this.length = index;
-
-      this.map.Length = this.length;
-    }
-
-    override public void ResetToDefaultElement(int index)
-    {
-      this.map[index] = false;
-      this.data.Remove(index);    
-    }
-
-    /// <summary>
-    /// A method used to iterate on the non-default elements of the sparse array
-    /// </summary>
-    /// <returns></returns>
-    override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-      return data as IEnumerable<KeyValuePair<int, Rational>>;
-    }
-
-    override public IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get
-      {
-        return data.Keys;
-      }
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key)
-    {
-      return this.map[key];
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      if (this.map[key] && this.data.TryGetValue(key, out value))
-      {
-        Contract.Assume(!object.Equals(value, null));
-
-        return true;
-      }
-      else
-      {
-        value = this.defaultElement;
-
-        return false;
-      }
-    }
-
-    override public bool ForEachKey(Predicate<int> pred)
-    {
-      foreach (int key in this.data.Keys)
-      {
-        if (!pred(key))
-          return false;
-      }
-
-      return true;
-    }
-
-    override public int SmallestIndexOfNonDefaultElement
-    {
-      get
-      {
-        for (var i = 0; i < this.map.Length; i++)
-        {
-          if (this.map[i])
-            return i;
-        }
-
-        return -1;
-      }
-    }
-
-    override public void CopyFrom(SparseRationalArray_Dictionary original)
-    {
-      Contract.Assume(original.data != null);
-      foreach (var pair in original.data)
-      {
-        Contract.Assume(!object.Equals(pair.Value, null));
-        this[pair.Key] = pair.Value;
-      }
-    }
-
-    override public void Swap(int x, int y)
-    {
-      if (x == y)
-        return;
-
-      Rational xval, yval;
-      xval = yval = defaultElement;
-      var xb = this.map[x] && this.data.TryGetValue(x, out xval);
-      var yb = this.map[y] && this.data.TryGetValue(y, out yval);
-
-      // F: Proving the assertions will require some more complex quantified invariant
-      Contract.Assume(xb ? (!object.Equals(xval, null) && xval != defaultElement) : true);
-      Contract.Assume(yb ? (!object.Equals(yval, null) && yval != defaultElement) : true);
-
-      if (xb)
-      {
-        if (yb)
-        { // we can swap x with y
-          this.data[x] = yval;
-          this.data[y] = xval;
-
-          this.map[x] = this.map[y] = true; // F: needless, but makes the code clearer
-        }
-        else
-        { // y has a default value
-          this.ResetToDefaultElement(x);
-          this.data[y] = xval;
-
-          this.map[y] = true;
-        }
-      }
-      else if (yb)
-      { // x has the default value
-        this.data[x] = yval;
-        this.ResetToDefaultElement(y);
-
-        this.map[x] = true;
-      }
-      else
-      { // both have the default value
-
-      }
-    }
-
-    /// <summary>
-    /// Copies just the elements of index [0, ... len-1]
-    /// </summary>
-    override public void CopyFrom(SparseRationalArray_Dictionary original, int len)
-    {
-      Contract.Assume(original.data != null);
-      foreach (var pair in original.data)
-      {
-        Contract.Assume(!object.Equals(pair.Value, null));
-        if (pair.Key < len)
-        {
-          this[pair.Key] = pair.Value;
-        }
-      }
-    }
-
-    // Idea: here we can share the internal representation?
-    override public SparseRationalArray_Dictionary DuplicateMe()
-    {
-      return new SparseRationalArray_Dictionary(this);
-    }
-
-    public object Clone()
-    {
-      return this.Duplicate();
-    }
-
-    new static internal String Statistics
-    {
-      get
-      {
-#if TRACE_PERFORMANCE
-        var s1 = string.Format("Max length of a sparse array : {0}", MaxLength);
-        var s2 = string.Format("Max # of non-default elements: {0}", MaxNonDefaultElements);
-
-        return s1 + Environment.NewLine + s2;
-#else
-        return "Performance tracing is off";
-#endif
-      }
-    }
-
-    [Conditional("DEBUG")]
-    private void CheckBounds(int i)
-    {
-      if (i < 0 || i >= length)
-      {
-        System.Diagnostics.Debugger.Break();
-        // throw new ArgumentOutOfRangeException();
-      }
-    }
-
-    public override string ToString()
-    {
-      var str = new StringBuilder();
-
-      foreach (var pair in this.data)
-      {
-        str.AppendFormat("({0},{1})", pair.Key, pair.Value);
-      }
-
-      return str.ToString();
-    }
-  }
-
-  /// <summary>
-  /// A sparse array implementation using a very stupid Hashtable
-  /// </summary>
-  [ContractVerification(false)]
-  sealed class SparseRationalArray_Hashtable
-    : SparseRationalArray<SparseRationalArray_Hashtable>
-  {
-    #region Performance counters
-#if TRACE_PERFORMANCE
-    [ThreadStatic]
-    static private int MaxLength;
-    [ThreadStatic]
-    static private int ResizeCount;
-#endif
-    #endregion
-
-    #region Private state
-
-    private int length;                               // The length of the array
-    private Entry[] data;                             // The data in the array
-    private int count;
-
-    readonly private Rational defaultElement;         // The default element
-
-    private const int Capacity = 7;
-
-    #endregion
-
-    #region Constructor
-    public SparseRationalArray_Hashtable(int length, Rational defaultElement)
-    {
-      Debug.Assert(length >= 0);
-
-#if TRACE_PERFORMANCE
-      MaxLength = Math.Max(length, MaxLength);
-#endif
-
-      this.length = length;
-      this.data = new Entry[Capacity];
-      this.count = 0;
-      this.defaultElement = defaultElement;
-    }
-
-    private SparseRationalArray_Hashtable(SparseRationalArray_Hashtable original)
-    {
-      original.CheckInvariant();
-
-      this.length = original.length;
-      this.data = CloneFrom(original.data);
-      this.count = original.count;
-      this.defaultElement = original.defaultElement;
-    }
-
-    #endregion
-
-    override public Rational this[int index]
-    {
-      get
-      {
-        CheckBounds(index);
-
-        Rational value;
-        if (this.TryGetValue(index, out value))
-          return value;
-        else
-          return defaultElement;
-      }
-      set
-      {
-        CheckBounds(index);
-
-        // We do not store the default element explicitly
-        if (value == defaultElement)
-        {
-          int indexInTheArray;
-          if (this.ContainsKey(index, out indexInTheArray))
-          {
-            this.Remove(index, indexInTheArray);
-            this.nonDefaultElementsCount--;
-          }
-        }
-        else
-        {
-          this.Set(index, value);
-          this.nonDefaultElementsCount++;
-        }
-
-        CheckInvariant();
-      }
-    }
-
-    override public int Length
-    {
-      get
-      {
-        return this.length;
-      }
-    }
-
-    /// <summary>
-    /// The number of non "default" elements in the sparse array
-    /// </summary>
-    override public int Count
-    {
-      get
-      {
-        return this.count;
-      }
-    }
-
-    override public void ExpandBy(int additionalRows)
-    {
-      Debug.Assert(additionalRows >= 0);
-
-      CheckInvariant();
-
-      this.length += additionalRows;
-
-      CheckInvariant();
-    }
-
-    override public void ShrinkTo(int index)
-    {
-      Debug.Assert(index >= 0);
-      Debug.Assert(index <= this.Length);
-
-      CheckInvariant();
-
-      if (index == this.Length)
-        return;
-
-      for (int i = index; i < this.length; i++)
-      {
-        this.Remove(i);
-      }
-
-      this.length = index;
-
-      CheckInvariant();
-    }
-
-    override public void ResetToDefaultElement(int index)
-    {
-      CheckInvariant();
-
-      this.Remove(index);
-
-      CheckInvariant();
-    }
-
-    /// <summary>
-    /// A method used to iterate on the non-default elements of the sparse array
-    /// </summary>
-    /// <returns></returns>
-    override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-      CheckInvariant();
-
-      int nondef = 0;
-      for (int i = 0; nondef < count && i < this.data.Length; i++)
-      {
-        if (this.data[i] != null)
-        {
-          nondef++;
-          yield return new KeyValuePair<int, Rational>(this.data[i].Index, this.data[i].Value);
-        }
-      }
-    }
-
-    override public IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get
-      {
-        CheckInvariant();
-
-        var nondef = 0;
-
-        for (int i = 0; nondef < this.count && i < this.data.Length; i++)
-        {
-          if (this.data[i] != null)
-          {
-            nondef++;
-             yield return this.data[i].Index;
-          }
-        }
-      }
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key)
-    {
-      Rational dummy;
-
-      return this.TryGetValue(key, out dummy);
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      if (this.TryGetValue(key, out value))
-      {
-        return true;
-      }
-      else
-      {
-        value = this.defaultElement;
-        return false;
-      }
-    }
-
-    override public bool ForEachKey(Predicate<int> pred)
-    {
-      foreach (int key in this.GetKeys())
-      {
-        if (!pred(key))
-          return false;
-      }
-
-      return true;
-    }
-
-    override public int SmallestIndexOfNonDefaultElement
-    {
-      get
-      {
-        int min = Int32.MaxValue;
-
-        foreach (int key in this.GetKeys())
-        {
-          if (key < min)
-            min = key;
-        }
-
-        return min == Int32.MaxValue ? -1 : min;
-      }
-    }
-
-    override public void CopyFrom(SparseRationalArray_Hashtable original)
-    {
-      foreach (var index_pair in original.data)
-      {
-        if (index_pair != null)
-        {
-          this[index_pair.Index] = index_pair.Value;
-        }
-      }
-    }
-
-    override public void Swap(int x, int y)
-    {
-      Rational xval, yval;
-      bool xb = this.TryGetValue(x, out xval);
-      bool yb = this.TryGetValue(y, out yval);
-
-      Debug.Assert(xb ? xval != defaultElement : true);
-      Debug.Assert(yb ? yval != defaultElement : true);
-
-      if (xb)
-      {
-        if (yb)
-        { // we can swap x with y
-          this[x] = yval;
-          this[y] = xval;
-        }
-        else
-        { // y has a default value
-          this.ResetToDefaultElement(x);
-          this[y] = xval;
-        }
-      }
-      else if (yb)
-      { // x has the default value
-        this[x] = yval;
-        this.ResetToDefaultElement(y);
-      }
-      else
-      { // both have the default value
-
-      }
-    }
-
-    /// <summary>
-    /// Copies just the elements of index [0, ... len-1]
-    /// </summary>
-    override public void CopyFrom(SparseRationalArray_Hashtable original, int len)
-    {
-      foreach (var index_pair in original.data)
-      {
-        if (index_pair != null && index_pair.Index < len)
-        {
-          this[index_pair.Index] = index_pair.Value;
-        }
-      }
-    }
-
-    // Idea: here we can share the internal representation?
-    override public SparseRationalArray_Hashtable DuplicateMe()
-    {
-      return new SparseRationalArray_Hashtable(this);
-    }
-
-    [Conditional("DEBUG")]
-    [Conditional("CHECKINVARIANTS")]
-    private void CheckBounds(int i)
-    {
-      CheckInvariant();
-
-      if (i < 0 || i >= length)
-        throw new ArgumentOutOfRangeException();
-    }
-
-    new static internal String Statistics
-    {
-      get
-      {
-#if TRACE_PERFORMANCE
-        return string.Format("Number of resizing {0}", ResizeCount);
-#else
-        return "Performance tracing is off";
-#endif
-      }
-    }
-
-    override public string ToString()
-    {
-      StringBuilder str = new StringBuilder();
-
-      foreach (var pair in this.data)
-      {
-        if (pair != null)
-        {
-          str.AppendFormat("({0},{1})", pair.Index, pair.Value);
-        }
-      }
-
-      return str.ToString();
-    }
-
-    [Conditional("CHECKINVARIANTS")]
-    private void CheckInvariant()
-    {
-      var indexes = new Set<int>();
-
-      foreach (var pair in this.data)
-      {
-        if (pair != null)
-        {
-          Debug.Assert(!indexes.Contains(pair.Index));
-
-          indexes.Add(pair.Index);
-        }
-      }
-    }
-
-    #region HashTable Manipulation
-
-    static private int Hash(int value)
-    {
-      // return value.GetHashCode();
-      return value;
-    }
-
-    private int Pos(int value)
-    {
-      return value % this.data.Length;
-    }
-
-    static private Entry[] CloneFrom(Entry[] entry)
-    {
-      Entry[] result = new Entry[entry.Length];
-      Array.Copy(entry, result, entry.Length);
-
-      return result;
-    }
-
-    private bool TryGetValue(int index, out int indexInTheArray, out Rational value)
-    {
-      int start = Pos(Hash(index));
-
-      if (this.data[start] != null && this.data[start].Index == index)
-      {
-        value = this.data[start].Value;
-        indexInTheArray = start;
-        return true;
-      }
-
-      for (int i = Pos(start + 1); i != start; i = Pos(i + 1))
-      {
-        if (this.data[i] != null && this.data[i].Index == index)
-        {
-          value = this.data[i].Value;
-          indexInTheArray = i;
-          return true;
-        }
-      }
-
-      value = default(Rational);
-      indexInTheArray = -1;
-      return false;
-    }
-
-    private bool TryGetValue(int index, out Rational value)
-    {
-      int indexInTheArray;
-      return this.TryGetValue(index, out indexInTheArray, out value);
-    }
-
-    private bool ContainsKey(int index, out int indexInTheArray)
-    {
-      Rational dummy;
-      return this.TryGetValue(index, out indexInTheArray, out dummy);
-    }
-
-    private void Remove(int index)
-    {
-      int indexInTheArray;
-      Rational dummy;
-
-      if (this.TryGetValue(index, out indexInTheArray, out dummy))
-      {
-        this.Remove(index, indexInTheArray);
-      }
-    }
-
-    private void Remove(int index, int indexInTheArray)
-    {
-      this.data[indexInTheArray] = null;
-    }
-
-    private void Set(int index, Rational value)
-    {
-      if (this.data.Length == this.count)
-      {
-        Resize(this.data.Length * 2 + 1);
-      }
-
-      this.Remove(index);
-
-      Set(this.data, index, value);
-
-      this.count++;
-    }
-
-    static private void Set(Entry[] where, int index, Rational value)
-    {
-      int len = where.Length;
-      int start = Hash(index) % len;
-
-      if (where[start] == null || where[start].Index == index)
-      {
-        where[start] = new Entry(index, value);
-        return;
-      }
-
-      for (int i = (start + 1) % len; i != start; i = (i + 1) % len)
-      {
-        if (where[i] == null || where[i].Index == index)
-        {
-          where[i] = new Entry(index, value);
-          return;
-        }
-      }
-
-      Debug.Assert(false);  // Should be unreachable
-    }
-
-    private void Resize(int newSize)
-    {
-#if TRACE_PERFORMANCE
-      ResizeCount++;
-#endif
-
-      Entry[] newArray = new Entry[newSize];
-
-      for (int i = 0; i < this.data.Length; i++)
-      {
-        if (this.data[i] != null)
-        {
-          Set(newArray, this.data[i].Index, this.data[i].Value);
-        }
-      }
-
-      this.data = newArray;
-    }
-
-    private IEnumerable<int> GetKeys()
-    {
-      int nondef = 0;
-
-      for (int i = 0; nondef < count && i < this.data.Length; i++)
-      {
-        if (this.data[i] != null)
-        {
-          nondef++;
-          yield return this.data[i].Index;
-        }
-      }
-    }
-
-    #endregion
-
-    class Entry
-    {
-      int index;
-      Rational value;
-
-      public int Index
-      {
-        get
-        {
-          return this.index;
-        }
-      }
-
-      public Rational Value
-      {
-        get
-        {
-          return this.value;
-        }
-      }
-
-      public Entry(int index, Rational value)
-      {
-        this.index = index;
-        this.value = value;
-      }
-
-      public override string ToString()
-      {
-        return string.Format("({0}, {1})", this.index, this.value);
-      }
-    }
-  }
-
-  [ContractVerification(false)]
-  sealed class SparseRationalArray_HashtableWithBuckets
-    : SparseRationalArray<SparseRationalArray_HashtableWithBuckets>
-  {
-    #region Performance counters
-#if TRACE_PERFORMANCE
-    [ThreadStatic]
-    static private int MaxLength;
-    [ThreadStatic]
-    static private int ResizeCount;
-#endif
-    #endregion
-
-    #region Private state
-
-    private int length;                               // The length of the array
-    private Entry[][] data;                           // The data in the array    
-    private int[] lastElement;                        // The last element in a bucket
-
-    private int count;
-
-    readonly private Rational defaultElement;         // The default element
-
-    private const int Capacity = 31;
-    private const int BucketSize = 1;
-
-    #endregion
-
-    #region Constructor
-    public SparseRationalArray_HashtableWithBuckets(int length, Rational defaultElement)
-    {
-      Debug.Assert(length >= 0);
-
-#if TRACE_PERFORMANCE
-      MaxLength = Math.Max(length, MaxLength);
-#endif
-
-      this.length = length;
-      
-      this.data = new Entry[Capacity][];
-      this.lastElement = new int[Capacity];
-     
-      this.count = 0;
-      this.defaultElement = defaultElement;
-    }
-
-    private SparseRationalArray_HashtableWithBuckets(SparseRationalArray_HashtableWithBuckets original)
-    {
-      original.CheckInvariant();
-
-      this.length = original.length;
-      this.data = CloneFrom(original.data);
-      
-      this.lastElement = new int[original.lastElement.Length];
-      Array.Copy(original.lastElement, this.lastElement, original.lastElement.Length);
-
-      this.count = original.count;
-      this.defaultElement = original.defaultElement;
-    }
-
-    #endregion
-
-    override public Rational this[int index]
-    {
-      get
-      {
-        CheckBounds(index);
-
-        Rational value;
-        if (this.TryGetValue(index, out value))
-          return value;
-        else
-          return defaultElement;
-      }
-      set
-      {
-        CheckBounds(index);
-
-        // We do not store the default element explicitly
-        if (value == defaultElement)
-        {
-          int indexInTheArray, indexInTheBucket;
-          if (this.ContainsKey(index, out indexInTheArray, out indexInTheBucket))
-          {
-            this.Remove(index, indexInTheArray, indexInTheBucket);
-            this.nonDefaultElementsCount--;
-          }
-        }
-        else
-        {
-          this.Set(index, value);
-          this.nonDefaultElementsCount++;
-        }
-
-        CheckInvariant();
-      }
-    }
-
-    override public int Length
-    {
-      get
-      {
-        return this.length;
-      }
-    }
-
-    /// <summary>
-    /// The number of non "default" elements in the sparse array
-    /// </summary>
-    override public int Count
-    {
-      get
-      {
-        return this.count;
-      }
-    }
-
-    override public void ExpandBy(int additionalRows)
-    {
-      Debug.Assert(additionalRows >= 0);
-
-      CheckInvariant();
-
-      this.length += additionalRows;
-
-      CheckInvariant();
-    }
-
-    override public void ShrinkTo(int index)
-    {
-      Debug.Assert(index >= 0);
-      Debug.Assert(index <= this.Length);
-
-      CheckInvariant();
-
-      if (index == this.Length)
-        return;
-
-      for (int i = index; i < this.length; i++)
-      {
-        this.Remove(i);
-      }
-
-      this.length = index;
-
-      CheckInvariant();
-    }
-
-    override public void ResetToDefaultElement(int index)
-    {
-      CheckInvariant();
-
-      this.Remove(index);
-
-      CheckInvariant();
-    }
-
-    /// <summary>
-    /// A method used to iterate on the non-default elements of the sparse array
-    /// </summary>
-    /// <returns></returns>
-    override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-      CheckInvariant();
-
-      var nondef = 0;
-      for (int i = 0; nondef < this.count && i < this.data.Length; i++)
-      {
-        if (this.data[i] != null)
-        {
-          for (int j = 0; j < this.lastElement[i]; j++)
-          {
-            var local = this.data[i][j];
-            nondef++;
-
-            yield return new KeyValuePair<int, Rational>(local.Index, local.Value);
-          }
-        }
-      }
-    }
-
-    override public IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get
-      {
-        CheckInvariant();
-
-        var nondef = 0;
-
-        for (int i = 0; nondef < this.count && i < this.data.Length; i++)
-        {
-          if (this.data[i] != null)
-          {
-            for (int j = 0; j < this.lastElement[i]; j++)
+            set
             {
-              nondef++;
-               yield return this.data[i][j].Index;
+                internalRepresentation = value;
             }
-          }
         }
-      }
-    }
 
-    override public bool IsIndexOfNonDefaultElement(int key)
-    {
-      Rational dummy;
-
-      return this.TryGetValue(key, out dummy);
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      if (this.TryGetValue(key, out value))
-      {
-        return true;
-      }
-      else
-      {
-        value = this.defaultElement;
-        return false;
-      }
-    }
-
-    override public bool ForEachKey(Predicate<int> pred)
-    {
-      foreach (int key in this.GetKeys())
-      {
-        if (!pred(key))
-          return false;
-      }
-
-      return true;
-    }
-
-    override public int SmallestIndexOfNonDefaultElement
-    {
-      get
-      {
-        int min = Int32.MaxValue;
-
-        foreach (int key in this.GetKeys())
+        static SparseRationalArray()
         {
-          if (key < min)
-            min = key;
+            //internalRepresentation = Representation.Dictionary;
+            internalRepresentation = Representation.SimpleHashTable;
         }
 
-        return min == Int32.MaxValue ? -1 : min;
-      }
-    }
-
-    override public void CopyFrom(SparseRationalArray_HashtableWithBuckets original)
-    {
-      foreach (var index_pair in original.GetElements())
-      {
-        this[index_pair.Key] = index_pair.Value;
-      }
-    }
-
-    override public void Swap(int x, int y)
-    {
-      Rational xval, yval;
-      bool xb = this.TryGetValue(x, out xval);
-      bool yb = this.TryGetValue(y, out yval);
-
-      Debug.Assert(xb ? xval != defaultElement : true);
-      Debug.Assert(yb ? yval != defaultElement : true);
-
-      if (xb)
-      {
-        if (yb)
-        { // we can swap x with y
-          this[x] = yval;
-          this[y] = xval;
-        }
-        else
-        { // y has a default value
-          this.ResetToDefaultElement(x);
-          this[y] = xval;
-        }
-      }
-      else if (yb)
-      { // x has the default value
-        this[x] = yval;
-        this.ResetToDefaultElement(y);
-      }
-      else
-      { // both have the default value
-
-      }
-    }
-
-    /// <summary>
-    /// Copies just the elements of index [0, ... len-1]
-    /// </summary>
-    override public void CopyFrom(SparseRationalArray_HashtableWithBuckets original, int len)
-    {
-      foreach (var index_pair in original.GetElements())
-      {
-        if (index_pair.Key < len)
+        static public SparseRationalArray New(int length, Int32 defaultElement)
         {
-          this[index_pair.Key] = index_pair.Value;
+            Contract.Requires(length >= 0);
+
+            return New(length, Rational.For(defaultElement));
         }
-      }
-    }
 
-    // Idea: here we can share the internal representation?
-    override public SparseRationalArray_HashtableWithBuckets DuplicateMe()
-    {
-      return new SparseRationalArray_HashtableWithBuckets(this);
-    }
-
-    [Conditional("DEBUG")]
-    [Conditional("CHECKINVARIANTS")]
-    private void CheckBounds(int i)
-    {
-      CheckInvariant();
-
-      if (i < 0 || i >= length)
-        throw new ArgumentOutOfRangeException();
-    }
-
-    new static internal String Statistics
-    {
-      get
-      {
-#if TRACE_PERFORMANCE
-        StringBuilder result = new StringBuilder();
-        result.AppendFormat("Resize count {0} " + Environment.NewLine, ResizeCount);
-
-        return result.ToString();
-#else
-        return "Performance tracing is off";
-#endif
-      }
-    }
-
-    override public string ToString()
-    {
-      StringBuilder str = new StringBuilder();
-
-      for(int i = 0; i < this.data.Length; i++)
-      {
-        if (this.data[i] != null)
+        /// <summary>
+        /// A fresh sparse array
+        /// </summary>
+        static public SparseRationalArray New(int length, Rational defaultElement)
         {
-          for (int j = 0; j < this.lastElement[i]; i++)
-          {
-            str.AppendFormat("({0},{1})", this.data[i][j].Index, this.data[i][j].Value);
-          }
+            Contract.Requires(length >= 0);
+            Contract.Requires(!object.Equals(defaultElement, null));
+
+            switch (internalRepresentation)
+            {
+                case Representation.Dictionary:
+                    return new SparseRationalArray_Dictionary(length, defaultElement);
+
+                case Representation.HashTable:
+                    return new SparseRationalArray_Hashtable(length, defaultElement);
+
+                case Representation.HashTableWithBuckets:
+                    return new SparseRationalArray_HashtableWithBuckets(length, defaultElement);
+
+                case Representation.SimpleHashTable:
+                    return new SparseRationalArray_SimpleHashtable(length, defaultElement);
+
+                case Representation.List:
+                    return new SparseRationalArray_List(length, defaultElement);
+
+                case Representation.Array:
+                    return new SparseRationalArray_Array(length, defaultElement);
+
+                default:
+                    throw new AbstractInterpretationException("Unknown sparse array representation " + internalRepresentation);
+            }
         }
-      }
 
-      return str.ToString();
-    }
-
-    [Conditional("CHECKINVARIANTS")]
-    private void CheckInvariant()
-    {
-      var indexes = new Set<int>();
-
-      Contract.Assert(Contract.ForAll(this.lastElement, i => i >= 0));
-
-      for(int i = 0; i< this.data.Length; i++)
-      {
-        Contract.Assert(this.data[i] != null || this.lastElement[i] == 0);
-
-        if (this.data[i] != null)
+        public static String Statistics
         {
-          for (int j = 0; j < this.lastElement[i]; j++)
-          {
-            Contract.Assert(this.data[i][j] != null);
-            Contract.Assert(!indexes.Contains(this.data[i][j].Index));
+            get
+            {
+                switch (internalRepresentation)
+                {
+                    case Representation.Dictionary:
+                        return SparseRationalArray_Dictionary.Statistics;
 
-            indexes.Add(this.data[i][j].Index);
-          }
+                    case Representation.HashTable:
+                        return SparseRationalArray_Hashtable.Statistics;
 
-          for (int j = this.lastElement[i]; j < this.data[i].Length; j++)
-          {
-            Contract.Assert(this.data[i][j] == null);
-          }
+                    case Representation.HashTableWithBuckets:
+                        return SparseRationalArray_HashtableWithBuckets.Statistics;
+
+                    case Representation.SimpleHashTable:
+                        return SparseRationalArray_SimpleHashtable.Statistics;
+
+                    case Representation.List:
+                        return SparseRationalArray_List.Statistics;
+
+                    default:
+                        throw new AbstractInterpretationException("Unknown sparse array representation " + internalRepresentation);
+                }
+            }
         }
-      }
-    }
 
-    #region HashTable Manipulation
+        protected int nonDefaultElementsCount = 0;
 
-    static private int Hash(int value)
-    {
-      return value % Capacity;
-    }
-
-    private int Pos(int value)
-    {
-      return value % this.data.Length;
-    }
-
-    static private Entry[][] CloneFrom(Entry[][] entry)
-    {
-      Entry[][] result = new Entry[entry.Length][];
-
-      for (int i = 0; i < entry.Length; i++)
-      {
-        if (entry[i] != null)
+        virtual public int NonDefaultElementsCount
         {
-          result[i] = new Entry[entry[i].Length];
-          Array.Copy(entry[i], result[i], entry[i].Length);
+            get
+            {
+                return this.nonDefaultElementsCount;
+            }
         }
-      }
-      return result;
+
+        abstract public void ExpandBy(int additionalRows);
+        abstract public bool ForEachKey(Predicate<int> pred);
+        abstract public IEnumerable<KeyValuePair<int, Rational>> GetElements();
+        abstract public IEnumerable<int> IndexesOfNonDefaultElements { get; }
+        abstract public bool IsIndexOfNonDefaultElement(int key);
+        abstract public bool IsIndexOfNonDefaultElement(int key, out Rational value);
+        abstract public int Length { get; }
+        abstract public void ResetToDefaultElement(int index);
+        abstract public void ShrinkTo(int index);
+        abstract public int SmallestIndexOfNonDefaultElement { get; }
+        abstract public Rational this[int index] { get; set; }
+        abstract public int Count { get; }
+        abstract public void Swap(int x, int y);
+
+        abstract public void CopyFrom(SparseRationalArray original);
+        abstract public void CopyFrom(SparseRationalArray original, int len);
+        abstract public SparseRationalArray Duplicate();
     }
 
-    private bool TryGetValue(int index, out int indexInTheArray, out int indexInTheBucket, out Rational value)
+    #region Contracts for SparseRationalArray
+
+    [ContractClassFor(typeof(SparseRationalArray))]
+    internal abstract class SparseRationalArrayContracts : SparseRationalArray
     {
-      int start = Pos(Hash(index));
-
-      if (this.data[start] == null)
-      {
-        indexInTheArray = -1;
-        indexInTheBucket = -1;
-        value = default(Rational);
-      
-        return false;
-      }
-
-      for (int i = 0; i < this.lastElement[start]; i++)
-      {
-        var local = this.data[start][i];
-        if (local.Index == index)
+        public override void ExpandBy(int additionalRows)
         {
-          indexInTheArray = start;
-          indexInTheBucket = i;
-          value = local.Value;
+            Contract.Requires(additionalRows >= 0);
 
-          return true;
+            throw new NotImplementedException();
         }
-      }
 
-      value = default(Rational);
-      indexInTheArray = -1;
-      indexInTheBucket = -1;
-    
-      return false;
-    }
-
-    private bool TryGetValue(int index, out Rational value)
-    {
-      int dummy1, dummy2;
-      return this.TryGetValue(index, out dummy1, out dummy2, out value);
-    }
-
-    private bool ContainsKey(int index, out int indexInTheArray, out int indexInTheBucket)
-    {
-      Rational dummy;
-      return this.TryGetValue(index, out indexInTheArray, out indexInTheBucket, out dummy);
-    }
-
-    private void Remove(int index)
-    {
-      int indexInTheArray, indexInTheBucket;
-      Rational dummy;
-
-      if (this.TryGetValue(index, out indexInTheArray, out indexInTheBucket, out dummy))
-      {
-        this.Remove(index, indexInTheArray, indexInTheBucket);
-      }
-    }
-
-    private void Remove(int index, int indexInTheArray, int indexInTheBucket)
-    {
-      CheckInvariant();
-
-      var lastElement = this.lastElement[indexInTheArray];
-      if (indexInTheBucket == 0 && lastElement == 1)
-      {
-        // The last element ...
-        this.data[indexInTheArray] = null;        
-      }
-      else
-      {
-        Swap(ref this.data[indexInTheArray][indexInTheBucket], ref this.data[indexInTheArray][lastElement-1]);
-
-        this.data[indexInTheArray][lastElement-1] = null;
-      }
-
-      this.count--;
-      this.lastElement[indexInTheArray]--;
-
-      CheckInvariant();
-    }
-
-    private void Swap(ref Entry entry1, ref Entry entry2)
-    {
-      Entry tmp = entry1;
-      entry1 = entry2;
-      entry2 = tmp;
-    }
-
-    private void Set(int index, Rational value)
-    {
-      int indexInTheArray, indexInTheBucket;
-      if (this.ContainsKey(index, out indexInTheArray, out indexInTheBucket))
-      {
-        this.data[indexInTheArray][indexInTheBucket] = new Entry(index, value);
-      }
-      else
-      {
-        indexInTheArray = Pos(Hash(index));
-
-        var local = this.data[indexInTheArray];
-
-        if (local == null)
+        public override bool ForEachKey(Predicate<int> pred)
         {
-          this.data[indexInTheArray] = new Entry[BucketSize];
+            Contract.Requires(pred != null);
+
+            throw new NotImplementedException();
         }
-        else if (this.lastElement[indexInTheArray] == local.Length)
+
+        public override IEnumerable<KeyValuePair<int, Rational>> GetElements()
         {
-#if TRACE_PERFORMANCE
-          ResizeCount++;
-#endif
-          if (local.Length > 1)
-          {
-            Console.WriteLine("Resize from {0} to {1}", local.Length, local.Length * 2 + 1);
-          }
+            Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<int, Rational>>>() != null);
 
-          Array.Resize(ref this.data[indexInTheArray], this.data[indexInTheArray].Length * 2 +1);
+            throw new NotImplementedException();
         }
 
-        this.data[indexInTheArray][this.lastElement[indexInTheArray]] = new Entry(index, value);
+        public override IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<int>>() != null);
 
-        this.lastElement[indexInTheArray]++;
-      }
+                throw new NotImplementedException();
+            }
+        }
 
-      this.count++;
+        public override bool IsIndexOfNonDefaultElement(int key)
+        {
+            Contract.Requires(key >= 0);
+
+            throw new NotImplementedException();
+        }
+
+        public override bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            Contract.Requires(key >= 0);
+            Contract.Ensures(!Contract.Result<bool>() || !object.Equals(Contract.ValueAtReturn(out value), null));
+
+            throw new NotImplementedException();
+        }
+
+        public override int Length
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override void ResetToDefaultElement(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void ShrinkTo(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SmallestIndexOfNonDefaultElement
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override Rational this[int index]
+        {
+            get
+            {
+                Contract.Ensures(!object.Equals(Contract.Result<Rational>(), null));
+
+                return default(Rational);
+            }
+            set
+            {
+                Contract.Requires(!object.Equals(value, null));
+            }
+        }
+
+        public override int Count
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override void Swap(int x, int y)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void CopyFrom(SparseRationalArray original)
+        {
+            Contract.Requires(original != null);
+
+            throw new NotImplementedException();
+        }
+
+        public override void CopyFrom(SparseRationalArray original, int len)
+        {
+            Contract.Requires(original != null);
+            Contract.Requires(len >= 0);
+
+            throw new NotImplementedException();
+        }
+
+        public override SparseRationalArray Duplicate()
+        {
+            Contract.Ensures(Contract.Result<SparseRationalArray>() != null);
+
+            throw new NotImplementedException();
+        }
+    }
+    #endregion
+
+    [ContractVerification(true)]
+    [ContractClass(typeof(SparseRationalArrayContracts<>))]
+    abstract public class SparseRationalArray<T>
+      : SparseRationalArray
+      where T : SparseRationalArray
+    {
+        abstract public void CopyFrom(T original);
+        abstract public void CopyFrom(T original, int len);
+        abstract public T DuplicateMe();
+
+        override public void CopyFrom(SparseRationalArray original)
+        {
+            this.CopyFrom((T)original);
+        }
+
+        override public void CopyFrom(SparseRationalArray original, int len)
+        {
+            this.CopyFrom((T)original, len);
+        }
+
+        override public SparseRationalArray Duplicate()
+        {
+            return this.DuplicateMe();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var right = obj as SparseRationalArray<T>;
+
+            if (right == null)
+                return false;
+
+            if (this.Count != right.Count)
+                return false;
+
+            foreach (var pair in this.GetElements())
+            {
+                Contract.Assume(!object.Equals(pair.Value, null));
+
+                if (right[pair.Key] != pair.Value)
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Count + this.Length;
+        }
     }
 
+    #region Contracts for  SparseRationalArray<T>
 
-
-    private IEnumerable<int> GetKeys()
+    [ContractClassFor(typeof(SparseRationalArray<>))]
+    internal abstract class SparseRationalArrayContracts<T> : SparseRationalArray<T>
+      where T : SparseRationalArray
     {
-      int nondef = 0;
-
-      for (int i = 0; nondef < count && i < this.data.Length; i++)
-      {
-        if (this.data[i] != null)
+        public override void CopyFrom(T original)
         {
-          for (int j = 0; j < this.lastElement[i]; j++)
-          {
-            nondef++;
-            yield return this.data[i][j].Index;
-          }
+            Contract.Requires(original != null);
+
+            throw new NotImplementedException();
         }
-      }
+
+        public override void CopyFrom(T original, int len)
+        {
+            Contract.Requires(original != null);
+
+            throw new NotImplementedException();
+        }
+
+        public override T DuplicateMe()
+        {
+            Contract.Ensures(Contract.Result<T>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public override void ExpandBy(int additionalRows)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool ForEachKey(Predicate<int> pred)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IEnumerable<KeyValuePair<int, Rational>> GetElements()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override bool IsIndexOfNonDefaultElement(int key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Length
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override void ResetToDefaultElement(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void ShrinkTo(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SmallestIndexOfNonDefaultElement
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override Rational this[int index]
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override int Count
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override void Swap(int x, int y)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     #endregion
 
-    class Entry
+    [ContractVerification(false)]
+    internal sealed class SparseRationalArray_SimpleHashtable
+    : SparseRationalArray<SparseRationalArray_SimpleHashtable>
     {
-      int index;
-      Rational value;
+        #region Performance counters
+#if TRACE_PERFORMANCE
+        [ThreadStatic]
+        static private int MaxLength;
+        [ThreadStatic]
+        static private double MaxNonDefaultElements;
+#endif
+        #endregion
 
-      public int Index
-      {
-        get
+        #region Private state
+
+        private int length;                                   // The length of the array
+        private SimpleHashtable<int, Rational> data;          // The data in the array
+
+        readonly private Rational defaultElement;             // The default element
+
+        #endregion
+
+        #region Constructor
+        public SparseRationalArray_SimpleHashtable(int length, Rational defaultElement)
         {
-          return this.index;
-        }
-      }
+            Contract.Requires(length >= 0);
 
-      public Rational Value
-      {
-        get
+            UpdateMaxLength(length);
+
+            this.length = length;
+            data = new SimpleHashtable<int, Rational>();
+            this.defaultElement = defaultElement;
+        }
+
+        private SparseRationalArray_SimpleHashtable(SparseRationalArray_SimpleHashtable original)
         {
-          return this.value;
+            length = original.length;
+            data = new SimpleHashtable<int, Rational>(original.data);    // TODO: share it
+            defaultElement = original.defaultElement;
         }
-      }
 
-      public Entry(int index, Rational value)
-      {
-        this.index = index;
-        this.value = value;
-      }
+        #endregion
 
-      public override string ToString()
-      {
-        return string.Format("({0}, {1})", this.index, this.value);
-      }
+        override public Rational this[int index]
+        {
+            get
+            {
+                CheckBounds(index);
+
+                Rational value;
+                if (data.TryGetValue(index, out value))
+                    return value;
+                else
+                    return defaultElement;
+            }
+            set
+            {
+                CheckBounds(index);
+
+                // We do not store the default element explicitly
+                if (value == defaultElement)
+                {
+                    if (data.ContainsKey(index))
+                    {
+                        data.Remove(index);
+                        this.nonDefaultElementsCount--;
+                    }
+                }
+                else
+                {
+                    data[index] = value;
+                    this.nonDefaultElementsCount++;
+
+                    UpdateMaxNonDefaultElements();
+                }
+            }
+        }
+
+        [Conditional("TRACE_PERFORMANCE")]
+        private static void UpdateMaxNonDefaultElements()
+        {
+#if TRACE_PERFORMANCE
+            MaxNonDefaultElements = Math.Max(MaxNonDefaultElements, data.Count);
+#endif
+        }
+
+        [Conditional("TRACE_PERFORMANCE")]
+        private static void UpdateMaxLength(int length)
+        {
+#if TRACE_PERFORMANCE
+            MaxLength = Math.Max(length, MaxLength);
+#endif
+        }
+
+        override public int Length
+        {
+            get
+            {
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The number of non "default" elements in the sparse array
+        /// </summary>
+        override public int Count
+        {
+            get
+            {
+                return data.Count;
+            }
+        }
+
+        override public void ExpandBy(int additionalRows)
+        {
+            //Contract.Requires(additionalRows >= 0);
+
+            length += additionalRows;
+        }
+
+        override public void ShrinkTo(int index)
+        {
+            //Contract.Requires(index >= 0);
+            //Contract.Requires(index <= this.Length);
+
+            if (index == this.Length)
+                return;
+
+            for (int i = index; i < length; i++)
+            {
+                data.Remove(i);
+            }
+
+            length = index;
+        }
+
+        override public void ResetToDefaultElement(int index)
+        {
+            data.Remove(index);
+        }
+
+
+        override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
+        {
+            return data.Elements;
+        }
+
+        override public IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get
+            {
+                return data.Keys;
+            }
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key)
+        {
+            return data.ContainsKey(key);
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            if (data.TryGetValue(key, out value))
+            {
+                return true;
+            }
+            else
+            {
+                value = defaultElement;
+                return false;
+            }
+        }
+
+        override public bool ForEachKey(Predicate<int> pred)
+        {
+            foreach (int key in data.Keys)
+            {
+                if (!pred(key))
+                    return false;
+            }
+
+            return true;
+        }
+
+        override public int SmallestIndexOfNonDefaultElement
+        {
+            get
+            {
+                int min = Int32.MaxValue;
+
+                foreach (int key in data.Keys)
+                {
+                    if (key < min)
+                        min = key;
+                }
+
+                return min == Int32.MaxValue ? -1 : min;
+            }
+        }
+
+        override public void CopyFrom(SparseRationalArray_SimpleHashtable original)
+        {
+            foreach (var pair in original.data.Elements)
+            {
+                this[pair.Key] = pair.Value;
+            }
+        }
+
+        override public void Swap(int x, int y)
+        {
+            Rational xval, yval;
+            bool xb = data.TryGetValue(x, out xval);
+            bool yb = data.TryGetValue(y, out yval);
+
+            Debug.Assert(xb ? xval != defaultElement : true);
+            Debug.Assert(yb ? yval != defaultElement : true);
+
+            if (xb)
+            {
+                if (yb)
+                { // we can swap x with y
+                    data[x] = yval;
+                    data[y] = xval;
+                }
+                else
+                { // y has a default value
+                    this.ResetToDefaultElement(x);
+                    data[y] = xval;
+                }
+            }
+            else if (yb)
+            { // x has the default value
+                data[x] = yval;
+                this.ResetToDefaultElement(y);
+            }
+            else
+            { // both have the default value
+            }
+        }
+
+        /// <summary>
+        /// Copies just the elements of index [0, ... len-1]
+        /// </summary>
+        override public void CopyFrom(SparseRationalArray_SimpleHashtable original, int len)
+        {
+            foreach (var index_pair in original.data.Elements)
+            {
+                if (index_pair.Key < len)
+                {
+                    this[index_pair.Key] = index_pair.Value;
+                }
+            }
+        }
+
+        // Idea: here we can share the internal representation?
+        override public SparseRationalArray_SimpleHashtable DuplicateMe()
+        {
+            return new SparseRationalArray_SimpleHashtable(this);
+        }
+
+        public object/*!*/ Clone()
+        {
+            return this.Duplicate();
+        }
+
+        new static internal String Statistics
+        {
+            get
+            {
+#if TRACE_PERFORMANCE
+                string s1 = string.Format("Max length of a sparse array : {0}", MaxLength);
+                string s2 = string.Format("Max # of non-default elements: {0}", MaxNonDefaultElements);
+
+                return s1 + Environment.NewLine + s2;
+#else
+                return "Performance tracing is off";
+#endif
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void CheckBounds(int i)
+        {
+            if (i < 0 || i >= length)
+            {
+                System.Diagnostics.Debugger.Break();
+                // throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public override string ToString()
+        {
+            StringBuilder str = new StringBuilder();
+
+            foreach (var pair in data.Elements)
+            {
+                str.AppendFormat("({0},{1})", pair.Key, pair.Value);
+            }
+
+            return str.ToString();
+        }
     }
-  }
 
-  [ContractVerification(false)]
-  sealed class SparseRationalArray_Array
-    : SparseRationalArray<SparseRationalArray_Array>
-  {
-    #region Performance counters
+    [ContractVerification(false)]
+    internal sealed class SparseRationalArray_Dictionary
+      : SparseRationalArray<SparseRationalArray_Dictionary>
+    {
+        #region Performance counters
 
 #if TRACE_PERFORMACE
-    [ThreadStatic]
-    static private int MaxLength;
-    [ThreadStatic]
-    static private double MaxNonDefaultElements;
+        [ThreadStatic]
+        static private int MaxLength;
+        [ThreadStatic]
+        static private double MaxNonDefaultElements;
 #endif
 
-    #endregion
+        #endregion
 
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.length >= 0);
-      Contract.Invariant(this.map != null);
-      Contract.Invariant(!object.Equals(defaultElement, null));
-      Contract.Invariant(this.length == this.map.Length);
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(length >= 0);
+            Contract.Invariant(data != null);
+            Contract.Invariant(map != null);
+            Contract.Invariant(!object.Equals(defaultElement, null));
+            Contract.Invariant(length == map.Length);
 #if CHECKINVARIANTS
-      Contract.Invariant(Contract.ForAll(0, this.map.Length, i => this.map[i] == this.data.ContainsKey(i)));
+            Contract.Invariant(Contract.ForAll(0, map.Length, i => map[i] == data.ContainsKey(i)));
 #endif
-    }
-
-    #region Private state
-
-    private int length;                                   // The length of the array
-    private Tuple<int, Rational>[] data;               // The data in the array
-    private BitArray map;
-
-    readonly private Rational defaultElement;             // The default element
-
-    #endregion
-
-    #region Constructor
-    public SparseRationalArray_Array(int length, Rational defaultElement)
-    {
-      Contract.Requires(length >= 0);
-      Contract.Requires(!object.Equals(defaultElement, null));
-
-      UpdateMaxLength(length);
-
-      this.length = length;
-      this.data = null;
-      this.map = new BitArray(length);
-      this.defaultElement = defaultElement;
-    }
-
-    private SparseRationalArray_Array(SparseRationalArray_Array original)
-    {
-      Contract.Requires(original != null);
-
-      Contract.Assume(original.length >= 0);
-      Contract.Assume(!object.Equals(original.defaultElement, null));
-
-      this.length = original.length;
-      this.data = original.data.Duplicate();
-      this.map = new BitArray(original.map);
-      this.defaultElement = original.defaultElement;
-    }
-
-    #endregion
-
-    public override int NonDefaultElementsCount
-    {
-      get
-      {
-        return this.data.CountNotNull();
-      }
-    }
-
-    override public Rational this[int index]
-    {
-      get
-      {
-        CheckBounds(index);
-
-        Rational value;
-        if (this.map[index] && this.data.TryGetValue(index, out value))
-        {
-          Contract.Assume(!object.Equals(value, null));
-          return value;
         }
-        else
+
+        #region Private state
+
+        private int length;                                   // The length of the array
+        private Dictionary<int, Rational> data;               // The data in the array
+        private BitArray map;
+
+        readonly private Rational defaultElement;             // The default element
+
+        #endregion
+
+        #region Constructor
+        public SparseRationalArray_Dictionary(int length, Rational defaultElement)
         {
-          return defaultElement;
-        }
-      }
-      set
-      {
-        CheckBounds(index);
+            Contract.Requires(length >= 0);
+            Contract.Requires(!object.Equals(defaultElement, null));
 
-        // We do not store the default element explicitly
-        if (value == defaultElement)
+            UpdateMaxLength(length);
+
+            this.length = length;
+            data = new Dictionary<int, Rational>(3);
+            map = new BitArray(length);
+            this.defaultElement = defaultElement;
+        }
+
+        private SparseRationalArray_Dictionary(SparseRationalArray_Dictionary original)
         {
-          if (this.data.ContainsKey(index))
-          {
-            this.map[index] = false;
-            this.data.Remove(index);
-          }
+            Contract.Requires(original != null);
+
+            Contract.Assume(original.length >= 0);
+            Contract.Assume(!object.Equals(original.defaultElement, null));
+
+            length = original.length;
+            data = new Dictionary<int, Rational>(original.data);    // TODO: share it
+            map = new BitArray(original.map);
+            defaultElement = original.defaultElement;
         }
-        else
+
+        #endregion
+
+        public override int NonDefaultElementsCount
         {
-          this.map[index] = true;
-          //this.data[index] = value;
-
-          this.data = this.data.Add(index, value);
-
-          UpdateMaxNonDefaultElements();
+            get
+            {
+                return data.Count;
+            }
         }
-      }
-    }
 
-    [Conditional("TRACE_PERFORMANCE")]
-    private void UpdateMaxNonDefaultElements()
-    {
+        override public Rational this[int index]
+        {
+            get
+            {
+                CheckBounds(index);
+
+                Rational value;
+                if (map[index] && data.TryGetValue(index, out value))
+                {
+                    Contract.Assume(!object.Equals(value, null));
+                    return value;
+                }
+                else
+                {
+                    return defaultElement;
+                }
+            }
+            set
+            {
+                CheckBounds(index);
+
+                // We do not store the default element explicitly
+                if (value == defaultElement)
+                {
+                    if (data.ContainsKey(index))
+                    {
+                        map[index] = false;
+                        data.Remove(index);
+                    }
+                }
+                else
+                {
+                    map[index] = true;
+                    data[index] = value;
+
+                    UpdateMaxNonDefaultElements();
+                }
+            }
+        }
+
+        [Conditional("TRACE_PERFORMANCE")]
+        private void UpdateMaxNonDefaultElements()
+        {
 #if TRACE_PERFORMANCE
-      MaxNonDefaultElements = Math.Max(MaxNonDefaultElements, this.data.Count);
+            MaxNonDefaultElements = Math.Max(MaxNonDefaultElements, data.Count);
 #endif
-    }
+        }
 
-    [Conditional("TRACE_PERFORMANCE")]
-    private static void UpdateMaxLength(int length)
-    {
+        [Conditional("TRACE_PERFORMANCE")]
+        private static void UpdateMaxLength(int length)
+        {
 #if TRACE_PERFORMANCE
-      MaxLength = Math.Max(length, MaxLength);
+            MaxLength = Math.Max(length, MaxLength);
 #endif
-    }
+        }
 
-    override public int Length
-    {
-      get
-      {
-        return this.length;
-      }
-    }
-
-    /// <summary>
-    /// The number of non "default" elements in the sparse array
-    /// </summary>
-    override public int Count
-    {
-      get
-      {
-        return this.data.CountNotNull();
-      }
-    }
-
-    override public void ExpandBy(int additionalRows)
-    {
-      this.length += additionalRows;
-
-      this.map.Length = this.length;
-    }
-
-    override public void ShrinkTo(int index)
-    {
-      if (index == this.Length || index < 0)
-      {
-        return;
-      }
-
-      for (int i = index; i < this.length; i++)
-      {
-        this.data.Remove(i);
-      }
-
-      this.length = index;
-
-      this.map.Length = this.length;
-    }
-
-    override public void ResetToDefaultElement(int index)
-    {
-      this.map[index] = false;
-      this.data.Remove(index);
-    }
-
-    /// <summary>
-    /// A method used to iterate on the non-default elements of the sparse array
-    /// </summary>
-    /// <returns></returns>
-    override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-      if (this.data == null)
-        yield break;
-
-      foreach (var x in this.data)
-      {
-        if (x != null)
-          yield return new KeyValuePair<int, Rational>(x.Item1, x.Item2);
-      }
-    }
-
-    override public IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get
-      {
-        if (this.data == null)
-          yield break;
-
-        foreach (var x in this.data)
+        override public int Length
         {
-          if (x != null)
-            yield return x.Item1;
+            get
+            {
+                return length;
+            }
         }
-      }
-    }
 
-    override public bool IsIndexOfNonDefaultElement(int key)
-    {
-      return this.map[key];
-    }
-
-    override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      if (this.map[key] && this.data.TryGetValue(key, out value))
-      {
-        Contract.Assume(!object.Equals(value, null));
-
-        return true;
-      }
-      else
-      {
-        value = this.defaultElement;
-
-        return false;
-      }
-    }
-
-    override public bool ForEachKey(Predicate<int> pred)
-    {
-      foreach (var key in this.IndexesOfNonDefaultElements)
-      {
-        if (!pred(key))
-          return false;
-      }
-
-      return true;
-    }
-
-    override public int SmallestIndexOfNonDefaultElement
-    {
-      get
-      {
-        for (var i = 0; i < this.map.Length; i++)
+        /// <summary>
+        /// The number of non "default" elements in the sparse array
+        /// </summary>
+        override public int Count
         {
-          if (this.map[i])
-            return i;
+            get
+            {
+                return data.Count;
+            }
         }
 
-        return -1;
-      }
-    }
-
-    override public void CopyFrom(SparseRationalArray_Array original)
-    {
-      if (original.data == null)
-      {
-        this.data = null;
-        return;
-      }
-      foreach (var pair in original.data)
-      {
-        if (pair != null)
+        override public void ExpandBy(int additionalRows)
         {
-          this[pair.Item1] = pair.Item2;
+            length += additionalRows;
+
+            map.Length = length;
         }
-      }
-    }
 
-    override public void Swap(int x, int y)
-    {
-      if (x == y)
-        return;
-
-      Rational xval, yval;
-      xval = yval = defaultElement;
-      var xb = this.map[x] && this.data.TryGetValue(x, out xval);
-      var yb = this.map[y] && this.data.TryGetValue(y, out yval);
-
-      // F: Proving the assertions will require some more complex quantified invariant
-      Contract.Assume(xb ? (!object.Equals(xval, null) && xval != defaultElement) : true);
-      Contract.Assume(yb ? (!object.Equals(yval, null) && yval != defaultElement) : true);
-
-      if (xb)
-      {
-        if (yb)
-        { // we can swap x with y
-          this[x] = yval;
-          this[y] = xval;
-
-          this.map[x] = this.map[y] = true; // F: needless, but makes the code clearer
-        }
-        else
-        { // y has a default value
-          this.ResetToDefaultElement(x);
-          this[y] = xval;
-
-          this.map[y] = true;
-        }
-      }
-      else if (yb)
-      { // x has the default value
-        this[x] = yval;
-        this.ResetToDefaultElement(y);
-
-        this.map[x] = true;
-      }
-      else
-      { // both have the default value
-
-      }
-    }
-
-    /// <summary>
-    /// Copies just the elements of index [0, ... len-1]
-    /// </summary>
-    override public void CopyFrom(SparseRationalArray_Array original, int len)
-    {
-      if (original.data == null)
-      {
-        this.data = null;
-        return;
-      }
-      foreach (var pair in original.data)
-      {
-        if (pair != null)
+        override public void ShrinkTo(int index)
         {
-          if (pair.Item1 < len)
-          {
-            this[pair.Item1] = pair.Item2;
-          }
+            if (index == this.Length || index < 0)
+            {
+                return;
+            }
+
+            for (int i = index; i < length; i++)
+            {
+                data.Remove(i);
+            }
+
+            length = index;
+
+            map.Length = length;
         }
-      }
-    }
 
-    // Idea: here we can share the internal representation?
-    override public SparseRationalArray_Array DuplicateMe()
-    {
-      return new SparseRationalArray_Array(this);
-    }
+        override public void ResetToDefaultElement(int index)
+        {
+            map[index] = false;
+            data.Remove(index);
+        }
 
-    public object Clone()
-    {
-      return this.Duplicate();
-    }
+        /// <summary>
+        /// A method used to iterate on the non-default elements of the sparse array
+        /// </summary>
+        /// <returns></returns>
+        override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
+        {
+            return data as IEnumerable<KeyValuePair<int, Rational>>;
+        }
 
-    new static internal String Statistics
-    {
-      get
-      {
+        override public IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get
+            {
+                return data.Keys;
+            }
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key)
+        {
+            return map[key];
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            if (map[key] && data.TryGetValue(key, out value))
+            {
+                Contract.Assume(!object.Equals(value, null));
+
+                return true;
+            }
+            else
+            {
+                value = defaultElement;
+
+                return false;
+            }
+        }
+
+        override public bool ForEachKey(Predicate<int> pred)
+        {
+            foreach (int key in data.Keys)
+            {
+                if (!pred(key))
+                    return false;
+            }
+
+            return true;
+        }
+
+        override public int SmallestIndexOfNonDefaultElement
+        {
+            get
+            {
+                for (var i = 0; i < map.Length; i++)
+                {
+                    if (map[i])
+                        return i;
+                }
+
+                return -1;
+            }
+        }
+
+        override public void CopyFrom(SparseRationalArray_Dictionary original)
+        {
+            Contract.Assume(original.data != null);
+            foreach (var pair in original.data)
+            {
+                Contract.Assume(!object.Equals(pair.Value, null));
+                this[pair.Key] = pair.Value;
+            }
+        }
+
+        override public void Swap(int x, int y)
+        {
+            if (x == y)
+                return;
+
+            Rational xval, yval;
+            xval = yval = defaultElement;
+            var xb = map[x] && data.TryGetValue(x, out xval);
+            var yb = map[y] && data.TryGetValue(y, out yval);
+
+            // F: Proving the assertions will require some more complex quantified invariant
+            Contract.Assume(xb ? (!object.Equals(xval, null) && xval != defaultElement) : true);
+            Contract.Assume(yb ? (!object.Equals(yval, null) && yval != defaultElement) : true);
+
+            if (xb)
+            {
+                if (yb)
+                { // we can swap x with y
+                    data[x] = yval;
+                    data[y] = xval;
+
+                    map[x] = map[y] = true; // F: needless, but makes the code clearer
+                }
+                else
+                { // y has a default value
+                    this.ResetToDefaultElement(x);
+                    data[y] = xval;
+
+                    map[y] = true;
+                }
+            }
+            else if (yb)
+            { // x has the default value
+                data[x] = yval;
+                this.ResetToDefaultElement(y);
+
+                map[x] = true;
+            }
+            else
+            { // both have the default value
+            }
+        }
+
+        /// <summary>
+        /// Copies just the elements of index [0, ... len-1]
+        /// </summary>
+        override public void CopyFrom(SparseRationalArray_Dictionary original, int len)
+        {
+            Contract.Assume(original.data != null);
+            foreach (var pair in original.data)
+            {
+                Contract.Assume(!object.Equals(pair.Value, null));
+                if (pair.Key < len)
+                {
+                    this[pair.Key] = pair.Value;
+                }
+            }
+        }
+
+        // Idea: here we can share the internal representation?
+        override public SparseRationalArray_Dictionary DuplicateMe()
+        {
+            return new SparseRationalArray_Dictionary(this);
+        }
+
+        public object Clone()
+        {
+            return this.Duplicate();
+        }
+
+        new static internal String Statistics
+        {
+            get
+            {
 #if TRACE_PERFORMANCE
-        var s1 = string.Format("Max length of a sparse array : {0}", MaxLength);
-        var s2 = string.Format("Max # of non-default elements: {0}", MaxNonDefaultElements);
+                var s1 = string.Format("Max length of a sparse array : {0}", MaxLength);
+                var s2 = string.Format("Max # of non-default elements: {0}", MaxNonDefaultElements);
 
-        return s1 + Environment.NewLine + s2;
+                return s1 + Environment.NewLine + s2;
 #else
-        return "Performance tracing is off";
+                return "Performance tracing is off";
 #endif
-      }
-    }
-
-    [Conditional("DEBUG")]
-    private void CheckBounds(int i)
-    {
-      if (i < 0 || i >= length)
-      {
-        System.Diagnostics.Debugger.Break();
-        // throw new ArgumentOutOfRangeException();
-      }
-    }
-
-    public override string ToString()
-    {
-      if (this.data == null)
-        return "empty sparse array";
-
-      var str = new StringBuilder();
-
-      foreach (var pair in this.data)
-      {
-        if(pair != null)
-          str.AppendFormat("({0},{1})", pair.Item1, pair.Item2);
-      }
-
-      return str.ToString();
-    }
-  }
-
-  // Still some bug, it does not seem it gives performance gains
-  sealed class SparseRationalArray_List
-    : SparseRationalArray<SparseRationalArray_List>
-  {
-    private int length;                                   // The length of the array
-    private List<Pair<int, Rational>> data;          // The data in the array
-
-    readonly private Rational defaultElement;             // The default element
-
-    public SparseRationalArray_List(int length, Rational defaultElement)
-    {
-      this.length = length;
-      this.data = new List<Pair<int, Rational>>();
-      this.defaultElement = defaultElement;
-    }
-
-    private SparseRationalArray_List(SparseRationalArray_List other)
-    {
-      this.length = other.length;
-      this.data = new List<Pair<int, Rational>>(other.data);
-      this.defaultElement = other.defaultElement;
-      this.nonDefaultElementsCount = other.nonDefaultElementsCount;
-    }
-
-    private void Set(Pair<int, Rational> value)
-    {
-      for (var i = 0; i < this.data.Count; i++)
-      {
-        if (data[i].One == value.One)
-        {
-          if (value.Two == defaultElement)          
-          {
-            data.RemoveAt(i);
-            nonDefaultElementsCount--;
-          }
-          else
-          {
-            data[i] = value;
-            nonDefaultElementsCount++;
-            return;
-          }
-        }
-      }
-
-      if (value.Two != defaultElement)
-      {
-        this.data.Add(value);
-        nonDefaultElementsCount++;
-      }
-    }
-
-    public override void CopyFrom(SparseRationalArray_List original)
-    {
-      foreach (var pair in original.data)
-      {
-        this.Set(pair);
-      }
-    }
-
-    public override void CopyFrom(SparseRationalArray_List original, int len)
-    {
-      foreach (var pair in original.data)
-      {
-        if (pair.One < len)
-        {
-          this.Set(pair);
-        }
-      }
-    }
-
-    public override SparseRationalArray_List DuplicateMe()
-    {
-      return new SparseRationalArray_List(this);
-    }
-
-    public override void ExpandBy(int additionalRows)
-    {
-      this.length += additionalRows;
-    }
-
-    public override bool ForEachKey(Predicate<int> pred)
-    {
-      foreach (var pair in this.data)
-      {
-        if (!pred(pair.One))
-          return false;
-      }
-
-      return true;
-    }
-
-    public override IEnumerable<KeyValuePair<int, Rational>> GetElements()
-    {
-      foreach(var pair in this.data)
-      {
-        yield return new KeyValuePair<int, Rational>(pair.One, pair.Two);
-      }
-    }
-
-    public override IEnumerable<int> IndexesOfNonDefaultElements
-    {
-      get 
-      {
-        foreach (var x in this.data)
-          yield return x.One;
-      }
-    }
-
-    public override bool IsIndexOfNonDefaultElement(int key)
-    {
-      foreach (var pair in this.data)
-      {
-        if (pair.One == key)
-          return true;
-      }
-
-      return false;
-    }
-
-    public override bool IsIndexOfNonDefaultElement(int key, out Rational value)
-    {
-      foreach (var pair in this.data)
-      {
-        if (pair.One == key)
-        {
-          value = pair.Two;
-          return true;
-        }
-      }
-
-      value = defaultElement;
-      return false;
-    }
-
-    public override int Length
-    {
-      get { return this.length; }
-    }
-
-    public override void ResetToDefaultElement(int index)
-    {
-      for (var i = 0; i < this.data.Count; i++)
-      {
-        if (data[i].One == index)
-        {
-          this.data.RemoveAt(i);
-          this.nonDefaultElementsCount--;
-
-          return;
-        }
-      }
-    }
-
-    public override void ShrinkTo(int index)
-    {
-      //Contract.Requires(index >= 0);
-      //Contract.Requires(index <= this.Length);
-
-      if (index == this.Length)
-      {
-        return;
-      }
-
-      for(var i = 0; i < this.data.Count; i++)
-      {
-        if(this.data[i].One >= index)
-        {
-          this.data.RemoveAt(i);
-          i--;
-        }
-      }
-
-      this.length = index;
-    }
-
-    public override int SmallestIndexOfNonDefaultElement
-    {
-      get 
-      {
-        var min = Int32.MaxValue;
-
-        foreach (var pair in this.data)
-        {
-          if (pair.One < min)
-            min = pair.One;
-        }
-
-        return min == Int32.MaxValue ? -1 : min;
-      }
-    }
-
-    public override Rational this[int index]
-    {
-      get
-      {
-        foreach (var pair in this.data)
-        {
-          if (pair.One == index)
-            return pair.Two;
-        }
-
-        return defaultElement;
-      }
-      set
-      {
-        Set(new Pair<int, Rational>(index, value));
-      }
-    }
-
-    public override int Count
-    {
-      get { return this.data.Count; }
-    }
-
-    public override void Swap(int x, int y)
-    {
-      int xPos = -1, yPos = -1, count = 0;
-
-      for (var i = 0; count < 2 && i < this.data.Count; i++)
-      {
-        var element = this.data[i];
-        if (element.One == x)
-        {
-          xPos = i;
-          count++;
-        }
-        else if (element.One == y)
-        {
-          yPos = i;
-          count++;
-        }
-      }
-
-      switch (count)
-      {
-        case 0:
-          return;
-
-        case 1:
-          {
-            if (xPos == -1)
-            {
-              this.data[yPos] = new Pair<int, Rational>(x, this.data[yPos].Two);
             }
-            if (yPos == -1)
+        }
+
+        [Conditional("DEBUG")]
+        private void CheckBounds(int i)
+        {
+            if (i < 0 || i >= length)
             {
-              this.data[xPos] = new Pair<int, Rational>(y, this.data[xPos].Two);
+                System.Diagnostics.Debugger.Break();
+                // throw new ArgumentOutOfRangeException();
             }
-          }
-          break;
+        }
 
-        case 2:
-          {
-            var tmp = this.data[xPos];
-            this.data[xPos] = this.data[yPos];
-            this.data[yPos] = tmp;
-          }
-          break;
+        public override string ToString()
+        {
+            var str = new StringBuilder();
 
-        default:
-          break;
-      }
+            foreach (var pair in data)
+            {
+                str.AppendFormat("({0},{1})", pair.Key, pair.Value);
+            }
+
+            return str.ToString();
+        }
     }
 
-    new static internal string Statistics
+    /// <summary>
+    /// A sparse array implementation using a very stupid Hashtable
+    /// </summary>
+    [ContractVerification(false)]
+    internal sealed class SparseRationalArray_Hashtable
+      : SparseRationalArray<SparseRationalArray_Hashtable>
     {
-      get { return ""; }
+        #region Performance counters
+#if TRACE_PERFORMANCE
+        [ThreadStatic]
+        static private int MaxLength;
+        [ThreadStatic]
+        static private int ResizeCount;
+#endif
+        #endregion
+
+        #region Private state
+
+        private int length;                               // The length of the array
+        private Entry[] data;                             // The data in the array
+        private int count;
+
+        readonly private Rational defaultElement;         // The default element
+
+        private const int Capacity = 7;
+
+        #endregion
+
+        #region Constructor
+        public SparseRationalArray_Hashtable(int length, Rational defaultElement)
+        {
+            Debug.Assert(length >= 0);
+
+#if TRACE_PERFORMANCE
+            MaxLength = Math.Max(length, MaxLength);
+#endif
+
+            this.length = length;
+            data = new Entry[Capacity];
+            count = 0;
+            this.defaultElement = defaultElement;
+        }
+
+        private SparseRationalArray_Hashtable(SparseRationalArray_Hashtable original)
+        {
+            original.CheckInvariant();
+
+            length = original.length;
+            data = CloneFrom(original.data);
+            count = original.count;
+            defaultElement = original.defaultElement;
+        }
+
+        #endregion
+
+        override public Rational this[int index]
+        {
+            get
+            {
+                CheckBounds(index);
+
+                Rational value;
+                if (this.TryGetValue(index, out value))
+                    return value;
+                else
+                    return defaultElement;
+            }
+            set
+            {
+                CheckBounds(index);
+
+                // We do not store the default element explicitly
+                if (value == defaultElement)
+                {
+                    int indexInTheArray;
+                    if (this.ContainsKey(index, out indexInTheArray))
+                    {
+                        this.Remove(index, indexInTheArray);
+                        this.nonDefaultElementsCount--;
+                    }
+                }
+                else
+                {
+                    this.Set(index, value);
+                    this.nonDefaultElementsCount++;
+                }
+
+                CheckInvariant();
+            }
+        }
+
+        override public int Length
+        {
+            get
+            {
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The number of non "default" elements in the sparse array
+        /// </summary>
+        override public int Count
+        {
+            get
+            {
+                return count;
+            }
+        }
+
+        override public void ExpandBy(int additionalRows)
+        {
+            Debug.Assert(additionalRows >= 0);
+
+            CheckInvariant();
+
+            length += additionalRows;
+
+            CheckInvariant();
+        }
+
+        override public void ShrinkTo(int index)
+        {
+            Debug.Assert(index >= 0);
+            Debug.Assert(index <= this.Length);
+
+            CheckInvariant();
+
+            if (index == this.Length)
+                return;
+
+            for (int i = index; i < length; i++)
+            {
+                this.Remove(i);
+            }
+
+            length = index;
+
+            CheckInvariant();
+        }
+
+        override public void ResetToDefaultElement(int index)
+        {
+            CheckInvariant();
+
+            this.Remove(index);
+
+            CheckInvariant();
+        }
+
+        /// <summary>
+        /// A method used to iterate on the non-default elements of the sparse array
+        /// </summary>
+        /// <returns></returns>
+        override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
+        {
+            CheckInvariant();
+
+            int nondef = 0;
+            for (int i = 0; nondef < count && i < data.Length; i++)
+            {
+                if (data[i] != null)
+                {
+                    nondef++;
+                    yield return new KeyValuePair<int, Rational>(data[i].Index, data[i].Value);
+                }
+            }
+        }
+
+        override public IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get
+            {
+                CheckInvariant();
+
+                var nondef = 0;
+
+                for (int i = 0; nondef < count && i < data.Length; i++)
+                {
+                    if (data[i] != null)
+                    {
+                        nondef++;
+                        yield return data[i].Index;
+                    }
+                }
+            }
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key)
+        {
+            Rational dummy;
+
+            return this.TryGetValue(key, out dummy);
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            if (this.TryGetValue(key, out value))
+            {
+                return true;
+            }
+            else
+            {
+                value = defaultElement;
+                return false;
+            }
+        }
+
+        override public bool ForEachKey(Predicate<int> pred)
+        {
+            foreach (int key in this.GetKeys())
+            {
+                if (!pred(key))
+                    return false;
+            }
+
+            return true;
+        }
+
+        override public int SmallestIndexOfNonDefaultElement
+        {
+            get
+            {
+                int min = Int32.MaxValue;
+
+                foreach (int key in this.GetKeys())
+                {
+                    if (key < min)
+                        min = key;
+                }
+
+                return min == Int32.MaxValue ? -1 : min;
+            }
+        }
+
+        override public void CopyFrom(SparseRationalArray_Hashtable original)
+        {
+            foreach (var index_pair in original.data)
+            {
+                if (index_pair != null)
+                {
+                    this[index_pair.Index] = index_pair.Value;
+                }
+            }
+        }
+
+        override public void Swap(int x, int y)
+        {
+            Rational xval, yval;
+            bool xb = this.TryGetValue(x, out xval);
+            bool yb = this.TryGetValue(y, out yval);
+
+            Debug.Assert(xb ? xval != defaultElement : true);
+            Debug.Assert(yb ? yval != defaultElement : true);
+
+            if (xb)
+            {
+                if (yb)
+                { // we can swap x with y
+                    this[x] = yval;
+                    this[y] = xval;
+                }
+                else
+                { // y has a default value
+                    this.ResetToDefaultElement(x);
+                    this[y] = xval;
+                }
+            }
+            else if (yb)
+            { // x has the default value
+                this[x] = yval;
+                this.ResetToDefaultElement(y);
+            }
+            else
+            { // both have the default value
+            }
+        }
+
+        /// <summary>
+        /// Copies just the elements of index [0, ... len-1]
+        /// </summary>
+        override public void CopyFrom(SparseRationalArray_Hashtable original, int len)
+        {
+            foreach (var index_pair in original.data)
+            {
+                if (index_pair != null && index_pair.Index < len)
+                {
+                    this[index_pair.Index] = index_pair.Value;
+                }
+            }
+        }
+
+        // Idea: here we can share the internal representation?
+        override public SparseRationalArray_Hashtable DuplicateMe()
+        {
+            return new SparseRationalArray_Hashtable(this);
+        }
+
+        [Conditional("DEBUG")]
+        [Conditional("CHECKINVARIANTS")]
+        private void CheckBounds(int i)
+        {
+            CheckInvariant();
+
+            if (i < 0 || i >= length)
+                throw new ArgumentOutOfRangeException();
+        }
+
+        new static internal String Statistics
+        {
+            get
+            {
+#if TRACE_PERFORMANCE
+                return string.Format("Number of resizing {0}", ResizeCount);
+#else
+                return "Performance tracing is off";
+#endif
+            }
+        }
+
+        override public string ToString()
+        {
+            StringBuilder str = new StringBuilder();
+
+            foreach (var pair in data)
+            {
+                if (pair != null)
+                {
+                    str.AppendFormat("({0},{1})", pair.Index, pair.Value);
+                }
+            }
+
+            return str.ToString();
+        }
+
+        [Conditional("CHECKINVARIANTS")]
+        private void CheckInvariant()
+        {
+            var indexes = new Set<int>();
+
+            foreach (var pair in data)
+            {
+                if (pair != null)
+                {
+                    Debug.Assert(!indexes.Contains(pair.Index));
+
+                    indexes.Add(pair.Index);
+                }
+            }
+        }
+
+        #region HashTable Manipulation
+
+        static private int Hash(int value)
+        {
+            // return value.GetHashCode();
+            return value;
+        }
+
+        private int Pos(int value)
+        {
+            return value % data.Length;
+        }
+
+        static private Entry[] CloneFrom(Entry[] entry)
+        {
+            Entry[] result = new Entry[entry.Length];
+            Array.Copy(entry, result, entry.Length);
+
+            return result;
+        }
+
+        private bool TryGetValue(int index, out int indexInTheArray, out Rational value)
+        {
+            int start = Pos(Hash(index));
+
+            if (data[start] != null && data[start].Index == index)
+            {
+                value = data[start].Value;
+                indexInTheArray = start;
+                return true;
+            }
+
+            for (int i = Pos(start + 1); i != start; i = Pos(i + 1))
+            {
+                if (data[i] != null && data[i].Index == index)
+                {
+                    value = data[i].Value;
+                    indexInTheArray = i;
+                    return true;
+                }
+            }
+
+            value = default(Rational);
+            indexInTheArray = -1;
+            return false;
+        }
+
+        private bool TryGetValue(int index, out Rational value)
+        {
+            int indexInTheArray;
+            return this.TryGetValue(index, out indexInTheArray, out value);
+        }
+
+        private bool ContainsKey(int index, out int indexInTheArray)
+        {
+            Rational dummy;
+            return this.TryGetValue(index, out indexInTheArray, out dummy);
+        }
+
+        private void Remove(int index)
+        {
+            int indexInTheArray;
+            Rational dummy;
+
+            if (this.TryGetValue(index, out indexInTheArray, out dummy))
+            {
+                this.Remove(index, indexInTheArray);
+            }
+        }
+
+        private void Remove(int index, int indexInTheArray)
+        {
+            data[indexInTheArray] = null;
+        }
+
+        private void Set(int index, Rational value)
+        {
+            if (data.Length == count)
+            {
+                Resize(data.Length * 2 + 1);
+            }
+
+            this.Remove(index);
+
+            Set(data, index, value);
+
+            count++;
+        }
+
+        static private void Set(Entry[] where, int index, Rational value)
+        {
+            int len = where.Length;
+            int start = Hash(index) % len;
+
+            if (where[start] == null || where[start].Index == index)
+            {
+                where[start] = new Entry(index, value);
+                return;
+            }
+
+            for (int i = (start + 1) % len; i != start; i = (i + 1) % len)
+            {
+                if (where[i] == null || where[i].Index == index)
+                {
+                    where[i] = new Entry(index, value);
+                    return;
+                }
+            }
+
+            Debug.Assert(false);  // Should be unreachable
+        }
+
+        private void Resize(int newSize)
+        {
+#if TRACE_PERFORMANCE
+            ResizeCount++;
+#endif
+
+            Entry[] newArray = new Entry[newSize];
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] != null)
+                {
+                    Set(newArray, data[i].Index, data[i].Value);
+                }
+            }
+
+            data = newArray;
+        }
+
+        private IEnumerable<int> GetKeys()
+        {
+            int nondef = 0;
+
+            for (int i = 0; nondef < count && i < data.Length; i++)
+            {
+                if (data[i] != null)
+                {
+                    nondef++;
+                    yield return data[i].Index;
+                }
+            }
+        }
+
+        #endregion
+
+        private class Entry
+        {
+            private int index;
+            private Rational value;
+
+            public int Index
+            {
+                get
+                {
+                    return index;
+                }
+            }
+
+            public Rational Value
+            {
+                get
+                {
+                    return value;
+                }
+            }
+
+            public Entry(int index, Rational value)
+            {
+                this.index = index;
+                this.value = value;
+            }
+
+            public override string ToString()
+            {
+                return string.Format("({0}, {1})", index, value);
+            }
+        }
     }
 
-    public override string ToString()
+    [ContractVerification(false)]
+    internal sealed class SparseRationalArray_HashtableWithBuckets
+      : SparseRationalArray<SparseRationalArray_HashtableWithBuckets>
     {
-      return this.data.ToString();
+        #region Performance counters
+#if TRACE_PERFORMANCE
+        [ThreadStatic]
+        static private int MaxLength;
+        [ThreadStatic]
+        static private int ResizeCount;
+#endif
+        #endregion
+
+        #region Private state
+
+        private int length;                               // The length of the array
+        private Entry[][] data;                           // The data in the array    
+        private int[] lastElement;                        // The last element in a bucket
+
+        private int count;
+
+        readonly private Rational defaultElement;         // The default element
+
+        private const int Capacity = 31;
+        private const int BucketSize = 1;
+
+        #endregion
+
+        #region Constructor
+        public SparseRationalArray_HashtableWithBuckets(int length, Rational defaultElement)
+        {
+            Debug.Assert(length >= 0);
+
+#if TRACE_PERFORMANCE
+            MaxLength = Math.Max(length, MaxLength);
+#endif
+
+            this.length = length;
+
+            data = new Entry[Capacity][];
+            lastElement = new int[Capacity];
+
+            count = 0;
+            this.defaultElement = defaultElement;
+        }
+
+        private SparseRationalArray_HashtableWithBuckets(SparseRationalArray_HashtableWithBuckets original)
+        {
+            original.CheckInvariant();
+
+            length = original.length;
+            data = CloneFrom(original.data);
+
+            lastElement = new int[original.lastElement.Length];
+            Array.Copy(original.lastElement, lastElement, original.lastElement.Length);
+
+            count = original.count;
+            defaultElement = original.defaultElement;
+        }
+
+        #endregion
+
+        override public Rational this[int index]
+        {
+            get
+            {
+                CheckBounds(index);
+
+                Rational value;
+                if (this.TryGetValue(index, out value))
+                    return value;
+                else
+                    return defaultElement;
+            }
+            set
+            {
+                CheckBounds(index);
+
+                // We do not store the default element explicitly
+                if (value == defaultElement)
+                {
+                    int indexInTheArray, indexInTheBucket;
+                    if (this.ContainsKey(index, out indexInTheArray, out indexInTheBucket))
+                    {
+                        this.Remove(index, indexInTheArray, indexInTheBucket);
+                        this.nonDefaultElementsCount--;
+                    }
+                }
+                else
+                {
+                    this.Set(index, value);
+                    this.nonDefaultElementsCount++;
+                }
+
+                CheckInvariant();
+            }
+        }
+
+        override public int Length
+        {
+            get
+            {
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The number of non "default" elements in the sparse array
+        /// </summary>
+        override public int Count
+        {
+            get
+            {
+                return count;
+            }
+        }
+
+        override public void ExpandBy(int additionalRows)
+        {
+            Debug.Assert(additionalRows >= 0);
+
+            CheckInvariant();
+
+            length += additionalRows;
+
+            CheckInvariant();
+        }
+
+        override public void ShrinkTo(int index)
+        {
+            Debug.Assert(index >= 0);
+            Debug.Assert(index <= this.Length);
+
+            CheckInvariant();
+
+            if (index == this.Length)
+                return;
+
+            for (int i = index; i < length; i++)
+            {
+                this.Remove(i);
+            }
+
+            length = index;
+
+            CheckInvariant();
+        }
+
+        override public void ResetToDefaultElement(int index)
+        {
+            CheckInvariant();
+
+            this.Remove(index);
+
+            CheckInvariant();
+        }
+
+        /// <summary>
+        /// A method used to iterate on the non-default elements of the sparse array
+        /// </summary>
+        /// <returns></returns>
+        override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
+        {
+            CheckInvariant();
+
+            var nondef = 0;
+            for (int i = 0; nondef < count && i < data.Length; i++)
+            {
+                if (data[i] != null)
+                {
+                    for (int j = 0; j < lastElement[i]; j++)
+                    {
+                        var local = data[i][j];
+                        nondef++;
+
+                        yield return new KeyValuePair<int, Rational>(local.Index, local.Value);
+                    }
+                }
+            }
+        }
+
+        override public IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get
+            {
+                CheckInvariant();
+
+                var nondef = 0;
+
+                for (int i = 0; nondef < count && i < data.Length; i++)
+                {
+                    if (data[i] != null)
+                    {
+                        for (int j = 0; j < lastElement[i]; j++)
+                        {
+                            nondef++;
+                            yield return data[i][j].Index;
+                        }
+                    }
+                }
+            }
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key)
+        {
+            Rational dummy;
+
+            return this.TryGetValue(key, out dummy);
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            if (this.TryGetValue(key, out value))
+            {
+                return true;
+            }
+            else
+            {
+                value = defaultElement;
+                return false;
+            }
+        }
+
+        override public bool ForEachKey(Predicate<int> pred)
+        {
+            foreach (int key in this.GetKeys())
+            {
+                if (!pred(key))
+                    return false;
+            }
+
+            return true;
+        }
+
+        override public int SmallestIndexOfNonDefaultElement
+        {
+            get
+            {
+                int min = Int32.MaxValue;
+
+                foreach (int key in this.GetKeys())
+                {
+                    if (key < min)
+                        min = key;
+                }
+
+                return min == Int32.MaxValue ? -1 : min;
+            }
+        }
+
+        override public void CopyFrom(SparseRationalArray_HashtableWithBuckets original)
+        {
+            foreach (var index_pair in original.GetElements())
+            {
+                this[index_pair.Key] = index_pair.Value;
+            }
+        }
+
+        override public void Swap(int x, int y)
+        {
+            Rational xval, yval;
+            bool xb = this.TryGetValue(x, out xval);
+            bool yb = this.TryGetValue(y, out yval);
+
+            Debug.Assert(xb ? xval != defaultElement : true);
+            Debug.Assert(yb ? yval != defaultElement : true);
+
+            if (xb)
+            {
+                if (yb)
+                { // we can swap x with y
+                    this[x] = yval;
+                    this[y] = xval;
+                }
+                else
+                { // y has a default value
+                    this.ResetToDefaultElement(x);
+                    this[y] = xval;
+                }
+            }
+            else if (yb)
+            { // x has the default value
+                this[x] = yval;
+                this.ResetToDefaultElement(y);
+            }
+            else
+            { // both have the default value
+            }
+        }
+
+        /// <summary>
+        /// Copies just the elements of index [0, ... len-1]
+        /// </summary>
+        override public void CopyFrom(SparseRationalArray_HashtableWithBuckets original, int len)
+        {
+            foreach (var index_pair in original.GetElements())
+            {
+                if (index_pair.Key < len)
+                {
+                    this[index_pair.Key] = index_pair.Value;
+                }
+            }
+        }
+
+        // Idea: here we can share the internal representation?
+        override public SparseRationalArray_HashtableWithBuckets DuplicateMe()
+        {
+            return new SparseRationalArray_HashtableWithBuckets(this);
+        }
+
+        [Conditional("DEBUG")]
+        [Conditional("CHECKINVARIANTS")]
+        private void CheckBounds(int i)
+        {
+            CheckInvariant();
+
+            if (i < 0 || i >= length)
+                throw new ArgumentOutOfRangeException();
+        }
+
+        new static internal String Statistics
+        {
+            get
+            {
+#if TRACE_PERFORMANCE
+                StringBuilder result = new StringBuilder();
+                result.AppendFormat("Resize count {0} " + Environment.NewLine, ResizeCount);
+
+                return result.ToString();
+#else
+                return "Performance tracing is off";
+#endif
+            }
+        }
+
+        override public string ToString()
+        {
+            StringBuilder str = new StringBuilder();
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] != null)
+                {
+                    for (int j = 0; j < lastElement[i]; i++)
+                    {
+                        str.AppendFormat("({0},{1})", data[i][j].Index, data[i][j].Value);
+                    }
+                }
+            }
+
+            return str.ToString();
+        }
+
+        [Conditional("CHECKINVARIANTS")]
+        private void CheckInvariant()
+        {
+            var indexes = new Set<int>();
+
+            Contract.Assert(Contract.ForAll(lastElement, i => i >= 0));
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                Contract.Assert(data[i] != null || lastElement[i] == 0);
+
+                if (data[i] != null)
+                {
+                    for (int j = 0; j < lastElement[i]; j++)
+                    {
+                        Contract.Assert(data[i][j] != null);
+                        Contract.Assert(!indexes.Contains(data[i][j].Index));
+
+                        indexes.Add(data[i][j].Index);
+                    }
+
+                    for (int j = lastElement[i]; j < data[i].Length; j++)
+                    {
+                        Contract.Assert(data[i][j] == null);
+                    }
+                }
+            }
+        }
+
+        #region HashTable Manipulation
+
+        static private int Hash(int value)
+        {
+            return value % Capacity;
+        }
+
+        private int Pos(int value)
+        {
+            return value % data.Length;
+        }
+
+        static private Entry[][] CloneFrom(Entry[][] entry)
+        {
+            Entry[][] result = new Entry[entry.Length][];
+
+            for (int i = 0; i < entry.Length; i++)
+            {
+                if (entry[i] != null)
+                {
+                    result[i] = new Entry[entry[i].Length];
+                    Array.Copy(entry[i], result[i], entry[i].Length);
+                }
+            }
+            return result;
+        }
+
+        private bool TryGetValue(int index, out int indexInTheArray, out int indexInTheBucket, out Rational value)
+        {
+            int start = Pos(Hash(index));
+
+            if (data[start] == null)
+            {
+                indexInTheArray = -1;
+                indexInTheBucket = -1;
+                value = default(Rational);
+
+                return false;
+            }
+
+            for (int i = 0; i < lastElement[start]; i++)
+            {
+                var local = data[start][i];
+                if (local.Index == index)
+                {
+                    indexInTheArray = start;
+                    indexInTheBucket = i;
+                    value = local.Value;
+
+                    return true;
+                }
+            }
+
+            value = default(Rational);
+            indexInTheArray = -1;
+            indexInTheBucket = -1;
+
+            return false;
+        }
+
+        private bool TryGetValue(int index, out Rational value)
+        {
+            int dummy1, dummy2;
+            return this.TryGetValue(index, out dummy1, out dummy2, out value);
+        }
+
+        private bool ContainsKey(int index, out int indexInTheArray, out int indexInTheBucket)
+        {
+            Rational dummy;
+            return this.TryGetValue(index, out indexInTheArray, out indexInTheBucket, out dummy);
+        }
+
+        private void Remove(int index)
+        {
+            int indexInTheArray, indexInTheBucket;
+            Rational dummy;
+
+            if (this.TryGetValue(index, out indexInTheArray, out indexInTheBucket, out dummy))
+            {
+                this.Remove(index, indexInTheArray, indexInTheBucket);
+            }
+        }
+
+        private void Remove(int index, int indexInTheArray, int indexInTheBucket)
+        {
+            CheckInvariant();
+
+            var lastElement = this.lastElement[indexInTheArray];
+            if (indexInTheBucket == 0 && lastElement == 1)
+            {
+                // The last element ...
+                data[indexInTheArray] = null;
+            }
+            else
+            {
+                Swap(ref data[indexInTheArray][indexInTheBucket], ref data[indexInTheArray][lastElement - 1]);
+
+                data[indexInTheArray][lastElement - 1] = null;
+            }
+
+            count--;
+            this.lastElement[indexInTheArray]--;
+
+            CheckInvariant();
+        }
+
+        private void Swap(ref Entry entry1, ref Entry entry2)
+        {
+            Entry tmp = entry1;
+            entry1 = entry2;
+            entry2 = tmp;
+        }
+
+        private void Set(int index, Rational value)
+        {
+            int indexInTheArray, indexInTheBucket;
+            if (this.ContainsKey(index, out indexInTheArray, out indexInTheBucket))
+            {
+                data[indexInTheArray][indexInTheBucket] = new Entry(index, value);
+            }
+            else
+            {
+                indexInTheArray = Pos(Hash(index));
+
+                var local = data[indexInTheArray];
+
+                if (local == null)
+                {
+                    data[indexInTheArray] = new Entry[BucketSize];
+                }
+                else if (lastElement[indexInTheArray] == local.Length)
+                {
+#if TRACE_PERFORMANCE
+                    ResizeCount++;
+#endif
+                    if (local.Length > 1)
+                    {
+                        Console.WriteLine("Resize from {0} to {1}", local.Length, local.Length * 2 + 1);
+                    }
+
+                    Array.Resize(ref data[indexInTheArray], data[indexInTheArray].Length * 2 + 1);
+                }
+
+                data[indexInTheArray][lastElement[indexInTheArray]] = new Entry(index, value);
+
+                lastElement[indexInTheArray]++;
+            }
+
+            count++;
+        }
+
+
+
+        private IEnumerable<int> GetKeys()
+        {
+            int nondef = 0;
+
+            for (int i = 0; nondef < count && i < data.Length; i++)
+            {
+                if (data[i] != null)
+                {
+                    for (int j = 0; j < lastElement[i]; j++)
+                    {
+                        nondef++;
+                        yield return data[i][j].Index;
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        private class Entry
+        {
+            private int index;
+            private Rational value;
+
+            public int Index
+            {
+                get
+                {
+                    return index;
+                }
+            }
+
+            public Rational Value
+            {
+                get
+                {
+                    return value;
+                }
+            }
+
+            public Entry(int index, Rational value)
+            {
+                this.index = index;
+                this.value = value;
+            }
+
+            public override string ToString()
+            {
+                return string.Format("({0}, {1})", index, value);
+            }
+        }
     }
-  }
+
+    [ContractVerification(false)]
+    internal sealed class SparseRationalArray_Array
+      : SparseRationalArray<SparseRationalArray_Array>
+    {
+        #region Performance counters
+
+#if TRACE_PERFORMACE
+        [ThreadStatic]
+        static private int MaxLength;
+        [ThreadStatic]
+        static private double MaxNonDefaultElements;
+#endif
+
+        #endregion
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(length >= 0);
+            Contract.Invariant(map != null);
+            Contract.Invariant(!object.Equals(defaultElement, null));
+            Contract.Invariant(length == map.Length);
+#if CHECKINVARIANTS
+            Contract.Invariant(Contract.ForAll(0, map.Length, i => map[i] == data.ContainsKey(i)));
+#endif
+        }
+
+        #region Private state
+
+        private int length;                                   // The length of the array
+        private Tuple<int, Rational>[] data;               // The data in the array
+        private BitArray map;
+
+        readonly private Rational defaultElement;             // The default element
+
+        #endregion
+
+        #region Constructor
+        public SparseRationalArray_Array(int length, Rational defaultElement)
+        {
+            Contract.Requires(length >= 0);
+            Contract.Requires(!object.Equals(defaultElement, null));
+
+            UpdateMaxLength(length);
+
+            this.length = length;
+            data = null;
+            map = new BitArray(length);
+            this.defaultElement = defaultElement;
+        }
+
+        private SparseRationalArray_Array(SparseRationalArray_Array original)
+        {
+            Contract.Requires(original != null);
+
+            Contract.Assume(original.length >= 0);
+            Contract.Assume(!object.Equals(original.defaultElement, null));
+
+            length = original.length;
+            data = original.data.Duplicate();
+            map = new BitArray(original.map);
+            defaultElement = original.defaultElement;
+        }
+
+        #endregion
+
+        public override int NonDefaultElementsCount
+        {
+            get
+            {
+                return data.CountNotNull();
+            }
+        }
+
+        override public Rational this[int index]
+        {
+            get
+            {
+                CheckBounds(index);
+
+                Rational value;
+                if (map[index] && data.TryGetValue(index, out value))
+                {
+                    Contract.Assume(!object.Equals(value, null));
+                    return value;
+                }
+                else
+                {
+                    return defaultElement;
+                }
+            }
+            set
+            {
+                CheckBounds(index);
+
+                // We do not store the default element explicitly
+                if (value == defaultElement)
+                {
+                    if (data.ContainsKey(index))
+                    {
+                        map[index] = false;
+                        data.Remove(index);
+                    }
+                }
+                else
+                {
+                    map[index] = true;
+                    //this.data[index] = value;
+
+                    data = data.Add(index, value);
+
+                    UpdateMaxNonDefaultElements();
+                }
+            }
+        }
+
+        [Conditional("TRACE_PERFORMANCE")]
+        private void UpdateMaxNonDefaultElements()
+        {
+#if TRACE_PERFORMANCE
+            MaxNonDefaultElements = Math.Max(MaxNonDefaultElements, data.Count);
+#endif
+        }
+
+        [Conditional("TRACE_PERFORMANCE")]
+        private static void UpdateMaxLength(int length)
+        {
+#if TRACE_PERFORMANCE
+            MaxLength = Math.Max(length, MaxLength);
+#endif
+        }
+
+        override public int Length
+        {
+            get
+            {
+                return length;
+            }
+        }
+
+        /// <summary>
+        /// The number of non "default" elements in the sparse array
+        /// </summary>
+        override public int Count
+        {
+            get
+            {
+                return data.CountNotNull();
+            }
+        }
+
+        override public void ExpandBy(int additionalRows)
+        {
+            length += additionalRows;
+
+            map.Length = length;
+        }
+
+        override public void ShrinkTo(int index)
+        {
+            if (index == this.Length || index < 0)
+            {
+                return;
+            }
+
+            for (int i = index; i < length; i++)
+            {
+                data.Remove(i);
+            }
+
+            length = index;
+
+            map.Length = length;
+        }
+
+        override public void ResetToDefaultElement(int index)
+        {
+            map[index] = false;
+            data.Remove(index);
+        }
+
+        /// <summary>
+        /// A method used to iterate on the non-default elements of the sparse array
+        /// </summary>
+        /// <returns></returns>
+        override public IEnumerable<KeyValuePair<int, Rational>> GetElements()
+        {
+            if (data == null)
+                yield break;
+
+            foreach (var x in data)
+            {
+                if (x != null)
+                    yield return new KeyValuePair<int, Rational>(x.Item1, x.Item2);
+            }
+        }
+
+        override public IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get
+            {
+                if (data == null)
+                    yield break;
+
+                foreach (var x in data)
+                {
+                    if (x != null)
+                        yield return x.Item1;
+                }
+            }
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key)
+        {
+            return map[key];
+        }
+
+        override public bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            if (map[key] && data.TryGetValue(key, out value))
+            {
+                Contract.Assume(!object.Equals(value, null));
+
+                return true;
+            }
+            else
+            {
+                value = defaultElement;
+
+                return false;
+            }
+        }
+
+        override public bool ForEachKey(Predicate<int> pred)
+        {
+            foreach (var key in this.IndexesOfNonDefaultElements)
+            {
+                if (!pred(key))
+                    return false;
+            }
+
+            return true;
+        }
+
+        override public int SmallestIndexOfNonDefaultElement
+        {
+            get
+            {
+                for (var i = 0; i < map.Length; i++)
+                {
+                    if (map[i])
+                        return i;
+                }
+
+                return -1;
+            }
+        }
+
+        override public void CopyFrom(SparseRationalArray_Array original)
+        {
+            if (original.data == null)
+            {
+                data = null;
+                return;
+            }
+            foreach (var pair in original.data)
+            {
+                if (pair != null)
+                {
+                    this[pair.Item1] = pair.Item2;
+                }
+            }
+        }
+
+        override public void Swap(int x, int y)
+        {
+            if (x == y)
+                return;
+
+            Rational xval, yval;
+            xval = yval = defaultElement;
+            var xb = map[x] && data.TryGetValue(x, out xval);
+            var yb = map[y] && data.TryGetValue(y, out yval);
+
+            // F: Proving the assertions will require some more complex quantified invariant
+            Contract.Assume(xb ? (!object.Equals(xval, null) && xval != defaultElement) : true);
+            Contract.Assume(yb ? (!object.Equals(yval, null) && yval != defaultElement) : true);
+
+            if (xb)
+            {
+                if (yb)
+                { // we can swap x with y
+                    this[x] = yval;
+                    this[y] = xval;
+
+                    map[x] = map[y] = true; // F: needless, but makes the code clearer
+                }
+                else
+                { // y has a default value
+                    this.ResetToDefaultElement(x);
+                    this[y] = xval;
+
+                    map[y] = true;
+                }
+            }
+            else if (yb)
+            { // x has the default value
+                this[x] = yval;
+                this.ResetToDefaultElement(y);
+
+                map[x] = true;
+            }
+            else
+            { // both have the default value
+            }
+        }
+
+        /// <summary>
+        /// Copies just the elements of index [0, ... len-1]
+        /// </summary>
+        override public void CopyFrom(SparseRationalArray_Array original, int len)
+        {
+            if (original.data == null)
+            {
+                data = null;
+                return;
+            }
+            foreach (var pair in original.data)
+            {
+                if (pair != null)
+                {
+                    if (pair.Item1 < len)
+                    {
+                        this[pair.Item1] = pair.Item2;
+                    }
+                }
+            }
+        }
+
+        // Idea: here we can share the internal representation?
+        override public SparseRationalArray_Array DuplicateMe()
+        {
+            return new SparseRationalArray_Array(this);
+        }
+
+        public object Clone()
+        {
+            return this.Duplicate();
+        }
+
+        new static internal String Statistics
+        {
+            get
+            {
+#if TRACE_PERFORMANCE
+                var s1 = string.Format("Max length of a sparse array : {0}", MaxLength);
+                var s2 = string.Format("Max # of non-default elements: {0}", MaxNonDefaultElements);
+
+                return s1 + Environment.NewLine + s2;
+#else
+                return "Performance tracing is off";
+#endif
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void CheckBounds(int i)
+        {
+            if (i < 0 || i >= length)
+            {
+                System.Diagnostics.Debugger.Break();
+                // throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public override string ToString()
+        {
+            if (data == null)
+                return "empty sparse array";
+
+            var str = new StringBuilder();
+
+            foreach (var pair in data)
+            {
+                if (pair != null)
+                    str.AppendFormat("({0},{1})", pair.Item1, pair.Item2);
+            }
+
+            return str.ToString();
+        }
+    }
+
+    // Still some bug, it does not seem it gives performance gains
+    internal sealed class SparseRationalArray_List
+      : SparseRationalArray<SparseRationalArray_List>
+    {
+        private int length;                                   // The length of the array
+        private List<Pair<int, Rational>> data;          // The data in the array
+
+        readonly private Rational defaultElement;             // The default element
+
+        public SparseRationalArray_List(int length, Rational defaultElement)
+        {
+            this.length = length;
+            data = new List<Pair<int, Rational>>();
+            this.defaultElement = defaultElement;
+        }
+
+        private SparseRationalArray_List(SparseRationalArray_List other)
+        {
+            length = other.length;
+            data = new List<Pair<int, Rational>>(other.data);
+            defaultElement = other.defaultElement;
+            this.nonDefaultElementsCount = other.nonDefaultElementsCount;
+        }
+
+        private void Set(Pair<int, Rational> value)
+        {
+            for (var i = 0; i < data.Count; i++)
+            {
+                if (data[i].One == value.One)
+                {
+                    if (value.Two == defaultElement)
+                    {
+                        data.RemoveAt(i);
+                        nonDefaultElementsCount--;
+                    }
+                    else
+                    {
+                        data[i] = value;
+                        nonDefaultElementsCount++;
+                        return;
+                    }
+                }
+            }
+
+            if (value.Two != defaultElement)
+            {
+                data.Add(value);
+                nonDefaultElementsCount++;
+            }
+        }
+
+        public override void CopyFrom(SparseRationalArray_List original)
+        {
+            foreach (var pair in original.data)
+            {
+                this.Set(pair);
+            }
+        }
+
+        public override void CopyFrom(SparseRationalArray_List original, int len)
+        {
+            foreach (var pair in original.data)
+            {
+                if (pair.One < len)
+                {
+                    this.Set(pair);
+                }
+            }
+        }
+
+        public override SparseRationalArray_List DuplicateMe()
+        {
+            return new SparseRationalArray_List(this);
+        }
+
+        public override void ExpandBy(int additionalRows)
+        {
+            length += additionalRows;
+        }
+
+        public override bool ForEachKey(Predicate<int> pred)
+        {
+            foreach (var pair in data)
+            {
+                if (!pred(pair.One))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override IEnumerable<KeyValuePair<int, Rational>> GetElements()
+        {
+            foreach (var pair in data)
+            {
+                yield return new KeyValuePair<int, Rational>(pair.One, pair.Two);
+            }
+        }
+
+        public override IEnumerable<int> IndexesOfNonDefaultElements
+        {
+            get
+            {
+                foreach (var x in data)
+                    yield return x.One;
+            }
+        }
+
+        public override bool IsIndexOfNonDefaultElement(int key)
+        {
+            foreach (var pair in data)
+            {
+                if (pair.One == key)
+                    return true;
+            }
+
+            return false;
+        }
+
+        public override bool IsIndexOfNonDefaultElement(int key, out Rational value)
+        {
+            foreach (var pair in data)
+            {
+                if (pair.One == key)
+                {
+                    value = pair.Two;
+                    return true;
+                }
+            }
+
+            value = defaultElement;
+            return false;
+        }
+
+        public override int Length
+        {
+            get { return length; }
+        }
+
+        public override void ResetToDefaultElement(int index)
+        {
+            for (var i = 0; i < data.Count; i++)
+            {
+                if (data[i].One == index)
+                {
+                    data.RemoveAt(i);
+                    this.nonDefaultElementsCount--;
+
+                    return;
+                }
+            }
+        }
+
+        public override void ShrinkTo(int index)
+        {
+            //Contract.Requires(index >= 0);
+            //Contract.Requires(index <= this.Length);
+
+            if (index == this.Length)
+            {
+                return;
+            }
+
+            for (var i = 0; i < data.Count; i++)
+            {
+                if (data[i].One >= index)
+                {
+                    data.RemoveAt(i);
+                    i--;
+                }
+            }
+
+            length = index;
+        }
+
+        public override int SmallestIndexOfNonDefaultElement
+        {
+            get
+            {
+                var min = Int32.MaxValue;
+
+                foreach (var pair in data)
+                {
+                    if (pair.One < min)
+                        min = pair.One;
+                }
+
+                return min == Int32.MaxValue ? -1 : min;
+            }
+        }
+
+        public override Rational this[int index]
+        {
+            get
+            {
+                foreach (var pair in data)
+                {
+                    if (pair.One == index)
+                        return pair.Two;
+                }
+
+                return defaultElement;
+            }
+            set
+            {
+                Set(new Pair<int, Rational>(index, value));
+            }
+        }
+
+        public override int Count
+        {
+            get { return data.Count; }
+        }
+
+        public override void Swap(int x, int y)
+        {
+            int xPos = -1, yPos = -1, count = 0;
+
+            for (var i = 0; count < 2 && i < data.Count; i++)
+            {
+                var element = data[i];
+                if (element.One == x)
+                {
+                    xPos = i;
+                    count++;
+                }
+                else if (element.One == y)
+                {
+                    yPos = i;
+                    count++;
+                }
+            }
+
+            switch (count)
+            {
+                case 0:
+                    return;
+
+                case 1:
+                    {
+                        if (xPos == -1)
+                        {
+                            data[yPos] = new Pair<int, Rational>(x, data[yPos].Two);
+                        }
+                        if (yPos == -1)
+                        {
+                            data[xPos] = new Pair<int, Rational>(y, data[xPos].Two);
+                        }
+                    }
+                    break;
+
+                case 2:
+                    {
+                        var tmp = data[xPos];
+                        data[xPos] = data[yPos];
+                        data[yPos] = tmp;
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        new static internal string Statistics
+        {
+            get { return ""; }
+        }
+
+        public override string ToString()
+        {
+            return data.ToString();
+        }
+    }
 }
 
-  

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SubPolyhedra/LinearEqualitiesForSubpolyhedra.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SubPolyhedra/LinearEqualitiesForSubpolyhedra.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // This file contains the classes and the abstract domains for implementing the abstract domain of Linear equalities
 
@@ -39,1942 +28,1937 @@ using Microsoft.SolverFoundation.Services;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-
-  /// <summary>
-  /// The abstract numerical domain of linear equalities
-  /// </summary> 
-  public class LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> :
-      LinearEqualitiesEnvironment<Variable, Expression>
-  {
-    const int MAX_VARS_FOR_COMBINE = 3;
-
-    protected const int MaxCoefficientInEquationsforSimplexReduction = 1024;
-    protected const long MaxBoundInIntervalsforSimplexReduction = (1L << 16);
-    protected const long MinBoundInIntervalsforSimplexReduction = -(1L << 16);
-
-    #region Constructors
-
     /// <summary>
-    /// How many linear equalities?
-    /// </summary>
-    /// <param name="decoder">The decoder for expressions</param>
-    public LinearEqualitiesForSubpolyhedraEnvironment(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : this(INITIAL_VARS_FOR_EQUATION_COUNT, INITIAL_EQUATIONS_COUNT, expManager)
+    /// The abstract numerical domain of linear equalities
+    /// </summary> 
+    public class LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> :
+        LinearEqualitiesEnvironment<Variable, Expression>
     {
-      Contract.Requires(expManager != null);
-    }
+        private const int MAX_VARS_FOR_COMBINE = 3;
 
-    /// <summary>
-    /// Build a Linear equalities environment with <code>n</code> dimensions
-    /// </summary>
-    /// <param name="var">The initial number of variables</param>
-    /// <param name="equations">The initial number of equations</param>
-    public LinearEqualitiesForSubpolyhedraEnvironment(int var, int equations,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(var, equations, expManager)
-    {
-      Contract.Requires(expManager != null);
-    }
+        protected const int MaxCoefficientInEquationsforSimplexReduction = 1024;
+        protected const long MaxBoundInIntervalsforSimplexReduction = (1L << 16);
+        protected const long MinBoundInIntervalsforSimplexReduction = -(1L << 16);
 
-    /// <summary>
-    /// A cosntructor used mainly for the internal operations of the abstract domain
-    /// </summary>
-    private LinearEqualitiesForSubpolyhedraEnvironment(SparseRationalArray[] matrix, int numOfRows, int numOfCols, VarsToDimensions varsToDimensions,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(matrix, numOfRows, numOfCols, varsToDimensions, expManager)
-    {
-      Contract.Requires(matrix != null);
-      Contract.Requires(expManager != null);
+        #region Constructors
 
-      LogPerformance("matrix length: {0}; rows: {1}; cols: {2}; vars: {3}",
-        matrix.Length.ToString(), numOfRows.ToString(), numOfCols.ToString(), varsToDimensions.Count.ToString());
-    }
-
-    /// <summary>
-    /// Copy constructor
-    /// </summary>
-    /// <param name="l"></param>
-    protected LinearEqualitiesForSubpolyhedraEnvironment(LinearEqualitiesEnvironment<Variable, Expression> l)
-      : base(l)
-    {
-      Contract.Requires(l != null);
-    }
-
-    protected override LinearEqualitiesEnvironment<Variable, Expression> New(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(expManager);
-    }
-
-
-    protected override LinearEqualitiesEnvironment<Variable, Expression> New(int var, int eqs, ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(var, eqs, expManager);
-    }
-
-    protected override LinearEqualitiesEnvironment<Variable, Expression> New(LinearEqualitiesEnvironment<Variable, Expression> other)
-    {
-      return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(other);
-    }
-
-    protected override LinearEqualitiesEnvironment<Variable, Expression> New(SparseRationalArray[] JoinedMatrix, int numberOfRowsInResult, int p, VarsToDimensions freshMap, ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(JoinedMatrix, numberOfRowsInResult, p, freshMap, expManager);
-    }
-    #endregion
-
-    #region ICloneable Members
-
-    /// <summary>
-    /// A type safe version of <code>Clone</code>
-    /// </summary>
-    override protected LinearEqualitiesEnvironment<Variable, Expression> Duplicate()
-    {
-      return DuplicateInternal();
-    }
-
-    private LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> DuplicateInternal()
-    {
-      return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
-    }
-
-    #endregion
-
-    protected IEnumerable<Variable> SlackVariables
-    {
-      get
-      {
-        var decoder = this.expManager.Decoder;
-        foreach (var x in this.varsToDimensions.Keys)
+        /// <summary>
+        /// How many linear equalities?
+        /// </summary>
+        /// <param name="decoder">The decoder for expressions</param>
+        public LinearEqualitiesForSubpolyhedraEnvironment(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : this(INITIAL_VARS_FOR_EQUATION_COUNT, INITIAL_EQUATIONS_COUNT, expManager)
         {
-          if (decoder.IsSlackVariable(x))
-          {
-            yield return x;
-          }
+            Contract.Requires(expManager != null);
         }
-      }
-    }
 
-    /// <summary>
-    /// Gets a row equivalent to the first one modulo linear combinations with the equalities in the state, using the mapping from <paramref name="exp"/> to <paramref name="dim"/>
-    /// </summary>
-    /// <param name="initial">The original row</param>
-    /// <param name="final">Will contain the result</param>
-    /// <param name="exp">A variable for which we need a mapping</param>
-    /// <param name="dim">The dimension for <paramref name="exp"/></param>
-    /// <returns>true if we managed to find an equivalent of <paramref name="initial"/> without slack variables, false otherwise</returns>
-    private bool GetEquivalentWithoutSlack(Polynomial<Variable, Expression> initial,
-      out SparseRationalArray final, Variable exp, int dim, IDictionary<Variable, FList<Variable>> sourcesToTargets)
-    {
-      final = AsVector(initial);
-      if (initial.IsTautology || initial.Variables.IsEmpty)
-      {
-        return false;
-      }
-
-      var source = default(Variable);
-      var found = false;
-      foreach (var pair in sourcesToTargets)
-      {
-        if (pair.Value.Head.Equals(exp))
+        /// <summary>
+        /// Build a Linear equalities environment with <code>n</code> dimensions
+        /// </summary>
+        /// <param name="var">The initial number of variables</param>
+        /// <param name="equations">The initial number of equations</param>
+        public LinearEqualitiesForSubpolyhedraEnvironment(int var, int equations,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(var, equations, expManager)
         {
-          source = pair.Key;
-          found = true;
-
-          Contract.Assert(source != null);
-
-          break;
+            Contract.Requires(expManager != null);
         }
-      }
-      try
-      {
-        if (initial.Variables.Count == 1)
-        {// exp had a constant value, we try to see if some variable "source" with another constant value is renamed to exp and return the relation exp - source == k
 
-          int dimSource;
+        /// <summary>
+        /// A cosntructor used mainly for the internal operations of the abstract domain
+        /// </summary>
+        private LinearEqualitiesForSubpolyhedraEnvironment(SparseRationalArray[] matrix, int numOfRows, int numOfCols, VarsToDimensions varsToDimensions,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(matrix, numOfRows, numOfCols, varsToDimensions, expManager)
+        {
+            Contract.Requires(matrix != null);
+            Contract.Requires(expManager != null);
 
-          if (!found || !varsToDimensions.TryGetValue(source, out dimSource))
-          {
-            return false;
-          }
-          
-          int rowSource = -1;
+            LogPerformance("matrix length: {0}; rows: {1}; cols: {2}; vars: {3}",
+              matrix.Length.ToString(), numOfRows.ToString(), numOfCols.ToString(), varsToDimensions.Count.ToString());
+        }
 
-          for (int i = this.NumberOfRows - 1; i >= 0; i--)
-          {
-            if (!this.equations.IsNullRow(i) && this.equations.At(i, dimSource).IsNotZero)
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="l"></param>
+        protected LinearEqualitiesForSubpolyhedraEnvironment(LinearEqualitiesEnvironment<Variable, Expression> l)
+          : base(l)
+        {
+            Contract.Requires(l != null);
+        }
+
+        protected override LinearEqualitiesEnvironment<Variable, Expression> New(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(expManager);
+        }
+
+
+        protected override LinearEqualitiesEnvironment<Variable, Expression> New(int var, int eqs, ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(var, eqs, expManager);
+        }
+
+        protected override LinearEqualitiesEnvironment<Variable, Expression> New(LinearEqualitiesEnvironment<Variable, Expression> other)
+        {
+            return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(other);
+        }
+
+        protected override LinearEqualitiesEnvironment<Variable, Expression> New(SparseRationalArray[] JoinedMatrix, int numberOfRowsInResult, int p, VarsToDimensions freshMap, ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(JoinedMatrix, numberOfRowsInResult, p, freshMap, expManager);
+        }
+        #endregion
+
+        #region ICloneable Members
+
+        /// <summary>
+        /// A type safe version of <code>Clone</code>
+        /// </summary>
+        override protected LinearEqualitiesEnvironment<Variable, Expression> Duplicate()
+        {
+            return DuplicateInternal();
+        }
+
+        private LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> DuplicateInternal()
+        {
+            return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
+        }
+
+        #endregion
+
+        protected IEnumerable<Variable> SlackVariables
+        {
+            get
             {
-              rowSource = i;
-
-              break;
-            }
-          }
-
-          if (rowSource < 0)
-          {
-            return false;
-          }
-
-          if (this.equations.IsConstantRow(rowSource) && this.equations.At(rowSource, dimSource) == 1)
-          {
-            final = FreshRow(numberOfCols);
-            final[dim] = Rational.For(1);
-            final[dimSource] = Rational.For(-1);
-            final[numberOfCols - 1] = (initial.Right[0].K / initial.Left[0].K) - this.equations.At(rowSource, numberOfCols - 1);
-
-            Contract.Assert(final[dim].IsNotZero);
-
-            return true;
-          }
-          else
-          {
-            return false;
-          }
-        }
-        else
-        {
-          if (source == null || source.Equals(default(Expression)) || !varsToDimensions.ContainsKey(source))
-          {
-            this.varsToDimensions[exp] = dim;
-            Variable e;
-
-            var combinations = Combine(initial, SubPolyhedra<Variable, Expression>.IsBetaDefinition(initial, out e, this.expManager.Decoder), 0, MAX_VARS_FOR_COMBINE);
-
-            this.varsToDimensions.Remove(exp);
-            if (combinations.IsEmpty)
-            {
-              return false;
-            }
-            final = AsVector(combinations.PickAnElement());
-
-            Contract.Assert(final[dim].IsNotZero);
-
-            return true;
-          }
-          else
-          {
-            var copy = this.DuplicateInternal();
-
-            copy.AddConstraint(copy.AsVector(initial));
-
-            foreach (var e in this.Variables)
-            {
-              if (e.Equals(exp) || e.Equals(source))
-              {
-                continue;
-              }
-              copy.RemoveVariable(e, true);
-            }
-
-            var copy_matrix = copy.equations.Unshare(copy, ref copy.equations);
-
-            Contract.Assert(copy.NumberOfRows <= 2);
-
-            if (copy.NumberOfRows == 1 && !copy.equations.IsConstantRow(0))
-            {
-              final = copy_matrix[0];
-              Contract.Assert(final[dim] != 0);
-
-              return true;
-            }
-            else if (copy.NumberOfRows == 2)
-            {
-              final = copy_matrix[0];
-              foreach (var pair in copy.equations.GetElementsForRow(1))
-              {
-                final[pair.Key] -= pair.Value;
-              }
-
-              Contract.Assert(final[dim].IsNotZero);
-
-              return true;
-            }
-            else
-            {
-              return false;
-            }
-          }
-        }
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return false;
-      }
-    }
-
-    #region Specific algorithms for SubPolyhedra
-    /// <summary>
-    /// Tries to infer the best intervals for each variable in the domain 
-    /// </summary>
-#if SUBPOLY_ONLY
-    internal
-#else
-    public
-#endif
-    IntervalEnvironment<Variable, Expression> BoundsInference(
-      IntervalEnvironment<Variable, Expression> initialBounds, 
-      SubPolyhedra.ReductionAlgorithm algorithm, int MaxVariablesForSimplex)
-    {
-      Contract.Requires(initialBounds != null);
-      Contract.Ensures(Contract.Result<IntervalEnvironment<Variable, Expression>>() != null);
-
-      CheckStateInvariant();
-
-      if (this.IsTop)
-      {
-        return initialBounds;
-      }
-
-      IntervalEnvironment<Variable, Expression> result;
-
-      if (algorithm == SubPolyhedra.ReductionAlgorithm.Simplex)
-      {
-        this.expManager.Log("Running Simplex");
-        result = RunSimplex(initialBounds, MaxVariablesForSimplex);
-      }
-      else if (algorithm == SubPolyhedra.ReductionAlgorithm.SimplexOptima)
-      {
-#if USESOLVERFOUNDATION
-
-#if false
-        var s1 = RunSimplex(initialBounds);
-        var s2 = RunSimplex_OptimaModel(initialBounds);
-
-        bool b1 = s1.LessEqual(s2);
-        bool b2 = s2.LessEqual(s1);
-        bool b = b1 && b2;
-
-        if (!b)
-        {
-          System.Diagnostics.Debugger.Break();
-        }
-        return s1;
-#else
-        var s2 = RunSimplex_OptimaModel(initialBounds);
-        return  s2;
-#endif
-#else
-        result = RunSimplex(initialBounds, MaxVariablesForSimplex);
-#endif
-      }
-      else
-      {
-        if (algorithm == SubPolyhedra.ReductionAlgorithm.MixSimplexFast)
-        {
-          if (this.Variables.Count < 20)
-          {
-            this.expManager.Log("Running Simplex");
-            result = RunSimplex(initialBounds, MaxVariablesForSimplex);
-          }
-          else
-          {
-            this.expManager.Log("Running Fast");
-            result = RunBasisExploration(initialBounds, SubPolyhedra.ReductionAlgorithm.Fast);
-          }
-        }
-        else
-        {
-          result = RunBasisExploration(initialBounds, algorithm);
-        }
-      }
-
-      this.expManager.Log("Result of the reduction:\n{0}", result.ToString);
-
-      return result;
-    }
-
-    private IntervalEnvironment<Variable, Expression> RunBasisExploration(
-      IntervalEnvironment<Variable, Expression> initialBounds, SubPolyhedra.ReductionAlgorithm algorithm)
-    {
-      var watch = new Stopwatch();
-      watch.Start();
-
-      SparseRationalArray row;
-      Interval interval, finiteInterval;
-      int infLower, infUpper;
-      int numberOfVariablesInBasis = 0;
-
-      var result = initialBounds.Clone() as IntervalEnvironment<Variable, Expression>;
-
-      Contract.Assert(result != null);
-
-      #region Step 1 : put the less precise variables in the basis
-
-      var matrix = this.equations.Unshare(this, ref this.equations);
-
-      for (int i = 0; i < NumberOfRows; i++)
-      {
-        row = matrix[i];
-
-        interval = result.EvalArray(row, this.varsToDimensions.InverseMap, this.NumberOfColumns - 1,
-          out finiteInterval, out infLower, out infUpper);
-
-        if (interval.IsBottom)
-        {
-          this.state = LinearEqualitiesState.Bottom;
-          return initialBounds;
-        }
-
-        var LessPrecise = default(Variable);
-        var WorstPrecision = Rational.For(0);
-
-        int infiniteInWorst = 0;
-        bool foundLessPrecise = false;
-
-        foreach (var pair in row.GetElements())
-        {
-          if (pair.Key == this.NumberOfColumns - 1)
-          { // constant
-            continue;
-          }
-
-          var var = varsToDimensions[pair.Key];
-          var k = pair.Value;
-          var varInterval = k * result.BoundsFor(var).AsInterval;
-
-          Rational lowerKX, upperKX;
-
-          try
-          {
-            lowerKX = varInterval.UpperBound.IsPlusInfinity ?
-              (infUpper > 1 ? Rational.MinusInfinity : -finiteInterval.UpperBound)
-              : varInterval.UpperBound - interval.UpperBound;
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            lowerKX = Rational.MinusInfinity;
-          }
-          try
-          {
-            upperKX = varInterval.LowerBound.IsMinusInfinity ?
-              (infLower > 1 ? Rational.PlusInfinity : -finiteInterval.LowerBound)
-              : varInterval.LowerBound - interval.LowerBound;
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            upperKX = Rational.PlusInfinity;
-          }
-
-          var intervalForX = Interval.For(lowerKX, upperKX) / k /* (Interval.For(k))*/;
-
-          if (intervalForX.LessEqual(result.BoundsFor(var).AsInterval))
-          {
-            int eRow = -1;
-
-            if (!TrySwapColumnsInRowEchelonForm(i, varsToDimensions[var], out eRow))
-            {
-              RemoveRow(eRow);
-              PutIntoRowEchelonForm(); // should not change the rows already treated
-              if (eRow <= i)
-              {
-                i--;
-              }
-            }
-
-            if (eRow == -1)
-            {
-              int dummy;
-              if (!TrySwapColumnsInRowEchelonForm(numberOfVariablesInBasis, i, out dummy))
-              {
-                throw new AbstractInterpretationException("I was not expecting a failure here! Is it a bug?");
-              }
-
-              numberOfVariablesInBasis++;
-
-              Contract.Assert(numberOfVariablesInBasis <= NumberOfRows);
-            }
-
-            foundLessPrecise = true;
-            break;
-          }
-
-          var resInt = result.BoundsFor(var).AsInterval.Meet(intervalForX);
-
-          // Found a contradiction?
-          if (resInt.IsBottom)
-          {
-            return result.Bottom;
-          }
-
-          result[var] = resInt;
-
-          Rational diff;
-
-          try
-          { // F: I've added it
-            diff = resInt.UpperBound - resInt.LowerBound;
-          }
-          catch (ArithmeticExceptionRational)
-          {
-            diff = Rational.PlusInfinity;
-          }
-
-          int infiniteInDiff = (resInt.UpperBound.IsInfinity ? 1 : 0) + (resInt.LowerBound.IsInfinity ? 1 : 0);
-
-          if (diff > WorstPrecision || infiniteInDiff > infiniteInWorst)
-          {
-            WorstPrecision = diff;
-            infiniteInWorst = infiniteInDiff;
-            LessPrecise = var;
-          }
-        }
-
-        if (!foundLessPrecise && WorstPrecision > 0)
-        {
-          int eRow;
-          if (!TrySwapColumnsInRowEchelonForm(i, varsToDimensions[LessPrecise], out eRow))
-          {
-            RemoveRow(eRow);
-            PutIntoRowEchelonForm();
-            if (eRow <= i)
-            {
-              i--;
-            }
-          }
-        }
-      }
-      #endregion
-
-      #region Step 2 : infer bounds for all the variables, trying different combinations for the variables not definitely in basis
-      Explorer comb;
-      var temp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
-      temp.PutVariablesInFront();
-
-      if (NumberOfVariables - numberOfVariablesInBasis < 0)
-      {
-        return result;
-      }
-
-      int[] previous = new int[NumberOfVariables - numberOfVariablesInBasis];
-      for (int i = 0; i < previous.Length; i++)
-      {
-        previous[i] = i;
-      }
-
-      // If we abstracted away some row because of Rational overflows, 
-      // it may have be the case that the invariant NumberOfRows - numberOfVariablesInBasis >= 0 does not hold anymore
-      int range = Math.Max(NumberOfRows - numberOfVariablesInBasis, 0);
-
-      switch (algorithm)
-      {
-        case SubPolyhedra.ReductionAlgorithm.Complete:
-          comb = new CombinatorialExplorer(NumberOfVariables - numberOfVariablesInBasis, range);
-          break;
-
-        case SubPolyhedra.ReductionAlgorithm.Fast:
-          comb = new LinearExplorer(NumberOfVariables - numberOfVariablesInBasis, range);
-          break;
-
-        default:
-          comb = new LinearExplorer(NumberOfVariables - numberOfVariablesInBasis, range);
-          break;
-      }
-
-      while (comb.MoveNext())
-      {
-        if (watch.Elapsed.Minutes >= 5)
-        {
-          throw new TimeoutExceptionFixpointComputation();
-        }
-
-        for (int i = 0; i < comb.Current.Length; i++)
-        {
-          if (previous[i] == comb.Current[i])
-          {
-            continue;
-          }
-
-          int j = Array.FindIndex(previous, delegate(int x) { return x == comb.Current[i]; });
-
-          if (temp.equations.At(i + numberOfVariablesInBasis, j + numberOfVariablesInBasis).IsZero)
-          {
-            for (int u = i + numberOfVariablesInBasis + 1; u < numberOfRows; u++)
-            {
-              if (temp.equations.At(u, j + numberOfVariablesInBasis).IsNotZero)
-              {
-                int dummy;
-                if (!temp.TrySwapColumnsInRowEchelonForm(u, j + numberOfVariablesInBasis, out dummy))
+                var decoder = this.expManager.Decoder;
+                foreach (var x in this.varsToDimensions.Keys)
                 {
-                  return result;
-                }
-
-                if (!temp.TrySwapColumnsInRowEchelonForm(i + numberOfVariablesInBasis, u, out dummy))
-                {
-                  return result;
-                }
-
-                previous[j] = previous[u - numberOfVariablesInBasis];
-                previous[u - numberOfVariablesInBasis] = previous[i];
-                previous[i] = comb.Current[i];
-                break;
-              }
-            }
-          }
-          else
-          {
-            int dummy;
-            if (!temp.TrySwapColumnsInRowEchelonForm(i + numberOfVariablesInBasis, j + numberOfVariablesInBasis, out dummy))
-            {
-              return result;
-            }
-
-            previous[j] = previous[i];
-            previous[i] = comb.Current[i];
-          }
-        }
-
-        var temp_matrix = temp.equations.Unshare(temp, ref temp.equations);
-
-        for (int i = 0; i < temp.NumberOfRows; i++)
-        {
-          row = temp_matrix[i];
-          interval = result.EvalArray(row, temp.varsToDimensions.InverseMap, temp.NumberOfColumns - 1, out finiteInterval, out infLower, out infUpper);
-
-          if (interval.IsBottom)
-          {
-            this.state = LinearEqualitiesState.Bottom;
-            return initialBounds.Bottom;
-          }
-
-          foreach (var pair in row.GetElements())
-          {
-            if (pair.Key == temp.NumberOfColumns - 1)
-            {// constant
-              continue;
-            }
-
-            var var = temp.varsToDimensions[pair.Key];
-            var k = pair.Value;
-            var varInterval = k * result.BoundsFor(var).AsInterval;
-
-            Rational lowerKX, upperKX;
-            try
-            {
-              lowerKX = varInterval.UpperBound.IsPlusInfinity ?
-                (infUpper > 1 ? Rational.MinusInfinity : -finiteInterval.UpperBound) : varInterval.UpperBound - interval.UpperBound;
-            }
-            catch (ArithmeticExceptionRational)
-            {
-              lowerKX = Rational.MinusInfinity;
-            }
-
-            try
-            {
-              upperKX = varInterval.LowerBound.IsMinusInfinity ?
-                (infLower > 1 ? Rational.PlusInfinity : -finiteInterval.LowerBound) : varInterval.LowerBound - interval.LowerBound;
-            }
-            catch (ArithmeticExceptionRational)
-            {
-              upperKX = Rational.PlusInfinity;
-            }
-
-            var intervalForKX = Interval.For(lowerKX, upperKX);
-            var intervalForX = intervalForKX / k;
-            var resInt = result.BoundsFor(var).AsInterval.Meet(intervalForX);
-
-            if (resInt.IsBottom)
-            {
-              return result.Bottom;
-            }
-
-            result[var] = resInt;
-          }
-        }
-      }
-      #endregion
-
-      return result;
-    }
-
-#if false
-    static TimeSpan TimeSpentInSimplex = new TimeSpan(0);
-#endif
-
-    private IntervalEnvironment<Variable, Expression> RunSimplex(IntervalEnvironment<Variable, Expression> initialBounds, int MaxVariables)
-    {
-#if TRACE_PERFORMANCE
-      return PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.Simplex, () => RunSimplexInternal(initialBounds, MaxVariables), true);
-#else
-      return RunSimplexInternal(initialBounds, MaxVariables);
-#endif
-    }
-
-    /// <summary>
-    /// Simplex algorithm : initializing the LP, then asking for the minimal solutions
-    /// </summary>
-
-    private IntervalEnvironment<Variable, Expression> RunSimplexInternal(IntervalEnvironment<Variable, Expression> initialBounds, int MaxVariables)
-    {
-      #if TRACE_PERFORMANCE
-      var watch = new Stopwatch();
-      watch.Start();
-    #endif
-      
-      var result = initialBounds.Clone() as IntervalEnvironment<Variable, Expression>;
-
-      if (result == null)
-      {
-        return initialBounds;
-      }
-
-      var allVars = Variables.SetUnion(initialBounds.Variables);
-
-      if (allVars.Count >= MaxVariables)
-      {
-        return initialBounds;
-      }
-      
-      var varsToDimsInLp = new List<Pair<Variable, int>>();
-
-      int n = 0;
-      foreach (var var in allVars)
-      {
-        varsToDimsInLp.Add(new Pair<Variable, int>(var, n++));
-      }
-      
-#if false
-      Console.WriteLine("Variables {0} (max {1})", n, UpdateMaxVarsInSimplex(n));
-#endif
-      LinearProgramInterface lp;
-      if (TryInitializeLP(initialBounds, varsToDimsInLp, out lp))
-      {
-        var costs = new double[n];
-        var varToMinimize = -1;
-
-        var lowerBounds = new List<Pair<Variable, Rational>>();
-
-        foreach (var toMinimizePair in varsToDimsInLp)
-        {
-          if (varToMinimize != -1)
-          {
-            costs[varToMinimize] = 0;
-          }
-
-          varToMinimize = toMinimizePair.Two;
-
-          // Get the minimum
-          costs[varToMinimize] = 1;
-          lp.InitCosts(costs);
-          var min = lp.GetMinimalValue();
-
-          if (lp.Status == Status.Infeasible)
-          {
-            return initialBounds.Bottom;
-          }
-
-          if (lp.Status == Status.FloatingPointError)
-          {
-            return initialBounds;
-          }
-
-          var lower = lp.Status == Status.Optimal ?
-            Rational.ConvertFromDouble(min).LowerBound :
-            Rational.MinusInfinity;
-
-          lowerBounds.Add(new Pair<Variable, Rational>(toMinimizePair.One, lower));
-        }
-
-        var count = 0;
-        foreach (var toMinimizePair in varsToDimsInLp)
-        {
-          if (varToMinimize != -1)
-          {
-            costs[varToMinimize] = 0;
-          }
-
-          varToMinimize = toMinimizePair.Two;
-
-          // Get the maximum
-          costs[varToMinimize] = -1;
-          lp.InitCosts(costs);
-          var max = -lp.GetMinimalValue();
-          var upper = lp.Status == Status.Optimal ?
-              Rational.ConvertFromDouble(max).UpperBound : Rational.PlusInfinity;
-
-          if (lp.Status == Status.FloatingPointError)
-          {
-            return initialBounds;
-          }
-
-          var refinedBound = DisInterval.For(lowerBounds[count].Two, upper);
-
-          // The double-based Simplex may have introduced errors in the computation, and have wrong bounds
-          // If this is the case, we abstract the result of the reduction
-          var newBound = refinedBound.IsBottom
-            ? initialBounds.BoundsFor(toMinimizePair.One)
-            : refinedBound.Meet(initialBounds.BoundsFor(toMinimizePair.One));
-
-          result[toMinimizePair.One] = newBound.AsInterval;
-
-#if DEBUG
-          if (newBound.IsBottom)
-          {
-            this.expManager.Log("Found a bottom in the reduction of " + toMinimizePair.One);
-          }
-#endif
-
-          count++;
-        }
-      }
-      else
-      {
-        this.expManager.Log("No reduction as the set of constraints is empty");
-      }
-#if false
-      var span  = watch.Elapsed;
-
-      TimeSpentInSimplex += span;
-
-      Console.WriteLine("Time spent in Simplex: {0} (total {1}, max {2})",  (span).ToString(), 
-       TimeSpentInSimplex.ToString(),
-       UpdateMaxSimplexTime(span));
-#endif 
-      return result;
-    }
-
-#if false
-    static TimeSpan maxSimplexTime = new TimeSpan(0);
-    static TimeSpan UpdateMaxSimplexTime(TimeSpan s)
-    {
-      if (maxSimplexTime < s)
-      {
-        maxSimplexTime = s;
-      }
-
-      return maxSimplexTime;
-    }
-
-    static int maxVarsInSimplex = 0;
-    static int UpdateMaxVarsInSimplex(int v)
-    {
-      if (v > maxVarsInSimplex)
-      {
-        maxVarsInSimplex = v;
-      }
-
-      return maxVarsInSimplex;
-    }
-#endif
-    override internal LinearEqualitiesEnvironment<Variable, Expression> Join(IAbstractDomain a, ref List<Polynomial<Variable, Expression>> deletedLeft, ref List<Polynomial<Variable, Expression>> deletedRight)
-    {
-      IAbstractDomain trivialresult;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivialresult))
-      {
-        if (trivialresult.IsTop)
-        {
-          deletedLeft.AddRange(this.ToPolynomial(false));
-          deletedRight.AddRange((a as LinearEqualitiesEnvironment<Variable, Expression>).ToPolynomial(false));
-        }
-        return trivialresult as LinearEqualitiesEnvironment<Variable, Expression>;
-      }
-
-      var right = a as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
-
-      Contract.Assert(a != null);
-
-      // 1. Make the domains the same, by uniforming the maps, and swapping columns
-
-      var t1 = Task.Run(
-        () =>
-        {
-          this.PutIntoRowEchelonForm();
-          this.RecoverUnusedColumns();
-          this.PutSlackVariablesInBasis();
-        });
-
-      var t2 = Task.Run(
-        () =>
-        {
-          right.PutIntoRowEchelonForm();
-          right.RecoverUnusedColumns();
-          right.PutSlackVariablesInBasis();
-        });
-
-      Task.WaitAll(t1, t2);
-
-      UniformEnvironments(this, right);
-
-      this.PutIntoWeakRowEchelonForm();
-      right.PutIntoWeakRowEchelonForm();
-
-      Task.WaitAll(t1, t2);
-
-      if (this.state == LinearEqualitiesState.Bottom)
-      {
-        return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(right);
-      }
-
-      if (right.state == LinearEqualitiesState.Bottom)
-      {
-        return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
-      }
-
-      Contract.Assert(this.NumberOfColumns == right.NumberOfColumns);
-
-      // 2. The join is computed according to Karr 1976 paper
-      var A = this.equations.GetClonedEquations();      // We clone the matrixes as Karr works with side effects
-      var B = right.equations.GetClonedEquations(); 
-
-      int numberOfRowsInResult;
-      var JoinedMatrix = DisjunctionOfLinearSpaces(A, B, this.NumberOfRows, right.numberOfRows, out numberOfRowsInResult, ref deletedLeft, ref deletedRight);
-
-      // 3. Create a clone of the current private state
-      var freshMap = new VarsToDimensions(this.varsToDimensions);
-
-      var result = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(JoinedMatrix, numberOfRowsInResult, this.NumberOfColumns, freshMap, this.expManager);
-
-      result.state = LinearEqualitiesState.Normal; // the condition implied by Karr's algorithm is weaker than what we call now row echelon form
-
-      return result;
-    }
-
-    internal void RemoveRedundantSlackVariables()
-    {
-      this.PutIntoRowEchelonForm();
-
-      this.expManager.Log("Matrix before removing equalities var == slackvar:\n {0}", this.ToString);
-
-      var equalities = new List<LinearEqualityRedundancy<Variable>>();
-
-      for (var row = 0; row < this.NumberOfRows; row++)
-      {
-        if (this.equations.RowCount(row) != 2)
-        {
-          continue;
-        }
-
-        Variable v1 = default(Variable), v2 = default(Variable);
-        Rational k1 = Rational.For(0), k2 = Rational.For(0);
-
-        bool first = true;
-        int varCount = 0;
-
-        foreach (var pair in this.equations.GetElementsForRow(row))
-        {
-          if (pair.Key == this.NumberOfColumns - 1)
-          {
-            continue;
-          }
-          else if (first)
-          {
-            v1 = this.varsToDimensions[pair.Key];
-            k1 = pair.Value;
-            first = false;
-            varCount++;
-          }
-          else
-          {
-            v2 = this.varsToDimensions[pair.Key];
-            k2 = pair.Value;
-            varCount++;
-          }
-        }
-
-        if (varCount != 2 ||
-          ((!this.ExpressionManager.Decoder.IsSlackVariable(v1) && !this.ExpressionManager.Decoder.IsSlackVariable(v2))))
-        {
-          continue;
-        }
-
-        if (((k1 == 1 && k2 == -1) || (k1 == -1 && k2 == 1)) || (k1 == 1 && k2 == 1))
-        {
-          if (this.ExpressionManager.Decoder.IsSlackVariable(v1))
-          {
-            var tmp = v1;
-            v1 = v2;
-            v2 = tmp;
-          }
-
-          int signK = 1;
-
-          if (k1 == 1 && k2 == 1)
-          {
-            signK = -1;
-          }
-
-          // Now remove 
-          int v1Col, v2Col;
-          if (this.varsToDimensions.TryGetValue(v1, out v1Col)  // Should always succeed?
-            && this.varsToDimensions.TryGetValue(v2, out v2Col)) // it may be the case we already removed eq.V2
-          {
-            var matrix = this.equations.Unshare(this, ref this.equations);
-            for (int i = 0; i < this.NumberOfRows; i++)
-            {
-              var currRow = matrix[i];
-              if (currRow != null && i != row)
-              {
-                Rational value;
-                if (currRow.IsIndexOfNonDefaultElement(v2Col, out value))
-                {
-                  value = value * signK;
-
-                  var oldVal = currRow[v1Col];
-                  currRow[v1Col] = oldVal + value;
-                  currRow[v2Col] = Rational.For(0);
-                }
-              }
-            }
-
-            Contract.Assert(this.ExpressionManager.Decoder.IsSlackVariable(v2));
-
-            var newMapping = new VarsToDimensions(this.varsToDimensions);
-            if (newMapping.ContainsKey(v2))
-            {
-              newMapping.Remove(v2);
-            }
-
-            RemoveRow(matrix, row);
-            row--;
-
-            // Checking code
-            CheckAreAllZeroAt(matrix, v2, row, true);
-
-            this.equations = new LinearEquations<Variable, Expression>(this, matrix);
-            this.numberOfRows--;
-          }
-        }
-      }
-
-      this.expManager.Log("Matrix after removing simple equalities : {0}", this.ToString);
-
-      return;
-    }
-
-    /// <summary>
-    /// The specific AssignInParallel for SubPolyhedra, which takes care of updating the dependencies
-    /// </summary>
-    /// <param name="sourcesToTargetsInitial">The renaming map</param>
-    /// <param name="betaDep">The dependencies to update</param>
-    /// <param name="hints">Keeps track of deleted dependencies, to be used at joins or widenings</param>
-    internal void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargetsInitial, Converter<Variable, Expression> convert,
-      ref Dictionary<Variable, Polynomial<Variable, Expression>> betaDep, ref Hints<Variable, Expression> hints)
-    {
-      Contract.Requires(this.IsConsistent, "LinEq inconstistent @ AssignInParallel entry");
-
-      var tmp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
-
-      // adding the domain-generated variables to the map as identity
-      var sourcesToTargets = new Dictionary<Variable, FList<Variable>>(sourcesToTargetsInitial);
-
-      if (!this.IsTop)
-      {
-        foreach (var e in this.SlackVariables)
-        {
-          sourcesToTargets.Add(e, FList<Variable>.Cons(e, FList<Variable>.Empty));
-        }
-      }
-
-      #region Compute the statistics on the renaming
-
-      var pairs = 0;
-      foreach (var pair in sourcesToTargets)
-      {
-        if (pair.Value.Length() > 1)
-        {
-          pairs++;
-        }
-      }
-
-      #endregion
-
-      #region If statistics are bad, then do a very simple renaming and we return
-
-      if (pairs > AdaptiveRenamingInSubpolyhedraThreshold)
-      {
-        var variablesToRemove = new List<Variable>();
-        var newNames = new Dictionary<Variable, Variable>();
-
-        foreach (var v in this.Variables_Internal)
-        {
-          FList<Variable> renamings;
-          if (sourcesToTargets.TryGetValue(v, out renamings))
-          {
-            newNames[v] = renamings.Head;
-          }
-          else
-          {
-            variablesToRemove.Add(v);
-          }
-        }
-
-        // now remove all the variables lost in the translation
-        foreach (var v in variablesToRemove)
-        {
-          this.RemoveVariable(v);
-        }
-
-        // and finally rename the survicing variables
-        foreach (var pair in newNames)
-        {
-          this.RenameVariable(pair.Key, pair.Value);
-        }
-
-        // We are done!
-        return;
-      }
-
-      #endregion
-      var toSkip = new Set<Variable>();
-
-      foreach (var x in this.varsToDimensions.Keys)
-      {
-        if (!sourcesToTargets.ContainsKey(x))
-        {
-          if (!toSkip.Contains(x)) // otherwise, it already represents a target variable and should not be removed
-          {
-            tmp.RemoveInAssignInParallel(x, ref betaDep, ref hints, sourcesToTargets);
-          }
-          continue;
-        }
-
-        var targets = sourcesToTargets[x];
-
-        // choosing the canonical element
-        var target =
-          (targets.Length() > 1 && x.Equals(targets.Head)) ?
-          targets.Tail.Head :
-          targets.Head;
-
-        if (x.Equals(target))
-        { // If it is the identity there is nothing to do...
-          continue;
-        }
-
-        if (tmp.varsToDimensions.ContainsKey(target))
-        {
-          tmp.RemoveInAssignInParallel(target, ref betaDep, ref hints, sourcesToTargets);
-          toSkip.Add(target);
-        }
-
-        int dimX = tmp.varsToDimensions[x];
-
-        tmp.varsToDimensions.Remove(x);
-
-        tmp.varsToDimensions[target] = dimX;
-
-        var toRemove = SubPolyhedra<Variable, Expression>.UpdateBetaDeps(x, sourcesToTargets[x].Head, ref betaDep);
-
-        foreach (var beta in toRemove)
-        {
-          hints.Add(betaDep[beta]);
-        }
-
-        foreach (var beta in toRemove)
-        {
-          betaDep.Remove(beta);
-        }
-
-        SubPolyhedra<Variable, Expression>.UpdateHints(x, sourcesToTargets[x].Head, ref hints);
-
-        this.expManager.Log("Result : {0}", tmp.ToString);
-
-        Contract.Assert(tmp.IsConsistent);
-      }
-
-      // now adding equalities between targets of a same source
-      foreach (var pair in sourcesToTargets)
-      {
-        var length = pair.Value.Length();
-        if (length <= 1)
-        {
-          continue;
-        }
-
-        if (base.PrintWarnsForLargeTargets && length > 10)
-        {
-          Console.WriteLine("[SUBPOLYHEDRA] Found more than 10 pairwise equalities!!! (exactly {0})", length);
-        }
-
-        var target = pair.Key.Equals(pair.Value.Head) ? pair.Value.Tail.Head : pair.Value.Head;
-        var targetExp = convert(target);
-
-        foreach (var otherTarget in pair.Value.GetEnumerable())
-        {
-          if (target.Equals(otherTarget))
-          {
-            continue;
-          }
- 
-          var otherTargetExp = convert(otherTarget);
-
-          tmp = tmp.TestTrueEqual(targetExp, otherTargetExp) as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
-
-          Contract.Assert(tmp != null);
-        }
-      }
-
-      // We change the state of this, using tmp
-      CloneThisFrom(tmp);
-
-      Contract.Assert(this.IsConsistent, "LinEq inconstistent @ AssignInParallel exit");
-    }
-
-
-    private static bool AreSmallNumbers(Int64 up, Int64 down)
-    {
-      return -MaxCoefficientInEquationsforSimplexReduction <= up && up <= MaxCoefficientInEquationsforSimplexReduction && -MaxCoefficientInEquationsforSimplexReduction <= down && down <= MaxCoefficientInEquationsforSimplexReduction;
-    }
-
-    private bool TryInitializeLP(IntervalEnvironment<Variable, Expression> bounds, List<Pair<Variable, int>> varsToDimsInLP, out LinearProgramInterface lp)
-    {
-      var equations = 0;
-      var intervals = 0;
-
-      lp = new RevisedSimplexMethod();
-
-      this.expManager.Log("Equalities for the LP problem:\n");
-
-      for (int i = 0; i < NumberOfRows; i++)
-      {
-        var equality = new double[varsToDimsInLP.Count];
-
-        foreach (var pair in varsToDimsInLP)
-        {
-          var var = pair.One;
-
-          if (this.ContainsKey(var))
-          {
-            var j = varsToDimensions[var];
-            var jlp = pair.Two;
-
-            var v = this.equations.At(i, j);
-
-            if (!AreSmallNumbers(v.Up, v.Down))
-            {
-              this.expManager.Log(string.Format("Skipped the equation because of {0}", v));
-
-              goto nextEquation;
-            }
-
-            equality[jlp] = (double)v;
-          }
-        }
-
-        var k = this.equations.At(i, NumberOfColumns - 1);
-
-        if (!AreSmallNumbers(k.Up, k.Down))
-        {
-          this.expManager.Log(string.Format("Skipped the equation because of the known coefficient {0}", k));
-
-          goto nextEquation;
-        }
-
-        this.expManager.Log(string.Format("{0} = {1}", equality.ToStringInDepth(), k.ToString()));
-
-        lp.AddConstraint(equality, Relation.Equal, (double)k);
-
-        equations++;
-
-      nextEquation: 
-        ;
-      }
-      if (NumberOfRows == 0 || equations == 0)
-      {
-        lp = default(LinearProgramInterface);
-        return false;
-        //lp.AddConstraint(new double[varsToDimsInLP.Count], Relation.Equal, 0);
-      }
-
-      this.expManager.Log(string.Format("Intervals for the LP problem:\n{0}", bounds.ToString()));
-
-      foreach (var pair in varsToDimsInLP)
-      {
-        var var = pair.One;
-
-        Interval intv;
-        if (bounds.TryGetValue(var, out intv))
-        {
-          if (!intv.UpperBound.IsPlusInfinity )
-          {
-            if (intv.UpperBound < MaxBoundInIntervalsforSimplexReduction)
-            {
-              lp.LimitVariableFromAbove(pair.Two, (double)intv.UpperBound);
-              intervals++;
-            }
-            else
-            {
-              this.expManager.Log(string.Format("Upper bound skipped {0}\n", intv.UpperBound)); 
-            }
-          }
-          if (!intv.LowerBound.IsMinusInfinity )
-          {
-            if (intv.LowerBound > MinBoundInIntervalsforSimplexReduction)
-            {
-              lp.LimitVariableFromBelow(pair.Two, (double)intv.LowerBound);
-              intervals++;
-            }
-            else
-            {
-              this.expManager.Log(string.Format("Lower bound skipped {0}\n", intv.LowerBound));              
-            }
-          }
-        }
-      }
-
-      lp.Status = Status.Unknown;
-
-      return true;
-    }
-
-    private void PutVariablesInFront()
-    {
-      int i = 0;
-      for (int j = 0; j < NumberOfColumns - 1; j++)
-      {
-        Variable var;
-        if (varsToDimensions.TryGetValue(j, out var))
-        {
-          int dummy;
-          if (!TrySwapColumnsInRowEchelonForm(i, j, out dummy))
-          {
-            throw new AbstractInterpretationException("Bug!!!");
-          }
-
-          i++;
-        }
-      }
-
-      Contract.Assert(i == NumberOfVariables);
-    }
-
-    /// <summary>
-    /// Get all the slack variables that are duplicates (up to an affine transformation) of another slack variable.
-    /// Returns a dictionary d such that d(e1) = (k, e2, c) iff (k != 0 AND e1 + k * e2 == c) OR (k == 0 AND \exists c e1 == c)
-    /// </summary>
-    /// <returns>A dictionary indexed by redundant variables, to be removed by the caller</returns>
-    internal List<LinearEqualityRedundancy<Variable>> GetRedundancies()
-    {
-      this.PutSlackVariablesOutOfBasis();
-
-      var toRemove = new List<LinearEqualityRedundancy<Variable>>();
-      var remaining = new List<int>(); // will contain row indices corresponding to equalities between slack variables not in the required form
-
-      var zero = Rational.For(0);
-      var equations = this.equations;
-      var decoder = this.ExpressionManager.Decoder;
-
-      #region Find equalities b1 + k * b2 == c directly
-      for (int i = 0; i < this.NumberOfRows; i++)
-      {
-        var redundant = true;
-        var exp = default(Variable);
-        var target = default(Variable);
-        var coeff1 = zero;
-        var coeff2 = zero;
-
-        int found = 0;
-
-        for (int j = 0; j < this.NumberOfColumns - 1; j++)
-        {
-          var eq_i_j = equations.At(i, j);
-
-          if (eq_i_j.IsZero)
-          {
-            continue;
-          }
-
-          var dim_J = this.varsToDimensions[j];
-
-          if (!decoder.IsSlackVariable(dim_J))
-          {
-            redundant = false;
-            break;
-          }
-          
-          if (found == 0)
-          {
-            exp = dim_J;
-            coeff1 = eq_i_j;
-          }
-
-          if (found == 1)
-          {
-            target = dim_J;
-            coeff2 = eq_i_j;
-          }
-          found++;
-        }
-
-        if (redundant)
-        {
-          if (found == 1)
-          {
-            toRemove.Add(new LinearEqualityRedundancy<Variable>(exp, zero, default(Variable), equations.At(i, NumberOfColumns - 1)));
-          }
-          else if (found == 2)
-          {
-            toRemove.Add(new LinearEqualityRedundancy<Variable>(exp, coeff2 / coeff1, target, equations.At(i, numberOfCols - 1) / coeff1));
-          }
-          else
-          {
-            remaining.Add(i);
-          }
-        }
-      }
-      #endregion
-
-      #region Refinement of "if x + p == 0 and y + p == 0 then x == y"
-      var remainingCount = remaining.Count;
-      if (remainingCount >= 0)
-      {
-        var removed = new bool[remainingCount];
-        for (int i = 0; i < remainingCount; i++)
-        {
-          // if any variable varj is "equivalent" to vari, it is also equivalent to the target of vari and has alredy been marked as such
-          if (removed[i])
-          {
-            continue;
-          }
-
-          for (int j = i + 1; j < remainingCount; j++)
-          {
-            // we have :
-            // vari + pi == ki
-            // varj + pj == kj
-            // now we are trying to see if pi and pj are colinear
-
-            // 0 for both rows contain only zeros so far, 1 for rows are colinear and non-zero, 2 for rows are not (strictly) colinear
-            var colinearity = 0;
-            var coeff = zero; // if colinearity != 2 then row j == coeff * row i
-            var remaining_i = remaining[i];
-            var remaining_j = remaining[j];
-
-            for (int k = this.numberOfRows; k < this.numberOfCols - 1; k++)
-            {
-              if (colinearity == 0)
-              {
-
-                if (equations.At(remaining_i, k).IsNotZero)
-                {
-                  if (equations.At(remaining_j, k).IsNotZero)
-                  {
-                    colinearity = 1;
-
-                    if (!Rational.TryDiv(equations.At(remaining_j, k), equations.At(remaining_i, k), out coeff))
+                    if (decoder.IsSlackVariable(x))
                     {
-                      // If we get an overflow from the division above, we skip this constraint and move to the new one
-                      goto NextIteration;
+                        yield return x;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a row equivalent to the first one modulo linear combinations with the equalities in the state, using the mapping from <paramref name="exp"/> to <paramref name="dim"/>
+        /// </summary>
+        /// <param name="initial">The original row</param>
+        /// <param name="final">Will contain the result</param>
+        /// <param name="exp">A variable for which we need a mapping</param>
+        /// <param name="dim">The dimension for <paramref name="exp"/></param>
+        /// <returns>true if we managed to find an equivalent of <paramref name="initial"/> without slack variables, false otherwise</returns>
+        private bool GetEquivalentWithoutSlack(Polynomial<Variable, Expression> initial,
+          out SparseRationalArray final, Variable exp, int dim, IDictionary<Variable, FList<Variable>> sourcesToTargets)
+        {
+            final = AsVector(initial);
+            if (initial.IsTautology || initial.Variables.IsEmpty)
+            {
+                return false;
+            }
+
+            var source = default(Variable);
+            var found = false;
+            foreach (var pair in sourcesToTargets)
+            {
+                if (pair.Value.Head.Equals(exp))
+                {
+                    source = pair.Key;
+                    found = true;
+
+                    Contract.Assert(source != null);
+
+                    break;
+                }
+            }
+            try
+            {
+                if (initial.Variables.Count == 1)
+                {// exp had a constant value, we try to see if some variable "source" with another constant value is renamed to exp and return the relation exp - source == k
+                    int dimSource;
+
+                    if (!found || !varsToDimensions.TryGetValue(source, out dimSource))
+                    {
+                        return false;
                     }
 
-                  }
-                  else
-                  {
-                    colinearity = 2;
-                    break;
-                  }
+                    int rowSource = -1;
+
+                    for (int i = this.NumberOfRows - 1; i >= 0; i--)
+                    {
+                        if (!this.equations.IsNullRow(i) && this.equations.At(i, dimSource).IsNotZero)
+                        {
+                            rowSource = i;
+
+                            break;
+                        }
+                    }
+
+                    if (rowSource < 0)
+                    {
+                        return false;
+                    }
+
+                    if (this.equations.IsConstantRow(rowSource) && this.equations.At(rowSource, dimSource) == 1)
+                    {
+                        final = FreshRow(numberOfCols);
+                        final[dim] = Rational.For(1);
+                        final[dimSource] = Rational.For(-1);
+                        final[numberOfCols - 1] = (initial.Right[0].K / initial.Left[0].K) - this.equations.At(rowSource, numberOfCols - 1);
+
+                        Contract.Assert(final[dim].IsNotZero);
+
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
                 else
                 {
-                  if (equations.At(remaining_j, k).IsNotZero)
-                  {
-                    colinearity = 2;
-                    break;
-                  }
+                    if (source == null || source.Equals(default(Expression)) || !varsToDimensions.ContainsKey(source))
+                    {
+                        this.varsToDimensions[exp] = dim;
+                        Variable e;
+
+                        var combinations = Combine(initial, SubPolyhedra<Variable, Expression>.IsBetaDefinition(initial, out e, this.expManager.Decoder), 0, MAX_VARS_FOR_COMBINE);
+
+                        this.varsToDimensions.Remove(exp);
+                        if (combinations.IsEmpty)
+                        {
+                            return false;
+                        }
+                        final = AsVector(combinations.PickAnElement());
+
+                        Contract.Assert(final[dim].IsNotZero);
+
+                        return true;
+                    }
+                    else
+                    {
+                        var copy = this.DuplicateInternal();
+
+                        copy.AddConstraint(copy.AsVector(initial));
+
+                        foreach (var e in this.Variables)
+                        {
+                            if (e.Equals(exp) || e.Equals(source))
+                            {
+                                continue;
+                            }
+                            copy.RemoveVariable(e, true);
+                        }
+
+                        var copy_matrix = copy.equations.Unshare(copy, ref copy.equations);
+
+                        Contract.Assert(copy.NumberOfRows <= 2);
+
+                        if (copy.NumberOfRows == 1 && !copy.equations.IsConstantRow(0))
+                        {
+                            final = copy_matrix[0];
+                            Contract.Assert(final[dim] != 0);
+
+                            return true;
+                        }
+                        else if (copy.NumberOfRows == 2)
+                        {
+                            final = copy_matrix[0];
+                            foreach (var pair in copy.equations.GetElementsForRow(1))
+                            {
+                                final[pair.Key] -= pair.Value;
+                            }
+
+                            Contract.Assert(final[dim].IsNotZero);
+
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
                 }
-              }
-              else
-              {
-                try
-                {
-                  if (coeff * equations.At(remaining_i, k) != equations.At(remaining_j, k))
-                  {
-                    colinearity = 2;
-                    break;
-                  }
-                }
-                catch (ArithmeticExceptionRational)
-                {
-                  // We skip the constraint and move to the nexr
-                  goto NextIteration;
-                }
-              }
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return false;
+            }
+        }
+
+        #region Specific algorithms for SubPolyhedra
+        /// <summary>
+        /// Tries to infer the best intervals for each variable in the domain 
+        /// </summary>
+#if SUBPOLY_ONLY
+        internal
+#else
+        public
+#endif
+    IntervalEnvironment<Variable, Expression> BoundsInference(
+              IntervalEnvironment<Variable, Expression> initialBounds,
+              SubPolyhedra.ReductionAlgorithm algorithm, int MaxVariablesForSimplex)
+        {
+            Contract.Requires(initialBounds != null);
+            Contract.Ensures(Contract.Result<IntervalEnvironment<Variable, Expression>>() != null);
+
+            CheckStateInvariant();
+
+            if (this.IsTop)
+            {
+                return initialBounds;
             }
 
-            if (colinearity == 1)
+            IntervalEnvironment<Variable, Expression> result;
+
+            if (algorithm == SubPolyhedra.ReductionAlgorithm.Simplex)
             {
-              // we have :
-              // ExpForI + p == k1
-              // ExpForJ + coeff * p == k2
-              // for some p, so ExpForJ - coeff * ExpForI == k2 - coeff * k1
-
-              //var remaining_i = remaining[i];
-              // var remaining_j = remaining[j];
-
-              Variable ExpForI, ExpForJ;
-              if (this.varsToDimensions.TryGetValue(remaining_i, out ExpForI)
-                && this.varsToDimensions.TryGetValue(remaining_j, out ExpForJ))
-              {
-                Rational value;
-                try
-                {
-                  value = equations.At(remaining_j, numberOfCols - 1)/*k2*/ - coeff * equations.At(remaining_i, numberOfCols - 1)/*k1*/;
-                }
-                catch (ArithmeticExceptionRational)
-                {
-                  // We abstract it away
-                  goto NextIteration;
-                }
-
-                toRemove.Add(new LinearEqualityRedundancy<Variable>(ExpForJ, -coeff, ExpForI, value));
-                removed[j] = true;
-              }
-              else
-              {
-                goto NextIteration;
-              }
+                this.expManager.Log("Running Simplex");
+                result = RunSimplex(initialBounds, MaxVariablesForSimplex);
             }
-
-          NextIteration:
-            ;
-          }
-        }
-      }
-      #endregion
-
-      foreach (var e in this.Variables)
-      {
-        if (decoder.IsSlackVariable(e) && equations.IsZeroCol(this.NumberOfRows, varsToDimensions[e]))
-        {
-          var dummy = new LinearEqualityRedundancy<Variable>(e, zero, default(Variable), Rational.PlusInfinity);
-          toRemove.Add(dummy);
-        }
-      }
-
-      return toRemove;
-    }
-
-    internal void PropagateValue(Variable exp, ref IntervalEnvironment<Variable, Expression> bounds)
-    {
-      var j = this.varsToDimensions[exp];
-      for (var i = 0; i < this.NumberOfRows; i++)
-      {
-        if (this.equations.At(i, j).IsZero)
-        {
-          continue;
-        }
-
-        var pol = this.ToPolynomial(i);
-
-        if (pol.Left.Length != 2)
-        {
-          continue;
-        }
-
-        var forExp = bounds.BoundsFor(exp);
-        Rational kexp, kother;
-        Variable other;
-
-        if (pol.Left[0].VariableAt(0).Equals(exp))
-        {
-          kexp = pol.Left[0].K;
-          kother = pol.Left[1].K;
-          other = pol.Left[1].VariableAt(0);
-        }
-        else
-        {
-          kexp = pol.Left[1].K;
-          kother = pol.Left[0].K;
-          other = pol.Left[0].VariableAt(0);
-        }
-        bounds[other] = bounds.BoundsFor(other).AsInterval.Meet(Interval.For(pol.Right[0].K / kother) - Interval.For(kexp / kother) * forExp.AsInterval);
-      }
-    }
-
-    /// <summary>
-    /// Removes all rows that only contain one variable (x == k), and returns a map from the expression removed to the associated constants
-    /// </summary>
-    /// <returns>A map from variables to their constant value</returns>
-    internal Dictionary<Variable, Rational> GetConstants()
-    {
-      var result = new Dictionary<Variable, Rational>();
-      int numberOfVars;
-      Variable exp = default(Variable);
-
-      for (int i = 0; i < this.numberOfRows; i++)
-      {
-        numberOfVars = 0;
-
-        foreach (var pair in this.equations.GetElementsForRow(i))
-        {
-          if (pair.Value.IsNotZero && pair.Key < this.numberOfCols - 1)
-          {
-            numberOfVars++;
-            if (numberOfVars == 1)
+            else if (algorithm == SubPolyhedra.ReductionAlgorithm.SimplexOptima)
             {
-              exp = this.varsToDimensions[pair.Key];
-            }
-          }
-        }
-        if (numberOfVars == 1)
-        {
-          result.Add(exp, this.equations.At(i, this.numberOfCols - 1));
-          RemoveRow(i--);
-        }
-      }
-      return result;
-    }
+#if USESOLVERFOUNDATION
 
-    /// <summary>
-    /// In row echelon form, put all slack variables in basis to try to get meaningfull information from dropped constraints at the join
-    /// </summary>
-    private void PutSlackVariablesInBasis()
-    {
-      Contract.Assert(this.state == LinearEqualitiesState.StrongRowEchelon);
+#if false
+                var s1 = RunSimplex(initialBounds);
+                var s2 = RunSimplex_OptimaModel(initialBounds);
 
-      foreach (var x in this.Variables)
-      {
-        if (!this.expManager.Decoder.IsSlackVariable(x))
-        {
-          continue;
-        }
+                bool b1 = s1.LessEqual(s2);
+                bool b2 = s2.LessEqual(s1);
+                bool b = b1 && b2;
 
-        // already in basis
-        if (varsToDimensions[x] < numberOfRows)
-        {
-          continue;
-        }
-
-        int j = varsToDimensions[x];
-        int row = -1;
-        for (int i = 0; i < numberOfRows; i++)
-        {
-          if (this.equations.At(i, j).IsNotZero && !expManager.Decoder.IsSlackVariable(varsToDimensions[i]))
-          {
-            row = i;
-            break;
-          }
-        }
-
-        if (row != -1)
-        {
-          int eRow;
-
-          if (!TrySwapColumnsInRowEchelonForm(row, j, out eRow))
-          {
-            RemoveRow(eRow);
-            PutIntoRowEchelonForm();
-          }
-        }
-      }
-    }
-
-    /// <summary>
-    /// In row echelon form, put all slack variables in basis to try to get as much redundancies as possible
-    /// </summary>
-    private void PutSlackVariablesOutOfBasis()
-    {
-      Contract.Requires(this.state == LinearEqualitiesState.StrongRowEchelon);
-
-      foreach (var x in this.Variables)
-      {
-        if (expManager.Decoder.IsSlackVariable(x) || varsToDimensions[x] < numberOfRows) // Already in the basis
-        {
-          continue;
-        }
-
-        int j = varsToDimensions[x];
-        int row = -1;
-        for (int i = 0; i < numberOfRows; i++)
-        {
-          if (this.equations.At(i,j).IsNotZero
-            && this.varsToDimensions.ContainsValue(i)  // F : I've added the test, as I cannot convince myself that InverseMap[i] is always there
-            && expManager.Decoder.IsSlackVariable(varsToDimensions[i]))
-          {
-            row = i;
-            break;
-          }
-        }
-
-        if (row != -1)
-        {
-          int dummy;
-          if (!TrySwapColumnsInRowEchelonForm(row, j, out dummy))
-          {
-            RemoveRow(dummy);
-            PutIntoRowEchelonForm();
-          }
-        }
-      }
-    }
-
-    internal void ProjectSlackVariables()
-    {
-      var decoder = expManager.Decoder;
-      foreach (var e in this.Variables)
-      {
-        if (decoder.IsSlackVariable(e))
-        {
-          this.ProjectVariable(e);
-        }
-      }
-    }
-
-    private void RemoveInAssignInParallel(Variable x,
-      ref Dictionary<Variable, Polynomial<Variable, Expression>> betaDep, ref Hints<Variable, Expression> hints, 
-      Dictionary<Variable, FList<Variable>> sourcesToTargets)
-    {
-      Polynomial<Variable, Expression> deletedRow;
-      int d;
-
-      this.RemoveVariable(x, false, out deletedRow, out d);
-
-      SparseRationalArray withoutSlack;
-      if (this.GetEquivalentWithoutSlack(deletedRow, out withoutSlack, x, d, sourcesToTargets))
-      { // this part is supposed to update the dependencies by replacing the variable x, which is deleted, by a polynomial p such that x == p is provable in the pre-state
-        // the polynomial p is represented by withoutSlack, and has the property that it doesn't contain any slack variable ; withoutSlack corresponds to coeff*x == p, not to p only
-        var slackVariables = new List<Variable>(betaDep.Keys);
-        foreach (var beta in slackVariables)
-        {
-          if (betaDep[beta].Variables.Contains(x))
-          { // here we know that beta depends on x, so we need to replace it
-            var updated = new List<Monomial<Variable>>();
-            var k = betaDep[beta].Relation == null ? Rational.For(0) : betaDep[beta].Right[0].K;
-            foreach (var m in betaDep[beta].Left)
-            {
-              if (m.IsConstant || !m.VariableAt(0).Equals(x))
-              { // keep a copy of the old monomials which don't contain x
-                updated.Add(new Monomial<Variable>(m.K, m.VariableAt(0)));
-              }
-              else
-              { // here we have the monomial m.K * x, so we need to replace it using withoutSlack
-                var coeff = withoutSlack[d]; // the coefficient for x
-                foreach (var pair in withoutSlack.GetElements())
+                if (!b)
                 {
-                  if (pair.Key == d)
-                    continue;
-                  if (pair.Key == this.NumberOfColumns - 1)
-                  { // coeff*x == -k1*y1 - ... - kn*yn + pair.Value, so we replace x by pair.Value / coeff, multiply by the coefficient m.K of x in the previous polynomial, and take the opposite as we will put the conatant on the other side of the equality
-                    k -= m.K * pair.Value / coeff;
-                  }
-                  else
-                  {
-                    updated.Add(new Monomial<Variable>(-m.K * pair.Value / coeff, this.varsToDimensions[pair.Key]));
-                  }
+                    System.Diagnostics.Debugger.Break();
                 }
-              }
-            }
-            var constant = new Monomial<Variable>[] { new Monomial<Variable>(k) };
-
-            Polynomial<Variable, Expression> dep;
-
-            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, updated.ToArray(), constant, out dep))
-            {
-              if (dep.Variables.Count > 2)
-                betaDep[beta] = dep;
-              else
-                betaDep.Remove(beta);
+                return s1;
+#else
+                var s2 = RunSimplex_OptimaModel(initialBounds);
+                return s2;
+#endif
+#else
+                result = RunSimplex(initialBounds, MaxVariablesForSimplex);
+#endif
             }
             else
             {
-#if DEBUG
-              Contract.Assert(false); // We should never get to this point
-#endif
-              return;
-            }
-          }
-        }
-        var newhints = new List<Polynomial<Variable, Expression>>();
-        foreach (var pol in hints.Enumerate())
-        {
-          if (pol.Variables.Contains(x))
-          { // here we know that pol depends on x, so we need to replace it
-            var updated = new List<Monomial<Variable>>();
-            var k = pol.Relation == null ? Rational.For(0) : pol.Right[0].K;
-            foreach (var m in pol.Left)
-            {
-              if (m.IsConstant || !m.VariableAt(0).Equals(x))
-              { // keep a copy of the old monomials which don't contain x
-                updated.Add(new Monomial<Variable>(m.K, m.VariableAt(0)));
-              }
-              else
-              { // here we have the monomial m.K * x, so we need to replace it using withoutSlack
-                var coeff = withoutSlack[d]; // the coefficient for x
-                foreach (var pair in withoutSlack.GetElements())
+                if (algorithm == SubPolyhedra.ReductionAlgorithm.MixSimplexFast)
                 {
-                  if (pair.Key == d)
-                    continue;
-                  if (pair.Key == this.NumberOfColumns - 1)
-                  { // coeff*x == -k1*y1 - ... - kn*yn + pair.Value, so we replace x by pair.Value / coeff, multiply by the coefficient m.K of x in the previous polynomial, and take the opposite as we will put the conatant on the other side of the equality
-                    k -= m.K * pair.Value / coeff;
-                  }
-                  else
-                  {
-                    updated.Add(new Monomial<Variable>(-m.K * pair.Value / coeff, this.varsToDimensions[pair.Key]));
-                  }
+                    if (this.Variables.Count < 20)
+                    {
+                        this.expManager.Log("Running Simplex");
+                        result = RunSimplex(initialBounds, MaxVariablesForSimplex);
+                    }
+                    else
+                    {
+                        this.expManager.Log("Running Fast");
+                        result = RunBasisExploration(initialBounds, SubPolyhedra.ReductionAlgorithm.Fast);
+                    }
                 }
-              }
+                else
+                {
+                    result = RunBasisExploration(initialBounds, algorithm);
+                }
             }
-            var constant = new Monomial<Variable>[] { new Monomial<Variable>(k) };
 
-            Polynomial<Variable, Expression> dep;
-            Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, updated.ToArray(), constant, out dep);
+            this.expManager.Log("Result of the reduction:\n{0}", result.ToString);
 
-            if (dep.Variables.Count > 2)
+            return result;
+        }
+
+        private IntervalEnvironment<Variable, Expression> RunBasisExploration(
+          IntervalEnvironment<Variable, Expression> initialBounds, SubPolyhedra.ReductionAlgorithm algorithm)
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+            SparseRationalArray row;
+            Interval interval, finiteInterval;
+            int infLower, infUpper;
+            int numberOfVariablesInBasis = 0;
+
+            var result = initialBounds.Clone() as IntervalEnvironment<Variable, Expression>;
+
+            Contract.Assert(result != null);
+
+            #region Step 1 : put the less precise variables in the basis
+
+            var matrix = this.equations.Unshare(this, ref this.equations);
+
+            for (int i = 0; i < NumberOfRows; i++)
             {
-              newhints.Add(dep);
+                row = matrix[i];
+
+                interval = result.EvalArray(row, this.varsToDimensions.InverseMap, this.NumberOfColumns - 1,
+                  out finiteInterval, out infLower, out infUpper);
+
+                if (interval.IsBottom)
+                {
+                    this.state = LinearEqualitiesState.Bottom;
+                    return initialBounds;
+                }
+
+                var LessPrecise = default(Variable);
+                var WorstPrecision = Rational.For(0);
+
+                int infiniteInWorst = 0;
+                bool foundLessPrecise = false;
+
+                foreach (var pair in row.GetElements())
+                {
+                    if (pair.Key == this.NumberOfColumns - 1)
+                    { // constant
+                        continue;
+                    }
+
+                    var var = varsToDimensions[pair.Key];
+                    var k = pair.Value;
+                    var varInterval = k * result.BoundsFor(var).AsInterval;
+
+                    Rational lowerKX, upperKX;
+
+                    try
+                    {
+                        lowerKX = varInterval.UpperBound.IsPlusInfinity ?
+                          (infUpper > 1 ? Rational.MinusInfinity : -finiteInterval.UpperBound)
+                          : varInterval.UpperBound - interval.UpperBound;
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        lowerKX = Rational.MinusInfinity;
+                    }
+                    try
+                    {
+                        upperKX = varInterval.LowerBound.IsMinusInfinity ?
+                          (infLower > 1 ? Rational.PlusInfinity : -finiteInterval.LowerBound)
+                          : varInterval.LowerBound - interval.LowerBound;
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        upperKX = Rational.PlusInfinity;
+                    }
+
+                    var intervalForX = Interval.For(lowerKX, upperKX) / k /* (Interval.For(k))*/;
+
+                    if (intervalForX.LessEqual(result.BoundsFor(var).AsInterval))
+                    {
+                        int eRow = -1;
+
+                        if (!TrySwapColumnsInRowEchelonForm(i, varsToDimensions[var], out eRow))
+                        {
+                            RemoveRow(eRow);
+                            PutIntoRowEchelonForm(); // should not change the rows already treated
+                            if (eRow <= i)
+                            {
+                                i--;
+                            }
+                        }
+
+                        if (eRow == -1)
+                        {
+                            int dummy;
+                            if (!TrySwapColumnsInRowEchelonForm(numberOfVariablesInBasis, i, out dummy))
+                            {
+                                throw new AbstractInterpretationException("I was not expecting a failure here! Is it a bug?");
+                            }
+
+                            numberOfVariablesInBasis++;
+
+                            Contract.Assert(numberOfVariablesInBasis <= NumberOfRows);
+                        }
+
+                        foundLessPrecise = true;
+                        break;
+                    }
+
+                    var resInt = result.BoundsFor(var).AsInterval.Meet(intervalForX);
+
+                    // Found a contradiction?
+                    if (resInt.IsBottom)
+                    {
+                        return result.Bottom;
+                    }
+
+                    result[var] = resInt;
+
+                    Rational diff;
+
+                    try
+                    { // F: I've added it
+                        diff = resInt.UpperBound - resInt.LowerBound;
+                    }
+                    catch (ArithmeticExceptionRational)
+                    {
+                        diff = Rational.PlusInfinity;
+                    }
+
+                    int infiniteInDiff = (resInt.UpperBound.IsInfinity ? 1 : 0) + (resInt.LowerBound.IsInfinity ? 1 : 0);
+
+                    if (diff > WorstPrecision || infiniteInDiff > infiniteInWorst)
+                    {
+                        WorstPrecision = diff;
+                        infiniteInWorst = infiniteInDiff;
+                        LessPrecise = var;
+                    }
+                }
+
+                if (!foundLessPrecise && WorstPrecision > 0)
+                {
+                    int eRow;
+                    if (!TrySwapColumnsInRowEchelonForm(i, varsToDimensions[LessPrecise], out eRow))
+                    {
+                        RemoveRow(eRow);
+                        PutIntoRowEchelonForm();
+                        if (eRow <= i)
+                        {
+                            i--;
+                        }
+                    }
+                }
             }
-          }
-          else
-          {
-            newhints.Add(pol);
-          }
+            #endregion
+
+            #region Step 2 : infer bounds for all the variables, trying different combinations for the variables not definitely in basis
+            Explorer comb;
+            var temp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
+            temp.PutVariablesInFront();
+
+            if (NumberOfVariables - numberOfVariablesInBasis < 0)
+            {
+                return result;
+            }
+
+            int[] previous = new int[NumberOfVariables - numberOfVariablesInBasis];
+            for (int i = 0; i < previous.Length; i++)
+            {
+                previous[i] = i;
+            }
+
+            // If we abstracted away some row because of Rational overflows, 
+            // it may have be the case that the invariant NumberOfRows - numberOfVariablesInBasis >= 0 does not hold anymore
+            int range = Math.Max(NumberOfRows - numberOfVariablesInBasis, 0);
+
+            switch (algorithm)
+            {
+                case SubPolyhedra.ReductionAlgorithm.Complete:
+                    comb = new CombinatorialExplorer(NumberOfVariables - numberOfVariablesInBasis, range);
+                    break;
+
+                case SubPolyhedra.ReductionAlgorithm.Fast:
+                    comb = new LinearExplorer(NumberOfVariables - numberOfVariablesInBasis, range);
+                    break;
+
+                default:
+                    comb = new LinearExplorer(NumberOfVariables - numberOfVariablesInBasis, range);
+                    break;
+            }
+
+            while (comb.MoveNext())
+            {
+                if (watch.Elapsed.Minutes >= 5)
+                {
+                    throw new TimeoutExceptionFixpointComputation();
+                }
+
+                for (int i = 0; i < comb.Current.Length; i++)
+                {
+                    if (previous[i] == comb.Current[i])
+                    {
+                        continue;
+                    }
+
+                    int j = Array.FindIndex(previous, delegate (int x) { return x == comb.Current[i]; });
+
+                    if (temp.equations.At(i + numberOfVariablesInBasis, j + numberOfVariablesInBasis).IsZero)
+                    {
+                        for (int u = i + numberOfVariablesInBasis + 1; u < numberOfRows; u++)
+                        {
+                            if (temp.equations.At(u, j + numberOfVariablesInBasis).IsNotZero)
+                            {
+                                int dummy;
+                                if (!temp.TrySwapColumnsInRowEchelonForm(u, j + numberOfVariablesInBasis, out dummy))
+                                {
+                                    return result;
+                                }
+
+                                if (!temp.TrySwapColumnsInRowEchelonForm(i + numberOfVariablesInBasis, u, out dummy))
+                                {
+                                    return result;
+                                }
+
+                                previous[j] = previous[u - numberOfVariablesInBasis];
+                                previous[u - numberOfVariablesInBasis] = previous[i];
+                                previous[i] = comb.Current[i];
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        int dummy;
+                        if (!temp.TrySwapColumnsInRowEchelonForm(i + numberOfVariablesInBasis, j + numberOfVariablesInBasis, out dummy))
+                        {
+                            return result;
+                        }
+
+                        previous[j] = previous[i];
+                        previous[i] = comb.Current[i];
+                    }
+                }
+
+                var temp_matrix = temp.equations.Unshare(temp, ref temp.equations);
+
+                for (int i = 0; i < temp.NumberOfRows; i++)
+                {
+                    row = temp_matrix[i];
+                    interval = result.EvalArray(row, temp.varsToDimensions.InverseMap, temp.NumberOfColumns - 1, out finiteInterval, out infLower, out infUpper);
+
+                    if (interval.IsBottom)
+                    {
+                        this.state = LinearEqualitiesState.Bottom;
+                        return initialBounds.Bottom;
+                    }
+
+                    foreach (var pair in row.GetElements())
+                    {
+                        if (pair.Key == temp.NumberOfColumns - 1)
+                        {// constant
+                            continue;
+                        }
+
+                        var var = temp.varsToDimensions[pair.Key];
+                        var k = pair.Value;
+                        var varInterval = k * result.BoundsFor(var).AsInterval;
+
+                        Rational lowerKX, upperKX;
+                        try
+                        {
+                            lowerKX = varInterval.UpperBound.IsPlusInfinity ?
+                              (infUpper > 1 ? Rational.MinusInfinity : -finiteInterval.UpperBound) : varInterval.UpperBound - interval.UpperBound;
+                        }
+                        catch (ArithmeticExceptionRational)
+                        {
+                            lowerKX = Rational.MinusInfinity;
+                        }
+
+                        try
+                        {
+                            upperKX = varInterval.LowerBound.IsMinusInfinity ?
+                              (infLower > 1 ? Rational.PlusInfinity : -finiteInterval.LowerBound) : varInterval.LowerBound - interval.LowerBound;
+                        }
+                        catch (ArithmeticExceptionRational)
+                        {
+                            upperKX = Rational.PlusInfinity;
+                        }
+
+                        var intervalForKX = Interval.For(lowerKX, upperKX);
+                        var intervalForX = intervalForKX / k;
+                        var resInt = result.BoundsFor(var).AsInterval.Meet(intervalForX);
+
+                        if (resInt.IsBottom)
+                        {
+                            return result.Bottom;
+                        }
+
+                        result[var] = resInt;
+                    }
+                }
+            }
+            #endregion
+
+            return result;
         }
-        hints.Clear();
-        hints.Add(newhints);
-      }
-      else
-      { // no equivalent, removing all dependencies and hints on x
-        var vars = new List<Variable>(betaDep.Keys);
-        foreach (var e in vars)
+
+#if false
+        static TimeSpan TimeSpentInSimplex = new TimeSpan(0);
+#endif
+
+        private IntervalEnvironment<Variable, Expression> RunSimplex(IntervalEnvironment<Variable, Expression> initialBounds, int MaxVariables)
         {
-          if (betaDep[e].Variables.Contains(x))
-          {
-            betaDep.Remove(e);
-          }
+#if TRACE_PERFORMANCE
+            return PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.Simplex, () => RunSimplexInternal(initialBounds, MaxVariables), true);
+#else
+            return RunSimplexInternal(initialBounds, MaxVariables);
+#endif
         }
-        var nHints = new Hints<Variable, Expression>();
-        foreach (var p in hints.Enumerate())
+
+        /// <summary>
+        /// Simplex algorithm : initializing the LP, then asking for the minimal solutions
+        /// </summary>
+
+        private IntervalEnvironment<Variable, Expression> RunSimplexInternal(IntervalEnvironment<Variable, Expression> initialBounds, int MaxVariables)
         {
-          if (!p.Variables.Contains(x))
-            nHints.Add(p);
+#if TRACE_PERFORMANCE
+            var watch = new Stopwatch();
+            watch.Start();
+#endif
+
+            var result = initialBounds.Clone() as IntervalEnvironment<Variable, Expression>;
+
+            if (result == null)
+            {
+                return initialBounds;
+            }
+
+            var allVars = Variables.SetUnion(initialBounds.Variables);
+
+            if (allVars.Count >= MaxVariables)
+            {
+                return initialBounds;
+            }
+
+            var varsToDimsInLp = new List<Pair<Variable, int>>();
+
+            int n = 0;
+            foreach (var var in allVars)
+            {
+                varsToDimsInLp.Add(new Pair<Variable, int>(var, n++));
+            }
+
+#if false
+            Console.WriteLine("Variables {0} (max {1})", n, UpdateMaxVarsInSimplex(n));
+#endif
+            LinearProgramInterface lp;
+            if (TryInitializeLP(initialBounds, varsToDimsInLp, out lp))
+            {
+                var costs = new double[n];
+                var varToMinimize = -1;
+
+                var lowerBounds = new List<Pair<Variable, Rational>>();
+
+                foreach (var toMinimizePair in varsToDimsInLp)
+                {
+                    if (varToMinimize != -1)
+                    {
+                        costs[varToMinimize] = 0;
+                    }
+
+                    varToMinimize = toMinimizePair.Two;
+
+                    // Get the minimum
+                    costs[varToMinimize] = 1;
+                    lp.InitCosts(costs);
+                    var min = lp.GetMinimalValue();
+
+                    if (lp.Status == Status.Infeasible)
+                    {
+                        return initialBounds.Bottom;
+                    }
+
+                    if (lp.Status == Status.FloatingPointError)
+                    {
+                        return initialBounds;
+                    }
+
+                    var lower = lp.Status == Status.Optimal ?
+                      Rational.ConvertFromDouble(min).LowerBound :
+                      Rational.MinusInfinity;
+
+                    lowerBounds.Add(new Pair<Variable, Rational>(toMinimizePair.One, lower));
+                }
+
+                var count = 0;
+                foreach (var toMinimizePair in varsToDimsInLp)
+                {
+                    if (varToMinimize != -1)
+                    {
+                        costs[varToMinimize] = 0;
+                    }
+
+                    varToMinimize = toMinimizePair.Two;
+
+                    // Get the maximum
+                    costs[varToMinimize] = -1;
+                    lp.InitCosts(costs);
+                    var max = -lp.GetMinimalValue();
+                    var upper = lp.Status == Status.Optimal ?
+                        Rational.ConvertFromDouble(max).UpperBound : Rational.PlusInfinity;
+
+                    if (lp.Status == Status.FloatingPointError)
+                    {
+                        return initialBounds;
+                    }
+
+                    var refinedBound = DisInterval.For(lowerBounds[count].Two, upper);
+
+                    // The double-based Simplex may have introduced errors in the computation, and have wrong bounds
+                    // If this is the case, we abstract the result of the reduction
+                    var newBound = refinedBound.IsBottom
+                      ? initialBounds.BoundsFor(toMinimizePair.One)
+                      : refinedBound.Meet(initialBounds.BoundsFor(toMinimizePair.One));
+
+                    result[toMinimizePair.One] = newBound.AsInterval;
+
+#if DEBUG
+                    if (newBound.IsBottom)
+                    {
+                        this.expManager.Log("Found a bottom in the reduction of " + toMinimizePair.One);
+                    }
+#endif
+
+                    count++;
+                }
+            }
+            else
+            {
+                this.expManager.Log("No reduction as the set of constraints is empty");
+            }
+#if false
+            var span = watch.Elapsed;
+
+            TimeSpentInSimplex += span;
+
+            Console.WriteLine("Time spent in Simplex: {0} (total {1}, max {2})", (span).ToString(),
+             TimeSpentInSimplex.ToString(),
+             UpdateMaxSimplexTime(span));
+#endif
+            return result;
         }
-        hints = nHints;
-      }
+
+#if false
+        static TimeSpan maxSimplexTime = new TimeSpan(0);
+        static TimeSpan UpdateMaxSimplexTime(TimeSpan s)
+        {
+            if (maxSimplexTime < s)
+            {
+                maxSimplexTime = s;
+            }
+
+            return maxSimplexTime;
+        }
+
+        static int maxVarsInSimplex = 0;
+        static int UpdateMaxVarsInSimplex(int v)
+        {
+            if (v > maxVarsInSimplex)
+            {
+                maxVarsInSimplex = v;
+            }
+
+            return maxVarsInSimplex;
+        }
+#endif
+        override internal LinearEqualitiesEnvironment<Variable, Expression> Join(IAbstractDomain a, ref List<Polynomial<Variable, Expression>> deletedLeft, ref List<Polynomial<Variable, Expression>> deletedRight)
+        {
+            IAbstractDomain trivialresult;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out trivialresult))
+            {
+                if (trivialresult.IsTop)
+                {
+                    deletedLeft.AddRange(this.ToPolynomial(false));
+                    deletedRight.AddRange((a as LinearEqualitiesEnvironment<Variable, Expression>).ToPolynomial(false));
+                }
+                return trivialresult as LinearEqualitiesEnvironment<Variable, Expression>;
+            }
+
+            var right = a as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
+
+            Contract.Assert(a != null);
+
+            // 1. Make the domains the same, by uniforming the maps, and swapping columns
+
+            var t1 = Task.Run(
+              () =>
+              {
+                  this.PutIntoRowEchelonForm();
+                  this.RecoverUnusedColumns();
+                  this.PutSlackVariablesInBasis();
+              });
+
+            var t2 = Task.Run(
+              () =>
+              {
+                  right.PutIntoRowEchelonForm();
+                  right.RecoverUnusedColumns();
+                  right.PutSlackVariablesInBasis();
+              });
+
+            Task.WaitAll(t1, t2);
+
+            UniformEnvironments(this, right);
+
+            this.PutIntoWeakRowEchelonForm();
+            right.PutIntoWeakRowEchelonForm();
+
+            Task.WaitAll(t1, t2);
+
+            if (this.state == LinearEqualitiesState.Bottom)
+            {
+                return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(right);
+            }
+
+            if (right.state == LinearEqualitiesState.Bottom)
+            {
+                return new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
+            }
+
+            Contract.Assert(this.NumberOfColumns == right.NumberOfColumns);
+
+            // 2. The join is computed according to Karr 1976 paper
+            var A = this.equations.GetClonedEquations();      // We clone the matrixes as Karr works with side effects
+            var B = right.equations.GetClonedEquations();
+
+            int numberOfRowsInResult;
+            var JoinedMatrix = DisjunctionOfLinearSpaces(A, B, this.NumberOfRows, right.numberOfRows, out numberOfRowsInResult, ref deletedLeft, ref deletedRight);
+
+            // 3. Create a clone of the current private state
+            var freshMap = new VarsToDimensions(this.varsToDimensions);
+
+            var result = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(JoinedMatrix, numberOfRowsInResult, this.NumberOfColumns, freshMap, this.expManager);
+
+            result.state = LinearEqualitiesState.Normal; // the condition implied by Karr's algorithm is weaker than what we call now row echelon form
+
+            return result;
+        }
+
+        internal void RemoveRedundantSlackVariables()
+        {
+            this.PutIntoRowEchelonForm();
+
+            this.expManager.Log("Matrix before removing equalities var == slackvar:\n {0}", this.ToString);
+
+            var equalities = new List<LinearEqualityRedundancy<Variable>>();
+
+            for (var row = 0; row < this.NumberOfRows; row++)
+            {
+                if (this.equations.RowCount(row) != 2)
+                {
+                    continue;
+                }
+
+                Variable v1 = default(Variable), v2 = default(Variable);
+                Rational k1 = Rational.For(0), k2 = Rational.For(0);
+
+                bool first = true;
+                int varCount = 0;
+
+                foreach (var pair in this.equations.GetElementsForRow(row))
+                {
+                    if (pair.Key == this.NumberOfColumns - 1)
+                    {
+                        continue;
+                    }
+                    else if (first)
+                    {
+                        v1 = this.varsToDimensions[pair.Key];
+                        k1 = pair.Value;
+                        first = false;
+                        varCount++;
+                    }
+                    else
+                    {
+                        v2 = this.varsToDimensions[pair.Key];
+                        k2 = pair.Value;
+                        varCount++;
+                    }
+                }
+
+                if (varCount != 2 ||
+                  ((!this.ExpressionManager.Decoder.IsSlackVariable(v1) && !this.ExpressionManager.Decoder.IsSlackVariable(v2))))
+                {
+                    continue;
+                }
+
+                if (((k1 == 1 && k2 == -1) || (k1 == -1 && k2 == 1)) || (k1 == 1 && k2 == 1))
+                {
+                    if (this.ExpressionManager.Decoder.IsSlackVariable(v1))
+                    {
+                        var tmp = v1;
+                        v1 = v2;
+                        v2 = tmp;
+                    }
+
+                    int signK = 1;
+
+                    if (k1 == 1 && k2 == 1)
+                    {
+                        signK = -1;
+                    }
+
+                    // Now remove 
+                    int v1Col, v2Col;
+                    if (this.varsToDimensions.TryGetValue(v1, out v1Col)  // Should always succeed?
+                      && this.varsToDimensions.TryGetValue(v2, out v2Col)) // it may be the case we already removed eq.V2
+                    {
+                        var matrix = this.equations.Unshare(this, ref this.equations);
+                        for (int i = 0; i < this.NumberOfRows; i++)
+                        {
+                            var currRow = matrix[i];
+                            if (currRow != null && i != row)
+                            {
+                                Rational value;
+                                if (currRow.IsIndexOfNonDefaultElement(v2Col, out value))
+                                {
+                                    value = value * signK;
+
+                                    var oldVal = currRow[v1Col];
+                                    currRow[v1Col] = oldVal + value;
+                                    currRow[v2Col] = Rational.For(0);
+                                }
+                            }
+                        }
+
+                        Contract.Assert(this.ExpressionManager.Decoder.IsSlackVariable(v2));
+
+                        var newMapping = new VarsToDimensions(this.varsToDimensions);
+                        if (newMapping.ContainsKey(v2))
+                        {
+                            newMapping.Remove(v2);
+                        }
+
+                        RemoveRow(matrix, row);
+                        row--;
+
+                        // Checking code
+                        CheckAreAllZeroAt(matrix, v2, row, true);
+
+                        this.equations = new LinearEquations<Variable, Expression>(this, matrix);
+                        this.numberOfRows--;
+                    }
+                }
+            }
+
+            this.expManager.Log("Matrix after removing simple equalities : {0}", this.ToString);
+
+            return;
+        }
+
+        /// <summary>
+        /// The specific AssignInParallel for SubPolyhedra, which takes care of updating the dependencies
+        /// </summary>
+        /// <param name="sourcesToTargetsInitial">The renaming map</param>
+        /// <param name="betaDep">The dependencies to update</param>
+        /// <param name="hints">Keeps track of deleted dependencies, to be used at joins or widenings</param>
+        internal void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargetsInitial, Converter<Variable, Expression> convert,
+          ref Dictionary<Variable, Polynomial<Variable, Expression>> betaDep, ref Hints<Variable, Expression> hints)
+        {
+            Contract.Requires(this.IsConsistent, "LinEq inconstistent @ AssignInParallel entry");
+
+            var tmp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(this);
+
+            // adding the domain-generated variables to the map as identity
+            var sourcesToTargets = new Dictionary<Variable, FList<Variable>>(sourcesToTargetsInitial);
+
+            if (!this.IsTop)
+            {
+                foreach (var e in this.SlackVariables)
+                {
+                    sourcesToTargets.Add(e, FList<Variable>.Cons(e, FList<Variable>.Empty));
+                }
+            }
+
+            #region Compute the statistics on the renaming
+
+            var pairs = 0;
+            foreach (var pair in sourcesToTargets)
+            {
+                if (pair.Value.Length() > 1)
+                {
+                    pairs++;
+                }
+            }
+
+            #endregion
+
+            #region If statistics are bad, then do a very simple renaming and we return
+
+            if (pairs > AdaptiveRenamingInSubpolyhedraThreshold)
+            {
+                var variablesToRemove = new List<Variable>();
+                var newNames = new Dictionary<Variable, Variable>();
+
+                foreach (var v in this.Variables_Internal)
+                {
+                    FList<Variable> renamings;
+                    if (sourcesToTargets.TryGetValue(v, out renamings))
+                    {
+                        newNames[v] = renamings.Head;
+                    }
+                    else
+                    {
+                        variablesToRemove.Add(v);
+                    }
+                }
+
+                // now remove all the variables lost in the translation
+                foreach (var v in variablesToRemove)
+                {
+                    this.RemoveVariable(v);
+                }
+
+                // and finally rename the survicing variables
+                foreach (var pair in newNames)
+                {
+                    this.RenameVariable(pair.Key, pair.Value);
+                }
+
+                // We are done!
+                return;
+            }
+
+            #endregion
+            var toSkip = new Set<Variable>();
+
+            foreach (var x in this.varsToDimensions.Keys)
+            {
+                if (!sourcesToTargets.ContainsKey(x))
+                {
+                    if (!toSkip.Contains(x)) // otherwise, it already represents a target variable and should not be removed
+                    {
+                        tmp.RemoveInAssignInParallel(x, ref betaDep, ref hints, sourcesToTargets);
+                    }
+                    continue;
+                }
+
+                var targets = sourcesToTargets[x];
+
+                // choosing the canonical element
+                var target =
+                  (targets.Length() > 1 && x.Equals(targets.Head)) ?
+                  targets.Tail.Head :
+                  targets.Head;
+
+                if (x.Equals(target))
+                { // If it is the identity there is nothing to do...
+                    continue;
+                }
+
+                if (tmp.varsToDimensions.ContainsKey(target))
+                {
+                    tmp.RemoveInAssignInParallel(target, ref betaDep, ref hints, sourcesToTargets);
+                    toSkip.Add(target);
+                }
+
+                int dimX = tmp.varsToDimensions[x];
+
+                tmp.varsToDimensions.Remove(x);
+
+                tmp.varsToDimensions[target] = dimX;
+
+                var toRemove = SubPolyhedra<Variable, Expression>.UpdateBetaDeps(x, sourcesToTargets[x].Head, ref betaDep);
+
+                foreach (var beta in toRemove)
+                {
+                    hints.Add(betaDep[beta]);
+                }
+
+                foreach (var beta in toRemove)
+                {
+                    betaDep.Remove(beta);
+                }
+
+                SubPolyhedra<Variable, Expression>.UpdateHints(x, sourcesToTargets[x].Head, ref hints);
+
+                this.expManager.Log("Result : {0}", tmp.ToString);
+
+                Contract.Assert(tmp.IsConsistent);
+            }
+
+            // now adding equalities between targets of a same source
+            foreach (var pair in sourcesToTargets)
+            {
+                var length = pair.Value.Length();
+                if (length <= 1)
+                {
+                    continue;
+                }
+
+                if (base.PrintWarnsForLargeTargets && length > 10)
+                {
+                    Console.WriteLine("[SUBPOLYHEDRA] Found more than 10 pairwise equalities!!! (exactly {0})", length);
+                }
+
+                var target = pair.Key.Equals(pair.Value.Head) ? pair.Value.Tail.Head : pair.Value.Head;
+                var targetExp = convert(target);
+
+                foreach (var otherTarget in pair.Value.GetEnumerable())
+                {
+                    if (target.Equals(otherTarget))
+                    {
+                        continue;
+                    }
+
+                    var otherTargetExp = convert(otherTarget);
+
+                    tmp = tmp.TestTrueEqual(targetExp, otherTargetExp) as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
+
+                    Contract.Assert(tmp != null);
+                }
+            }
+
+            // We change the state of this, using tmp
+            CloneThisFrom(tmp);
+
+            Contract.Assert(this.IsConsistent, "LinEq inconstistent @ AssignInParallel exit");
+        }
+
+
+        private static bool AreSmallNumbers(Int64 up, Int64 down)
+        {
+            return -MaxCoefficientInEquationsforSimplexReduction <= up && up <= MaxCoefficientInEquationsforSimplexReduction && -MaxCoefficientInEquationsforSimplexReduction <= down && down <= MaxCoefficientInEquationsforSimplexReduction;
+        }
+
+        private bool TryInitializeLP(IntervalEnvironment<Variable, Expression> bounds, List<Pair<Variable, int>> varsToDimsInLP, out LinearProgramInterface lp)
+        {
+            var equations = 0;
+            var intervals = 0;
+
+            lp = new RevisedSimplexMethod();
+
+            this.expManager.Log("Equalities for the LP problem:\n");
+
+            for (int i = 0; i < NumberOfRows; i++)
+            {
+                var equality = new double[varsToDimsInLP.Count];
+
+                foreach (var pair in varsToDimsInLP)
+                {
+                    var var = pair.One;
+
+                    if (this.ContainsKey(var))
+                    {
+                        var j = varsToDimensions[var];
+                        var jlp = pair.Two;
+
+                        var v = this.equations.At(i, j);
+
+                        if (!AreSmallNumbers(v.Up, v.Down))
+                        {
+                            this.expManager.Log(string.Format("Skipped the equation because of {0}", v));
+
+                            goto nextEquation;
+                        }
+
+                        equality[jlp] = (double)v;
+                    }
+                }
+
+                var k = this.equations.At(i, NumberOfColumns - 1);
+
+                if (!AreSmallNumbers(k.Up, k.Down))
+                {
+                    this.expManager.Log(string.Format("Skipped the equation because of the known coefficient {0}", k));
+
+                    goto nextEquation;
+                }
+
+                this.expManager.Log(string.Format("{0} = {1}", equality.ToStringInDepth(), k.ToString()));
+
+                lp.AddConstraint(equality, Relation.Equal, (double)k);
+
+                equations++;
+
+            nextEquation:
+                ;
+            }
+            if (NumberOfRows == 0 || equations == 0)
+            {
+                lp = default(LinearProgramInterface);
+                return false;
+                //lp.AddConstraint(new double[varsToDimsInLP.Count], Relation.Equal, 0);
+            }
+
+            this.expManager.Log(string.Format("Intervals for the LP problem:\n{0}", bounds.ToString()));
+
+            foreach (var pair in varsToDimsInLP)
+            {
+                var var = pair.One;
+
+                Interval intv;
+                if (bounds.TryGetValue(var, out intv))
+                {
+                    if (!intv.UpperBound.IsPlusInfinity)
+                    {
+                        if (intv.UpperBound < MaxBoundInIntervalsforSimplexReduction)
+                        {
+                            lp.LimitVariableFromAbove(pair.Two, (double)intv.UpperBound);
+                            intervals++;
+                        }
+                        else
+                        {
+                            this.expManager.Log(string.Format("Upper bound skipped {0}\n", intv.UpperBound));
+                        }
+                    }
+                    if (!intv.LowerBound.IsMinusInfinity)
+                    {
+                        if (intv.LowerBound > MinBoundInIntervalsforSimplexReduction)
+                        {
+                            lp.LimitVariableFromBelow(pair.Two, (double)intv.LowerBound);
+                            intervals++;
+                        }
+                        else
+                        {
+                            this.expManager.Log(string.Format("Lower bound skipped {0}\n", intv.LowerBound));
+                        }
+                    }
+                }
+            }
+
+            lp.Status = Status.Unknown;
+
+            return true;
+        }
+
+        private void PutVariablesInFront()
+        {
+            int i = 0;
+            for (int j = 0; j < NumberOfColumns - 1; j++)
+            {
+                Variable var;
+                if (varsToDimensions.TryGetValue(j, out var))
+                {
+                    int dummy;
+                    if (!TrySwapColumnsInRowEchelonForm(i, j, out dummy))
+                    {
+                        throw new AbstractInterpretationException("Bug!!!");
+                    }
+
+                    i++;
+                }
+            }
+
+            Contract.Assert(i == NumberOfVariables);
+        }
+
+        /// <summary>
+        /// Get all the slack variables that are duplicates (up to an affine transformation) of another slack variable.
+        /// Returns a dictionary d such that d(e1) = (k, e2, c) iff (k != 0 AND e1 + k * e2 == c) OR (k == 0 AND \exists c e1 == c)
+        /// </summary>
+        /// <returns>A dictionary indexed by redundant variables, to be removed by the caller</returns>
+        internal List<LinearEqualityRedundancy<Variable>> GetRedundancies()
+        {
+            this.PutSlackVariablesOutOfBasis();
+
+            var toRemove = new List<LinearEqualityRedundancy<Variable>>();
+            var remaining = new List<int>(); // will contain row indices corresponding to equalities between slack variables not in the required form
+
+            var zero = Rational.For(0);
+            var equations = this.equations;
+            var decoder = this.ExpressionManager.Decoder;
+
+            #region Find equalities b1 + k * b2 == c directly
+            for (int i = 0; i < this.NumberOfRows; i++)
+            {
+                var redundant = true;
+                var exp = default(Variable);
+                var target = default(Variable);
+                var coeff1 = zero;
+                var coeff2 = zero;
+
+                int found = 0;
+
+                for (int j = 0; j < this.NumberOfColumns - 1; j++)
+                {
+                    var eq_i_j = equations.At(i, j);
+
+                    if (eq_i_j.IsZero)
+                    {
+                        continue;
+                    }
+
+                    var dim_J = this.varsToDimensions[j];
+
+                    if (!decoder.IsSlackVariable(dim_J))
+                    {
+                        redundant = false;
+                        break;
+                    }
+
+                    if (found == 0)
+                    {
+                        exp = dim_J;
+                        coeff1 = eq_i_j;
+                    }
+
+                    if (found == 1)
+                    {
+                        target = dim_J;
+                        coeff2 = eq_i_j;
+                    }
+                    found++;
+                }
+
+                if (redundant)
+                {
+                    if (found == 1)
+                    {
+                        toRemove.Add(new LinearEqualityRedundancy<Variable>(exp, zero, default(Variable), equations.At(i, NumberOfColumns - 1)));
+                    }
+                    else if (found == 2)
+                    {
+                        toRemove.Add(new LinearEqualityRedundancy<Variable>(exp, coeff2 / coeff1, target, equations.At(i, numberOfCols - 1) / coeff1));
+                    }
+                    else
+                    {
+                        remaining.Add(i);
+                    }
+                }
+            }
+            #endregion
+
+            #region Refinement of "if x + p == 0 and y + p == 0 then x == y"
+            var remainingCount = remaining.Count;
+            if (remainingCount >= 0)
+            {
+                var removed = new bool[remainingCount];
+                for (int i = 0; i < remainingCount; i++)
+                {
+                    // if any variable varj is "equivalent" to vari, it is also equivalent to the target of vari and has alredy been marked as such
+                    if (removed[i])
+                    {
+                        continue;
+                    }
+
+                    for (int j = i + 1; j < remainingCount; j++)
+                    {
+                        // we have :
+                        // vari + pi == ki
+                        // varj + pj == kj
+                        // now we are trying to see if pi and pj are colinear
+
+                        // 0 for both rows contain only zeros so far, 1 for rows are colinear and non-zero, 2 for rows are not (strictly) colinear
+                        var colinearity = 0;
+                        var coeff = zero; // if colinearity != 2 then row j == coeff * row i
+                        var remaining_i = remaining[i];
+                        var remaining_j = remaining[j];
+
+                        for (int k = this.numberOfRows; k < this.numberOfCols - 1; k++)
+                        {
+                            if (colinearity == 0)
+                            {
+                                if (equations.At(remaining_i, k).IsNotZero)
+                                {
+                                    if (equations.At(remaining_j, k).IsNotZero)
+                                    {
+                                        colinearity = 1;
+
+                                        if (!Rational.TryDiv(equations.At(remaining_j, k), equations.At(remaining_i, k), out coeff))
+                                        {
+                                            // If we get an overflow from the division above, we skip this constraint and move to the new one
+                                            goto NextIteration;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        colinearity = 2;
+                                        break;
+                                    }
+                                }
+                                else
+                                {
+                                    if (equations.At(remaining_j, k).IsNotZero)
+                                    {
+                                        colinearity = 2;
+                                        break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    if (coeff * equations.At(remaining_i, k) != equations.At(remaining_j, k))
+                                    {
+                                        colinearity = 2;
+                                        break;
+                                    }
+                                }
+                                catch (ArithmeticExceptionRational)
+                                {
+                                    // We skip the constraint and move to the nexr
+                                    goto NextIteration;
+                                }
+                            }
+                        }
+
+                        if (colinearity == 1)
+                        {
+                            // we have :
+                            // ExpForI + p == k1
+                            // ExpForJ + coeff * p == k2
+                            // for some p, so ExpForJ - coeff * ExpForI == k2 - coeff * k1
+
+                            //var remaining_i = remaining[i];
+                            // var remaining_j = remaining[j];
+
+                            Variable ExpForI, ExpForJ;
+                            if (this.varsToDimensions.TryGetValue(remaining_i, out ExpForI)
+                              && this.varsToDimensions.TryGetValue(remaining_j, out ExpForJ))
+                            {
+                                Rational value;
+                                try
+                                {
+                                    value = equations.At(remaining_j, numberOfCols - 1)/*k2*/ - coeff * equations.At(remaining_i, numberOfCols - 1)/*k1*/;
+                                }
+                                catch (ArithmeticExceptionRational)
+                                {
+                                    // We abstract it away
+                                    goto NextIteration;
+                                }
+
+                                toRemove.Add(new LinearEqualityRedundancy<Variable>(ExpForJ, -coeff, ExpForI, value));
+                                removed[j] = true;
+                            }
+                            else
+                            {
+                                goto NextIteration;
+                            }
+                        }
+
+                    NextIteration:
+                        ;
+                    }
+                }
+            }
+            #endregion
+
+            foreach (var e in this.Variables)
+            {
+                if (decoder.IsSlackVariable(e) && equations.IsZeroCol(this.NumberOfRows, varsToDimensions[e]))
+                {
+                    var dummy = new LinearEqualityRedundancy<Variable>(e, zero, default(Variable), Rational.PlusInfinity);
+                    toRemove.Add(dummy);
+                }
+            }
+
+            return toRemove;
+        }
+
+        internal void PropagateValue(Variable exp, ref IntervalEnvironment<Variable, Expression> bounds)
+        {
+            var j = this.varsToDimensions[exp];
+            for (var i = 0; i < this.NumberOfRows; i++)
+            {
+                if (this.equations.At(i, j).IsZero)
+                {
+                    continue;
+                }
+
+                var pol = this.ToPolynomial(i);
+
+                if (pol.Left.Length != 2)
+                {
+                    continue;
+                }
+
+                var forExp = bounds.BoundsFor(exp);
+                Rational kexp, kother;
+                Variable other;
+
+                if (pol.Left[0].VariableAt(0).Equals(exp))
+                {
+                    kexp = pol.Left[0].K;
+                    kother = pol.Left[1].K;
+                    other = pol.Left[1].VariableAt(0);
+                }
+                else
+                {
+                    kexp = pol.Left[1].K;
+                    kother = pol.Left[0].K;
+                    other = pol.Left[0].VariableAt(0);
+                }
+                bounds[other] = bounds.BoundsFor(other).AsInterval.Meet(Interval.For(pol.Right[0].K / kother) - Interval.For(kexp / kother) * forExp.AsInterval);
+            }
+        }
+
+        /// <summary>
+        /// Removes all rows that only contain one variable (x == k), and returns a map from the expression removed to the associated constants
+        /// </summary>
+        /// <returns>A map from variables to their constant value</returns>
+        internal Dictionary<Variable, Rational> GetConstants()
+        {
+            var result = new Dictionary<Variable, Rational>();
+            int numberOfVars;
+            Variable exp = default(Variable);
+
+            for (int i = 0; i < this.numberOfRows; i++)
+            {
+                numberOfVars = 0;
+
+                foreach (var pair in this.equations.GetElementsForRow(i))
+                {
+                    if (pair.Value.IsNotZero && pair.Key < this.numberOfCols - 1)
+                    {
+                        numberOfVars++;
+                        if (numberOfVars == 1)
+                        {
+                            exp = this.varsToDimensions[pair.Key];
+                        }
+                    }
+                }
+                if (numberOfVars == 1)
+                {
+                    result.Add(exp, this.equations.At(i, this.numberOfCols - 1));
+                    RemoveRow(i--);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// In row echelon form, put all slack variables in basis to try to get meaningfull information from dropped constraints at the join
+        /// </summary>
+        private void PutSlackVariablesInBasis()
+        {
+            Contract.Assert(this.state == LinearEqualitiesState.StrongRowEchelon);
+
+            foreach (var x in this.Variables)
+            {
+                if (!this.expManager.Decoder.IsSlackVariable(x))
+                {
+                    continue;
+                }
+
+                // already in basis
+                if (varsToDimensions[x] < numberOfRows)
+                {
+                    continue;
+                }
+
+                int j = varsToDimensions[x];
+                int row = -1;
+                for (int i = 0; i < numberOfRows; i++)
+                {
+                    if (this.equations.At(i, j).IsNotZero && !expManager.Decoder.IsSlackVariable(varsToDimensions[i]))
+                    {
+                        row = i;
+                        break;
+                    }
+                }
+
+                if (row != -1)
+                {
+                    int eRow;
+
+                    if (!TrySwapColumnsInRowEchelonForm(row, j, out eRow))
+                    {
+                        RemoveRow(eRow);
+                        PutIntoRowEchelonForm();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// In row echelon form, put all slack variables in basis to try to get as much redundancies as possible
+        /// </summary>
+        private void PutSlackVariablesOutOfBasis()
+        {
+            Contract.Requires(this.state == LinearEqualitiesState.StrongRowEchelon);
+
+            foreach (var x in this.Variables)
+            {
+                if (expManager.Decoder.IsSlackVariable(x) || varsToDimensions[x] < numberOfRows) // Already in the basis
+                {
+                    continue;
+                }
+
+                int j = varsToDimensions[x];
+                int row = -1;
+                for (int i = 0; i < numberOfRows; i++)
+                {
+                    if (this.equations.At(i, j).IsNotZero
+                      && this.varsToDimensions.ContainsValue(i)  // F : I've added the test, as I cannot convince myself that InverseMap[i] is always there
+                      && expManager.Decoder.IsSlackVariable(varsToDimensions[i]))
+                    {
+                        row = i;
+                        break;
+                    }
+                }
+
+                if (row != -1)
+                {
+                    int dummy;
+                    if (!TrySwapColumnsInRowEchelonForm(row, j, out dummy))
+                    {
+                        RemoveRow(dummy);
+                        PutIntoRowEchelonForm();
+                    }
+                }
+            }
+        }
+
+        internal void ProjectSlackVariables()
+        {
+            var decoder = expManager.Decoder;
+            foreach (var e in this.Variables)
+            {
+                if (decoder.IsSlackVariable(e))
+                {
+                    this.ProjectVariable(e);
+                }
+            }
+        }
+
+        private void RemoveInAssignInParallel(Variable x,
+          ref Dictionary<Variable, Polynomial<Variable, Expression>> betaDep, ref Hints<Variable, Expression> hints,
+          Dictionary<Variable, FList<Variable>> sourcesToTargets)
+        {
+            Polynomial<Variable, Expression> deletedRow;
+            int d;
+
+            this.RemoveVariable(x, false, out deletedRow, out d);
+
+            SparseRationalArray withoutSlack;
+            if (this.GetEquivalentWithoutSlack(deletedRow, out withoutSlack, x, d, sourcesToTargets))
+            { // this part is supposed to update the dependencies by replacing the variable x, which is deleted, by a polynomial p such that x == p is provable in the pre-state
+              // the polynomial p is represented by withoutSlack, and has the property that it doesn't contain any slack variable ; withoutSlack corresponds to coeff*x == p, not to p only
+                var slackVariables = new List<Variable>(betaDep.Keys);
+                foreach (var beta in slackVariables)
+                {
+                    if (betaDep[beta].Variables.Contains(x))
+                    { // here we know that beta depends on x, so we need to replace it
+                        var updated = new List<Monomial<Variable>>();
+                        var k = betaDep[beta].Relation == null ? Rational.For(0) : betaDep[beta].Right[0].K;
+                        foreach (var m in betaDep[beta].Left)
+                        {
+                            if (m.IsConstant || !m.VariableAt(0).Equals(x))
+                            { // keep a copy of the old monomials which don't contain x
+                                updated.Add(new Monomial<Variable>(m.K, m.VariableAt(0)));
+                            }
+                            else
+                            { // here we have the monomial m.K * x, so we need to replace it using withoutSlack
+                                var coeff = withoutSlack[d]; // the coefficient for x
+                                foreach (var pair in withoutSlack.GetElements())
+                                {
+                                    if (pair.Key == d)
+                                        continue;
+                                    if (pair.Key == this.NumberOfColumns - 1)
+                                    { // coeff*x == -k1*y1 - ... - kn*yn + pair.Value, so we replace x by pair.Value / coeff, multiply by the coefficient m.K of x in the previous polynomial, and take the opposite as we will put the conatant on the other side of the equality
+                                        k -= m.K * pair.Value / coeff;
+                                    }
+                                    else
+                                    {
+                                        updated.Add(new Monomial<Variable>(-m.K * pair.Value / coeff, this.varsToDimensions[pair.Key]));
+                                    }
+                                }
+                            }
+                        }
+                        var constant = new Monomial<Variable>[] { new Monomial<Variable>(k) };
+
+                        Polynomial<Variable, Expression> dep;
+
+                        if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, updated.ToArray(), constant, out dep))
+                        {
+                            if (dep.Variables.Count > 2)
+                                betaDep[beta] = dep;
+                            else
+                                betaDep.Remove(beta);
+                        }
+                        else
+                        {
+#if DEBUG
+                            Contract.Assert(false); // We should never get to this point
+#endif
+                            return;
+                        }
+                    }
+                }
+                var newhints = new List<Polynomial<Variable, Expression>>();
+                foreach (var pol in hints.Enumerate())
+                {
+                    if (pol.Variables.Contains(x))
+                    { // here we know that pol depends on x, so we need to replace it
+                        var updated = new List<Monomial<Variable>>();
+                        var k = pol.Relation == null ? Rational.For(0) : pol.Right[0].K;
+                        foreach (var m in pol.Left)
+                        {
+                            if (m.IsConstant || !m.VariableAt(0).Equals(x))
+                            { // keep a copy of the old monomials which don't contain x
+                                updated.Add(new Monomial<Variable>(m.K, m.VariableAt(0)));
+                            }
+                            else
+                            { // here we have the monomial m.K * x, so we need to replace it using withoutSlack
+                                var coeff = withoutSlack[d]; // the coefficient for x
+                                foreach (var pair in withoutSlack.GetElements())
+                                {
+                                    if (pair.Key == d)
+                                        continue;
+                                    if (pair.Key == this.NumberOfColumns - 1)
+                                    { // coeff*x == -k1*y1 - ... - kn*yn + pair.Value, so we replace x by pair.Value / coeff, multiply by the coefficient m.K of x in the previous polynomial, and take the opposite as we will put the conatant on the other side of the equality
+                                        k -= m.K * pair.Value / coeff;
+                                    }
+                                    else
+                                    {
+                                        updated.Add(new Monomial<Variable>(-m.K * pair.Value / coeff, this.varsToDimensions[pair.Key]));
+                                    }
+                                }
+                            }
+                        }
+                        var constant = new Monomial<Variable>[] { new Monomial<Variable>(k) };
+
+                        Polynomial<Variable, Expression> dep;
+                        Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, updated.ToArray(), constant, out dep);
+
+                        if (dep.Variables.Count > 2)
+                        {
+                            newhints.Add(dep);
+                        }
+                    }
+                    else
+                    {
+                        newhints.Add(pol);
+                    }
+                }
+                hints.Clear();
+                hints.Add(newhints);
+            }
+            else
+            { // no equivalent, removing all dependencies and hints on x
+                var vars = new List<Variable>(betaDep.Keys);
+                foreach (var e in vars)
+                {
+                    if (betaDep[e].Variables.Contains(x))
+                    {
+                        betaDep.Remove(e);
+                    }
+                }
+                var nHints = new Hints<Variable, Expression>();
+                foreach (var p in hints.Enumerate())
+                {
+                    if (!p.Variables.Contains(x))
+                        nHints.Add(p);
+                }
+                hints = nHints;
+            }
+        }
+        #endregion
     }
-    #endregion
-  }
 
 
-  /// <summary>
-  /// A class for exploring combinations of m values between 0 and n - 1
-  /// </summary>
-  public abstract class Explorer : IEnumerator<int[]>
-  {
-    protected int n;
-    protected int m;
-    protected int[] current;
-
-    public Explorer(int n, int m)
-    {
-      Contract.Requires(m <= n);
-
-      this.n = n;
-      this.m = m;
-      this.current = null;
-    }
-
-    #region IEnumerator<int[]> Members
-
-    public int[] Current
-    {
-      get { return current; }
-    }
-
-    #endregion
-
-    #region IDisposable Members
-
-    public void Dispose()
-    {
-    }
-
-    #endregion
-
-    #region IEnumerator Members
-
-    object System.Collections.IEnumerator.Current
-    {
-      get { return current; }
-    }
-
-    public abstract bool MoveNext();
-
-    public void Reset()
-    {
-      current = null;
-    }
-
-    #endregion
-  }
-
-  public class CombinatorialExplorer : Explorer
-  {
     /// <summary>
-    /// Explores all possible combinations of m values in 0 ... n - 1
+    /// A class for exploring combinations of m values between 0 and n - 1
     /// </summary>
-    /// <param name="n"></param>
-    /// <param name="m"></param>
-    public CombinatorialExplorer(int n, int m)
-      : base(n, m)
+    public abstract class Explorer : IEnumerator<int[]>
     {
-    }
+        protected int n;
+        protected int m;
+        protected int[] current;
 
-    public override bool MoveNext()
-    {
-      int i;
-      if (current == null)
-      {
-        current = new int[m];
-        for (i = 0; i < m; i++)
+        public Explorer(int n, int m)
         {
-          current[i] = i;
+            Contract.Requires(m <= n);
+
+            this.n = n;
+            this.m = m;
+            this.current = null;
         }
-        return true;
-      }
-      i = m - 1;
-      if (i < 0) return false;
-      while (current[i] >= i + n - m)
-      {
-        i--;
-        if (i < 0) return false;
-      }
-      current[i]++;
-      int k = current[i];
-      for (int j = i + 1; j < m; j++)
-      {
-        k++;
-        current[j] = k;
-      }
-      return true;
-    }
 
-  }
+        #region IEnumerator<int[]> Members
 
-  public class LinearExplorer : Explorer
-  {
-    private int next;
-
-    public LinearExplorer(int n, int m)
-      : base(n, m)
-    {
-      Contract.Assert(m >= 0);
-
-      next = m;
-    }
-
-    public override bool MoveNext()
-    {
-      if (current == null)
-      {
-        current = new int[m];
-        for (int j = 0; j < m; j++)
+        public int[] Current
         {
-          current[j] = j;
+            get { return current; }
         }
-        return true;
-      }
-      if (m == 0)
-      {
-        return false;
-      }
 
-      if (next >= n)
-      {
-        return false;
-      }
-      int i = next % m;
-      current[i] = next;
-      next++;
-      return true;
+        #endregion
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+        }
+
+        #endregion
+
+        #region IEnumerator Members
+
+        object System.Collections.IEnumerator.Current
+        {
+            get { return current; }
+        }
+
+        public abstract bool MoveNext();
+
+        public void Reset()
+        {
+            current = null;
+        }
+
+        #endregion
     }
-  }
+
+    public class CombinatorialExplorer : Explorer
+    {
+        /// <summary>
+        /// Explores all possible combinations of m values in 0 ... n - 1
+        /// </summary>
+        /// <param name="n"></param>
+        /// <param name="m"></param>
+        public CombinatorialExplorer(int n, int m)
+          : base(n, m)
+        {
+        }
+
+        public override bool MoveNext()
+        {
+            int i;
+            if (current == null)
+            {
+                current = new int[m];
+                for (i = 0; i < m; i++)
+                {
+                    current[i] = i;
+                }
+                return true;
+            }
+            i = m - 1;
+            if (i < 0) return false;
+            while (current[i] >= i + n - m)
+            {
+                i--;
+                if (i < 0) return false;
+            }
+            current[i]++;
+            int k = current[i];
+            for (int j = i + 1; j < m; j++)
+            {
+                k++;
+                current[j] = k;
+            }
+            return true;
+        }
+    }
+
+    public class LinearExplorer : Explorer
+    {
+        private int next;
+
+        public LinearExplorer(int n, int m)
+          : base(n, m)
+        {
+            Contract.Assert(m >= 0);
+
+            next = m;
+        }
+
+        public override bool MoveNext()
+        {
+            if (current == null)
+            {
+                current = new int[m];
+                for (int j = 0; j < m; j++)
+                {
+                    current[j] = j;
+                }
+                return true;
+            }
+            if (m == 0)
+            {
+                return false;
+            }
+
+            if (next >= n)
+            {
+                return false;
+            }
+            int i = next % m;
+            current[i] = next;
+            next++;
+            return true;
+        }
+    }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SubPolyhedra/Redundancy.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SubPolyhedra/Redundancy.cs
@@ -1,49 +1,36 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 
-
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  public struct LinearEqualityRedundancy<Variable>
-  {
-    readonly public Variable V1;
-    readonly public Variable V2;
-    readonly public Rational Coeff2;
-    readonly public Rational Offset;
-
-    readonly public int Row;
-
-    public LinearEqualityRedundancy(Variable v1, Rational coeff2, Variable v2, Rational offset)
-      : this(v1, coeff2, v2, offset, -23456)
+    public struct LinearEqualityRedundancy<Variable>
     {
-    }
+        readonly public Variable V1;
+        readonly public Variable V2;
+        readonly public Rational Coeff2;
+        readonly public Rational Offset;
 
-    public LinearEqualityRedundancy(Variable v1, Rational coeff2, Variable v2, Rational offset, int row)
-    {
-      this.V1 = v1;
-      this.Coeff2 = coeff2;
-      this.V2 = v2;
-      this.Offset = offset;
-      this.Row = row;
-    }
+        readonly public int Row;
 
-    public override string ToString()
-    {
-      return string.Format("<{0}, {1}, {2}, {3}, row: {4}>", V1, Coeff2, V2, Offset, Row);
-    }
-  }
+        public LinearEqualityRedundancy(Variable v1, Rational coeff2, Variable v2, Rational offset)
+          : this(v1, coeff2, v2, offset, -23456)
+        {
+        }
 
+        public LinearEqualityRedundancy(Variable v1, Rational coeff2, Variable v2, Rational offset, int row)
+        {
+            this.V1 = v1;
+            this.Coeff2 = coeff2;
+            this.V2 = v2;
+            this.Offset = offset;
+            this.Row = row;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("<{0}, {1}, {2}, {3}, row: {4}>", V1, Coeff2, V2, Offset, Row);
+        }
+    }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SubPolyhedra/SubPolyhedra.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/SubPolyhedra/SubPolyhedra.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // #define TRACE_PERFORMANCE
 
@@ -37,2662 +26,2656 @@ using System.Linq;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  static public class SubPolyhedra
-  {
-    public enum JoinConstraintInference { Standard, ConvexHull2D, Octagons, CHOct }
-    public enum ReductionAlgorithm { Simplex, SimplexOptima, MixSimplexFast, Fast, Complete }
-
-    #region Precision parameters
-
-    [ThreadStatic]
-    private static ReductionAlgorithm algorithm; // the algorithm for inferring tighter intervals
-    public static ReductionAlgorithm Algorithm
+    static public class SubPolyhedra
     {
-      set
-      {
-        algorithm = value;
-      }
-      internal get
-      {
-        return algorithm;
-      }
-    }
+        public enum JoinConstraintInference { Standard, ConvexHull2D, Octagons, CHOct }
+        public enum ReductionAlgorithm { Simplex, SimplexOptima, MixSimplexFast, Fast, Complete }
 
-    [ThreadStatic]
-    private static JoinConstraintInference inference; // what constraints we guess at the join
-    public static JoinConstraintInference Inference
-    {
-      set
-      {
-        inference = value;
-      }
-      internal get
-      {
-        return inference;
-      }
-    }
+        #region Precision parameters
 
-    #endregion
-
-    [ThreadStatic]
-    public static int MaxVariablesInOctagonsConstraintInference;
-    public const int MaxHintsToRetainInWidening = 128;
-
-    public const int MaxVariablesToRunSimplex = 500;
-
-    [ThreadStatic]
-    public static TimeSpan TimeSpentInReduction = new TimeSpan(0);
-  }
-
-  public class SubPolyhedra<Variable, Expression> 
-    : ReducedNumericalDomains<LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>, IntervalEnvironment<Variable, Expression>, Variable, Expression>
-  {
-    #region State
-
-    private SPTestTrueVisitor testTrueVisitor;
-    private SPTestFalseVisitor testFalseVisitor;
-    private SPCheckIfHoldsVisitor checkIfHoldsVisitor;
-
-    private int numberOfWidenings;
-    private bool WideningOnHints = false;
-
-    #endregion
-
-    #region Dependencies for slack variables
-    private Dictionary<Variable, Polynomial<Variable, Expression>> betaDep; // a map from slack variables to the linear equality that introduced it. Useful since the row echelon form tends to lose this kind of information
-    private Hints<Variable, Expression> hints = new Hints<Variable, Expression>(); // linear functionals that we want to bound (i.e.candidates for slack variables). Each one contains excatly one slack variable, for convenience.
-    #endregion
-
-    #region Constructors
-
-    public SubPolyhedra(
-      LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> linEq, 
-      IntervalEnvironment<Variable, Expression> intEnv,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-      : base(linEq, intEnv, expManager)
-    {
-      Contract.Requires(expManager != null);
-
-      this.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-      this.hints = new Hints<Variable, Expression>();
-      this.numberOfWidenings = 0;
-      this.testTrueVisitor = new SubPolyhedra<Variable, Expression>.SPTestTrueVisitor(expManager);
-      this.testFalseVisitor = new SubPolyhedra<Variable, Expression>.SPTestFalseVisitor(expManager.Decoder);
-      this.checkIfHoldsVisitor = new SubPolyhedra<Variable, Expression>.SPCheckIfHoldsVisitor(expManager);
-      this.testTrueVisitor.FalseVisitor = this.testFalseVisitor;
-      this.testFalseVisitor.TrueVisitor = this.testTrueVisitor;
-    }
-
-    /// <summary>
-    /// Construct a subpolyhedra which is the same as <code>prev</code> but for the interval environment, which is <code>intEnv</code>
-    /// </summary>
-    /// <param name="prev"></param>
-    /// <param name="intvEnv"></param>
-    private SubPolyhedra(SubPolyhedra<Variable, Expression> prev, IntervalEnvironment<Variable, Expression> intvEnv)
-      : base(prev.Left, intvEnv, prev.ExpressionManager)
-    {
-      this.betaDep = new Dictionary<Variable,Polynomial<Variable,Expression>>(prev.betaDep);
-      this.hints = new Hints<Variable, Expression>(prev.hints);
-      this.numberOfWidenings = prev.numberOfWidenings;
-      this.testFalseVisitor = prev.testFalseVisitor;
-      this.testTrueVisitor = prev.testTrueVisitor;          // Mutual recursive calls already set
-      this.checkIfHoldsVisitor = prev.checkIfHoldsVisitor;
-    }
-
-    public override object Clone()
-    {
-      return this.DuplicateMe();
-    }
-
-    public SubPolyhedra<Variable, Expression> DuplicateMe()
-    {
-      var result = base.Clone() as SubPolyhedra<Variable, Expression>;
-
-      result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(this.betaDep);
-      result.hints = new Hints<Variable, Expression>(this.hints);
-      result.numberOfWidenings = 0;
-      result.WideningOnHints = this.WideningOnHints;
-      return result;
-    }
-    #endregion
-
-#if TRACEJOIN
-    public override void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      this.DebugCheckLessEq("sv27", "sv9", "before assign");
-      base.Assign(x, exp, preState);
-      this.DebugCheckLessEq("sv27", "sv9", "after assign");
-    }
-#endif
-
-    #region Test* methods
-    public SubPolyhedra<Variable, Expression> Assume(Expression guard)
-    {
-      return this.TestTrue(guard) as SubPolyhedra<Variable, Expression>;
-    }
-
-    public override IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      var result = this.testTrueVisitor.Visit(guard, this);
-
-      var deps = result.betaDep;
-      var hintSet = result.hints;
-      
-      result = result.ReduceInternal(result.Left, result.Right, false);
-      result.betaDep = deps;
-      result.hints = hintSet;
-
-      if (!result.IsBottom)
-      {
-        result.CleanUpBetaVariables();
-      }
-
-      return result;
-    }
-
-    public override IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      var result = this.testFalseVisitor.Visit(guard, this);
-
-      // the reduction, if precise enough, will tell us if this branch is unreachable
-      var deps = result.betaDep;
-      var hintSet = result.hints;
-
-      result = result.ReduceInternal(result.Left, result.Right, false);
-
-      result.betaDep = deps;
-      result.hints = hintSet;
-
-      if (!result.IsBottom)
-      {
-        result.CleanUpBetaVariables();
-      }
-
-      return result;
-    }
-
-    public override INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.GreaterEqualThan, exp, 
-        this.ExpressionManager.Encoder.ConstantFor(0))) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    public override INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, exp1, exp2)) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    public override INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, exp1, exp2)) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    public override INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, exp1, exp2)) as INumericalAbstractDomain<Variable, Expression>;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Variable v1, Variable v2)
-    {
-      var v1Exp = this.ExpressionManager.Encoder.VariableFor(v1);
-      var v2Exp = this.ExpressionManager.Encoder.VariableFor(v2);
-
-      return this.TestTrueEqual(v1Exp, v2Exp);
-    }
-    #endregion
-
-    #region Abstract Domain Operations
-
-    #region !!!!Debugging ONLY!!!!
-
-#if DEBUG
-    private bool TrySearchVariable(string varstr, ref Variable v)
-    {
-        foreach (var x in this.Variables)
+        [ThreadStatic]
+        private static ReductionAlgorithm algorithm; // the algorithm for inferring tighter intervals
+        public static ReductionAlgorithm Algorithm
         {
-          if (x.ToString().Contains(varstr))
-          {
-            v = x;
-            return true;
-          }
-        }
-
-        return false;
-    }
-
-    public bool DebugCheckSv18LessThanSv21(string where)
-    {
-      var b = this.DebugCheckLessEq("sv18", "sv21", where);
-/*      if (!b)
-      {       
-        return this.DebugCheckLessEq("sv19", "sv11", where);
-      }
-      else*/
-      {
-        return b;
-      }
-    }
-
-    public bool DebugCheckLessEq(string left, string right, string where)
-    {
-    // We want to be sure it does not go in the release bits
-#if DEBUG
-      Variable l,r;
-      l = r = default(Variable);
-      if (TrySearchVariable(left, ref l) && TrySearchVariable(right, ref r))
-      {
-        return DebugCheckLessEq(l, r, where);
-      }
-#endif
-      return false;
-    }
-
-    public bool DebugCheckLessEq(Variable l, Variable r, string where)
-    {
-      var isTrue = this.CheckIfLessThan(this.ExpressionManager.Encoder.VariableFor(l), this.ExpressionManager.Encoder.VariableFor(r));
-
-      //this.ExpressionManager.Log("{3}: {0} < {1} is {2}", () =>left, ()=>right, ()=>isTrue.ToString(), () =>where); 
-
-      Console.WriteLine("{3}: {0} < {1} is {2}", l.ToString(), r.ToString(), isTrue.ToString(), where);
-      if (!isTrue.IsTrue())
-      {
-        isTrue = this.CheckIfLessEqualThan(this.ExpressionManager.Encoder.VariableFor(l), this.ExpressionManager.Encoder.VariableFor(r));
-
-        Console.WriteLine("{3}: {0} <= {1} is {2}", l.ToString(), r.ToString(), isTrue.ToString(), where);
-      }
-
-      return isTrue.IsTrue();
-    }
-
-#endif
-
-    #endregion
-
-#if TRACEJOIN
-    private static int joincount = 0;
-#endif
-
-    public override IAbstractDomain Join(IAbstractDomain a)
-    {
-      return PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.SubPolyJoin, () => JoinInternal(a), true);
-    }
-
-    private IAbstractDomain JoinInternal(IAbstractDomain a)
-    {
-      var watch = new Stopwatch();
-      watch.Start();
-
-#if TRACEJOIN
-      Console.WriteLine("join #{0}", joincount++);
-#endif
-
-      IAbstractDomain result;
-      SubPolyhedra<Variable, Expression> resultAsSubPolyhedra;
-      SubPolyhedra<Variable, Expression> other = a as SubPolyhedra<Variable, Expression>;
-
-      Contract.Assert(other != null);
-
-#if TRACEJOIN
-      this.DebugCheckLessEq("sv18", "sv9", "this");
-      other.DebugCheckLessEq("sv18", "sv9", "other");
-
-      this.DebugCheckLessEq("sv21", "sv9", "this");
-      other.DebugCheckLessEq("sv21", "sv9", "other");
-
-      this.DebugCheckLessEq("sv26", "sv9", "this");
-      other.DebugCheckLessEq("sv26", "sv9", "other");
-#endif
-
-      PrintStatisticsForJoin(this);
-      PrintStatisticsForJoin(other);
-
-      SubPolyhedra<Variable, Expression> simpleResult;
-      if (this.TrySimpleJoin(other, out simpleResult))
-      {
-        return simpleResult;
-      }
-
-      List<Polynomial<Variable, Expression>> deletedLeft;
-      List<Polynomial<Variable, Expression>> deletedRight;
-      SubPolyhedra<Variable, Expression> left;
-      SubPolyhedra<Variable, Expression> right;
-
-      NormalizeOperands(other, out deletedLeft, out deletedRight, out left, out right);
-
-      // Try the trivial join
-      if (AbstractDomainsHelper.TryTrivialJoin(left, right, out result))
-      {
-        return result;
-      }
-
-      // Do the pairwise join
-      resultAsSubPolyhedra = PairwiseJoin(other, ref deletedLeft, ref deletedRight, left, right);
-
-      // Using hints      
-
-      var newHints = ApplyHints(resultAsSubPolyhedra, other, left, right);
-
-      newHints = DoTheCleanup(watch, resultAsSubPolyhedra, newHints);
-
-#if TRACEJOIN
-      resultAsSubPolyhedra.DebugCheckLessEq("sv18", "sv9", "result");
-      resultAsSubPolyhedra.DebugCheckLessEq("sv21", "sv9", "this");
-      resultAsSubPolyhedra.DebugCheckLessEq("sv26", "sv9", "this");
-#endif
-
-      if (resultAsSubPolyhedra.hints.Count > SubPolyhedra.MaxHintsToRetainInWidening)
-      {
-        resultAsSubPolyhedra.hints = new Hints<Variable, Expression>();
-        resultAsSubPolyhedra.WideningOnHints = true;
-      }
-
-      resultAsSubPolyhedra.PrintStatistics("@ join point");
-
-      return resultAsSubPolyhedra;
-    }
-   
-    #region Join helpers
-    private bool TrySimpleJoin(SubPolyhedra<Variable, Expression> other, out SubPolyhedra<Variable, Expression> result)
-    {
-      if (Object.ReferenceEquals(this, other))
-      {
-        result = this;
-        return true;
-      }
-
-      this.Left.RemoveUnusedVariables();
-      other.Left.RemoveUnusedVariables();
-
-      Contract.Assert(other != null);
-
-      if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
-      {
-        return true;
-      }
-
-      return false;
-    }
-
-    private void NormalizeOperands(SubPolyhedra<Variable, Expression> other, out List<Polynomial<Variable, Expression>> deletedLeft, out List<Polynomial<Variable, Expression>> deletedRight, out SubPolyhedra<Variable, Expression> left, out SubPolyhedra<Variable, Expression> right)
-    {
-      deletedLeft = new List<Polynomial<Variable, Expression>>();
-      deletedRight = new List<Polynomial<Variable, Expression>>();
-
-      // simplify
-      this.CleanUpBetaVariables();
-      other.CleanUpBetaVariables();
-
-      // Transfer the definitions for the slack variables : Step 1
-
-      this.HarmonizeSlackVariables(this, other);
-      this.HarmonizeSlackVariables(other, this);
-
-      // Do the reduction (infer the tightest bounds) 
-      
-      left = ReduceAndPutConstants(this.Left, this.Right);
-      right = ReduceAndPutConstants(other.Left, other.Right);
-
-      //MyParallel.Invoke(leftAct, rightAct);
-
-      this.ExpressionManager.Log("** Left state after harmonization and reduction :\n{0}", left.ToString);
-      this.ExpressionManager.Log("** Right state after harmonization and reduction :\n{0}", right.ToString);
-
-      // Reduction may have removed some variables for efficiency, we need to put them back
-      ReintroduceDroppedVariables(left, right, this, other);
-    }
-
-    private SubPolyhedra<Variable, Expression> PairwiseJoin(SubPolyhedra<Variable, Expression> other, ref List<Polynomial<Variable, Expression>> deletedLeft, ref List<Polynomial<Variable, Expression>> deletedRight, SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right)
-    {
-      SubPolyhedra<Variable, Expression> resultAsSubPolyhedra;
-      this.ExpressionManager.Log("** Karr Join Left\n{0}", left.Left.ToString);
-      this.ExpressionManager.Log("** Karr Join Right\n{0}", right.Left.ToString);
-
-      var leftKarr = left.Left.DuplicateMe();
-      var rightKarr = right.Left.DuplicateMe();
-      var resultLeft = leftKarr.Join(rightKarr) as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
-
-      this.ExpressionManager.Log("** Karr Join Result\n{0}", resultLeft.ToString);
-
-      var resultRight = left.Right.Join(right.Right) as IntervalEnvironment<Variable, Expression>;
-      resultAsSubPolyhedra = Factory(resultLeft, resultRight) as SubPolyhedra<Variable, Expression>;
-
-      this.ExpressionManager.Log("** Temporay Result after pairwise join: \n{0}", resultAsSubPolyhedra.ToString);
-
-      // Set the dependencies for the result
-      SetDependencies(resultAsSubPolyhedra, this.betaDep);
-      SetDependencies(resultAsSubPolyhedra, other.betaDep);
-
-      // Do some clean up (mainly for performances)
-      resultAsSubPolyhedra.CleanUpBetaVariables();
-
-      // here we want to get any equality between program variables that may have been lost
-      var simplifiedLeft = left.Left.DuplicateMe() as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
-      var simplifiedRight = right.Left.DuplicateMe() as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
-
-      simplifiedLeft.ProjectSlackVariables();
-      simplifiedRight.ProjectSlackVariables();
-
-      simplifiedLeft.Join(simplifiedRight, ref deletedLeft, ref deletedRight);
-
-      // Try to recover relations using dropped equalities
-      ReintroduceDroppedConstraints(resultAsSubPolyhedra, right, deletedLeft);
-      ReintroduceDroppedConstraints(resultAsSubPolyhedra, left, deletedRight);
-
-      this.ExpressionManager.Log("** Temporay Result after reintroducing dropped equalities: \n{0}", resultAsSubPolyhedra.ToString);
-      return resultAsSubPolyhedra;
-    }
-
-    private Dictionary<Variable, Polynomial<Variable, Expression>> ApplyHints(SubPolyhedra<Variable, Expression> resultAsSubPolyhedra, SubPolyhedra<Variable, Expression> other, SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right)
-    {
-      this.ExpressionManager.Log("** Left state before using hints \n{0}", left.ToString);
-      this.ExpressionManager.Log("** Right state before using hints \n{0}", right.ToString);
-
-      var betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-      var intvResult = new Dictionary<Variable, Interval>();
-
-      var allHints = new Hints<Variable, Expression>(this.hints);
-      allHints.Add(other.hints);
-
-      HintsFromBetaDeps(allHints, left.betaDep);
-      HintsFromBetaDeps(allHints, right.betaDep);
-
-      // we add the same slack variable to all polynomials, so renaming will be necessary
-      var beta = this.ExpressionManager.Encoder.FreshVariable<int>();
-
-      // Infer the semantic hints
-      var semanticHints = left.Right.ConvexHullHelper(right.Right, beta, SubPolyhedra.Inference);
-
-      this.ExpressionManager.Log("**Computed hints \n{0}", semanticHints.ToString);
-
-      // Begin
-
-#if false
-      // F: This code does not quite work for some reasons that are unclear to me
-      var octagonsHints = InferOctagonHints(left, right, semanticHints, beta);
-
-      foreach (var triple in octagonsHints)
-      {
-        resultAsSubPolyhedra.Left.AddConstraint(triple.Two);
-        resultAsSubPolyhedra.Right.AssumeInInterval(triple.One, triple.Three);
-
-        Console.WriteLine("Inferred {0} {1}", triple.Two, triple.Three);
-      }
-      Console.WriteLine("----");
-#else
-      allHints.Add(semanticHints);
-#endif
-      // End
-
-
-      CleanHints(ref allHints, this.ExpressionManager);
-
-      this.ExpressionManager.Log("**All hints \n{0}", Print(allHints));
-
-      // build list of polynomials to check
-      foreach (var pol in allHints.Enumerate())
-      {
-        var k = IsBetaDefinition(pol, out beta, this.ExpressionManager.Decoder);
-        if (k != 1)
-        {
-          continue;
-        }
-
-        var betaTwo = this.ExpressionManager.Encoder.FreshVariable<int>();
-        var polBeta = pol.Rename(false, beta, betaTwo);
-        betaList[betaTwo] = polBeta;
-      }
-
-      // simplify list
-      CleanDeps(ref betaList, this.ExpressionManager);
-
-      var clonedLeft = left.DuplicateMe();
-
-      // get the ranges for the slack variables proved by the left element
-      foreach (var pair in betaList)
-      {
-        clonedLeft.Left.AddConstraint(clonedLeft.Left.AsVector(pair.Value));
-      }
-
-      this.ExpressionManager.Log("** Left state before reduction\n{0}", clonedLeft.ToString);
-
-      clonedLeft = clonedLeft.ReduceInternal(clonedLeft.Left, clonedLeft.Right, false);
-
-      this.ExpressionManager.Log("** Left state after reduction\n{0}", clonedLeft.ToString);
-
-      foreach (var alpha in betaList.Keys)
-      {
-        var bounds = clonedLeft.Right.BoundsFor(alpha);
-        if (bounds.IsNormal)
-        {
-          intvResult[alpha] = bounds.AsInterval;
-        }
-      }
-
-      // get the ranges for the slack variables proved by the right element and join them with the previous intervals
-      var clonedRight = right.DuplicateMe();
-      foreach (var alpha_pair in betaList)
-      {
-        clonedRight.Left.AddConstraint(clonedRight.Left.AsVector(alpha_pair.Value));
-      }
-
-      this.ExpressionManager.Log("Right state before reduction\n{0}", clonedRight.ToString);
-
-      clonedRight = clonedRight.ReduceInternal(clonedRight.Left, clonedRight.Right, false);
-
-      this.ExpressionManager.Log("Rigth state after reduction\n{0}", clonedRight.ToString);
-
-      foreach (var alpha in betaList.Keys)
-      {
-        Interval bounds;
-        if (intvResult.TryGetValue(alpha, out bounds))
-        {
-          intvResult[alpha] = bounds.Join(clonedRight.Right.BoundsFor(alpha).AsInterval);
-        }
-      }
-
-      // keep non-top results only
-      foreach (var pair in intvResult)
-      {
-        if (!pair.Value.IsTop)
-        {
-          this.ExpressionManager.Log("Adding hint {0} == {1}", betaList[pair.Key].ToString, pair.Value.ToString);
-
-          //Console.WriteLine("Inferred* {0} {1}", betaList[pair.Key], pair.Value);
-
-          var linearEq = betaList[pair.Key];
-          resultAsSubPolyhedra.Left.AddConstraint(resultAsSubPolyhedra.Left.AsVector(linearEq));
-          resultAsSubPolyhedra.Right[pair.Key] = pair.Value;
-          resultAsSubPolyhedra.betaDep[pair.Key] = linearEq;
-        }
-      }
-
-      var newHints = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-
-#if false
-      foreach (var triple in octagonsHints)
-      {
-        newHints[triple.One] = triple.Two;
-        }
-#endif
-
-      foreach (var pair in this.betaDep)
-      {
-        if (!resultAsSubPolyhedra.betaDep.ContainsKey(pair.Key))
-        {
-          newHints.Add(pair.Key, pair.Value);
-        }
-      }
-
-      foreach (var pair in other.betaDep)
-      {
-        if (!resultAsSubPolyhedra.betaDep.ContainsKey(pair.Key) && !newHints.ContainsKey(pair.Key))
-        {
-          newHints.Add(pair.Key, pair.Value);
-        }
-      }
-      return newHints;
-    }
-
-    private Dictionary<Variable, Polynomial<Variable, Expression>> DoTheCleanup(Stopwatch watch, SubPolyhedra<Variable, Expression> resultAsSubPolyhedra, Dictionary<Variable, Polynomial<Variable, Expression>> newHints)
-    {
-      CleanDeps(ref newHints, this.ExpressionManager);
-
-      resultAsSubPolyhedra.hints = new Hints<Variable, Expression>(newHints.Values);
-
-      resultAsSubPolyhedra.Left.PutIntoRowEchelonForm();
-
-      resultAsSubPolyhedra.CleanUpBetaVariables();
-
-      CleanDeps(ref resultAsSubPolyhedra.betaDep, this.ExpressionManager);
-
-      CleanHints(ref resultAsSubPolyhedra.hints, this.ExpressionManager);
-
-      this.ExpressionManager.Log("Elapsed: {0}", watch.Elapsed.ToString);
-
-      PrintStatisticsForJoin(resultAsSubPolyhedra);
-
-      resultAsSubPolyhedra.Left.RemoveUnusedVariables();
-
-      resultAsSubPolyhedra.Left.RemoveRedundantSlackVariables();
-
-      this.ExpressionManager.Log("Join result: {0}", resultAsSubPolyhedra.ToString);
-      
-      return newHints;
-    }
-    #endregion
-
-    private List<STuple<Variable, Polynomial<Variable, Expression>, DisInterval>> InferOctagonHints(
-      SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right,
-      Set<Polynomial<Variable, Expression>> semanticHints, Variable beta)
-    {
-      var leftCloned = left.DuplicateMe();
-      var rightCloned = right.DuplicateMe();
-
-      var myBetaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-      foreach (var pol in semanticHints)
-      {
-        var k = IsBetaDefinition(pol, out beta, this.ExpressionManager.Decoder);
-        if (k != 1)
-        {
-          continue;
-        }
-
-        var betaTwo = this.ExpressionManager.Encoder.FreshVariable<int>();
-        var polBeta = pol.Rename(false, beta, betaTwo);
-        myBetaList[betaTwo] = polBeta;
-
-        leftCloned.Left.AddConstraint(leftCloned.Left.AsVector(polBeta));
-        rightCloned.Left.AddConstraint(rightCloned.Left.AsVector(polBeta));
-      }
-
-      leftCloned = leftCloned.ReduceInternal(leftCloned.Left, leftCloned.Right, true);
-      rightCloned = rightCloned.ReduceInternal(rightCloned.Left, rightCloned.Right, true);
-
-      var result = new List<STuple<Variable, Polynomial<Variable, Expression>, DisInterval>>();
-      foreach (var pair in myBetaList)
-      {
-        var intvLeft = leftCloned.BoundsFor(pair.Key);
-        var intvRight = rightCloned.BoundsFor(pair.Key);
-        var join = intvLeft.Join(intvRight);
-
-        if (join.IsNormal)
-        {
-          var newConstraint = new STuple<Variable, Polynomial<Variable, Expression>, DisInterval>(pair.Key, pair.Value, join);
-          result.Add(newConstraint);
-        }
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Works with side effects in place
-    /// </summary>
-    private void HarmonizeSlackVariables(SubPolyhedra<Variable, Expression> from, SubPolyhedra<Variable, Expression> to)
-    {
-      var vars = new List<Variable>(from.betaDep.Keys);
-
-      var cached_to_Variables = to.Variables.ToSet();
-      foreach (var alpha in vars)
-      {
-        if (cached_to_Variables.Contains(alpha))
-        {
-          // Most likely, the definitions are not the same so we need to rename
-          var newName = this.ExpressionManager.Encoder.FreshVariable<int>();
-          from.RenameVariable(alpha, newName);
-          to.Left.AddConstraint(to.Left.AsVector(from.betaDep[newName]));
-        }
-        else
-        {
-          to.Left.AddConstraint(to.Left.AsVector(from.betaDep[alpha]));
-        }
-      }
-    }
-
-    private SubPolyhedra<Variable, Expression> ReduceAndPutConstants(LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> lineq, IntervalEnvironment<Variable, Expression> intv)
-    {
-      var res = ReduceInternal(lineq, intv, false);
-      res.PutConstantsInKarr(); // the join in Karr is more precise when constants are present
-
-      return res;
-    }
-
-    /// <summary>
-    /// Works with in place updates
-    /// </summary>
-    static private void ReintroduceDroppedVariables(SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right, SubPolyhedra<Variable, Expression> originalLeft, SubPolyhedra<Variable, Expression> originalRight)
-    {
-      var vars = new List<Variable>(originalLeft.betaDep.Keys);
-      foreach (var alpha in vars)
-      {
-        if (left.Left.Variables.Contains(alpha))
-        {
-          // ok, reduction kept it
-        }
-        else
-        {
-          left.Left.AddConstraint(left.Left.AsVector(originalLeft.betaDep[alpha]));
-        }
-
-        if (right.Left.Variables.Contains(alpha))
-        {
-          // ok, reduction kept it
-        }
-        else
-        {
-          right.Left.AddConstraint(right.Left.AsVector(originalLeft.betaDep[alpha]));
-        }
-      }
-
-      vars = new List<Variable>(originalRight.betaDep.Keys);
-      foreach (var alpha in vars)
-      {
-        if (left.Left.Variables.Contains(alpha))
-        {
-          // ok, reduction kept it
-        }
-        else
-        {
-          left.Left.AddConstraint(left.Left.AsVector(originalRight.betaDep[alpha]));
-        }
-
-        if (right.Left.Variables.Contains(alpha))
-        {
-          // ok, reduction kept it
-        }
-        else
-        {
-          right.Left.AddConstraint(right.Left.AsVector(originalRight.betaDep[alpha]));
-        }
-      }
-    }
-
-    /// <summary>
-    /// Works with in place updates
-    /// </summary>
-    static private void SetDependencies(SubPolyhedra<Variable, Expression> result, Dictionary<Variable, Polynomial<Variable, Expression>> betaDep)
-    {
-      foreach (var alpha_pair in betaDep)
-      {
-        if (result.Variables.Contains(alpha_pair.Key))
-        {
-          result.betaDep[alpha_pair.Key] = alpha_pair.Value;
-        }
-      }
-    }
-
-    /// <summary>
-    /// Works with in place updates to result
-    /// </summary>
-    private void ReintroduceDroppedConstraints(
-      SubPolyhedra<Variable, Expression> result, SubPolyhedra<Variable, Expression> original, List<Polynomial<Variable, Expression>> dropped)
-    {
-      var betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-      var intvResult = new Dictionary<Variable, DisInterval>();
-      var cloned = original.DuplicateMe();
-
-      foreach (var pol in dropped)
-      {
-        if (pol.Variables.IsSingleton)
-        {// should be handled by intervals
-          continue;
-        }
-
-        Polynomial<Variable, Expression> polBeta;
-        Variable beta, betaTwo;
-
-        int k = IsBetaDefinition(pol, out betaTwo, this.ExpressionManager.Decoder);
-
-        if (k == 0 && pol.Variables.Count > 1)
-        { // equality between program variables that doesn't hold in right : 
-          // trying to get some bounds for the corresponding linear functional
-          beta = this.ExpressionManager.Encoder.FreshVariable<int>();
-          polBeta = pol.AddMonomialToTheLeft(new Monomial<Variable>(-1, beta));
-          cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
-          betaList[beta] = polBeta;
-          intvResult[beta] = DisInterval.For(0);
-        }
-        else if (k == 1 && pol.Variables.Count > 2)
-        { // linear functional bounded on the left : 
-          // as it may not correspond to the actual definition of the slack variable, we will try to bound it also on the right
-          beta = this.ExpressionManager.Encoder.FreshVariable<int>();
-          polBeta = pol.Rename(false, betaTwo, beta);
-          cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
-          betaList[beta] = polBeta;
-          intvResult[beta] = original.BoundsFor(betaTwo);
-        }
-        else
-        {
-          // in all the other cases, we don't try to get any information,
-          // either because it should be kept by intervals or because it involves several slack variables
-        }
-      }
-
-      cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
-
-      foreach (var alpha_pair in betaList)
-      {
-        if (!cloned.Right.BoundsFor(alpha_pair.Key).IsTop)
-        {
-          result.Left.AddConstraint(result.Left.AsVector(alpha_pair.Value));
-          var disinterval = cloned.Right.BoundsFor(alpha_pair.Key).Join(intvResult[alpha_pair.Key]);
-          result.Right[alpha_pair.Key] = disinterval.AsInterval;
-          result.betaDep[alpha_pair.Key] = alpha_pair.Value;
-        }
-      }
-    }
-
-    private void HintsFromBetaDeps(Hints<Variable, Expression> result, Dictionary<Variable, Polynomial<Variable, Expression>> betaDeps)
-    {
-      foreach (var e_pair in betaDeps)
-      {
-        Variable beta;
-        if (IsBetaDefinition(e_pair.Value, out beta, this.ExpressionManager.Decoder) == 1)
-        {
-          result.Add(e_pair.Value);
-        }
-      }
-    }
-    
-
-    [Conditional("TRACE_JOIN")]
-    private static void PrintStatisticsForJoin(SubPolyhedra<Variable, Expression> sp)
-    {
-    }
-
-    public override bool LessEqual(IAbstractDomain a)
-    { // here we assume that we are called after a widening, so the slack variables in this are renamings of slack variables in a
-      if (this.IsBottom)
-        return true;
-
-      if (a.IsTop)
-        return true;
-
-      var other = a as SubPolyhedra<Variable, Expression>;
-
-#if false
-      // First, direct try -- it breaks regression test. Probably of some aliasing?
-      if (this.Left.LessEqual(other.Left) && this.Right.LessEqual(other.Right))
-      {
-        return true;
-      }
-#endif
-
-
-      Contract.Assert(other != null);
-
-      #region Quick Checks
-
-      var decoder = this.ExpressionManager.Decoder;
-      var intvRight = this.Right;
-      var intvLeft = other.Right;
-
-      foreach (var var in other.Right.Variables)
-      {
-        if (!decoder.IsSlackVariable(var) && !intvRight.BoundsFor(var).LessEqual(intvLeft.BoundsFor(var)))
-        {
-          return false;
-        }
-      }
-
-      #endregion
-
-      #region Implementation using the fact that slack variables in the two states are related
-      var cloned = this.DuplicateMe();
-      foreach (var pair in this.betaDep)
-      {
-        var e = pair.Key;
-        var def = pair.Value;
-
-        Variable equivalent;
-        Rational coeff, k;
-        if (other.TryGetEquivalent(e, def, out equivalent, out coeff, out k))
-        {
-          // Avoid trivial equalities
-          if (e.Equals(equivalent))
-          {
-            continue;
-          }
-
-          if (coeff == 1 && k.IsZero )
-          {
-            if (cloned.Variables.Contains(equivalent))
+            set
             {
-              // If the equivalent is in cloned, then they should have the same value
-              // So we assume e == cloned
-              cloned = cloned.TestTrueEqual(equivalent, e) as SubPolyhedra<Variable, Expression>;
-              if (cloned.IsBottom)
-              {
-                return false;
-              }
+                algorithm = value;
+            }
+            internal get
+            {
+                return algorithm;
+            }
+        }
+
+        [ThreadStatic]
+        private static JoinConstraintInference inference; // what constraints we guess at the join
+        public static JoinConstraintInference Inference
+        {
+            set
+            {
+                inference = value;
+            }
+            internal get
+            {
+                return inference;
+            }
+        }
+
+        #endregion
+
+        [ThreadStatic]
+        public static int MaxVariablesInOctagonsConstraintInference;
+        public const int MaxHintsToRetainInWidening = 128;
+
+        public const int MaxVariablesToRunSimplex = 500;
+
+        [ThreadStatic]
+        public static TimeSpan TimeSpentInReduction = new TimeSpan(0);
+    }
+
+    public class SubPolyhedra<Variable, Expression>
+      : ReducedNumericalDomains<LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>, IntervalEnvironment<Variable, Expression>, Variable, Expression>
+    {
+        #region State
+
+        private SPTestTrueVisitor testTrueVisitor;
+        private SPTestFalseVisitor testFalseVisitor;
+        private SPCheckIfHoldsVisitor checkIfHoldsVisitor;
+
+        private int numberOfWidenings;
+        private bool WideningOnHints = false;
+
+        #endregion
+
+        #region Dependencies for slack variables
+        private Dictionary<Variable, Polynomial<Variable, Expression>> betaDep; // a map from slack variables to the linear equality that introduced it. Useful since the row echelon form tends to lose this kind of information
+        private Hints<Variable, Expression> hints = new Hints<Variable, Expression>(); // linear functionals that we want to bound (i.e.candidates for slack variables). Each one contains excatly one slack variable, for convenience.
+        #endregion
+
+        #region Constructors
+
+        public SubPolyhedra(
+          LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> linEq,
+          IntervalEnvironment<Variable, Expression> intEnv,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+          : base(linEq, intEnv, expManager)
+        {
+            Contract.Requires(expManager != null);
+
+            betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+            hints = new Hints<Variable, Expression>();
+            numberOfWidenings = 0;
+            testTrueVisitor = new SubPolyhedra<Variable, Expression>.SPTestTrueVisitor(expManager);
+            testFalseVisitor = new SubPolyhedra<Variable, Expression>.SPTestFalseVisitor(expManager.Decoder);
+            checkIfHoldsVisitor = new SubPolyhedra<Variable, Expression>.SPCheckIfHoldsVisitor(expManager);
+            testTrueVisitor.FalseVisitor = testFalseVisitor;
+            testFalseVisitor.TrueVisitor = testTrueVisitor;
+        }
+
+        /// <summary>
+        /// Construct a subpolyhedra which is the same as <code>prev</code> but for the interval environment, which is <code>intEnv</code>
+        /// </summary>
+        /// <param name="prev"></param>
+        /// <param name="intvEnv"></param>
+        private SubPolyhedra(SubPolyhedra<Variable, Expression> prev, IntervalEnvironment<Variable, Expression> intvEnv)
+          : base(prev.Left, intvEnv, prev.ExpressionManager)
+        {
+            betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(prev.betaDep);
+            hints = new Hints<Variable, Expression>(prev.hints);
+            numberOfWidenings = prev.numberOfWidenings;
+            testFalseVisitor = prev.testFalseVisitor;
+            testTrueVisitor = prev.testTrueVisitor;          // Mutual recursive calls already set
+            checkIfHoldsVisitor = prev.checkIfHoldsVisitor;
+        }
+
+        public override object Clone()
+        {
+            return this.DuplicateMe();
+        }
+
+        public SubPolyhedra<Variable, Expression> DuplicateMe()
+        {
+            var result = base.Clone() as SubPolyhedra<Variable, Expression>;
+
+            result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(betaDep);
+            result.hints = new Hints<Variable, Expression>(hints);
+            result.numberOfWidenings = 0;
+            result.WideningOnHints = WideningOnHints;
+            return result;
+        }
+        #endregion
+
+#if TRACEJOIN
+        public override void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            this.DebugCheckLessEq("sv27", "sv9", "before assign");
+            base.Assign(x, exp, preState);
+            this.DebugCheckLessEq("sv27", "sv9", "after assign");
+        }
+#endif
+
+        #region Test* methods
+        public SubPolyhedra<Variable, Expression> Assume(Expression guard)
+        {
+            return this.TestTrue(guard) as SubPolyhedra<Variable, Expression>;
+        }
+
+        public override IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            var result = testTrueVisitor.Visit(guard, this);
+
+            var deps = result.betaDep;
+            var hintSet = result.hints;
+
+            result = result.ReduceInternal(result.Left, result.Right, false);
+            result.betaDep = deps;
+            result.hints = hintSet;
+
+            if (!result.IsBottom)
+            {
+                result.CleanUpBetaVariables();
+            }
+
+            return result;
+        }
+
+        public override IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            var result = testFalseVisitor.Visit(guard, this);
+
+            // the reduction, if precise enough, will tell us if this branch is unreachable
+            var deps = result.betaDep;
+            var hintSet = result.hints;
+
+            result = result.ReduceInternal(result.Left, result.Right, false);
+
+            result.betaDep = deps;
+            result.hints = hintSet;
+
+            if (!result.IsBottom)
+            {
+                result.CleanUpBetaVariables();
+            }
+
+            return result;
+        }
+
+        public override INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.GreaterEqualThan, exp,
+              this.ExpressionManager.Encoder.ConstantFor(0))) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        public override INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, exp1, exp2)) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        public override INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, exp1, exp2)) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        public override INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            return TestTrue(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, exp1, exp2)) as INumericalAbstractDomain<Variable, Expression>;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Variable v1, Variable v2)
+        {
+            var v1Exp = this.ExpressionManager.Encoder.VariableFor(v1);
+            var v2Exp = this.ExpressionManager.Encoder.VariableFor(v2);
+
+            return this.TestTrueEqual(v1Exp, v2Exp);
+        }
+        #endregion
+
+        #region Abstract Domain Operations
+
+        #region !!!!Debugging ONLY!!!!
+
+#if DEBUG
+        private bool TrySearchVariable(string varstr, ref Variable v)
+        {
+            foreach (var x in this.Variables)
+            {
+                if (x.ToString().Contains(varstr))
+                {
+                    v = x;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool DebugCheckSv18LessThanSv21(string where)
+        {
+            var b = this.DebugCheckLessEq("sv18", "sv21", where);
+            /*      if (!b)
+                  {       
+                    return this.DebugCheckLessEq("sv19", "sv11", where);
+                  }
+                  else*/
+            {
+                return b;
+            }
+        }
+
+        public bool DebugCheckLessEq(string left, string right, string where)
+        {
+            // We want to be sure it does not go in the release bits
+#if DEBUG
+            Variable l, r;
+            l = r = default(Variable);
+            if (TrySearchVariable(left, ref l) && TrySearchVariable(right, ref r))
+            {
+                return DebugCheckLessEq(l, r, where);
+            }
+#endif
+            return false;
+        }
+
+        public bool DebugCheckLessEq(Variable l, Variable r, string where)
+        {
+            var isTrue = this.CheckIfLessThan(this.ExpressionManager.Encoder.VariableFor(l), this.ExpressionManager.Encoder.VariableFor(r));
+
+            //this.ExpressionManager.Log("{3}: {0} < {1} is {2}", () =>left, ()=>right, ()=>isTrue.ToString(), () =>where); 
+
+            Console.WriteLine("{3}: {0} < {1} is {2}", l.ToString(), r.ToString(), isTrue.ToString(), where);
+            if (!isTrue.IsTrue())
+            {
+                isTrue = this.CheckIfLessEqualThan(this.ExpressionManager.Encoder.VariableFor(l), this.ExpressionManager.Encoder.VariableFor(r));
+
+                Console.WriteLine("{3}: {0} <= {1} is {2}", l.ToString(), r.ToString(), isTrue.ToString(), where);
+            }
+
+            return isTrue.IsTrue();
+        }
+
+#endif
+
+        #endregion
+
+#if TRACEJOIN
+        private static int joincount = 0;
+#endif
+
+        public override IAbstractDomain Join(IAbstractDomain a)
+        {
+            return PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.SubPolyJoin, () => JoinInternal(a), true);
+        }
+
+        private IAbstractDomain JoinInternal(IAbstractDomain a)
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+
+#if TRACEJOIN
+            Console.WriteLine("join #{0}", joincount++);
+#endif
+
+            IAbstractDomain result;
+            SubPolyhedra<Variable, Expression> resultAsSubPolyhedra;
+            SubPolyhedra<Variable, Expression> other = a as SubPolyhedra<Variable, Expression>;
+
+            Contract.Assert(other != null);
+
+#if TRACEJOIN
+            this.DebugCheckLessEq("sv18", "sv9", "this");
+            other.DebugCheckLessEq("sv18", "sv9", "other");
+
+            this.DebugCheckLessEq("sv21", "sv9", "this");
+            other.DebugCheckLessEq("sv21", "sv9", "other");
+
+            this.DebugCheckLessEq("sv26", "sv9", "this");
+            other.DebugCheckLessEq("sv26", "sv9", "other");
+#endif
+
+            PrintStatisticsForJoin(this);
+            PrintStatisticsForJoin(other);
+
+            SubPolyhedra<Variable, Expression> simpleResult;
+            if (this.TrySimpleJoin(other, out simpleResult))
+            {
+                return simpleResult;
+            }
+
+            List<Polynomial<Variable, Expression>> deletedLeft;
+            List<Polynomial<Variable, Expression>> deletedRight;
+            SubPolyhedra<Variable, Expression> left;
+            SubPolyhedra<Variable, Expression> right;
+
+            NormalizeOperands(other, out deletedLeft, out deletedRight, out left, out right);
+
+            // Try the trivial join
+            if (AbstractDomainsHelper.TryTrivialJoin(left, right, out result))
+            {
+                return result;
+            }
+
+            // Do the pairwise join
+            resultAsSubPolyhedra = PairwiseJoin(other, ref deletedLeft, ref deletedRight, left, right);
+
+            // Using hints      
+
+            var newHints = ApplyHints(resultAsSubPolyhedra, other, left, right);
+
+            newHints = DoTheCleanup(watch, resultAsSubPolyhedra, newHints);
+
+#if TRACEJOIN
+            resultAsSubPolyhedra.DebugCheckLessEq("sv18", "sv9", "result");
+            resultAsSubPolyhedra.DebugCheckLessEq("sv21", "sv9", "this");
+            resultAsSubPolyhedra.DebugCheckLessEq("sv26", "sv9", "this");
+#endif
+
+            if (resultAsSubPolyhedra.hints.Count > SubPolyhedra.MaxHintsToRetainInWidening)
+            {
+                resultAsSubPolyhedra.hints = new Hints<Variable, Expression>();
+                resultAsSubPolyhedra.WideningOnHints = true;
+            }
+
+            resultAsSubPolyhedra.PrintStatistics("@ join point");
+
+            return resultAsSubPolyhedra;
+        }
+
+        #region Join helpers
+        private bool TrySimpleJoin(SubPolyhedra<Variable, Expression> other, out SubPolyhedra<Variable, Expression> result)
+        {
+            if (Object.ReferenceEquals(this, other))
+            {
+                result = this;
+                return true;
+            }
+
+            this.Left.RemoveUnusedVariables();
+            other.Left.RemoveUnusedVariables();
+
+            Contract.Assert(other != null);
+
+            if (AbstractDomainsHelper.TryTrivialJoin(this, other, out result))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void NormalizeOperands(SubPolyhedra<Variable, Expression> other, out List<Polynomial<Variable, Expression>> deletedLeft, out List<Polynomial<Variable, Expression>> deletedRight, out SubPolyhedra<Variable, Expression> left, out SubPolyhedra<Variable, Expression> right)
+        {
+            deletedLeft = new List<Polynomial<Variable, Expression>>();
+            deletedRight = new List<Polynomial<Variable, Expression>>();
+
+            // simplify
+            this.CleanUpBetaVariables();
+            other.CleanUpBetaVariables();
+
+            // Transfer the definitions for the slack variables : Step 1
+
+            this.HarmonizeSlackVariables(this, other);
+            this.HarmonizeSlackVariables(other, this);
+
+            // Do the reduction (infer the tightest bounds) 
+
+            left = ReduceAndPutConstants(this.Left, this.Right);
+            right = ReduceAndPutConstants(other.Left, other.Right);
+
+            //MyParallel.Invoke(leftAct, rightAct);
+
+            this.ExpressionManager.Log("** Left state after harmonization and reduction :\n{0}", left.ToString);
+            this.ExpressionManager.Log("** Right state after harmonization and reduction :\n{0}", right.ToString);
+
+            // Reduction may have removed some variables for efficiency, we need to put them back
+            ReintroduceDroppedVariables(left, right, this, other);
+        }
+
+        private SubPolyhedra<Variable, Expression> PairwiseJoin(SubPolyhedra<Variable, Expression> other, ref List<Polynomial<Variable, Expression>> deletedLeft, ref List<Polynomial<Variable, Expression>> deletedRight, SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right)
+        {
+            SubPolyhedra<Variable, Expression> resultAsSubPolyhedra;
+            this.ExpressionManager.Log("** Karr Join Left\n{0}", left.Left.ToString);
+            this.ExpressionManager.Log("** Karr Join Right\n{0}", right.Left.ToString);
+
+            var leftKarr = left.Left.DuplicateMe();
+            var rightKarr = right.Left.DuplicateMe();
+            var resultLeft = leftKarr.Join(rightKarr) as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
+
+            this.ExpressionManager.Log("** Karr Join Result\n{0}", resultLeft.ToString);
+
+            var resultRight = left.Right.Join(right.Right) as IntervalEnvironment<Variable, Expression>;
+            resultAsSubPolyhedra = Factory(resultLeft, resultRight) as SubPolyhedra<Variable, Expression>;
+
+            this.ExpressionManager.Log("** Temporay Result after pairwise join: \n{0}", resultAsSubPolyhedra.ToString);
+
+            // Set the dependencies for the result
+            SetDependencies(resultAsSubPolyhedra, betaDep);
+            SetDependencies(resultAsSubPolyhedra, other.betaDep);
+
+            // Do some clean up (mainly for performances)
+            resultAsSubPolyhedra.CleanUpBetaVariables();
+
+            // here we want to get any equality between program variables that may have been lost
+            var simplifiedLeft = left.Left.DuplicateMe() as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
+            var simplifiedRight = right.Left.DuplicateMe() as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
+
+            simplifiedLeft.ProjectSlackVariables();
+            simplifiedRight.ProjectSlackVariables();
+
+            simplifiedLeft.Join(simplifiedRight, ref deletedLeft, ref deletedRight);
+
+            // Try to recover relations using dropped equalities
+            ReintroduceDroppedConstraints(resultAsSubPolyhedra, right, deletedLeft);
+            ReintroduceDroppedConstraints(resultAsSubPolyhedra, left, deletedRight);
+
+            this.ExpressionManager.Log("** Temporay Result after reintroducing dropped equalities: \n{0}", resultAsSubPolyhedra.ToString);
+            return resultAsSubPolyhedra;
+        }
+
+        private Dictionary<Variable, Polynomial<Variable, Expression>> ApplyHints(SubPolyhedra<Variable, Expression> resultAsSubPolyhedra, SubPolyhedra<Variable, Expression> other, SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right)
+        {
+            this.ExpressionManager.Log("** Left state before using hints \n{0}", left.ToString);
+            this.ExpressionManager.Log("** Right state before using hints \n{0}", right.ToString);
+
+            var betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+            var intvResult = new Dictionary<Variable, Interval>();
+
+            var allHints = new Hints<Variable, Expression>(hints);
+            allHints.Add(other.hints);
+
+            HintsFromBetaDeps(allHints, left.betaDep);
+            HintsFromBetaDeps(allHints, right.betaDep);
+
+            // we add the same slack variable to all polynomials, so renaming will be necessary
+            var beta = this.ExpressionManager.Encoder.FreshVariable<int>();
+
+            // Infer the semantic hints
+            var semanticHints = left.Right.ConvexHullHelper(right.Right, beta, SubPolyhedra.Inference);
+
+            this.ExpressionManager.Log("**Computed hints \n{0}", semanticHints.ToString);
+
+            // Begin
+
+#if false
+            // F: This code does not quite work for some reasons that are unclear to me
+            var octagonsHints = InferOctagonHints(left, right, semanticHints, beta);
+
+            foreach (var triple in octagonsHints)
+            {
+                resultAsSubPolyhedra.Left.AddConstraint(triple.Two);
+                resultAsSubPolyhedra.Right.AssumeInInterval(triple.One, triple.Three);
+
+                Console.WriteLine("Inferred {0} {1}", triple.Two, triple.Three);
+            }
+            Console.WriteLine("----");
+#else
+            allHints.Add(semanticHints);
+#endif
+            // End
+
+
+            CleanHints(ref allHints, this.ExpressionManager);
+
+            this.ExpressionManager.Log("**All hints \n{0}", Print(allHints));
+
+            // build list of polynomials to check
+            foreach (var pol in allHints.Enumerate())
+            {
+                var k = IsBetaDefinition(pol, out beta, this.ExpressionManager.Decoder);
+                if (k != 1)
+                {
+                    continue;
+                }
+
+                var betaTwo = this.ExpressionManager.Encoder.FreshVariable<int>();
+                var polBeta = pol.Rename(false, beta, betaTwo);
+                betaList[betaTwo] = polBeta;
+            }
+
+            // simplify list
+            CleanDeps(ref betaList, this.ExpressionManager);
+
+            var clonedLeft = left.DuplicateMe();
+
+            // get the ranges for the slack variables proved by the left element
+            foreach (var pair in betaList)
+            {
+                clonedLeft.Left.AddConstraint(clonedLeft.Left.AsVector(pair.Value));
+            }
+
+            this.ExpressionManager.Log("** Left state before reduction\n{0}", clonedLeft.ToString);
+
+            clonedLeft = clonedLeft.ReduceInternal(clonedLeft.Left, clonedLeft.Right, false);
+
+            this.ExpressionManager.Log("** Left state after reduction\n{0}", clonedLeft.ToString);
+
+            foreach (var alpha in betaList.Keys)
+            {
+                var bounds = clonedLeft.Right.BoundsFor(alpha);
+                if (bounds.IsNormal)
+                {
+                    intvResult[alpha] = bounds.AsInterval;
+                }
+            }
+
+            // get the ranges for the slack variables proved by the right element and join them with the previous intervals
+            var clonedRight = right.DuplicateMe();
+            foreach (var alpha_pair in betaList)
+            {
+                clonedRight.Left.AddConstraint(clonedRight.Left.AsVector(alpha_pair.Value));
+            }
+
+            this.ExpressionManager.Log("Right state before reduction\n{0}", clonedRight.ToString);
+
+            clonedRight = clonedRight.ReduceInternal(clonedRight.Left, clonedRight.Right, false);
+
+            this.ExpressionManager.Log("Rigth state after reduction\n{0}", clonedRight.ToString);
+
+            foreach (var alpha in betaList.Keys)
+            {
+                Interval bounds;
+                if (intvResult.TryGetValue(alpha, out bounds))
+                {
+                    intvResult[alpha] = bounds.Join(clonedRight.Right.BoundsFor(alpha).AsInterval);
+                }
+            }
+
+            // keep non-top results only
+            foreach (var pair in intvResult)
+            {
+                if (!pair.Value.IsTop)
+                {
+                    this.ExpressionManager.Log("Adding hint {0} == {1}", betaList[pair.Key].ToString, pair.Value.ToString);
+
+                    //Console.WriteLine("Inferred* {0} {1}", betaList[pair.Key], pair.Value);
+
+                    var linearEq = betaList[pair.Key];
+                    resultAsSubPolyhedra.Left.AddConstraint(resultAsSubPolyhedra.Left.AsVector(linearEq));
+                    resultAsSubPolyhedra.Right[pair.Key] = pair.Value;
+                    resultAsSubPolyhedra.betaDep[pair.Key] = linearEq;
+                }
+            }
+
+            var newHints = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+
+#if false
+            foreach (var triple in octagonsHints)
+            {
+                newHints[triple.One] = triple.Two;
+            }
+#endif
+
+            foreach (var pair in betaDep)
+            {
+                if (!resultAsSubPolyhedra.betaDep.ContainsKey(pair.Key))
+                {
+                    newHints.Add(pair.Key, pair.Value);
+                }
+            }
+
+            foreach (var pair in other.betaDep)
+            {
+                if (!resultAsSubPolyhedra.betaDep.ContainsKey(pair.Key) && !newHints.ContainsKey(pair.Key))
+                {
+                    newHints.Add(pair.Key, pair.Value);
+                }
+            }
+            return newHints;
+        }
+
+        private Dictionary<Variable, Polynomial<Variable, Expression>> DoTheCleanup(Stopwatch watch, SubPolyhedra<Variable, Expression> resultAsSubPolyhedra, Dictionary<Variable, Polynomial<Variable, Expression>> newHints)
+        {
+            CleanDeps(ref newHints, this.ExpressionManager);
+
+            resultAsSubPolyhedra.hints = new Hints<Variable, Expression>(newHints.Values);
+
+            resultAsSubPolyhedra.Left.PutIntoRowEchelonForm();
+
+            resultAsSubPolyhedra.CleanUpBetaVariables();
+
+            CleanDeps(ref resultAsSubPolyhedra.betaDep, this.ExpressionManager);
+
+            CleanHints(ref resultAsSubPolyhedra.hints, this.ExpressionManager);
+
+            this.ExpressionManager.Log("Elapsed: {0}", watch.Elapsed.ToString);
+
+            PrintStatisticsForJoin(resultAsSubPolyhedra);
+
+            resultAsSubPolyhedra.Left.RemoveUnusedVariables();
+
+            resultAsSubPolyhedra.Left.RemoveRedundantSlackVariables();
+
+            this.ExpressionManager.Log("Join result: {0}", resultAsSubPolyhedra.ToString);
+
+            return newHints;
+        }
+        #endregion
+
+        private List<STuple<Variable, Polynomial<Variable, Expression>, DisInterval>> InferOctagonHints(
+          SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right,
+          Set<Polynomial<Variable, Expression>> semanticHints, Variable beta)
+        {
+            var leftCloned = left.DuplicateMe();
+            var rightCloned = right.DuplicateMe();
+
+            var myBetaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+            foreach (var pol in semanticHints)
+            {
+                var k = IsBetaDefinition(pol, out beta, this.ExpressionManager.Decoder);
+                if (k != 1)
+                {
+                    continue;
+                }
+
+                var betaTwo = this.ExpressionManager.Encoder.FreshVariable<int>();
+                var polBeta = pol.Rename(false, beta, betaTwo);
+                myBetaList[betaTwo] = polBeta;
+
+                leftCloned.Left.AddConstraint(leftCloned.Left.AsVector(polBeta));
+                rightCloned.Left.AddConstraint(rightCloned.Left.AsVector(polBeta));
+            }
+
+            leftCloned = leftCloned.ReduceInternal(leftCloned.Left, leftCloned.Right, true);
+            rightCloned = rightCloned.ReduceInternal(rightCloned.Left, rightCloned.Right, true);
+
+            var result = new List<STuple<Variable, Polynomial<Variable, Expression>, DisInterval>>();
+            foreach (var pair in myBetaList)
+            {
+                var intvLeft = leftCloned.BoundsFor(pair.Key);
+                var intvRight = rightCloned.BoundsFor(pair.Key);
+                var join = intvLeft.Join(intvRight);
+
+                if (join.IsNormal)
+                {
+                    var newConstraint = new STuple<Variable, Polynomial<Variable, Expression>, DisInterval>(pair.Key, pair.Value, join);
+                    result.Add(newConstraint);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Works with side effects in place
+        /// </summary>
+        private void HarmonizeSlackVariables(SubPolyhedra<Variable, Expression> from, SubPolyhedra<Variable, Expression> to)
+        {
+            var vars = new List<Variable>(from.betaDep.Keys);
+
+            var cached_to_Variables = to.Variables.ToSet();
+            foreach (var alpha in vars)
+            {
+                if (cached_to_Variables.Contains(alpha))
+                {
+                    // Most likely, the definitions are not the same so we need to rename
+                    var newName = this.ExpressionManager.Encoder.FreshVariable<int>();
+                    from.RenameVariable(alpha, newName);
+                    to.Left.AddConstraint(to.Left.AsVector(from.betaDep[newName]));
+                }
+                else
+                {
+                    to.Left.AddConstraint(to.Left.AsVector(from.betaDep[alpha]));
+                }
+            }
+        }
+
+        private SubPolyhedra<Variable, Expression> ReduceAndPutConstants(LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> lineq, IntervalEnvironment<Variable, Expression> intv)
+        {
+            var res = ReduceInternal(lineq, intv, false);
+            res.PutConstantsInKarr(); // the join in Karr is more precise when constants are present
+
+            return res;
+        }
+
+        /// <summary>
+        /// Works with in place updates
+        /// </summary>
+        static private void ReintroduceDroppedVariables(SubPolyhedra<Variable, Expression> left, SubPolyhedra<Variable, Expression> right, SubPolyhedra<Variable, Expression> originalLeft, SubPolyhedra<Variable, Expression> originalRight)
+        {
+            var vars = new List<Variable>(originalLeft.betaDep.Keys);
+            foreach (var alpha in vars)
+            {
+                if (left.Left.Variables.Contains(alpha))
+                {
+                    // ok, reduction kept it
+                }
+                else
+                {
+                    left.Left.AddConstraint(left.Left.AsVector(originalLeft.betaDep[alpha]));
+                }
+
+                if (right.Left.Variables.Contains(alpha))
+                {
+                    // ok, reduction kept it
+                }
+                else
+                {
+                    right.Left.AddConstraint(right.Left.AsVector(originalLeft.betaDep[alpha]));
+                }
+            }
+
+            vars = new List<Variable>(originalRight.betaDep.Keys);
+            foreach (var alpha in vars)
+            {
+                if (left.Left.Variables.Contains(alpha))
+                {
+                    // ok, reduction kept it
+                }
+                else
+                {
+                    left.Left.AddConstraint(left.Left.AsVector(originalRight.betaDep[alpha]));
+                }
+
+                if (right.Left.Variables.Contains(alpha))
+                {
+                    // ok, reduction kept it
+                }
+                else
+                {
+                    right.Left.AddConstraint(right.Left.AsVector(originalRight.betaDep[alpha]));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Works with in place updates
+        /// </summary>
+        static private void SetDependencies(SubPolyhedra<Variable, Expression> result, Dictionary<Variable, Polynomial<Variable, Expression>> betaDep)
+        {
+            foreach (var alpha_pair in betaDep)
+            {
+                if (result.Variables.Contains(alpha_pair.Key))
+                {
+                    result.betaDep[alpha_pair.Key] = alpha_pair.Value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Works with in place updates to result
+        /// </summary>
+        private void ReintroduceDroppedConstraints(
+          SubPolyhedra<Variable, Expression> result, SubPolyhedra<Variable, Expression> original, List<Polynomial<Variable, Expression>> dropped)
+        {
+            var betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+            var intvResult = new Dictionary<Variable, DisInterval>();
+            var cloned = original.DuplicateMe();
+
+            foreach (var pol in dropped)
+            {
+                if (pol.Variables.IsSingleton)
+                {// should be handled by intervals
+                    continue;
+                }
+
+                Polynomial<Variable, Expression> polBeta;
+                Variable beta, betaTwo;
+
+                int k = IsBetaDefinition(pol, out betaTwo, this.ExpressionManager.Decoder);
+
+                if (k == 0 && pol.Variables.Count > 1)
+                { // equality between program variables that doesn't hold in right : 
+                  // trying to get some bounds for the corresponding linear functional
+                    beta = this.ExpressionManager.Encoder.FreshVariable<int>();
+                    polBeta = pol.AddMonomialToTheLeft(new Monomial<Variable>(-1, beta));
+                    cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
+                    betaList[beta] = polBeta;
+                    intvResult[beta] = DisInterval.For(0);
+                }
+                else if (k == 1 && pol.Variables.Count > 2)
+                { // linear functional bounded on the left : 
+                  // as it may not correspond to the actual definition of the slack variable, we will try to bound it also on the right
+                    beta = this.ExpressionManager.Encoder.FreshVariable<int>();
+                    polBeta = pol.Rename(false, betaTwo, beta);
+                    cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
+                    betaList[beta] = polBeta;
+                    intvResult[beta] = original.BoundsFor(betaTwo);
+                }
+                else
+                {
+                    // in all the other cases, we don't try to get any information,
+                    // either because it should be kept by intervals or because it involves several slack variables
+                }
+            }
+
+            cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
+
+            foreach (var alpha_pair in betaList)
+            {
+                if (!cloned.Right.BoundsFor(alpha_pair.Key).IsTop)
+                {
+                    result.Left.AddConstraint(result.Left.AsVector(alpha_pair.Value));
+                    var disinterval = cloned.Right.BoundsFor(alpha_pair.Key).Join(intvResult[alpha_pair.Key]);
+                    result.Right[alpha_pair.Key] = disinterval.AsInterval;
+                    result.betaDep[alpha_pair.Key] = alpha_pair.Value;
+                }
+            }
+        }
+
+        private void HintsFromBetaDeps(Hints<Variable, Expression> result, Dictionary<Variable, Polynomial<Variable, Expression>> betaDeps)
+        {
+            foreach (var e_pair in betaDeps)
+            {
+                Variable beta;
+                if (IsBetaDefinition(e_pair.Value, out beta, this.ExpressionManager.Decoder) == 1)
+                {
+                    result.Add(e_pair.Value);
+                }
+            }
+        }
+
+
+        [Conditional("TRACE_JOIN")]
+        private static void PrintStatisticsForJoin(SubPolyhedra<Variable, Expression> sp)
+        {
+        }
+
+        public override bool LessEqual(IAbstractDomain a)
+        { // here we assume that we are called after a widening, so the slack variables in this are renamings of slack variables in a
+            if (this.IsBottom)
+                return true;
+
+            if (a.IsTop)
+                return true;
+
+            var other = a as SubPolyhedra<Variable, Expression>;
+
+#if false
+            // First, direct try -- it breaks regression test. Probably of some aliasing?
+            if (this.Left.LessEqual(other.Left) && this.Right.LessEqual(other.Right))
+            {
+                return true;
+            }
+#endif
+
+
+            Contract.Assert(other != null);
+
+            #region Quick Checks
+
+            var decoder = this.ExpressionManager.Decoder;
+            var intvRight = this.Right;
+            var intvLeft = other.Right;
+
+            foreach (var var in other.Right.Variables)
+            {
+                if (!decoder.IsSlackVariable(var) && !intvRight.BoundsFor(var).LessEqual(intvLeft.BoundsFor(var)))
+                {
+                    return false;
+                }
+            }
+
+            #endregion
+
+            #region Implementation using the fact that slack variables in the two states are related
+            var cloned = this.DuplicateMe();
+            foreach (var pair in betaDep)
+            {
+                var e = pair.Key;
+                var def = pair.Value;
+
+                Variable equivalent;
+                Rational coeff, k;
+                if (other.TryGetEquivalent(e, def, out equivalent, out coeff, out k))
+                {
+                    // Avoid trivial equalities
+                    if (e.Equals(equivalent))
+                    {
+                        continue;
+                    }
+
+                    if (coeff == 1 && k.IsZero)
+                    {
+                        if (cloned.Variables.Contains(equivalent))
+                        {
+                            // If the equivalent is in cloned, then they should have the same value
+                            // So we assume e == cloned
+                            cloned = cloned.TestTrueEqual(equivalent, e) as SubPolyhedra<Variable, Expression>;
+                            if (cloned.IsBottom)
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            cloned.RenameVariable(e, equivalent);
+                        }
+                    }
+                    else
+                    {
+                        var monos = new Monomial<Variable>[]
+                        {
+              new Monomial<Variable>(e),
+              new Monomial<Variable>(-coeff, equivalent),
+              new Monomial<Variable>(-k)
+                        };
+
+                        Polynomial<Variable, Expression> pol;
+                        Polynomial<Variable, Expression>.TryToPolynomialForm(monos, out pol);
+
+                        var karr = cloned.Left;
+                        var intervals = cloned.Right;
+
+                        karr.AddConstraint(karr.AsVector(pol));
+
+                        var diff = (intervals.BoundsFor(e) - DisInterval.For(k));
+                        intervals[equivalent] = diff.AsInterval / coeff;
+
+                        cloned.RemoveVariable(e);
+                    }
+                }
+            }
+
+            var lreduced = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
+            var rreduced = other.ReduceInternal(other.Left, other.Right, false);
+            #endregion
+
+            if (lreduced.Left.LessEqual(rreduced.Left) && lreduced.Right.LessEqual(rreduced.Right))
+            {
+                return WideningOnHints == other.WideningOnHints;
+            }
+
+            return false;
+        }
+
+        public override IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            var other = prev as SubPolyhedra<Variable, Expression>;
+            Contract.Assert(other != null);
+
+            this.CleanUpBetaVariables(true);
+
+            #region Transfer the definitions for the slack variables
+            // from other to this ; not the other way since we are widening
+            var vars = new List<Variable>(other.betaDep.Keys);
+            foreach (var alpha in vars)
+            {
+                if (this.Variables.Contains(alpha))
+                {
+                    Variable newName = this.ExpressionManager.Encoder.FreshVariable<int>();
+                    other.RenameVariable(alpha, newName);
+                    this.Left.AddConstraint(this.Left.AsVector(other.betaDep[newName]));
+                }
+                else
+                    this.Left.AddConstraint(this.Left.AsVector(other.betaDep[alpha]));
+            }
+            #endregion
+
+            var newState = this.Reduce(this.Left, this.Right) as SubPolyhedra<Variable, Expression>;
+
+            foreach (var alpha in newState.Variables.SetDifference(newState.Left.Variables))
+            { // some slack variables may have been removed from Karr to speed up reduction, we need to put them back
+                if (betaDep.ContainsKey(alpha))
+                {
+                    newState.Left.AddConstraint(newState.Left.AsVector(betaDep[alpha]));
+                }
+                else if (other.betaDep.ContainsKey(alpha))
+                {
+                    newState.Left.AddConstraint(newState.Left.AsVector(other.betaDep[alpha]));
+                }
+            }
+
+            var deletedLeft = new List<Polynomial<Variable, Expression>>();
+            var deletedRight = new List<Polynomial<Variable, Expression>>();
+
+            var cloned = newState.DuplicateMe(); // We need to clone because the Join in Karr modifies the state : UniformEnvironments removes variables, including useful slack variables
+
+            var joinedLeft = cloned.Left.Join(other.Left, ref deletedLeft, ref deletedRight) as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
+            var joinedRight = newState.Right.Widening(other.Right);
+
+            cloned = newState.DuplicateMe();
+
+            var betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+
+            Variable beta;
+            Variable existing;
+            int k;
+
+            foreach (var pol in deletedRight) // only try to put back the equalities dropped from the previous state
+            {
+                k = IsBetaDefinition(pol, out existing, this.ExpressionManager.Decoder);
+                if (k == 0 && pol.Variables.Count > 1)
+                { // Equality between program variables, adding a slack variable
+                    beta = this.ExpressionManager.Encoder.FreshVariable<int>();
+                    Polynomial<Variable, Expression> polBeta = pol.AddMonomialToTheLeft(new Monomial<Variable>(-1, beta));
+                    cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
+                    betaList[beta] = polBeta;
+                    other.Right[beta] = Interval.For(0);
+                }
+                else if (k == 1)
+                { // Definition of a slack variable, finding a bound for the existing slack variable, and renaming it to avoid any possible conflict
+                    beta = this.ExpressionManager.Encoder.FreshVariable<int>();
+                    if (cloned.Variables.Contains(existing))
+                    { // We must avoid conflicts when the definition is not the same
+                        Polynomial<Variable, Expression> polTwo = pol.Rename(existing, beta);
+                        cloned.Left.AddConstraint(cloned.Left.AsVector(polTwo));
+                        betaList[beta] = polTwo;
+                        other.Right[beta] = other.Right.BoundsFor(existing).AsInterval;
+                    }
+                    else
+                    {
+                        cloned.Left.AddConstraint(cloned.Left.AsVector(pol));
+                        betaList[existing] = pol;
+                    }
+                }
+            }
+
+            var nDeps = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+            if (betaList.Count > 0)
+            {
+                cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
+
+                foreach (var alpha in betaList)
+                {
+                    if (!cloned.Right.BoundsFor(alpha.Key).IsTop)
+                    {
+                        joinedLeft.AddConstraint(joinedLeft.AsVector(alpha.Value));
+
+                        var disInterval = cloned.Right.BoundsFor(alpha.Key).Widening(other.Right.BoundsFor(alpha.Key));
+                        joinedRight[alpha.Key] = disInterval.AsInterval;
+                        nDeps[alpha.Key] = alpha.Value;
+                    }
+                }
+            }
+            var result = Factory(joinedLeft, joinedRight) as SubPolyhedra<Variable, Expression>;
+            foreach (var e in other.betaDep)
+            {
+                if (result.Variables.Contains(e.Key))
+                {
+                    result.betaDep[e.Key] = e.Value;
+                }
+            }
+            foreach (var e in nDeps)
+            {
+                result.betaDep.Add(e.Key, e.Value);
+            }
+
+            #region Using hints
+            betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+            var intvResult = new Dictionary<Variable, Interval>();
+            cloned = newState.DuplicateMe();
+
+            var allHints = other.hints;
+
+            if (SubPolyhedra.Algorithm != SubPolyhedra.ReductionAlgorithm.Fast && other.numberOfWidenings <= 5) // to enforce termination
+            {
+                allHints.Add(hints);
+                foreach (var alpha in betaDep)
+                {
+                    allHints.Add(alpha.Value);
+                }
+            }
+            var resultVars = result.Variables;
+            foreach (var e in other.betaDep)
+            {
+                if (!resultVars.Contains(e.Key))
+                {
+                    allHints.Add(e.Value);
+                }
+            }
+
+            CleanHints(ref allHints, this.ExpressionManager);
+
+            foreach (var pol in allHints.Enumerate())
+            {
+                k = IsBetaDefinition(pol, out existing, this.ExpressionManager.Decoder);
+
+                if (k != 1 || pol.Variables.Count <= 2)
+                {
+                    continue;
+                }
+
+                beta = this.ExpressionManager.Encoder.FreshVariable<int>();
+
+                var polBeta = pol.Rename(false, existing, beta);
+                cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
+                betaList[beta] = polBeta;
+            }
+
+            cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
+            foreach (var alpha in betaList.Keys)
+            {
+                intvResult[alpha] = cloned.Right.BoundsFor(alpha).AsInterval;
+            }
+
+            cloned = other.DuplicateMe();
+
+            foreach (var alpha in betaList)
+            {
+                cloned.Left.AddConstraint(cloned.Left.AsVector(alpha.Value));
+            }
+
+            cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
+            foreach (var alpha in betaList.Keys)
+            {
+                intvResult[alpha] = intvResult[alpha].Widening(cloned.Right.BoundsFor(alpha).AsInterval);
+            }
+
+            foreach (var alpha in intvResult)
+            {
+                if (!alpha.Value.IsTop)
+                {
+                    result.Left.AddConstraint(result.Left.AsVector(betaList[alpha.Key]));
+                    result.Right[alpha.Key] = alpha.Value;
+                    result.betaDep[alpha.Key] = betaList[alpha.Key];
+                }
+                else
+                {
+                    if (other.hints.Contains(betaList[alpha.Key]))
+                        result.hints.Add(betaList[alpha.Key]);
+                }
+            }
+            #endregion
+
+            // Apply widening to the hints: if we have too many, project some to save time
+            result.WideningOnHints = CleanHints(ref result.hints, this.ExpressionManager, SubPolyhedra.MaxHintsToRetainInWidening);
+
+            result.Left.PutIntoRowEchelonForm();
+
+            result.CleanUpBetaVariables(true);
+            other.CleanUpBetaVariables(true);
+
+            List<Variable> removed;
+            CleanDeps(result.betaDep, this.ExpressionManager, out removed);
+
+            foreach (var e in removed)
+            {
+                result.RemoveVariableWithoutHints(e);
+            }
+
+            foreach (var pol in new Set<Polynomial<Variable, Expression>>(result.hints.Enumerate())) // create a new collection since we will modify the hints
+            {
+                if (!other.hints.Contains(pol))
+                {
+                    result.hints.Remove(pol);
+                }
+            }
+
+            result.numberOfWidenings = other.numberOfWidenings + 1;
+
+            if (result.hints.Count > SubPolyhedra.MaxHintsToRetainInWidening)
+            {
+                result.hints = new Hints<Variable, Expression>();
+                result.WideningOnHints = true;
+            }
+
+            return result;
+        }
+
+        public override bool IsBottom
+        {
+            get
+            {
+                return base.IsBottom;
+            }
+        }
+
+        public bool IsBottomWithReduction()
+        {
+            var dup = this.DuplicateMe();
+            var reduced = this.ReduceInternal(dup.Left, dup.Right, true);
+
+            return reduced.IsBottom;
+        }
+        #endregion
+
+        #region Checks
+        public override FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return checkIfHoldsVisitor.Visit(exp, this);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            return checkIfHoldsVisitor.Visit(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool,
+              ExpressionOperator.GreaterEqualThan, exp, this.ExpressionManager.Encoder.ConstantFor(0)), this);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            return checkIfHoldsVisitor.Visit(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, e1, e2), this);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessThan(e1, e2);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            return checkIfHoldsVisitor.Visit(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, e1, e2), this);
+        }
+
+        public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return this.CheckIfLessEqualThan(e1, e2);
+        }
+        #endregion
+
+        #region Operations on variables
+        public override void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            this.ExpressionManager.Log("Subpoly before renaming:\n{0}", this.ToString);
+
+            this.PrintStatistics("@ BEFORE - assign in parallel");
+
+#if TRACEJOIN
+            this.DebugCheckLessEq("sv27", "sv9", "before parallel assign");
+#endif
+
+            if (sourcesToTargets.IsIdentityMap())
+            {
+                return;
+            }
+
+            Left.AssignInParallel(sourcesToTargets, convert, ref betaDep, ref hints);
+            Right.AssignInParallel(sourcesToTargets, convert);
+
+#if TRACEJOIN
+            this.DebugCheckLessEq("sv18", "sv9", "after parallel assign");
+#endif
+            this.ExpressionManager.Log("Subpoly after renaming:\n{0}", this.ToString);
+
+            this.PrintStatistics("@ AFTER - assign in parallel");
+        }
+
+#if DEBUG
+        private SubPolyhedra<Variable, Expression> cloned;
+
+        private void MyScript(Dictionary<Variable, FList<Variable>> s, Converter<Variable, Expression> c)
+        {
+            cloned = this.DuplicateMe();
+            var reduced = this.ReduceInternal(cloned.Left, cloned.Right, true);
+            reduced.DebugCheckLessEq("sv27", "sv9", "before parallel assign");
+            reduced.AssignInParallel(s, c);
+            reduced.DebugCheckLessEq("sv18", "sv9", "after parallel assign");
+        }
+#endif
+
+        public override void ProjectVariable(Variable var)
+        {
+            base.ProjectVariable(var);
+            if (betaDep.ContainsKey(var))
+            {
+                hints.Add(betaDep[var]);
+                betaDep.Remove(var);
+            }
+        }
+
+        public override void RemoveVariable(Variable var)
+        {
+            base.RemoveVariable(var);
+            if (betaDep.ContainsKey(var))
+            {
+                hints.Add(betaDep[var]);
+                betaDep.Remove(var);
+            }
+        }
+
+        private void RemoveVariableWithoutHints(Variable var)
+        {
+            base.RemoveVariable(var);
+            if (betaDep.ContainsKey(var))
+                betaDep.Remove(var);
+        }
+
+        public override void RenameVariable(Variable OldName, Variable NewName)
+        {
+            if (NewName.Equals(OldName)) return;
+            base.RenameVariable(OldName, NewName);
+            if (betaDep.ContainsKey(NewName))
+                betaDep.Remove(NewName);
+            var vars = new List<Variable>(betaDep.Keys);
+            foreach (var beta in vars)
+            {
+                if (beta.Equals(OldName))
+                {
+                    betaDep[NewName] = betaDep[beta].Rename(OldName, NewName);
+                    betaDep.Remove(OldName);
+                }
+                else
+                {
+                    betaDep[beta] = betaDep[beta].Rename(OldName, NewName);
+                }
+            }
+        }
+        #endregion
+
+        #region Implementation of Reduce and Factory
+
+        private SubPolyhedra<Variable, Expression> ReduceInternal(
+          LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> left, IntervalEnvironment<Variable, Expression> right,
+          bool forceSimplex)
+        {
+            var reductionAlg = forceSimplex ? SubPolyhedra.ReductionAlgorithm.Simplex : SubPolyhedra.Algorithm;
+
+            var result = Factory(left, right) as SubPolyhedra<Variable, Expression>;
+            if (!result.IsNormal())
+            {
+                return result;
+            }
+
+            left.PutIntoRowEchelonForm();
+
+            var redundancies = left.GetRedundancies();
+
+            foreach (var redundancy in redundancies)
+            {
+                var e = redundancy.V1;
+                var coeff = redundancy.Coeff2;
+                var target = redundancy.V2;
+                var cst = redundancy.Offset;
+
+                if (coeff.IsNotZero)
+                {
+                    right[target] = right.BoundsFor(target).AsInterval.Meet((cst - right.BoundsFor(e).AsInterval) / coeff);
+                }
+                else
+                {
+                    if (!cst.IsPlusInfinity && Interval.For(cst).Meet(right.BoundsFor(e).AsInterval).IsBottom)
+                    {
+                        return this.Bottom as SubPolyhedra<Variable, Expression>;
+                    }
+                }
+
+                left.RemoveVariable(e);
+                right.RemoveVariable(e);
+            }
+
+            #region Phase 1 : Constant Propagation from Intervals to Karr
+
+            foreach (var pair in right.Elements)
+            {
+                var var = pair.Key;
+                var value = pair.Value;
+
+                if (value.IsSingleton && left.Variables.Contains(var))
+                {
+                    result.Left.AddConstraintEqual(var, value.LowerBound);
+                }
+            }
+
+            result.Left.PutIntoRowEchelonForm();
+
+            if (result.IsBottom)
+            {
+                return result.Bottom as SubPolyhedra<Variable, Expression>;
+            }
+            #endregion
+
+            #region Phase 2 : Bounds Inference in Karr
+            result = Factory(result.Left, result.Left.BoundsInference(result.Right, reductionAlg, SubPolyhedra.MaxVariablesToRunSimplex)) as SubPolyhedra<Variable, Expression>;
+            #endregion
+
+
+            var intvEnv = result.Right;
+
+            foreach (var alpha_pair in redundancies)
+            {
+                var coeff = alpha_pair.Coeff2;
+                var cst = alpha_pair.Offset;
+
+                if (coeff.IsZero)
+                {
+                    if (!cst.IsInfinity)
+                    {
+                        var disInterval = DisInterval.For(cst).Meet(intvEnv.BoundsFor(alpha_pair.V1));
+                        intvEnv[alpha_pair.V1] = disInterval.AsInterval;
+                    }
+                }
+                else
+                {
+                    intvEnv[alpha_pair.V1] = cst - intvEnv.BoundsFor(alpha_pair.V2).AsInterval * coeff;
+                }
+            }
+
+            return Factory(result.Left, intvEnv) as SubPolyhedra<Variable, Expression>;
+        }
+
+        private SubPolyhedra<Variable, Expression> ReduceComplete()
+        {
+            if (SubPolyhedra.Algorithm == SubPolyhedra.ReductionAlgorithm.Fast)
+            {
+                SubPolyhedra.Algorithm = SubPolyhedra.ReductionAlgorithm.Complete;
+                var result = this.ReduceInternal(this.Left, this.Right, false);
+                SubPolyhedra.Algorithm = SubPolyhedra.ReductionAlgorithm.Fast;
+
+                return result;
             }
             else
             {
-              cloned.RenameVariable(e, equivalent);
+                return this.ReduceInternal(this.Left, this.Right, false);
             }
-          }
-          else
-          {
-            var monos = new Monomial<Variable> []
+        }
+
+        protected override ReducedCartesianAbstractDomain<LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>, IntervalEnvironment<Variable, Expression>> Factory(LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> left, IntervalEnvironment<Variable, Expression> right)
+        {
+            return new SubPolyhedra<Variable, Expression>(left, right, this.ExpressionManager);
+        }
+
+        public override ReducedCartesianAbstractDomain<LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>, IntervalEnvironment<Variable, Expression>>
+      Reduce(LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> left, IntervalEnvironment<Variable, Expression> right)
+        {
+            return this.ReduceInternal(left, right, false);
+        }
+        #endregion
+
+        #region Helper methods
+        /// <summary>
+        /// Propagate the renaming to the dependencies map and return the variables that should be deleted
+        /// </summary>
+        /// <param name="oldExp">The expression to replace</param>
+        /// <param name="newExp">The new expression</param>
+        /// <returns>A set of variables who depend on previous values of <paramref name="newExp"/></returns>
+        internal static Set<Variable> UpdateBetaDeps(Variable oldExp, Variable newExp, ref Dictionary<Variable, Polynomial<Variable, Expression>> betaDep)
+        {
+            var result = new Set<Variable>();
+            var updated = new Dictionary<Variable, Polynomial<Variable, Expression>>(betaDep.Count);
+
+            foreach (var e in betaDep.Keys)
             {
-              new Monomial<Variable>(e),
-              new Monomial<Variable>(-coeff, equivalent),
-              new Monomial<Variable>(-k) 
-            };
-            
-            Polynomial<Variable, Expression> pol;
-            Polynomial<Variable, Expression>.TryToPolynomialForm(monos, out pol);
+                var deps = betaDep[e];
+                if (deps.Variables.Contains(newExp))
+                {
+                    result.Add(e);
+                    updated[e] = betaDep[e]; // we rely on the caller to remove it
+                }
+                else
+                {
+                    updated[e] = deps.Rename(oldExp, newExp);
+                }
+            }
+            betaDep = updated;
 
-            var karr = cloned.Left;
-            var intervals = cloned.Right;
-
-            karr.AddConstraint(karr.AsVector(pol));
-
-            var diff = (intervals.BoundsFor(e) - DisInterval.For(k));
-            intervals[equivalent] =  diff.AsInterval / coeff;
-            
-            cloned.RemoveVariable(e);
-          }
+            return result;
         }
-      }
 
-      var lreduced = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
-      var rreduced = other.ReduceInternal(other.Left, other.Right, false);
-      #endregion
-
-      if (lreduced.Left.LessEqual(rreduced.Left) && lreduced.Right.LessEqual(rreduced.Right))
-      {
-        return this.WideningOnHints == other.WideningOnHints;
-      }
-
-      return false;
-    }
-
-    public override IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      var other = prev as SubPolyhedra<Variable, Expression>;
-      Contract.Assert(other != null);
-
-      this.CleanUpBetaVariables(true);
-
-      #region Transfer the definitions for the slack variables
-      // from other to this ; not the other way since we are widening
-      var vars = new List<Variable>(other.betaDep.Keys);
-      foreach (var alpha in vars)
-      {
-        if (this.Variables.Contains(alpha))
+        internal static void UpdateHints(Variable oldExp, Variable newExp, ref Hints<Variable, Expression> hints)
         {
-          Variable newName = this.ExpressionManager.Encoder.FreshVariable<int>();
-          other.RenameVariable(alpha, newName);
-          this.Left.AddConstraint(this.Left.AsVector(other.betaDep[newName]));
+            var result = new Hints<Variable, Expression>();
+            foreach (var pol in hints.Enumerate())
+            {
+                if (!pol.Variables.Contains(newExp))
+                {
+                    result.Add(pol.Rename(false, oldExp, newExp));
+                }
+            }
+            hints = result;
         }
-        else
-          this.Left.AddConstraint(this.Left.AsVector(other.betaDep[alpha]));
-      }
-      #endregion
 
-      var newState = this.Reduce(this.Left, this.Right) as SubPolyhedra<Variable, Expression>;
-
-      foreach (var alpha in newState.Variables.SetDifference(newState.Left.Variables))
-      { // some slack variables may have been removed from Karr to speed up reduction, we need to put them back
-        if (this.betaDep.ContainsKey(alpha))
+        /// <summary>
+        /// Remove useless slack variables (either redundant ones or those that are only present in one side of the product)
+        /// </summary>
+        private bool CleanUpBetaVariables(bool IsWidening = false)
         {
-          newState.Left.AddConstraint(newState.Left.AsVector(this.betaDep[alpha]));
+            if (Left.IsBottom)
+            {
+                return true;
+            }
+
+            this.ExpressionManager.Log("SubPoly before cleaning up: {0}", this.ToString);
+
+            var result = false;
+            var zero = Rational.For(0);
+            var decoder = this.ExpressionManager.Decoder;
+            var toRemove = (this.Left as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>).GetRedundancies();
+
+            // Propagate the value for the variable to be removed to its equivalent
+            foreach (var redundancy in toRemove)
+            {
+                var k = redundancy.Coeff2;
+
+                if (k.IsZero)
+                {// e is a constant and doesn't have a target
+                    continue;
+                }
+
+                var target = redundancy.V2;
+                var c = redundancy.Offset;
+
+                // e + k * target == c or
+                // target = (c - e) / k
+                var forE = Right.BoundsFor(redundancy.V1).AsInterval;
+                var forTarget = (c - forE) / k;
+                Right[target] = forTarget.Meet(Right.BoundsFor(target).AsInterval);
+            }
+
+            var leftVars = this.Left.Variables;
+
+            foreach (var e in this.Variables)
+            {
+                if (decoder.IsSlackVariable(e))
+                {
+                    var boundsForE = Right.BoundsFor(e);
+                    if (!leftVars.Contains(e) || boundsForE.IsTop)
+                    {
+                        toRemove.Add(new LinearEqualityRedundancy<Variable>(e, zero, default(Variable), zero));
+                    }
+                    else if (boundsForE.IsSingleton)
+                    {
+                        toRemove.Add(new LinearEqualityRedundancy<Variable>(e, zero, default(Variable), zero));
+
+                        Left.AddConstraintEqual(e, boundsForE.LowerBound);
+                    }
+                }
+            }
+
+            foreach (var redundancy in toRemove)
+            {
+                this.ExpressionManager.Log("Removing redundant variable: {0}", redundancy.V1.ToString);
+
+                result = true;
+                this.RemoveVariable(redundancy.V1);
+            }
+
+            if (!IsWidening)
+            {
+                this.ExpressionManager.Log("Hints before injecting beta-deps: {0}", hints.Count.ToString);
+
+                // F: Here we add all the betaDeps to the hints! It seems that if we do not do it, then sometimes the precision depends on the variable ordering!!!
+                foreach (var pair in betaDep)
+                {
+                    hints.Add(pair.Value);
+                }
+
+                this.ExpressionManager.Log("Hints after: {0}", hints.Count.ToString);
+            }
+
+            this.ExpressionManager.Log("SubPoly after cleaning up: {0}", this.ToString);
+
+            return result;
         }
-        else if (other.betaDep.ContainsKey(alpha))
-        {
-          newState.Left.AddConstraint(newState.Left.AsVector(other.betaDep[alpha]));
-        }
-      }
-
-      var deletedLeft = new List<Polynomial<Variable, Expression>>();
-      var deletedRight = new List<Polynomial<Variable, Expression>>();
-
-      var cloned = newState.DuplicateMe(); // We need to clone because the Join in Karr modifies the state : UniformEnvironments removes variables, including useful slack variables
-
-      var joinedLeft = cloned.Left.Join(other.Left, ref deletedLeft, ref deletedRight) as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>;
-      var joinedRight = newState.Right.Widening(other.Right);
-
-      cloned = newState.DuplicateMe();
-
-      var betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-
-      Variable beta;
-      Variable existing;
-      int k;
-      
-      foreach (var pol in deletedRight) // only try to put back the equalities dropped from the previous state
-      {
-        k = IsBetaDefinition(pol, out existing, this.ExpressionManager.Decoder);
-        if (k == 0 && pol.Variables.Count > 1)
-        { // Equality between program variables, adding a slack variable
-          beta = this.ExpressionManager.Encoder.FreshVariable<int>();
-          Polynomial<Variable, Expression> polBeta = pol.AddMonomialToTheLeft(new Monomial<Variable>(-1, beta));
-          cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
-          betaList[beta] = polBeta;
-          other.Right[beta] = Interval.For(0);
-        }
-        else if (k == 1)
-        { // Definition of a slack variable, finding a bound for the existing slack variable, and renaming it to avoid any possible conflict
-          beta = this.ExpressionManager.Encoder.FreshVariable<int>();
-          if (cloned.Variables.Contains(existing))
-          { // We must avoid conflicts when the definition is not the same
-            Polynomial<Variable, Expression> polTwo = pol.Rename(existing, beta);
-            cloned.Left.AddConstraint(cloned.Left.AsVector(polTwo));
-            betaList[beta] = polTwo;
-            other.Right[beta] = other.Right.BoundsFor(existing).AsInterval;
-          }
-          else
-          {
-            cloned.Left.AddConstraint(cloned.Left.AsVector(pol));
-            betaList[existing] = pol;
-          }
-        }
-      }
-
-      var nDeps = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-      if (betaList.Count > 0)
-      {
-        cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
-
-        foreach (var alpha in betaList)
-        {
-          if (!cloned.Right.BoundsFor(alpha.Key).IsTop)
-          {
-            joinedLeft.AddConstraint(joinedLeft.AsVector(alpha.Value));
- 
-            var disInterval = cloned.Right.BoundsFor(alpha.Key).Widening(other.Right.BoundsFor(alpha.Key));
-            joinedRight[alpha.Key] = disInterval.AsInterval;
-            nDeps[alpha.Key] = alpha.Value;
-          }
-        }
-      }
-      var result = Factory(joinedLeft, joinedRight) as SubPolyhedra<Variable, Expression>;
-      foreach (var e in other.betaDep)
-      {
-        if (result.Variables.Contains(e.Key))
-        {
-          result.betaDep[e.Key] = e.Value;
-        }
-      }
-      foreach (var e in nDeps)
-      {
-        result.betaDep.Add(e.Key, e.Value);
-      }
-
-      #region Using hints
-      betaList = new Dictionary<Variable, Polynomial<Variable, Expression>>();
-      var intvResult = new Dictionary<Variable, Interval>();
-      cloned = newState.DuplicateMe();
-      
-      var allHints = other.hints;
-
-      if (SubPolyhedra.Algorithm != SubPolyhedra.ReductionAlgorithm.Fast && other.numberOfWidenings <= 5) // to enforce termination
-      {
-        allHints.Add(this.hints);
-        foreach (var alpha in this.betaDep)
-        {
-          allHints.Add(alpha.Value);
-        }
-      }
-      var resultVars = result.Variables;
-      foreach (var e in other.betaDep)
-      {
-        if (!resultVars.Contains(e.Key))
-        {
-          allHints.Add(e.Value);
-        }
-      }
-
-      CleanHints(ref allHints, this.ExpressionManager);
-
-      foreach (var pol in allHints.Enumerate())
-      {
-        k = IsBetaDefinition(pol, out existing, this.ExpressionManager.Decoder);
-
-        if (k != 1 || pol.Variables.Count <= 2)
-        {
-          continue;
-        }
-
-        beta = this.ExpressionManager.Encoder.FreshVariable<int>();
-        
-        var polBeta = pol.Rename(false, existing, beta);
-        cloned.Left.AddConstraint(cloned.Left.AsVector(polBeta));
-        betaList[beta] = polBeta;
-      }
-
-      cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
-      foreach (var alpha in betaList.Keys)
-      {
-        intvResult[alpha] = cloned.Right.BoundsFor(alpha).AsInterval;
-      }
-
-      cloned = other.DuplicateMe();
-
-      foreach (var alpha in betaList)
-      {
-        cloned.Left.AddConstraint(cloned.Left.AsVector(alpha.Value));
-      }
-
-      cloned = cloned.ReduceInternal(cloned.Left, cloned.Right, false);
-      foreach (var alpha in betaList.Keys)
-      {
-        intvResult[alpha] = intvResult[alpha].Widening(cloned.Right.BoundsFor(alpha).AsInterval);
-      }
-
-      foreach (var alpha in intvResult)
-      {
-        if (!alpha.Value.IsTop)
-        {
-          result.Left.AddConstraint(result.Left.AsVector(betaList[alpha.Key]));
-          result.Right[alpha.Key] = alpha.Value;
-          result.betaDep[alpha.Key] = betaList[alpha.Key];
-        }
-        else
-        {
-          if (other.hints.Contains(betaList[alpha.Key]))
-            result.hints.Add(betaList[alpha.Key]);
-        }
-      }
-      #endregion
-
-      // Apply widening to the hints: if we have too many, project some to save time
-      result.WideningOnHints = CleanHints(ref result.hints, this.ExpressionManager, SubPolyhedra.MaxHintsToRetainInWidening);
-
-      result.Left.PutIntoRowEchelonForm();
-
-      result.CleanUpBetaVariables(true);
-      other.CleanUpBetaVariables(true);
-
-      List<Variable> removed;
-      CleanDeps(result.betaDep, this.ExpressionManager, out removed);
-
-      foreach (var e in removed)
-      {
-        result.RemoveVariableWithoutHints(e);
-      }
-
-      foreach (var pol in new Set<Polynomial<Variable, Expression>>(result.hints.Enumerate())) // create a new collection since we will modify the hints
-      {
-        if (!other.hints.Contains(pol))
-        {
-          result.hints.Remove(pol);
-        }
-      }
-
-      result.numberOfWidenings = other.numberOfWidenings + 1;
-
-      if (result.hints.Count > SubPolyhedra.MaxHintsToRetainInWidening)
-      {
-        result.hints = new Hints<Variable, Expression>();
-        result.WideningOnHints = true;
-      }
-
-      return result;
-    }
-
-    public override bool IsBottom
-    {
-      get
-      {
-        return base.IsBottom;
-      }
-    }
-
-    public bool IsBottomWithReduction()
-    {
-      var dup = this.DuplicateMe();
-      var reduced = this.ReduceInternal(dup.Left, dup.Right, true);
-
-      return reduced.IsBottom;
-    }
-    #endregion
-
-    #region Checks
-    public override FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      return this.checkIfHoldsVisitor.Visit(exp, this);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      return this.checkIfHoldsVisitor.Visit(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool,
-        ExpressionOperator.GreaterEqualThan, exp, this.ExpressionManager.Encoder.ConstantFor(0)), this);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      return this.checkIfHoldsVisitor.Visit(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessThan, e1, e2), this);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessThan(e1, e2);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      return this.checkIfHoldsVisitor.Visit(this.ExpressionManager.Encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan, e1, e2), this);
-    }
-
-    public override FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return this.CheckIfLessEqualThan(e1, e2);
-    }
-    #endregion
-
-    #region Operations on variables
-    public override void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      this.ExpressionManager.Log("Subpoly before renaming:\n{0}", this.ToString);
-
-      this.PrintStatistics("@ BEFORE - assign in parallel");
-
-#if TRACEJOIN
-      this.DebugCheckLessEq("sv27", "sv9", "before parallel assign");
-#endif
-
-      if (sourcesToTargets.IsIdentityMap())
-      {
-        return;
-      }
-
-      Left.AssignInParallel(sourcesToTargets, convert, ref betaDep, ref hints);
-      Right.AssignInParallel(sourcesToTargets, convert);
-
-#if TRACEJOIN
-      this.DebugCheckLessEq("sv18", "sv9", "after parallel assign");
-#endif
-      this.ExpressionManager.Log("Subpoly after renaming:\n{0}", this.ToString);
-
-      this.PrintStatistics("@ AFTER - assign in parallel");
-    }
-
-#if DEBUG 
-    SubPolyhedra<Variable, Expression> cloned;
-    
-    private void MyScript(Dictionary<Variable, FList<Variable>> s, Converter<Variable, Expression> c)
-    {
-      this.cloned = this.DuplicateMe();
-      var reduced = this.ReduceInternal(cloned.Left, cloned.Right, true);
-      reduced.DebugCheckLessEq("sv27", "sv9", "before parallel assign");
-      reduced.AssignInParallel(s, c);
-      reduced.DebugCheckLessEq("sv18", "sv9", "after parallel assign");
-    }
-#endif
-
-    public override void ProjectVariable(Variable var)
-    {
-      base.ProjectVariable(var);
-      if (betaDep.ContainsKey(var))
-      {
-        hints.Add(betaDep[var]);
-        betaDep.Remove(var);
-      }
-    }
-
-    public override void RemoveVariable(Variable var)
-    {
-      base.RemoveVariable(var);
-      if (betaDep.ContainsKey(var))
-      {
-        hints.Add(betaDep[var]);
-        betaDep.Remove(var);
-      }
-    }
-
-    private void RemoveVariableWithoutHints(Variable var)
-    {
-      base.RemoveVariable(var);
-      if (betaDep.ContainsKey(var))
-        betaDep.Remove(var);
-    }
-
-    public override void RenameVariable(Variable OldName, Variable NewName)
-    {
-      if (NewName.Equals(OldName)) return;
-      base.RenameVariable(OldName, NewName);
-      if (betaDep.ContainsKey(NewName))
-        betaDep.Remove(NewName);
-      var vars = new List<Variable>(betaDep.Keys);
-      foreach (var beta in vars)
-      {
-        if (beta.Equals(OldName))
-        {
-          betaDep[NewName] = betaDep[beta].Rename(OldName, NewName);
-          betaDep.Remove(OldName);
-        }
-        else
-        {
-          betaDep[beta] = betaDep[beta].Rename(OldName, NewName);
-        }
-      }
-    }
-    #endregion
-
-    #region Implementation of Reduce and Factory
-
-    private SubPolyhedra<Variable, Expression> ReduceInternal(
-      LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> left, IntervalEnvironment<Variable, Expression> right, 
-      bool forceSimplex)
-    {
-      var reductionAlg = forceSimplex ? SubPolyhedra.ReductionAlgorithm.Simplex : SubPolyhedra.Algorithm;
-
-      var result = Factory(left, right) as SubPolyhedra<Variable, Expression>;
-      if (!result.IsNormal())
-      {
-        return result;
-      }
-
-      left.PutIntoRowEchelonForm();
-
-      var redundancies = left.GetRedundancies();
-
-      foreach (var redundancy in redundancies)
-      {
-        var e = redundancy.V1;
-        var coeff = redundancy.Coeff2;
-        var target = redundancy.V2;
-        var cst = redundancy.Offset;
-
-        if (coeff.IsNotZero)
-        {
-          right[target] = right.BoundsFor(target).AsInterval.Meet((cst - right.BoundsFor(e).AsInterval) / coeff);
-        }
-        else
-        {
-          if (!cst.IsPlusInfinity && Interval.For(cst).Meet(right.BoundsFor(e).AsInterval).IsBottom)
-          {
-            return this.Bottom as SubPolyhedra<Variable, Expression>;
-          }
-        }
-
-        left.RemoveVariable(e);
-        right.RemoveVariable(e);
-      }
-
-      #region Phase 1 : Constant Propagation from Intervals to Karr
-
-      foreach (var pair in right.Elements)
-      {
-        var var = pair.Key;
-        var value = pair.Value;
-
-        if (value.IsSingleton && left.Variables.Contains(var))
-        {
-          result.Left.AddConstraintEqual(var, value.LowerBound);
-        }
-      }
-
-      result.Left.PutIntoRowEchelonForm();
-
-      if (result.IsBottom)
-      {
-        return result.Bottom as SubPolyhedra<Variable, Expression>;
-      }
-      #endregion
-
-      #region Phase 2 : Bounds Inference in Karr
-      result = Factory(result.Left, result.Left.BoundsInference(result.Right, reductionAlg, SubPolyhedra.MaxVariablesToRunSimplex)) as SubPolyhedra<Variable, Expression>;
-      #endregion
-
-
-      var intvEnv = result.Right;
-
-      foreach (var alpha_pair in redundancies)
-      {
-        var coeff = alpha_pair.Coeff2;
-        var cst = alpha_pair.Offset;
-
-        if (coeff.IsZero)
-        {
-          if (!cst.IsInfinity)
-          {
-            var disInterval = DisInterval.For(cst).Meet(intvEnv.BoundsFor(alpha_pair.V1));
-            intvEnv[alpha_pair.V1] = disInterval.AsInterval;
-          }
-        }
-        else
-        {
-          intvEnv[alpha_pair.V1] = cst - intvEnv.BoundsFor(alpha_pair.V2).AsInterval * coeff;
-        }
-      }
-
-      return Factory(result.Left, intvEnv) as SubPolyhedra<Variable, Expression>;
-    }
-    
-    private SubPolyhedra<Variable, Expression> ReduceComplete()
-    {
-      if (SubPolyhedra.Algorithm == SubPolyhedra.ReductionAlgorithm.Fast)
-      {
-        SubPolyhedra.Algorithm = SubPolyhedra.ReductionAlgorithm.Complete;
-        var result = this.ReduceInternal(this.Left, this.Right, false);
-        SubPolyhedra.Algorithm = SubPolyhedra.ReductionAlgorithm.Fast;
-
-        return result;
-      }
-      else
-      {
-        return this.ReduceInternal(this.Left, this.Right, false);
-      }
-    }
-
-    protected override ReducedCartesianAbstractDomain<LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>, IntervalEnvironment<Variable, Expression>> Factory(LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> left, IntervalEnvironment<Variable, Expression> right)
-    {
-      return new SubPolyhedra<Variable, Expression>(left, right, this.ExpressionManager);
-    }
-
-    public override ReducedCartesianAbstractDomain<LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>, IntervalEnvironment<Variable, Expression>>
-  Reduce(LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression> left, IntervalEnvironment<Variable, Expression> right)
-    {
-      return this.ReduceInternal(left, right, false);
-    }
-    #endregion
-
-    #region Helper methods
-    /// <summary>
-    /// Propagate the renaming to the dependencies map and return the variables that should be deleted
-    /// </summary>
-    /// <param name="oldExp">The expression to replace</param>
-    /// <param name="newExp">The new expression</param>
-    /// <returns>A set of variables who depend on previous values of <paramref name="newExp"/></returns>
-    internal static Set<Variable> UpdateBetaDeps(Variable oldExp, Variable newExp, ref Dictionary<Variable, Polynomial<Variable, Expression>> betaDep)
-    {
-      var result = new Set<Variable>();
-      var updated = new Dictionary<Variable, Polynomial<Variable, Expression>>(betaDep.Count);
-      
-      foreach (var e in betaDep.Keys)
-      {
-        var deps = betaDep[e];
-        if (deps.Variables.Contains(newExp))
-        {
-          result.Add(e);
-          updated[e] = betaDep[e]; // we rely on the caller to remove it
-        }
-        else
-        {
-          updated[e] = deps.Rename(oldExp, newExp);
-        }
-      }
-      betaDep = updated;
-
-      return result;
-    }
-
-    internal static void UpdateHints(Variable oldExp, Variable newExp, ref Hints<Variable, Expression> hints)
-    {
-      var result = new Hints<Variable, Expression>();
-      foreach (var pol in hints.Enumerate())
-      {
-        if (!pol.Variables.Contains(newExp))
-        {
-          result.Add(pol.Rename(false, oldExp, newExp));
-        }
-      }
-      hints = result;
-    }
-
-    /// <summary>
-    /// Remove useless slack variables (either redundant ones or those that are only present in one side of the product)
-    /// </summary>
-    private bool CleanUpBetaVariables(bool IsWidening = false)
-    {
-      if (Left.IsBottom)
-      {
-        return true;
-      }
-
-      this.ExpressionManager.Log("SubPoly before cleaning up: {0}", this.ToString);
-
-      var result = false;
-      var zero = Rational.For(0);
-      var decoder = this.ExpressionManager.Decoder;
-      var toRemove = (this.Left as LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>).GetRedundancies();
-
-      // Propagate the value for the variable to be removed to its equivalent
-      foreach (var redundancy in toRemove)
-      {
-        var k = redundancy.Coeff2;
-
-        if (k.IsZero)
-        {// e is a constant and doesn't have a target
-          continue;
-        }
-
-        var target = redundancy.V2;
-        var c = redundancy.Offset;
-
-        // e + k * target == c or
-        // target = (c - e) / k
-        var forE = Right.BoundsFor(redundancy.V1).AsInterval;
-        var forTarget = (c - forE) / k;
-        Right[target] = forTarget.Meet(Right.BoundsFor(target).AsInterval);
-      }
-
-      var leftVars = this.Left.Variables;
-
-      foreach (var e in this.Variables)
-      {
-        if (decoder.IsSlackVariable(e))
-        {
-          var boundsForE = Right.BoundsFor(e);
-          if (!leftVars.Contains(e) || boundsForE.IsTop)
-          {
-            toRemove.Add(new LinearEqualityRedundancy<Variable>(e, zero, default(Variable), zero));
-          }
-          else if (boundsForE.IsSingleton)
-          {
-            toRemove.Add(new LinearEqualityRedundancy<Variable>(e, zero, default(Variable), zero));
-
-            Left.AddConstraintEqual(e, boundsForE.LowerBound);
-          }
-        }
-      }
-
-      foreach (var redundancy in toRemove)
-      {
-        this.ExpressionManager.Log("Removing redundant variable: {0}", redundancy.V1.ToString);
-
-        result = true;
-        this.RemoveVariable(redundancy.V1);
-      }
-
-      if (!IsWidening)
-      {
-        this.ExpressionManager.Log("Hints before injecting beta-deps: {0}", this.hints.Count.ToString);
-
-        // F: Here we add all the betaDeps to the hints! It seems that if we do not do it, then sometimes the precision depends on the variable ordering!!!
-        foreach (var pair in this.betaDep)
-        {
-          this.hints.Add(pair.Value);
-        }
-
-        this.ExpressionManager.Log("Hints after: {0}", this.hints.Count.ToString);
-      }
-
-      this.ExpressionManager.Log("SubPoly after cleaning up: {0}", this.ToString);
-
-      return result;
-    }
 
 #if false
-      static int count = 0;
+        static int count = 0;
 #endif
 
-    /// <summary>
-    /// Method used to remove redundant definitions from a dictionary mapping slack variables to their definitions
-    /// </summary>
-    /// <param name="deps">The dictionary mapping slack variables to their definition in terms of program variables</param>
-    private static void CleanDeps(ref Dictionary<Variable, Polynomial<Variable, Expression>> deps, 
-      ExpressionManagerWithEncoder<Variable, Expression> expManager)
-    {
-      Contract.Requires(expManager != null);
-
-#if TRACECLEANDEPS      
-      Console.WriteLine("== CleanDeps #{0}, Constraints #{1}", count, deps.Count);
-
-      var originalCount = deps.Count;
-            
-      foreach (var pair in deps)
-      {
-        Console.WriteLine("{0} -> {1}", pair.Key, pair.Value);
-      }
-      var prev = new Dictionary<Variable, Polynomial<Variable, Expression>>(deps);      
-#endif
-
-      deps = CleanDepsSyntactical(deps);
+        /// <summary>
+        /// Method used to remove redundant definitions from a dictionary mapping slack variables to their definitions
+        /// </summary>
+        /// <param name="deps">The dictionary mapping slack variables to their definition in terms of program variables</param>
+        private static void CleanDeps(ref Dictionary<Variable, Polynomial<Variable, Expression>> deps,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager)
+        {
+            Contract.Requires(expManager != null);
 
 #if TRACECLEANDEPS
-       Console.WriteLine("==== After syntactic cleaning #{0} (were #{1})", deps.Count, originalCount);
+            Console.WriteLine("== CleanDeps #{0}, Constraints #{1}", count, deps.Count);
 
-       foreach (var pair in deps)
-       {
-         Console.WriteLine("{0} -> {1}", pair.Key, pair.Value);
-       }
+            var originalCount = deps.Count;
+
+            foreach (var pair in deps)
+            {
+                Console.WriteLine("{0} -> {1}", pair.Key, pair.Value);
+            }
+            var prev = new Dictionary<Variable, Polynomial<Variable, Expression>>(deps);
 #endif
 
-      if (deps.Count == 0)
-      {
+            deps = CleanDepsSyntactical(deps);
+
 #if TRACECLEANDEPS
-      Console.WriteLine("No deps -- nothing to do");
+            Console.WriteLine("==== After syntactic cleaning #{0} (were #{1})", deps.Count, originalCount);
+
+            foreach (var pair in deps)
+            {
+                Console.WriteLine("{0} -> {1}", pair.Key, pair.Value);
+            }
 #endif
 
-        return;
-      }
-
-      var temp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(expManager);
-
-      foreach (var pair in deps)
-      {
-        temp.AddConstraint(pair.Value);
-      }     
-
-      // Hot path!
-      temp.PutIntoRowEchelonForm();
- 
+            if (deps.Count == 0)
+            {
 #if TRACECLEANDEPS
-    Console.WriteLine("===== Removed Constraints");
+                Console.WriteLine("No deps -- nothing to do");
 #endif
 
-      var toRemove = temp.GetRedundancies();
-      foreach (var redundancy in toRemove)
-      {
+                return;
+            }
+
+            var temp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(expManager);
+
+            foreach (var pair in deps)
+            {
+                temp.AddConstraint(pair.Value);
+            }
+
+            // Hot path!
+            temp.PutIntoRowEchelonForm();
 
 #if TRACECLEANDEPS
-        Console.WriteLine("entry : {0}", redundancy.V1);
+            Console.WriteLine("===== Removed Constraints");
 #endif
-        deps.Remove(redundancy.V1);
-      }
+
+            var toRemove = temp.GetRedundancies();
+            foreach (var redundancy in toRemove)
+            {
+#if TRACECLEANDEPS
+                Console.WriteLine("entry : {0}", redundancy.V1);
+#endif
+                deps.Remove(redundancy.V1);
+            }
 
 #if TRACECLEANDEPS
-      Console.WriteLine("===== Cleaned Constraints #{0}", deps.Count);
-     
-      foreach (var e_pair in deps)
-      {
-        Console.WriteLine("{0} -> {1}", e_pair.Key, e_pair.Value);
-      }
+            Console.WriteLine("===== Cleaned Constraints #{0}", deps.Count);
 
-      Console.WriteLine("===============================================");
+            foreach (var e_pair in deps)
+            {
+                Console.WriteLine("{0} -> {1}", e_pair.Key, e_pair.Value);
+            }
+
+            Console.WriteLine("===============================================");
 #endif
 #if false
-      count++;
+            count++;
 #endif
-    }
+        }
 
-    private static Dictionary<Variable, Polynomial<Variable, Expression>> CleanDepsSyntactical(
-      Dictionary<Variable, Polynomial<Variable, Expression>> deps)
-    {
-      var buffer2 = new Set<Pair<Pair<Rational, Variable>, Pair<Rational, Variable>>>();
-      var buffer3 = new Set<Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>>();
-      var buffer4 = new Set<Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>>();
+        private static Dictionary<Variable, Polynomial<Variable, Expression>> CleanDepsSyntactical(
+          Dictionary<Variable, Polynomial<Variable, Expression>> deps)
+        {
+            var buffer2 = new Set<Pair<Pair<Rational, Variable>, Pair<Rational, Variable>>>();
+            var buffer3 = new Set<Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>>();
+            var buffer4 = new Set<Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>>();
 
 #if false
-      var stringbuff = new Set<string>();
+            var stringbuff = new Set<string>();
 #endif
-      var result = new Dictionary<Variable, Polynomial<Variable, Expression>>();
+            var result = new Dictionary<Variable, Polynomial<Variable, Expression>>();
 
-      foreach (var pair in deps)
-      {
+            foreach (var pair in deps)
+            {
 #if false // this way of removing redundances seems way slower
-        var key = pair.Value.ToString(v => !v.Equals(pair.Key));
+                var key = pair.Value.ToString(v => !v.Equals(pair.Key));
 
-        if (stringbuff.Contains(key))
-        {
-          continue;
-        }
-        else
-        {
-          stringbuff.Add(key);
-        }
+                if (stringbuff.Contains(key))
+                {
+                    continue;
+                }
+                else
+                {
+                    stringbuff.Add(key);
+                }
 #else
-        List<Pair<Rational, Variable>> val;
+                List<Pair<Rational, Variable>> val;
 
-        if (pair.Value.TryToList(out val))
-        {
-
-          val.Remove(new Pair<Rational, Variable>(Rational.For(-1), pair.Key)); // Vincent's representation has the slack variable in the polynomial 
-
-          switch (val.Count)
-          {
-            case 2:
-              {
-                var key = new Pair<Pair<Rational, Variable>, Pair<Rational, Variable>>(val[0], val[1]);
-
-                if (buffer2.Contains(key))
+                if (pair.Value.TryToList(out val))
                 {
-                  continue;
+                    val.Remove(new Pair<Rational, Variable>(Rational.For(-1), pair.Key)); // Vincent's representation has the slack variable in the polynomial 
+
+                    switch (val.Count)
+                    {
+                        case 2:
+                            {
+                                var key = new Pair<Pair<Rational, Variable>, Pair<Rational, Variable>>(val[0], val[1]);
+
+                                if (buffer2.Contains(key))
+                                {
+                                    continue;
+                                }
+
+                                buffer2.Add(key);
+                            }
+                            break;
+
+                        case 3:
+                            {
+                                var key = new Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>(val[0], val[1], val[2]);
+                                if (buffer3.Contains(key))
+                                {
+                                    continue;
+                                }
+
+                                buffer3.Add(key);
+                            }
+                            break;
+
+                        case 4:
+                            {
+                                var key = new Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>(val[0], val[1], val[2], val[3]);
+                                if (buffer4.Contains(key))
+                                {
+                                    continue;
+                                }
+
+                                buffer4.Add(key);
+                            }
+                            break;
+                    }
                 }
-
-                buffer2.Add(key);
-              }
-              break;
-
-            case 3:
-              {
-                var key = new Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>(val[0], val[1], val[2]);
-                if (buffer3.Contains(key))
-                {
-                  continue;
-                }
-
-                buffer3.Add(key);
-              }
-              break;
-
-            case 4:
-              {
-                var key = new Tuple<Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>, Pair<Rational, Variable>>(val[0], val[1], val[2], val[3]);
-                if (buffer4.Contains(key))
-                {
-                  continue;
-                }
-
-                buffer4.Add(key);
-
-              }
-              break;
-          }
-        } 
 #endif
-        result[pair.Key] = pair.Value;
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Method used to remove redundant definitions from a dictionary mapping slack variables to their definitions, returning redundant variables
-    /// </summary>
-    /// <param name="deps">The dictionary mapping slack variables to their definition in terms of program variables</param>
-    private static void CleanDeps(Dictionary<Variable, Polynomial<Variable, Expression>> deps, 
-      ExpressionManagerWithEncoder<Variable, Expression> expManager, out List<Variable> removed)
-    {
-      var temp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(expManager);
-      foreach (var pair in deps)
-      {
-        temp.AddConstraint(temp.AsVector(pair.Value));
-      }
-      temp.PutIntoRowEchelonForm();
-      var toRemove = temp.GetRedundancies();
-
-      removed = new List<Variable>();
-      foreach (var e in toRemove)
-      {
-        deps.Remove(e.V1);
-        removed.Add(e.V1);
-      }
-    }
-    
-    /// <returns>true iff the threshold has been reached</returns>
-    private static bool CleanHints(ref Hints<Variable, Expression> hints,
-      ExpressionManagerWithEncoder<Variable, Expression> expManager,
-      int ThresholdForHints = Int32.MaxValue)
-    {
-      var deps = new Dictionary<Variable, Polynomial<Variable, Expression>>(hints.Count);
-      foreach (var pol in hints.Enumerate())
-      {
-        Variable beta;
-        int k = IsBetaDefinition(pol, out beta, expManager.Decoder);
-
-        if (k == 0)
-        { //shouldn't be reached for now, but it may come handy in the future
-          beta = expManager.Encoder.FreshVariable<int>();
-          deps.Add(beta, pol.AddMonomialToTheLeft(new Monomial<Variable>(-1, beta)));
-        }
-        else if (k == 1)
-        {
-          if (deps.ContainsKey(beta))
-          {
-            var betaTwo = expManager.Encoder.FreshVariable<int>();
-            deps.Add(betaTwo, pol.Rename(beta, betaTwo));
-          }
-          else
-          {
-            deps.Add(beta, pol);
-          }
-        }
-        else
-        {
-          // do nothing ; this case should not be reached, 
-          // but if it becomes so, we may want to treat it better by extracting the underlying relation on program variables
-        }
-      }
-
-      CleanDeps(ref deps, expManager);
-
-      // Turn all the dependencies into hints
-      hints = new Hints<Variable, Expression>(deps.Values);
-      return false;
-    }
-
-    private Rational Separate(Polynomial<Variable, Expression> pol, out Polynomial<Variable, Expression> programVariables, out Polynomial<Variable, Expression> slackVariables)
-    {
-      Debug.Assert(pol.IsLinear);
-
-      var pV = new List<Monomial<Variable>>();
-      var sV = new List<Monomial<Variable>>();
-      var result = Rational.For(0);
-
-      foreach (var mono in pol.Left)
-      {
-        if (mono.IsConstant)
-        {
-          result -= mono.K;
-        }
-        else if (this.ExpressionManager.Decoder.IsSlackVariable(mono.VariableAt(0)))
-        {
-          sV.Add(mono);
-        }
-        else
-        {
-          pV.Add(mono);
-        }
-      }
-      
-      Debug.Assert(pol.Relation == ExpressionOperator.Equal || pol.Relation == ExpressionOperator.Equal_Obj);
-      
-      result += pol.Right[0].K;
-      
-      if (!Polynomial<Variable, Expression>.TryToPolynomialForm(pV.ToArray(), out programVariables))
-      {
-        throw new AbstractInterpretationException();
-      }
-
-      if (!Polynomial<Variable, Expression>.TryToPolynomialForm(sV.ToArray(), out slackVariables))
-      {
-        throw new AbstractInterpretationException();
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// beta = result * coeff + k
-    /// </summary>
-    private bool TryGetEquivalent(Variable beta, Polynomial<Variable, Expression> betaDef, out Variable result, out Rational coeff, out Rational k)
-    {
-      result = default(Variable);
-      coeff = Rational.For(0);
-
-      k = Rational.For(0);
-
-        if (betaDep.ContainsKey(beta))
-        {
-          Polynomial<Variable, Expression> pol;
-          if (LinearEqualitiesEnvironment<Variable, Expression>.TryCombine(betaDep[beta], betaDef, beta, out pol) && pol.IsTautology)
-          {
-            result = beta;
-            coeff = Rational.For(1);
-            k = Rational.For(0);
-          
-            return true;
-          }
-        }
-       
-      try 
-        {
-        var otherVar = default(Variable);
-        
-        foreach (var m in betaDef.Left)
-        {
-          if (m.VariableAt(0).Equals(beta)) 
-            continue;
-          
-          otherVar = m.VariableAt(0);
-          break;
-        }
-
-        Contract.Assert(!otherVar.Equals(default(Expression)));
-        
-        foreach (var e in this.betaDep.Keys)
-        {
-          var other = betaDep[e];
-          if (!other.Variables.Contains(otherVar)) 
-            continue;
-
-          Polynomial<Variable, Expression> combined;
-          if (!LinearEqualitiesEnvironment<Variable, Expression>.TryCombine(betaDef, other, otherVar, out combined))
-          {
-            continue;
-          }
-          if (combined.Variables.Count == 2) // both variables should be slack variables
-          {
-            var k1 = Rational.For(0);
-            var k2 = Rational.For(0);
-            foreach (var m in combined.Left)
-            {
-              if (m.VariableAt(0).Equals(beta))
-              {
-                k1 = m.K;
-              }
-              else
-              {
-                k2 = m.K;
-                result = m.VariableAt(0);
-              }
+                result[pair.Key] = pair.Value;
             }
-            coeff = -k2 / k1;
-            k = combined.Right[0].K / k1;
 
-            return true;
-          }
+            return result;
         }
 
-        return false;
-      }
-      catch (ArithmeticExceptionRational)
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// Method to put equalities in Karr for variables whose interval is a singleton. Used for keeping equalities at the join
-    /// </summary>
-    private void PutConstantsInKarr()
-    {
-      foreach (var e in Right.Variables)
-      {
-        var intv = Right.BoundsFor(e);
-        if (intv.IsSingleton)
+        /// <summary>
+        /// Method used to remove redundant definitions from a dictionary mapping slack variables to their definitions, returning redundant variables
+        /// </summary>
+        /// <param name="deps">The dictionary mapping slack variables to their definition in terms of program variables</param>
+        private static void CleanDeps(Dictionary<Variable, Polynomial<Variable, Expression>> deps,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager, out List<Variable> removed)
         {
-          Left.AddConstraintEqual(e, intv.LowerBound);
-        } 
-      }
-    }
+            var temp = new LinearEqualitiesForSubpolyhedraEnvironment<Variable, Expression>(expManager);
+            foreach (var pair in deps)
+            {
+                temp.AddConstraint(temp.AsVector(pair.Value));
+            }
+            temp.PutIntoRowEchelonForm();
+            var toRemove = temp.GetRedundancies();
 
-
-    /// <summary>
-    /// Method for Checking whether a polynomial corresponds to the definition of a slack variable. The result is the number of occurrences of slack variables, the out parameter one of the encountered slack variables if any.
-    /// </summary>
-    /// <param name="pol">The polynomial to check</param>
-    /// <param name="beta">The last slack variable encountered, if any</param>
-    /// <returns>The number of occurences of slack variables</returns>
-    internal static int IsBetaDefinition(Polynomial<Variable, Expression> pol, out Variable beta, 
-      IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(pol.IsLinear);
-
-      beta = default(Variable);
-      int result = 0;
-      
-      foreach (var m in pol.Left)
-      {
-        if (m.IsConstant)
-        {
-          continue;
+            removed = new List<Variable>();
+            foreach (var e in toRemove)
+            {
+                deps.Remove(e.V1);
+                removed.Add(e.V1);
+            }
         }
 
-        if (decoder.IsSlackVariable(m.VariableAt(0)))
+        /// <returns>true iff the threshold has been reached</returns>
+        private static bool CleanHints(ref Hints<Variable, Expression> hints,
+          ExpressionManagerWithEncoder<Variable, Expression> expManager,
+          int ThresholdForHints = Int32.MaxValue)
         {
-          result++;
-          beta = m.VariableAt(0);
+            var deps = new Dictionary<Variable, Polynomial<Variable, Expression>>(hints.Count);
+            foreach (var pol in hints.Enumerate())
+            {
+                Variable beta;
+                int k = IsBetaDefinition(pol, out beta, expManager.Decoder);
+
+                if (k == 0)
+                { //shouldn't be reached for now, but it may come handy in the future
+                    beta = expManager.Encoder.FreshVariable<int>();
+                    deps.Add(beta, pol.AddMonomialToTheLeft(new Monomial<Variable>(-1, beta)));
+                }
+                else if (k == 1)
+                {
+                    if (deps.ContainsKey(beta))
+                    {
+                        var betaTwo = expManager.Encoder.FreshVariable<int>();
+                        deps.Add(betaTwo, pol.Rename(beta, betaTwo));
+                    }
+                    else
+                    {
+                        deps.Add(beta, pol);
+                    }
+                }
+                else
+                {
+                    // do nothing ; this case should not be reached, 
+                    // but if it becomes so, we may want to treat it better by extracting the underlying relation on program variables
+                }
+            }
+
+            CleanDeps(ref deps, expManager);
+
+            // Turn all the dependencies into hints
+            hints = new Hints<Variable, Expression>(deps.Values);
+            return false;
         }
-      }
-      return result;
-    }
 
-    internal static int IsBetaDefinition(Polynomial<Variable, Expression> pol, out Variable beta,
-      IExpressionDecoder<Variable, Expression> decoder, out bool result)
-    {
-      result = false;
-      int k = IsBetaDefinition(pol, out beta, decoder);
-      if (k == 1 && pol.Variables.Count > 2)
-        result = true;
-      return k;
-    }
-    #endregion
-
-    #region Print statistics
-
-    [Conditional("TRACE_PERFORMANCE")]
-    public void PrintStatistics(string msg = "")
-    {
-      Console.WriteLine("Subpolyhedra {0} (mem: {1}Mbytes)", msg, System.GC.GetTotalMemory(false) / (1024 * 1024));
-      Console.WriteLine("Linear equalities: {0}", this.Left.Statistics());
-      Console.WriteLine("Intervals: {0}", this.Right.Statistics());
-    }
-    
-    #endregion
-
-    #region overriden : ToString
-
-    private StringClosure Print(Hints<Variable, Expression> allHints)
-    {
-      return () =>
+        private Rational Separate(Polynomial<Variable, Expression> pol, out Polynomial<Variable, Expression> programVariables, out Polynomial<Variable, Expression> slackVariables)
         {
-          var s = new StringBuilder();
-          foreach (var p in allHints.Enumerate())
-          {
-            s.AppendFormat("{0} ", p.ToString());
-          }
+            Debug.Assert(pol.IsLinear);
 
-          return s.ToString();
-        };
-    }
+            var pV = new List<Monomial<Variable>>();
+            var sV = new List<Monomial<Variable>>();
+            var result = Rational.For(0);
 
-    public override string ToString()
-    {
+            foreach (var mono in pol.Left)
+            {
+                if (mono.IsConstant)
+                {
+                    result -= mono.K;
+                }
+                else if (this.ExpressionManager.Decoder.IsSlackVariable(mono.VariableAt(0)))
+                {
+                    sV.Add(mono);
+                }
+                else
+                {
+                    pV.Add(mono);
+                }
+            }
+
+            Debug.Assert(pol.Relation == ExpressionOperator.Equal || pol.Relation == ExpressionOperator.Equal_Obj);
+
+            result += pol.Right[0].K;
+
+            if (!Polynomial<Variable, Expression>.TryToPolynomialForm(pV.ToArray(), out programVariables))
+            {
+                throw new AbstractInterpretationException();
+            }
+
+            if (!Polynomial<Variable, Expression>.TryToPolynomialForm(sV.ToArray(), out slackVariables))
+            {
+                throw new AbstractInterpretationException();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// beta = result * coeff + k
+        /// </summary>
+        private bool TryGetEquivalent(Variable beta, Polynomial<Variable, Expression> betaDef, out Variable result, out Rational coeff, out Rational k)
+        {
+            result = default(Variable);
+            coeff = Rational.For(0);
+
+            k = Rational.For(0);
+
+            if (betaDep.ContainsKey(beta))
+            {
+                Polynomial<Variable, Expression> pol;
+                if (LinearEqualitiesEnvironment<Variable, Expression>.TryCombine(betaDep[beta], betaDef, beta, out pol) && pol.IsTautology)
+                {
+                    result = beta;
+                    coeff = Rational.For(1);
+                    k = Rational.For(0);
+
+                    return true;
+                }
+            }
+
+            try
+            {
+                var otherVar = default(Variable);
+
+                foreach (var m in betaDef.Left)
+                {
+                    if (m.VariableAt(0).Equals(beta))
+                        continue;
+
+                    otherVar = m.VariableAt(0);
+                    break;
+                }
+
+                Contract.Assert(!otherVar.Equals(default(Expression)));
+
+                foreach (var e in betaDep.Keys)
+                {
+                    var other = betaDep[e];
+                    if (!other.Variables.Contains(otherVar))
+                        continue;
+
+                    Polynomial<Variable, Expression> combined;
+                    if (!LinearEqualitiesEnvironment<Variable, Expression>.TryCombine(betaDef, other, otherVar, out combined))
+                    {
+                        continue;
+                    }
+                    if (combined.Variables.Count == 2) // both variables should be slack variables
+                    {
+                        var k1 = Rational.For(0);
+                        var k2 = Rational.For(0);
+                        foreach (var m in combined.Left)
+                        {
+                            if (m.VariableAt(0).Equals(beta))
+                            {
+                                k1 = m.K;
+                            }
+                            else
+                            {
+                                k2 = m.K;
+                                result = m.VariableAt(0);
+                            }
+                        }
+                        coeff = -k2 / k1;
+                        k = combined.Right[0].K / k1;
+
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            catch (ArithmeticExceptionRational)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Method to put equalities in Karr for variables whose interval is a singleton. Used for keeping equalities at the join
+        /// </summary>
+        private void PutConstantsInKarr()
+        {
+            foreach (var e in Right.Variables)
+            {
+                var intv = Right.BoundsFor(e);
+                if (intv.IsSingleton)
+                {
+                    Left.AddConstraintEqual(e, intv.LowerBound);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Method for Checking whether a polynomial corresponds to the definition of a slack variable. The result is the number of occurrences of slack variables, the out parameter one of the encountered slack variables if any.
+        /// </summary>
+        /// <param name="pol">The polynomial to check</param>
+        /// <param name="beta">The last slack variable encountered, if any</param>
+        /// <returns>The number of occurences of slack variables</returns>
+        internal static int IsBetaDefinition(Polynomial<Variable, Expression> pol, out Variable beta,
+          IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(pol.IsLinear);
+
+            beta = default(Variable);
+            int result = 0;
+
+            foreach (var m in pol.Left)
+            {
+                if (m.IsConstant)
+                {
+                    continue;
+                }
+
+                if (decoder.IsSlackVariable(m.VariableAt(0)))
+                {
+                    result++;
+                    beta = m.VariableAt(0);
+                }
+            }
+            return result;
+        }
+
+        internal static int IsBetaDefinition(Polynomial<Variable, Expression> pol, out Variable beta,
+          IExpressionDecoder<Variable, Expression> decoder, out bool result)
+        {
+            result = false;
+            int k = IsBetaDefinition(pol, out beta, decoder);
+            if (k == 1 && pol.Variables.Count > 2)
+                result = true;
+            return k;
+        }
+        #endregion
+
+        #region Print statistics
+
+        [Conditional("TRACE_PERFORMANCE")]
+        public void PrintStatistics(string msg = "")
+        {
+            Console.WriteLine("Subpolyhedra {0} (mem: {1}Mbytes)", msg, System.GC.GetTotalMemory(false) / (1024 * 1024));
+            Console.WriteLine("Linear equalities: {0}", this.Left.Statistics());
+            Console.WriteLine("Intervals: {0}", this.Right.Statistics());
+        }
+
+        #endregion
+
+        #region overriden : ToString
+
+        private StringClosure Print(Hints<Variable, Expression> allHints)
+        {
+            return () =>
+              {
+                  var s = new StringBuilder();
+                  foreach (var p in allHints.Enumerate())
+                  {
+                      s.AppendFormat("{0} ", p.ToString());
+                  }
+
+                  return s.ToString();
+              };
+        }
+
+        public override string ToString()
+        {
 #if LOG
-      StringBuilder deps = new StringBuilder();
-      deps.AppendLine();
-      foreach (var beta in betaDep.Keys)
-      {
-        deps.AppendLine(beta.ToString + " : " + betaDep[beta].ToString);
-      }
-      deps.AppendLine("hints :");
-      foreach (var p in hints)
-      {
-        deps.AppendLine(p.ToString());
-      }
-      deps.AppendLine("number of widenings : " + numberOfWidenings);
-      return "betaDeps :" + deps.ToString() + base.ToString();
-#else 
-
-#if LOG
-      var isBottom = this.IsBottomWithReduction();
-      return isBottom ? "bottom after reduction! (_|_)" : base.ToString();
+            StringBuilder deps = new StringBuilder();
+            deps.AppendLine();
+            foreach (var beta in betaDep.Keys)
+            {
+                deps.AppendLine(beta.ToString + " : " + betaDep[beta].ToString);
+            }
+            deps.AppendLine("hints :");
+            foreach (var p in hints)
+            {
+                deps.AppendLine(p.ToString());
+            }
+            deps.AppendLine("number of widenings : " + numberOfWidenings);
+            return "betaDeps :" + deps.ToString() + base.ToString();
 #else
-      var hintsCount = this.hints.Count.ToString();
-      hintsCount += "\nHints:\n" + ToString(this.hints);
-      var depsCount = this.betaDep.Count;
-      return string.Format("#Hints:{0}\n#Deps:{1}\n{2}", hintsCount, depsCount, base.ToString());
+
+#if LOG
+            var isBottom = this.IsBottomWithReduction();
+            return isBottom ? "bottom after reduction! (_|_)" : base.ToString();
+#else
+            var hintsCount = hints.Count.ToString();
+            hintsCount += "\nHints:\n" + ToString(hints);
+            var depsCount = betaDep.Count;
+            return string.Format("#Hints:{0}\n#Deps:{1}\n{2}", hintsCount, depsCount, base.ToString());
 #endif
 
 #endif
-    }
-
-    private string ToString(Hints<Variable, Expression> lists)
-    {
-      if (lists == null || lists.Count == 0)
-        return "";
-
-      string result = "";
-
-      foreach (var p in lists.Enumerate())
-      {
-        result += p.ToString() + " ";
-      }
-
-      return result.ToString();
-    }
-
-    #endregion
-
-    #region Visitors
-
-    private class SPTestTrueVisitor 
-      : TestTrueVisitor<SubPolyhedra<Variable, Expression>, Variable, Expression>
-    {
-      private readonly ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
-
-      public SPTestTrueVisitor(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-        : base(expManager.Decoder)
-      {
-        Contract.Requires(expManager != null);
-
-        this.ExpressionManager = expManager;
-      }
-
-      protected override SubPolyhedra<Variable, Expression> DispatchCompare(
-        GenericExpressionVisitor<SubPolyhedra<Variable, Expression>, 
-        SubPolyhedra<Variable, Expression>, Variable, Expression>.CompareVisitor cmp, Expression left, Expression right, Expression original, 
-        SubPolyhedra<Variable, Expression> data)
-      {
-        return base.DispatchCompare(cmp, left, right, original, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        Polynomial<Variable, Expression> pol;
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, this.ExpressionManager.Decoder, out pol) || !pol.IsLinear)
-        {
-          return data;
         }
 
-        if (pol.IsInconsistent)
+        private string ToString(Hints<Variable, Expression> lists)
         {
-          return data.Bottom as SubPolyhedra<Variable, Expression>;
+            if (lists == null || lists.Count == 0)
+                return "";
+
+            string result = "";
+
+            foreach (var p in lists.Enumerate())
+            {
+                result += p.ToString() + " ";
+            }
+
+            return result.ToString();
         }
 
-        data.Left.AddConstraint(data.Left.AsVector(pol));
-        var newIntv = data.Right.TestTrueEqual(left, right);
+        #endregion
 
-        var result = new SubPolyhedra<Variable,Expression>(data.Left, data.Right, data.ExpressionManager);
+        #region Visitors
 
-        result.betaDep = data.betaDep;
-        result.hints = data.hints;
-
-        return result;
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        return HelperForVisitLessEqualSignedOrUnsigned(true, left, right, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        return HelperForVisitLessEqualSignedOrUnsigned(false, left, right, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        return HelperForVisitLessThanSignedOrUnsigned(true, left, right, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitLessThan_Un(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        return HelperForVisitLessThanSignedOrUnsigned(false, left, right, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitAddition(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        var encoder = this.ExpressionManager.Encoder;
-        var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, left, right);
-        var zero = Rational.For(0).ToExpression(encoder);
-        var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero);
-
-        return VisitNotEqual(l1, zero, exp, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitSubtraction(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        var encoder = this.ExpressionManager.Encoder;
-        var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
-        var zero = Rational.For(0).ToExpression(encoder);
-        var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero);
-
-        return VisitNotEqual(l1, zero, exp, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitUnaryMinus(Expression left, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        var encoder = this.ExpressionManager.Encoder;
-        var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.UnaryMinus, left);
-        var zero = Rational.For(0).ToExpression(encoder);
-        var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero); 
-
-        return VisitNotEqual(l1, zero, exp, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitMultiplication(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        var encoder = this.ExpressionManager.Encoder;
-        var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, left, right);
-        var zero = Rational.For(0).ToExpression(encoder);
-        var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero); 
-
-        return VisitNotEqual(l1, zero, exp, data);
-      }
-
-      public override SubPolyhedra<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        var leftVar = this.ExpressionManager.Decoder.UnderlyingVariable(left);
-        var rightVar = this.ExpressionManager.Decoder.UnderlyingVariable(right);
-
-        // left != null || right != null
-        // We do not care, so we return
-        if (this.ExpressionManager.Decoder.IsNull(right) || this.ExpressionManager.Decoder.IsNull(left) )
+        private class SPTestTrueVisitor
+          : TestTrueVisitor<SubPolyhedra<Variable, Expression>, Variable, Expression>
         {
-          return data;
-        }
+            private readonly ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
 
-        // If we have x != const (or const != x) then we have intervals to handle it
-        int value;
-        if (this.ExpressionManager.Decoder.IsConstantInt(left, out value) && this.ExpressionManager.Decoder.IsVariable(right))
-        {
-          return TestTrueNotEqualOnlyOnIntervals(left, right, data);
-        }
+            public SPTestTrueVisitor(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+              : base(expManager.Decoder)
+            {
+                Contract.Requires(expManager != null);
 
-        if (this.ExpressionManager.Decoder.IsConstantInt(right, out value) && this.ExpressionManager.Decoder.IsVariable(left))
-        {
-          return TestTrueNotEqualOnlyOnIntervals(left, right, data);
-        }
+                ExpressionManager = expManager;
+            }
 
-        var subpoly1 = data.DuplicateMe();
-        var subpoly2 = data.DuplicateMe();
+            protected override SubPolyhedra<Variable, Expression> DispatchCompare(
+              GenericExpressionVisitor<SubPolyhedra<Variable, Expression>,
+              SubPolyhedra<Variable, Expression>, Variable, Expression>.CompareVisitor cmp, Expression left, Expression right, Expression original,
+              SubPolyhedra<Variable, Expression> data)
+            {
+                return base.DispatchCompare(cmp, left, right, original, data);
+            }
 
-        subpoly1 = subpoly1.TestTrueLessThan(left, right) as SubPolyhedra<Variable, Expression>;
-        subpoly2 = subpoly2.TestTrueLessThan(right, left) as SubPolyhedra<Variable, Expression>;
+            public override SubPolyhedra<Variable, Expression> VisitEqual(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                Polynomial<Variable, Expression> pol;
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.Equal, left, right, ExpressionManager.Decoder, out pol) || !pol.IsLinear)
+                {
+                    return data;
+                }
 
-        return subpoly1.Join(subpoly2) as SubPolyhedra<Variable, Expression>;
-      }
+                if (pol.IsInconsistent)
+                {
+                    return data.Bottom as SubPolyhedra<Variable, Expression>;
+                }
 
-      public override SubPolyhedra<Variable, Expression> VisitVariable(Variable variable, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        var result = data.Factory(data.Left, data.Right.TestTrue(original)) as SubPolyhedra<Variable, Expression>;
-        result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(data.betaDep);
-        //result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(data.betaDep);
-        result.hints = new Hints<Variable, Expression>(data.hints);
+                data.Left.AddConstraint(data.Left.AsVector(pol));
+                var newIntv = data.Right.TestTrueEqual(left, right);
 
-        return result;
-      }
+                var result = new SubPolyhedra<Variable, Expression>(data.Left, data.Right, data.ExpressionManager);
 
-      private static SubPolyhedra<Variable, Expression> TestTrueNotEqualOnlyOnIntervals(Expression left, Expression right, SubPolyhedra<Variable, Expression> data)
-      {
-        var newIntv = data.Right.TestNotEqual(left, right);
+                result.betaDep = data.betaDep;
+                result.hints = data.hints;
 
-        return data.Factory(data.Left, newIntv) as SubPolyhedra<Variable, Expression>;
-      }
+                return result;
+            }
 
-      private SubPolyhedra<Variable, Expression> HelperForVisitLessEqualSignedOrUnsigned(
-        bool isSignedComparison, Expression left, Expression right, SubPolyhedra<Variable, Expression> data)
-      {
-        Variable beta;
-        Polynomial<Variable, Expression> pol;
+            public override SubPolyhedra<Variable, Expression> VisitLessEqualThan(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                return HelperForVisitLessEqualSignedOrUnsigned(true, left, right, data);
+            }
 
-        var encoder = this.ExpressionManager.Encoder;
+            public override SubPolyhedra<Variable, Expression> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                return HelperForVisitLessEqualSignedOrUnsigned(false, left, right, data);
+            }
 
-        // We are not allowed to infer it with an unsigned comparison
-        if (isSignedComparison && !Decoder.IsConstant(left) && !Decoder.IsConstant(right))
-        {
-          beta = encoder.FreshVariable<int>();
-          var monos = new Monomial<Variable>[]
-          { 
-            new Monomial<Variable>(Decoder.UnderlyingVariable(Decoder.Stripped(left))), 
-            new Monomial<Variable>(-1, Decoder.UnderlyingVariable(Decoder.Stripped(right))),
-            new Monomial<Variable>(-1, beta)
-          };
+            public override SubPolyhedra<Variable, Expression> VisitLessThan(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                return HelperForVisitLessThanSignedOrUnsigned(true, left, right, data);
+            }
 
-          Polynomial<Variable, Expression>.TryToPolynomialForm(monos, out pol);
+            public override SubPolyhedra<Variable, Expression> VisitLessThan_Un(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                return HelperForVisitLessThanSignedOrUnsigned(false, left, right, data);
+            }
 
-          data.Left.AddConstraint(data.Left.AsVector(pol));
-          data.betaDep[beta] = pol;
-          data.Right[beta] = Interval.NegativeInterval;
-        }
-        else
-        {
-          var newIntv = isSignedComparison ?
-            data.Right.TestTrueLessEqualThan(left, right) :
-            data.Right.TestTrue(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan_Un, left, right));
+            public override SubPolyhedra<Variable, Expression> VisitAddition(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                var encoder = ExpressionManager.Encoder;
+                var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Addition, left, right);
+                var zero = Rational.For(0).ToExpression(encoder);
+                var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero);
 
-          data = new SubPolyhedra<Variable, Expression>(data, newIntv);
-        }
+                return VisitNotEqual(l1, zero, exp, data);
+            }
 
-        var bop = isSignedComparison ? ExpressionOperator.LessEqualThan : ExpressionOperator.LessEqualThan_Un;
+            public override SubPolyhedra<Variable, Expression> VisitSubtraction(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                var encoder = ExpressionManager.Encoder;
+                var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right);
+                var zero = Rational.For(0).ToExpression(encoder);
+                var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero);
 
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(bop, left, right, this.ExpressionManager.Decoder, out pol) 
-          || !pol.IsLinear)
-        {
-          return data;
-        }
+                return VisitNotEqual(l1, zero, exp, data);
+            }
 
-        if (pol.IsInconsistent)
-        {
-          return data.Bottom as SubPolyhedra<Variable, Expression>;
-        }
+            public override SubPolyhedra<Variable, Expression> VisitUnaryMinus(Expression left, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                var encoder = ExpressionManager.Encoder;
+                var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.UnaryMinus, left);
+                var zero = Rational.For(0).ToExpression(encoder);
+                var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero);
 
-        if (pol.Left.Length == 1)
-        {
-          var newIntv = data.Right.TestTrue(pol.ToPureExpression(encoder));
-          return new SubPolyhedra<Variable, Expression>(data, newIntv);
-        }
+                return VisitNotEqual(l1, zero, exp, data);
+            }
 
-        beta = encoder.FreshVariable<int>();
-        var mono = new Monomial<Variable>(beta);
-        mono.K = -mono.K;
-        var newPolLeft = new List<Monomial<Variable>>(pol.Left);
-        newPolLeft.Add(mono);
+            public override SubPolyhedra<Variable, Expression> VisitMultiplication(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                var encoder = ExpressionManager.Encoder;
+                var l1 = encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Multiplication, left, right);
+                var zero = Rational.For(0).ToExpression(encoder);
+                var exp = encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.NotEqual, l1, zero);
 
-        Polynomial<Variable, Expression> eq;
+                return VisitNotEqual(l1, zero, exp, data);
+            }
 
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(newPolLeft.ToArray(), out eq))
-        {
-          data.Left.AddConstraint(data.Left.AsVector(eq));
-          data.betaDep[beta] = eq;
-          data.hints.Add(eq);
-        }
-        data.Right[beta] = Interval.For(Rational.MinusInfinity, pol.Right[0].K);
+            public override SubPolyhedra<Variable, Expression> VisitNotEqual(Expression left, Expression right, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                var leftVar = ExpressionManager.Decoder.UnderlyingVariable(left);
+                var rightVar = ExpressionManager.Decoder.UnderlyingVariable(right);
 
-        return data;
-      }
+                // left != null || right != null
+                // We do not care, so we return
+                if (ExpressionManager.Decoder.IsNull(right) || ExpressionManager.Decoder.IsNull(left))
+                {
+                    return data;
+                }
 
-      private SubPolyhedra<Variable, Expression> HelperForVisitLessThanSignedOrUnsigned(
-        bool isSignedComparison, Expression left, Expression right, SubPolyhedra<Variable, Expression> data)
-      {
-        Variable beta;
-        var encoder = this.ExpressionManager.Encoder;
+                // If we have x != const (or const != x) then we have intervals to handle it
+                int value;
+                if (ExpressionManager.Decoder.IsConstantInt(left, out value) && ExpressionManager.Decoder.IsVariable(right))
+                {
+                    return TestTrueNotEqualOnlyOnIntervals(left, right, data);
+                }
 
-        // We are not allowed to infer it with an unsigned comparison
-        Polynomial<Variable, Expression> pol;
-        if (isSignedComparison && !Decoder.IsConstant(left) && !Decoder.IsConstant(right))
-        {
-          beta = encoder.FreshVariable<int>();
-          var monos = new Monomial<Variable>[]
-          {
+                if (ExpressionManager.Decoder.IsConstantInt(right, out value) && ExpressionManager.Decoder.IsVariable(left))
+                {
+                    return TestTrueNotEqualOnlyOnIntervals(left, right, data);
+                }
+
+                var subpoly1 = data.DuplicateMe();
+                var subpoly2 = data.DuplicateMe();
+
+                subpoly1 = subpoly1.TestTrueLessThan(left, right) as SubPolyhedra<Variable, Expression>;
+                subpoly2 = subpoly2.TestTrueLessThan(right, left) as SubPolyhedra<Variable, Expression>;
+
+                return subpoly1.Join(subpoly2) as SubPolyhedra<Variable, Expression>;
+            }
+
+            public override SubPolyhedra<Variable, Expression> VisitVariable(Variable variable, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                var result = data.Factory(data.Left, data.Right.TestTrue(original)) as SubPolyhedra<Variable, Expression>;
+                result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(data.betaDep);
+                //result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(data.betaDep);
+                result.hints = new Hints<Variable, Expression>(data.hints);
+
+                return result;
+            }
+
+            private static SubPolyhedra<Variable, Expression> TestTrueNotEqualOnlyOnIntervals(Expression left, Expression right, SubPolyhedra<Variable, Expression> data)
+            {
+                var newIntv = data.Right.TestNotEqual(left, right);
+
+                return data.Factory(data.Left, newIntv) as SubPolyhedra<Variable, Expression>;
+            }
+
+            private SubPolyhedra<Variable, Expression> HelperForVisitLessEqualSignedOrUnsigned(
+              bool isSignedComparison, Expression left, Expression right, SubPolyhedra<Variable, Expression> data)
+            {
+                Variable beta;
+                Polynomial<Variable, Expression> pol;
+
+                var encoder = ExpressionManager.Encoder;
+
+                // We are not allowed to infer it with an unsigned comparison
+                if (isSignedComparison && !Decoder.IsConstant(left) && !Decoder.IsConstant(right))
+                {
+                    beta = encoder.FreshVariable<int>();
+                    var monos = new Monomial<Variable>[]
+                    {
             new Monomial<Variable>(Decoder.UnderlyingVariable(Decoder.Stripped(left))),
             new Monomial<Variable>(-1, Decoder.UnderlyingVariable(Decoder.Stripped(right))),
             new Monomial<Variable>(-1, beta)
-          };
+                    };
 
-          Polynomial<Variable, Expression>.TryToPolynomialForm(monos, out pol);
-          data.Left.AddConstraint(data.Left.AsVector(pol));
-          data.betaDep[beta] = pol;
-          data.Right[beta] = Interval.For(Rational.MinusInfinity, -1);
+                    Polynomial<Variable, Expression>.TryToPolynomialForm(monos, out pol);
+
+                    data.Left.AddConstraint(data.Left.AsVector(pol));
+                    data.betaDep[beta] = pol;
+                    data.Right[beta] = Interval.NegativeInterval;
+                }
+                else
+                {
+                    var newIntv = isSignedComparison ?
+                      data.Right.TestTrueLessEqualThan(left, right) :
+                      data.Right.TestTrue(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.LessEqualThan_Un, left, right));
+
+                    data = new SubPolyhedra<Variable, Expression>(data, newIntv);
+                }
+
+                var bop = isSignedComparison ? ExpressionOperator.LessEqualThan : ExpressionOperator.LessEqualThan_Un;
+
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(bop, left, right, ExpressionManager.Decoder, out pol)
+                  || !pol.IsLinear)
+                {
+                    return data;
+                }
+
+                if (pol.IsInconsistent)
+                {
+                    return data.Bottom as SubPolyhedra<Variable, Expression>;
+                }
+
+                if (pol.Left.Length == 1)
+                {
+                    var newIntv = data.Right.TestTrue(pol.ToPureExpression(encoder));
+                    return new SubPolyhedra<Variable, Expression>(data, newIntv);
+                }
+
+                beta = encoder.FreshVariable<int>();
+                var mono = new Monomial<Variable>(beta);
+                mono.K = -mono.K;
+                var newPolLeft = new List<Monomial<Variable>>(pol.Left);
+                newPolLeft.Add(mono);
+
+                Polynomial<Variable, Expression> eq;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(newPolLeft.ToArray(), out eq))
+                {
+                    data.Left.AddConstraint(data.Left.AsVector(eq));
+                    data.betaDep[beta] = eq;
+                    data.hints.Add(eq);
+                }
+                data.Right[beta] = Interval.For(Rational.MinusInfinity, pol.Right[0].K);
+
+                return data;
+            }
+
+            private SubPolyhedra<Variable, Expression> HelperForVisitLessThanSignedOrUnsigned(
+              bool isSignedComparison, Expression left, Expression right, SubPolyhedra<Variable, Expression> data)
+            {
+                Variable beta;
+                var encoder = ExpressionManager.Encoder;
+
+                // We are not allowed to infer it with an unsigned comparison
+                Polynomial<Variable, Expression> pol;
+                if (isSignedComparison && !Decoder.IsConstant(left) && !Decoder.IsConstant(right))
+                {
+                    beta = encoder.FreshVariable<int>();
+                    var monos = new Monomial<Variable>[]
+                    {
+            new Monomial<Variable>(Decoder.UnderlyingVariable(Decoder.Stripped(left))),
+            new Monomial<Variable>(-1, Decoder.UnderlyingVariable(Decoder.Stripped(right))),
+            new Monomial<Variable>(-1, beta)
+                    };
+
+                    Polynomial<Variable, Expression>.TryToPolynomialForm(monos, out pol);
+                    data.Left.AddConstraint(data.Left.AsVector(pol));
+                    data.betaDep[beta] = pol;
+                    data.Right[beta] = Interval.For(Rational.MinusInfinity, -1);
+                }
+                else
+                {
+                    var newIntv = isSignedComparison ?
+                      data.Right.TestTrueLessThan(left, right) :
+                      data.Right.TestTrueLessThan_Un(left, right);
+
+                    data = new SubPolyhedra<Variable, Expression>(data, newIntv);
+                }
+
+                var bop = isSignedComparison ? ExpressionOperator.LessThan : ExpressionOperator.LessThan_Un;
+
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(bop, left, right, ExpressionManager.Decoder, out pol) || !pol.IsLinear)
+                {
+                    return data;
+                }
+
+                if (pol.IsInconsistent)
+                {
+                    return data.Bottom as SubPolyhedra<Variable, Expression>;
+                }
+
+                if (pol.Left.Length == 1)
+                {
+                    var newIntv = data.Right.TestTrue(pol.ToPureExpression(encoder));
+                    return new SubPolyhedra<Variable, Expression>(data, newIntv);
+                }
+
+                beta = encoder.FreshVariable<int>();
+                var mono = new Monomial<Variable>(beta);
+                mono.K = -mono.K;
+
+                var newPolLeft = new List<Monomial<Variable>>(pol.Left);
+                newPolLeft.Add(mono);
+
+                Polynomial<Variable, Expression> eq;
+
+                if (Polynomial<Variable, Expression>.TryToPolynomialForm(newPolLeft.ToArray(), out eq))
+                {
+                    data.Left.AddConstraint(data.Left.AsVector(eq));
+                    data.betaDep[beta] = eq;
+                    data.hints.Add(eq);
+                }
+                data.Right[beta] = Interval.For(Rational.MinusInfinity, pol.Right[0].K.IsInteger ? pol.Right[0].K - 1 : pol.Right[0].K);
+
+                return data;
+            }
         }
-        else
+
+        private class SPTestFalseVisitor
+          : TestFalseVisitor<SubPolyhedra<Variable, Expression>, Variable, Expression>
         {
-          var newIntv = isSignedComparison ?
-            data.Right.TestTrueLessThan(left, right) :
-            data.Right.TestTrueLessThan_Un(left, right);
+            public SPTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
+              : base(decoder)
+            {
+            }
 
-          data = new SubPolyhedra<Variable, Expression>(data, newIntv);
+            public override SubPolyhedra<Variable, Expression> VisitVariable(Variable variable, Expression original, SubPolyhedra<Variable, Expression> data)
+            {
+                var result = data.Factory(data.Left, data.Right.TestFalse(original)) as SubPolyhedra<Variable, Expression>;
+
+                result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(data.betaDep);
+                result.hints = new Hints<Variable, Expression>(data.hints);
+
+                return result;
+            }
         }
 
-        var bop = isSignedComparison ? ExpressionOperator.LessThan : ExpressionOperator.LessThan_Un;
-
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(bop, left, right, this.ExpressionManager.Decoder, out pol) ||  !pol.IsLinear)
+        private class SPCheckIfHoldsVisitor
+          : CheckIfHoldsVisitor<SubPolyhedra<Variable, Expression>, Variable, Expression>
         {
-          return data;
+            private readonly ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
+
+            public SPCheckIfHoldsVisitor(ExpressionManagerWithEncoder<Variable, Expression> expManager)
+              : base(expManager.Decoder)
+            {
+                Contract.Requires(expManager != null);
+
+                ExpressionManager = expManager;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                if (Domain.IsBottom)
+                {
+                    return data.Bottom;
+                }
+
+                var encoder = ExpressionManager.Encoder;
+                var decoder = ExpressionManager.Decoder;
+
+                if ((decoder.VariablesIn(left).IsSingleton && decoder.IsConstant(right))
+                  || (decoder.VariablesIn(right).IsSingleton && decoder.IsConstant(left)))
+                {
+                    return Domain.Left.BoundsInference(Domain.Right, SubPolyhedra.Algorithm, SubPolyhedra.MaxVariablesToRunSimplex).CheckIfHolds(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, left, right));
+                }
+
+                var beta = Domain.ExpressionManager.Encoder.FreshVariable<int>();
+
+                Polynomial<Variable, Expression> polBeta;
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(encoder.CompoundExpressionFor(ExpressionType.Int32,
+                  ExpressionOperator.Subtraction,
+                    encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right),
+                    encoder.VariableFor(beta)),
+                    Domain.ExpressionManager.Decoder, out polBeta))
+                {
+                    return CheckOutcome.Top;
+                }
+
+                if (!polBeta.IsLinear)
+                {
+                    return CheckOutcome.Top;
+                }
+
+                var enlarged = Domain.DuplicateMe();
+                enlarged.Left.AddConstraint(enlarged.Left.AsVector(polBeta));
+                enlarged = enlarged.ReduceInternal(enlarged.Left, enlarged.Right, false);
+
+                return enlarged.Right.BoundsFor(beta).IsSingleton && enlarged.Right.BoundsFor(beta).LowerBound.IsZero ?
+                  CheckOutcome.True :
+                  CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                return VisitEqual(left, right, original, data);
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                // We check if one of the two operands is a constant because of the polymorphic behavior of constants with *_un
+                if (Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(left)) || Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(right)))
+                {
+                    var c1 = Domain.Left.CheckIfLessEqualThan_Un(left, right);
+                    var c2 = Domain.Right.CheckIfLessEqualThan_Un(left, right);
+
+                    return c1.Meet(c2);
+                }
+                else
+                {
+                    return VisitLessEqualThan(left, right, original, data);
+                }
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                // We check if one of the two operands is a constant because of the polymorphic behavior of constants with *_un
+                if (Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(left)) || Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(right)))
+                {
+                    var c1 = Domain.Left.CheckIfLessThan_Un(left, right);
+                    var c2 = Domain.Right.CheckIfLessThan_Un(left, right);
+
+                    return c1.Meet(c2);
+                }
+                else
+                {
+                    return VisitLessThan(left, right, original, data);
+                }
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                if (Domain.IsBottom)
+                {
+                    return data.Bottom;
+                }
+
+                // First try: discharge constants
+                var intervalsOutcome = this.Domain.Right.CheckIfLessEqualThan(left, right);
+                if (!intervalsOutcome.IsTop)
+                {
+                    return intervalsOutcome;
+                }
+
+                var decoder = ExpressionManager.Decoder;
+
+                if ((decoder.VariablesIn(left).IsSingleton && decoder.IsConstant(right))
+                  || (decoder.VariablesIn(right).IsSingleton && decoder.IsConstant(left)))
+                {
+                    return Domain.Left.BoundsInference(Domain.Right, SubPolyhedra.Algorithm, SubPolyhedra.MaxVariablesToRunSimplex).CheckIfLessEqualThan(left, right);
+                }
+
+                var encoder = ExpressionManager.Encoder;
+
+                var beta = Domain.ExpressionManager.Encoder.FreshVariable<int>();
+
+                Polynomial<Variable, Expression> polBeta;
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(encoder.CompoundExpressionFor(ExpressionType.Int32,
+                  ExpressionOperator.Subtraction,
+                    encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right),
+                    encoder.VariableFor(beta)),
+                    Domain.ExpressionManager.Decoder, out polBeta))
+                {
+                    // F: we are not closing applying the reduction here
+                    var intvLeft = this.Domain.BoundsFor(left);
+                    var intvRight = this.Domain.BoundsFor(right);
+
+                    if (intvLeft.IsNormal && intvRight.IsNormal)
+                    {
+                        return intvLeft.UpperBound <= intvRight.LowerBound ? CheckOutcome.True : CheckOutcome.Top;
+                    }
+
+                    return CheckOutcome.Top;
+                }
+
+                if (!polBeta.IsLinear)
+                {
+                    return CheckOutcome.Top;
+                }
+
+                var enlarged = Domain.DuplicateMe();
+                enlarged.Left.AddConstraint(enlarged.Left.AsVector(polBeta));
+                enlarged = enlarged.ReduceInternal(enlarged.Left, enlarged.Right, false);
+
+                var intv = enlarged.Right.BoundsFor(beta);
+                return intv.IsNormal && intv.UpperBound <= 0 ? CheckOutcome.True : CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+            {
+                if (Domain.IsBottom)
+                {
+                    return data.Bottom;
+                }
+
+                // First try: discharge constants
+                var intervalsOutcome = this.Domain.Right.CheckIfLessThan(left, right);
+                if (!intervalsOutcome.IsTop)
+                {
+                    return intervalsOutcome;
+                }
+
+                var decoder = ExpressionManager.Decoder;
+
+                if ((decoder.VariablesIn(left).IsSingleton && decoder.IsConstant(right))
+                  || (decoder.VariablesIn(right).IsSingleton && decoder.IsConstant(left)))
+                {
+                    return Domain.Left.BoundsInference(Domain.Right, SubPolyhedra.Algorithm, SubPolyhedra.MaxVariablesToRunSimplex).CheckIfLessThan(left, right);
+                }
+
+                var beta = Domain.ExpressionManager.Encoder.FreshVariable<int>();
+
+                var encoder = ExpressionManager.Encoder;
+
+                Polynomial<Variable, Expression> polBeta;
+
+                if (!Polynomial<Variable, Expression>.TryToPolynomialForm(encoder.CompoundExpressionFor(ExpressionType.Int32,
+                  ExpressionOperator.Subtraction,
+                    encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right),
+                    encoder.VariableFor(beta)),
+                    Domain.ExpressionManager.Decoder, out polBeta))
+                {
+                    // F: we are not closing applying the reduction here
+                    var intvLeft = this.Domain.BoundsFor(left);
+                    var intvRight = this.Domain.BoundsFor(right);
+
+                    if (intvLeft.IsNormal && intvRight.IsNormal)
+                    {
+                        return intvLeft.UpperBound < intvRight.LowerBound ? CheckOutcome.True : CheckOutcome.Top;
+                    }
+
+                    return CheckOutcome.Top;
+                }
+
+                if (!polBeta.IsLinear)
+                {
+                    return CheckOutcome.Top;
+                }
+
+                var enlarged = Domain.DuplicateMe();
+                enlarged.Left.AddConstraint(enlarged.Left.AsVector(polBeta));
+                enlarged = enlarged.ReduceInternal(enlarged.Left, enlarged.Right, false);
+
+                var intv = enlarged.Right.BoundsFor(beta);
+
+                return intv.IsNormal && intv.UpperBound < 0 ? CheckOutcome.True : CheckOutcome.Top;
+            }
+
+            public override FlatAbstractDomain<bool> VisitConstant(Expression left, FlatAbstractDomain<bool> data)
+            {
+                if (Domain.IsBottom)
+                {
+                    return CheckOutcome.Bottom;
+                }
+
+                return Domain.Right.CheckIfHolds(left);
+            }
         }
 
-        if (pol.IsInconsistent)
-        {
-          return data.Bottom as SubPolyhedra<Variable, Expression>;
-        }
-
-        if (pol.Left.Length == 1)
-        {
-          var newIntv = data.Right.TestTrue(pol.ToPureExpression(encoder));
-          return new SubPolyhedra<Variable, Expression>(data, newIntv);
-        }
-
-        beta = encoder.FreshVariable<int>();
-        var mono = new Monomial<Variable>(beta);
-        mono.K = -mono.K;
-        
-        var newPolLeft = new List<Monomial<Variable>>(pol.Left);
-        newPolLeft.Add(mono);
-
-        Polynomial<Variable, Expression> eq;
-
-        if (Polynomial<Variable, Expression>.TryToPolynomialForm(newPolLeft.ToArray(), out eq))
-        {
-          data.Left.AddConstraint(data.Left.AsVector(eq));
-          data.betaDep[beta] = eq;
-          data.hints.Add(eq);
-        }
-        data.Right[beta] = Interval.For(Rational.MinusInfinity, pol.Right[0].K.IsInteger ? pol.Right[0].K - 1 : pol.Right[0].K);
-
-        return data;
-      }
-
+        #endregion
     }
 
-    private class SPTestFalseVisitor
-      : TestFalseVisitor<SubPolyhedra<Variable, Expression>, Variable, Expression>
+    internal class Hints<Variable, Expression>
     {
-      public SPTestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
-        : base(decoder)
-      {
-      }
+        private readonly List<Polynomial<Variable, Expression>> hints;
 
-      public override SubPolyhedra<Variable, Expression> VisitVariable(Variable variable, Expression original, SubPolyhedra<Variable, Expression> data)
-      {
-        var result = data.Factory(data.Left, data.Right.TestFalse(original)) as SubPolyhedra<Variable, Expression>;
+        public Hints()
+        {
+            hints = new List<Polynomial<Variable, Expression>>();
+        }
 
-        result.betaDep = new Dictionary<Variable, Polynomial<Variable, Expression>>(data.betaDep);
-        result.hints = new Hints<Variable, Expression>(data.hints);
-        
-        return result;
-      }
+        public Hints(Hints<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+            hints = new List<Polynomial<Variable, Expression>>(other.hints);
+        }
+
+        public Hints(IEnumerable<Polynomial<Variable, Expression>> others)
+        {
+            Contract.Requires(others != null);
+            hints = new List<Polynomial<Variable, Expression>>(others);
+        }
+
+        public int Count { get { return hints.Count; } }
+
+        public bool Contains(Polynomial<Variable, Expression> pol)
+        {
+            return hints.Contains(pol);
+        }
+
+        public IEnumerable<Polynomial<Variable, Expression>> Enumerate(int max = -1)
+        {
+            max = max < 0 ? SubPolyhedra.MaxHintsToRetainInWidening : max;
+
+            return hints.Take(max);
+        }
+
+        public void Add(Polynomial<Variable, Expression> hint)
+        {
+            hints.Add(hint);
+        }
+
+        public void Add(IEnumerable<Polynomial<Variable, Expression>> hints)
+        {
+            Contract.Requires(hints != null);
+
+            this.hints.AddRange(hints);
+        }
+
+        public void Add(Hints<Variable, Expression> other)
+        {
+            Contract.Requires(other != null);
+
+            hints.AddRange(other.hints);
+        }
+
+        public void Remove(Polynomial<Variable, Expression> p)
+        {
+            hints.Remove(p);
+        }
+
+        public void Clear()
+        {
+            hints.Clear();
+        }
+
+        public override string ToString()
+        {
+            return hints.ToString();
+        }
     }
-
-    private class SPCheckIfHoldsVisitor
-      : CheckIfHoldsVisitor<SubPolyhedra<Variable, Expression>, Variable, Expression>
-    {
-      private readonly ExpressionManagerWithEncoder<Variable, Expression> ExpressionManager;
-
-      public SPCheckIfHoldsVisitor(ExpressionManagerWithEncoder<Variable, Expression> expManager)
-        : base(expManager.Decoder)
-      {
-        Contract.Requires(expManager != null);
-
-        this.ExpressionManager = expManager;
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        if (Domain.IsBottom)
-        {
-          return data.Bottom;
-        }
-
-        var encoder = this.ExpressionManager.Encoder;
-        var decoder = this.ExpressionManager.Decoder;
-
-        if ((decoder.VariablesIn(left).IsSingleton && decoder.IsConstant(right))
-          || (decoder.VariablesIn(right).IsSingleton && decoder.IsConstant(left)))
-        {
-          return Domain.Left.BoundsInference(Domain.Right, SubPolyhedra.Algorithm, SubPolyhedra.MaxVariablesToRunSimplex).CheckIfHolds(encoder.CompoundExpressionFor(ExpressionType.Bool, ExpressionOperator.Equal, left, right));
-        }
-        
-        var beta = Domain.ExpressionManager.Encoder.FreshVariable<int>();
-
-        Polynomial<Variable, Expression> polBeta;
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(encoder.CompoundExpressionFor(ExpressionType.Int32,
-          ExpressionOperator.Subtraction,
-            encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right),
-            encoder.VariableFor(beta)),
-            Domain.ExpressionManager.Decoder, out polBeta))
-        {
-          return CheckOutcome.Top;
-        }
-
-        if (!polBeta.IsLinear)
-        {
-          return CheckOutcome.Top;
-        }
-
-        var enlarged = Domain.DuplicateMe();
-        enlarged.Left.AddConstraint(enlarged.Left.AsVector(polBeta));
-        enlarged = enlarged.ReduceInternal(enlarged.Left, enlarged.Right, false);
-
-        return enlarged.Right.BoundsFor(beta).IsSingleton && enlarged.Right.BoundsFor(beta).LowerBound.IsZero? 
-          CheckOutcome.True : 
-          CheckOutcome.Top;
-      }
-
-      public override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        return VisitEqual(left, right, original, data);
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        // We check if one of the two operands is a constant because of the polymorphic behavior of constants with *_un
-        if (Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(left)) || Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(right)))
-        {
-          var c1 = Domain.Left.CheckIfLessEqualThan_Un(left, right);
-          var c2 = Domain.Right.CheckIfLessEqualThan_Un(left, right);
-
-          return c1.Meet(c2);
-        }
-        else
-        {
-          return VisitLessEqualThan(left, right, original, data);
-        }
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan_Un(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        // We check if one of the two operands is a constant because of the polymorphic behavior of constants with *_un
-        if (Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(left)) || Domain.ExpressionManager.Decoder.IsConstant(Decoder.Stripped(right)))
-        {
-          var c1 = Domain.Left.CheckIfLessThan_Un(left, right);
-          var c2 = Domain.Right.CheckIfLessThan_Un(left, right);
-
-          return c1.Meet(c2);
-        }
-        else
-        {
-          return VisitLessThan(left, right, original, data);
-        }
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        if (Domain.IsBottom)
-        {
-          return data.Bottom;
-        }
-
-        // First try: discharge constants
-        var intervalsOutcome = this.Domain.Right.CheckIfLessEqualThan(left, right);
-        if (!intervalsOutcome.IsTop)
-        {
-          return intervalsOutcome;
-        }
-
-        var decoder = this.ExpressionManager.Decoder;
-
-        if ((decoder.VariablesIn(left).IsSingleton && decoder.IsConstant(right))
-          || (decoder.VariablesIn(right).IsSingleton && decoder.IsConstant(left)))
-        {
-          return Domain.Left.BoundsInference(Domain.Right, SubPolyhedra.Algorithm, SubPolyhedra.MaxVariablesToRunSimplex).CheckIfLessEqualThan(left, right);
-        }
-
-        var encoder = this.ExpressionManager.Encoder;
-
-        var beta = Domain.ExpressionManager.Encoder.FreshVariable<int>();
-
-        Polynomial<Variable, Expression> polBeta;
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(encoder.CompoundExpressionFor(ExpressionType.Int32,
-          ExpressionOperator.Subtraction,
-            encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right), 
-            encoder.VariableFor(beta)),
-            Domain.ExpressionManager.Decoder, out polBeta))
-        {
-          // F: we are not closing applying the reduction here
-          var intvLeft = this.Domain.BoundsFor(left);
-          var intvRight = this.Domain.BoundsFor(right);
-
-          if (intvLeft.IsNormal && intvRight.IsNormal)
-          {
-            return intvLeft.UpperBound <= intvRight.LowerBound ? CheckOutcome.True : CheckOutcome.Top;
-          }
-
-          return CheckOutcome.Top;
-        }
-
-        if (!polBeta.IsLinear)
-        {
-          return CheckOutcome.Top;
-        }
-
-        var enlarged = Domain.DuplicateMe();
-        enlarged.Left.AddConstraint(enlarged.Left.AsVector(polBeta));
-        enlarged = enlarged.ReduceInternal(enlarged.Left, enlarged.Right, false);
-        
-        var intv = enlarged.Right.BoundsFor(beta);
-        return intv.IsNormal && intv.UpperBound <= 0 ? CheckOutcome.True : CheckOutcome.Top;
-      }
-
-      public override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-      {
-        if (Domain.IsBottom)
-        {
-          return data.Bottom;
-        }
-
-        // First try: discharge constants
-        var intervalsOutcome = this.Domain.Right.CheckIfLessThan(left, right);
-        if (!intervalsOutcome.IsTop)
-        {
-          return intervalsOutcome;
-        }
-
-        var decoder = this.ExpressionManager.Decoder;
-
-        if ((decoder.VariablesIn(left).IsSingleton && decoder.IsConstant(right))
-          || (decoder.VariablesIn(right).IsSingleton && decoder.IsConstant(left)))
-        {
-          return Domain.Left.BoundsInference(Domain.Right, SubPolyhedra.Algorithm, SubPolyhedra.MaxVariablesToRunSimplex).CheckIfLessThan(left, right);
-        }
-
-        var beta = Domain.ExpressionManager.Encoder.FreshVariable<int>();
-
-        var encoder = this.ExpressionManager.Encoder;
-
-        Polynomial<Variable, Expression> polBeta;
-        
-        if (!Polynomial<Variable, Expression>.TryToPolynomialForm(encoder.CompoundExpressionFor(ExpressionType.Int32,
-          ExpressionOperator.Subtraction,
-            encoder.CompoundExpressionFor(ExpressionType.Int32, ExpressionOperator.Subtraction, left, right), 
-            encoder.VariableFor(beta)),
-            Domain.ExpressionManager.Decoder, out polBeta))
-        {
-          // F: we are not closing applying the reduction here
-          var intvLeft = this.Domain.BoundsFor(left);
-          var intvRight = this.Domain.BoundsFor(right);
-
-          if (intvLeft.IsNormal && intvRight.IsNormal)
-          {
-            return intvLeft.UpperBound < intvRight.LowerBound ? CheckOutcome.True : CheckOutcome.Top;
-          }
-
-          return CheckOutcome.Top;
-        }
-
-        if (!polBeta.IsLinear)
-        {
-          return CheckOutcome.Top;
-        }
-
-        var enlarged = Domain.DuplicateMe();
-        enlarged.Left.AddConstraint(enlarged.Left.AsVector(polBeta));
-        enlarged = enlarged.ReduceInternal(enlarged.Left, enlarged.Right, false);
-
-        var intv = enlarged.Right.BoundsFor(beta);
-
-        return intv.IsNormal && intv.UpperBound < 0 ? CheckOutcome.True: CheckOutcome.Top;
-      }
-
-      public override FlatAbstractDomain<bool> VisitConstant(Expression left, FlatAbstractDomain<bool> data)
-      {
-        if (Domain.IsBottom)
-        {
-          return CheckOutcome.Bottom;
-        }
-
-        return Domain.Right.CheckIfHolds(left);
-      }
-    }
-
-    #endregion
-  }
-
-  internal class Hints<Variable, Expression>
-  {
-    private readonly List<Polynomial<Variable, Expression>> hints;
-
-    public Hints()
-    {
-      this.hints = new List<Polynomial<Variable, Expression>>();
-    }
-
-    public Hints(Hints<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-      this.hints = new List<Polynomial<Variable, Expression>>(other.hints);
-    }
-
-    public Hints(IEnumerable<Polynomial<Variable, Expression>> others)
-    {
-      Contract.Requires(others != null);
-      this.hints = new List<Polynomial<Variable, Expression>>(others);
-    }
-
-    public int Count { get { return this.hints.Count; } }
-
-    public bool Contains(Polynomial<Variable, Expression> pol)
-    {
-      return this.hints.Contains(pol);
-    }
-
-    public IEnumerable<Polynomial<Variable, Expression>> Enumerate(int max = -1)
-    {
-      max = max < 0 ? SubPolyhedra.MaxHintsToRetainInWidening : max;
-
-      return this.hints.Take(max);
-    }
-
-    public void Add(Polynomial<Variable, Expression> hint)
-    {
-      this.hints.Add(hint);
-    }
-
-    public void Add(IEnumerable<Polynomial<Variable, Expression>> hints)
-    {
-      Contract.Requires(hints != null);
-
-      this.hints.AddRange(hints);
-    }
-
-    public void Add(Hints<Variable, Expression> other)
-    {
-      Contract.Requires(other != null);
-
-      this.hints.AddRange(other.hints);
-    }
-
-    public void Remove(Polynomial<Variable, Expression> p)
-    {
-      this.hints.Remove(p);
-    }
-
-    public void Clear()
-    {
-      this.hints.Clear();
-    }
- 
-    public override string ToString()
-    {
-      return this.hints.ToString();
-    }
-
-  }
-
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Thresholds.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/Thresholds.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The Interface and the implementation for ints of the thresholds to be used to improved the precision of widenings
 
@@ -24,468 +13,468 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  /// <summary>
-  /// A threshold gives some "points" where to jump during widening
-  /// </summary>
-  interface IThreshold<Type>
-  {
-    void Add(Type threshold);
-    Type GetNext(Type aValue);
-    Type GetPrevious(Type aValue);
-    Type[] ToArray();
-  }
-
-  public class SimpleThreshold
-  {
-    [ThreadStatic]
-    protected static List<int> userProvided;
-
-    protected SimpleThreshold()
-    {
-    }
-
-    static public List<int> UserProvided
-    {
-      get
-      {
-        if (userProvided == null)
-          userProvided = new List<int>();
-        return userProvided;
-      }
-      set
-      {
-        userProvided = value;
-      }
-    }  
-  }
-
-  abstract public class SimpleThreshold<Type> :
-    SimpleThreshold,
-    IThreshold<Type>
-  {
-    #region Constants
-    protected const int DEFAULT_SIZE = 10;
-    #endregion
-
-    #region Private state
-
-    protected int nextFree;           // The pointer to the first free position in the array
-    protected readonly Type[] values;
- 
-    #endregion
-
-    #region Protected State
-    protected SimpleThreshold(int size)
-    {
-      Contract.Requires(size > 5);
-
-      this.values = new Type[size];
-
-      this.values[0] = this.MinusInfinity;
-      this.values[1] = this.Zero;
-      this.values[2] = this.PlusInfinity;
-
-      this.nextFree = 3;
-
-      var converted = UserProvided.ConvertAll<Type>(this.From);
-
-      this.AddRange(converted);
-    }
-    #endregion
-
-    #region To be implemented by the subclasses
-
-    [Pure]
-    abstract protected bool LessThan(Type t1, Type t2);
-
-    abstract protected Type From(int x);
-
-    abstract protected Type MinusInfinity
-    {
-      get;
-    }
-
-    abstract protected Type PlusInfinity
-    {
-      get;
-    }
-
-    abstract protected Type Zero
-    {
-      get;
-    }
-
-    #endregion
-
-    #region Public methods
     /// <summary>
-    /// Add the threshold to our list.
+    /// A threshold gives some "points" where to jump during widening
     /// </summary>
-    /// <param name="threshold"></param>
-    public void Add(Type threshold)
+    internal interface IThreshold<Type>
     {
-      // TODO4: a better policy, for elimitaning the thresholds that are too close
-
-      if (this.nextFree == this.values.Length)     // no more space, give up...
-        return;
-
-      int i = 0;
-      for (; i < this.nextFree && LessThan(this.values[i], threshold); i++)     // search for the right position for the threshold
-        ;
-
-      if (this.values[i].Equals(threshold))        // Is the threshold already there?
-        return;
-
-      int j;
-      for (j = this.nextFree; i < j; j--)     // Move all the elements one position on the right
-        this.values[j] = this.values[j - 1];
-
-      this.values[i] = threshold;
-      this.nextFree++;
+        void Add(Type threshold);
+        Type GetNext(Type aValue);
+        Type GetPrevious(Type aValue);
+        Type[] ToArray();
     }
 
-    public void AddRange(IEnumerable<Type> from)
+    public class SimpleThreshold
     {
-      foreach (var x in from)
-      {
-        this.Add(x);
-      }
+        [ThreadStatic]
+        protected static List<int> userProvided;
+
+        protected SimpleThreshold()
+        {
+        }
+
+        static public List<int> UserProvided
+        {
+            get
+            {
+                if (userProvided == null)
+                    userProvided = new List<int>();
+                return userProvided;
+            }
+            set
+            {
+                userProvided = value;
+            }
+        }
     }
 
-    #endregion
-
-    #region IThreshold<Type, Type> Members
-
-    public int Length
+    abstract public class SimpleThreshold<Type> :
+      SimpleThreshold,
+      IThreshold<Type>
     {
-      get
-      {
-        return this.values.Length;
-      }
+        #region Constants
+        protected const int DEFAULT_SIZE = 10;
+        #endregion
+
+        #region Private state
+
+        protected int nextFree;           // The pointer to the first free position in the array
+        protected readonly Type[] values;
+
+        #endregion
+
+        #region Protected State
+        protected SimpleThreshold(int size)
+        {
+            Contract.Requires(size > 5);
+
+            this.values = new Type[size];
+
+            this.values[0] = this.MinusInfinity;
+            this.values[1] = this.Zero;
+            this.values[2] = this.PlusInfinity;
+
+            this.nextFree = 3;
+
+            var converted = UserProvided.ConvertAll<Type>(this.From);
+
+            this.AddRange(converted);
+        }
+        #endregion
+
+        #region To be implemented by the subclasses
+
+        [Pure]
+        abstract protected bool LessThan(Type t1, Type t2);
+
+        abstract protected Type From(int x);
+
+        abstract protected Type MinusInfinity
+        {
+            get;
+        }
+
+        abstract protected Type PlusInfinity
+        {
+            get;
+        }
+
+        abstract protected Type Zero
+        {
+            get;
+        }
+
+        #endregion
+
+        #region Public methods
+        /// <summary>
+        /// Add the threshold to our list.
+        /// </summary>
+        /// <param name="threshold"></param>
+        public void Add(Type threshold)
+        {
+            // TODO4: a better policy, for elimitaning the thresholds that are too close
+
+            if (this.nextFree == this.values.Length)     // no more space, give up...
+                return;
+
+            int i = 0;
+            for (; i < this.nextFree && LessThan(this.values[i], threshold); i++)     // search for the right position for the threshold
+                ;
+
+            if (this.values[i].Equals(threshold))        // Is the threshold already there?
+                return;
+
+            int j;
+            for (j = this.nextFree; i < j; j--)     // Move all the elements one position on the right
+                this.values[j] = this.values[j - 1];
+
+            this.values[i] = threshold;
+            this.nextFree++;
+        }
+
+        public void AddRange(IEnumerable<Type> from)
+        {
+            foreach (var x in from)
+            {
+                this.Add(x);
+            }
+        }
+
+        #endregion
+
+        #region IThreshold<Type, Type> Members
+
+        public int Length
+        {
+            get
+            {
+                return this.values.Length;
+            }
+        }
+
+        /// <summary>
+        /// Get the smallest threshold larger than <code>aValue</code>
+        /// </summary>
+        public Type GetNext(Type aValue)
+        {
+            Contract.Assume(this.nextFree >= 1);
+
+            return BinarySearch(aValue, 0, this.nextFree - 1);
+        }
+
+        public Type GetPrevious(Type aValue)
+        {
+            for (int i = 0; i < this.nextFree; i++)
+            {
+                if (LessThan(aValue, this.values[i]))
+                {
+                    return this.values[i - 1];
+                }
+            }
+
+            return this.values[0];
+        }
+
+        public Type[] ToArray()
+        {
+            Type[] copy = new Type[this.values.Length];
+            Array.Copy(this.values, copy, this.values.Length);
+
+            return copy;
+        }
+
+        #endregion
+
+        #region Private methods (BinarySearch)
+        [Pure]
+        private Type BinarySearch(Type inputValue, int inf, int sup)
+        {
+            Contract.Requires(inf >= 0);
+            Contract.Requires(inf <= sup);
+
+            if (inf == sup)
+            {
+                return this.values[sup];
+            }
+            else
+            {
+                int halfWay = (sup + inf) / 2;
+
+                if (LessThan(inputValue, this.values[halfWay]))
+                {
+                    return BinarySearch(inputValue, inf, halfWay);
+                }
+                else if (LessThan(this.values[halfWay], inputValue))
+                {
+                    return BinarySearch(inputValue, halfWay + 1, sup);
+                }
+                else // if (this.values[halfWay] == inputvalue)
+                {
+                    return inputValue;
+                }
+            }
+        }
+        #endregion
+
+        #region Overridden
+        //^ [Confined]
+        public override string/*!*/ ToString()
+        {
+            var result = new StringBuilder();
+            var prev = this.MinusInfinity;
+
+            for (var i = 0; i < this.values.Length && LessThan(prev, this.values[i]); i++)
+            {
+                result.Append(this.values[i] + ", ");
+                prev = this.values[i];
+            }
+
+            if (result.Length >= 2)
+            {
+                result.Remove(result.Length - 2, 2);
+            }
+
+            return result.ToString();
+        }
+        #endregion
     }
 
     /// <summary>
-    /// Get the smallest threshold larger than <code>aValue</code>
+    /// The implementation for a threshold of ints.
+    /// It uses a static allocated array, so it cannot grow 
     /// </summary>
-    public Type GetNext(Type aValue)
-    {
-      Contract.Assume(this.nextFree >= 1);
-
-      return BinarySearch(aValue, 0, this.nextFree - 1);
-    }
-
-    public Type GetPrevious(Type aValue)
-    {
-      for (int i = 0; i < this.nextFree; i++)
-      {
-        if (LessThan(aValue, this.values[i]))
-        {
-          return this.values[i - 1];
-        }
-      }
-
-      return this.values[0];
-    }
-
-    public Type[] ToArray()
-    {
-      Type[] copy = new Type[this.values.Length];
-      Array.Copy(this.values, copy, this.values.Length);
-
-      return copy;
-    }
-
-    #endregion
-
-    #region Private methods (BinarySearch)
-    [Pure]
-    private Type BinarySearch(Type inputValue, int inf, int sup)
-    {
-      Contract.Requires(inf >= 0);
-      Contract.Requires(inf <= sup);
-
-      if (inf == sup)
-      {
-        return this.values[sup];
-      }
-      else
-      {
-        int halfWay = (sup + inf) / 2;
-
-        if (LessThan(inputValue, this.values[halfWay]))
-        {
-          return BinarySearch(inputValue, inf, halfWay);
-        }
-        else if (LessThan(this.values[halfWay], inputValue))
-        {
-          return BinarySearch(inputValue, halfWay + 1, sup);
-        }
-        else // if (this.values[halfWay] == inputvalue)
-        {
-          return inputValue;
-        }
-      }
-    }
-    #endregion
-
-    #region Overridden
-    //^ [Confined]
-    public override string/*!*/ ToString()
-    {
-      var result = new StringBuilder();
-      var prev = this.MinusInfinity;
-
-      for (var i = 0; i < this.values.Length && LessThan(prev, this.values[i]); i++)
-      {
-        result.Append(this.values[i] + ", ");
-        prev = this.values[i];
-      }
-
-      if (result.Length >= 2)
-      {
-        result.Remove(result.Length - 2, 2);
-      }
-
-      return result.ToString();
-    }
-    #endregion
-  }
-
-  /// <summary>
-  /// The implementation for a threshold of ints.
-  /// It uses a static allocated array, so it cannot grow 
-  /// </summary>
 #if SUBPOLY_ONLY
-  internal
+    internal
 #else
-  public
+    public
 #endif
  class SimpleRationalThreshold : SimpleThreshold<Rational>
-  {
-    #region Constructors
+    {
+        #region Constructors
+        /// <summary>
+        /// Construct a Threshold object of default size
+        /// </summary>
+        public SimpleRationalThreshold()
+          : this(DEFAULT_SIZE)
+        { }
+
+        /// <param name="size">must be > 2</param>
+        public SimpleRationalThreshold(int size)
+          : base(size)
+        {
+            Contract.Requires(size > 5);
+        }
+        #endregion
+
+        #region Implementation of Abstact methods
+        protected override bool LessThan(Rational t1, Rational t2)
+        {
+            return t1 < t2;
+        }
+
+        protected override Rational MinusInfinity
+        {
+            get { return Rational.MinusInfinity; }
+        }
+
+        protected override Rational PlusInfinity
+        {
+            get { return Rational.PlusInfinity; }
+        }
+
+        protected override Rational Zero
+        {
+            get { return Rational.For(0); }
+        }
+
+        protected override Rational From(int x)
+        {
+            return Rational.For(x);
+        }
+        #endregion
+    }
+
     /// <summary>
-    /// Construct a Threshold object of default size
+    /// The implementation for a threshold of ints.
+    /// It uses a static allocated array, so it cannot grow 
     /// </summary>
-    public SimpleRationalThreshold()
-      : this(DEFAULT_SIZE)
-    { }
-
-    /// <param name="size">must be > 2</param>
-    public SimpleRationalThreshold(int size)
-      : base(size)
-    {
-      Contract.Requires(size > 5);
-    } 
-    #endregion
-
-    #region Implementation of Abstact methods
-    protected override bool LessThan(Rational t1, Rational t2)
-    {
-      return t1 < t2;
-    }
-
-    protected override Rational MinusInfinity
-    {
-      get { return Rational.MinusInfinity; }
-    }
-
-    protected override Rational PlusInfinity
-    {
-      get { return Rational.PlusInfinity; }
-    }
-
-    protected override Rational Zero
-    {
-      get { return Rational.For(0); }
-    }
-
-    protected override Rational From(int x)
-    {
-      return Rational.For(x);
-    }
-    #endregion
-  }
-
-  /// <summary>
-  /// The implementation for a threshold of ints.
-  /// It uses a static allocated array, so it cannot grow 
-  /// </summary>
 #if SUBPOLY_ONLY
-  internal
+    internal
 #else
-  public
+    public
 #endif
  class SimpleDoubleThreshold : SimpleThreshold<Double>
-  {
-    #region Constructors
+    {
+        #region Constructors
+        /// <summary>
+        /// Construct a Threshold object of default size
+        /// </summary>
+        public SimpleDoubleThreshold()
+          : this(DEFAULT_SIZE)
+        { }
+
+        /// <param name="size">must be > 2</param>
+        public SimpleDoubleThreshold(int size)
+          : base(size)
+        {
+            Contract.Requires(size > 5);
+        }
+        #endregion
+
+        #region Implementation of Abstact methods
+        protected override bool LessThan(Double t1, Double t2)
+        {
+            return t1 < t2;
+        }
+
+        protected override double MinusInfinity
+        {
+            get { return Double.NegativeInfinity; }
+        }
+
+        protected override double PlusInfinity
+        {
+            get { return Double.PositiveInfinity; }
+        }
+
+        protected override double Zero
+        {
+            get { return 0.0; }
+        }
+
+        protected override double From(int x)
+        {
+            return (double)x;
+        }
+
+        #endregion
+    }
+
+
     /// <summary>
-    /// Construct a Threshold object of default size
+    /// The implementation for a threshold of ints.
+    /// It uses a static allocated array, so it cannot grow 
     /// </summary>
-    public SimpleDoubleThreshold()
-      : this(DEFAULT_SIZE)
-    { }
-
-    /// <param name="size">must be > 2</param>
-    public SimpleDoubleThreshold(int size)
-      : base(size)
-    {
-      Contract.Requires(size > 5);
-    }
-    #endregion
-
-    #region Implementation of Abstact methods
-    protected override bool LessThan(Double t1, Double t2)
-    {
-      return t1 < t2;
-    }
-
-    protected override double MinusInfinity
-    {
-      get { return Double.NegativeInfinity; }
-    }
-
-    protected override double PlusInfinity
-    {
-      get { return Double.PositiveInfinity; }
-    }
-
-    protected override double Zero
-    {
-      get { return 0.0;  }
-    }
-
-    protected override double From(int x)
-    {
-      return (double) x;
-    }
-
-    #endregion
-  }
-
-
-  /// <summary>
-  /// The implementation for a threshold of ints.
-  /// It uses a static allocated array, so it cannot grow 
-  /// </summary>
 #if SUBPOLY_ONLY
-  internal
+    internal
 #else
-  public
+    public
 #endif
  class IntThreshold : SimpleThreshold<Int32>
-  {
-    #region Constructors
+    {
+        #region Constructors
+        /// <summary>
+        /// Construct a Threshold object of default size
+        /// </summary>
+        public IntThreshold()
+          : this(DEFAULT_SIZE)
+        { }
+
+        /// <param name="size">must be > 2</param>
+        public IntThreshold(int size)
+          : base(size)
+        {
+        }
+        #endregion
+
+        #region Overridden
+
+        protected override bool LessThan(int t1, int t2)
+        {
+            return t1 < t2;
+        }
+
+        protected override int MinusInfinity
+        {
+            get { return Int32.MinValue; }
+        }
+
+        protected override int PlusInfinity
+        {
+            get { return Int32.MaxValue; }
+        }
+
+        protected override int Zero
+        {
+            get { return 0; }
+        }
+
+        protected override int From(int x)
+        {
+            return x;
+        }
+        #endregion
+    }
+
+
     /// <summary>
-    /// Construct a Threshold object of default size
+    /// A database that contains some thresholds using for the analysis
     /// </summary>
-    public IntThreshold()
-      : this(DEFAULT_SIZE)
-    { }
-
-    /// <param name="size">must be > 2</param>
-    public IntThreshold(int size)
-      : base(size)
-    {
-    }
-    #endregion
-
-    #region Overridden
-
-    protected override bool LessThan(int t1, int t2)
-    {
-      return t1 < t2;
-    }
-
-    protected override int MinusInfinity
-    {
-      get { return Int32.MinValue; }
-    }
-
-    protected override int PlusInfinity
-    {
-      get { return Int32.MaxValue; }
-    }
-
-    protected override int Zero
-    {
-      get { return 0; }
-    }
-
-    protected override int From(int x)
-    {
-      return x;
-    }
-    #endregion
-  }
-
-
-  /// <summary>
-  /// A database that contains some thresholds using for the analysis
-  /// </summary>
 #if SUBPOLY_ONLY
-  internal
+    internal
 #else
-  public 
+    public
 #endif
     static class ThresholdDB
-  {
-    // [ThreadStatic]
-    static private SimpleRationalThreshold thresholds_Rational;
-    // [ThreadStatic]
-    static private SimpleDoubleThreshold thresholds_Double;
-
-    // Reset always called before these fields are used?
-    public static void Reset()
     {
-      thresholds_Rational = new SimpleRationalThreshold();
-      thresholds_Double = new SimpleDoubleThreshold();
+        // [ThreadStatic]
+        static private SimpleRationalThreshold thresholds_Rational;
+        // [ThreadStatic]
+        static private SimpleDoubleThreshold thresholds_Double;
+
+        // Reset always called before these fields are used?
+        public static void Reset()
+        {
+            thresholds_Rational = new SimpleRationalThreshold();
+            thresholds_Double = new SimpleDoubleThreshold();
+        }
+
+        public static void Add(List<int> values)
+        {
+            foreach (var val in values)
+            {
+                thresholds_Rational.Add(Rational.For(val));
+            }
+        }
+
+        public static void Add(Double val)
+        {
+            thresholds_Double.Add(val);
+        }
+
+        public static Rational GetNext(Rational v)
+        {
+            Contract.Requires(((object)v) != null);
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            var tmp = thresholds_Rational.GetNext(v);
+
+            Contract.Assume(((object)tmp) != null);
+
+            return tmp;
+        }
+
+        public static Double GetNext(Double v)
+        {
+            return thresholds_Double.GetNext(v);
+        }
+
+        public static Rational GetPrevious(Rational v)
+        {
+            Contract.Requires(((object)v) != null);
+            Contract.Ensures(((object)Contract.Result<Rational>()) != null);
+
+            var tmp = thresholds_Rational.GetPrevious(v);
+
+            Contract.Assume(((object)tmp) != null);
+
+            return tmp;
+        }
+
+        public static Double GetPrevious(Double v)
+        {
+            return thresholds_Double.GetPrevious(v);
+        }
     }
-
-    public static void Add(List<int> values)
-    {
-      foreach (var val in values)
-      {
-        thresholds_Rational.Add(Rational.For(val));
-      }
-    }
-
-    public static void Add(Double val)
-    {
-      thresholds_Double.Add(val);
-    }
-
-    public static Rational GetNext(Rational v)
-    {
-      Contract.Requires(((object)v) != null);
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-
-      var tmp = thresholds_Rational.GetNext(v);
-
-      Contract.Assume(((object)tmp) != null);
-
-      return tmp;
-    }
-
-    public static Double GetNext(Double v)
-    {
-      return thresholds_Double.GetNext(v);
-    }
-
-    public static Rational GetPrevious(Rational v)
-    {
-      Contract.Requires(((object)v) != null);
-      Contract.Ensures(((object)Contract.Result<Rational>()) != null);
-      
-      var tmp =  thresholds_Rational.GetPrevious(v);
-
-      Contract.Assume(((object)tmp) != null);
-
-      return tmp;
-    }
-
-    public static Double GetPrevious(Double v)
-    {
-      return thresholds_Double.GetPrevious(v);
-    }
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/TopNumericalDomain.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/TopNumericalDomain.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,446 +10,446 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// A numerical abstract domain that does nothing
-  /// </summary>  
-  [ContractVerification(true)]
-  public class TopNumericalDomain<Variable, Expression> : 
-    INumericalAbstractDomain<Variable, Expression>,
-    IIntervalAbstraction<Variable, Expression>
-  {
-    #region Private static state
-    static private TopNumericalDomain<Variable, Expression> cached;
-    #endregion
-
-
     /// <summary>
-    /// The only instance of the TopNumericalDomain
-    /// </summary>
-    public static TopNumericalDomain<Variable, Expression> Singleton
+    /// A numerical abstract domain that does nothing
+    /// </summary>  
+    [ContractVerification(true)]
+    public class TopNumericalDomain<Variable, Expression> :
+      INumericalAbstractDomain<Variable, Expression>,
+      IIntervalAbstraction<Variable, Expression>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<TopNumericalDomain<Variable, Expression>>() != null);
+        #region Private static state
+        static private TopNumericalDomain<Variable, Expression> cached;
+        #endregion
 
-        if (cached == null)
+
+        /// <summary>
+        /// The only instance of the TopNumericalDomain
+        /// </summary>
+        public static TopNumericalDomain<Variable, Expression> Singleton
         {
-          cached = new TopNumericalDomain<Variable, Expression>();
+            get
+            {
+                Contract.Ensures(Contract.Result<TopNumericalDomain<Variable, Expression>>() != null);
+
+                if (cached == null)
+                {
+                    cached = new TopNumericalDomain<Variable, Expression>();
+                }
+
+                return cached;
+            }
         }
 
-        return cached;
-      }
-    }
-
-    #region Private constructor
-    private TopNumericalDomain()
-    {
-      // do nothing
-    }
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression>Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> c)
-    {
-    }
-
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      // does nothing
-    }
-
-    virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      return this;
-    }
-
-    public DisInterval BoundsFor(Expression v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      return DisInterval.UnknownInterval;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
-    {
-      return CheckOutcome.Top;
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get { return false;  }
-    }
-
-    public bool IsTop
-    {
-      get { return true;  }
-    }
-
-    public bool LessEqual(IAbstractDomain a)
-    {
-      return a == this;
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get { return this; }
-    }
-
-    public IAbstractDomain Top
-    {
-      get { return this; }
-    }
-
-    public IAbstractDomain Join(IAbstractDomain a)
-    {
-      return this;
-    }
-
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      return this;
-    }
-
-    public IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      return this;
-    }
-
-    public T To<T>(IFactory<T> factory)
-    {
-      return factory.Constant(true);
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      return this;
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignmentsWithForward<Expression> Members
-
-    public void Assign(Expression x, Expression exp)
-    {
-      // do nothing
-    }
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      // do nothing
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get { return new List<Variable>(); }
-    }
-
-    public void AddVariable(Variable var)
-    { 
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      return this;
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression/*!*/ exp)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
-    {
-      return this;
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression/*!*/ exp1, Expression/*!*/ exp2)
-    {
-      return this;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      return CheckOutcome.Top;
-    }
-
-    #endregion
+        #region Private constructor
+        private TopNumericalDomain()
+        {
+            // do nothing
+        }
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression>Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> c)
+        {
+        }
+
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            // does nothing
+        }
+
+        virtual public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            return this;
+        }
+
+        public DisInterval BoundsFor(Expression v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            return DisInterval.UnknownInterval;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression exp)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
+        {
+            return CheckOutcome.Top;
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        public bool IsBottom
+        {
+            get { return false; }
+        }
+
+        public bool IsTop
+        {
+            get { return true; }
+        }
 
-    #region To
+        public bool LessEqual(IAbstractDomain a)
+        {
+            return a == this;
+        }
+
+        public IAbstractDomain Bottom
+        {
+            get { return this; }
+        }
+
+        public IAbstractDomain Top
+        {
+            get { return this; }
+        }
+
+        public IAbstractDomain Join(IAbstractDomain a)
+        {
+            return this;
+        }
+
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            return this;
+        }
+
+        public IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            return this;
+        }
+
+        public T To<T>(IFactory<T> factory)
+        {
+            return factory.Constant(true);
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            return this;
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignmentsWithForward<Expression> Members
+
+        public void Assign(Expression x, Expression exp)
+        {
+            // do nothing
+        }
+
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            // do nothing
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        public List<Variable> Variables
+        {
+            get { return new List<Variable>(); }
+        }
+
+        public void AddVariable(Variable var)
+        {
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            return this;
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression/*!*/ exp)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
+        {
+            return this;
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression/*!*/ exp1, Expression/*!*/ exp2)
+        {
+            return this;
+        }
 
-    public string ToString(Expression exp)
-    {
-      return "< missing expression decoder >";
-    }
-
-    public override string ToString()
-    {
-      return "TopAD";
-    }
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression>Members
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return new List<Pair<Variable, Int32>>();
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      yield break; //not implemented
-    }
+        public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression/*!*/ exp1, Expression/*!*/ exp2)
+        {
+            return this;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            return CheckOutcome.Top;
+        }
 
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      yield break; //not implemented
-    }
-
-    #endregion
+        #endregion
 
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
+        #region To
 
-    public Variable ToVariable(Expression exp)
-    {
-      // This abstract domain knows nothing, not even how to read the variable underlying an expression
-      return default(Variable);
-    }
+        public string ToString(Expression exp)
+        {
+            return "< missing expression decoder >";
+        }
 
-    #endregion
+        public override string ToString()
+        {
+            return "TopAD";
+        }
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression>Members
 
-    #region Floating point types
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                return new List<Pair<Variable, Int32>>();
+            }
+        }
 
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            yield break; //not implemented
+        }
 
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            yield break; //not implemented
+        }
 
-    #endregion
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
 
-    #region IIntervalAbstraction<Variable,Expression> Members
+        public Variable ToVariable(Expression exp)
+        {
+            // This abstract domain knows nothing, not even how to read the variable underlying an expression
+            return default(Variable);
+        }
+
+        #endregion
 
-    bool IIntervalAbstraction<Variable, Expression>.LessEqual(IIntervalAbstraction<Variable, Expression> other)
-    {
-      return this.LessEqual(other);
-    }
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
+
+        #region IIntervalAbstraction<Variable,Expression> Members
+
+        bool IIntervalAbstraction<Variable, Expression>.LessEqual(IIntervalAbstraction<Variable, Expression> other)
+        {
+            return this.LessEqual(other);
+        }
+
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Join(IIntervalAbstraction<Variable, Expression> other)
+        {
+            var result = this.Join(other) as IIntervalAbstraction<Variable, Expression>;
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Join(IIntervalAbstraction<Variable, Expression> other)
-    {
-      var result = this.Join(other) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Widening(IIntervalAbstraction<Variable, Expression> other)
+        {
+            var result = this.Widening(other) as IIntervalAbstraction<Variable, Expression>;
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.Widening(IIntervalAbstraction<Variable, Expression> other)
-    {
-      var result = this.Widening(other) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        List<Pair<Variable, Int32>> IIntervalAbstraction<Variable, Expression>.IntConstants
+        {
+            get { return new List<Pair<Variable, Int32>>(); }
+        }
 
-    List<Pair<Variable, Int32>> IIntervalAbstraction<Variable, Expression>.IntConstants
-    {
-      get { return new List<Pair<Variable, Int32>>(); }
-    }
+        void IIntervalAbstraction<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            this.AssumeInDisInterval(x, value);
+        }
 
-    void IIntervalAbstraction<Variable, Expression>.AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      this.AssumeInDisInterval(x, value);
-    }
+        void IIntervalAbstraction<Variable, Expression>.Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            this.Assign(x, exp, preState);
+        }
 
-    void IIntervalAbstraction<Variable, Expression>.Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      this.Assign(x, exp, preState);
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            var result = this.RemoveRedundanciesWith(oracle) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      var result =  this.RemoveRedundanciesWith(oracle) as IIntervalAbstraction<Variable, Expression>;
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrue(Expression exp)
+        {
+            var result = this.TestTrue(exp) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrue(Expression exp)
-    {
-      var result = this.TestTrue(exp) as IIntervalAbstraction<Variable, Expression>;
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestFalse(Expression exp)
+        {
+            var result = this.TestFalse(exp) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestFalse(Expression exp)
-    {
-      var result = this.TestFalse(exp) as IIntervalAbstraction<Variable, Expression>;
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            var result = this.TestTrueLessThan(exp1, exp2) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      var result = this.TestTrueLessThan(exp1, exp2) as IIntervalAbstraction<Variable, Expression>;
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Variable v1, Variable v2)
+        {
+            return this;
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessThan(Variable v1, Variable v2)
-    {
-      return this;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            var result = this.TestTrueLessEqualThan(exp1, exp2) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      var result = this.TestTrueLessEqualThan(exp1, exp2) as IIntervalAbstraction<Variable, Expression>;
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Variable v1, Variable v2)
+        {
+            return this;
+        }
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueLessEqualThan(Variable v1, Variable v2)
-    {
-      return this;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            var result = this.TestTrueEqual(exp1, exp2) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      var result = this.TestTrueEqual(exp1, exp2) as IIntervalAbstraction<Variable, Expression>;
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
-    }
+        IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueGeqZero(Expression exp)
+        {
+            var result = this.TestTrueGeqZero(exp) as IIntervalAbstraction<Variable, Expression>;
+            Contract.Assume(result != null);
 
-    IIntervalAbstraction<Variable, Expression> IIntervalAbstraction<Variable, Expression>.TestTrueGeqZero(Expression exp)
-    {
-      var result = this.TestTrueGeqZero(exp) as IIntervalAbstraction<Variable, Expression>;
-      Contract.Assume(result != null);
+            return result;
+        }
 
-      return result;
+        #endregion
     }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/TracePartitioning.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Numerical/TracePartitioning.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,722 +10,721 @@ using Microsoft.Research.CodeAnalysis;
 
 namespace Microsoft.Research.AbstractDomains.Numerical
 {
-  /// <summary>
-  /// We keep a bounded disjunction of abstract domains
-  /// </summary>
-  public class BoundedDisjunction<Variable, Expression>
-    : INumericalAbstractDomain<Variable, Expression>
-  {
-    #region Private state
-    private readonly int MaxDisjuncts = 8; // TODO Want to make it a command line option
-    private INumericalAbstractDomain<Variable, Expression>[] disjuncts;
-
-    private INumericalAbstractDomain<Variable, Expression>FirstDisjunct
-    {
-      get
-      {
-        return this.disjuncts[0];
-      }
-    }
-
-    #endregion
-
-    #region Constructor
-
-    public BoundedDisjunction(INumericalAbstractDomain<Variable, Expression> initial)
-    {
-      this.disjuncts = new INumericalAbstractDomain<Variable, Expression>[1];
-      this.disjuncts[0] = initial;
-    }
-
-    private BoundedDisjunction(INumericalAbstractDomain<Variable, Expression>[] domains)
-    {
-      if (domains.Length <= MaxDisjuncts)
-      {
-        this.disjuncts = domains;
-      }
-      else
-      {
-        this.disjuncts = new INumericalAbstractDomain<Variable, Expression>[1] { SmashTogether(domains) };
-      }
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomain<Variable, Expression>Members
-
-    public DisInterval BoundsFor(Expression v)
-    {
-      var result = FirstDisjunct.BoundsFor(v);
-
-      for (int i = 1; i < this.disjuncts.Length; i++)
-      {
-        result = (DisInterval)result.Join(this.disjuncts[i].BoundsFor(v));
-      }
-
-      return result;
-    }
-
-    public DisInterval BoundsFor(Variable v)
-    {
-      var result = FirstDisjunct.BoundsFor(v);
-
-      for (int i = 1; i < this.disjuncts.Length; i++)
-      {
-        result = (DisInterval)result.Join(this.disjuncts[i].BoundsFor(v));
-      }
-
-      return result;
-    }
-
-    public List<Pair<Variable, Int32>> IntConstants
-    {
-      get
-      {
-        return new List<Pair<Variable, Int32>>();
-      }
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
-    {
-      yield break; //not implemented
-    }
-
-    public IEnumerable<Variable> EqualitiesFor(Variable v)
-    {
-      yield break; //not implemented
-    }
-
-    public void AssumeInDisInterval(Variable x, DisInterval value)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].AssumeInDisInterval(x, value);
-      }
-    }
-
-    public void AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].AssumeDomainSpecificFact(fact);
-      }
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
-    {
-      var result = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result[i] = this.disjuncts[i].TestTrueGeqZero(exp);
-      }
-
-      return new BoundedDisjunction<Variable, Expression>(result);
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
-    {
-      var result = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result[i] = this.disjuncts[i].TestTrueLessThan(exp1, exp2);
-      }
-
-      return new  BoundedDisjunction<Variable, Expression>(result);
-    }      
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
-    {
-      var result = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result[i] = this.disjuncts[i].TestTrueLessEqualThan(exp1, exp2);
-      }
-
-      return new  BoundedDisjunction<Variable, Expression>(result);      
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
-    {
-      var result = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result[i] = this.disjuncts[i].TestTrueEqual(exp1, exp2);
-      }
-
-      return new BoundedDisjunction<Variable, Expression>(result);
-    }
-
-    public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
-    {
-      var result = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result[i] = this.disjuncts[i].RemoveRedundanciesWith(oracle);
-      }
-
-      return new BoundedDisjunction<Variable, Expression>(result);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfGreaterEqualThanZero(exp));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfLessThan(e1, e2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfLessThan_Un(e1, e2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfLessThan(v1, v2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
-    {
-      var result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfLessEqualThan(e1, e2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
-    {
-      var result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfLessThanIncomplete(e1, e2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfLessEqualThan_Un(e1, e2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfEqual(e1, e2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
-    {
-      return this.CheckIfEqual(e1, e2);
-    }
-
-    public FlatAbstractDomain<bool> CheckIfEqualThan(Expression e1, Expression e2)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfEqual(e1, e2));
-      }
-
-      return result;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
-    {
-      var result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfLessEqualThan(v1, v2));
-      }
-
-      return result;
-    }
-
-
-
-    public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result = result.Join(this.disjuncts[i].CheckIfNonZero(e));
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get 
-      {
-        for (int i = 0; i < this.disjuncts.Length; i++)
-        {
-          if (!this.disjuncts[i].IsBottom)
-          {
-            return false;
-          }
-        }
-        return true;
-      }
-    }
-
-    public bool IsTop
-    {
-      get 
-      {
-        for (int i = 0; i < this.disjuncts.Length; i++)
-        {
-          if (this.disjuncts[i].IsTop)
-          {
-            INumericalAbstractDomain<Variable, Expression>[] newDisjunct = new INumericalAbstractDomain<Variable, Expression>[1];
-            newDisjunct[0] = this.disjuncts[i];
-            this.disjuncts = newDisjunct;
-
-            return true;
-          }
-        }
-        return false;
-      }
-    }
-
-    public bool LessEqual(IAbstractDomain a)
-    {
-      bool r;
-      if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out r))
-      {
-        return r;
-      }
-
-      INumericalAbstractDomain<Variable, Expression>leftSmashed = SmashTogether(this, true);
-      INumericalAbstractDomain<Variable, Expression>rightSmashed = SmashTogether(a, true);
-
-      return leftSmashed.LessEqual(rightSmashed);
-    }
-
-    static private INumericalAbstractDomain<Variable, Expression>SmashTogether(IAbstractDomain boundedDisjunction, bool p)
-    {
-      INumericalAbstractDomain<Variable, Expression>asNumericalDomain = (INumericalAbstractDomain<Variable, Expression>)boundedDisjunction;
-
-      Debug.Assert(boundedDisjunction != null);
-
-      if (p)
-      { // It is a 
-         BoundedDisjunction<Variable, Expression> asDisjunction = asNumericalDomain as  BoundedDisjunction<Variable, Expression>;
-
-        Debug.Assert(asDisjunction != null);
-
-        return SmashTogether(asDisjunction.disjuncts);
-      }
-      else
-      {
-        return asNumericalDomain;
-      }
-    }
-
-    private static INumericalAbstractDomain<Variable, Expression> SmashTogether(INumericalAbstractDomain<Variable, Expression>[] asDisjunction)
-    {
-      IAbstractDomain result = asDisjunction[0];
-      
-      for (int i = 1; i < asDisjunction.Length; i++)
-      {
-        result = result.Join(asDisjunction[i]);
-      }
-
-      return (INumericalAbstractDomain<Variable, Expression>) result;
-    }
-
-    public IAbstractDomain Bottom
-    {
-      get 
-      {
-        return new  BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>) this.FirstDisjunct.Bottom);
-      }
-    }
-
-    public IAbstractDomain Top
-    {
-      get 
-      {
-        return new  BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>)this.FirstDisjunct.Top);
-
-      }
-    }
-
-    public IAbstractDomain Join(IAbstractDomain a)
-    {
-      IAbstractDomain result;
-      if(AbstractDomainsHelper.TryTrivialJoin(this, a, out result))
-      {
-        return result;
-      }
-
-       BoundedDisjunction<Variable, Expression> asDisjunctionDomain = a as  BoundedDisjunction<Variable, Expression>;
-
-      Debug.Assert(asDisjunctionDomain != null);
-
-      INumericalAbstractDomain<Variable, Expression>[] joinDisjuncts = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length + asDisjunctionDomain.disjuncts.Length];
-
-      // Copy both the domains
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        joinDisjuncts[i] = this.disjuncts[i];
-      }
-
-      for (int i = 0; i < asDisjunctionDomain.disjuncts.Length; i++)
-      {
-        joinDisjuncts[this.disjuncts.Length + i] = asDisjunctionDomain.disjuncts[i];
-      }
-
-      return new  BoundedDisjunction<Variable, Expression>(joinDisjuncts);
-    }
-
-    public IAbstractDomain Meet(IAbstractDomain a)
-    {
-      IAbstractDomain result;
-      if (AbstractDomainsHelper.TryTrivialMeet(this, a, out result))
-      {
-        return result;
-      }
-
-       BoundedDisjunction<Variable, Expression> asDisjunctionDomain = a as  BoundedDisjunction<Variable, Expression>;
-
-      Debug.Assert(asDisjunctionDomain != null);
-
-      INumericalAbstractDomain<Variable, Expression>left = SmashTogether(this.disjuncts);
-      INumericalAbstractDomain<Variable, Expression>right = SmashTogether(asDisjunctionDomain.disjuncts);
-
-      return new  BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>)left.Meet(right));
-    }
-
-    public IAbstractDomain Widening(IAbstractDomain prev)
-    {
-      IAbstractDomain result;
-      if (AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
-      {
-        return result;
-      }
-
-       BoundedDisjunction<Variable, Expression> asDisjunctionDomain = prev as  BoundedDisjunction<Variable, Expression>;
-
-      Debug.Assert(asDisjunctionDomain != null);
-
-      INumericalAbstractDomain<Variable, Expression>left = SmashTogether(this.disjuncts);
-      INumericalAbstractDomain<Variable, Expression>right = SmashTogether(asDisjunctionDomain.disjuncts);
-
-      return new  BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>)left.Widening(right));
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      INumericalAbstractDomain<Variable, Expression>[] cloned = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        cloned[i] = (INumericalAbstractDomain<Variable, Expression>)this.disjuncts[i].Clone();
-      }
-
-      return new  BoundedDisjunction<Variable, Expression>(cloned);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get 
-      {
-        var result = new Set<Variable>();
-        for (int i = 0; i < this.disjuncts.Length; i++)
-        {
-          result.AddRange(this.disjuncts[i].Variables);
-        }
-
-        return result.ToList();
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].AddVariable(var);
-      }
-    }
-
-    public void Assign(Expression x, Expression exp)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].Assign(x, exp);
-      }
-    }
-
-    public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].Assign(x, exp, preState); 
-      }
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].ProjectVariable(var);
-      }
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].RemoveVariable(var);
-      }
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].RenameVariable(OldName, NewName);
-      }
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
-    {
-      INumericalAbstractDomain<Variable, Expression>[] result = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for(int i = 0; i< this.disjuncts.Length; i++)
-      {
-        result[i] = (INumericalAbstractDomain<Variable, Expression>) this.disjuncts[i].TestTrue(guard);
-      }
-
-      return Reduce(result);
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
-    {
-      INumericalAbstractDomain<Variable, Expression>[] result = new INumericalAbstractDomain<Variable, Expression>[this.disjuncts.Length];
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result[i] = (INumericalAbstractDomain<Variable, Expression>)this.disjuncts[i].TestFalse(guard);
-      }
-
-      return Reduce(result);      
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
-    {
-      FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        result =   result.Join(this.disjuncts[i].CheckIfHolds(exp));
-      }
-
-      return result;        
-    }
-
-    #endregion
-
-    #region IAssignInParallel<Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        this.disjuncts[i].AssignInParallel(sourcesToTargets, convert);
-      }
-    }
-
-    #endregion
-
-    #region To
-    public T To<T>(IFactory<T> factory)
-    {
-      if (this.IsBottom)
-        return factory.Constant(false);
-
-      if (this.IsTop)
-        return factory.Constant(true);
-
-      T result = factory.IdentityForOr;
-
-      for (int i = 0; i < this.disjuncts.Length; i++)
-      {
-        T atom = this.disjuncts[i].To(factory);
-        result = factory.Or(result, atom);
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    public string Statistics
-    {
-      get
-      {
-        return string.Empty;
-      }
-    }
-
-    public override string ToString()
-    {
-      if (this.IsTop)
-      {
-        return "Top";
-      }
-      else if (this.disjuncts.Length == 1)
-      {
-        return this.FirstDisjunct.ToString();
-      }
-      else
-      {
-        return "Bounded disjunction with " + this.disjuncts.Length +" disjuncts";
-      }
-    }
-
-    public string ToString(Expression exp)
-    {
-      return "< missing expression decoder >";
-    }
-
     /// <summary>
-    /// For the moment the reduction just get rid of the bottom elements
+    /// We keep a bounded disjunction of abstract domains
     /// </summary>
-    private BoundedDisjunction<Variable, Expression> Reduce(INumericalAbstractDomain<Variable, Expression>[] domains)
+    public class BoundedDisjunction<Variable, Expression>
+      : INumericalAbstractDomain<Variable, Expression>
     {
-      bool[] isBottom = new bool[domains.Length];
-      int countBottom = 0;
+        #region Private state
+        private readonly int MaxDisjuncts = 8; // TODO Want to make it a command line option
+        private INumericalAbstractDomain<Variable, Expression>[] disjuncts;
 
-      for (int i = 0; i < domains.Length; i++)
-      {
-        if (domains[i].IsBottom)
+        private INumericalAbstractDomain<Variable, Expression> FirstDisjunct
         {
-          isBottom[i] = true;
-          countBottom++;
-        }
-      }
-
-      if (countBottom == 0 || countBottom == domains.Length)
-      {
-        return new BoundedDisjunction<Variable, Expression>(domains);
-      }
-      else
-      {
-        INumericalAbstractDomain<Variable, Expression>[] tmp = new INumericalAbstractDomain<Variable, Expression>[domains.Length - countBottom];
-
-        for (int i = 0, k = 0; i < domains.Length; i++)
-        {
-          if (!isBottom[i])
-          {
-            tmp[k] = domains[i];
-            k++;
-          }
+            get
+            {
+                return disjuncts[0];
+            }
         }
 
-        return new  BoundedDisjunction<Variable, Expression>(tmp);
-      }
+        #endregion
+
+        #region Constructor
+
+        public BoundedDisjunction(INumericalAbstractDomain<Variable, Expression> initial)
+        {
+            disjuncts = new INumericalAbstractDomain<Variable, Expression>[1];
+            disjuncts[0] = initial;
+        }
+
+        private BoundedDisjunction(INumericalAbstractDomain<Variable, Expression>[] domains)
+        {
+            if (domains.Length <= MaxDisjuncts)
+            {
+                disjuncts = domains;
+            }
+            else
+            {
+                disjuncts = new INumericalAbstractDomain<Variable, Expression>[1] { SmashTogether(domains) };
+            }
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomain<Variable, Expression>Members
+
+        public DisInterval BoundsFor(Expression v)
+        {
+            var result = FirstDisjunct.BoundsFor(v);
+
+            for (int i = 1; i < disjuncts.Length; i++)
+            {
+                result = (DisInterval)result.Join(disjuncts[i].BoundsFor(v));
+            }
+
+            return result;
+        }
+
+        public DisInterval BoundsFor(Variable v)
+        {
+            var result = FirstDisjunct.BoundsFor(v);
+
+            for (int i = 1; i < disjuncts.Length; i++)
+            {
+                result = (DisInterval)result.Join(disjuncts[i].BoundsFor(v));
+            }
+
+            return result;
+        }
+
+        public List<Pair<Variable, Int32>> IntConstants
+        {
+            get
+            {
+                return new List<Pair<Variable, Int32>>();
+            }
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Expression v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Expression v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> LowerBoundsFor(Variable v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Expression> UpperBoundsFor(Variable v, bool strict)
+        {
+            yield break; //not implemented
+        }
+
+        public IEnumerable<Variable> EqualitiesFor(Variable v)
+        {
+            yield break; //not implemented
+        }
+
+        public void AssumeInDisInterval(Variable x, DisInterval value)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].AssumeInDisInterval(x, value);
+            }
+        }
+
+        public void AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].AssumeDomainSpecificFact(fact);
+            }
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueGeqZero(Expression exp)
+        {
+            var result = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result[i] = disjuncts[i].TestTrueGeqZero(exp);
+            }
+
+            return new BoundedDisjunction<Variable, Expression>(result);
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessThan(Expression exp1, Expression exp2)
+        {
+            var result = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result[i] = disjuncts[i].TestTrueLessThan(exp1, exp2);
+            }
+
+            return new BoundedDisjunction<Variable, Expression>(result);
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueLessEqualThan(Expression exp1, Expression exp2)
+        {
+            var result = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result[i] = disjuncts[i].TestTrueLessEqualThan(exp1, exp2);
+            }
+
+            return new BoundedDisjunction<Variable, Expression>(result);
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> TestTrueEqual(Expression exp1, Expression exp2)
+        {
+            var result = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result[i] = disjuncts[i].TestTrueEqual(exp1, exp2);
+            }
+
+            return new BoundedDisjunction<Variable, Expression>(result);
+        }
+
+        public INumericalAbstractDomain<Variable, Expression> RemoveRedundanciesWith(INumericalAbstractDomain<Variable, Expression> oracle)
+        {
+            var result = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result[i] = disjuncts[i].RemoveRedundanciesWith(oracle);
+            }
+
+            return new BoundedDisjunction<Variable, Expression>(result);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfGreaterEqualThanZero(Expression exp)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfGreaterEqualThanZero(exp));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfLessThan(e1, e2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan_Un(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfLessThan_Un(e1, e2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThan(Variable v1, Variable v2)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfLessThan(v1, v2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Expression e1, Expression e2)
+        {
+            var result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfLessEqualThan(e1, e2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessThanIncomplete(Expression e1, Expression e2)
+        {
+            var result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfLessThanIncomplete(e1, e2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan_Un(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfLessEqualThan_Un(e1, e2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqual(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfEqual(e1, e2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualIncomplete(Expression e1, Expression e2)
+        {
+            return this.CheckIfEqual(e1, e2);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfEqualThan(Expression e1, Expression e2)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfEqual(e1, e2));
+            }
+
+            return result;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfLessEqualThan(Variable v1, Variable v2)
+        {
+            var result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfLessEqualThan(v1, v2));
+            }
+
+            return result;
+        }
+
+
+
+        public FlatAbstractDomain<bool> CheckIfNonZero(Expression e)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfNonZero(e));
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region IAbstractDomain Members
+
+        public bool IsBottom
+        {
+            get
+            {
+                for (int i = 0; i < disjuncts.Length; i++)
+                {
+                    if (!disjuncts[i].IsBottom)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                for (int i = 0; i < disjuncts.Length; i++)
+                {
+                    if (disjuncts[i].IsTop)
+                    {
+                        INumericalAbstractDomain<Variable, Expression>[] newDisjunct = new INumericalAbstractDomain<Variable, Expression>[1];
+                        newDisjunct[0] = disjuncts[i];
+                        disjuncts = newDisjunct;
+
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool LessEqual(IAbstractDomain a)
+        {
+            bool r;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out r))
+            {
+                return r;
+            }
+
+            INumericalAbstractDomain<Variable, Expression> leftSmashed = SmashTogether(this, true);
+            INumericalAbstractDomain<Variable, Expression> rightSmashed = SmashTogether(a, true);
+
+            return leftSmashed.LessEqual(rightSmashed);
+        }
+
+        static private INumericalAbstractDomain<Variable, Expression> SmashTogether(IAbstractDomain boundedDisjunction, bool p)
+        {
+            INumericalAbstractDomain<Variable, Expression> asNumericalDomain = (INumericalAbstractDomain<Variable, Expression>)boundedDisjunction;
+
+            Debug.Assert(boundedDisjunction != null);
+
+            if (p)
+            { // It is a 
+                BoundedDisjunction<Variable, Expression> asDisjunction = asNumericalDomain as BoundedDisjunction<Variable, Expression>;
+
+                Debug.Assert(asDisjunction != null);
+
+                return SmashTogether(asDisjunction.disjuncts);
+            }
+            else
+            {
+                return asNumericalDomain;
+            }
+        }
+
+        private static INumericalAbstractDomain<Variable, Expression> SmashTogether(INumericalAbstractDomain<Variable, Expression>[] asDisjunction)
+        {
+            IAbstractDomain result = asDisjunction[0];
+
+            for (int i = 1; i < asDisjunction.Length; i++)
+            {
+                result = result.Join(asDisjunction[i]);
+            }
+
+            return (INumericalAbstractDomain<Variable, Expression>)result;
+        }
+
+        public IAbstractDomain Bottom
+        {
+            get
+            {
+                return new BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>)this.FirstDisjunct.Bottom);
+            }
+        }
+
+        public IAbstractDomain Top
+        {
+            get
+            {
+                return new BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>)this.FirstDisjunct.Top);
+            }
+        }
+
+        public IAbstractDomain Join(IAbstractDomain a)
+        {
+            IAbstractDomain result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out result))
+            {
+                return result;
+            }
+
+            BoundedDisjunction<Variable, Expression> asDisjunctionDomain = a as BoundedDisjunction<Variable, Expression>;
+
+            Debug.Assert(asDisjunctionDomain != null);
+
+            INumericalAbstractDomain<Variable, Expression>[] joinDisjuncts = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length + asDisjunctionDomain.disjuncts.Length];
+
+            // Copy both the domains
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                joinDisjuncts[i] = disjuncts[i];
+            }
+
+            for (int i = 0; i < asDisjunctionDomain.disjuncts.Length; i++)
+            {
+                joinDisjuncts[disjuncts.Length + i] = asDisjunctionDomain.disjuncts[i];
+            }
+
+            return new BoundedDisjunction<Variable, Expression>(joinDisjuncts);
+        }
+
+        public IAbstractDomain Meet(IAbstractDomain a)
+        {
+            IAbstractDomain result;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, a, out result))
+            {
+                return result;
+            }
+
+            BoundedDisjunction<Variable, Expression> asDisjunctionDomain = a as BoundedDisjunction<Variable, Expression>;
+
+            Debug.Assert(asDisjunctionDomain != null);
+
+            INumericalAbstractDomain<Variable, Expression> left = SmashTogether(disjuncts);
+            INumericalAbstractDomain<Variable, Expression> right = SmashTogether(asDisjunctionDomain.disjuncts);
+
+            return new BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>)left.Meet(right));
+        }
+
+        public IAbstractDomain Widening(IAbstractDomain prev)
+        {
+            IAbstractDomain result;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, prev, out result))
+            {
+                return result;
+            }
+
+            BoundedDisjunction<Variable, Expression> asDisjunctionDomain = prev as BoundedDisjunction<Variable, Expression>;
+
+            Debug.Assert(asDisjunctionDomain != null);
+
+            INumericalAbstractDomain<Variable, Expression> left = SmashTogether(disjuncts);
+            INumericalAbstractDomain<Variable, Expression> right = SmashTogether(asDisjunctionDomain.disjuncts);
+
+            return new BoundedDisjunction<Variable, Expression>((INumericalAbstractDomain<Variable, Expression>)left.Widening(right));
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            INumericalAbstractDomain<Variable, Expression>[] cloned = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                cloned[i] = (INumericalAbstractDomain<Variable, Expression>)disjuncts[i].Clone();
+            }
+
+            return new BoundedDisjunction<Variable, Expression>(cloned);
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        public List<Variable> Variables
+        {
+            get
+            {
+                var result = new Set<Variable>();
+                for (int i = 0; i < disjuncts.Length; i++)
+                {
+                    result.AddRange(disjuncts[i].Variables);
+                }
+
+                return result.ToList();
+            }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].AddVariable(var);
+            }
+        }
+
+        public void Assign(Expression x, Expression exp)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].Assign(x, exp);
+            }
+        }
+
+        public void Assign(Expression x, Expression exp, INumericalAbstractDomainQuery<Variable, Expression> preState)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].Assign(x, exp, preState);
+            }
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].ProjectVariable(var);
+            }
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].RemoveVariable(var);
+            }
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].RenameVariable(OldName, NewName);
+            }
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestTrue(Expression guard)
+        {
+            INumericalAbstractDomain<Variable, Expression>[] result = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result[i] = (INumericalAbstractDomain<Variable, Expression>)disjuncts[i].TestTrue(guard);
+            }
+
+            return Reduce(result);
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression> TestFalse(Expression guard)
+        {
+            INumericalAbstractDomain<Variable, Expression>[] result = new INumericalAbstractDomain<Variable, Expression>[disjuncts.Length];
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result[i] = (INumericalAbstractDomain<Variable, Expression>)disjuncts[i].TestFalse(guard);
+            }
+
+            return Reduce(result);
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression exp)
+        {
+            FlatAbstractDomain<bool> result = CheckOutcome.Bottom;
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                result = result.Join(disjuncts[i].CheckIfHolds(exp));
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region IAssignInParallel<Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                disjuncts[i].AssignInParallel(sourcesToTargets, convert);
+            }
+        }
+
+        #endregion
+
+        #region To
+        public T To<T>(IFactory<T> factory)
+        {
+            if (this.IsBottom)
+                return factory.Constant(false);
+
+            if (this.IsTop)
+                return factory.Constant(true);
+
+            T result = factory.IdentityForOr;
+
+            for (int i = 0; i < disjuncts.Length; i++)
+            {
+                T atom = disjuncts[i].To(factory);
+                result = factory.Or(result, atom);
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        public string Statistics
+        {
+            get
+            {
+                return string.Empty;
+            }
+        }
+
+        public override string ToString()
+        {
+            if (this.IsTop)
+            {
+                return "Top";
+            }
+            else if (disjuncts.Length == 1)
+            {
+                return this.FirstDisjunct.ToString();
+            }
+            else
+            {
+                return "Bounded disjunction with " + disjuncts.Length + " disjuncts";
+            }
+        }
+
+        public string ToString(Expression exp)
+        {
+            return "< missing expression decoder >";
+        }
+
+        /// <summary>
+        /// For the moment the reduction just get rid of the bottom elements
+        /// </summary>
+        private BoundedDisjunction<Variable, Expression> Reduce(INumericalAbstractDomain<Variable, Expression>[] domains)
+        {
+            bool[] isBottom = new bool[domains.Length];
+            int countBottom = 0;
+
+            for (int i = 0; i < domains.Length; i++)
+            {
+                if (domains[i].IsBottom)
+                {
+                    isBottom[i] = true;
+                    countBottom++;
+                }
+            }
+
+            if (countBottom == 0 || countBottom == domains.Length)
+            {
+                return new BoundedDisjunction<Variable, Expression>(domains);
+            }
+            else
+            {
+                INumericalAbstractDomain<Variable, Expression>[] tmp = new INumericalAbstractDomain<Variable, Expression>[domains.Length - countBottom];
+
+                for (int i = 0, k = 0; i < domains.Length; i++)
+                {
+                    if (!isBottom[i])
+                    {
+                        tmp[k] = domains[i];
+                        k++;
+                    }
+                }
+
+                return new BoundedDisjunction<Variable, Expression>(tmp);
+            }
+        }
+
+        #region Floating point types
+
+        public void SetFloatType(Variable v, ConcreteFloat f)
+        {
+            // does nothing
+        }
+
+        public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
+        {
+            return FloatTypes<Variable, Expression>.Unknown;
+        }
+
+        #endregion
+
+        #region INumericalAbstractDomainQuery<Variable,Expression> Members
+
+        public Variable ToVariable(Expression exp)
+        {
+            return default(Variable);
+        }
+
+        #endregion
     }
-
-    #region Floating point types
-
-    public void SetFloatType(Variable v, ConcreteFloat f)
-    {
-      // does nothing
-    }
-
-    public FlatAbstractDomain<ConcreteFloat> GetFloatType(Variable v)
-    {
-      return FloatTypes<Variable, Expression>.Unknown;
-    }
-
-    #endregion
-
-    #region INumericalAbstractDomainQuery<Variable,Expression> Members
-
-    public Variable ToVariable(Expression exp)
-    {
-      return default(Variable);
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/StringDomain.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/StringDomain.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,1444 +10,1442 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  public interface IStringAbstraction : IAbstractDomain
-  {    
-    IStringAbstraction ConcatWith(IStringAbstraction what);
-    IStringAbstraction Insert(int where, IStringAbstraction what);
-    IStringAbstraction Trim();
-
-    FlatAbstractDomain<int> CompareTo(IStringAbstraction who);
-    FlatAbstractDomain<bool> Contains(IStringAbstraction what);
-    FlatAbstractDomain<bool> StartsWith(IStringAbstraction what);
-  }
-
-  /// <summary>
-  /// A simple abstract domain abstracting (environments of) strings
-  /// </summary>
-  /// <typeparam name="Expression"></typeparam>
-  public class SimpleStringAbstractDomain<Variable, Expression> :
-    FunctionalAbstractDomain<SimpleStringAbstractDomain<Variable, Expression>, Variable, IStringAbstraction>,
-    IStringAbstractDomain<IStringAbstraction, Variable, Expression>
-  {
-    #region Static
-    private static readonly IStringAbstraction topString = new StringAbstraction(); // We cache it, as we will use very often top (Thread-safe)
-    #endregion
-
-    #region Private state
-    IExpressionDecoder<Variable, Expression>/*!*/ decoder;
-    #endregion
-
-    #region Constructor
-
-    public SimpleStringAbstractDomain(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
+    public interface IStringAbstraction : IAbstractDomain
     {
-      this.decoder = decoder;
+        IStringAbstraction ConcatWith(IStringAbstraction what);
+        IStringAbstraction Insert(int where, IStringAbstraction what);
+        IStringAbstraction Trim();
+
+        FlatAbstractDomain<int> CompareTo(IStringAbstraction who);
+        FlatAbstractDomain<bool> Contains(IStringAbstraction what);
+        FlatAbstractDomain<bool> StartsWith(IStringAbstraction what);
     }
 
-    private SimpleStringAbstractDomain(SimpleStringAbstractDomain<Variable, Expression>/*!*/ source)
+    /// <summary>
+    /// A simple abstract domain abstracting (environments of) strings
+    /// </summary>
+    /// <typeparam name="Expression"></typeparam>
+    public class SimpleStringAbstractDomain<Variable, Expression> :
+      FunctionalAbstractDomain<SimpleStringAbstractDomain<Variable, Expression>, Variable, IStringAbstraction>,
+      IStringAbstractDomain<IStringAbstraction, Variable, Expression>
     {
-      this.decoder = source.decoder;
-      foreach (var x in source.Keys)
-      {
-        var cloned = source[x].Clone() as IStringAbstraction;
-        this[x] = cloned;
-      }
-    }
-    #endregion
+        #region Static
+        private static readonly IStringAbstraction topString = new StringAbstraction(); // We cache it, as we will use very often top (Thread-safe)
+        #endregion
 
-    #region From FunctionalAbstractDomain
-    public override object Clone()
-    {
-      return new SimpleStringAbstractDomain<Variable, Expression>(this); 
-    }
+        #region Private state
+        private IExpressionDecoder<Variable, Expression>/*!*/ decoder;
+        #endregion
 
-    protected override SimpleStringAbstractDomain<Variable, Expression> Factory()
-    {
-      return new SimpleStringAbstractDomain<Variable, Expression>(this.decoder);
-    }
-    #endregion
+        #region Constructor
 
-    #region IPureExpressionAssignmentsWithForward<Expression> Members
-
-    public void Assign(Expression x, Expression exp)
-    {
-      this.State = AbstractState.Normal;
-      this[this.decoder.UnderlyingVariable(x)] = Eval(exp);
-    }
-
-    #endregion
-
-    #region IPureExpressionAssignments<Expression> Members
-
-    public List<Variable> Variables
-    {
-      get 
-      {
-        return new List<Variable>(this.Keys);
-      }
-    }
-
-    public void AddVariable(Variable var)
-    {
-      // do nothing
-    }
-
-    public void ProjectVariable(Variable var)
-    {
-      this.RemoveVariable(var);
-    }
-
-    public void RemoveVariable(Variable var)
-    {
-      this.RemoveElement(var);
-    }
-
-    public void RenameVariable(Variable OldName, Variable NewName)
-    {
-      this[NewName] = this[OldName];
-      this.RemoveVariable(OldName);
-    }
-
-    #endregion
-
-    #region IPureExpressionTest<Expression> Members
-
-    public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestTrue(Expression/*!*/ guard)
-    {
-      return this;
-    }
-
-    public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestFalse(Expression/*!*/ guard)
-    {
-      return this;
-    }
-
-    public FlatAbstractDomain<bool> CheckIfHolds(Expression/*!*/ exp)
-    {
-      return  new FlatAbstractDomain<bool>(true).Top;
-    }
-
-    void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
-    {
-      this.AssumeDomainSpecificFact(fact);
-    }
-    #endregion
-
-    #region IAssignInParallel<Expression> Members
-
-    public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
-    {
-
-      this.State = AbstractState.Normal;
-
-      if (sourcesToTargets.Count == 0)
-      {
-        // do nothing...
-      }
-      else
-      {
-        // Evaluate the values in the pre-state
-        var values = new Dictionary<Variable, IStringAbstraction>();
-
-        foreach (var exp in sourcesToTargets.Keys)
+        public SimpleStringAbstractDomain(IExpressionDecoder<Variable, Expression>/*!*/ decoder)
         {
-          values[exp] = Eval(convert(exp));
+            this.decoder = decoder;
         }
 
-        // Update the values
-        foreach (var exp in sourcesToTargets.Keys)
+        private SimpleStringAbstractDomain(SimpleStringAbstractDomain<Variable, Expression>/*!*/ source)
         {
-          var value = values[exp];   // The new value in the pre-state
-
-          foreach (var target in sourcesToTargets[exp].GetEnumerable())
-          {
-            if (!value.IsTop)
+            decoder = source.decoder;
+            foreach (var x in source.Keys)
             {
-              this[target] = value;
+                var cloned = source[x].Clone() as IStringAbstraction;
+                this[x] = cloned;
+            }
+        }
+        #endregion
+
+        #region From FunctionalAbstractDomain
+        public override object Clone()
+        {
+            return new SimpleStringAbstractDomain<Variable, Expression>(this);
+        }
+
+        protected override SimpleStringAbstractDomain<Variable, Expression> Factory()
+        {
+            return new SimpleStringAbstractDomain<Variable, Expression>(decoder);
+        }
+        #endregion
+
+        #region IPureExpressionAssignmentsWithForward<Expression> Members
+
+        public void Assign(Expression x, Expression exp)
+        {
+            this.State = AbstractState.Normal;
+            this[decoder.UnderlyingVariable(x)] = Eval(exp);
+        }
+
+        #endregion
+
+        #region IPureExpressionAssignments<Expression> Members
+
+        public List<Variable> Variables
+        {
+            get
+            {
+                return new List<Variable>(this.Keys);
+            }
+        }
+
+        public void AddVariable(Variable var)
+        {
+            // do nothing
+        }
+
+        public void ProjectVariable(Variable var)
+        {
+            this.RemoveVariable(var);
+        }
+
+        public void RemoveVariable(Variable var)
+        {
+            this.RemoveElement(var);
+        }
+
+        public void RenameVariable(Variable OldName, Variable NewName)
+        {
+            this[NewName] = this[OldName];
+            this.RemoveVariable(OldName);
+        }
+
+        #endregion
+
+        #region IPureExpressionTest<Expression> Members
+
+        public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestTrue(Expression/*!*/ guard)
+        {
+            return this;
+        }
+
+        public IAbstractDomainForEnvironments<Variable, Expression>/*!*/ TestFalse(Expression/*!*/ guard)
+        {
+            return this;
+        }
+
+        public FlatAbstractDomain<bool> CheckIfHolds(Expression/*!*/ exp)
+        {
+            return new FlatAbstractDomain<bool>(true).Top;
+        }
+
+        void IPureExpressionTest<Variable, Expression>.AssumeDomainSpecificFact(DomainSpecificFact fact)
+        {
+            this.AssumeDomainSpecificFact(fact);
+        }
+        #endregion
+
+        #region IAssignInParallel<Expression> Members
+
+        public void AssignInParallel(Dictionary<Variable, FList<Variable>> sourcesToTargets, Converter<Variable, Expression> convert)
+        {
+            this.State = AbstractState.Normal;
+
+            if (sourcesToTargets.Count == 0)
+            {
+                // do nothing...
             }
             else
             {
-              if (this.ContainsKey(target))
-              {
-                this.RemoveVariable(target);
-              }
+                // Evaluate the values in the pre-state
+                var values = new Dictionary<Variable, IStringAbstraction>();
+
+                foreach (var exp in sourcesToTargets.Keys)
+                {
+                    values[exp] = Eval(convert(exp));
+                }
+
+                // Update the values
+                foreach (var exp in sourcesToTargets.Keys)
+                {
+                    var value = values[exp];   // The new value in the pre-state
+
+                    foreach (var target in sourcesToTargets[exp].GetEnumerable())
+                    {
+                        if (!value.IsTop)
+                        {
+                            this[target] = value;
+                        }
+                        else
+                        {
+                            if (this.ContainsKey(target))
+                            {
+                                this.RemoveVariable(target);
+                            }
+                        }
+                    }
+                }
             }
-          }
-
         }
-      }
-    }
 
-    #endregion
+        #endregion
 
-    #region IStringAbstractDomain<IStringAbstraction,Expression> Members
+        #region IStringAbstractDomain<IStringAbstraction,Expression> Members
 
-    public void Concat(Expression/*!*/ target, Expression/*!*/ left, Expression/*!*/ right)
-    {
-      var leftVal = Eval(left);
-      var rightVal = Eval(right);
-
-      this[this.decoder.UnderlyingVariable(target)] = leftVal.ConcatWith(rightVal);
-    }
-
-    public void Insert(Expression/*!*/ target, Expression/*!*/ which, Expression/*!*/ where, Expression/*!*/ what)
-    {
-      if (this.decoder.IsConstant(where))
-      {
-        Int32 index;
-
-        if (this.decoder.TryValueOf<Int32>(where, ExpressionType.Int32, out index))
+        public void Concat(Expression/*!*/ target, Expression/*!*/ left, Expression/*!*/ right)
         {
-          var left = Eval(which);
-          var right = Eval(what);
+            var leftVal = Eval(left);
+            var rightVal = Eval(right);
 
-          this[this.decoder.UnderlyingVariable(target)] = left.Insert(index, right);
+            this[decoder.UnderlyingVariable(target)] = leftVal.ConcatWith(rightVal);
         }
-        else
+
+        public void Insert(Expression/*!*/ target, Expression/*!*/ which, Expression/*!*/ where, Expression/*!*/ what)
         {
-          this.RemoveElement(this.decoder.UnderlyingVariable(target));
+            if (decoder.IsConstant(where))
+            {
+                Int32 index;
+
+                if (decoder.TryValueOf<Int32>(where, ExpressionType.Int32, out index))
+                {
+                    var left = Eval(which);
+                    var right = Eval(what);
+
+                    this[decoder.UnderlyingVariable(target)] = left.Insert(index, right);
+                }
+                else
+                {
+                    this.RemoveElement(decoder.UnderlyingVariable(target));
+                }
+            }
+            else
+            {
+                this.RemoveElement(decoder.UnderlyingVariable(target));
+            }
         }
-      }
-      else
-      {
-        this.RemoveElement(this.decoder.UnderlyingVariable(target));
-      }
-    }
 
-    public void Trim(Expression/*!*/ who, Expression/*!*/ what)
-    {
-      var value = Eval(what);
-      this[this.decoder.UnderlyingVariable(who)] = value.Trim();
-    }
-
-    public FlatAbstractDomain<int> CompareTo(Expression/*!*/ left, Expression/*!*/ right)
-    {
-      var leftVal = Eval(left);
-      var rightVal = Eval(right);
-
-      return leftVal.CompareTo(rightVal);
-    }
-
-    public FlatAbstractDomain<bool> Contains(Expression/*!*/ who, Expression/*!*/ what)
-    {
-      var leftVal = Eval(who);
-      var rightVal = Eval(what);
-
-      return leftVal.Contains(rightVal);
-    }
-
-    public FlatAbstractDomain<bool> StartsWith(Expression/*!*/ who, Expression/*!*/ what)
-    {
-      var leftVal = Eval(who);
-      var rightVal = Eval(what);
-      return leftVal.StartsWith(rightVal);
-    }
-
-    #endregion
-
-    #region Eval
-    private IStringAbstraction Eval(Expression/*!*/ exp)
-    {
-      IStringAbstraction result;
-      switch (this.decoder.OperatorFor(exp))
-      {
-        case ExpressionOperator.Constant:
-          result = EvalConstant(exp);
-          break;
-
-        case ExpressionOperator.Variable:
-          var v = this.decoder.UnderlyingVariable(exp);
-          result = EvalVariable(v);
-          break;
-
-        default:
-          result = topString;
-          break;
-      }
-
-      return result;
-    }
-
-    private IStringAbstraction EvalConstant(Expression/*!*/ exp)
-    //^ this.decoder.IsConstant(exp);
-    {
-      IStringAbstraction result;
-      string val;
-
-      if (this.decoder.TryValueOf<string>(exp, ExpressionType.String, out val))
-      {
-        result = new StringAbstraction(val);
-      }
-      else
-      {
-        result = topString;
-      }
-
-      return result;
-    }
-
-    private IStringAbstraction EvalVariable(Variable/*!*/ var)
-    {
-      IStringAbstraction result;
-
-      if (this.ContainsKey(var))
-      {
-        result = this[var];
-      }
-      else
-      {
-        result = topString;
-      }
-
-      return result;
-    }
-
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      string result;
-
-      if (this.IsBottom)
-      {
-        result = "_|_";
-      }
-      else if (this.IsTop)
-      {
-        result = "Top";
-      }
-      else
-      {
-        var tempStr = new StringBuilder();
-
-        foreach (var x in this.Keys)
+        public void Trim(Expression/*!*/ who, Expression/*!*/ what)
         {
-          string xAsString = this.decoder != null ? this.decoder.NameOf(x) : x.ToString();
-          tempStr.Append(xAsString + ": " + this[x] + ", ");
+            var value = Eval(what);
+            this[decoder.UnderlyingVariable(who)] = value.Trim();
         }
 
-        result = tempStr.ToString();
-        int indexOfLastComma = result.LastIndexOf(",");
-        if (indexOfLastComma > 0)
+        public FlatAbstractDomain<int> CompareTo(Expression/*!*/ left, Expression/*!*/ right)
         {
-          result = result.Remove(indexOfLastComma);
+            var leftVal = Eval(left);
+            var rightVal = Eval(right);
+
+            return leftVal.CompareTo(rightVal);
         }
-      }
 
-      return result;
-    }
+        public FlatAbstractDomain<bool> Contains(Expression/*!*/ who, Expression/*!*/ what)
+        {
+            var leftVal = Eval(who);
+            var rightVal = Eval(what);
 
-    public string ToString(Expression exp)
-    {
-      if (this.decoder != null)
-      {
-        return ExpressionPrinter.ToString(exp, this.decoder);
-      }
-      else
-      {
-        return "< missing expression decoder >";
-      }
-    }
-    #endregion
+            return leftVal.Contains(rightVal);
+        }
 
-    protected override string ToLogicalFormula(Variable d, IStringAbstraction c)
-    {
-      return null;
-    }
+        public FlatAbstractDomain<bool> StartsWith(Expression/*!*/ who, Expression/*!*/ what)
+        {
+            var leftVal = Eval(who);
+            var rightVal = Eval(what);
+            return leftVal.StartsWith(rightVal);
+        }
 
-    protected override T To<T>(Variable d, IStringAbstraction c, IFactory<T> factory)
-    {
-      return factory.Constant(true);
-    }
-  }
+        #endregion
 
-  /// <summary>
-  /// The class abstracting strings
-  /// </summary>
-  internal class StringAbstraction : IStringAbstraction
-  {
-    enum ContentType {String, Prefix, SetOfCharacters, Top, Bottom}
+        #region Eval
+        private IStringAbstraction Eval(Expression/*!*/ exp)
+        {
+            IStringAbstraction result;
+            switch (decoder.OperatorFor(exp))
+            {
+                case ExpressionOperator.Constant:
+                    result = EvalConstant(exp);
+                    break;
 
-    private readonly ContentType content;
-    private readonly string fullstring = null;
-    private readonly string prefix = null;
-    private readonly Set<SimpleCharacterAbstraction> characters = null;
+                case ExpressionOperator.Variable:
+                    var v = decoder.UnderlyingVariable(exp);
+                    result = EvalVariable(v);
+                    break;
 
-    private static readonly StringAbstraction CachedTop = new StringAbstraction();
-    private static readonly StringAbstraction CachedBottom = new StringAbstraction(ContentType.Bottom);
+                default:
+                    result = topString;
+                    break;
+            }
 
-    #region Constructors
+            return result;
+        }
 
-    private StringAbstraction(ContentType content)
-    {
-      this.content = content;
+        private IStringAbstraction EvalConstant(Expression/*!*/ exp)
+        //^ this.decoder.IsConstant(exp);
+        {
+            IStringAbstraction result;
+            string val;
+
+            if (decoder.TryValueOf<string>(exp, ExpressionType.String, out val))
+            {
+                result = new StringAbstraction(val);
+            }
+            else
+            {
+                result = topString;
+            }
+
+            return result;
+        }
+
+        private IStringAbstraction EvalVariable(Variable/*!*/ var)
+        {
+            IStringAbstraction result;
+
+            if (this.ContainsKey(var))
+            {
+                result = this[var];
+            }
+            else
+            {
+                result = topString;
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            string result;
+
+            if (this.IsBottom)
+            {
+                result = "_|_";
+            }
+            else if (this.IsTop)
+            {
+                result = "Top";
+            }
+            else
+            {
+                var tempStr = new StringBuilder();
+
+                foreach (var x in this.Keys)
+                {
+                    string xAsString = decoder != null ? decoder.NameOf(x) : x.ToString();
+                    tempStr.Append(xAsString + ": " + this[x] + ", ");
+                }
+
+                result = tempStr.ToString();
+                int indexOfLastComma = result.LastIndexOf(",");
+                if (indexOfLastComma > 0)
+                {
+                    result = result.Remove(indexOfLastComma);
+                }
+            }
+
+            return result;
+        }
+
+        public string ToString(Expression exp)
+        {
+            if (decoder != null)
+            {
+                return ExpressionPrinter.ToString(exp, decoder);
+            }
+            else
+            {
+                return "< missing expression decoder >";
+            }
+        }
+        #endregion
+
+        protected override string ToLogicalFormula(Variable d, IStringAbstraction c)
+        {
+            return null;
+        }
+
+        protected override T To<T>(Variable d, IStringAbstraction c, IFactory<T> factory)
+        {
+            return factory.Constant(true);
+        }
     }
 
     /// <summary>
-    /// The top element
+    /// The class abstracting strings
     /// </summary>
-    public StringAbstraction()
-      : this(ContentType.Top)
-    { }
-
-    /// <summary>
-    /// The abstract element containing just <code>s</code>
-    /// </summary>
-    public StringAbstraction(string/*!*/ s)
+    internal class StringAbstraction : IStringAbstraction
     {
-      this.content = ContentType.String;
-      this.fullstring = s;
-    }
+        private enum ContentType { String, Prefix, SetOfCharacters, Top, Bottom }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    public StringAbstraction(Set<SimpleCharacterAbstraction>/*!*/ characters)
-    {
-      this.content = ContentType.SetOfCharacters;
-      this.characters = characters;
-    }
+        private readonly ContentType content;
+        private readonly string fullstring = null;
+        private readonly string prefix = null;
+        private readonly Set<SimpleCharacterAbstraction> characters = null;
 
-    /// <summary>
-    /// Builds a prefix
-    /// </summary>
-    /// <param name="b">It is ignored</param>
-    private StringAbstraction(string/*!*/ prefix, bool b)
-    {
-      this.content = ContentType.Prefix;
-      this.prefix = prefix;
-    }
+        private static readonly StringAbstraction CachedTop = new StringAbstraction();
+        private static readonly StringAbstraction CachedBottom = new StringAbstraction(ContentType.Bottom);
 
-    private StringAbstraction(StringAbstraction/*!*/ a)
-    {
-      this.content = a.content;
-      this.fullstring = a.fullstring;
-      this.characters = a.characters;
-      this.prefix = a.prefix;
-    }
-    #endregion
+        #region Constructors
 
-    public T To<T>(IFactory<T> factory)
-    {
-      return factory.Constant(true);
-    }
-
-    #region IStringAbstraction Members
-
-    /// <summary>
-    /// Do the concatenation
-    /// </summary>
-    /// <param name="param"></param>
-    /// <returns></returns>
-    public IStringAbstraction ConcatWith(IStringAbstraction/*!*/ param)
-    {
-      IStringAbstraction result;
-      if (this.IsTop || param.IsTop)
-      {
-        result = CachedTop;
-      }
-      else
-      {
-        StringAbstraction what = param as StringAbstraction; //^ assert what != null;
-        Debug.Assert(what != null);
-
-        if (this.content == what.content)
+        private StringAbstraction(ContentType content)
         {
-          switch (this.content)
-          {
-            #region All the cases
-            case ContentType.Prefix:
-              result = this;          // prefix1 \cdot prefix2 = prefix1
-              break;
-
-            case ContentType.SetOfCharacters:
-              result = new StringAbstraction(this.characters.Union(what.characters)); // { bla1 bla12 } \code {bla2 bla22} = {bla1, bla12, bla2, bla22} 
-              break;
-
-            case ContentType.String:  // Simple concatenation
-              result = new StringAbstraction(this.fullstring + what.fullstring);
-              break;
-
-            default:
-              throw new AbstractInterpretationException("Impossible case?");
-            #endregion
-          }
+            this.content = content;
         }
-        else
+
+        /// <summary>
+        /// The top element
+        /// </summary>
+        public StringAbstraction()
+          : this(ContentType.Top)
+        { }
+
+        /// <summary>
+        /// The abstract element containing just <code>s</code>
+        /// </summary>
+        public StringAbstraction(string/*!*/ s)
         {
-          switch (this.content)
-          {
-            #region All the cases
-            case ContentType.Prefix:
-              if (what.content == ContentType.SetOfCharacters)
-              {
-                result = this;       // prefix \cdot {bla bla} = prefix
-              }
-              else if (what.content == ContentType.String)
-              {                     // prefix \cdot string = prefix
-                result = this;
-              }
-              else
-              {
-                goto default;
-              }
-              break;
-
-            case ContentType.SetOfCharacters:
-              if (what.content == ContentType.Prefix)
-              {
-                result = (StringAbstraction) this.Top;    
-              }
-              else if (what.content == ContentType.String)
-              {
-                result = new StringAbstraction(this.characters.Union(AlphaToSetOfCharacters(what.fullstring)));
-              }
-              else
-              {
-                goto default;
-              }
-              break;
-
-            case ContentType.String:
-              if (what.content == ContentType.SetOfCharacters)
-              {
-                result = new StringAbstraction(AlphaToSetOfCharacters(this.fullstring).Union(what.characters));
-              }
-              else if (what.content == ContentType.Prefix)
-              {
-                result = new StringAbstraction(this.fullstring + what.prefix, true);
-              }
-              else
-              {
-                goto default;
-              }
-              break;
-
-            default:
-              throw new AbstractInterpretationException("Impossible case?");
-            #endregion
-          }
+            content = ContentType.String;
+            fullstring = s;
         }
-      }
-      return result;
-    }
 
-    public IStringAbstraction Insert(int where, IStringAbstraction/*!*/ param)
+        /// <summary>
+        /// 
+        /// </summary>
+        public StringAbstraction(Set<SimpleCharacterAbstraction>/*!*/ characters)
+        {
+            content = ContentType.SetOfCharacters;
+            this.characters = characters;
+        }
+
+        /// <summary>
+        /// Builds a prefix
+        /// </summary>
+        /// <param name="b">It is ignored</param>
+        private StringAbstraction(string/*!*/ prefix, bool b)
+        {
+            content = ContentType.Prefix;
+            this.prefix = prefix;
+        }
+
+        private StringAbstraction(StringAbstraction/*!*/ a)
+        {
+            content = a.content;
+            fullstring = a.fullstring;
+            characters = a.characters;
+            prefix = a.prefix;
+        }
+        #endregion
+
+        public T To<T>(IFactory<T> factory)
+        {
+            return factory.Constant(true);
+        }
+
+        #region IStringAbstraction Members
+
+        /// <summary>
+        /// Do the concatenation
+        /// </summary>
+        /// <param name="param"></param>
+        /// <returns></returns>
+        public IStringAbstraction ConcatWith(IStringAbstraction/*!*/ param)
+        {
+            IStringAbstraction result;
+            if (this.IsTop || param.IsTop)
+            {
+                result = CachedTop;
+            }
+            else
+            {
+                StringAbstraction what = param as StringAbstraction; //^ assert what != null;
+                Debug.Assert(what != null);
+
+                if (content == what.content)
+                {
+                    switch (content)
+                    {
+                        #region All the cases
+                        case ContentType.Prefix:
+                            result = this;          // prefix1 \cdot prefix2 = prefix1
+                            break;
+
+                        case ContentType.SetOfCharacters:
+                            result = new StringAbstraction(characters.Union(what.characters)); // { bla1 bla12 } \code {bla2 bla22} = {bla1, bla12, bla2, bla22} 
+                            break;
+
+                        case ContentType.String:  // Simple concatenation
+                            result = new StringAbstraction(fullstring + what.fullstring);
+                            break;
+
+                        default:
+                            throw new AbstractInterpretationException("Impossible case?");
+                            #endregion
+                    }
+                }
+                else
+                {
+                    switch (content)
+                    {
+                        #region All the cases
+                        case ContentType.Prefix:
+                            if (what.content == ContentType.SetOfCharacters)
+                            {
+                                result = this;       // prefix \cdot {bla bla} = prefix
+                            }
+                            else if (what.content == ContentType.String)
+                            {                     // prefix \cdot string = prefix
+                                result = this;
+                            }
+                            else
+                            {
+                                goto default;
+                            }
+                            break;
+
+                        case ContentType.SetOfCharacters:
+                            if (what.content == ContentType.Prefix)
+                            {
+                                result = (StringAbstraction)this.Top;
+                            }
+                            else if (what.content == ContentType.String)
+                            {
+                                result = new StringAbstraction(characters.Union(AlphaToSetOfCharacters(what.fullstring)));
+                            }
+                            else
+                            {
+                                goto default;
+                            }
+                            break;
+
+                        case ContentType.String:
+                            if (what.content == ContentType.SetOfCharacters)
+                            {
+                                result = new StringAbstraction(AlphaToSetOfCharacters(fullstring).Union(what.characters));
+                            }
+                            else if (what.content == ContentType.Prefix)
+                            {
+                                result = new StringAbstraction(fullstring + what.prefix, true);
+                            }
+                            else
+                            {
+                                goto default;
+                            }
+                            break;
+
+                        default:
+                            throw new AbstractInterpretationException("Impossible case?");
+                            #endregion
+                    }
+                }
+            }
+            return result;
+        }
+
+        public IStringAbstraction Insert(int where, IStringAbstraction/*!*/ param)
         //^ requires where >= 0;
-    {
-      Debug.Assert(where >= 0);
-      IStringAbstraction result;
-      if (this.IsTop || param.IsTop)
-      {
-        result = CachedTop;
-      }
-      else
-      {
-        StringAbstraction what = param as StringAbstraction; //^ assert what != null;
-        Debug.Assert(what != null);
-
-        if (this.content == what.content)
         {
-          switch (this.content)
-          {
-            #region All the cases
-            case ContentType.Prefix:
-              if (where < this.prefix.Length)
-              {
-                string tmp = this.prefix.Substring(0, where);
-                result = new StringAbstraction(tmp + prefix, true);
-              }
-              else
-              {
+            Debug.Assert(where >= 0);
+            IStringAbstraction result;
+            if (this.IsTop || param.IsTop)
+            {
                 result = CachedTop;
-              }
-              break;
+            }
+            else
+            {
+                StringAbstraction what = param as StringAbstraction; //^ assert what != null;
+                Debug.Assert(what != null);
 
-            case ContentType.SetOfCharacters:
-              result = new StringAbstraction(this.characters.Union(what.characters));
-              break;
-
-            case ContentType.String:
-              result = new StringAbstraction(this.fullstring.Insert(where, what.fullstring));
-              break;
-
-            default:
-              throw new AbstractInterpretationException("Impossible case?");
-            #endregion
-          }
-        }
-        else
-        {
-          switch (this.content)
-          {
-            #region All the cases
-            case ContentType.Prefix:
-              if (what.content == ContentType.SetOfCharacters)
-              {
-                result = CachedTop;
-              }
-              else if (what.content == ContentType.String)
-              {
-                if (where < this.fullstring.Length)
+                if (content == what.content)
                 {
-                  result = new StringAbstraction(this.prefix.Insert(where, what.fullstring));
+                    switch (content)
+                    {
+                        #region All the cases
+                        case ContentType.Prefix:
+                            if (where < prefix.Length)
+                            {
+                                string tmp = prefix.Substring(0, where);
+                                result = new StringAbstraction(tmp + prefix, true);
+                            }
+                            else
+                            {
+                                result = CachedTop;
+                            }
+                            break;
+
+                        case ContentType.SetOfCharacters:
+                            result = new StringAbstraction(characters.Union(what.characters));
+                            break;
+
+                        case ContentType.String:
+                            result = new StringAbstraction(fullstring.Insert(where, what.fullstring));
+                            break;
+
+                        default:
+                            throw new AbstractInterpretationException("Impossible case?");
+                            #endregion
+                    }
                 }
                 else
                 {
-                  result = this;
+                    switch (content)
+                    {
+                        #region All the cases
+                        case ContentType.Prefix:
+                            if (what.content == ContentType.SetOfCharacters)
+                            {
+                                result = CachedTop;
+                            }
+                            else if (what.content == ContentType.String)
+                            {
+                                if (where < fullstring.Length)
+                                {
+                                    result = new StringAbstraction(prefix.Insert(where, what.fullstring));
+                                }
+                                else
+                                {
+                                    result = this;
+                                }
+                            }
+                            else
+                            {
+                                goto default;
+                            }
+                            break;
+
+                        case ContentType.SetOfCharacters:
+                            if (what.content == ContentType.Prefix)
+                            {
+                                result = CachedTop;
+                            }
+                            else if (what.content == ContentType.String)
+                            {
+                                result = new StringAbstraction(characters.Union(AlphaToSetOfCharacters(what.fullstring)));
+                            }
+                            else
+                            {
+                                goto default;
+                            }
+                            break;
+
+                        case ContentType.String:
+                            if (what.content == ContentType.SetOfCharacters)
+                            {
+                                result = new StringAbstraction(AlphaToSetOfCharacters(fullstring).Union(what.characters));
+                            }
+                            else if (what.content == ContentType.Prefix)
+                            {
+                                if (where < fullstring.Length)
+                                {
+                                    string tmp = fullstring.Substring(0, where);
+                                    result = new StringAbstraction(tmp + what.prefix, true);
+                                }
+                                else
+                                {
+                                    result = this;
+                                }
+                            }
+                            else
+                            {
+                                goto default;
+                            }
+                            break;
+
+                        default:
+                            throw new AbstractInterpretationException("Impossible case?");
+                            #endregion
+                    }
                 }
-              }
-              else
-              {
-                goto default;
-              }
-              break;
+            }
+            return result;
+        }
 
-            case ContentType.SetOfCharacters:
-              if (what.content == ContentType.Prefix)
-              {
-                result = CachedTop;
-              }
-              else if (what.content == ContentType.String)
-              {
-                result = new StringAbstraction(this.characters.Union(AlphaToSetOfCharacters(what.fullstring)));
-              }
-              else
-              {
-                goto default;
-              }
-              break;
+        public IStringAbstraction Trim()
+        {
+            StringAbstraction result;
+            switch (content)
+            {
+                case ContentType.Bottom:
+                    result = this;
+                    break;
 
-            case ContentType.String:
-              if (what.content == ContentType.SetOfCharacters)
-              {
-                result = new StringAbstraction(AlphaToSetOfCharacters(this.fullstring).Union(what.characters));
-              }
-              else if (what.content == ContentType.Prefix)
-              {
-                if (where < this.fullstring.Length)
+                case ContentType.Prefix:
+                    result = new StringAbstraction(prefix.Trim(), true);
+                    break;
+
+                case ContentType.SetOfCharacters:
+                    Set<SimpleCharacterAbstraction> tmp = RemoveWhiteSpaces(characters);
+                    result = new StringAbstraction(tmp);
+                    break;
+
+                case ContentType.String:
+                    result = new StringAbstraction(fullstring.Trim());
+                    break;
+
+                case ContentType.Top:
+                    result = this;
+                    break;
+
+                default:
+                    throw new AbstractInterpretationException("Impossible case?");
+            }
+            return result;
+        }
+
+        public FlatAbstractDomain<int>/*!*/ CompareTo(IStringAbstraction/*!*/ param)
+        {
+            FlatAbstractDomain<int> result;
+            FlatAbstractDomain<int> top = (FlatAbstractDomain<int>)new FlatAbstractDomain<int>(1).Top;
+
+            if (this.IsTop || param.IsTop)
+            {
+                return top;
+            }
+            else
+            {
+                StringAbstraction who = param as StringAbstraction; //^ assert who != null;
+                Debug.Assert(who != null);
+
+                if (content == ContentType.String && who.content == ContentType.String)
                 {
-                  string tmp = this.fullstring.Substring(0, where);
-                  result = new StringAbstraction(tmp + what.prefix, true);
+                    result = new FlatAbstractDomain<int>(fullstring.CompareTo(who.fullstring));
                 }
                 else
                 {
-                  result = this;
+                    result = top;
                 }
-              }
-              else
-              {
-                goto default;
-              }
-              break;
+            }
 
-            default:
-              throw new AbstractInterpretationException("Impossible case?");
-            #endregion
-          }
+            return result;
         }
-      }
-      return result;
-    }
 
-    public IStringAbstraction Trim()
-    {
-      StringAbstraction result;
-      switch (this.content)
-      {
-        case ContentType.Bottom:
-          result = this;
-          break;
-
-        case ContentType.Prefix:
-          result = new StringAbstraction(this.prefix.Trim(), true);
-          break;
-
-        case ContentType.SetOfCharacters:
-          Set<SimpleCharacterAbstraction> tmp = RemoveWhiteSpaces(this.characters);
-          result = new StringAbstraction(tmp);
-          break;
-
-        case ContentType.String:
-          result = new StringAbstraction(this.fullstring.Trim());
-          break;
-
-        case ContentType.Top:
-          result = this;
-          break;
-
-        default:
-          throw new AbstractInterpretationException("Impossible case?");
-      }
-      return result;
-    }
-
-    public FlatAbstractDomain<int>/*!*/ CompareTo(IStringAbstraction/*!*/ param)
-    {
-      FlatAbstractDomain<int> result;
-      FlatAbstractDomain<int> top = (FlatAbstractDomain<int>)new FlatAbstractDomain<int>(1).Top;
-
-      if (this.IsTop || param.IsTop)
-      {
-        return top;
-      }
-      else
-      {
-        StringAbstraction who = param as StringAbstraction; //^ assert who != null;
-        Debug.Assert(who != null);
-
-        if (this.content == ContentType.String && who.content == ContentType.String)
+        public FlatAbstractDomain<bool>/*!*/ Contains(IStringAbstraction/*!*/ param)
         {
-          result = new FlatAbstractDomain<int>(this.fullstring.CompareTo(who.fullstring));
-        }
-        else
-        {
-          result = top;
-        }
-      }
+            FlatAbstractDomain<bool> result;
+            FlatAbstractDomain<bool> top = new FlatAbstractDomain<bool>(false).Top;
 
-      return result;
-    }
-
-    public FlatAbstractDomain<bool>/*!*/ Contains(IStringAbstraction/*!*/ param)
-    {
-      FlatAbstractDomain<bool> result;
-      FlatAbstractDomain<bool> top =  new FlatAbstractDomain<bool>(false).Top;
-
-      if (this.IsTop || param.IsTop)
-      {
-        result = top;
-      }
-      else
-      {
-        StringAbstraction what = param as StringAbstraction; //^ assert what != null;
-        Debug.Assert(what != null);
-
-        if (this.content == what.content)
-        {
-          #region All the cases...
-          switch (this.content)
-          {
-            case ContentType.Prefix:
-              result = top;
-              break;
-            
-            case ContentType.SetOfCharacters:
-              result = top;
-              break;
-
-            case ContentType.String:
-              result = new FlatAbstractDomain<bool>(this.fullstring.Contains(what.fullstring));
-              break;
-
-            default:
-              throw new AbstractInterpretationException("Impossible case?");
-          }
-          #endregion
-        }
-        else
-        {
-          switch (this.content)
-          {
-            #region All the cases
-            case ContentType.Prefix:
-              if (what.content == ContentType.String && this.prefix.Contains(what.fullstring))
-              {
-                result = new FlatAbstractDomain<bool>(true);
-              }
-              else
-              {
+            if (this.IsTop || param.IsTop)
+            {
                 result = top;
-              }
-              break;
-
-            case ContentType.SetOfCharacters:
-            case ContentType.String:
-              result = top;
-              break;
-
-            default:
-              throw new AbstractInterpretationException("Impossible case?");
-            #endregion
-          }
-        }
-      }
-      return result;
-    }
-
-    public FlatAbstractDomain<bool>/*!*/ StartsWith(IStringAbstraction/*!*/ param)
-    {
-      FlatAbstractDomain<bool> result;
-      FlatAbstractDomain<bool> top =  new FlatAbstractDomain<bool>(false).Top;
-
-      if (this.IsTop || param.IsTop)
-      {
-        result = top;
-      }
-      else
-      {
-        StringAbstraction what = param as StringAbstraction; //^ assert what != null;
-        Debug.Assert(what != null);
-
-        if (this.content == ContentType.String && what.content == ContentType.String)
-        {
-          result = new FlatAbstractDomain<bool>(this.fullstring.StartsWith(what.fullstring)); 
-        }
-        else if (this.content == ContentType.Prefix && what.content == ContentType.String)
-        {
-          result = new FlatAbstractDomain<bool>(this.prefix.StartsWith(what.fullstring));
-        }
-        else
-        {
-          result = top;
-        }
-      }
-      return result;
-    }
-
-    #region IAbstractDomain Members
-
-    public bool IsBottom
-    {
-      get 
-      {
-        return this.content == ContentType.Bottom;
-      }
-    }
-
-    public bool IsTop
-    {
-      get 
-      {
-        return this.content == ContentType.Top;
-      }
-    }
-
-    public bool LessEqual(IAbstractDomain/*!*/ a)
-    {
-      bool tryResult;
-      if(AbstractDomainsHelper.TryTrivialLessEqual(this, a, out tryResult))
-      {
-        return tryResult;
-      }
-
-      StringAbstraction right = a as StringAbstraction;
-      //^ assert right != null;
-      Debug.Assert(right != null, "I was expecting a " + this.GetType().ToString());
-
-      bool result;
-
-      if (this.content == right.content)
-      {
-        switch (this.content)
-        {
-          #region All the cases
-          case ContentType.Prefix:
-            result = this.prefix.StartsWith(right.prefix);    // it is larger if it is a substring
-            break;
-
-          case ContentType.SetOfCharacters:
-            result = this.characters.IsSubset(right.characters);  // it is larger if it is a subset
-            break;
-
-          case ContentType.String:
-            result = this.fullstring.CompareTo(right.fullstring) == 0;    // must be the same string
-            break;
-
-          case ContentType.Bottom:
-          case ContentType.Top:
-          default:
-            throw new AbstractInterpretationException("Unexpected case : " + this.content);
-          #endregion
-        }
-      }
-      else
-      {
-        switch (this.content)
-        {
-          #region All the cases
-          case ContentType.Prefix:
-            if (right.content == ContentType.SetOfCharacters)
-            {
-              result = false;
-            }
-            else if (right.content == ContentType.String)
-            {
-              result = false;
             }
             else
             {
-              goto default;
-            }
-            break;
+                StringAbstraction what = param as StringAbstraction; //^ assert what != null;
+                Debug.Assert(what != null);
 
-          case ContentType.SetOfCharacters:
-            if (right.content == ContentType.Prefix)
-            {
-              result = false;
-            }
-            else if (right.content == ContentType.String)
-            {
-              result = false;
-            }
-            else
-            {
-              goto default;
-            }
-            break;
+                if (content == what.content)
+                {
+                    #region All the cases...
+                    switch (content)
+                    {
+                        case ContentType.Prefix:
+                            result = top;
+                            break;
 
-          case ContentType.String:
-            if (right.content == ContentType.Prefix)
-            {
-              result = this.fullstring.StartsWith(right.prefix);
-            }
-            else if (right.content == ContentType.SetOfCharacters)
-            {
-              Set<SimpleCharacterAbstraction> tmp = AlphaToSetOfCharacters(this.fullstring);
-              result = tmp.IsSubset(right.characters);
-            }
-            else
-            {
-              goto default;
-            }
-            break;
+                        case ContentType.SetOfCharacters:
+                            result = top;
+                            break;
 
-          case ContentType.Bottom:
-          case ContentType.Top:
-          default:
-            throw new AbstractInterpretationException("Unexpected case : " + this.content);
-          #endregion
+                        case ContentType.String:
+                            result = new FlatAbstractDomain<bool>(fullstring.Contains(what.fullstring));
+                            break;
+
+                        default:
+                            throw new AbstractInterpretationException("Impossible case?");
+                    }
+                    #endregion
+                }
+                else
+                {
+                    switch (content)
+                    {
+                        #region All the cases
+                        case ContentType.Prefix:
+                            if (what.content == ContentType.String && prefix.Contains(what.fullstring))
+                            {
+                                result = new FlatAbstractDomain<bool>(true);
+                            }
+                            else
+                            {
+                                result = top;
+                            }
+                            break;
+
+                        case ContentType.SetOfCharacters:
+                        case ContentType.String:
+                            result = top;
+                            break;
+
+                        default:
+                            throw new AbstractInterpretationException("Impossible case?");
+                            #endregion
+                    }
+                }
+            }
+            return result;
         }
-      }
 
-      return result;
-    }
-
-    public IAbstractDomain/*!*/ Bottom
-    {
-      get 
-      {
-        return CachedBottom;
-      }
-    }
-
-    public IAbstractDomain/*!*/ Top
-    {
-      get 
-      {
-        return CachedTop;
-      }
-    }
-
-    public IAbstractDomain/*!*/ Join(IAbstractDomain/*!*/ a)
-    {
-      IAbstractDomain tryResult;
-      if(AbstractDomainsHelper.TryTrivialJoin(this, a, out tryResult))
-      {
-        return tryResult;
-      }
-
-      StringAbstraction right = a as StringAbstraction;
-      //^ assert right != null;
-      Debug.Assert(right != null, "I was expecting a " + this.GetType().ToString());
-
-      IAbstractDomain/*!*/ result;
-
-      if (this.content == right.content)
-      {
-        switch (this.content)
+        public FlatAbstractDomain<bool>/*!*/ StartsWith(IStringAbstraction/*!*/ param)
         {
-          #region All the cases
-          case ContentType.Prefix:
-            result = HelperForPrefixJoin(this.prefix, right.prefix);
-            break;
+            FlatAbstractDomain<bool> result;
+            FlatAbstractDomain<bool> top = new FlatAbstractDomain<bool>(false).Top;
 
-          case ContentType.SetOfCharacters:
-            result = HelperForSetOfCharactersJoin(this.characters, right.characters);
-            break;
+            if (this.IsTop || param.IsTop)
+            {
+                result = top;
+            }
+            else
+            {
+                StringAbstraction what = param as StringAbstraction; //^ assert what != null;
+                Debug.Assert(what != null);
 
-          case ContentType.String:
-            result = HelperForStringJoin(this.fullstring, right.fullstring);
-            break;
-
-          case ContentType.Top:
-          case ContentType.Bottom:
-          default:
-            // Impossible cases as they have already been checked before
-            throw new AbstractInterpretationException("Impossible case?");   
-          #endregion
+                if (content == ContentType.String && what.content == ContentType.String)
+                {
+                    result = new FlatAbstractDomain<bool>(fullstring.StartsWith(what.fullstring));
+                }
+                else if (content == ContentType.Prefix && what.content == ContentType.String)
+                {
+                    result = new FlatAbstractDomain<bool>(prefix.StartsWith(what.fullstring));
+                }
+                else
+                {
+                    result = top;
+                }
+            }
+            return result;
         }
-      }
-      else
-      {
-        switch (this.content)
+
+        #region IAbstractDomain Members
+
+        public bool IsBottom
         {
-          #region All the cases...
-          case ContentType.Prefix:
-            if (right.content == ContentType.SetOfCharacters)
+            get
             {
-              result = this.Top;    
+                return content == ContentType.Bottom;
             }
-            else if (right.content == ContentType.String)
-            {
-              result = HelperForStringPrefixJoin(right.fullstring, this.prefix);
-            }
-            else
-            {
-              goto default;
-            }
-            break;
-
-          case ContentType.SetOfCharacters:
-            if (right.content == ContentType.Prefix)
-            {
-              result = this.Top;
-            }
-            else if (right.content == ContentType.String)
-            {
-              result = HelperForSetOfCharactersJoin(this.characters, AlphaToSetOfCharacters(right.fullstring));
-            }
-            else
-            {
-              goto default;
-            }
-            break;
-
-          case ContentType.String:
-            if(right.content == ContentType.Prefix)
-            {
-             result = HelperForStringPrefixJoin(this.fullstring, right.prefix);
-            }
-            else if (right.content == ContentType.SetOfCharacters)
-            {
-              result = HelperForSetOfCharactersJoin(AlphaToSetOfCharacters(this.fullstring), right.characters);
-            }
-            else
-            {
-              goto default;
-            }
-            break;
-
-          case ContentType.Top:
-          case ContentType.Bottom:
-          default:
-            // Impossible cases as they have already been checked before
-            throw new AbstractInterpretationException("Impossible case?");  
-          #endregion
         }
-      }
 
-      return result;
+        public bool IsTop
+        {
+            get
+            {
+                return content == ContentType.Top;
+            }
+        }
+
+        public bool LessEqual(IAbstractDomain/*!*/ a)
+        {
+            bool tryResult;
+            if (AbstractDomainsHelper.TryTrivialLessEqual(this, a, out tryResult))
+            {
+                return tryResult;
+            }
+
+            StringAbstraction right = a as StringAbstraction;
+            //^ assert right != null;
+            Debug.Assert(right != null, "I was expecting a " + this.GetType().ToString());
+
+            bool result;
+
+            if (content == right.content)
+            {
+                switch (content)
+                {
+                    #region All the cases
+                    case ContentType.Prefix:
+                        result = prefix.StartsWith(right.prefix);    // it is larger if it is a substring
+                        break;
+
+                    case ContentType.SetOfCharacters:
+                        result = characters.IsSubset(right.characters);  // it is larger if it is a subset
+                        break;
+
+                    case ContentType.String:
+                        result = fullstring.CompareTo(right.fullstring) == 0;    // must be the same string
+                        break;
+
+                    case ContentType.Bottom:
+                    case ContentType.Top:
+                    default:
+                        throw new AbstractInterpretationException("Unexpected case : " + content);
+                        #endregion
+                }
+            }
+            else
+            {
+                switch (content)
+                {
+                    #region All the cases
+                    case ContentType.Prefix:
+                        if (right.content == ContentType.SetOfCharacters)
+                        {
+                            result = false;
+                        }
+                        else if (right.content == ContentType.String)
+                        {
+                            result = false;
+                        }
+                        else
+                        {
+                            goto default;
+                        }
+                        break;
+
+                    case ContentType.SetOfCharacters:
+                        if (right.content == ContentType.Prefix)
+                        {
+                            result = false;
+                        }
+                        else if (right.content == ContentType.String)
+                        {
+                            result = false;
+                        }
+                        else
+                        {
+                            goto default;
+                        }
+                        break;
+
+                    case ContentType.String:
+                        if (right.content == ContentType.Prefix)
+                        {
+                            result = fullstring.StartsWith(right.prefix);
+                        }
+                        else if (right.content == ContentType.SetOfCharacters)
+                        {
+                            Set<SimpleCharacterAbstraction> tmp = AlphaToSetOfCharacters(fullstring);
+                            result = tmp.IsSubset(right.characters);
+                        }
+                        else
+                        {
+                            goto default;
+                        }
+                        break;
+
+                    case ContentType.Bottom:
+                    case ContentType.Top:
+                    default:
+                        throw new AbstractInterpretationException("Unexpected case : " + content);
+                        #endregion
+                }
+            }
+
+            return result;
+        }
+
+        public IAbstractDomain/*!*/ Bottom
+        {
+            get
+            {
+                return CachedBottom;
+            }
+        }
+
+        public IAbstractDomain/*!*/ Top
+        {
+            get
+            {
+                return CachedTop;
+            }
+        }
+
+        public IAbstractDomain/*!*/ Join(IAbstractDomain/*!*/ a)
+        {
+            IAbstractDomain tryResult;
+            if (AbstractDomainsHelper.TryTrivialJoin(this, a, out tryResult))
+            {
+                return tryResult;
+            }
+
+            StringAbstraction right = a as StringAbstraction;
+            //^ assert right != null;
+            Debug.Assert(right != null, "I was expecting a " + this.GetType().ToString());
+
+            IAbstractDomain/*!*/ result;
+
+            if (content == right.content)
+            {
+                switch (content)
+                {
+                    #region All the cases
+                    case ContentType.Prefix:
+                        result = HelperForPrefixJoin(prefix, right.prefix);
+                        break;
+
+                    case ContentType.SetOfCharacters:
+                        result = HelperForSetOfCharactersJoin(characters, right.characters);
+                        break;
+
+                    case ContentType.String:
+                        result = HelperForStringJoin(fullstring, right.fullstring);
+                        break;
+
+                    case ContentType.Top:
+                    case ContentType.Bottom:
+                    default:
+                        // Impossible cases as they have already been checked before
+                        throw new AbstractInterpretationException("Impossible case?");
+                        #endregion
+                }
+            }
+            else
+            {
+                switch (content)
+                {
+                    #region All the cases...
+                    case ContentType.Prefix:
+                        if (right.content == ContentType.SetOfCharacters)
+                        {
+                            result = this.Top;
+                        }
+                        else if (right.content == ContentType.String)
+                        {
+                            result = HelperForStringPrefixJoin(right.fullstring, prefix);
+                        }
+                        else
+                        {
+                            goto default;
+                        }
+                        break;
+
+                    case ContentType.SetOfCharacters:
+                        if (right.content == ContentType.Prefix)
+                        {
+                            result = this.Top;
+                        }
+                        else if (right.content == ContentType.String)
+                        {
+                            result = HelperForSetOfCharactersJoin(characters, AlphaToSetOfCharacters(right.fullstring));
+                        }
+                        else
+                        {
+                            goto default;
+                        }
+                        break;
+
+                    case ContentType.String:
+                        if (right.content == ContentType.Prefix)
+                        {
+                            result = HelperForStringPrefixJoin(fullstring, right.prefix);
+                        }
+                        else if (right.content == ContentType.SetOfCharacters)
+                        {
+                            result = HelperForSetOfCharactersJoin(AlphaToSetOfCharacters(fullstring), right.characters);
+                        }
+                        else
+                        {
+                            goto default;
+                        }
+                        break;
+
+                    case ContentType.Top:
+                    case ContentType.Bottom:
+                    default:
+                        // Impossible cases as they have already been checked before
+                        throw new AbstractInterpretationException("Impossible case?");
+                        #endregion
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// The meet works only on the same contents
+        /// </summary>
+        public IAbstractDomain/*!*/ Meet(IAbstractDomain/*!*/ a)
+        {
+            IAbstractDomain tryResult;
+            if (AbstractDomainsHelper.TryTrivialMeet(this, a, out tryResult))
+            {
+                return tryResult;
+            }
+
+            StringAbstraction right = a as StringAbstraction;
+            //^ assert right != null;
+            Debug.Assert(right != null, "I was expecting a " + this.GetType().ToString());
+
+            IAbstractDomain/*!*/ result;
+
+            if (content == right.content)
+            {
+                switch (content)
+                {
+                    #region All the cases ...
+                    case ContentType.Prefix:
+                        if (prefix.CompareTo(right.prefix) == 0)
+                        {
+                            result = this;
+                        }
+                        else
+                        {
+                            result = this.Bottom;
+                        }
+                        break;
+
+                    case ContentType.SetOfCharacters:
+                        var intersection = characters.Intersection(right.characters);
+                        if (intersection.IsEmpty)
+                        {
+                            result = this.Bottom;
+                        }
+                        else
+                        {
+                            result = new StringAbstraction(intersection);
+                        }
+                        break;
+
+                    case ContentType.String:
+                        if (fullstring.CompareTo(right.fullstring) == 0)
+                        {
+                            result = this;
+                        }
+                        else
+                        {
+                            result = this.Bottom;
+                        }
+                        break;
+
+                    case ContentType.Top:
+                    case ContentType.Bottom:
+                    default:
+                        // Impossible cases as they have already been checked before
+                        throw new AbstractInterpretationException("Impossible case?");
+                        #endregion
+                }
+            }
+            else
+            {
+                result = this.Bottom;
+            }
+
+            return result;
+        }
+
+        public IAbstractDomain/*!*/ Widening(IAbstractDomain/*!*/ prev)
+        {
+            return this.Join(prev);
+        }
+
+        #endregion
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            return new StringAbstraction(this);
+        }
+
+        #endregion
+
+        #region Private
+
+        static private IAbstractDomain/*!*/ HelperForStringPrefixJoin(string/*!*/ fullstring, string/*!*/ prefix)
+        {
+            IAbstractDomain result;
+
+            if (fullstring.StartsWith(prefix))
+            {
+                result = new StringAbstraction(prefix, true);
+            }
+            else
+            {
+                result = new StringAbstraction();   // i.e. top
+            }
+            return result;
+        }
+
+        static private IAbstractDomain/*!*/ HelperForStringJoin(string/*!*/ s1, string/*!*/ s2)
+        {
+            IAbstractDomain/*!*/ result;
+            if (s1.CompareTo(s2) == 0)
+            { // If they are the same string, nothing to do
+                result = new StringAbstraction(s1);
+            }
+            else
+            { // If they are different strings, try to find a common prefix, or simply abstract away all the characters
+                int i;
+                StringBuilder commonPrefix = new StringBuilder();
+                // we look for the common prefix of the two strings
+                for (i = 0; i < Math.Min(s1.Length, s2.Length); i++)
+                {
+                    if (s1[i] == s2[i])
+                    {
+                        commonPrefix.Append(s1[i]);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                if (i == 0)
+                { // there is no common prefix
+                    Set<SimpleCharacterAbstraction> chars1 = AlphaToSetOfCharacters(s1);
+                    Set<SimpleCharacterAbstraction> chars2 = AlphaToSetOfCharacters(s2);
+
+                    result = new StringAbstraction(chars1.Union(chars2));
+                }
+                else
+                {
+                    result = new StringAbstraction(commonPrefix.ToString(), true);
+                }
+            }
+
+            return result;
+        }
+
+        static private IAbstractDomain/*!*/ HelperForSetOfCharactersJoin(Set<SimpleCharacterAbstraction>/*!*/ iSet1, Set<SimpleCharacterAbstraction>/*!*/ iSet2)
+        {
+            Set<SimpleCharacterAbstraction> union = iSet1.Union(iSet2);
+
+            return new StringAbstraction(union);
+        }
+
+        static private IAbstractDomain/*!*/ HelperForPrefixJoin(string/*!*/ p1, string/*!*/ p2)
+        {
+            IAbstractDomain/*!*/ result;
+            if (p1.CompareTo(p2) == 0)
+            { // If they are the same string, nothing to do
+                result = new StringAbstraction(p1, true);
+            }
+            else
+            {
+                result = HelperForPrefixJoin(p1, p2);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Abstract the string <code>s</code> to a set of abstract characters
+        /// </summary>
+        /// <returns></returns>
+        static private Set<SimpleCharacterAbstraction>/*!*/ AlphaToSetOfCharacters(string/*!*/ s)
+        {
+            Set<SimpleCharacterAbstraction> result = new Set<SimpleCharacterAbstraction>();
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                // This below is maybe not the most optimized version, but it works
+                SimpleCharacterAbstraction tmp = new SimpleCharacterAbstraction(s[i]);
+                result.Add(tmp);
+            }
+
+            return result;
+        }
+
+        private Set<SimpleCharacterAbstraction> RemoveWhiteSpaces(Set<SimpleCharacterAbstraction> iSet)
+        {
+            Set<SimpleCharacterAbstraction> result = new Set<SimpleCharacterAbstraction>();
+
+            foreach (SimpleCharacterAbstraction c in iSet)
+            {
+                if (!c.IsSpace)
+                {
+                    result.Add(c);
+                }
+            }
+            return result;
+        }
+
+        #endregion
+
+        #region ToString
+        public override string ToString()
+        {
+            string result;
+            switch (content)
+            {
+                case ContentType.Prefix:
+                    result = "Prefix(" + prefix + ")";
+                    break;
+
+                case ContentType.SetOfCharacters:
+                    result = "Chars(" + characters + ")";
+                    break;
+
+                case ContentType.String:
+                    result = "String(" + fullstring + ")";
+                    break;
+
+                case ContentType.Top:
+                    result = "Top";
+                    break;
+
+                case ContentType.Bottom:
+                    result = "Bottom";
+                    break;
+
+                default:
+                    throw new AbstractInterpretationException("Error!!!");
+            }
+
+            return result;
+        }
+        #endregion
+
+        #endregion
     }
 
     /// <summary>
-    /// The meet works only on the same contents
+    /// A simple abstraction set of characters
     /// </summary>
-    public IAbstractDomain/*!*/ Meet(IAbstractDomain/*!*/ a)
+    internal class SimpleCharacterAbstraction
     {
-      IAbstractDomain tryResult;
-      if(AbstractDomainsHelper.TryTrivialMeet(this, a, out tryResult))
-      {
-        return tryResult;
-      }
+        #region Private state
+        private enum ContentType { Control, Digit, Letter, Punctuation, Space }
 
-      StringAbstraction right = a as StringAbstraction;
-      //^ assert right != null;
-      Debug.Assert(right != null, "I was expecting a " + this.GetType().ToString());
+        private ContentType content;
+        private char? c = null;
+        #endregion
 
-      IAbstractDomain/*!*/ result;
-
-      if (this.content == right.content)
-      {
-        switch (this.content)
+        public SimpleCharacterAbstraction(char c)
         {
-          #region All the cases ...
-          case ContentType.Prefix:
-            if(this.prefix.CompareTo(right.prefix) == 0)
+            Init(c);
+        }
+
+        public bool IsSpace
+        {
+            get
             {
-              result = this;
+                return content == ContentType.Space;
+            }
+        }
+
+        /// <summary>
+        /// Redefine equals
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            SimpleCharacterAbstraction right = obj as SimpleCharacterAbstraction;
+            if (right == null)
+            {
+                return false;
             }
             else
             {
-              result = this.Bottom;
-            }
-            break;
+                if (content != right.content)
+                {
+                    return false;
+                }
+                else
+                {
+                    switch (content)
+                    {
+                        case ContentType.Control:
+                        case ContentType.Punctuation:
+                        case ContentType.Space:
+                            return c.Equals(right.c);
 
-          case ContentType.SetOfCharacters:
-            var intersection = this.characters.Intersection(right.characters);
-            if (intersection.IsEmpty)
+                        case ContentType.Digit:
+                            return true;
+
+                        case ContentType.Letter:
+                            return true;
+
+                        default:
+                            throw new AbstractInterpretationException("Unreacheable case? " + content);
+                    }
+                }
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            int result;
+
+            switch (content)
             {
-              result = this.Bottom;
+                case ContentType.Control:
+                    result = c.GetHashCode();
+                    break;
+
+                case ContentType.Digit:
+                    result = '0'.GetHashCode();
+                    break;
+
+                case ContentType.Letter:
+                    result = 'a'.GetHashCode();
+                    break;
+
+                case ContentType.Punctuation:
+                    result = c.GetHashCode();
+                    break;
+
+                case ContentType.Space:
+                    result = c.GetHashCode();
+                    break;
+
+                default:
+                    throw new AbstractInterpretationException("Unreacheable case? " + content);
+            }
+
+            return result;
+        }
+
+        #region Private
+
+        private void Init(char c)
+        {
+            if (Char.IsControl(c))
+            {
+                this.c = c;
+                content = ContentType.Control;
+            }
+            else if (Char.IsDigit(c))
+            {
+                this.c = null;
+                content = ContentType.Digit;
+            }
+            else if (Char.IsLetter(c))
+            {
+                this.c = null;
+                content = ContentType.Letter;
+            }
+            else if (Char.IsPunctuation(c))
+            {
+                this.c = c;
+                content = ContentType.Punctuation;
+            }
+            else if (Char.IsWhiteSpace(c))
+            {
+                this.c = c;
+                content = ContentType.Space;
             }
             else
             {
-              result = new StringAbstraction(intersection);
+                throw new AbstractInterpretationTODOException("Unknown character : " + c);
             }
-            break;
+        }
 
-          case ContentType.String:
-            if (this.fullstring.CompareTo(right.fullstring) == 0)
+        #endregion
+
+        #region ToString
+        public string ToLogicalFormula()
+        {
+            return null;
+        }
+
+        public override string ToString()
+        {
+            string result;
+
+            switch (content)
             {
-              result = this;
+                case ContentType.Control:
+                    result = "Control(" + c + ")";
+                    break;
+
+                case ContentType.Digit:
+                    result = "Digit(?)";
+                    break;
+
+                case ContentType.Letter:
+                    result = "Letter(?)";
+                    break;
+
+                case ContentType.Punctuation:
+                    result = "Punctuation(" + c + ")";
+                    break;
+
+                case ContentType.Space:
+                    result = "Space(" + c + ")";
+                    break;
+
+                default:
+                    throw new AbstractInterpretationException("Unreacheable case? " + content);
             }
-            else
-            {
-              result = this.Bottom;
-            }
-            break;
-
-          case ContentType.Top:
-          case ContentType.Bottom:
-          default:
-            // Impossible cases as they have already been checked before
-            throw new AbstractInterpretationException("Impossible case?");
-          #endregion
+            return result;
         }
-      }
-      else
-      {
-        result = this.Bottom;
-      }
-
-      return result;
+        #endregion
     }
-
-    public IAbstractDomain/*!*/ Widening(IAbstractDomain/*!*/ prev)
-    {
-      return this.Join(prev);
-    }
-
-    #endregion
-
-    #region ICloneable Members
-
-    public object Clone()
-    {
-      return new StringAbstraction(this);
-    }
-
-    #endregion
-
-    #region Private
-
-    static private IAbstractDomain/*!*/ HelperForStringPrefixJoin(string/*!*/ fullstring, string/*!*/ prefix)
-    {
-      IAbstractDomain result;
-
-      if (fullstring.StartsWith(prefix))
-      {
-        result = new StringAbstraction(prefix, true);
-      }
-      else
-      {
-        result = new StringAbstraction();   // i.e. top
-      }
-      return result;
-    }
-
-    static private IAbstractDomain/*!*/ HelperForStringJoin(string/*!*/ s1, string/*!*/ s2)
-    {
-      IAbstractDomain/*!*/ result;
-      if (s1.CompareTo(s2) == 0)
-      { // If they are the same string, nothing to do
-        result = new StringAbstraction(s1);
-      }
-      else
-      { // If they are different strings, try to find a common prefix, or simply abstract away all the characters
-        int i;
-        StringBuilder commonPrefix = new StringBuilder();
-        // we look for the common prefix of the two strings
-        for (i = 0; i < Math.Min(s1.Length, s2.Length); i++)
-        {
-          if (s1[i] == s2[i])
-          {
-            commonPrefix.Append(s1[i]);
-          }
-          else
-          {
-            break;
-          }
-        }
-        if (i == 0)
-        { // there is no common prefix
-          Set<SimpleCharacterAbstraction> chars1 = AlphaToSetOfCharacters(s1);
-          Set<SimpleCharacterAbstraction> chars2 = AlphaToSetOfCharacters(s2);
-
-          result = new StringAbstraction(chars1.Union(chars2));
-        }
-        else
-        {
-          result = new StringAbstraction(commonPrefix.ToString(), true);
-        }
-      }
-
-      return result;
-    }
-
-    static private IAbstractDomain/*!*/ HelperForSetOfCharactersJoin(Set<SimpleCharacterAbstraction>/*!*/ iSet1, Set<SimpleCharacterAbstraction>/*!*/ iSet2)
-    {
-      Set<SimpleCharacterAbstraction> union = iSet1.Union(iSet2);
-
-      return new StringAbstraction(union);
-    }
-
-    static private IAbstractDomain/*!*/ HelperForPrefixJoin(string/*!*/ p1, string/*!*/ p2)
-    {
-      IAbstractDomain/*!*/ result;
-      if (p1.CompareTo(p2) == 0)
-      { // If they are the same string, nothing to do
-        result = new StringAbstraction(p1, true);
-      }
-      else
-      {
-        result = HelperForPrefixJoin(p1, p2);
-      }
-
-      return result;
-    }
-
-    /// <summary>
-    /// Abstract the string <code>s</code> to a set of abstract characters
-    /// </summary>
-    /// <returns></returns>
-    static private Set<SimpleCharacterAbstraction>/*!*/ AlphaToSetOfCharacters(string/*!*/ s)
-    {
-      Set<SimpleCharacterAbstraction> result = new Set<SimpleCharacterAbstraction>();
-
-      for (int i = 0; i < s.Length; i++)
-      {
-        // This below is maybe not the most optimized version, but it works
-        SimpleCharacterAbstraction tmp = new SimpleCharacterAbstraction(s[i]);
-        result.Add(tmp);
-      }
-
-      return result;
-    }
-
-    private Set<SimpleCharacterAbstraction> RemoveWhiteSpaces(Set<SimpleCharacterAbstraction> iSet)
-    {
-      Set<SimpleCharacterAbstraction> result = new Set<SimpleCharacterAbstraction>();
-
-      foreach (SimpleCharacterAbstraction c in iSet)
-      {
-        if (!c.IsSpace)
-        {
-          result.Add(c);
-        }
-      }
-      return result;
-    }
-
-    #endregion
-
-    #region ToString
-    public override string ToString()
-    {
-      string result;
-      switch (this.content)
-      {
-        case ContentType.Prefix:
-          result = "Prefix(" + this.prefix + ")";
-          break;
-
-        case ContentType.SetOfCharacters:
-          result = "Chars(" + this.characters + ")";
-          break;
-
-        case ContentType.String:
-          result = "String(" + this.fullstring + ")";
-          break;
-
-        case ContentType.Top:
-          result = "Top";
-          break;
-
-        case ContentType.Bottom:
-          result = "Bottom";
-          break;
-
-        default:
-          throw new AbstractInterpretationException("Error!!!");
-      }
-
-      return result;
-    }
-    #endregion
-
-    #endregion
-  }
-
-  /// <summary>
-  /// A simple abstraction set of characters
-  /// </summary>
-  internal class SimpleCharacterAbstraction 
-  {
-    #region Private state
-    enum ContentType { Control, Digit, Letter, Punctuation, Space}
-
-    private ContentType content;
-    private char? c = null;
-    #endregion
-
-    public SimpleCharacterAbstraction(char c)
-    {
-      Init(c);
-    }
-
-    public bool IsSpace
-    {
-      get
-      {
-        return this.content == ContentType.Space;
-      }
-    }
-
-    /// <summary>
-    /// Redefine equals
-    /// </summary>
-    public override bool Equals(object obj)
-    {
-      SimpleCharacterAbstraction right = obj as SimpleCharacterAbstraction;
-      if (right == null)
-      {
-        return false;
-      }
-      else
-      {
-        if (this.content != right.content)
-        {
-          return false;
-        }
-        else
-        {
-          switch (this.content)
-          {
-            case ContentType.Control:
-            case ContentType.Punctuation:
-            case ContentType.Space:
-              return this.c.Equals(right.c);
-
-            case ContentType.Digit:
-              return true;
-
-            case ContentType.Letter:
-              return true;
-
-            default:
-              throw new AbstractInterpretationException("Unreacheable case? " + this.content);
-          }
-        }
-      }
-    }
-
-    public override int GetHashCode()
-    {
-      int result;
-
-      switch (this.content)
-      {
-        case ContentType.Control:
-          result = this.c.GetHashCode();
-          break;
-
-        case ContentType.Digit:
-          result = '0'.GetHashCode();
-          break;
-
-        case ContentType.Letter:
-          result = 'a'.GetHashCode();
-          break;
-
-        case ContentType.Punctuation:
-          result = this.c.GetHashCode();
-          break;
-
-        case ContentType.Space:
-          result = this.c.GetHashCode();
-          break;
-
-        default:
-          throw new AbstractInterpretationException("Unreacheable case? " + this.content);
-      }
-
-      return result;
-    }
-
-    #region Private
-
-    private void Init(char c)
-    {
-      if (Char.IsControl(c))
-      {
-        this.c = c;
-        this.content = ContentType.Control;
-      }
-      else if (Char.IsDigit(c))
-      {
-        this.c = null;
-        this.content = ContentType.Digit;
-      }
-      else if (Char.IsLetter(c))
-      {
-        this.c = null;
-        this.content = ContentType.Letter;
-      }
-      else if (Char.IsPunctuation(c))
-      {
-        this.c = c;
-        this.content = ContentType.Punctuation;
-      }
-      else if (Char.IsWhiteSpace(c))
-      {
-        this.c = c;
-        this.content = ContentType.Space;
-      }
-      else
-      {
-        throw new AbstractInterpretationTODOException("Unknown character : " + c);
-      }
-    }
-
-    #endregion
-
-    #region ToString
-    public string ToLogicalFormula()
-    {
-      return null;
-    }
-
-    public override string ToString()
-    {
-      string result;
-
-      switch (this.content)
-      {
-        case ContentType.Control:
-          result = "Control(" + this.c + ")";
-          break;
-
-        case ContentType.Digit:
-          result = "Digit(?)";
-          break;
-
-        case ContentType.Letter:
-          result = "Letter(?)";
-          break;
-
-        case ContentType.Punctuation:
-          result = "Punctuation(" + this.c + ")";
-          break;
-
-        case ContentType.Space:
-          result = "Space(" + this.c + ")";
-          break;
-
-        default:
-          throw new AbstractInterpretationException("Unreacheable case? " + this.content); 
-      }
-      return result;
-    }
-    #endregion
-  }
 }

--- a/Microsoft.Research/AbstractInterpretation/Abstract Domains/Utils.cs
+++ b/Microsoft.Research/AbstractInterpretation/Abstract Domains/Utils.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -24,1923 +13,1917 @@ using System.Linq;
 
 namespace Microsoft.Research.AbstractDomains
 {
-  /// <summary>
-  /// Some helper method for the abstract domains
-  /// </summary>
-  public static class AbstractDomainsHelper
-  {
-    [Pure]
-    public static bool TryTrivialLessEqual<This>(This left, This right, out bool result)
-      where This : IAbstractDomain
-    {
-      Contract.Ensures(Contract.Result<bool>() || !left.IsTop);
-      Contract.Ensures(Contract.Result<bool>() || !right.IsTop);
-
-      if (object.ReferenceEquals(left, right))
-      {
-        result = true;
-        return true;
-      }
-
-      if (left.IsBottom)
-      {
-        result = true;
-        return true;
-      }
-      else if (left.IsTop)
-      {
-        result = right.IsTop;
-        return true;
-      }
-      else if (right.IsBottom)
-      {
-        result = false;                   // At this point we already know that it is false
-        return true;
-      }
-      else if (right.IsTop)
-      {
-        result = true;
-        return true;
-      }
-      else
-      {
-        result = false;   // no matter what
-        return false;
-      }
-    }
-
-    [Pure]
-    public static bool TryTrivialJoin<This>(This left, This right, out This result)
-      where This : class, IAbstractDomain
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out result) != null));
-
-      if (object.ReferenceEquals(left, right))
-      {
-        result = left;
-        return true;
-      }
-
-      if (left.IsBottom)
-      {
-        result = right;
-        return true;
-      }
-      else if (left.IsTop)
-      {
-        result = left;
-        return true;
-      }
-      else if (right.IsBottom)
-      {
-        result = left;
-        return true;
-      }
-      else if (right.IsTop)
-      {
-        result = right;
-        return true;
-      }
-      else
-      {
-        result = default(This);
-        return false;
-      }
-    }
-
-    [Pure]
-    public static bool TryTrivialJoinRefinedWithEmptyArrays<AD, Variable, Expression>(
-      ArraySegmentation<AD, Variable, Expression> left,
-      ArraySegmentation<AD, Variable, Expression> right, 
-      out ArraySegmentation<AD, Variable, Expression> result)
-      where AD : class, IAbstractDomainForArraySegmentationAbstraction<AD, Variable>
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out result) != null));
-
-      // IsEmptyArray may determine that a segmentation is bottom, so it is more precise if we perform this check before
-      if (left.IsEmptyArray)
-      {
-        result = right;
-        return true;
-      }
-
-      if (right.IsEmptyArray)
-      {
-        result = left;
-        return true;
-      }
-
-      if (TryTrivialJoin(left, right, out result))
-      {
-        return true;
-      }
-
-      result = default(ArraySegmentation<AD, Variable, Expression>);
-      return false;
-
-    }
-
-
-
-    public static bool TryTrivialMeet<This>(This left, This right, out This result)
-      where This : class, IAbstractDomain
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out result) != null));
-
-      if (object.ReferenceEquals(left, right))
-      {
-        result = left;
-        return true;
-      }
-
-      if (left.IsBottom)
-      {
-        result = left;
-        return true;
-      }
-      else if (left.IsTop)
-      {
-        result = right;
-        return true;
-      }
-      else if (right.IsBottom)
-      {
-        result = right;
-        return true;
-      }
-      else if (right.IsTop)
-      {
-        result = left;
-        return true;
-      }
-      else
-      {
-        result = default(This);
-        return false;
-      }
-    }
-
     /// <summary>
-    /// Tries to get a threshod from the booleand guard <code>guard</code>
+    /// Some helper method for the abstract domains
     /// </summary>
-    public static bool TryToGetAThreshold<Variable, Expression>(Expression exp, out List<int> thresholds, IExpressionDecoder<Variable, Expression> decoder)
+    public static class AbstractDomainsHelper
     {
-      var searchForAThreshold = new GetAThresholdVisitor<Variable, Expression>(decoder);
-      if (searchForAThreshold.Visit(exp, Void.Value) && searchForAThreshold.Thresholds.Count == 1)
-      { // We do not want the thresholds to be too much, as it may slow down the analysis, 
-        // so we consider them relevant when they are only one
-        var t = searchForAThreshold.Thresholds[0];
-        thresholds = new List<int>() { t, t + 1, t - 1 };
-        return t != 0;
-      }
-      else
-      {
-        thresholds = null;
-        return false;
-      }
-    }
-  }
-
-  public static class CommonChecks
-  {
-    /// <summary>
-    /// Checks if <code>e1 \leq e2</code> is always true.
-    /// It can use some bound information from the oracledomain
-    /// </summary>
-    public static FlatAbstractDomain<bool> CheckLessEqualThan<Variable, Expression>(
-      Expression e1, Expression e2, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Polynomial<Variable, Expression> leq;
-      // Try to see if it holds using the oracleDomain
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1, e2, decoder, out leq))
-      {
-        if (leq.Degree == 0)
-        { // If it is a constant
-          var leftConstant = leq.Left[0].K;
-          var rightConstant = leq.Right[0].K;
-
-          if (leftConstant <= rightConstant)
-          {
-            return CheckOutcome.True;
-          }
-          else if (leftConstant > rightConstant)
-          {
-            return CheckOutcome.False;
-          }
-          else
-          {
-            return CheckOutcome.Top;
-          }
-        }
-        else if (leq.Degree == 1)
+        [Pure]
+        public static bool TryTrivialLessEqual<This>(This left, This right, out bool result)
+          where This : IAbstractDomain
         {
-          Variable x;
-          Rational k1, k2;
-          if (leq.TryMatch_k1XLessThank2(out k1, out x, out k2))
-          {
-            // Very easy for the moment
-            if (k1 == -1)
-            {  // -1 * x <= k2
-              var b = oracleDomain.BoundsFor(x);
-              if (!b.IsTop && -b.LowerBound <= k2)
-              {
-                return CheckOutcome.True;
-              }
-            }
-          }
-          /*  We do not care at the moment, it can be refined if we want */
-          /*
-            else if (PolynomialHelper.Match_k1XLessEqualThank2(leq, out k1, out x, out k2))
+            Contract.Ensures(Contract.Result<bool>() || !left.IsTop);
+            Contract.Ensures(Contract.Result<bool>() || !right.IsTop);
+
+            if (object.ReferenceEquals(left, right))
             {
-              return  CheckOutcome.Top; 
+                result = true;
+                return true;
             }
-           */
-        }
-      }
 
-      return CheckOutcome.Top;
-    }
-
-    /// <summary>
-    /// Checks if <code>e1 \lt e2 </code> is always true.
-    /// </summary>
-    /// It can use some bound information from the oracledomain
-#if SUBPOLY_ONLY
-  internal
-#else
-    public
-#endif
- static FlatAbstractDomain<bool> CheckLessThan<Variable, Expression>(Expression e1, Expression e2,
-      INumericalAbstractDomainQuery<Variable, Expression> oracleDomain, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      Polynomial<Variable, Expression> ltPol;
-
-      if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1, e2, decoder, out ltPol))
-      {
-        if (ltPol.Degree == 0)
-        { // If it is a constant
-          var leftConstant = ltPol.Left[0].K;
-          var rightConstant = ltPol.Right[0].K;
-
-          if (leftConstant < rightConstant)
-          {
-            return CheckOutcome.True;
-          }
-          else if (leftConstant >= rightConstant)
-          {
-            return CheckOutcome.False;
-          }
-        }
-        else if (ltPol.Degree == 1)
-        {
-          Variable x;
-          Rational k1, k2;
-
-          if (ltPol.TryMatch_k1XLessThank2(out k1, out x, out k2) && k1 == -1)
-          {
-            // -1 * x < k2
-            var b = oracleDomain.BoundsFor(x);
-            if (!b.IsTop && -b.LowerBound < k2)
+            if (left.IsBottom)
             {
-              return CheckOutcome.True;
+                result = true;
+                return true;
             }
-          }
-        }
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    static public FlatAbstractDomain<bool> CheckGreaterEqualThanZero<Variable, Expression>(Expression e, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      var anIntervalDomain = new IntervalEnvironment<Variable, Expression>(decoder, VoidLogger.Log);
-
-      return anIntervalDomain.CheckIfGreaterEqualThanZero(e);
-    }
-
-    /// <summary>
-    /// If the expression is an equality or disequality, see it the two operands are the same symbolic value
-    /// </summary>
-    static public bool CheckTrivialEquality<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
-    {
-      var op = decoder.OperatorFor(exp);
-
-      switch (op)
-      {
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          {
-            // Is the case that left == right ?
-            var left = decoder.LeftExpressionFor(exp);
-            var right = decoder.RightExpressionFor(exp);
-
-            if (op == ExpressionOperator.Equal &&
-              (decoder.IsNaN(left) || decoder.IsNaN(right)))
+            else if (left.IsTop)
             {
-              return false;
+                result = right.IsTop;
+                return true;
             }
-
-            if (left.Equals(right) || decoder.UnderlyingVariable(left).Equals(decoder.UnderlyingVariable(right)))
-            { // left == right
-              return true;
+            else if (right.IsBottom)
+            {
+                result = false;                   // At this point we already know that it is false
+                return true;
+            }
+            else if (right.IsTop)
+            {
+                result = true;
+                return true;
             }
             else
             {
-              var strippedLeft = decoder.Stripped(left);
-              var strippedRight = decoder.Stripped(right);
-
-              return strippedLeft.Equals(strippedRight) || decoder.UnderlyingVariable(strippedLeft).Equals(decoder.UnderlyingVariable(strippedRight));
+                result = false;   // no matter what
+                return false;
             }
-          }
+        }
 
-        case ExpressionOperator.NotEqual:
-          {
-            // Is the case that (x == x) != 0 ?
-            int value;
-            var left = decoder.LeftExpressionFor(exp);
-            if (decoder.OperatorFor(left) == ExpressionOperator.Equal
-              && decoder.IsConstantInt(decoder.RightExpressionFor(exp), out value)
-              && value == 0)
+        [Pure]
+        public static bool TryTrivialJoin<This>(This left, This right, out This result)
+          where This : class, IAbstractDomain
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out result) != null));
+
+            if (object.ReferenceEquals(left, right))
             {
-              return decoder.LeftExpressionFor(left).Equals(decoder.RightExpressionFor(left));
+                result = left;
+                return true;
             }
+
+            if (left.IsBottom)
+            {
+                result = right;
+                return true;
+            }
+            else if (left.IsTop)
+            {
+                result = left;
+                return true;
+            }
+            else if (right.IsBottom)
+            {
+                result = left;
+                return true;
+            }
+            else if (right.IsTop)
+            {
+                result = right;
+                return true;
+            }
+            else
+            {
+                result = default(This);
+                return false;
+            }
+        }
+
+        [Pure]
+        public static bool TryTrivialJoinRefinedWithEmptyArrays<AD, Variable, Expression>(
+          ArraySegmentation<AD, Variable, Expression> left,
+          ArraySegmentation<AD, Variable, Expression> right,
+          out ArraySegmentation<AD, Variable, Expression> result)
+          where AD : class, IAbstractDomainForArraySegmentationAbstraction<AD, Variable>
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out result) != null));
+
+            // IsEmptyArray may determine that a segmentation is bottom, so it is more precise if we perform this check before
+            if (left.IsEmptyArray)
+            {
+                result = right;
+                return true;
+            }
+
+            if (right.IsEmptyArray)
+            {
+                result = left;
+                return true;
+            }
+
+            if (TryTrivialJoin(left, right, out result))
+            {
+                return true;
+            }
+
+            result = default(ArraySegmentation<AD, Variable, Expression>);
             return false;
-          }
+        }
 
-        default:
-          return false;
-      }
+
+
+        public static bool TryTrivialMeet<This>(This left, This right, out This result)
+          where This : class, IAbstractDomain
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out result) != null));
+
+            if (object.ReferenceEquals(left, right))
+            {
+                result = left;
+                return true;
+            }
+
+            if (left.IsBottom)
+            {
+                result = left;
+                return true;
+            }
+            else if (left.IsTop)
+            {
+                result = right;
+                return true;
+            }
+            else if (right.IsBottom)
+            {
+                result = right;
+                return true;
+            }
+            else if (right.IsTop)
+            {
+                result = left;
+                return true;
+            }
+            else
+            {
+                result = default(This);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Tries to get a threshod from the booleand guard <code>guard</code>
+        /// </summary>
+        public static bool TryToGetAThreshold<Variable, Expression>(Expression exp, out List<int> thresholds, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            var searchForAThreshold = new GetAThresholdVisitor<Variable, Expression>(decoder);
+            if (searchForAThreshold.Visit(exp, Void.Value) && searchForAThreshold.Thresholds.Count == 1)
+            { // We do not want the thresholds to be too much, as it may slow down the analysis, 
+              // so we consider them relevant when they are only one
+                var t = searchForAThreshold.Thresholds[0];
+                thresholds = new List<int>() { t, t + 1, t - 1 };
+                return t != 0;
+            }
+            else
+            {
+                thresholds = null;
+                return false;
+            }
+        }
     }
 
-    static public bool CheckTrivialEquality<Variable, Expression>(Expression e1, Expression e2, 
-      IExpressionDecoder<Variable, Expression> decoder, out FlatAbstractDomain<bool> outcome)
+    public static class CommonChecks
     {
-      if (decoder.UnderlyingVariable(e1).Equals(decoder.UnderlyingVariable(e2)))
-      {
-        outcome = CheckOutcome.True;
-        return true;
-      }
+        /// <summary>
+        /// Checks if <code>e1 \leq e2</code> is always true.
+        /// It can use some bound information from the oracledomain
+        /// </summary>
+        public static FlatAbstractDomain<bool> CheckLessEqualThan<Variable, Expression>(
+          Expression e1, Expression e2, INumericalAbstractDomainQuery<Variable, Expression> oracleDomain, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Polynomial<Variable, Expression> leq;
+            // Try to see if it holds using the oracleDomain
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessEqualThan, e1, e2, decoder, out leq))
+            {
+                if (leq.Degree == 0)
+                { // If it is a constant
+                    var leftConstant = leq.Left[0].K;
+                    var rightConstant = leq.Right[0].K;
 
-      int v1, v2;
-      if (decoder.IsConstantInt(e1, out v1) && decoder.IsConstantInt(e2, out v2))
-      {
-        outcome = v1 == v2 ? CheckOutcome.True : CheckOutcome.False;
-        return true;
-      }
+                    if (leftConstant <= rightConstant)
+                    {
+                        return CheckOutcome.True;
+                    }
+                    else if (leftConstant > rightConstant)
+                    {
+                        return CheckOutcome.False;
+                    }
+                    else
+                    {
+                        return CheckOutcome.Top;
+                    }
+                }
+                else if (leq.Degree == 1)
+                {
+                    Variable x;
+                    Rational k1, k2;
+                    if (leq.TryMatch_k1XLessThank2(out k1, out x, out k2))
+                    {
+                        // Very easy for the moment
+                        if (k1 == -1)
+                        {  // -1 * x <= k2
+                            var b = oracleDomain.BoundsFor(x);
+                            if (!b.IsTop && -b.LowerBound <= k2)
+                            {
+                                return CheckOutcome.True;
+                            }
+                        }
+                    }
+                    /*  We do not care at the moment, it can be refined if we want */
+                    /*
+                      else if (PolynomialHelper.Match_k1XLessEqualThank2(leq, out k1, out x, out k2))
+                      {
+                        return  CheckOutcome.Top; 
+                      }
+                     */
+                }
+            }
 
-      outcome = CheckOutcome.Top;
-      return false;
+            return CheckOutcome.Top;
+        }
+
+        /// <summary>
+        /// Checks if <code>e1 \lt e2 </code> is always true.
+        /// </summary>
+        /// It can use some bound information from the oracledomain
+#if SUBPOLY_ONLY
+        internal
+#else
+        public
+#endif
+ static FlatAbstractDomain<bool> CheckLessThan<Variable, Expression>(Expression e1, Expression e2,
+                INumericalAbstractDomainQuery<Variable, Expression> oracleDomain, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            Polynomial<Variable, Expression> ltPol;
+
+            if (Polynomial<Variable, Expression>.TryToPolynomialForm(ExpressionOperator.LessThan, e1, e2, decoder, out ltPol))
+            {
+                if (ltPol.Degree == 0)
+                { // If it is a constant
+                    var leftConstant = ltPol.Left[0].K;
+                    var rightConstant = ltPol.Right[0].K;
+
+                    if (leftConstant < rightConstant)
+                    {
+                        return CheckOutcome.True;
+                    }
+                    else if (leftConstant >= rightConstant)
+                    {
+                        return CheckOutcome.False;
+                    }
+                }
+                else if (ltPol.Degree == 1)
+                {
+                    Variable x;
+                    Rational k1, k2;
+
+                    if (ltPol.TryMatch_k1XLessThank2(out k1, out x, out k2) && k1 == -1)
+                    {
+                        // -1 * x < k2
+                        var b = oracleDomain.BoundsFor(x);
+                        if (!b.IsTop && -b.LowerBound < k2)
+                        {
+                            return CheckOutcome.True;
+                        }
+                    }
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        static public FlatAbstractDomain<bool> CheckGreaterEqualThanZero<Variable, Expression>(Expression e, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            var anIntervalDomain = new IntervalEnvironment<Variable, Expression>(decoder, VoidLogger.Log);
+
+            return anIntervalDomain.CheckIfGreaterEqualThanZero(e);
+        }
+
+        /// <summary>
+        /// If the expression is an equality or disequality, see it the two operands are the same symbolic value
+        /// </summary>
+        static public bool CheckTrivialEquality<Variable, Expression>(Expression exp, IExpressionDecoder<Variable, Expression> decoder)
+        {
+            var op = decoder.OperatorFor(exp);
+
+            switch (op)
+            {
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    {
+                        // Is the case that left == right ?
+                        var left = decoder.LeftExpressionFor(exp);
+                        var right = decoder.RightExpressionFor(exp);
+
+                        if (op == ExpressionOperator.Equal &&
+                          (decoder.IsNaN(left) || decoder.IsNaN(right)))
+                        {
+                            return false;
+                        }
+
+                        if (left.Equals(right) || decoder.UnderlyingVariable(left).Equals(decoder.UnderlyingVariable(right)))
+                        { // left == right
+                            return true;
+                        }
+                        else
+                        {
+                            var strippedLeft = decoder.Stripped(left);
+                            var strippedRight = decoder.Stripped(right);
+
+                            return strippedLeft.Equals(strippedRight) || decoder.UnderlyingVariable(strippedLeft).Equals(decoder.UnderlyingVariable(strippedRight));
+                        }
+                    }
+
+                case ExpressionOperator.NotEqual:
+                    {
+                        // Is the case that (x == x) != 0 ?
+                        int value;
+                        var left = decoder.LeftExpressionFor(exp);
+                        if (decoder.OperatorFor(left) == ExpressionOperator.Equal
+                          && decoder.IsConstantInt(decoder.RightExpressionFor(exp), out value)
+                          && value == 0)
+                        {
+                            return decoder.LeftExpressionFor(left).Equals(decoder.RightExpressionFor(left));
+                        }
+                        return false;
+                    }
+
+                default:
+                    return false;
+            }
+        }
+
+        static public bool CheckTrivialEquality<Variable, Expression>(Expression e1, Expression e2,
+          IExpressionDecoder<Variable, Expression> decoder, out FlatAbstractDomain<bool> outcome)
+        {
+            if (decoder.UnderlyingVariable(e1).Equals(decoder.UnderlyingVariable(e2)))
+            {
+                outcome = CheckOutcome.True;
+                return true;
+            }
+
+            int v1, v2;
+            if (decoder.IsConstantInt(e1, out v1) && decoder.IsConstantInt(e2, out v2))
+            {
+                outcome = v1 == v2 ? CheckOutcome.True : CheckOutcome.False;
+                return true;
+            }
+
+            outcome = CheckOutcome.Top;
+            return false;
+        }
     }
 
-  }
+    #region Visitors for the expressions
 
-  #region Visitors for the expressions
-
-  abstract public class GenericExpressionVisitor<In, Out, Variable, Expression>
-  {
-    #region Object invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    abstract public class GenericExpressionVisitor<In, Out, Variable, Expression>
     {
-      Contract.Invariant(this.decoder != null);
-    }
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(decoder != null);
+        }
 
-    #endregion
-
-    #region Private state
-    private IExpressionDecoder<Variable, Expression> decoder;
-    #endregion
-
-    #region Protected state
-    protected IExpressionDecoder<Variable, Expression> Decoder
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IExpressionDecoder<Variable, Expression>>() != null);
-        
-        return this.decoder;
-      }
-    }
-    #endregion
-
-    #region Constructor
-    public GenericExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(decoder != null);
-
-      this.decoder = decoder;
-    }
-    #endregion
-
-    abstract protected Out Default(In data);
-
-    virtual public Out Visit(Expression exp, In data)
-    {
-      Contract.Requires(exp != null);
-
-      Contract.Ensures(Contract.Result<Out>() != null);
-
-      var op = this.decoder.OperatorFor(exp);
-      switch (op)
-      {
-        #region All the cases
-        case ExpressionOperator.Addition_Overflow:
-          return VisitAddition_Overflow(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-        
-        case ExpressionOperator.Addition:
-          return VisitAddition(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.And:
-          return VisitAnd(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Constant:
-          return VisitConstant(exp, data);
-
-        case ExpressionOperator.ConvertToInt8:
-          return VisitConvertToInt8(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ConvertToInt32:
-          return VisitConvertToInt32(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ConvertToUInt8:
-          return VisitConvertToUInt8(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ConvertToUInt16:
-          return VisitConvertToUInt16(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ConvertToFloat32:
-          return VisitConvertToFloat32(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ConvertToFloat64:
-          return VisitConvertToFloat64(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ConvertToUInt32:
-          return VisitConvertToUInt32(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Division:
-          return VisitDivision(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          // we want to handle cases as "(a <= b) == 0" rewritten to "a > b"
-          return DispatchVisitEqual(op, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.GreaterEqualThan:
-          return VisitGreaterEqualThan(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.GreaterEqualThan_Un:
-          return VisitGreaterEqualThan_Un(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.GreaterThan:
-          return VisitGreaterThan(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.GreaterThan_Un:
-          return VisitGreaterThan_Un(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessEqualThan:
-          return DispatchCompare(VisitLessEqualThan, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessEqualThan_Un:
-          return DispatchCompare(VisitLessEqualThan_Un, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessThan:
-          return DispatchCompare(VisitLessThan, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessThan_Un:
-          return DispatchCompare(VisitLessThan_Un, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LogicalAnd:
-          return VisitLogicalAnd(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LogicalNot:
-          return VisitLogicalNot(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LogicalOr:
-          return VisitLogicalOr(this.decoder.Disjunctions(exp), exp, data);
-
-        case ExpressionOperator.Modulus:
-          return VisitModulus(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Multiplication:
-          return VisitMultiplication(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Multiplication_Overflow:
-          return VisitMultiplication_Overflow(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Not:
-          return DispatchVisitNot(this.decoder.LeftExpressionFor(exp), data);
-
-        case ExpressionOperator.NotEqual:
-          return VisitNotEqual(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Or:
-          return VisitOr(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ShiftLeft:
-          return VisitShiftLeft(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.ShiftRight:
-          return VisitShiftRight(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.SizeOf:
-          return VisitSizeOf(exp, data);
-
-        case ExpressionOperator.Subtraction:
-          return VisitSubtraction(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Subtraction_Overflow:
-          return VisitSubtraction_Overflow(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.UnaryMinus:
-          return VisitUnaryMinus(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Unknown:
-          return VisitUnknown(exp, data);
-
-        case ExpressionOperator.WritableBytes:
-          return VisitWritableBytes(this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Variable:
-          return VisitVariable(this.decoder.UnderlyingVariable(exp), exp, data);
-
-        case ExpressionOperator.Xor:
-          return VisitXor(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        default:
-          Contract.Assert(false);
-          throw new AbstractInterpretationException("I do not know this expression symbol " + this.decoder.OperatorFor(exp));
         #endregion
-      }
+
+        #region Private state
+        private IExpressionDecoder<Variable, Expression> decoder;
+        #endregion
+
+        #region Protected state
+        protected IExpressionDecoder<Variable, Expression> Decoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IExpressionDecoder<Variable, Expression>>() != null);
+
+                return decoder;
+            }
+        }
+        #endregion
+
+        #region Constructor
+        public GenericExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+
+            this.decoder = decoder;
+        }
+        #endregion
+
+        abstract protected Out Default(In data);
+
+        virtual public Out Visit(Expression exp, In data)
+        {
+            Contract.Requires(exp != null);
+
+            Contract.Ensures(Contract.Result<Out>() != null);
+
+            var op = decoder.OperatorFor(exp);
+            switch (op)
+            {
+                #region All the cases
+                case ExpressionOperator.Addition_Overflow:
+                    return VisitAddition_Overflow(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Addition:
+                    return VisitAddition(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.And:
+                    return VisitAnd(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Constant:
+                    return VisitConstant(exp, data);
+
+                case ExpressionOperator.ConvertToInt8:
+                    return VisitConvertToInt8(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ConvertToInt32:
+                    return VisitConvertToInt32(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ConvertToUInt8:
+                    return VisitConvertToUInt8(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ConvertToUInt16:
+                    return VisitConvertToUInt16(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ConvertToFloat32:
+                    return VisitConvertToFloat32(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ConvertToFloat64:
+                    return VisitConvertToFloat64(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ConvertToUInt32:
+                    return VisitConvertToUInt32(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Division:
+                    return VisitDivision(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    // we want to handle cases as "(a <= b) == 0" rewritten to "a > b"
+                    return DispatchVisitEqual(op, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.GreaterEqualThan:
+                    return VisitGreaterEqualThan(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    return VisitGreaterEqualThan_Un(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.GreaterThan:
+                    return VisitGreaterThan(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.GreaterThan_Un:
+                    return VisitGreaterThan_Un(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessEqualThan:
+                    return DispatchCompare(VisitLessEqualThan, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessEqualThan_Un:
+                    return DispatchCompare(VisitLessEqualThan_Un, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessThan:
+                    return DispatchCompare(VisitLessThan, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessThan_Un:
+                    return DispatchCompare(VisitLessThan_Un, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LogicalAnd:
+                    return VisitLogicalAnd(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LogicalNot:
+                    return VisitLogicalNot(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LogicalOr:
+                    return VisitLogicalOr(decoder.Disjunctions(exp), exp, data);
+
+                case ExpressionOperator.Modulus:
+                    return VisitModulus(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Multiplication:
+                    return VisitMultiplication(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Multiplication_Overflow:
+                    return VisitMultiplication_Overflow(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Not:
+                    return DispatchVisitNot(decoder.LeftExpressionFor(exp), data);
+
+                case ExpressionOperator.NotEqual:
+                    return VisitNotEqual(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Or:
+                    return VisitOr(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ShiftLeft:
+                    return VisitShiftLeft(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.ShiftRight:
+                    return VisitShiftRight(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.SizeOf:
+                    return VisitSizeOf(exp, data);
+
+                case ExpressionOperator.Subtraction:
+                    return VisitSubtraction(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Subtraction_Overflow:
+                    return VisitSubtraction_Overflow(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.UnaryMinus:
+                    return VisitUnaryMinus(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Unknown:
+                    return VisitUnknown(exp, data);
+
+                case ExpressionOperator.WritableBytes:
+                    return VisitWritableBytes(decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Variable:
+                    return VisitVariable(decoder.UnderlyingVariable(exp), exp, data);
+
+                case ExpressionOperator.Xor:
+                    return VisitXor(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                default:
+                    Contract.Assert(false);
+                    throw new AbstractInterpretationException("I do not know this expression symbol " + decoder.OperatorFor(exp));
+                    #endregion
+            }
+        }
+
+        private Out DispatchVisitEqual(ExpressionOperator eqKind, Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(eqKind == ExpressionOperator.Equal || eqKind == ExpressionOperator.Equal_Obj);
+
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            // Try matching ==(RelOp(l1, l2), right), RelOp is a relation operator and right is a constant
+
+            var op = decoder.OperatorFor(left);
+            if (op == ExpressionOperator.Equal || op == ExpressionOperator.Equal_Obj
+                      || op.IsGreaterEqualThan() || op.IsGreaterThan()
+                      || op.IsLessEqualThan() || op.IsLessThan())
+            {
+                bool shouldnegate;
+                if (this.TryPolarity(right, data, out shouldnegate))
+                {
+                    if (shouldnegate)
+                    {
+                        return DispatchVisitNot(left, data);
+                    }
+                    else
+                    {
+                        return Visit(left, data);
+                    }
+                }
+                if (this.TryPolarity(left, data, out shouldnegate))
+                {
+                    if (shouldnegate)
+                    {
+                        return DispatchVisitNot(right, data);
+                    }
+                    else
+                    {
+                        return Visit(right, data);
+                    }
+                }
+            }
+
+            // visit "left == right"
+            if (eqKind == ExpressionOperator.Equal)
+            {
+                return VisitEqual(left, right, original, data);
+            }
+            else
+            {
+                Contract.Assert(eqKind == ExpressionOperator.Equal_Obj);
+
+                return VisitEqual_Obj(left, right, original, data);
+            }
+        }
+
+        virtual protected bool TryPolarity(Expression exp, In data, out bool shouldNegate)
+        {
+            Contract.Requires(exp != null);
+
+            if (decoder.IsConstant(exp))
+            {
+                int intValue;
+                if (decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out intValue))
+                {
+                    shouldNegate = intValue == 0;
+                    return true;
+                }
+
+                bool boolValue;
+                if (decoder.TryValueOf<bool>(exp, ExpressionType.Bool, out boolValue))
+                {
+                    shouldNegate = boolValue;
+                    return true;
+                }
+            }
+
+            shouldNegate = default(bool);
+            return false;
+        }
+
+
+        private Out DispatchVisitNot(Expression exp, In data)
+        {
+            Contract.Requires(exp != null);
+
+            switch (decoder.OperatorFor(exp))
+            {
+                case ExpressionOperator.GreaterEqualThan:
+                case ExpressionOperator.GreaterEqualThan_Un:
+                    // !(a >= b) = a < b
+                    return DispatchCompare(VisitLessThan, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.GreaterThan:
+                    // !(a > b) = a <= b
+                    return DispatchCompare(VisitLessEqualThan, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.GreaterThan_Un:
+                    // !(a > b) = a <= b
+                    return DispatchCompare(VisitLessEqualThan_Un, decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessEqualThan:
+                    // !(a <= b) = b < a
+                    return DispatchCompare(VisitLessThan, decoder.RightExpressionFor(exp), decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessEqualThan_Un:
+                    // !(a <= b) = b < a
+                    return DispatchCompare(VisitLessThan_Un, decoder.RightExpressionFor(exp), decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessThan:
+                    // !(a < b) = b <= a
+                    return DispatchCompare(VisitLessEqualThan, decoder.RightExpressionFor(exp), decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.LessThan_Un:
+                    // !(a < b) = b <= a
+                    return DispatchCompare(VisitLessEqualThan_Un, decoder.RightExpressionFor(exp), decoder.LeftExpressionFor(exp), exp, data);
+
+                case ExpressionOperator.Equal:
+                case ExpressionOperator.Equal_Obj:
+                    // !(a == b) = a != b
+                    return VisitNotEqual(decoder.LeftExpressionFor(exp), decoder.RightExpressionFor(exp), exp, data);
+
+                default:
+                    return VisitNot(exp, data);
+            }
+        }
+
+        protected delegate Out CompareVisitor(Expression left, Expression right, Expression original, In data);
+
+        /// <summary>
+        /// Factors out some code so that for instance a - b \leq 0, becomes a \leq b
+        /// </summary>
+        virtual protected Out DispatchCompare(CompareVisitor cmp, Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(cmp != null);
+
+            if (decoder.IsConstant(left) && decoder.OperatorFor(right) == ExpressionOperator.Subtraction)
+            {
+                Int32 value;
+                if (decoder.TryValueOf<Int32>(left, ExpressionType.Int32, out value) && value == 0)
+                {
+                    return cmp(decoder.RightExpressionFor(right), decoder.LeftExpressionFor(right), right, data);
+                }
+                else
+                {
+                    return cmp(left, right, original, data);
+                }
+            }
+
+            if (decoder.IsConstant(right) && decoder.OperatorFor(left) == ExpressionOperator.Subtraction)
+            {
+                Int32 value;
+                if (decoder.TryValueOf<Int32>(right, ExpressionType.Int32, out value) && value == 0)
+                {
+                    return cmp(decoder.LeftExpressionFor(left), decoder.RightExpressionFor(left), left, data);
+                }
+                else
+                {
+                    return cmp(left, right, original, data);
+                }
+            }
+
+            return cmp(left, right, original, data);
+        }
+
+        #region The default Visitors
+        virtual public Out VisitAddition(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitAddition_Overflow(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return VisitAddition(left, right, original, data);
+        }
+
+        virtual public Out VisitAnd(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConstant(Expression left, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConvertToInt8(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConvertToInt32(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConvertToUInt8(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConvertToUInt16(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConvertToUInt32(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConvertToFloat32(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitConvertToFloat64(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitDivision(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitEqual(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitEqual_Obj(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitGreaterEqualThan(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return DispatchCompare(VisitLessEqualThan, right, left, original, data);
+        }
+
+        virtual public Out VisitGreaterEqualThan_Un(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return DispatchCompare(VisitLessEqualThan_Un, right, left, original, data);
+        }
+
+        virtual public Out VisitGreaterThan(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return DispatchCompare(VisitLessThan, right, left, original, data);
+        }
+
+        virtual public Out VisitGreaterThan_Un(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return DispatchCompare(VisitLessThan_Un, right, left, original, data);
+        }
+
+        virtual public Out VisitLessEqualThan(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        /// <summary>
+        /// Default: dispatch to VisitLessEqualThan
+        /// </summary>
+        virtual public Out VisitLessEqualThan_Un(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return VisitLessEqualThan(left, right, original, data);
+        }
+
+        virtual public Out VisitLessThan(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        /// <summary>
+        /// Default: dispatch to VisistLessThan
+        /// </summary>
+        virtual public Out VisitLessThan_Un(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return VisitLessThan(left, right, original, data);
+        }
+
+        virtual public Out VisitLogicalAnd(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitLogicalNot(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitLogicalOr(IEnumerable<Expression> disjunctions, Expression original, In data)
+        {
+            Contract.Requires(disjunctions != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitModulus(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitMultiplication(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitMultiplication_Overflow(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return VisitMultiplication(left, right, original, data);
+        }
+
+        virtual public Out VisitNot(Expression left, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitNotEqual(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitOr(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitShiftLeft(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitShiftRight(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitSizeOf(Expression left, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitSubtraction(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitSubtraction_Overflow(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return VisitSubtraction(left, right, original, data);
+        }
+
+        virtual public Out VisitUnaryMinus(Expression left, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitUnknown(Expression left, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitVariable(Variable variable, Expression original, In data)
+        {
+            return Default(data);
+        }
+
+        virtual public Out VisitWritableBytes(Expression left, Expression wholeExpression, In data)
+        {
+            Contract.Requires(left != null);
+
+            return Default(data);
+        }
+
+        virtual public Out VisitXor(Expression left, Expression right, Expression original, In data)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            return Default(data);
+        }
+        #endregion
     }
 
-    private Out DispatchVisitEqual(ExpressionOperator eqKind, Expression left, Expression right, Expression original, In data)
+    abstract public class GenericNormalizingExpressionVisitor<Data, Variable, Expression>
+      : GenericExpressionVisitor<Data, Data, Variable, Expression>
     {
-      Contract.Requires(eqKind == ExpressionOperator.Equal || eqKind == ExpressionOperator.Equal_Obj);
-
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      // Try matching ==(RelOp(l1, l2), right), RelOp is a relation operator and right is a constant
-
-      var op = this.decoder.OperatorFor(left);
-      if (op == ExpressionOperator.Equal || op == ExpressionOperator.Equal_Obj
-                || op.IsGreaterEqualThan() || op.IsGreaterThan()
-                || op.IsLessEqualThan() || op.IsLessThan())
-      {
-        bool shouldnegate;
-        if (this.TryPolarity(right, data, out shouldnegate))
+        public GenericNormalizingExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
         {
-          if (shouldnegate)
-          {
-            return DispatchVisitNot(left, data);
-          }
-          else
-          {
+        }
+
+        /// <summary>
+        /// a \geq b ==> b \leq a
+        /// </summary>
+        sealed public override Data VisitGreaterEqualThan(Expression left, Expression right, Expression original, Data data)
+        {
+            return VisitLessEqualThan(right, left, original, data);
+        }
+
+        /// <summary>
+        /// a \gt b ==> b \lt a
+        /// </summary>
+        sealed public override Data VisitGreaterThan(Expression left, Expression right, Expression original, Data data)
+        {
+            return VisitLessThan(right, left, original, data);
+        }
+    }
+
+    abstract public class GenericTypeExpressionVisitor<Variable, Expression, In, Out>
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(decoder != null);
+        }
+
+
+        private IExpressionDecoder<Variable, Expression> decoder;
+
+        protected IExpressionDecoder<Variable, Expression> Decoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IExpressionDecoder<Variable, Expression>>() != null);
+
+                return decoder;
+            }
+        }
+
+        public GenericTypeExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
+        {
+            Contract.Requires(decoder != null);
+
+            this.decoder = decoder;
+        }
+
+        virtual public Out Visit(Expression exp, In input)
+        {
+            Contract.Requires(exp != null);
+
+            switch (decoder.TypeOf(exp))
+            {
+                case ExpressionType.Bool:
+                    return VisitBool(exp, input);
+
+                case ExpressionType.Float32:
+                    return VisitFloat32(exp, input);
+
+                case ExpressionType.Float64:
+                    return VisitFloat64(exp, input);
+
+                case ExpressionType.Int8:
+                    return VisitInt8(exp, input);
+
+                case ExpressionType.Int16:
+                    return VisitInt16(exp, input);
+
+                case ExpressionType.Int32:
+                    return VisitInt32(exp, input);
+
+                case ExpressionType.Int64:
+                    return VisitInt64(exp, input);
+
+                case ExpressionType.String:
+                    return VisitString(exp, input);
+
+                case ExpressionType.UInt8:
+                    return VisitUInt8(exp, input);
+
+                case ExpressionType.UInt16:
+                    return VisitUInt16(exp, input);
+
+                case ExpressionType.UInt32:
+                    return VisitUInt32(exp, input);
+
+                case ExpressionType.Unknown:
+                    return Default(exp);
+
+                default:
+                    throw new AbstractInterpretationException("Unknown type for expressions " + decoder.TypeOf(exp));
+            }
+        }
+
+        virtual public Out VisitFloat64(Expression exp, In input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitFloat32(Expression exp, In input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitBool(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitInt8(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitInt16(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitInt32(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitInt64(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitString(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitUInt8(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitUInt16(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        virtual public Out VisitUInt32(Expression/*!*/ exp, In/*!*/ input)
+        {
+            return Default(exp);
+        }
+
+        public abstract Out Default(Expression exp);
+    }
+
+    abstract public class TestTrueVisitor<AbstractDomain, Variable, Expression> :
+      GenericNormalizingExpressionVisitor<AbstractDomain, Variable, Expression>
+      where AbstractDomain : IAbstractDomainForEnvironments<Variable, Expression>
+    {
+        #region Constants
+
+        private const int MAXDISJUNCTS = 4;
+
+        #endregion
+
+        #region Private state
+
+        private TestFalseVisitor<AbstractDomain, Variable, Expression> falseVisitor;
+        private AbstractDomain result;
+
+        #endregion
+
+        protected TestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
+        { }
+
+        #region Protected
+        internal TestFalseVisitor<AbstractDomain, Variable, Expression> FalseVisitor
+        {
+            get
+            {
+                return falseVisitor;
+            }
+            set
+            { // this.trueVisitor == null
+                Contract.Requires(value != null);
+
+                Contract.Assume(falseVisitor == null, "Why are you setting twice the false visitor?"); // let's leave it as a runtime check
+
+                falseVisitor = value;
+            }
+        }
+        #endregion
+
+
+        #region TO BE OVERRIDDEN!
+
+        abstract override public AbstractDomain VisitEqual(Expression left, Expression right, Expression original, AbstractDomain data);
+
+        abstract public override AbstractDomain VisitLessEqualThan(Expression left, Expression right, Expression original, AbstractDomain data);
+
+        abstract public override AbstractDomain VisitLessThan(Expression left, Expression right, Expression original, AbstractDomain data);
+
+        abstract public override AbstractDomain VisitNotEqual(Expression left, Expression right, Expression original, AbstractDomain data);
+
+        abstract public override AbstractDomain VisitVariable(Variable var, Expression original, AbstractDomain data);
+
+        #endregion
+
+        protected override AbstractDomain Default(AbstractDomain data)
+        {
+            return data;
+        }
+
+        public override AbstractDomain VisitLogicalAnd(Expression left, Expression right, Expression original, AbstractDomain data)
+        {
+            var isLeftAVar = this.Decoder.IsVariable(left);
+            var isLeftAConst = this.Decoder.IsConstant(left);
+            var isRightAVar = this.Decoder.IsVariable(right);
+            var isRightAConst = this.Decoder.IsConstant(right);
+
+            if ((isLeftAVar && isRightAConst) || (isLeftAConst && isRightAVar))
+            {
+                result = data;
+            }
+            else
+            {
+                var cloned = (AbstractDomain)data.Clone();
+
+                cloned = (AbstractDomain)cloned.TestTrue(left);
+                cloned = (AbstractDomain)cloned.TestTrue(right);
+
+                result = cloned;
+            }
+            return result;
+        }
+
+        public override AbstractDomain VisitConstant(Expression left, AbstractDomain data)
+        {
+            bool success;
+            Int32 v;
+
+            #region [[0]] == \bot, [[1]] == state
+            if (this.Decoder.TryValueOf<bool>(left, ExpressionType.Bool, out success))
+            {
+                if (success == false)
+                {
+                    result = (AbstractDomain)data.Bottom;
+                }
+                else
+                {
+                    result = data;
+                }
+            }
+            else if (this.Decoder.TryValueOf<Int32>(left, ExpressionType.Int32, out v))
+            {
+                if (v != 0)
+                {
+                    result = data;
+                }
+                else
+                {
+                    result = (AbstractDomain)data.Bottom;
+                }
+            }
+            else
+            {
+                result = data;
+            }
+            #endregion
+            return result;
+        }
+
+        public override AbstractDomain VisitConvertToInt32(Expression left, Expression original, AbstractDomain data)
+        {
             return Visit(left, data);
-          }
         }
-        if (this.TryPolarity(left, data, out shouldnegate))
+
+        public override AbstractDomain VisitConvertToUInt8(Expression left, Expression original, AbstractDomain data)
         {
-          if (shouldnegate)
-          {
-            return DispatchVisitNot(right, data);
-          }
-          else
-          {
-            return Visit(right, data);
-          }
+            return Visit(left, data);
         }
-      }
 
-      // visit "left == right"
-      if (eqKind == ExpressionOperator.Equal)
-      {
-        return VisitEqual(left, right, original, data);
-      }
-      else
-      {
-        Contract.Assert(eqKind == ExpressionOperator.Equal_Obj);
-
-        return VisitEqual_Obj(left, right, original, data);
-      }
-    }
-
-    virtual protected bool TryPolarity(Expression exp, In data, out bool shouldNegate)
-    {
-      Contract.Requires(exp != null);
-
-      if (this.decoder.IsConstant(exp))
-      {
-        int intValue;
-        if (this.decoder.TryValueOf<Int32>(exp, ExpressionType.Int32, out intValue))
+        public override AbstractDomain VisitConvertToUInt16(Expression left, Expression original, AbstractDomain data)
         {
-          shouldNegate = intValue == 0;
-          return true;
+            return Visit(left, data);
         }
 
-        bool boolValue;
-        if (this.decoder.TryValueOf<bool>(exp, ExpressionType.Bool, out boolValue))
+        public override AbstractDomain VisitConvertToUInt32(Expression left, Expression original, AbstractDomain data)
         {
-          shouldNegate = boolValue;
-          return true;
+            return Visit(left, data);
         }
-      }
 
-      shouldNegate = default(bool);
-      return false;
-    }
-
-
-    private Out DispatchVisitNot(Expression exp, In data)
-    {
-      Contract.Requires(exp != null);
-
-      switch (this.decoder.OperatorFor(exp))
-      {
-        case ExpressionOperator.GreaterEqualThan:
-        case ExpressionOperator.GreaterEqualThan_Un:
-          // !(a >= b) = a < b
-          return DispatchCompare(VisitLessThan, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.GreaterThan:
-          // !(a > b) = a <= b
-          return DispatchCompare(VisitLessEqualThan, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.GreaterThan_Un:
-          // !(a > b) = a <= b
-          return DispatchCompare(VisitLessEqualThan_Un, this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessEqualThan:
-          // !(a <= b) = b < a
-          return DispatchCompare(VisitLessThan, this.decoder.RightExpressionFor(exp), this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessEqualThan_Un:
-          // !(a <= b) = b < a
-          return DispatchCompare(VisitLessThan_Un, this.decoder.RightExpressionFor(exp), this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessThan:
-          // !(a < b) = b <= a
-          return DispatchCompare(VisitLessEqualThan, this.decoder.RightExpressionFor(exp), this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.LessThan_Un:
-          // !(a < b) = b <= a
-          return DispatchCompare(VisitLessEqualThan_Un, this.decoder.RightExpressionFor(exp), this.decoder.LeftExpressionFor(exp), exp, data);
-
-        case ExpressionOperator.Equal:
-        case ExpressionOperator.Equal_Obj:
-          // !(a == b) = a != b
-          return VisitNotEqual(this.decoder.LeftExpressionFor(exp), this.decoder.RightExpressionFor(exp), exp, data);
-
-        default:
-          return VisitNot(exp, data);
-      }
-    }
-
-    protected delegate Out CompareVisitor(Expression left, Expression right, Expression original, In data);
-
-    /// <summary>
-    /// Factors out some code so that for instance a - b \leq 0, becomes a \leq b
-    /// </summary>
-    virtual protected Out DispatchCompare(CompareVisitor cmp, Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(cmp != null);
-
-      if (this.decoder.IsConstant(left) && this.decoder.OperatorFor(right) == ExpressionOperator.Subtraction)
-      {
-        Int32 value;
-        if (this.decoder.TryValueOf<Int32>(left, ExpressionType.Int32, out value) && value == 0)
+        public override AbstractDomain VisitNot(Expression left, AbstractDomain data)
         {
-          return cmp(this.decoder.RightExpressionFor(right), this.decoder.LeftExpressionFor(right), right, data);
+            return this.FalseVisitor.Visit(left, data);
         }
-        else
+
+        public override AbstractDomain VisitLogicalOr(IEnumerable<Expression> disjuncts, Expression original, AbstractDomain data)
         {
-          return cmp(left, right, original, data);
-        }
-      }
+            if (disjuncts.Count() > MAXDISJUNCTS)
+            {
+                return data;
+            }
 
-      if (this.decoder.IsConstant(right) && this.decoder.OperatorFor(left) == ExpressionOperator.Subtraction)
-      {
-        Int32 value;
-        if (this.decoder.TryValueOf<Int32>(right, ExpressionType.Int32, out value) && value == 0)
+            var immutable = (AbstractDomain)data.Clone();
+            var r = data;
+            var first = true;
+            foreach (var dis in disjuncts)
+            {
+                if (first)
+                {
+                    r = (AbstractDomain)data.TestTrue(dis);
+                    first = false;
+                }
+                else
+                {
+                    var tmp = ((AbstractDomain)immutable.Clone()).TestTrue(dis);
+                    r = (AbstractDomain)r.Join(tmp);
+                }
+
+                if (r.IsTop)
+                {
+                    break;
+                }
+            }
+            return (result = r);
+        }
+
+        protected override bool TryPolarity(Expression exp, AbstractDomain data, out bool shouldNegate)
         {
-          return cmp(this.decoder.LeftExpressionFor(left), this.decoder.RightExpressionFor(left), left, data);
+            if (base.TryPolarity(exp, data, out shouldNegate))
+            {
+                return true;
+            }
+
+            var tryTautology = data.CheckIfHolds(exp);
+
+            if (tryTautology.IsNormal())
+            {
+                shouldNegate = tryTautology.IsFalse();
+
+                return true;
+            }
+
+            // shouldNegate already set by base.TryPolarity
+            return false;
         }
-        else
+    }
+
+    abstract internal class TestFalseVisitor<AbstractDomain, Variable, Expression> :
+      GenericNormalizingExpressionVisitor<AbstractDomain, Variable, Expression>
+      where AbstractDomain : IAbstractDomainForEnvironments<Variable, Expression>
+    {
+        #region protected state
+        private TestTrueVisitor<AbstractDomain, Variable, Expression> trueVisitor;
+        #endregion
+
+        #region Constructor
+        protected TestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
+        { }
+        #endregion
+
+        /// <summary>
+        /// The visitor for the positive case 
+        /// </summary>
+        internal TestTrueVisitor<AbstractDomain, Variable, Expression> TrueVisitor
         {
-          return cmp(left, right, original, data);
+            get
+            {
+                Contract.Ensures(Contract.Result<TestTrueVisitor<AbstractDomain, Variable, Expression>>() != null);
+
+                Contract.Assume(trueVisitor != null);  // F: When calling this method, the visitor should have already been set
+                return trueVisitor;
+            }
+            set
+            {
+                Contract.Assume(trueVisitor == null, "Why are you setting twice the true visitor?");
+
+                trueVisitor = value;
+            }
         }
-      }
 
-      return cmp(left, right, original, data);
-    }
+        #region TO BE OVERRIDDEN!
 
-    #region The default Visitors
-    virtual public Out VisitAddition(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
+        abstract public override AbstractDomain VisitVariable(Variable variable, Expression original, AbstractDomain data);
 
-      return Default(data);
-    }
+        #endregion
 
-    virtual public Out VisitAddition_Overflow(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
+        protected override AbstractDomain Default(AbstractDomain data)
+        {
+            return data;
+        }
 
-      return VisitAddition(left, right, original, data);
-    }
+        public override AbstractDomain VisitEqual(Expression left, Expression right, Expression original, AbstractDomain data)
+        {
+            Int32 value;
+            // !((a relop b) == 0) => a reolpb
+            if (this.Decoder.TryValueOf<Int32>(right, ExpressionType.Int32, out value) && value == 0)
+                if (!this.Decoder.IsConstant(left) && !this.Decoder.IsVariable(left) && !this.Decoder.IsUnaryExpression(left))
+                {
+                    return this.TrueVisitor.Visit(left, data);
+                }
 
-    virtual public Out VisitAnd(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
+            // !(a == b) -> a != b
+            return this.TrueVisitor.VisitNotEqual(left, right, original, data);
+        }
 
-      return Default(data);
-    }
+        public override AbstractDomain VisitLessEqualThan(Expression left, Expression right, Expression original, AbstractDomain data)
+        { // !(a <= b) -> a > b -> b < a
+            return this.TrueVisitor.VisitLessThan(right, left, original, data);
+        }
 
-    virtual public Out VisitConstant(Expression left, In data)
-    {
-      Contract.Requires(left != null);
+        public override AbstractDomain VisitLessEqualThan_Un(Expression left, Expression right, Expression original, AbstractDomain data)
+        {
+            return this.TrueVisitor.VisitLessThan_Un(right, left, original, data);
+        }
 
-      return Default(data);
-    }
+        public override AbstractDomain VisitLessThan(Expression left, Expression right, Expression original, AbstractDomain data)
+        { // !(a < b) -> a >= b -> b <= a
+            return this.TrueVisitor.VisitLessEqualThan(right, left, original, data);
+        }
 
-    virtual public Out VisitConvertToInt8(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
+        public override AbstractDomain VisitLessThan_Un(Expression left, Expression right, Expression original, AbstractDomain data)
+        {
+            return this.TrueVisitor.VisitLessEqualThan_Un(right, left, original, data);
+        }
 
-      return Default(data);
-    }
+        public override AbstractDomain VisitNot(Expression left, AbstractDomain data)
+        { // !(!a) -> a
+            return this.TrueVisitor.Visit(left, data);
+        }
 
-    virtual public Out VisitConvertToInt32(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
+        public override AbstractDomain VisitNotEqual(Expression left, Expression right, Expression original, AbstractDomain data)
+        { // ! (a != b) -> a == b
+            return this.TrueVisitor.VisitEqual(left, right, original, data);
+        }
 
-      return Default(data);
-    }
+        public override AbstractDomain VisitLogicalAnd(Expression leftGuard, Expression rightGuard, Expression original, AbstractDomain data)
+        { // ! (a && b) -> !a || !b
+            IAbstractDomainForEnvironments<Variable, Expression>/*!*/ leftDomain, rightDomain;
+            AbstractDomain/*!*/ result;
 
-    virtual public Out VisitConvertToUInt8(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
+            var isLeftAVar = this.Decoder.IsVariable(leftGuard);
+            var isLeftAConst = this.Decoder.IsConstant(leftGuard);
+            var isRightAVar = this.Decoder.IsVariable(rightGuard);
+            var isRightAConst = this.Decoder.IsConstant(rightGuard);
 
-      return Default(data);
-    }
+            if ((isLeftAVar && isRightAConst) || (isLeftAConst && isRightAVar))
+            {
+                result = data;
+            }
+            else if (this.Decoder.TypeOf(leftGuard) == ExpressionType.Bool && this.Decoder.TypeOf(rightGuard) == ExpressionType.Bool)
+            {
+                // Use de morgan laws
+                leftDomain = data.TestFalse(leftGuard);
+                rightDomain = data.TestFalse(rightGuard);
 
-    virtual public Out VisitConvertToUInt16(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
+                result = (AbstractDomain)leftDomain.Join(rightDomain);
+            }
+            else
+            {
+                result = data;
+            }
 
-      return Default(data);
-    }
+            return result;
+        }
 
-    virtual public Out VisitConvertToUInt32(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
+        public override AbstractDomain VisitConstant(Expression guard, AbstractDomain data)
+        {
+            AbstractDomain result;
+            bool b; Int32 v;
 
-      return Default(data);
-    }
+            if (this.Decoder.TryValueOf<bool>(guard, ExpressionType.Bool, out b))
+            {
+                if (!b)
+                {
+                    result = data;
+                }
+                else
+                {
+                    result = (AbstractDomain)data.Bottom;
+                }
+            }
+            else if (this.Decoder.TryValueOf<Int32>(guard, ExpressionType.Int32, out v))
+            {
+                if (v == 0)
+                {
+                    result = data;
+                }
+                else
+                {
+                    result = (AbstractDomain)data.Bottom;
+                }
+            }
+            else
+            {
+                result = data;
+            }
 
-    virtual public Out VisitConvertToFloat32(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
+            return result;
+        }
 
-      return Default(data);
-    }
+        public override AbstractDomain VisitConvertToInt32(Expression left, Expression original, AbstractDomain data)
+        {
+            return this.Visit(left, data);
+        }
 
-    virtual public Out VisitConvertToFloat64(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
+        public override AbstractDomain VisitConvertToUInt8(Expression left, Expression original, AbstractDomain data)
+        {
+            return this.Visit(left, data);
+        }
 
-      return Default(data);
-    }
+        public override AbstractDomain VisitConvertToUInt16(Expression left, Expression original, AbstractDomain data)
+        {
+            return this.Visit(left, data);
+        }
 
-    virtual public Out VisitDivision(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
+        public override AbstractDomain VisitConvertToUInt32(Expression left, Expression original, AbstractDomain data)
+        {
+            return this.Visit(left, data);
+        }
 
-      return Default(data);
-    }
+        public override AbstractDomain VisitLogicalOr(IEnumerable<Expression> disjuncts, Expression original, AbstractDomain data)
+        {
+            // ! (a || b) -> !a && !b
+            var result = (AbstractDomain)data.Clone();
 
-    virtual public Out VisitEqual(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
+            foreach (var dis in disjuncts)
+            {
+                result = (AbstractDomain)result.TestFalse(dis);
+            }
 
-      return Default(data);
-    }
-
-    virtual public Out VisitEqual_Obj(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitGreaterEqualThan(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return DispatchCompare(VisitLessEqualThan, right, left, original, data);
-    }
-
-    virtual public Out VisitGreaterEqualThan_Un(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return DispatchCompare(VisitLessEqualThan_Un, right, left, original, data);
-    }
-
-    virtual public Out VisitGreaterThan(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return DispatchCompare(VisitLessThan, right, left, original, data);
-    }
-
-    virtual public Out VisitGreaterThan_Un(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return DispatchCompare(VisitLessThan_Un, right, left, original, data);
-    }
-
-    virtual public Out VisitLessEqualThan(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
+            return result;
+        }
     }
 
     /// <summary>
-    /// Default: dispatch to VisitLessEqualThan
+    /// The base class to be used as starting point in the implementation of CheckIfHolds in the abstract domains
     /// </summary>
-    virtual public Out VisitLessEqualThan_Un(Expression left, Expression right, Expression original, In data)
+    abstract public class CheckIfHoldsVisitor<AbstractDomain, Variable, Expression> :
+      GenericNormalizingExpressionVisitor<FlatAbstractDomain<bool>, Variable, Expression>
+      where AbstractDomain : INumericalAbstractDomain<Variable, Expression>
     {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
+        private AbstractDomain domain;
 
-      return VisitLessEqualThan(left, right, original, data);
+        protected AbstractDomain Domain
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<AbstractDomain>() != null);
+
+                return domain;
+            }
+        }
+
+        public CheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
+        {
+            Contract.Requires(decoder != null);
+        }
+
+        /// <summary>
+        /// The entry point for checking if the expression <code>exp</code> holds in the state <code>domain</code>
+        /// </summary>
+        public FlatAbstractDomain<bool> Visit(Expression exp, AbstractDomain domain)
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(domain != null);
+
+            Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
+
+            this.domain = domain;
+
+            var result = base.Visit(exp, CheckOutcome.Top);
+
+            return result;
+        }
+
+        #region To be implemented by the client
+        public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            var leftType = this.Decoder.TypeOf(left);
+            var rightType = this.Decoder.TypeOf(right);
+
+            // if they are not floats, and Var(left).Equals(Var(right)) 
+            if (!leftType.IsFloatingPointType() && !rightType.IsFloatingPointType())
+            {
+                if (left.Equals(right)      // We check for expression equality as the WP may have generated the same expression
+                ||
+                  this.Decoder.UnderlyingVariable(left).Equals(this.Decoder.UnderlyingVariable(right)))
+                {
+                    return CheckOutcome.True;
+                }
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public abstract override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data);
+
+        public abstract override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data);
+
+        public abstract override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data);
+        #endregion
+
+        #region Some standard implementations
+
+        public override FlatAbstractDomain<bool> VisitAddition(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return this.Domain.CheckIfNonZero(original);
+        }
+
+        public override FlatAbstractDomain<bool> VisitLogicalAnd(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            var resultLeft = Visit(left, data);
+            // false && X == false
+            if (resultLeft.IsFalse())
+            {
+                return resultLeft;
+            }
+
+            var resultRight = Visit(right, data);
+            // top && false == resultRight == true && resultRight
+            if (resultRight.IsFalse() || (resultLeft.IsTrue() && resultRight.IsNormal()))
+            {
+                return resultRight;
+            }
+
+            return CheckOutcome.Top;
+        }
+
+        public override FlatAbstractDomain<bool> VisitLogicalOr(IEnumerable<Expression> disjuncts, Expression original, FlatAbstractDomain<bool> data)
+        {
+            var allBottoms = true;
+            foreach (var dis in disjuncts)
+            {
+                var outcome = Visit(dis, data);
+
+                if (outcome.IsTrue())
+                {
+                    return outcome;
+                }
+                if (outcome.IsFalse() || outcome.IsTop)
+                {
+                    allBottoms = false;
+                    continue;
+                }
+            }
+
+            return allBottoms ? CheckOutcome.Bottom : CheckOutcome.Top;
+
+            /*
+            var resultLeft = Visit(left, data);
+
+            if (resultLeft.IsTrue())
+            {
+              return resultLeft;
+            }
+
+            var resultRight = Visit(right, data);
+
+            if (resultLeft.IsFalse())
+            {
+              return resultRight;
+            }
+
+            if (resultLeft.IsBottom)
+            {
+              return resultRight;
+            }
+            if (resultRight.IsBottom)
+            {
+              return resultLeft;
+            }
+            if (resultLeft.IsTop)
+            {
+              return resultRight;
+            }
+            if (resultRight.IsTop)
+            {
+              return resultLeft;
+            }
+
+            return new FlatAbstractDomain<bool>(resultLeft.BoxedElement || resultRight.BoxedElement);
+             */
+        }
+
+        public override FlatAbstractDomain<bool> VisitConstant(Expression left, FlatAbstractDomain<bool> data)
+        {
+            var value = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(this.Decoder).Visit(left, new IntervalEnvironment<Variable, Expression>(this.Decoder, VoidLogger.Log));
+
+            Contract.Assert(!value.IsBottom);
+
+            if (value.IsTop)
+            {
+                return CheckOutcome.Top;
+            }
+
+            Rational v;
+            if (value.TryGetSingletonValue(out v))
+            {
+                if (v.IsNotZero)
+                {
+                    return CheckOutcome.True;
+                }
+                else
+                {
+                    return CheckOutcome.False;
+                }
+            }
+
+            // We can return Top if for instance left is -oo or +oo (doubles)
+            return CheckOutcome.Top;
+        }
+
+        public override FlatAbstractDomain<bool> VisitDivision(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return this.Visit(left, data);
+        }
+
+        public override FlatAbstractDomain<bool> VisitModulus(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return this.Domain.CheckIfNonZero(original);
+        }
+
+        public override FlatAbstractDomain<bool> VisitMultiplication(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return this.Domain.CheckIfNonZero(original);
+        }
+
+        public override FlatAbstractDomain<bool> VisitSubtraction(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return this.Domain.CheckIfNonZero(original);
+        }
+
+        public override FlatAbstractDomain<bool> VisitNot(Expression left, FlatAbstractDomain<bool> data)
+        {
+            var leftHolds = this.Visit(left, data);
+
+            if (leftHolds.IsNormal())
+            {
+                return new FlatAbstractDomain<bool>(!leftHolds.BoxedElement);
+            }
+            else
+            {
+                return leftHolds;
+            }
+        }
+
+        public override FlatAbstractDomain<bool> VisitUnaryMinus(Expression left, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return this.Domain.CheckIfNonZero(left);
+        }
+
+        public override FlatAbstractDomain<bool> VisitXor(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
+        {
+            return this.Domain.CheckIfNonZero(original);
+        }
+
+        protected override FlatAbstractDomain<bool> Default(FlatAbstractDomain<bool> data)
+        {
+            return CheckOutcome.Top;
+        }
+        #endregion
     }
 
-    virtual public Out VisitLessThan(Expression left, Expression right, Expression original, In data)
+    internal class Void
     {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
+        static public Void Value { get { return new Void(); } }
     }
 
-    /// <summary>
-    /// Default: dispatch to VisistLessThan
-    /// </summary>
-    virtual public Out VisitLessThan_Un(Expression left, Expression right, Expression original, In data)
+    internal class GetAThresholdVisitor<Variable, Expression>
+      : GenericExpressionVisitor<Void, bool, Variable, Expression>
     {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
+        private List<int> thresholds;
 
-      return VisitLessThan(left, right, original, data);
+        public List<int> Thresholds
+        {
+            get
+            {
+                return thresholds;
+            }
+        }
+
+        public GetAThresholdVisitor(IExpressionDecoder<Variable, Expression> decoder)
+          : base(decoder)
+        {
+            thresholds = new List<int>();
+        }
+
+        public override bool VisitConstant(Expression left, Void data)
+        {
+            int v;
+
+            if (this.Decoder.IsConstantInt(left, out v))
+            {
+                thresholds.Add(v);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override bool VisitConvertToInt32(Expression left, Expression original, Void data)
+        {
+            return this.Visit(left, data);
+        }
+
+        public override bool VisitConvertToUInt16(Expression left, Expression original, Void data)
+        {
+            return this.Visit(left, data);
+        }
+
+        public override bool VisitConvertToUInt32(Expression left, Expression original, Void data)
+        {
+            return this.Visit(left, data);
+        }
+
+        public override bool VisitConvertToUInt8(Expression left, Expression original, Void data)
+        {
+            return this.Visit(left, data);
+        }
+
+        public override bool VisitEqual(Expression left, Expression right, Expression original, Void data)
+        {
+            return this.VisitBinary(left, right, data);
+        }
+
+        public override bool VisitNotEqual(Expression left, Expression right, Expression original, Void data)
+        {
+            return this.VisitBinary(left, right, data);
+        }
+
+        public override bool VisitGreaterEqualThan(Expression left, Expression right, Expression original, Void data)
+        {
+            return this.VisitBinary(left, right, data);
+        }
+
+        public override bool VisitGreaterThan(Expression left, Expression right, Expression original, Void data)
+        {
+            return this.VisitBinary(left, right, data);
+        }
+
+        public override bool VisitLessEqualThan(Expression left, Expression right, Expression original, Void data)
+        {
+            return this.VisitBinary(left, right, data);
+        }
+
+        public override bool VisitLessThan(Expression left, Expression right, Expression original, Void data)
+        {
+            return this.VisitBinary(left, right, data);
+        }
+
+        protected override bool Default(Void data)
+        {
+            return false;
+        }
+
+        private bool VisitBinary(Expression left, Expression right, Void data)
+        {
+            bool b1 = this.Visit(left, data);
+            bool b2 = this.Visit(right, data);
+
+            return b1 || b2;
+        }
     }
-
-    virtual public Out VisitLogicalAnd(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitLogicalNot(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitLogicalOr(IEnumerable<Expression> disjunctions, Expression original, In data)
-    {
-      Contract.Requires(disjunctions != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitModulus(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitMultiplication(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitMultiplication_Overflow(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return VisitMultiplication(left, right, original, data);
-    }
-
-    virtual public Out VisitNot(Expression left, In data)
-    {
-      Contract.Requires(left != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitNotEqual(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitOr(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitShiftLeft(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitShiftRight(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitSizeOf(Expression left, In data)
-    {
-      Contract.Requires(left != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitSubtraction(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitSubtraction_Overflow(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return VisitSubtraction(left, right, original, data);
-    }
-
-    virtual public Out VisitUnaryMinus(Expression left, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitUnknown(Expression left, In data)
-    {
-      Contract.Requires(left != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitVariable(Variable variable, Expression original, In data)
-    {
-
-      return Default(data);
-    }
-
-    virtual public Out VisitWritableBytes(Expression left, Expression wholeExpression, In data)
-    {
-      Contract.Requires(left != null);
-
-      return Default(data);
-    }
-
-    virtual public Out VisitXor(Expression left, Expression right, Expression original, In data)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      return Default(data);
-    }
-    #endregion
-  }
-
-  abstract public class GenericNormalizingExpressionVisitor<Data, Variable, Expression>
-    : GenericExpressionVisitor<Data, Data, Variable, Expression>
-  {
-    public GenericNormalizingExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    {
-    }
-
-    /// <summary>
-    /// a \geq b ==> b \leq a
-    /// </summary>
-    sealed public override Data VisitGreaterEqualThan(Expression left, Expression right, Expression original, Data data)
-    {
-      return VisitLessEqualThan(right, left, original, data);
-    }
-
-    /// <summary>
-    /// a \gt b ==> b \lt a
-    /// </summary>
-    sealed public override Data VisitGreaterThan(Expression left, Expression right, Expression original, Data data)
-    {
-      return VisitLessThan(right, left, original, data);
-    }
-  }
-
-  abstract public class GenericTypeExpressionVisitor<Variable, Expression, In, Out>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.decoder != null);
-    }
-
-
-    private IExpressionDecoder<Variable, Expression> decoder;
-
-    protected IExpressionDecoder<Variable, Expression> Decoder
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IExpressionDecoder<Variable, Expression>>() != null);
-
-        return this.decoder;
-      }
-    }
-
-    public GenericTypeExpressionVisitor(IExpressionDecoder<Variable, Expression> decoder)
-    {
-      Contract.Requires(decoder != null);
-
-      this.decoder = decoder;
-    }
-
-    virtual public Out Visit(Expression exp, In input)
-    {
-      Contract.Requires(exp != null);
-
-      switch (this.decoder.TypeOf(exp))
-      {
-        case ExpressionType.Bool:
-          return VisitBool(exp, input);
-
-        case ExpressionType.Float32:
-          return VisitFloat32(exp, input);
-
-        case ExpressionType.Float64:
-          return VisitFloat64(exp, input);
-
-        case ExpressionType.Int8:
-          return VisitInt8(exp, input);
-
-        case ExpressionType.Int16:
-          return VisitInt16(exp, input);
-
-        case ExpressionType.Int32:
-          return VisitInt32(exp, input);
-
-        case ExpressionType.Int64:
-          return VisitInt64(exp, input);
-
-        case ExpressionType.String:
-          return VisitString(exp, input);
-
-        case ExpressionType.UInt8:
-          return VisitUInt8(exp, input);
-
-        case ExpressionType.UInt16:
-          return VisitUInt16(exp, input);
-
-        case ExpressionType.UInt32:
-          return VisitUInt32(exp, input);
-
-        case ExpressionType.Unknown:
-          return Default(exp);
-
-        default:
-          throw new AbstractInterpretationException("Unknown type for expressions " + this.decoder.TypeOf(exp));
-      }
-    }
-
-    virtual public Out VisitFloat64(Expression exp, In input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitFloat32(Expression exp, In input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitBool(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitInt8(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitInt16(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitInt32(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitInt64(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitString(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitUInt8(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitUInt16(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    virtual public Out VisitUInt32(Expression/*!*/ exp, In/*!*/ input)
-    {
-      return Default(exp);
-    }
-
-    public abstract Out Default(Expression exp);
-  }
-
-  abstract public class TestTrueVisitor<AbstractDomain, Variable, Expression> :
-    GenericNormalizingExpressionVisitor<AbstractDomain, Variable, Expression>
-    where AbstractDomain : IAbstractDomainForEnvironments<Variable, Expression>
-  {
-
-    #region Constants
-
-    private const int MAXDISJUNCTS = 4;
 
     #endregion
-
-    #region Private state
-    
-    private TestFalseVisitor<AbstractDomain, Variable, Expression> falseVisitor;
-    private AbstractDomain result;
-
-    #endregion
-
-    protected TestTrueVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    { }
-
-    #region Protected
-    internal TestFalseVisitor<AbstractDomain, Variable, Expression> FalseVisitor
-    {
-      get
-      {
-        return this.falseVisitor;
-      }
-      set
-      { // this.trueVisitor == null
-
-        Contract.Requires(value != null);
-
-        Contract.Assume(this.falseVisitor == null, "Why are you setting twice the false visitor?"); // let's leave it as a runtime check
-
-        this.falseVisitor = value;
-      }
-    }
-    #endregion
-
-
-    #region TO BE OVERRIDDEN!
-
-    abstract override public AbstractDomain VisitEqual(Expression left, Expression right, Expression original, AbstractDomain data);
-
-    abstract public override AbstractDomain VisitLessEqualThan(Expression left, Expression right, Expression original, AbstractDomain data);
-
-    abstract public override AbstractDomain VisitLessThan(Expression left, Expression right, Expression original, AbstractDomain data);
-
-    abstract public override AbstractDomain VisitNotEqual(Expression left, Expression right, Expression original, AbstractDomain data);
-
-    abstract public override AbstractDomain VisitVariable(Variable var, Expression original, AbstractDomain data);
-
-    #endregion
-
-    protected override AbstractDomain Default(AbstractDomain data)
-    {
-      return data;
-    }
-
-    public override AbstractDomain VisitLogicalAnd(Expression left, Expression right, Expression original, AbstractDomain data)
-    {
-      var isLeftAVar = this.Decoder.IsVariable(left);
-      var isLeftAConst = this.Decoder.IsConstant(left);
-      var isRightAVar = this.Decoder.IsVariable(right);
-      var isRightAConst = this.Decoder.IsConstant(right);
-
-      if ((isLeftAVar && isRightAConst) || (isLeftAConst && isRightAVar))
-      {
-        this.result = data;
-      }
-      else
-      {
-        var cloned = (AbstractDomain)data.Clone();
-
-        cloned = (AbstractDomain)cloned.TestTrue(left);
-        cloned = (AbstractDomain)cloned.TestTrue(right);
-
-        this.result = cloned;
-      }
-      return this.result;
-    }
-
-    public override AbstractDomain VisitConstant(Expression left, AbstractDomain data)
-    {
-      bool success;
-      Int32 v;
-
-      #region [[0]] == \bot, [[1]] == state
-      if (this.Decoder.TryValueOf<bool>(left, ExpressionType.Bool, out success))
-      {
-        if (success == false)
-        {
-          result = (AbstractDomain)data.Bottom;
-        }
-        else
-        {
-          result = data;
-        }
-      }
-      else if (this.Decoder.TryValueOf<Int32>(left, ExpressionType.Int32, out v))
-      {
-        if (v != 0)
-        {
-          result = data;
-        }
-        else
-        {
-          result = (AbstractDomain)data.Bottom;
-        }
-      }
-      else
-      {
-        result = data;
-      }
-      #endregion
-      return result;
-    }
-
-    public override AbstractDomain VisitConvertToInt32(Expression left, Expression original, AbstractDomain data)
-    {
-      return Visit(left, data);
-    }
-
-    public override AbstractDomain VisitConvertToUInt8(Expression left, Expression original, AbstractDomain data)
-    {
-      return Visit(left, data);
-    }
-
-    public override AbstractDomain VisitConvertToUInt16(Expression left, Expression original, AbstractDomain data)
-    {
-      return Visit(left, data);
-    }
-
-    public override AbstractDomain VisitConvertToUInt32(Expression left, Expression original, AbstractDomain data)
-    {
-      return Visit(left, data);
-    }
-
-    public override AbstractDomain VisitNot(Expression left, AbstractDomain data)
-    {
-      return this.FalseVisitor.Visit(left, data);
-    }
-
-    public override AbstractDomain VisitLogicalOr(IEnumerable<Expression> disjuncts, Expression original, AbstractDomain data)
-    {
-      if (disjuncts.Count() > MAXDISJUNCTS)
-      {
-        return data;
-      }
-
-      var immutable = (AbstractDomain) data.Clone();
-      var r = data;
-      var first = true;
-      foreach (var dis in disjuncts)
-      {
-        if (first)
-        {
-          r = (AbstractDomain)data.TestTrue(dis);
-          first = false;
-        }
-        else
-        {
-          var tmp = ((AbstractDomain)immutable.Clone()).TestTrue(dis);
-          r = (AbstractDomain) r.Join(tmp);
-        }
-
-        if (r.IsTop)
-        {
-          break;
-        }
-
-      }
-      return (this.result = r);
-    }
-
-    protected override bool TryPolarity(Expression exp, AbstractDomain data, out bool shouldNegate)
-    {      
-      if (base.TryPolarity(exp, data, out shouldNegate))
-      {
-        return true;
-      }
-
-      var tryTautology = data.CheckIfHolds(exp);
-
-      if (tryTautology.IsNormal())
-      {
-        shouldNegate = tryTautology.IsFalse();
-
-        return true;
-      }
-
-      // shouldNegate already set by base.TryPolarity
-      return false;
-    }
-  }
-
-  abstract internal class TestFalseVisitor<AbstractDomain, Variable, Expression> :
-    GenericNormalizingExpressionVisitor<AbstractDomain, Variable, Expression>
-    where AbstractDomain : IAbstractDomainForEnvironments<Variable, Expression>
-  {
-    #region protected state
-    private TestTrueVisitor<AbstractDomain, Variable, Expression> trueVisitor;
-    #endregion
-
-    #region Constructor
-    protected TestFalseVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    { }
-    #endregion
-
-    /// <summary>
-    /// The visitor for the positive case 
-    /// </summary>
-    internal TestTrueVisitor<AbstractDomain, Variable, Expression> TrueVisitor
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<TestTrueVisitor<AbstractDomain, Variable, Expression>>() != null);
-
-        Contract.Assume(this.trueVisitor != null);  // F: When calling this method, the visitor should have already been set
-        return this.trueVisitor;
-      }
-      set
-      {
-        Contract.Assume(this.trueVisitor == null, "Why are you setting twice the true visitor?");
-
-        this.trueVisitor = value;
-      }
-    }
-
-    #region TO BE OVERRIDDEN!
-
-    abstract public override AbstractDomain VisitVariable(Variable variable, Expression original, AbstractDomain data);
-
-    #endregion
-
-    protected override AbstractDomain Default(AbstractDomain data)
-    {
-      return data;
-    }
-
-    public override AbstractDomain VisitEqual(Expression left, Expression right, Expression original, AbstractDomain data)
-    {
-      Int32 value;
-      // !((a relop b) == 0) => a reolpb
-      if (this.Decoder.TryValueOf<Int32>(right, ExpressionType.Int32, out value) && value == 0)
-        if (!this.Decoder.IsConstant(left) && !this.Decoder.IsVariable(left) && !this.Decoder.IsUnaryExpression(left))
-        {
-          return this.TrueVisitor.Visit(left, data);
-        }
-
-      // !(a == b) -> a != b
-      return this.TrueVisitor.VisitNotEqual(left, right, original, data);
-    }
-
-    public override AbstractDomain VisitLessEqualThan(Expression left, Expression right, Expression original, AbstractDomain data)
-    { // !(a <= b) -> a > b -> b < a
-      return this.TrueVisitor.VisitLessThan(right, left, original, data);
-    }
-
-    public override AbstractDomain VisitLessEqualThan_Un(Expression left, Expression right, Expression original, AbstractDomain data)
-    {
-      return this.TrueVisitor.VisitLessThan_Un(right, left, original, data);
-    }
-
-    public override AbstractDomain VisitLessThan(Expression left, Expression right, Expression original, AbstractDomain data)
-    { // !(a < b) -> a >= b -> b <= a
-      return this.TrueVisitor.VisitLessEqualThan(right, left, original, data);
-    }
-
-    public override AbstractDomain VisitLessThan_Un(Expression left, Expression right, Expression original, AbstractDomain data)
-    {
-      return this.TrueVisitor.VisitLessEqualThan_Un(right, left, original, data);
-    }
-
-    public override AbstractDomain VisitNot(Expression left, AbstractDomain data)
-    { // !(!a) -> a
-      return this.TrueVisitor.Visit(left, data);
-    }
-
-    public override AbstractDomain VisitNotEqual(Expression left, Expression right, Expression original, AbstractDomain data)
-    { // ! (a != b) -> a == b
-      return this.TrueVisitor.VisitEqual(left, right, original, data);
-    }
-
-    public override AbstractDomain VisitLogicalAnd(Expression leftGuard, Expression rightGuard, Expression original, AbstractDomain data)
-    { // ! (a && b) -> !a || !b
-      IAbstractDomainForEnvironments<Variable, Expression>/*!*/ leftDomain, rightDomain;
-      AbstractDomain/*!*/ result;
-
-      var isLeftAVar = this.Decoder.IsVariable(leftGuard);
-      var isLeftAConst = this.Decoder.IsConstant(leftGuard);
-      var isRightAVar = this.Decoder.IsVariable(rightGuard);
-      var isRightAConst = this.Decoder.IsConstant(rightGuard);
-
-      if ((isLeftAVar && isRightAConst) || (isLeftAConst && isRightAVar))
-      {
-        result = data;
-      }
-      else if (this.Decoder.TypeOf(leftGuard) == ExpressionType.Bool && this.Decoder.TypeOf(rightGuard) == ExpressionType.Bool)
-      {
-        // Use de morgan laws
-        leftDomain = data.TestFalse(leftGuard);
-        rightDomain = data.TestFalse(rightGuard);
-
-        result = (AbstractDomain)leftDomain.Join(rightDomain);
-      }
-      else
-      {
-        result = data;
-      }
-
-      return result;
-    }
-
-    public override AbstractDomain VisitConstant(Expression guard, AbstractDomain data)
-    {
-      AbstractDomain result;
-      bool b; Int32 v;
-
-      if (this.Decoder.TryValueOf<bool>(guard, ExpressionType.Bool, out b))
-      {
-        if (!b)
-        {
-          result = data;
-        }
-        else
-        {
-          result = (AbstractDomain)data.Bottom;
-        }
-      }
-      else if (this.Decoder.TryValueOf<Int32>(guard, ExpressionType.Int32, out v))
-      {
-        if (v == 0)
-        {
-          result = data;
-        }
-        else
-        {
-          result = (AbstractDomain)data.Bottom;
-        }
-      }
-      else
-      {
-        result = data;
-      }
-
-      return result;
-    }
-
-    public override AbstractDomain VisitConvertToInt32(Expression left, Expression original, AbstractDomain data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override AbstractDomain VisitConvertToUInt8(Expression left, Expression original, AbstractDomain data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override AbstractDomain VisitConvertToUInt16(Expression left, Expression original, AbstractDomain data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override AbstractDomain VisitConvertToUInt32(Expression left, Expression original, AbstractDomain data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override AbstractDomain VisitLogicalOr(IEnumerable<Expression> disjuncts, Expression original, AbstractDomain data)
-    { 
-      // ! (a || b) -> !a && !b
-      var result = (AbstractDomain)data.Clone();
-
-      foreach (var dis in disjuncts)
-      {
-        result = (AbstractDomain)result.TestFalse(dis);
-      }
-
-      return result;
-    }
-  }
-
-  /// <summary>
-  /// The base class to be used as starting point in the implementation of CheckIfHolds in the abstract domains
-  /// </summary>
-  abstract public class CheckIfHoldsVisitor<AbstractDomain, Variable, Expression> :
-    GenericNormalizingExpressionVisitor<FlatAbstractDomain<bool>, Variable, Expression>
-    where AbstractDomain : INumericalAbstractDomain<Variable, Expression>
-  {
-    private AbstractDomain domain;
-
-    protected AbstractDomain Domain
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<AbstractDomain>() != null);        
-
-        return this.domain;
-      }
-    }
-
-    public CheckIfHoldsVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    {
-      Contract.Requires(decoder != null);
-    }
-
-    /// <summary>
-    /// The entry point for checking if the expression <code>exp</code> holds in the state <code>domain</code>
-    /// </summary>
-    public FlatAbstractDomain<bool> Visit(Expression exp, AbstractDomain domain)
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(domain != null);
-
-      Contract.Ensures(Contract.Result<FlatAbstractDomain<bool>>() != null);
-
-      this.domain = domain;
-
-      var result = base.Visit(exp, CheckOutcome.Top);
-
-      return result;
-    }
-
-    #region To be implemented by the client
-    public override FlatAbstractDomain<bool> VisitEqual(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      var leftType = this.Decoder.TypeOf(left);
-      var rightType = this.Decoder.TypeOf(right);
-
-      // if they are not floats, and Var(left).Equals(Var(right)) 
-      if (!leftType.IsFloatingPointType() && !rightType.IsFloatingPointType() )
-      {
-        if (left.Equals(right)      // We check for expression equality as the WP may have generated the same expression
-        ||
-          this.Decoder.UnderlyingVariable(left).Equals(this.Decoder.UnderlyingVariable(right)))
-        {
-          return CheckOutcome.True;
-        }
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public abstract override FlatAbstractDomain<bool> VisitEqual_Obj(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data);
-
-    public abstract override FlatAbstractDomain<bool> VisitLessEqualThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data);
-
-    public abstract override FlatAbstractDomain<bool> VisitLessThan(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data);
-    #endregion
-
-    #region Some standard implementations
-
-    public override FlatAbstractDomain<bool> VisitAddition(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return this.Domain.CheckIfNonZero(original);
-    }
-
-    public override FlatAbstractDomain<bool> VisitLogicalAnd(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      var resultLeft = Visit(left, data);
-      // false && X == false
-      if (resultLeft.IsFalse())
-      {
-        return resultLeft;
-      }
-
-      var resultRight = Visit(right, data);
-      // top && false == resultRight == true && resultRight
-      if (resultRight.IsFalse() || (resultLeft.IsTrue() && resultRight.IsNormal()))
-      {
-        return resultRight;
-      }
-
-      return CheckOutcome.Top;
-    }
-
-    public override FlatAbstractDomain<bool> VisitLogicalOr(IEnumerable<Expression> disjuncts, Expression original, FlatAbstractDomain<bool> data)
-    {
-      var allBottoms = true;
-      foreach (var dis in disjuncts)
-      {
-        var outcome = Visit(dis, data);
-
-        if (outcome.IsTrue())
-        {
-          return outcome;
-        }
-        if (outcome.IsFalse() || outcome.IsTop)
-        {
-          allBottoms = false;
-          continue;
-        }
-      }
-
-      return allBottoms? CheckOutcome.Bottom : CheckOutcome.Top;
-
-      /*
-      var resultLeft = Visit(left, data);
-
-      if (resultLeft.IsTrue())
-      {
-        return resultLeft;
-      }
-
-      var resultRight = Visit(right, data);
-
-      if (resultLeft.IsFalse())
-      {
-        return resultRight;
-      }
-
-      if (resultLeft.IsBottom)
-      {
-        return resultRight;
-      }
-      if (resultRight.IsBottom)
-      {
-        return resultLeft;
-      }
-      if (resultLeft.IsTop)
-      {
-        return resultRight;
-      }
-      if (resultRight.IsTop)
-      {
-        return resultLeft;
-      }
-
-      return new FlatAbstractDomain<bool>(resultLeft.BoxedElement || resultRight.BoxedElement);
-       */
-    }
-
-    public override FlatAbstractDomain<bool> VisitConstant(Expression left, FlatAbstractDomain<bool> data)
-    {
-      var value = new IntervalEnvironment<Variable, Expression>.EvalConstantVisitor(this.Decoder).Visit(left, new IntervalEnvironment<Variable, Expression>(this.Decoder, VoidLogger.Log));
-
-      Contract.Assert(!value.IsBottom);
-
-      if (value.IsTop)
-      {
-        return CheckOutcome.Top;
-      }
-
-      Rational v;
-      if (value.TryGetSingletonValue(out v))
-      {
-        if (v.IsNotZero)
-        {
-          return CheckOutcome.True;
-        }
-        else
-        {
-          return CheckOutcome.False;
-        }
-      }
-
-      // We can return Top if for instance left is -oo or +oo (doubles)
-      return CheckOutcome.Top; 
-    }
-
-    public override FlatAbstractDomain<bool> VisitDivision(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override FlatAbstractDomain<bool> VisitModulus(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return this.Domain.CheckIfNonZero(original);
-    }
-
-    public override FlatAbstractDomain<bool> VisitMultiplication(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return this.Domain.CheckIfNonZero(original);
-    }
-
-    public override FlatAbstractDomain<bool> VisitSubtraction(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return this.Domain.CheckIfNonZero(original);
-    }
-
-    public override FlatAbstractDomain<bool> VisitNot(Expression left, FlatAbstractDomain<bool> data)
-    {
-      var leftHolds = this.Visit(left, data);
-
-      if (leftHolds.IsNormal())
-      {
-        return new FlatAbstractDomain<bool>(!leftHolds.BoxedElement);
-      }
-      else
-      {
-        return leftHolds;
-      }
-    }
-
-    public override FlatAbstractDomain<bool> VisitUnaryMinus(Expression left, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return this.Domain.CheckIfNonZero(left);
-    }
-
-    public override FlatAbstractDomain<bool> VisitXor(Expression left, Expression right, Expression original, FlatAbstractDomain<bool> data)
-    {
-      return this.Domain.CheckIfNonZero(original);
-    }
-
-    protected override FlatAbstractDomain<bool> Default(FlatAbstractDomain<bool> data)
-    {
-      return CheckOutcome.Top;
-    }
-    #endregion
-  }
-
-  class Void
-  {
-    static public Void Value { get { return new Void(); } }
-  }
-
-  class GetAThresholdVisitor<Variable, Expression>
-    : GenericExpressionVisitor<Void, bool, Variable, Expression>
-  {
-    List<int> thresholds;
-
-    public List<int> Thresholds
-    {
-      get
-      {
-        return this.thresholds;
-      }
-    }
-
-    public GetAThresholdVisitor(IExpressionDecoder<Variable, Expression> decoder)
-      : base(decoder)
-    {
-      this.thresholds = new List<int>();
-    }
-
-    public override bool VisitConstant(Expression left, Void data)
-    {
-      int v;
-
-      if (this.Decoder.IsConstantInt(left, out v))
-      {
-        this.thresholds.Add(v);
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
-
-    public override bool VisitConvertToInt32(Expression left, Expression original, Void data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override bool VisitConvertToUInt16(Expression left, Expression original, Void data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override bool VisitConvertToUInt32(Expression left, Expression original, Void data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override bool VisitConvertToUInt8(Expression left, Expression original, Void data)
-    {
-      return this.Visit(left, data);
-    }
-
-    public override bool VisitEqual(Expression left, Expression right, Expression original, Void data)
-    {
-      return this.VisitBinary(left, right, data);
-    }
-
-    public override bool VisitNotEqual(Expression left, Expression right, Expression original, Void data)
-    {
-      return this.VisitBinary(left, right, data);
-    }
-
-    public override bool VisitGreaterEqualThan(Expression left, Expression right, Expression original, Void data)
-    {
-      return this.VisitBinary(left, right, data);
-    }
-
-    public override bool VisitGreaterThan(Expression left, Expression right, Expression original, Void data)
-    {
-      return this.VisitBinary(left, right, data);
-    }
-
-    public override bool VisitLessEqualThan(Expression left, Expression right, Expression original, Void data)
-    {
-      return this.VisitBinary(left, right, data);
-    }
-
-    public override bool VisitLessThan(Expression left, Expression right, Expression original, Void data)
-    {
-      return this.VisitBinary(left, right, data);
-    }
-
-    protected override bool Default(Void data)
-    {
-      return false;
-    }
-
-    private bool VisitBinary(Expression left, Expression right, Void data)
-    {
-      bool b1 = this.Visit(left, data);
-      bool b2 = this.Visit(right, data);
-
-      return b1 || b2;
-    }
-  }
-
-  #endregion
 }


### PR DESCRIPTION
This reformat operation used dotnet/codeformatter@1d719e4e with `/rule-:FieldNames`.