### PR TITLE
Reformat code in AnalysisTypes

### DIFF
--- a/Microsoft.Research/AnalysisTypes/AnalysisStatistics.cs
+++ b/Microsoft.Research/AnalysisTypes/AnalysisStatistics.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,208 +11,207 @@ using System.Linq;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public enum MethodClassification { NewMethod, IdenticalMethod, ChangedMethod };
+    public enum MethodClassification { NewMethod, IdenticalMethod, ChangedMethod };
 
 
-  [ContractVerification(true)]
-  public class AnalysisStatisticsDB
-  {
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
+    [ContractVerification(true)]
+    public class AnalysisStatisticsDB
     {
-      Contract.Invariant(this.totalStatistics != null);
-      Contract.Invariant(this.statisticsTime != null);
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(totalStatistics != null);
+            Contract.Invariant(statisticsTime != null);
+        }
+
+        private readonly Dictionary<object, AnalysisStatistics> totalStatistics;
+        private readonly List<MethodAnalysisTimeStatistics> statisticsTime;
+
+        public AnalysisStatisticsDB()
+        {
+            totalStatistics = new Dictionary<object, AnalysisStatistics>();
+            statisticsTime = new List<MethodAnalysisTimeStatistics>();
+        }
+
+        public void Add(object method, AnalysisStatistics stat, MethodClassification methodKind)
+        {
+            totalStatistics[method] = stat;
+        }
+
+        public void Add(MethodAnalysisTimeStatistics methodStat)
+        {
+            statisticsTime.Add(methodStat);
+        }
+
+        public int MethodsWithZeroWarnings()
+        {
+            return totalStatistics.Values.Where(s => s.True == s.Total).Count();
+        }
+
+        public AnalysisStatistics OverallStatistics()
+        {
+            var result = new AnalysisStatistics();
+            ComputeStatistics(totalStatistics.Values, out result.Total, out result.True, out result.Top, out result.Bottom, out result.False);
+
+            return result;
+        }
+
+        public IEnumerable<MethodAnalysisTimeStatistics> MethodsByAnalysisTime(int howMany = 10)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<MethodAnalysisTimeStatistics>>() != null);
+
+            return statisticsTime.OrderByDescending(stat => stat.OverallTime).Take(howMany);
+        }
+
+        public override string ToString()
+        {
+            uint Total, True, Top, Bottom, False;
+            ComputeStatistics(totalStatistics.Values, out Total, out True, out Top, out Bottom, out False);
+
+            return AnalysisStatistics.PrettyPrint(Total, True, Top, Bottom, False);
+        }
+
+        private void ComputeStatistics(IEnumerable<AnalysisStatistics> values, out uint Total, out uint True, out uint Top, out uint Bottom, out uint False)
+        {
+            Contract.Requires(values != null);
+            Contract.Ensures(Contract.ValueAtReturn(out Total) == Contract.ValueAtReturn(out True) + Contract.ValueAtReturn(out Top) + Contract.ValueAtReturn(out Bottom) + Contract.ValueAtReturn(out False));
+
+            Total = True = Top = Bottom = False = 0;
+            foreach (var value in values)
+            {
+                Contract.Assume(value.Total == value.Top + value.Bottom + value.True + value.False);
+
+                Total += value.Total;
+                Top += value.Top;
+                Bottom += value.Bottom;
+                True += value.True;
+                False += value.False;
+            }
+        }
     }
 
-    private readonly Dictionary<object, AnalysisStatistics> totalStatistics;
-    private readonly List<MethodAnalysisTimeStatistics> statisticsTime; 
-
-    public AnalysisStatisticsDB()
+    [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
+    [ContractVerification(true)]
+    public struct AnalysisStatistics
     {
-      this.totalStatistics = new Dictionary<object, AnalysisStatistics>();
-      this.statisticsTime = new List<MethodAnalysisTimeStatistics>();
+        #region Invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.Total >= 0);
+            Contract.Invariant(this.Top >= 0);
+            Contract.Invariant(this.Bottom >= 0);
+            Contract.Invariant(this.True >= 0);
+            Contract.Invariant(this.False >= 0);
+
+            Contract.Invariant(this.Total == this.Top + this.Bottom + this.True + this.False);
+        }
+        #endregion
+
+        public uint Total;
+        public uint Top;
+        public uint Bottom;
+        public uint True;
+        public uint False;
+        public int InferredPreconditions;
+        public int InferredInvariants;
+        public int InferredEntryAssumes;
+
+        public void Add(AnalysisStatistics right)
+        {
+            Contract.Assert(right.True >= 0);
+            Contract.Assert(right.Top >= 0);
+            Contract.Assert(right.False >= 0);
+            Contract.Assert(right.Bottom >= 0);
+            Contract.Assume(right.Total == right.True + right.Top + right.False + right.Bottom);
+
+            this.Total += right.Total;
+            this.Top += right.Top;
+            this.Bottom += right.Bottom;
+            this.True += right.True;
+            this.False += right.False;
+        }
+
+        public void Add(ProofOutcome color, uint howMany = 1)
+        {
+            Contract.Requires(howMany > 0);
+
+            switch (color)
+            {
+                case ProofOutcome.Bottom:
+                    this.Bottom += howMany;
+                    break;
+                case ProofOutcome.Top:
+                    this.Top += howMany;
+                    break;
+                case ProofOutcome.True:
+                    this.True += howMany;
+                    break;
+                case ProofOutcome.False:
+                    this.False += howMany;
+                    break;
+            }
+            this.Total += howMany;
+        }
+
+        override public string ToString()
+        {
+            return PrettyPrint(this.Total, this.True, this.Top, this.Bottom, this.False);
+        }
+
+        internal static string PrettyPrint(uint Total, uint True, uint Top, uint Bottom, uint False)
+        {
+            Contract.Requires(Total == True + Top + Bottom + False);
+
+            string cp, pc, pt, pu, pf;
+
+            if (Total > 0)
+            {
+                cp = "Checked " + Total + " assertion" + (Total > 1 ? "s" : "") + ": ";
+                pc = True > 0 ? True + " correct " : "";
+                pt = Top > 0 ? Top + " unknown " : "";
+                pu = Bottom > 0 ? Bottom + " unreached " : "";
+                pf = False > 0 ? False + " false " : "";
+            }
+            else
+            {
+                cp = "Checked 0 assertions.";
+                pc = pt = pu = pf = "";
+            }
+
+            var precision = Total > 0 ? ((True + Bottom) * 100) / (double)(Total) : -1;
+
+            var result = cp + pc + pt + pu + pf;
+
+            if (precision >= 0)
+            {
+                var tmp = Math.Truncate(precision * 10) / 10;
+                result = result + Environment.NewLine + "Validated: " + tmp + "%";
+            }
+
+            return result;
+        }
     }
 
-    public void Add(object method, AnalysisStatistics stat, MethodClassification methodKind)
+    [ContractVerification(true)]
+    public struct MethodAnalysisTimeStatistics
     {
-      this.totalStatistics[method] = stat;
+        readonly public int MethodNumber;
+        readonly public string MethodName;
+        readonly public TimeSpan OverallTime;
+        readonly public TimeSpan CFGConstructionTime;
+
+        public MethodAnalysisTimeStatistics(int methodNumber, string methodName, TimeSpan overall, TimeSpan CFGConstructionTime)
+        {
+            this.MethodNumber = methodNumber;
+            this.MethodName = methodName;
+            this.OverallTime = overall;
+            this.CFGConstructionTime = CFGConstructionTime;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("Overall = {0} ({1} in CFG Construction)", this.OverallTime, this.CFGConstructionTime);
+        }
     }
-
-    public void Add(MethodAnalysisTimeStatistics methodStat)
-    {
-      this.statisticsTime.Add(methodStat);
-    }
-    
-    public int MethodsWithZeroWarnings()
-    {
-      return this.totalStatistics.Values.Where(s => s.True == s.Total).Count();
-    }
-
-    public AnalysisStatistics OverallStatistics()
-    {
-      var result = new AnalysisStatistics();
-      ComputeStatistics(this.totalStatistics.Values, out result.Total, out result.True, out result.Top, out result.Bottom, out result.False);
-
-      return result;
-    }
-
-    public IEnumerable<MethodAnalysisTimeStatistics> MethodsByAnalysisTime(int howMany = 10)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<MethodAnalysisTimeStatistics>>() != null);
-
-      return this.statisticsTime.OrderByDescending(stat => stat.OverallTime).Take(howMany); 
-    }
-
-    public override string ToString()
-    {
-      uint Total, True, Top, Bottom, False;
-      ComputeStatistics(this.totalStatistics.Values, out Total, out True, out Top, out Bottom, out False);
-
-      return AnalysisStatistics.PrettyPrint(Total, True, Top, Bottom, False);
-    }
-
-    private void ComputeStatistics(IEnumerable<AnalysisStatistics> values, out uint Total, out uint True, out uint Top, out uint Bottom, out uint False)
-    {
-      Contract.Requires(values != null);
-      Contract.Ensures(Contract.ValueAtReturn(out Total) == Contract.ValueAtReturn(out True) + Contract.ValueAtReturn(out Top) + Contract.ValueAtReturn(out Bottom)+Contract.ValueAtReturn(out False));
-
-      Total = True = Top = Bottom = False = 0;
-      foreach (var value in values)
-      {
-        Contract.Assume(value.Total == value.Top + value.Bottom + value.True + value.False);
-
-        Total += value.Total;
-        Top += value.Top;
-        Bottom += value.Bottom;
-        True += value.True;
-        False += value.False;
-      }
-    }
-
-  }
-
-  [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
-  [ContractVerification(true)]
-  public struct AnalysisStatistics
-  {
-    #region Invariant
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.Total >= 0);
-      Contract.Invariant(this.Top >= 0);
-      Contract.Invariant(this.Bottom >= 0);
-      Contract.Invariant(this.True >= 0);
-      Contract.Invariant(this.False >= 0);
-
-      Contract.Invariant(this.Total == this.Top + this.Bottom + this.True + this.False);
-    }
-    #endregion
-
-    public uint Total;
-    public uint Top;
-    public uint Bottom;
-    public uint True;
-    public uint False;
-    public int InferredPreconditions;
-    public int InferredInvariants;
-    public int InferredEntryAssumes;
-
-    public void Add(AnalysisStatistics right)
-    {
-      Contract.Assert(right.True >= 0);
-      Contract.Assert(right.Top >= 0);
-      Contract.Assert(right.False >= 0);
-      Contract.Assert(right.Bottom >= 0);
-      Contract.Assume(right.Total == right.True + right.Top + right.False + right.Bottom);
-
-      this.Total += right.Total;
-      this.Top += right.Top;
-      this.Bottom += right.Bottom;
-      this.True += right.True;
-      this.False += right.False;
-    }
-
-    public void Add(ProofOutcome color, uint howMany = 1)
-    {
-      Contract.Requires(howMany > 0);
-
-      switch (color)
-      {
-        case ProofOutcome.Bottom:
-          this.Bottom += howMany;
-          break;
-        case ProofOutcome.Top:
-          this.Top += howMany;
-          break;
-        case ProofOutcome.True:
-          this.True += howMany;
-          break;
-        case ProofOutcome.False:
-          this.False += howMany;
-          break;
-      }
-      this.Total += howMany;
-    }
-
-    override public string ToString()
-    {
-      return PrettyPrint(this.Total, this.True, this.Top, this.Bottom, this.False);
-    }
-
-    internal static string PrettyPrint(uint Total, uint True, uint Top, uint Bottom, uint False)
-    {
-      Contract.Requires(Total == True + Top + Bottom + False);
-
-      string cp, pc, pt, pu, pf;
-
-      if (Total > 0)
-      {
-        cp = "Checked " + Total + " assertion" + (Total > 1 ? "s" : "") + ": ";
-        pc = True > 0 ? True + " correct " : "";
-        pt = Top > 0 ? Top + " unknown " : "";
-        pu = Bottom > 0 ? Bottom + " unreached " : "";
-        pf = False > 0 ? False + " false " : "";
-      }
-      else
-      {
-        cp = "Checked 0 assertions.";
-        pc = pt = pu = pf = "";
-      }
-
-      var precision = Total > 0 ? ((True + Bottom) * 100) / (double)(Total) : -1;
-
-      var result = cp + pc + pt + pu + pf;
-
-      if (precision >= 0)
-      {
-        var tmp = Math.Truncate(precision * 10) / 10;
-        result = result + Environment.NewLine + "Validated: " + tmp + "%";
-      }
-
-      return result;
-    }
-  }
-
-  [ContractVerification(true)]
-  public struct MethodAnalysisTimeStatistics
-  {
-    readonly public int MethodNumber;
-    readonly public string MethodName;
-    readonly public TimeSpan OverallTime;
-    readonly public TimeSpan CFGConstructionTime;
-
-    public MethodAnalysisTimeStatistics(int methodNumber, string methodName, TimeSpan overall, TimeSpan CFGConstructionTime)
-    {
-      this.MethodNumber = methodNumber;
-      this.MethodName = methodName;
-      this.OverallTime = overall;
-      this.CFGConstructionTime = CFGConstructionTime;
-    }
-
-    public override string ToString()
-    {
-      return string.Format("Overall = {0} ({1} in CFG Construction)", this.OverallTime, this.CFGConstructionTime); 
-    }
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/ContractDensity.cs
+++ b/Microsoft.Research/AnalysisTypes/ContractDensity.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Research.CodeAnalysis
 {
@@ -19,11 +8,11 @@ namespace Microsoft.Research.CodeAnalysis
         /// <summary>
         /// Contains all contracts, not just Assert
         /// </summary>
-        ulong contracts;
+        private ulong contracts;
 
-        ulong methodInstructions;
+        private ulong methodInstructions;
 
-        ulong contractInstructions;
+        private ulong contractInstructions;
 
         public ContractDensity(ulong methodInstructions, ulong contractInstructions, ulong contracts)
         {
@@ -37,19 +26,19 @@ namespace Microsoft.Research.CodeAnalysis
             get
             {
                 if (methodInstructions == 0) return 0;
-                return ((float)this.contractInstructions) / this.methodInstructions;
+                return ((float)contractInstructions) / methodInstructions;
             }
         }
 
-        public ulong Contracts { get { return this.contracts; } }
-        public ulong MethodInstructions { get { return this.methodInstructions; } }
-        public ulong ContractInstructions { get { return this.contractInstructions; } }
+        public ulong Contracts { get { return contracts; } }
+        public ulong MethodInstructions { get { return methodInstructions; } }
+        public ulong ContractInstructions { get { return contractInstructions; } }
 
         public void Add(ContractDensity other)
         {
-            this.methodInstructions += other.methodInstructions;
-            this.contractInstructions += other.contractInstructions;
-            this.contracts += other.contracts;
+            methodInstructions += other.methodInstructions;
+            contractInstructions += other.contractInstructions;
+            contracts += other.contracts;
         }
     }
 }

--- a/Microsoft.Research/AnalysisTypes/ContractHelpers.cs
+++ b/Microsoft.Research/AnalysisTypes/ContractHelpers.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,36 +8,35 @@ using System.Text;
 
 namespace System.Diagnostics.Contracts
 {
-  public static class ContractHelpers
-  {
-    [Pure]
-    [ContractVerification(false)]
-    static public void AssumeInvariant<T>(this T obj)
+    public static class ContractHelpers
     {
-      // does nothing
+        [Pure]
+        [ContractVerification(false)]
+        static public void AssumeInvariant<T>(this T obj)
+        {
+            // does nothing
+        }
+
+        [Pure]
+        [ContractVerification(false)]
+        static public T AssumeNotNull<T>(this T obj)
+          where T : class
+        {
+            Contract.Ensures(Contract.Result<T>() != null);
+            Contract.Ensures(Contract.Result<T>() == obj);
+
+            return obj;
+        }
+
+        [Pure]
+        [ContractVerification(false)]
+        static public string AssumeNotNullOrEmpty(this string str)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            Contract.Ensures(Contract.Result<string>().Length > 0);
+            Contract.Ensures(Contract.Result<string>() == str);
+
+            return str;
+        }
     }
-
-    [Pure]
-    [ContractVerification(false)]
-    static public T AssumeNotNull<T>(this T obj)
-      where T : class
-    {
-      Contract.Ensures(Contract.Result<T>() != null);
-      Contract.Ensures(Contract.Result<T>() == obj);
-
-      return obj;
-    }
-
-    [Pure]
-    [ContractVerification(false)]
-    static public string AssumeNotNullOrEmpty(this string str)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      Contract.Ensures(Contract.Result<string>().Length > 0);
-      Contract.Ensures(Contract.Result<string>() == str);
-
-      return str;
-    }
-
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/Logging.cs
+++ b/Microsoft.Research/AnalysisTypes/Logging.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //#define TRACEPERFORMANCE
 
@@ -22,61 +11,61 @@ using System.Text;
 
 namespace Microsoft.Research
 {
-  public static class PerformanceMeasure
-  {
-    public enum ActionTags { CheckIfEqual, Simplex, KarrIsBottom, KarrPutIntoRowEchelonForm, KarrRemoveVars, ArraysJoin, ArraysAssignInParallel, WP, SubPolyJoin }
-
-    private readonly static TimeSpan LongSingleOperation = new TimeSpan(0, 0, 0, 0, 500);
-    private readonly static TimeSpan LongOverallOperation = new TimeSpan(10000);
-
-    private readonly static Dictionary<ActionTags, Tuple<int, TimeSpan>> performanceCounters = new Dictionary<ActionTags, Tuple<int, TimeSpan>>();
-    private static int invocationCounter = 0;
-
-    [Pure]
-    public static T Measure<T>(ActionTags slot, Func<T> action, bool warnIfOperationTakesTooLong = false)
+    public static class PerformanceMeasure
     {
-      Contract.Requires(action != null);
+        public enum ActionTags { CheckIfEqual, Simplex, KarrIsBottom, KarrPutIntoRowEchelonForm, KarrRemoveVars, ArraysJoin, ArraysAssignInParallel, WP, SubPolyJoin }
 
-      var now = DateTime.Now;
-      var result = action();
-      var elapsed = DateTime.Now - now;
-      var count = 0;
+        private readonly static TimeSpan LongSingleOperation = new TimeSpan(0, 0, 0, 0, 500);
+        private readonly static TimeSpan LongOverallOperation = new TimeSpan(10000);
+
+        private readonly static Dictionary<ActionTags, Tuple<int, TimeSpan>> performanceCounters = new Dictionary<ActionTags, Tuple<int, TimeSpan>>();
+        private static int invocationCounter = 0;
+
+        [Pure]
+        public static T Measure<T>(ActionTags slot, Func<T> action, bool warnIfOperationTakesTooLong = false)
+        {
+            Contract.Requires(action != null);
+
+            var now = DateTime.Now;
+            var result = action();
+            var elapsed = DateTime.Now - now;
+            var count = 0;
 
 #if TRACEPERFORMANCE
-      if (warnIfOperationTakesTooLong && elapsed > LongSingleOperation)
-      {
-        Console.WriteLine("Time performing action #{0}: {1} (invocationCounter = {2})", slot, elapsed, invocationCounter);
-      }
+            if (warnIfOperationTakesTooLong && elapsed > LongSingleOperation)
+            {
+                Console.WriteLine("Time performing action #{0}: {1} (invocationCounter = {2})", slot, elapsed, invocationCounter);
+            }
 #endif
-      lock (performanceCounters)
-      {
-        Tuple<int, TimeSpan> prev;
-        if (performanceCounters.TryGetValue(slot, out prev))
-        {
-          count = prev.Item1;
-          elapsed += prev.Item2;
+            lock (performanceCounters)
+            {
+                Tuple<int, TimeSpan> prev;
+                if (performanceCounters.TryGetValue(slot, out prev))
+                {
+                    count = prev.Item1;
+                    elapsed += prev.Item2;
+                }
+
+                performanceCounters[slot] = new Tuple<int, TimeSpan>(count + 1, elapsed);
+            }
+            invocationCounter++;
+            return result;
         }
 
-        performanceCounters[slot] = new Tuple<int, TimeSpan>(count + 1, elapsed);
-      }
-      invocationCounter++;
-      return result;
-    }
-
-    public static StringBuilder GetStats()
-    {
-      Contract.Ensures(Contract.Result<StringBuilder>() != null);
-
-      var str = new StringBuilder();
-
-      lock (performanceCounters) // For the Clousot2 regression test run in parallel
-      {
-        foreach (var pair in performanceCounters)
+        public static StringBuilder GetStats()
         {
-          str.AppendFormat("Overall time spent performing action #{0}: {1} (invoked {2} times)\n", pair.Key, pair.Value.Item2, pair.Value.Item1);
+            Contract.Ensures(Contract.Result<StringBuilder>() != null);
+
+            var str = new StringBuilder();
+
+            lock (performanceCounters) // For the Clousot2 regression test run in parallel
+            {
+                foreach (var pair in performanceCounters)
+                {
+                    str.AppendFormat("Overall time spent performing action #{0}: {1} (invoked {2} times)\n", pair.Key, pair.Value.Item2, pair.Value.Item1);
+                }
+            }
+            return str;
         }
-      }
-      return str;
     }
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/Messages.cs
+++ b/Microsoft.Research/AnalysisTypes/Messages.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Research.CodeAnalysis;
 using System;
@@ -25,280 +14,279 @@ using System.Text;
 
 namespace Microsoft.Research.ClousotPulse.Messages
 {
-  public class CommonNames
-  {
-    private const string PIPENAME = "CCCHECKPulsePipe";
-    private const string PIPENAME_CALLBACK = "CCCHECKPulsePipeForCallback";
-    private const string PIPENAME_CLOUDOT = "CLOUDOT_WorkerPipe";
-
-    [Pure]
-    public static string GetPipeNameForCCCheckPulse()
+    public class CommonNames
     {
-      Contract.Ensures(Contract.Result<string>() != null);
+        private const string PIPENAME = "CCCHECKPulsePipe";
+        private const string PIPENAME_CALLBACK = "CCCHECKPulsePipeForCallback";
+        private const string PIPENAME_CLOUDOT = "CLOUDOT_WorkerPipe";
 
-      return GetPipeNameForCCCheckPulse(Process.GetCurrentProcess().Id);
-    }
-
-    [Pure]
-    public static string GetPipeNameForCCCheckPulse(int procID)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return PIPENAME + procID;
-    }
-
-    [Pure]
-    public static string GetPipeNameForCCCheckPulseCallBack(int procID)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return PIPENAME_CALLBACK + procID;
-    }
-
-    [Pure]
-    public static string GetPipeNameForCloudotWorker()
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return GetPipeNameForCloudotWorker(Process.GetCurrentProcess().Id);
-    }
-
-    [Pure]
-    public static string GetPipeNameForCloudotWorker(int procID)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return PIPENAME_CLOUDOT + procID;
-    }
-  }
-
-  public class PipeStreamSimple
-  {
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.formatter != null);
-    }
-
-    private readonly PipeStream stream;
-    private readonly IFormatter formatter;
-
-    public PipeStreamSimple(PipeStream stream)
-    {
-      Contract.Requires(stream != null);
-
-      this.stream = stream;
-      this.formatter = new BinaryFormatter();
-    }
-
-    public bool TryRead<T>(out T result)
-    {
-      try
-      {
-        if (this.stream.IsConnected)
+        [Pure]
+        public static string GetPipeNameForCCCheckPulse()
         {
-          var tmp = this.formatter.Deserialize(this.stream);
-          if (tmp is T)
-          {
-            result = (T)tmp;
-            return true;
-          }
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return GetPipeNameForCCCheckPulse(Process.GetCurrentProcess().Id);
         }
-      }
-      catch(Exception e)
-      {
-        Trace.TraceWarning("error in reading from the stream: {0}", e.Message);
-        // do nothing?
-      }
 
-      result = default(T);
-      return false;
-    }
-
-    public bool WriteIfConnected(string graph)
-    {
-      try
-      {
-        if (this.stream.IsConnected)
+        [Pure]
+        public static string GetPipeNameForCCCheckPulse(int procID)
         {
-          this.formatter.Serialize(this.stream, graph);
-          return true;
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return PIPENAME + procID;
         }
-      }
-      catch
-      {
-        // do nothing?
-      }
 
-      return false; // we failed
-    }
-
-    public bool WriteIfConnected(List<Tuple<string, object>> graph)
-    {
-      try
-      {
-        if (this.stream.IsConnected)
+        [Pure]
+        public static string GetPipeNameForCCCheckPulseCallBack(int procID)
         {
-          this.formatter.Serialize(this.stream, graph);
-          return true;
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return PIPENAME_CALLBACK + procID;
         }
-      }
-      catch
-      {
-        // do nothing?
-      }
 
-      return false; // we failed
-    }
-  }
-  public static class PipesUtils
-  {
-
-    [ContractVerification(true)]
-    public static string[] WaitForArgsIfNeeded(string[] args)
-    {
-      Contract.Requires(args != null);
-      Contract.Requires(Contract.ForAll(args, arg => arg != null));
-
-      if (args.Length == 1 && args[0].ToLower() == StringConstants.ClousotWait)
-      {
-        var namedPipeServer = new NamedPipeServerStream(CommonNames.GetPipeNameForCloudotWorker(), PipeDirection.InOut, 254);
-        while (true)
+        [Pure]
+        public static string GetPipeNameForCloudotWorker()
         {
-          try
-          {
-            namedPipeServer.WaitForConnection(); // wait for connection
+            Contract.Ensures(Contract.Result<string>() != null);
 
-            var stream = new PipeStreamSimple(namedPipeServer);
+            return GetPipeNameForCloudotWorker(Process.GetCurrentProcess().Id);
+        }
 
-            string[] obj;
-            if (stream.TryRead(out obj))
+        [Pure]
+        public static string GetPipeNameForCloudotWorker(int procID)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return PIPENAME_CLOUDOT + procID;
+        }
+    }
+
+    public class PipeStreamSimple
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(formatter != null);
+        }
+
+        private readonly PipeStream stream;
+        private readonly IFormatter formatter;
+
+        public PipeStreamSimple(PipeStream stream)
+        {
+            Contract.Requires(stream != null);
+
+            this.stream = stream;
+            formatter = new BinaryFormatter();
+        }
+
+        public bool TryRead<T>(out T result)
+        {
+            try
             {
-              args = obj;
+                if (stream.IsConnected)
+                {
+                    var tmp = formatter.Deserialize(stream);
+                    if (tmp is T)
+                    {
+                        result = (T)tmp;
+                        return true;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Trace.TraceWarning("error in reading from the stream: {0}", e.Message);
+                // do nothing?
             }
 
-            namedPipeServer.Disconnect();
-            goto done;
-          }
-          catch
-          {
-            // just swallow the error
-            Console.Error.WriteLine("Some error in reading the Clousot arguments from the pipe");
-          }
+            result = default(T);
+            return false;
         }
-      }
-    done:
-      return args;
+
+        public bool WriteIfConnected(string graph)
+        {
+            try
+            {
+                if (stream.IsConnected)
+                {
+                    formatter.Serialize(stream, graph);
+                    return true;
+                }
+            }
+            catch
+            {
+                // do nothing?
+            }
+
+            return false; // we failed
+        }
+
+        public bool WriteIfConnected(List<Tuple<string, object>> graph)
+        {
+            try
+            {
+                if (stream.IsConnected)
+                {
+                    formatter.Serialize(stream, graph);
+                    return true;
+                }
+            }
+            catch
+            {
+                // do nothing?
+            }
+
+            return false; // we failed
+        }
     }
-  }
-
-  public abstract class ClousotAnalysisInfoBaseClass
-  {
-    #region Poor man serialization, to avoid the issues from the type being defined in cccheck (via ILMERGE) and cccpulse
-
-    public List<Tuple<string, object>> ToList()
+    public static class PipesUtils
     {
-      Contract.Ensures(Contract.Result<List<Tuple<string, object>> >() != null);
+        [ContractVerification(true)]
+        public static string[] WaitForArgsIfNeeded(string[] args)
+        {
+            Contract.Requires(args != null);
+            Contract.Requires(Contract.ForAll(args, arg => arg != null));
 
-      var result = new List<Tuple<string, object>>();
-      foreach (var f in this.GetType().GetFields())
-      {
-        result.Add(new Tuple<string, object>(f.Name, f.GetValue(this)));
-      }
+            if (args.Length == 1 && args[0].ToLower() == StringConstants.ClousotWait)
+            {
+                var namedPipeServer = new NamedPipeServerStream(CommonNames.GetPipeNameForCloudotWorker(), PipeDirection.InOut, 254);
+                while (true)
+                {
+                    try
+                    {
+                        namedPipeServer.WaitForConnection(); // wait for connection
 
-      return result;
+                        var stream = new PipeStreamSimple(namedPipeServer);
+
+                        string[] obj;
+                        if (stream.TryRead(out obj))
+                        {
+                            args = obj;
+                        }
+
+                        namedPipeServer.Disconnect();
+                        goto done;
+                    }
+                    catch
+                    {
+                        // just swallow the error
+                        Console.Error.WriteLine("Some error in reading the Clousot arguments from the pipe");
+                    }
+                }
+            }
+        done:
+            return args;
+        }
     }
 
-    protected void FromList(List<Tuple<string, object>> list)
+    public abstract class ClousotAnalysisInfoBaseClass
     {
-      Contract.Requires(list != null);
+        #region Poor man serialization, to avoid the issues from the type being defined in cccheck (via ILMERGE) and cccpulse
 
-      foreach (var tuple in list)
-      {
-        Contract.Assume(tuple != null);
-        var f = this.GetType().GetField(tuple.Item1);
-        Contract.Assume(f != null);
-        f.SetValue(this, tuple.Item2);
-      }
+        public List<Tuple<string, object>> ToList()
+        {
+            Contract.Ensures(Contract.Result<List<Tuple<string, object>>>() != null);
+
+            var result = new List<Tuple<string, object>>();
+            foreach (var f in this.GetType().GetFields())
+            {
+                result.Add(new Tuple<string, object>(f.Name, f.GetValue(this)));
+            }
+
+            return result;
+        }
+
+        protected void FromList(List<Tuple<string, object>> list)
+        {
+            Contract.Requires(list != null);
+
+            foreach (var tuple in list)
+            {
+                Contract.Assume(tuple != null);
+                var f = this.GetType().GetField(tuple.Item1);
+                Contract.Assume(f != null);
+                f.SetValue(this, tuple.Item2);
+            }
+        }
+
+        #endregion
     }
 
-    #endregion
-  }
-
-  [Serializable]
-  public class ClousotAnalysisState : ClousotAnalysisInfoBaseClass
-  {
-    public int CurrMethodNumber;
-    public string CurrMethodName;
-    public double CurrPercentage;
-    public string CurrPhase;
-    public string CurrAssembly;
-    public int CurrMemory;
-
-    public ClousotAnalysisState() { }
-
-    public ClousotAnalysisState(List<Tuple<string, object>> list)
+    [Serializable]
+    public class ClousotAnalysisState : ClousotAnalysisInfoBaseClass
     {
-      Contract.Requires(list != null);
+        public int CurrMethodNumber;
+        public string CurrMethodName;
+        public double CurrPercentage;
+        public string CurrPhase;
+        public string CurrAssembly;
+        public int CurrMemory;
 
-      this.FromList(list);
+        public ClousotAnalysisState() { }
+
+        public ClousotAnalysisState(List<Tuple<string, object>> list)
+        {
+            Contract.Requires(list != null);
+
+            this.FromList(list);
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0,6:P1}, Method #{1} {2} {3}", CurrPercentage, CurrMethodNumber, CurrMethodName, CurrPhase ?? " ");
+        }
     }
 
-    public override string ToString()
+    [Serializable]
+    public class ClousotAnalysisResults : ClousotAnalysisInfoBaseClass
     {
-      return string.Format("{0,6:P1}, Method #{1} {2} {3}", CurrPercentage, CurrMethodNumber, CurrMethodName, CurrPhase ?? " ");
+        public int Pid;
+
+        public string AnalyzedAssembly;
+
+        // Assertions
+        public long Total, True, Top, False, Bottom, Masked;
+
+
+        // Methods
+        public int MethodsTotal, MethodsFromCache, MethodsMissedInCache, MethodsTimedOut, MethodsWithCheaperAD;
+
+        public DateTime StartTime, EndTime;
+
+        public TimeSpan Elapsed;
+
+        // Crashed?
+        public bool ClousotCrashed = false;
+
+        public ClousotAnalysisResults()
+        {
+            this.Pid = Process.GetCurrentProcess().Id;
+            this.StartTime = DateTime.Now;
+        }
+
+        public ClousotAnalysisResults(List<Tuple<string, object>> list)
+        {
+            Contract.Requires(list != null);
+            this.FromList(list);
+        }
+
+        public void NotifyDone()
+        {
+            this.EndTime = DateTime.Now;
+            this.Elapsed = this.EndTime - this.StartTime;
+        }
+
+        public void UpdateAssertionStatisticsFrom(ClousotAnalysisResults results, int outputWarns)
+        {
+            Contract.Requires(results != null);
+
+            this.Total = results.Total;
+            this.True = results.True;
+            this.False = results.False;
+            this.Bottom = results.Bottom;
+            this.Top = results.Top;
+            this.Masked = results.Masked;
+        }
     }
-  }
-  
-  [Serializable]
-  public class ClousotAnalysisResults : ClousotAnalysisInfoBaseClass
-  {
-    public int Pid;
-
-    public string AnalyzedAssembly;
-
-    // Assertions
-    public long Total, True, Top, False, Bottom, Masked;
-
-
-    // Methods
-    public int MethodsTotal, MethodsFromCache, MethodsMissedInCache, MethodsTimedOut, MethodsWithCheaperAD;
-
-    public DateTime StartTime, EndTime;
-
-    public TimeSpan Elapsed;
-
-    // Crashed?
-    public bool ClousotCrashed = false;
-
-    public ClousotAnalysisResults()
-    {
-      this.Pid = Process.GetCurrentProcess().Id;
-      this.StartTime = DateTime.Now;
-    }
-
-    public ClousotAnalysisResults(List<Tuple<string, object>> list)
-    {
-      Contract.Requires(list != null);
-      this.FromList(list);
-    }
-    
-    public void NotifyDone()
-    {
-      this.EndTime = DateTime.Now;
-      this.Elapsed = this.EndTime - this.StartTime;
-    }
-
-    public void UpdateAssertionStatisticsFrom(ClousotAnalysisResults results, int outputWarns)
-    {
-      Contract.Requires(results != null);
-
-      this.Total = results.Total;
-      this.True = results.True;
-      this.False = results.False;
-      this.Bottom = results.Bottom;
-      this.Top = results.Top;
-      this.Masked = results.Masked;
-    }
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/OptionWithPathsAttribute.cs
+++ b/Microsoft.Research/AnalysisTypes/OptionWithPathsAttribute.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,10 +8,10 @@ using System.Text;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// Marker to denote whether an option has an attribute or not
-  /// </summary>
-  public class OptionWithPathsAttribute : Attribute
-  {
-  }
+    /// <summary>
+    /// Marker to denote whether an option has an attribute or not
+    /// </summary>
+    public class OptionWithPathsAttribute : Attribute
+    {
+    }
 }

--- a/Microsoft.Research/AnalysisTypes/ProofOutcome.cs
+++ b/Microsoft.Research/AnalysisTypes/ProofOutcome.cs
@@ -1,72 +1,61 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.Research.CodeAnalysis {
+namespace Microsoft.Research.CodeAnalysis
+{
+    public enum ExpressionCacheMode { None, Mem, Time }
 
-  public enum ExpressionCacheMode { None, Mem, Time }
 
+    public enum ProofOutcome : byte { Top = 0, Bottom, True, False }
 
-  public enum ProofOutcome : byte { Top = 0, Bottom, True, False }
-
-  public static class ProofOutcomeExtensions
-  {
-    public static ProofOutcome Meet(this ProofOutcome o1, ProofOutcome o2)
+    public static class ProofOutcomeExtensions
     {
-      if (o1 == o2) return o1;
-      if (o1 == ProofOutcome.Top || o2 == ProofOutcome.Bottom) return o2;
-      if (o2 == ProofOutcome.Top || o1 == ProofOutcome.Bottom) return o1;
+        public static ProofOutcome Meet(this ProofOutcome o1, ProofOutcome o2)
+        {
+            if (o1 == o2) return o1;
+            if (o1 == ProofOutcome.Top || o2 == ProofOutcome.Bottom) return o2;
+            if (o2 == ProofOutcome.Top || o1 == ProofOutcome.Bottom) return o1;
 
-      // different and none is top or bottom, so meet of true and false
-      return ProofOutcome.Bottom;
+            // different and none is top or bottom, so meet of true and false
+            return ProofOutcome.Bottom;
+        }
+
+        public static ProofOutcome Join(this ProofOutcome o1, ProofOutcome o2)
+        {
+            if (o1 == o2) return o1;
+            if (o1 == ProofOutcome.Top || o2 == ProofOutcome.Bottom) return o1;
+            if (o2 == ProofOutcome.Top || o1 == ProofOutcome.Bottom) return o2;
+
+            // different and none is top or bottom, so join of true and false
+            return ProofOutcome.Top;
+        }
+
+        public static bool IsNormal(this ProofOutcome o)
+        {
+            return o == ProofOutcome.True || o == ProofOutcome.False;
+        }
+
+        public static ProofOutcome Negate(this ProofOutcome o)
+        {
+            switch (o)
+            {
+                case ProofOutcome.Bottom:
+                case ProofOutcome.Top:
+                    return o;
+
+                case ProofOutcome.False:
+                    return ProofOutcome.True;
+
+                case ProofOutcome.True:
+                    return ProofOutcome.False;
+
+                default:
+                    return ProofOutcome.Top;
+            }
+        }
     }
-
-    public static ProofOutcome Join(this ProofOutcome o1, ProofOutcome o2)
-    {
-      if (o1 == o2) return o1;
-      if (o1 == ProofOutcome.Top || o2 == ProofOutcome.Bottom) return o1;
-      if (o2 == ProofOutcome.Top || o1 == ProofOutcome.Bottom) return o2;
-
-      // different and none is top or bottom, so join of true and false
-      return ProofOutcome.Top;
-    }
-
-    public static bool IsNormal(this ProofOutcome o)
-    {
-      return o == ProofOutcome.True || o == ProofOutcome.False;
-    }
-
-    public static ProofOutcome Negate(this ProofOutcome o)
-    {
-      switch (o)
-      {
-        case ProofOutcome.Bottom:
-        case ProofOutcome.Top:
-          return o;
-
-        case ProofOutcome.False:
-          return ProofOutcome.True;
-
-        case ProofOutcome.True:
-          return ProofOutcome.False;
-
-        default: 
-          return ProofOutcome.Top;
-      }
-    }
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/Properties/AssemblyInfo.cs
+++ b/Microsoft.Research/AnalysisTypes/Properties/AssemblyInfo.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -24,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft IT")]
 [assembly: AssemblyProduct("AnalysisTypes")]
-[assembly: AssemblyCopyright("Copyright © Microsoft IT 2012")]
+[assembly: AssemblyCopyright("Copyright \u00A9 Microsoft IT 2012")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Microsoft.Research/AnalysisTypes/StringConstants.cs
+++ b/Microsoft.Research/AnalysisTypes/StringConstants.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,52 +8,50 @@ using System.Text;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public static class StringConstants
-  {
-    public const string ClousotWait = "wait";
-    public const string Cloudot = "cloudot";
-    public const string DoNotUseCloudot = "+cloudot";
-
-    public const string StringSeparator = "$%^";
-
-    public static class Contract
+    public static class StringConstants
     {
-      public const string ContractsNamespace = "System.Diagnostics.Contracts";
-      public const string Result = "Contract.Result"; 
-      public const string EnsuresWithHole = "Contract.Ensures({0});";
+        public const string ClousotWait = "wait";
+        public const string Cloudot = "cloudot";
+        public const string DoNotUseCloudot = "+cloudot";
+
+        public const string StringSeparator = "$%^";
+
+        public static class Contract
+        {
+            public const string ContractsNamespace = "System.Diagnostics.Contracts";
+            public const string Result = "Contract.Result";
+            public const string EnsuresWithHole = "Contract.Ensures({0});";
+        }
+
+        public static class XML
+        {
+            public const string Root = "CCCheckOutput";
+            public const string Assembly = "Assembly";
+            public const string Method = "Method";
+            public const string Message = "Message";
+            public const string Suggestion = "Suggestion";
+            public const string SuggestionKind = "SuggestionKind";
+            public const string Suggested = "Suggested";
+            public const string Statistics = "Statistics";
+            public const string FinalStatistics = "FinalStatistic";
+            public const string Check = "Check";
+            public const string Kind = "Kind";
+            public const string Name = "Name";
+            public const string Trace = "Trace";
+            public const string Result = "Result";
+            public const string Score = "Score";
+            public const string RelatedLocation = "RelatedLocation";
+            public const string SourceLocation = "SourceLocation";
+            public const string Justification = "Justification";
+            public const string Feature = "Feature";
+            public const string SuggestionExtraInfo = "SuggestionExtraInfo";
+
+            public const string Interface = "Interface";
+            public const string ProperMember = "Member";
+            public const string Extern = "Extern";
+            public const string Abstract = "Abstract";
+            public const string ConfidenceLevel = "ConfidenceLevel";
+            public const string SuggestionTurnedIntoWarning = "SuggestionTurnedIntoWarning_";
+        }
     }
-
-    public static class XML
-    {
-      public const string Root = "CCCheckOutput";
-      public const string Assembly = "Assembly";
-      public const string Method = "Method";
-      public const string Message = "Message";
-      public const string Suggestion = "Suggestion";
-      public const string SuggestionKind = "SuggestionKind";
-      public const string Suggested = "Suggested";
-      public const string Statistics = "Statistics";
-      public const string FinalStatistics = "FinalStatistic";
-      public const string Check = "Check";
-      public const string Kind = "Kind";
-      public const string Name = "Name";
-      public const string Trace = "Trace";
-      public const string Result = "Result";
-      public const string Score = "Score";
-      public const string RelatedLocation = "RelatedLocation";
-      public const string SourceLocation = "SourceLocation";
-      public const string Justification = "Justification";
-      public const string Feature = "Feature";
-      public const string SuggestionExtraInfo = "SuggestionExtraInfo";
-
-      public const string Interface = "Interface";
-      public const string ProperMember = "Member";
-      public const string Extern = "Extern";
-      public const string Abstract = "Abstract";
-      public const string ConfidenceLevel = "ConfidenceLevel";
-      public const string SuggestionTurnedIntoWarning = "SuggestionTurnedIntoWarning_";
-    }
-  
-  }
-
 }

--- a/Microsoft.Research/AnalysisTypes/Suggestions.cs
+++ b/Microsoft.Research/AnalysisTypes/Suggestions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -23,246 +12,244 @@ using System.Xml.Serialization;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-
-  public static class ClousotSuggestion
-  {
-    public class ExtraSuggestionInfo
+    public static class ClousotSuggestion
     {
-      static public ExtraSuggestionInfo None
-      {
-        get
+        public class ExtraSuggestionInfo
         {
-          Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
+            static public ExtraSuggestionInfo None
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
 
-          return new ExtraSuggestionInfo();
+                    return new ExtraSuggestionInfo();
+                }
+            }
+
+            static public ExtraSuggestionInfo ForObjectInvariant(string suggestedCode, string typeDocumentID)
+            {
+                Contract.Requires(suggestedCode != null);
+                Contract.Requires(typeDocumentID != null);
+                Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
+
+                var result = new ExtraSuggestionInfo();
+                result.SuggestedCode = suggestedCode;
+                result.TypeDocumentId = typeDocumentID;
+
+                return result;
+            }
+
+            public string CalleeDocumentId;
+            public string CalleeMemberKind;
+            public string CalleeIsDeclaredInTheSameAssembly;
+            public string TypeDocumentId;
+            public string SuggestedCode;
+
+            #region API
+            public static ExtraSuggestionInfo FromStream(IEnumerable<string> enumerable)
+            {
+                Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
+
+                if (enumerable == null)
+                    return new ExtraSuggestionInfo();
+
+                var fields = new List<string>();
+                var values = new List<string>();
+
+                var count = 0;
+                foreach (var str in enumerable)
+                {
+                    if (count % 2 == 0)
+                        fields.Add(str);
+                    else
+                        values.Add(str);
+                    count++;
+                }
+                if (fields.Count != values.Count)
+                {
+                    return ExtraSuggestionInfo.None;
+                }
+
+                var freshObj = new ExtraSuggestionInfo();
+                var type = typeof(ExtraSuggestionInfo);
+
+                for (var i = 0; i < fields.Count; i++)
+                {
+                    var fi = type.GetField(fields[i], PublicInstances());
+                    Contract.Assume(fi != null);
+                    fi.SetValue(freshObj, values[i]);
+                }
+
+                return freshObj;
+            }
+
+            public static ExtraSuggestionInfo FromStream(string str)
+            {
+                Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
+                if (string.IsNullOrEmpty(str))
+                    return FromStream((IEnumerable<string>)null);
+
+                var deserializer = new XmlSerializer(typeof(string[]));
+                var obj = deserializer.Deserialize(new StringReader(str));
+
+                return FromStream(obj as string[]);
+            }
+
+            public IEnumerable<string> ToCollection()
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<string>>() != null);
+
+                foreach (var fi in PublicFields())
+                {
+                    yield return fi.Name;
+                    var value = fi.GetValue(this);
+                    yield return value != null ? value.ToString() : null;
+                }
+            }
+
+            public string Serialize()
+            {
+                Contract.Ensures(Contract.Result<string>() != null);
+
+                var serializer = new XmlSerializer(typeof(string[]));
+                var str = new StringWriter();
+                serializer.Serialize(str, this.ToCollection().ToArray());
+
+                return str.ToString();
+            }
+
+            public IEnumerable<Tuple<string, string>> GetXml()
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Tuple<string, string>>>() != null);
+
+                foreach (var fi in PublicFields())
+                {
+                    var value = fi.GetValue(this);
+                    if (value != null)
+                    {
+                        yield return new Tuple<string, string>(fi.Name, value.ToString());
+                    }
+                }
+            }
+
+            [Pure]
+            static private BindingFlags PublicInstances()
+            {
+                return BindingFlags.Public | BindingFlags.Instance;
+            }
+
+            [Pure]
+            static private IEnumerable<FieldInfo> PublicFields()
+            {
+                return typeof(ExtraSuggestionInfo).GetFields(PublicInstances());
+            }
+
+            #endregion
         }
-      }
 
-      static public ExtraSuggestionInfo ForObjectInvariant(string suggestedCode, string typeDocumentID)
-      {
-        Contract.Requires(suggestedCode != null);
-        Contract.Requires(typeDocumentID != null);
-        Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
-
-        var result = new ExtraSuggestionInfo();
-        result.SuggestedCode = suggestedCode;
-        result.TypeDocumentId = typeDocumentID;
-
-        return result;
-      }
-
-      public string CalleeDocumentId;
-      public string CalleeMemberKind;
-      public string CalleeIsDeclaredInTheSameAssembly;
-      public string TypeDocumentId;
-      public string SuggestedCode;
-
-      #region API
-      public static ExtraSuggestionInfo FromStream(IEnumerable<string> enumerable)
-      {
-        Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
-
-        if (enumerable == null)
-          return new ExtraSuggestionInfo();
-
-        var fields = new List<string>();
-        var values = new List<string>();
-
-        var count = 0;
-        foreach (var str in enumerable)
+        public enum Kind : byte
         {
-          if (count % 2 == 0)
-            fields.Add(str);
-          else
-            values.Add(str);
-          count++;
+            AbstractState,
+            AssertToContract,
+            Action,
+            AssumeOnEntry,
+            AssumeOnCallee,
+            AssumptionCanBeProven,
+            CalleeInvariant,
+            CodeFix,
+            Ensures,
+            EnsuresExtractedMethod,
+            EnsuresNecessary,
+            InterMethodTrace,
+            ObjectInvariant,
+            ReadonlyField,
+            Requires,
+            RequiresCanBeProven,
+            RequiresOnBaseMethod,
+            RequiresIsRedundant,
+            RequiresExtractedMethod,
+            SuppressionWarning,
+            UnusedSuppressWarning,
+            NotInteresting,
         }
-        if (fields.Count != values.Count)
+
+        public enum Ensures
         {
-          return ExtraSuggestionInfo.None;
+            None,
+            NonNullReturnOnly,
+            NonNull,
+            All
         }
 
-        var freshObj = new ExtraSuggestionInfo();
-        var type = typeof(ExtraSuggestionInfo);
-
-        for (var i = 0; i < fields.Count; i++)
+        public static string Message(this Kind suggestion, string extra = null)
         {
-          var fi = type.GetField(fields[i], PublicInstances());
-          Contract.Assume(fi != null);
-          fi.SetValue(freshObj, values[i]);
+            Contract.Ensures(Contract.Result<System.String>() != null);
+            switch (suggestion)
+            {
+                case Kind.AbstractState:
+                    return "Suggested abstract state";
+
+                case Kind.Action:
+                    return "action";
+
+                case Kind.AssertToContract:
+                    return "code improvement";
+
+                case Kind.AssumeOnCallee:
+                case Kind.AssumeOnEntry:
+                    return "assume";
+
+                case Kind.AssumptionCanBeProven:
+                    return "assumption";
+
+                case Kind.CalleeInvariant:
+                    return "callee invariant";
+
+                case Kind.CodeFix:
+                    return "Code fix";
+
+                case Kind.Ensures:
+                    return "ensures";
+
+                case Kind.EnsuresExtractedMethod:
+                    return "Postcondition for the extracted method ";
+
+                case Kind.EnsuresNecessary:
+                    return string.Format("ensures for member {0}", extra);
+
+                case Kind.InterMethodTrace:
+                    return "inter-method trace";
+
+                case Kind.NotInteresting:
+                    return "";
+
+                case Kind.ObjectInvariant:
+                    return "invariant";
+
+                case Kind.ReadonlyField:
+                    return "readonly field";
+
+                case Kind.Requires:
+                case Kind.RequiresCanBeProven:
+                case Kind.RequiresIsRedundant:
+                    return "requires";
+
+                case Kind.RequiresOnBaseMethod:
+                    return string.Format("requires for base method {0}", extra);
+
+                case Kind.RequiresExtractedMethod:
+                    return "Precondition for the extracted method ";
+
+                case Kind.SuppressionWarning:
+                    return "suppression ";
+
+                case Kind.UnusedSuppressWarning:
+                    return "Unused SuppressWarning";
+
+                default:
+                    Contract.Assert(false);
+                    return "unknown";
+            }
         }
-
-        return freshObj;
-      }
-
-      public static ExtraSuggestionInfo FromStream(string str)
-      {
-        Contract.Ensures(Contract.Result<ExtraSuggestionInfo>() != null);
-        if (string.IsNullOrEmpty(str))
-          return FromStream((IEnumerable<string>) null);
-
-        var deserializer = new XmlSerializer(typeof(string[]));
-        var obj = deserializer.Deserialize(new StringReader(str));
-
-        return FromStream(obj as string[]);
-      }
-
-      public IEnumerable<string> ToCollection()
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<string>>() != null);
-
-        foreach(var fi in PublicFields())
-        {
-          yield return fi.Name;
-          var value = fi.GetValue(this);
-          yield return value != null ? value.ToString() : null;
-        }
-      }
-
-      public string Serialize()
-      {
-        Contract.Ensures(Contract.Result<string>() != null);
-
-        var serializer = new XmlSerializer(typeof(string[]));
-        var str = new StringWriter();
-        serializer.Serialize(str, this.ToCollection().ToArray());
-
-        return str.ToString();
-      }
-
-      public IEnumerable<Tuple<string, string>> GetXml()
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<Tuple<string, string>>>() != null);
-
-        foreach(var fi in PublicFields())
-        {
-          var value = fi.GetValue(this);
-          if(value != null)
-          {
-            yield return new Tuple<string, string>(fi.Name, value.ToString());
-          }
-        }
-      }
-
-      [Pure]
-      static private BindingFlags PublicInstances()
-      {
-        return BindingFlags.Public | BindingFlags.Instance;
-      }
-
-      [Pure]
-      static private IEnumerable<FieldInfo> PublicFields()
-      {
-        return typeof(ExtraSuggestionInfo).GetFields(PublicInstances());
-      }
-
-      #endregion
     }
-
-    public enum Kind : byte
-    {
-      AbstractState,
-      AssertToContract,
-      Action,
-      AssumeOnEntry,
-      AssumeOnCallee,
-      AssumptionCanBeProven,
-      CalleeInvariant,
-      CodeFix,
-      Ensures,
-      EnsuresExtractedMethod,
-      EnsuresNecessary,
-      InterMethodTrace,
-      ObjectInvariant,
-      ReadonlyField,
-      Requires,
-      RequiresCanBeProven,
-      RequiresOnBaseMethod,
-      RequiresIsRedundant,
-      RequiresExtractedMethod,
-      SuppressionWarning,
-      UnusedSuppressWarning,
-      NotInteresting,
-    }
-
-    public enum Ensures 
-    {
-      None,
-      NonNullReturnOnly,
-      NonNull,
-      All
-    }
-
-    public static string Message(this Kind suggestion, string extra = null)
-    {
-      Contract.Ensures(Contract.Result<System.String>() != null);
-      switch(suggestion)
-      {
-        case Kind.AbstractState:
-          return "Suggested abstract state";
-
-        case Kind.Action:
-          return "action";
-
-        case Kind.AssertToContract:
-          return "code improvement";
-
-        case Kind.AssumeOnCallee:
-        case Kind.AssumeOnEntry:
-          return "assume";
-
-        case Kind.AssumptionCanBeProven:
-          return "assumption";
-
-        case Kind.CalleeInvariant:
-          return "callee invariant";
-
-        case Kind.CodeFix:
-          return "Code fix";
-          
-        case Kind.Ensures:
-          return "ensures";
-
-        case Kind.EnsuresExtractedMethod:
-          return "Postcondition for the extracted method ";
-
-        case Kind.EnsuresNecessary:
-          return string.Format("ensures for member {0}", extra);
-
-        case Kind.InterMethodTrace:
-          return "inter-method trace";
-
-        case Kind.NotInteresting:
-          return "";
-
-        case Kind.ObjectInvariant:
-          return "invariant";
-
-        case Kind.ReadonlyField:
-          return "readonly field";
-
-        case Kind.Requires:
-        case Kind.RequiresCanBeProven:
-        case Kind.RequiresIsRedundant:
-          return "requires";
-
-        case Kind.RequiresOnBaseMethod:
-          return string.Format("requires for base method {0}", extra);
-
-        case Kind.RequiresExtractedMethod:
-          return "Precondition for the extracted method ";
-
-        case Kind.SuppressionWarning:
-          return "suppression ";
-
-        case Kind.UnusedSuppressWarning:
-          return "Unused SuppressWarning";
-
-        default:
-          Contract.Assert(false);
-          return "unknown";
-      }
-    }
-
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/SwallowedBuckets.cs
+++ b/Microsoft.Research/AnalysisTypes/SwallowedBuckets.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Diagnostics.Contracts;
@@ -18,62 +7,62 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public class SwallowedBuckets
-  {
-    #region Object invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
+    public class SwallowedBuckets
     {
-      Contract.Invariant(this.counter != null);
+        #region Object invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(counter != null);
+        }
+
+        #endregion
+
+        readonly private int[] counter;
+
+        public SwallowedBuckets()
+        {
+            counter = new int[4];
+        }
+
+        public delegate int CounterGetter(ProofOutcome outcome);
+
+        public SwallowedBuckets(CounterGetter counterGetter)
+          : this()
+        {
+            Contract.Requires(counterGetter != null);
+
+            for (int i = 0; i < counter.Length; i++)
+            {
+                counter[i] = counterGetter((ProofOutcome)i);
+            }
+        }
+
+        public void UpdateCounter(ProofOutcome outcome)
+        {
+            Contract.Assert(0 <= outcome);
+            Contract.Assume((int)outcome < counter.Length);
+
+            counter[(int)outcome]++;
+        }
+
+        [Pure]
+        public int GetCounter(ProofOutcome outcome)
+        {
+            Contract.Assert(0 <= outcome);
+            Contract.Assume((int)outcome < counter.Length);
+            return counter[(int)outcome];
+        }
+
+        [Pure]
+        public static SwallowedBuckets operator -(SwallowedBuckets sw1, SwallowedBuckets sw2)
+        {
+            Contract.Requires(sw1 != null);
+            Contract.Requires(sw2 != null);
+            Contract.Ensures(Contract.Result<SwallowedBuckets>() != null);
+
+            return new SwallowedBuckets(outcome => sw1.GetCounter(outcome) - sw2.GetCounter(outcome));
+        }
     }
-    
-    #endregion
-
-    readonly private int[] counter;
-
-    public SwallowedBuckets()
-    {
-      this.counter = new int[4];
-    }
-
-    public delegate int CounterGetter(ProofOutcome outcome);
-
-    public SwallowedBuckets(CounterGetter counterGetter)
-      : this()
-    {
-      Contract.Requires(counterGetter != null);
-
-      for (int i = 0; i < this.counter.Length; i++)
-      {
-        this.counter[i] = counterGetter((ProofOutcome)i);
-      }
-    }
-
-    public void UpdateCounter(ProofOutcome outcome)
-    {
-      Contract.Assert(0 <= outcome);
-      Contract.Assume((int)outcome < this.counter.Length);
-
-      this.counter[(int)outcome]++;
-    }
-
-    [Pure]
-    public int GetCounter(ProofOutcome outcome)
-    {
-      Contract.Assert(0 <= outcome);
-      Contract.Assume((int)outcome < this.counter.Length);
-      return this.counter[(int)outcome];
-    }
-
-    [Pure]
-    public static SwallowedBuckets operator -(SwallowedBuckets sw1, SwallowedBuckets sw2)
-    {
-      Contract.Requires(sw1 != null);
-      Contract.Requires(sw2 != null);
-      Contract.Ensures(Contract.Result<SwallowedBuckets>() != null);
-
-      return new SwallowedBuckets(outcome => sw1.GetCounter(outcome) - sw2.GetCounter(outcome));
-    }
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/ThresholdConstants.cs
+++ b/Microsoft.Research/AnalysisTypes/ThresholdConstants.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,15 +8,15 @@ using System.Text;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// Factor out all the thresholds used in Clousot
-  /// </summary>
-  public static class Thresholds
-  {
-    public static class Renamings
+    /// <summary>
+    /// Factor out all the thresholds used in Clousot
+    /// </summary>
+    public static class Thresholds
     {
-      public const double TooManyRenamings = 200;
-      public const double TooManyVariableRenamingsonAverage = 300;
+        public static class Renamings
+        {
+            public const double TooManyRenamings = 200;
+            public const double TooManyVariableRenamingsonAverage = 300;
+        }
     }
-  }
 }

--- a/Microsoft.Research/AnalysisTypes/WarningContext.cs
+++ b/Microsoft.Research/AnalysisTypes/WarningContext.cs
@@ -1,169 +1,156 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 namespace Microsoft.Research.CodeAnalysis
 {
-  public struct WarningContext
-  {
-    [Flags]
-    public enum CalleeInfo
+    public struct WarningContext
     {
-      Nothing = 0x0,
-      IsAbstract = 0x1,
-      IsAutoProperty = 0x2,
-      IsCompilerGenerated = 0x4,
-      IsConstructor = 0x8,
-      IsDispose = 0x10,
-      IsExtern = 0x20,
-      IsFinalizer = 0x40,
-      IsGeneric = 0x80,
-      IsImplicitImplementation = 0x100,
-      IsInternal = 0x200,
-      IsNewSlot = 0x400,
-      IsOverride = 0x800,
-      IsPrivate = 0x1000,
-      IsPropertyGetterOrSetter = 0x2000,
-      IsProtected = 0x4000,
-      IsPublic = 0x8000,
-      IsSealed = 0x10000,
-      IsStatic = 0x20000,
-      IsVirtual = 0x4000,
-      IsVoidMethod = 0x8000,
-      ReturnPrimitiveValue = 0x100000,
-      ReturnReferenceType = 0x200000,
-      ReturnStructValue = 0x400000,
-      DeclaredInTheSameType = 0x800000, // We want to give credit to those
-      DeclaredInADifferentAssembly = 0x1000000, // we have low confindence in those, or not... depending on the cmd line switch
-      DeclaredInAFrameworkAssembly = 0x2000000
+        [Flags]
+        public enum CalleeInfo
+        {
+            Nothing = 0x0,
+            IsAbstract = 0x1,
+            IsAutoProperty = 0x2,
+            IsCompilerGenerated = 0x4,
+            IsConstructor = 0x8,
+            IsDispose = 0x10,
+            IsExtern = 0x20,
+            IsFinalizer = 0x40,
+            IsGeneric = 0x80,
+            IsImplicitImplementation = 0x100,
+            IsInternal = 0x200,
+            IsNewSlot = 0x400,
+            IsOverride = 0x800,
+            IsPrivate = 0x1000,
+            IsPropertyGetterOrSetter = 0x2000,
+            IsProtected = 0x4000,
+            IsPublic = 0x8000,
+            IsSealed = 0x10000,
+            IsStatic = 0x20000,
+            IsVirtual = 0x4000,
+            IsVoidMethod = 0x8000,
+            ReturnPrimitiveValue = 0x100000,
+            ReturnReferenceType = 0x200000,
+            ReturnStructValue = 0x400000,
+            DeclaredInTheSameType = 0x800000, // We want to give credit to those
+            DeclaredInADifferentAssembly = 0x1000000, // we have low confindence in those, or not... depending on the cmd line switch
+            DeclaredInAFrameworkAssembly = 0x2000000
+        }
+
+        // The contexts
+        public enum ContextType
+        {
+            NonNullAccessPath,
+
+            InferredPrecondition,
+            InferredObjectInvariant,
+            InferredEntryAssume,
+            InferredCalleeAssume,
+
+            InferredConditionIsSufficient,
+            InferredConditionContainsDisjunction,
+            InferredCalleeAssumeContainsDisjunction,
+
+            ViaCast,
+            ViaOutParameter,
+            ViaPureMethodReturn,
+            ViaOldValue,
+            ViaCallThisHavoc,
+
+            ViaArray,
+            ViaField,
+            ViaMethodCall,
+            ViaParameterUnmodified,
+
+            ViaMethodCallThatMayReturnNull,
+
+            ContainsReadOnly,
+            MayContainForAllOrADisjunction,
+            ContainsIsInst,
+
+            OffByOne,
+
+            CodeRepairLikelyFixingABug,
+            CodeRepairLikelyFoundAWeakenessInClousot,
+
+            AssertMayBeTurnedIntoAssume,
+
+            WPReachedMethodEntry,
+            WPReachedMaxPathSize,
+            WPReachedLoop,
+            WPSkippedBecauseAdaptiveAnalysis,
+
+            InheritedEnsures,
+            ObjectInvariantNeededForEnsures,
+
+            InsideUnsafeMethod,
+            StringComparedAgainstNullInSwitchStatement,
+
+            InterproceduralPathToError,
+            IsVarNotEqNullCheck,
+            CodeRepairThinksWrongInitialization,
+            IsPureMethodCallNotEqNullCheck,
+
+            ConditionContainsValueAtReturn,
+        }
+
+        public readonly ContextType Type;
+        public readonly int AssociatedInfo;
+        public readonly string Name;
+
+        public WarningContext(WarningContext.ContextType type, int associatedNumericalinfo)
+        {
+            this.Type = type;
+            this.AssociatedInfo = associatedNumericalinfo;
+            this.Name = null;
+        }
+        public WarningContext(WarningContext.ContextType type, string varName)
+          : this(type, 0)
+        {
+            this.Name = varName;
+        }
+
+        public WarningContext(WarningContext.ContextType type)
+          : this(type, 0)
+        {
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            if (obj is WarningContext)
+            {
+                var that = (WarningContext)obj;
+
+                return this.Type == that.Type && this.AssociatedInfo == that.AssociatedInfo;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Type.GetHashCode() + this.AssociatedInfo;
+        }
+
+        public override string ToString()
+        {
+            if (this.Type != ContextType.InferredCalleeAssume)
+            {
+                return string.Format("{0}{1}", this.Type.ToString(), this.AssociatedInfo > 1 ? " (x" + this.AssociatedInfo.ToString() + ")" : null);
+            }
+            else
+            {
+                return string.Format("{0} ({1})", this.Type, ((CalleeInfo)this.AssociatedInfo).ToString());
+            }
+        }
     }
-
-    // The contexts
-    public enum ContextType
-    {
-      NonNullAccessPath,
-
-      InferredPrecondition,
-      InferredObjectInvariant,
-      InferredEntryAssume,
-      InferredCalleeAssume,
-
-      InferredConditionIsSufficient,
-      InferredConditionContainsDisjunction,
-      InferredCalleeAssumeContainsDisjunction,
-
-      ViaCast,
-      ViaOutParameter,
-      ViaPureMethodReturn,
-      ViaOldValue,
-      ViaCallThisHavoc,
-
-      ViaArray,
-      ViaField,
-      ViaMethodCall,
-      ViaParameterUnmodified,
-
-      ViaMethodCallThatMayReturnNull,
-
-      ContainsReadOnly,
-      MayContainForAllOrADisjunction,
-      ContainsIsInst,
-
-      OffByOne,
-
-      CodeRepairLikelyFixingABug,
-      CodeRepairLikelyFoundAWeakenessInClousot,
-
-      AssertMayBeTurnedIntoAssume,
-
-      WPReachedMethodEntry,
-      WPReachedMaxPathSize,
-      WPReachedLoop,
-      WPSkippedBecauseAdaptiveAnalysis,
-
-      InheritedEnsures,
-      ObjectInvariantNeededForEnsures,
-
-      InsideUnsafeMethod,
-      StringComparedAgainstNullInSwitchStatement,
-
-      InterproceduralPathToError,
-      IsVarNotEqNullCheck,
-      CodeRepairThinksWrongInitialization,
-      IsPureMethodCallNotEqNullCheck,
-
-      ConditionContainsValueAtReturn,
-    }
-
-    public readonly ContextType Type;
-    public readonly int AssociatedInfo;
-    public readonly string Name;
-
-    public WarningContext(WarningContext.ContextType type, int associatedNumericalinfo)
-    {
-      this.Type = type;
-      this.AssociatedInfo = associatedNumericalinfo;
-      this.Name = null;
-    }
-    public WarningContext(WarningContext.ContextType type, string varName)
-      : this(type, 0)
-    {
-      this.Name = varName;
-    }
-
-    public WarningContext(WarningContext.ContextType type)
-      : this(type, 0)
-    {
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj == null)
-      {
-        return false;
-      }
-
-      if (obj is WarningContext)
-      {
-        var that = (WarningContext)obj;
-
-        return this.Type == that.Type && this.AssociatedInfo == that.AssociatedInfo;
-      }
-      else
-      {
-        return false;
-      }
-    }
-
-    public override int GetHashCode()
-    {
-      return this.Type.GetHashCode() + this.AssociatedInfo;
-    }
-
-    public override string ToString()
-    {
- 
-     if (this.Type != ContextType.InferredCalleeAssume)
-      {
-        return string.Format("{0}{1}", this.Type.ToString(), this.AssociatedInfo > 1 ? " (x" + this.AssociatedInfo.ToString() + ")" : null);
-      }
-      else
-      {
-        return string.Format("{0} ({1})", this.Type, ((CalleeInfo) this.AssociatedInfo).ToString());
-      }
-    }
-
-  }
-
 }

--- a/Microsoft.Research/AnalysisTypes/WarningType.cs
+++ b/Microsoft.Research/AnalysisTypes/WarningType.cs
@@ -1,74 +1,62 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Research.CodeAnalysis
 {
+    // The warnings that can be emitted by Clousot
+    public enum WarningType : byte
+    {
+        // no explicit proof obligation
+        UnreachedCodeAfterPrecondition,         // The program point after the precondition is unreached
+        TestAlwaysEvaluatingToAConstant,
+        FalseRequires,
+        FalseEnsures,
 
-  // The warnings that can be emitted by Clousot
-  public enum WarningType : byte
-  {
-    // no explicit proof obligation
-    UnreachedCodeAfterPrecondition,         // The program point after the precondition is unreached
-    TestAlwaysEvaluatingToAConstant,
-    FalseRequires,
-    FalseEnsures,
+        // Arithmetics
+        ArithmeticDivisionByZero,
+        ArithmeticDivisionOverflow,
+        ArithmeticMinValueNegation,
+        ArithmeticOverflow,
+        ArithmeticUnderflow,
+        ArithmeticFloatEqualityPrecisionMismatch,
 
-    // Arithmetics
-    ArithmeticDivisionByZero,
-    ArithmeticDivisionOverflow,
-    ArithmeticMinValueNegation,
-    ArithmeticOverflow,
-    ArithmeticUnderflow,
-    ArithmeticFloatEqualityPrecisionMismatch,
+        // Arrays
+        ArrayCreation,
+        ArrayLowerBound,
+        ArrayUpperBound,
 
-    // Arrays
-    ArrayCreation,
-    ArrayLowerBound,
-    ArrayUpperBound,
+        // Array Purity
+        ArrayPurity,
 
-    // Array Purity
-    ArrayPurity,
+        // Contracts
+        ContractAssert,
+        ContractAssume, // this is used by the -checkassumptions option
+        ContractEnsures,
+        ContractInvariant,
+        ContractRequires,
 
-    // Contracts
-    ContractAssert,
-    ContractAssume, // this is used by the -checkassumptions option
-    ContractEnsures,
-    ContractInvariant,
-    ContractRequires,
+        // Missing validations
+        MissingPrecondition,
+        MissingPreconditionInvolvingReadonly,  // A missing precondition that involves a readonly field
 
-    // Missing validations
-    MissingPrecondition,
-    MissingPreconditionInvolvingReadonly,  // A missing precondition that involves a readonly field
+        // A suggestion turned into a warning
+        Suggestion,
 
-    // A suggestion turned into a warning
-    Suggestion, 
+        // Enum
+        EnumRange,
 
-    // Enum
-    EnumRange,
+        // Nonnull
+        NonnullArray,
+        NonnullCall,
+        NonnullField,
+        NonnullUnbox,
 
-    // Nonnull
-    NonnullArray,
-    NonnullCall,
-    NonnullField,
-    NonnullUnbox,
+        // Unsafe memory accesses
+        UnsafeCreation,
+        UnsafeLowerBound,
+        UnsafeUpperBound,
 
-    // Unsafe memory accesses
-    UnsafeCreation,
-    UnsafeLowerBound,
-    UnsafeUpperBound,
-
-    // Can't connect to the cache
-    ClousotCacheNotAvailable,
-  }
+        // Can't connect to the cache
+        ClousotCacheNotAvailable,
+    }
 }


### PR DESCRIPTION
This reformat operation used dotnet/codeformatter@1d719e4e with `/rule-:FieldNames`.