### PR TITLE
Reformat code in CodeAnalysis

### DIFF
--- a/Microsoft.Research/CodeAnalysis/AbstractionProviders.cs
+++ b/Microsoft.Research/CodeAnalysis/AbstractionProviders.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 //#define DEBUGSTACK
 
@@ -26,553 +15,567 @@ using StackTemp = System.Int32;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
-  using SubroutineEdge = Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>;
-  using System.Diagnostics.Contracts;
+    using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
+    using SubroutineEdge = Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>;
+    using System.Diagnostics.Contracts;
 
 
-  /// <summary>
-  /// Turns any type T that is Equatable into a flat abstract domain
-  /// </summary>
-  /// <typeparam name="T">Elements in the domain besides Top and Bottom</typeparam>
-  public struct FlatDomain<T> : IEquatable<FlatDomain<T>>, IAbstractValue<FlatDomain<T>>
-    where T : IEquatable<T>
-  {
     /// <summary>
-    /// Make sure that Top = 0 so default(FlatDomain) is Top
+    /// Turns any type T that is Equatable into a flat abstract domain
     /// </summary>
-    enum State { Top=0, Bottom, Normal }
-
-    private FlatDomain(State state)
+    /// <typeparam name="T">Elements in the domain besides Top and Bottom</typeparam>
+    public struct FlatDomain<T> : IEquatable<FlatDomain<T>>, IAbstractValue<FlatDomain<T>>
+      where T : IEquatable<T>
     {
-      this.state = state;
-      this.Value = default(T);
+        /// <summary>
+        /// Make sure that Top = 0 so default(FlatDomain) is Top
+        /// </summary>
+        private enum State { Top = 0, Bottom, Normal }
+
+        private FlatDomain(State state)
+        {
+            this.state = state;
+            this.Value = default(T);
+        }
+
+        public FlatDomain(T/*!*/ value)
+        {
+            this.Value = value;
+            state = State.Normal;
+        }
+
+        private readonly State state;
+        public readonly T Value;
+
+        public static readonly FlatDomain<T> BottomValue = new FlatDomain<T>(State.Bottom); // Thread-safe if T is thread-safe
+        public static readonly FlatDomain<T> TopValue = new FlatDomain<T>(State.Top); // Thread-safe if T is thread-safe
+
+
+        public static implicit operator FlatDomain<T>(T/*!*/ value) { return new FlatDomain<T>(value); }
+
+        public bool IsNormal { get { return state == State.Normal; } }
+
+        #region IAbstractValue<LiftedDomain<T>> Members
+
+        public FlatDomain<T> Top
+        {
+            get { return FlatDomain<T>.TopValue; }
+        }
+
+        public FlatDomain<T> Bottom
+        {
+            get { return FlatDomain<T>.BottomValue; }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return state == State.Top;
+            }
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                return state == State.Bottom;
+            }
+        }
+
+        public FlatDomain<T> ImmutableVersion()
+        {
+            return this;
+        }
+
+        public FlatDomain<T> Clone()
+        {
+            return this;
+        }
+
+        public FlatDomain<T> Join(FlatDomain<T> newState, out bool weaker, bool widen)
+        {
+            if (this.IsTop) { weaker = false; return this; }
+            if (newState.IsTop) { weaker = !this.IsTop; return newState; }
+            if (this.IsBottom) { weaker = !newState.IsBottom; return newState; }
+            if (newState.IsBottom) { weaker = false; return this; }
+
+            if (this.Value.Equals(newState.Value)) { weaker = false; return newState; }
+            weaker = true;
+            return TopValue;
+        }
+
+        public FlatDomain<T> Meet(FlatDomain<T> that)
+        {
+            if (this.IsTop) return that;
+            if (that.IsTop) return this;
+            if (this.IsBottom) return this;
+            if (that.IsBottom) return that;
+
+            if (this.Value.Equals(that.Value)) return that;
+            return BottomValue;
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            if (this.IsTop) { tw.WriteLine("Top"); }
+            else if (this.IsBottom) { tw.WriteLine("Bot"); }
+            else
+            {
+                tw.WriteLine("<{0}>", Value);
+            }
+        }
+
+        public bool LessEqual(FlatDomain<T> that)
+        {
+            if (that.IsTop) return true;
+            if (this.IsBottom) return true;
+            if (this.IsTop) return false;
+            if (that.IsBottom) return false;
+            return this.Value.Equals(that.Value);
+        }
+
+        #endregion
+
+        public override string ToString()
+        {
+            if (this.IsTop) { return ("Top"); }
+            else if (this.IsBottom) { return ("Bot"); }
+            else
+            {
+                // invariant IsNormal => Value != null
+                //^ assume Value != null;
+                return Value.ToString();
+            }
+        }
+        #region IEquatable<LiftedDomain<T>> Members
+
+        //^ [StateIndependent]
+        public bool Equals(FlatDomain<T> other)
+        {
+            return state == other.state && (!this.IsNormal || this.Value.Equals(other.Value));
+        }
+
+        #endregion
     }
-    
-    public FlatDomain(T/*!*/ value)
+
+    public struct EnvironmentDomain<Key, Val> : IAbstractValue<EnvironmentDomain<Key, Val>>
+      where Val : IAbstractValue<Val>
     {
-      this.Value = value;
-      this.state = State.Normal;
-    }
-
-    private readonly State state;
-    public readonly T Value;
-
-    public static readonly FlatDomain<T> BottomValue = new FlatDomain<T>(State.Bottom); // Thread-safe if T is thread-safe
-    public static readonly FlatDomain<T> TopValue = new FlatDomain<T>(State.Top); // Thread-safe if T is thread-safe
-
-
-    public static implicit operator FlatDomain<T>(T/*!*/ value) { return new FlatDomain<T>(value); }
-
-    public bool IsNormal { get { return this.state == State.Normal; } }
-
-    #region IAbstractValue<LiftedDomain<T>> Members
-
-    public FlatDomain<T> Top
-    {
-      get { return FlatDomain<T>.TopValue; }
-    }
-
-    public FlatDomain<T> Bottom
-    {
-      get { return FlatDomain<T>.BottomValue; }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.state == State.Top;
-      }
-    }
-
-    public bool IsBottom
-    {
-      get
-      {
-        return this.state == State.Bottom;
-      }
-    }
-
-    public FlatDomain<T> ImmutableVersion()
-    {
-      return this;
-    }
-
-    public FlatDomain<T> Clone()
-    {
-      return this;
-    }
-
-    public FlatDomain<T> Join(FlatDomain<T> newState, out bool weaker, bool widen)
-    {
-      if (this.IsTop) { weaker = false; return this; }
-      if (newState.IsTop) { weaker = !this.IsTop; return newState; }
-      if (this.IsBottom) { weaker = !newState.IsBottom; return newState; }
-      if (newState.IsBottom) { weaker = false; return this; }
-
-      if (this.Value.Equals(newState.Value)) { weaker = false; return newState; }
-      weaker = true;
-      return TopValue;
-    }
-
-    public FlatDomain<T> Meet(FlatDomain<T> that)
-    {
-      if (this.IsTop) return that;
-      if (that.IsTop) return this;
-      if (this.IsBottom) return this;
-      if (that.IsBottom) return that;
-
-      if (this.Value.Equals(that.Value)) return that;
-      return BottomValue;
-    }
-
-    public void Dump(TextWriter tw)
-    {
-      if (this.IsTop) { tw.WriteLine("Top"); }
-      else if (this.IsBottom) { tw.WriteLine("Bot"); }
-      else {
-        tw.WriteLine("<{0}>", Value);
-      }
-    }
-
-    public bool LessEqual(FlatDomain<T> that)
-    {
-      if (that.IsTop) return true;
-      if (this.IsBottom) return true;
-      if (this.IsTop) return false;
-      if (that.IsBottom) return false;
-      return this.Value.Equals(that.Value);
-    }
-
-    #endregion
-
-    public override string ToString()
-    {
-      if (this.IsTop) { return ("Top"); }
-      else if (this.IsBottom) { return ("Bot"); }
-      else {
-        // invariant IsNormal => Value != null
-        //^ assume Value != null;
-        return Value.ToString();
-      }
-
-    }
-    #region IEquatable<LiftedDomain<T>> Members
-
-    //^ [StateIndependent]
-    public bool Equals(FlatDomain<T> other)
-    {
-      return this.state == other.state && (!this.IsNormal || this.Value.Equals(other.Value));
-    }
-
-    #endregion
-
-  }
-
-  public struct EnvironmentDomain<Key, Val> : IAbstractValue<EnvironmentDomain<Key, Val>>
-    where Val : IAbstractValue<Val>
-  {
-
 #if false //unused?
-    public static bool Debug;
+        public static bool Debug;
 #endif
 
-    private readonly IFunctionalMap<Key, Val>/*?*/ map;
+        private readonly IFunctionalMap<Key, Val>/*?*/ map;
 
-    public EnvironmentDomain(IFunctionalMap<Key, Val>/*?*/ value)
-    {
-      this.map = value;
-    }
-
-    [ThreadStatic] // Current implementation: (only) depends on the analysis driver used
-    private static Converter<Key/*!*/, int> KeyNumber;
-
-    public static EnvironmentDomain<Key, Val> TopValue(Converter<Key/*!*/, int> keyNumber)
-    {
-      if (KeyNumber == null) { KeyNumber = keyNumber; }
-      return new EnvironmentDomain<Key, Val>(FunctionalIntKeyMap<Key, Val>.Empty(keyNumber));
-    }
-
-    public EnvironmentDomain<Key, Val> Add(Key key, Val val)
-    {
-      if(this.map == null)
-      {
-        throw new InvalidOperationException();
-      }
-
-      return new EnvironmentDomain<Key, Val>(this.map.Add(key, val));
-    }
-
-    public EnvironmentDomain<Key, Val> Remove(Key key)
-    {
-      if (this.map == null)
-      {
-        throw new InvalidOperationException();
-      }
-
-      return new EnvironmentDomain<Key, Val>(this.map.Remove(key));
-    }
-
-    public bool Contains(Key/*!*/ key)
-    {
-      if (this.map == null)
-      {
-        throw new InvalidOperationException();
-      }
-
-      return this.map.Contains(key);
-    }
-
-    public Val/*?*/ this[Key/*!*/ key] { get { if (this.map == null) return default(Val); return this.map[key]; } }
-
-    public IEnumerable<Key/*!*/> Keys { get { return this.map.Keys; } }
-
-    public static readonly EnvironmentDomain<Key, Val> BottomValue = new EnvironmentDomain<Key, Val>(null); // Thread-safe
-
-    #region IAbstractValue<EnvironmentDomain<Key,Val>> Members
-
-    public EnvironmentDomain<Key, Val> Top
-    {
-      get
-      {
-        return EnvironmentDomain<Key, Val>.TopValue(KeyNumber);
-      }
-    }
-
-    public EnvironmentDomain<Key, Val> Bottom
-    {
-      get { return new EnvironmentDomain<Key, Val>(null); }
-    }
-
-    public bool IsTop
-    {
-      get
-      {
-        return this.map != null && this.map.Count == 0;
-      }
-    }
-
-    public bool IsBottom
-    {
-      get
-      {
-        return this.map == null;
-      }
-    }
-
-    public EnvironmentDomain<Key, Val> ImmutableVersion()
-    {
-      return this;
-    }
-
-    public EnvironmentDomain<Key, Val> Clone()
-    {
-      return this;
-    }
-
-    public EnvironmentDomain<Key, Val> Join(EnvironmentDomain<Key, Val> newState, out bool weaker, bool widen)
-    {
-      if (this.map == newState.map) { weaker = false; return this; }
-
-      bool resultWeaker = false;
-      if (this.IsTop) { weaker = false; return this; }
-      if (newState.IsTop) { weaker = !this.IsTop; return newState; }
-      if (this.IsBottom) { weaker = !newState.IsBottom; return newState; }
-      if (newState.IsBottom) { weaker = false; return this; }
-
-      // compare pointwise
-      IFunctionalMap<Key, Val> smaller;
-      IFunctionalMap<Key, Val> larger;
-      if (this.map.Count < newState.map.Count) {
-        smaller = this.map;
-        larger = newState.map;
-      }
-      else {
-        smaller = newState.map;
-        larger = this.map;
-      }
-      IFunctionalMap<Key, Val> result = smaller;
-      foreach (Key k in smaller.Keys) {
-        if (!larger.Contains(k)) {
-          result = result.Remove(k);
-        }
-        else {
-          bool joinWeaker;
-          Val join = smaller[k].Join(larger[k], out joinWeaker, widen);
-          if (joinWeaker) {
-            resultWeaker = true;
-            if (join.IsTop) {
-              result = result.Remove(k);
-            }
-            else {
-              result = result.Add(k, join);
-            }
-          }
-        }
-      }
-      weaker = resultWeaker || (result.Count < this.map.Count);
-      return new EnvironmentDomain<Key, Val>(result);
-    }
-
-    public EnvironmentDomain<Key, Val> Meet(EnvironmentDomain<Key, Val> that)
-    {
-      if (this.map == that.map) { return this; }
-
-      if (this.IsTop) return that;
-      if (that.IsTop) return this;
-      if (this.IsBottom) return this;
-      if (that.IsBottom) return that;
-
-      Contract.Assume(this.map != null);
-
-      // compare pointwise
-      IFunctionalMap<Key, Val> smaller;
-      IFunctionalMap<Key, Val> larger;
-      if (this.map.Count < that.map.Count) {
-        smaller = this.map;
-        larger = that.map;
-      }
-      else {
-        smaller = that.map;
-        larger = this.map;
-      }
-      IFunctionalMap<Key, Val> result = larger;
-      foreach (Key k in smaller.Keys) {
-        if (larger.Contains(k)) {
-          // must meet the values
-          Val meet = smaller[k].Meet(larger[k]);
-          result = result.Add(k, meet);
-        }
-        else {
-          // just add the value to the result
-          result = result.Add(k, smaller[k]);
-        }
-      }
-
-      return new EnvironmentDomain<Key,Val>(result);
-    }
-
-    public void Dump(TextWriter tw)
-    {
-      Contract.Assume(tw != null);
-      if (this.IsTop) { tw.WriteLine("Top"); }
-      else if (this.IsBottom) { tw.WriteLine("Bot"); }
-      else {
-        this.map.Visit(delegate(Key/*!*/ k, Val v) { tw.WriteLine("{0} -> {1}", k.ToString(), v.ToString()); return VisitStatus.ContinueVisit; });
-      }
-    }
-    #endregion
-
-    public override string ToString()
-    {
-      if (this.IsTop) { return ("Top"); }
-      else if (this.IsBottom) { return ("Bot"); }
-      else {
-        StringBuilder sb = new StringBuilder();
-        map.Visit(delegate(Key/*!*/ k, Val v) { sb.AppendFormat("({0}->{1}),", k.ToString(), v.ToString()); return VisitStatus.ContinueVisit; });
-        return sb.ToString();
-      }
-
-    }
-
-    public EnvironmentDomain<Key, Val> Empty()
-    {
-      return new EnvironmentDomain<Key, Val>(this.map.EmptyMap);
-    }
-
-    #region IAbstractValue<EnvironmentDomain<Key,Val>> Members
-
-    public bool LessEqual(EnvironmentDomain<Key, Val> that)
-    {
-      if (that.IsTop) return true;
-      if (this.IsBottom) return true;
-      if (this.IsTop) return false;
-      if (that.IsBottom) return false;
-      if (this.map.Count < that.map.Count) return false;
-
-      // pointwise
-      foreach (Key k in that.map.Keys) {
-        if (!this.map.Contains(k) || !this.map[k].LessEqual(that.map[k])) return false;
-      }
-      return true;
-    }
-
-    #endregion
-  }
-
-
-  public struct SetDomain<T> : IAbstractValue<SetDomain<T>>
-    where T : IEquatable<T>
-  {
-
-    #region Privates
-    // null represents bottom
-    private readonly IFunctionalSet<T>/*?*/ set;
-
-    #endregion
-
-    public SetDomain(IFunctionalSet<T>/*?*/ value)
-    {
-      this.set = value;
-    }
-
-    public SetDomain(Converter<T, int> keyNumber)
-    {
-      this.set = FunctionalSet<T>.Empty(keyNumber);
-    }
-
-    public static readonly SetDomain<T> TopValue = new SetDomain<T>(Microsoft.Research.DataStructures.FunctionalSet<T>.Empty()); // Thread-safe
-    public static readonly SetDomain<T> BottomValue = new SetDomain<T>((IFunctionalSet<T>)null); // Thread-safe
-
-    public SetDomain<T> Add(T elem)
-    {
-      if(this.set == null)
-      {
-        throw new InvalidOperationException("The set is null");
-      }
-      return new SetDomain<T>(this.set.Add(elem));
-    }
-
-    public SetDomain<T> Remove(T elem)
-    {
-      if (this.set == null)
-      {
-        throw new InvalidOperationException("The set is null");
-      }
-
-      return new SetDomain<T>(this.set.Remove(elem));
-    }
-
-    public bool Contains(T elem)
-    {
-      if (this.set == null)
-      {
-        throw new InvalidOperationException("The set is null");
-      }
-
-      return this.set.Contains(elem);
-    }
-
-    public IEnumerable<T> Elements
-    {
-      get
-      {
-        if (this.set == null)
+        public EnvironmentDomain(IFunctionalMap<Key, Val>/*?*/ value)
         {
-          throw new InvalidOperationException("The set is null");
+            map = value;
         }
 
-        return this.set.Elements;
-      }
+        [ThreadStatic] // Current implementation: (only) depends on the analysis driver used
+        private static Converter<Key/*!*/, int> KeyNumber;
+
+        public static EnvironmentDomain<Key, Val> TopValue(Converter<Key/*!*/, int> keyNumber)
+        {
+            if (KeyNumber == null) { KeyNumber = keyNumber; }
+            return new EnvironmentDomain<Key, Val>(FunctionalIntKeyMap<Key, Val>.Empty(keyNumber));
+        }
+
+        public EnvironmentDomain<Key, Val> Add(Key key, Val val)
+        {
+            if (map == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return new EnvironmentDomain<Key, Val>(map.Add(key, val));
+        }
+
+        public EnvironmentDomain<Key, Val> Remove(Key key)
+        {
+            if (map == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return new EnvironmentDomain<Key, Val>(map.Remove(key));
+        }
+
+        public bool Contains(Key/*!*/ key)
+        {
+            if (map == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return map.Contains(key);
+        }
+
+        public Val/*?*/ this[Key/*!*/ key] { get { if (map == null) return default(Val); return map[key]; } }
+
+        public IEnumerable<Key/*!*/> Keys { get { return map.Keys; } }
+
+        public static readonly EnvironmentDomain<Key, Val> BottomValue = new EnvironmentDomain<Key, Val>(null); // Thread-safe
+
+        #region IAbstractValue<EnvironmentDomain<Key,Val>> Members
+
+        public EnvironmentDomain<Key, Val> Top
+        {
+            get
+            {
+                return EnvironmentDomain<Key, Val>.TopValue(KeyNumber);
+            }
+        }
+
+        public EnvironmentDomain<Key, Val> Bottom
+        {
+            get { return new EnvironmentDomain<Key, Val>(null); }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return map != null && map.Count == 0;
+            }
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                return map == null;
+            }
+        }
+
+        public EnvironmentDomain<Key, Val> ImmutableVersion()
+        {
+            return this;
+        }
+
+        public EnvironmentDomain<Key, Val> Clone()
+        {
+            return this;
+        }
+
+        public EnvironmentDomain<Key, Val> Join(EnvironmentDomain<Key, Val> newState, out bool weaker, bool widen)
+        {
+            if (map == newState.map) { weaker = false; return this; }
+
+            bool resultWeaker = false;
+            if (this.IsTop) { weaker = false; return this; }
+            if (newState.IsTop) { weaker = !this.IsTop; return newState; }
+            if (this.IsBottom) { weaker = !newState.IsBottom; return newState; }
+            if (newState.IsBottom) { weaker = false; return this; }
+
+            // compare pointwise
+            IFunctionalMap<Key, Val> smaller;
+            IFunctionalMap<Key, Val> larger;
+            if (map.Count < newState.map.Count)
+            {
+                smaller = map;
+                larger = newState.map;
+            }
+            else
+            {
+                smaller = newState.map;
+                larger = map;
+            }
+            IFunctionalMap<Key, Val> result = smaller;
+            foreach (Key k in smaller.Keys)
+            {
+                if (!larger.Contains(k))
+                {
+                    result = result.Remove(k);
+                }
+                else
+                {
+                    bool joinWeaker;
+                    Val join = smaller[k].Join(larger[k], out joinWeaker, widen);
+                    if (joinWeaker)
+                    {
+                        resultWeaker = true;
+                        if (join.IsTop)
+                        {
+                            result = result.Remove(k);
+                        }
+                        else
+                        {
+                            result = result.Add(k, join);
+                        }
+                    }
+                }
+            }
+            weaker = resultWeaker || (result.Count < map.Count);
+            return new EnvironmentDomain<Key, Val>(result);
+        }
+
+        public EnvironmentDomain<Key, Val> Meet(EnvironmentDomain<Key, Val> that)
+        {
+            if (map == that.map) { return this; }
+
+            if (this.IsTop) return that;
+            if (that.IsTop) return this;
+            if (this.IsBottom) return this;
+            if (that.IsBottom) return that;
+
+            Contract.Assume(map != null);
+
+            // compare pointwise
+            IFunctionalMap<Key, Val> smaller;
+            IFunctionalMap<Key, Val> larger;
+            if (map.Count < that.map.Count)
+            {
+                smaller = map;
+                larger = that.map;
+            }
+            else
+            {
+                smaller = that.map;
+                larger = map;
+            }
+            IFunctionalMap<Key, Val> result = larger;
+            foreach (Key k in smaller.Keys)
+            {
+                if (larger.Contains(k))
+                {
+                    // must meet the values
+                    Val meet = smaller[k].Meet(larger[k]);
+                    result = result.Add(k, meet);
+                }
+                else
+                {
+                    // just add the value to the result
+                    result = result.Add(k, smaller[k]);
+                }
+            }
+
+            return new EnvironmentDomain<Key, Val>(result);
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            Contract.Assume(tw != null);
+            if (this.IsTop) { tw.WriteLine("Top"); }
+            else if (this.IsBottom) { tw.WriteLine("Bot"); }
+            else
+            {
+                map.Visit(delegate (Key/*!*/ k, Val v) { tw.WriteLine("{0} -> {1}", k.ToString(), v.ToString()); return VisitStatus.ContinueVisit; });
+            }
+        }
+        #endregion
+
+        public override string ToString()
+        {
+            if (this.IsTop) { return ("Top"); }
+            else if (this.IsBottom) { return ("Bot"); }
+            else
+            {
+                StringBuilder sb = new StringBuilder();
+                map.Visit(delegate (Key/*!*/ k, Val v) { sb.AppendFormat("({0}->{1}),", k.ToString(), v.ToString()); return VisitStatus.ContinueVisit; });
+                return sb.ToString();
+            }
+        }
+
+        public EnvironmentDomain<Key, Val> Empty()
+        {
+            return new EnvironmentDomain<Key, Val>(map.EmptyMap);
+        }
+
+        #region IAbstractValue<EnvironmentDomain<Key,Val>> Members
+
+        public bool LessEqual(EnvironmentDomain<Key, Val> that)
+        {
+            if (that.IsTop) return true;
+            if (this.IsBottom) return true;
+            if (this.IsTop) return false;
+            if (that.IsBottom) return false;
+            if (map.Count < that.map.Count) return false;
+
+            // pointwise
+            foreach (Key k in that.map.Keys)
+            {
+                if (!map.Contains(k) || !map[k].LessEqual(that.map[k])) return false;
+            }
+            return true;
+        }
+
+        #endregion
     }
 
-    public override string ToString()
+
+    public struct SetDomain<T> : IAbstractValue<SetDomain<T>>
+      where T : IEquatable<T>
     {
-      if (IsBottom) { return "Bot"; }
-      if (IsTop) { return ("Top"); }
+        #region Privates
+        // null represents bottom
+        private readonly IFunctionalSet<T>/*?*/ set;
 
-      Contract.Assert(this.set != null);
+        #endregion
 
-      StringBuilder sb = new StringBuilder();
-      set.Visit(delegate(T/*!*/ elem) { sb.AppendFormat("{0},", elem.ToString()); });
-      return sb.ToString();
+        public SetDomain(IFunctionalSet<T>/*?*/ value)
+        {
+            set = value;
+        }
+
+        public SetDomain(Converter<T, int> keyNumber)
+        {
+            set = FunctionalSet<T>.Empty(keyNumber);
+        }
+
+        public static readonly SetDomain<T> TopValue = new SetDomain<T>(Microsoft.Research.DataStructures.FunctionalSet<T>.Empty()); // Thread-safe
+        public static readonly SetDomain<T> BottomValue = new SetDomain<T>((IFunctionalSet<T>)null); // Thread-safe
+
+        public SetDomain<T> Add(T elem)
+        {
+            if (set == null)
+            {
+                throw new InvalidOperationException("The set is null");
+            }
+            return new SetDomain<T>(set.Add(elem));
+        }
+
+        public SetDomain<T> Remove(T elem)
+        {
+            if (set == null)
+            {
+                throw new InvalidOperationException("The set is null");
+            }
+
+            return new SetDomain<T>(set.Remove(elem));
+        }
+
+        public bool Contains(T elem)
+        {
+            if (set == null)
+            {
+                throw new InvalidOperationException("The set is null");
+            }
+
+            return set.Contains(elem);
+        }
+
+        public IEnumerable<T> Elements
+        {
+            get
+            {
+                if (set == null)
+                {
+                    throw new InvalidOperationException("The set is null");
+                }
+
+                return set.Elements;
+            }
+        }
+
+        public override string ToString()
+        {
+            if (IsBottom) { return "Bot"; }
+            if (IsTop) { return ("Top"); }
+
+            Contract.Assert(set != null);
+
+            StringBuilder sb = new StringBuilder();
+            set.Visit(delegate (T/*!*/ elem) { sb.AppendFormat("{0},", elem.ToString()); });
+            return sb.ToString();
+        }
+
+        #region IAbstractValue<SetDomain<T>> Members
+
+        public SetDomain<T> Top
+        {
+            get { return TopValue; }
+        }
+
+        public SetDomain<T> Bottom
+        {
+            get { return BottomValue; }
+        }
+
+        public bool IsTop
+        {
+            get { return set != null && set.Count == 0; }
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<bool>() == (set == null));
+
+                return set == null;
+            }
+        }
+
+        public SetDomain<T> ImmutableVersion()
+        {
+            // pure
+            return this;
+        }
+
+        public SetDomain<T> Clone()
+        {
+            // pure
+            return this;
+        }
+
+        /// <summary>
+        /// Implemented as Intersection
+        /// </summary>
+        [ContractVerification(false)]
+        public SetDomain<T> Join(SetDomain<T> newState, out bool weaker, bool widen)
+        {
+            if (set == newState.set) { weaker = false; return this; }
+            if (this.IsBottom) { weaker = !newState.IsBottom; return newState; }
+            if (newState.IsBottom || this.IsTop) { weaker = false; return this; }
+            if (newState.IsTop) { weaker = !this.IsTop; return newState; }
+
+            Contract.Assert(set != null);
+
+            IFunctionalSet<T> result = set.Intersect(newState.set);
+            weaker = result.Count < set.Count;
+            return new SetDomain<T>(result);
+        }
+
+        /// <summary>
+        /// Implemented as Union
+        /// </summary>
+        [ContractVerification(false)]
+        public SetDomain<T> Meet(SetDomain<T> that)
+        {
+            if (set == that.set) { return this; }
+            if (this.IsBottom || that.IsTop) { return this; }
+            if (that.IsBottom || this.IsTop) { return that; }
+
+            Contract.Assert(set != null);
+
+            IFunctionalSet<T> result = set.Union(that.set);
+            return new SetDomain<T>(result);
+        }
+
+
+        public bool LessEqual(SetDomain<T> that)
+        {
+            if (this.IsBottom) return true;
+            if (that.IsBottom) return false;
+
+            Contract.Assert(set != null);
+
+            return that.set.Contained(set);
+        }
+
+        public void Dump(TextWriter tw)
+        {
+            if (this.IsBottom) { tw.WriteLine("Bot"); return; }
+            if (this.IsTop) { tw.WriteLine("Top"); return; }
+
+            Contract.Assert(set != null);
+
+            set.Dump(tw);
+        }
+
+        #endregion
     }
-
-    #region IAbstractValue<SetDomain<T>> Members
-
-    public SetDomain<T> Top
-    {
-      get { return TopValue; }
-    }
-
-    public SetDomain<T> Bottom
-    {
-      get { return BottomValue; }
-    }
-
-    public bool IsTop
-    {
-      get { return this.set != null && this.set.Count == 0; }
-    }
-
-    public bool IsBottom
-    {
-      get {
-        Contract.Ensures(Contract.Result<bool>() == (this.set == null));
-        
-        return this.set == null; }
-    }
-
-    public SetDomain<T> ImmutableVersion()
-    {
-      // pure
-      return this;
-    }
-
-    public SetDomain<T> Clone()
-    {
-      // pure
-      return this;
-    }
-
-    /// <summary>
-    /// Implemented as Intersection
-    /// </summary>
-    [ContractVerification(false)]
-    public SetDomain<T> Join(SetDomain<T> newState, out bool weaker, bool widen)
-    {
-      if (this.set == newState.set) { weaker = false; return this; }
-      if (this.IsBottom) { weaker = !newState.IsBottom; return newState; }
-      if (newState.IsBottom || this.IsTop) { weaker = false; return this; }
-      if (newState.IsTop) { weaker = !this.IsTop; return newState; }
-
-      Contract.Assert(this.set != null);
-
-      IFunctionalSet<T> result = this.set.Intersect(newState.set);
-      weaker = result.Count < this.set.Count;
-      return new SetDomain<T>(result);
-    }
-
-    /// <summary>
-    /// Implemented as Union
-    /// </summary>
-    [ContractVerification(false)]
-    public SetDomain<T> Meet(SetDomain<T> that)
-    {
-      if (this.set == that.set) { return this; }
-      if (this.IsBottom || that.IsTop) { return this; }
-      if (that.IsBottom || this.IsTop) { return that; }
-
-      Contract.Assert(this.set != null);
-
-      IFunctionalSet<T> result = this.set.Union(that.set);
-      return new SetDomain<T>(result);
-    }
-
-
-    public bool LessEqual(SetDomain<T> that)
-    {
-      if (this.IsBottom) return true;
-      if (that.IsBottom) return false;
-      
-      Contract.Assert(this.set != null);
-
-      return that.set.Contained(this.set);
-    }
-
-    public void Dump(TextWriter tw)
-    {
-      if (this.IsBottom) { tw.WriteLine("Bot"); return; }
-      if (this.IsTop) { tw.WriteLine("Top"); return; }
-
-      Contract.Assert(this.set != null);
-      
-      this.set.Dump(tw);
-    }
-
-    #endregion
-  }
-
 }
 

--- a/Microsoft.Research/CodeAnalysis/AnalysisDriver.cs
+++ b/Microsoft.Research/CodeAnalysis/AnalysisDriver.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,705 +9,704 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using Provenance = IEnumerable<ProofObligation>;
-  using System.Diagnostics.CodeAnalysis;
+    using Provenance = IEnumerable<ProofObligation>;
+    using System.Diagnostics.CodeAnalysis;
 
-  public class BasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    : IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    #region Protected
-
-    protected readonly LogOptions options;
-    protected readonly IOutput output;
-
-    protected readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache;
-    protected readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-    protected readonly IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder;
-    #endregion
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
+    public class BasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      : IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-      Contract.Invariant(this.options != null);
-    }
+        #region Protected
 
-    public BasicAnalysisDriver(
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder,
-      IOutput output,
-      LogOptions options
-    )
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Requires(contractDecoder != null);
-      Contract.Requires(output != null);
-      Contract.Requires(options != null);
+        protected readonly LogOptions options;
+        protected readonly IOutput output;
 
-      this.methodCache = new MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(mdDecoder, contractDecoder, output.WriteLine);
-      this.mdDecoder = mdDecoder;
-      this.contractDecoder = contractDecoder;
-      this.output = output;
-      this.options = options;
-    }
+        protected readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache;
+        protected readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+        protected readonly IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder;
+        #endregion
 
-    public LogOptions Options { get { return this.options; } }
-
-    public MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache { get { return this.methodCache; } }
-
-    public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get { return this.mdDecoder; } }
-
-    public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get { return this.contractDecoder; } }
-
-    public IOutput Output { get { return this.output; } }
-
-    //public abstract IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> BasicMethodDriver(Method method);
-
-  }
-
-  public abstract class AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    : IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    #region Invariant
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.mCDrivers != null);
-    }
-    
-    #endregion
-
-    #region Protected
-
-    // public (anyone can register a contract for pretty output, or ask for them)
-    protected readonly OutputPrettyCS.ContractsHandlerMgr<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mContractsHandlerMgr;
-    public OutputPrettyCS.ContractsHandlerMgr<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ContractsHandlerManager { get { return this.mContractsHandlerMgr; } }
-
-    protected readonly Dictionary<Type, WeakReference> mCDrivers;
-    protected int mMaxClassDriversCount;
-    /// class drivers actually stored (ie. non-null in the map, so != mCDrivers.Count)
-    protected int mCDriversCount
-    {
-      get
-      {
-        return this.mCDrivers.Where(pair => pair.Value != null && pair.Value.IsAlive).Count();
-      }
-    }
-    protected IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> basicDriver;
-    #endregion
-
-    protected AnalysisDriver(
-      IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> basicDriver
-    )
-    {
-      this.basicDriver = basicDriver;
-      this.mContractsHandlerMgr = new OutputPrettyCS.ContractsHandlerMgr<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>(this, this.Output);
-      this.mCDrivers = new Dictionary<Type, WeakReference>();
-      this.mMaxClassDriversCount = 0;
-    }
-
-    public void InstallPostconditions(List<BoxedExpression.AssertExpression> inferredPostconditions, Method method)
-    {
-      Contract.Requires(inferredPostconditions != null);
-
-      if (inferredPostconditions.Count == 0) return;
-      //this.Output.WriteLine("Trying to install {0} inferred postconditions.", inferredPostconditions.Count);
-      // Ordering by ToString should avoid in most of the cases the non-determinism problem we have 
-      // when the order of inferred post conditions changes, causing the hash to change in the caching.
-      var ordered = inferredPostconditions.OrderBy(post => post.ToString()).ToList();
-      var seq = BoxedExpression.Sequence(ordered.Cast<BoxedExpression>());
-      BoxedExpression.PC postStart = new BoxedExpression.PC(seq, 0);
-      bool result = this.MethodCache.AddPostCondition(method, postStart, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder);
-      if (result)
-      {
-        foreach (var post in ordered)
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
         {
-          this.mContractsHandlerMgr.RegisterMethodPostCondition(method, post.Condition);
+            Contract.Invariant(this.options != null);
         }
-      }
 
-    }
-
-    public void InstallPreconditions(List<BoxedExpression.AssumeExpression> inferredPreconditions, Method method)
-    {
-      Contract.Requires(inferredPreconditions != null);
-
-      if (inferredPreconditions.Count == 0) return;
-      //this.Output.WriteLine("Trying to install {0} inferred preconditions.", inferredPreconditions.Count);
-
-      // Ordering by ToString should avoid in most of the cases the non-determinism problem we have 
-      // when the order of inferred pre conditions changes, causing the hash to change in the caching.
-      var ordered = inferredPreconditions.OrderBy(pre => pre.ToString()).ToList();
-      var seq = BoxedExpression.Sequence(ordered.Cast<BoxedExpression>());
-      BoxedExpression.PC preStart = new BoxedExpression.PC(seq, 0);
-      if (this.MethodCache.AddPreCondition(method, preStart, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder))
-      {
-        foreach (var pre in ordered)
+        public BasicAnalysisDriver(
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder,
+          IOutput output,
+          LogOptions options
+        )
         {
-          this.mContractsHandlerMgr.RegisterMethodPreCondition(method, pre.Condition);
+            Contract.Requires(mdDecoder != null);
+            Contract.Requires(contractDecoder != null);
+            Contract.Requires(output != null);
+            Contract.Requires(options != null);
+
+            this.methodCache = new MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(mdDecoder, contractDecoder, output.WriteLine);
+            this.mdDecoder = mdDecoder;
+            this.contractDecoder = contractDecoder;
+            this.output = output;
+            this.options = options;
         }
-      }
+
+        public LogOptions Options { get { return this.options; } }
+
+        public MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache { get { return this.methodCache; } }
+
+        public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get { return this.mdDecoder; } }
+
+        public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get { return this.contractDecoder; } }
+
+        public IOutput Output { get { return this.output; } }
+
+        //public abstract IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> BasicMethodDriver(Method method);
     }
 
-    public void InstallObjectInvariants(List<BoxedExpression> objectInvariants, Type type)
+    public abstract class AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
+      : IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-      Contract.Requires(objectInvariants != null);
+        #region Invariant
 
-      if (objectInvariants.Count == 0)
-      {
-        return;
-      }
-      // Ordering by ToString should avoid in most of the cases the non-determinism problem we have 
-      // when the order of inferred invariants, causing the hash to change in the caching.
-      var ordered = objectInvariants.OrderBy(inv => inv.ToString()).ToList();
-
-
-      // TODO: COMMENT
-      Console.WriteLine("Installing the object invariants");
-      foreach(var e in ordered)
-      {
-        Console.WriteLine("   {0}", e);
-      }
-      // END TODO
-
-      var seq = BoxedExpression.Sequence(ordered);
-      var pc = new BoxedExpression.PC(seq, 0);
-      if (this.MethodCache.AddInvariant(type, pc, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder))
-      {
-        foreach (var inv in ordered)
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
         {
-          this.mContractsHandlerMgr.RegisterClassInvariant(type, inv);
+            Contract.Invariant(this.mCDrivers != null);
         }
-      }
-    }
 
+        #endregion
 
-    /// <summary>
-    /// Responsibility to make sure the assume can be properly decoded lies with the serializer/deserializer.
-    /// The SER/DES should have enough detail and checks to make sure a deserialized expression can be decoded without
-    /// failing due to stack mismatch or failed type assumptions.
-    /// </summary>
-    public void InstallCalleeAssumes(ICFG cfg, IEnumerable<Pair<BoxedExpression, Method>> inferredAssumes, Method method)
-    {
-      Contract.Requires(inferredAssumes != null);
+        #region Protected
 
-#if false
-      if (!inferredAssumes.Any())
-        return;
-      //this.Output.WriteLine("Trying to install {0} inferred assumes.", inferredAssumes.Count);
+        // public (anyone can register a contract for pretty output, or ask for them)
+        protected readonly OutputPrettyCS.ContractsHandlerMgr<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mContractsHandlerMgr;
+        public OutputPrettyCS.ContractsHandlerMgr<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ContractsHandlerManager { get { return this.mContractsHandlerMgr; } }
 
-      // We lookup by name
-      var locs = this.MetaDataDecoder.Locals(method).Enumerate().Select(local => this.MetaDataDecoder.Name(local));
-      var paramz = this.MetaDataDecoder.Parameters(method).Enumerate().Select(parameter => this.MetaDataDecoder.Name(parameter));
-      var fields = this.MetaDataDecoder.Fields(this.MetaDataDecoder.DeclaringType(method)).Select(m => this.MetaDataDecoder.Name(method));
-#endif
-      // TODO: can the name / expr matching get mixed up during deserialization?
-      foreach (var inferredAssume in inferredAssumes)
-      {
-        var assume = inferredAssume.One;
-        //this.Output.WriteLine("Installing assume " + assume);
-#if false
-        #region Ensure that all var's in the assume expression still exist in the new version of the function
-
-        // Check that the variables appearing in the assume to install exists in the scope.
-        // We use the name of the variables to make sure they are the same variable
-        var foundAllVariables = assume.Variables().TrueForAll(v =>
-          {
-            var vToString = v.ToString();
-
-            // check for var in locs
-            var found = locs.Any(loc => vToString == loc);
-
-            // check for var in params
-            found = found || paramz.Any(param => vToString == param);
-            //string paramStr = this.MetaDataDecoder.ParameterType(paramz[j]) + " " + v.ToString(); // create str with same format as parameter string; hacky, but needed
-
-            // check for var in fields
-            found = found || fields.Any(fName =>
+        protected readonly Dictionary<Type, WeakReference> mCDrivers;
+        protected int mMaxClassDriversCount;
+        /// class drivers actually stored (ie. non-null in the map, so != mCDrivers.Count)
+        protected int mCDriversCount
+        {
+            get
             {
-              return vToString == fName // "normal" case
-                  || vToString == String.Format("this.{0}", fName); // case where field prefixed with "this"
+                return this.mCDrivers.Where(pair => pair.Value != null && pair.Value.IsAlive).Count();
+            }
+        }
+        protected IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> basicDriver;
+        #endregion
+
+        protected AnalysisDriver(
+          IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> basicDriver
+        )
+        {
+            this.basicDriver = basicDriver;
+            this.mContractsHandlerMgr = new OutputPrettyCS.ContractsHandlerMgr<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>(this, this.Output);
+            this.mCDrivers = new Dictionary<Type, WeakReference>();
+            this.mMaxClassDriversCount = 0;
+        }
+
+        public void InstallPostconditions(List<BoxedExpression.AssertExpression> inferredPostconditions, Method method)
+        {
+            Contract.Requires(inferredPostconditions != null);
+
+            if (inferredPostconditions.Count == 0) return;
+            //this.Output.WriteLine("Trying to install {0} inferred postconditions.", inferredPostconditions.Count);
+            // Ordering by ToString should avoid in most of the cases the non-determinism problem we have 
+            // when the order of inferred post conditions changes, causing the hash to change in the caching.
+            var ordered = inferredPostconditions.OrderBy(post => post.ToString()).ToList();
+            var seq = BoxedExpression.Sequence(ordered.Cast<BoxedExpression>());
+            BoxedExpression.PC postStart = new BoxedExpression.PC(seq, 0);
+            bool result = this.MethodCache.AddPostCondition(method, postStart, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder);
+            if (result)
+            {
+                foreach (var post in ordered)
+                {
+                    this.mContractsHandlerMgr.RegisterMethodPostCondition(method, post.Condition);
+                }
+            }
+        }
+
+        public void InstallPreconditions(List<BoxedExpression.AssumeExpression> inferredPreconditions, Method method)
+        {
+            Contract.Requires(inferredPreconditions != null);
+
+            if (inferredPreconditions.Count == 0) return;
+            //this.Output.WriteLine("Trying to install {0} inferred preconditions.", inferredPreconditions.Count);
+
+            // Ordering by ToString should avoid in most of the cases the non-determinism problem we have 
+            // when the order of inferred pre conditions changes, causing the hash to change in the caching.
+            var ordered = inferredPreconditions.OrderBy(pre => pre.ToString()).ToList();
+            var seq = BoxedExpression.Sequence(ordered.Cast<BoxedExpression>());
+            BoxedExpression.PC preStart = new BoxedExpression.PC(seq, 0);
+            if (this.MethodCache.AddPreCondition(method, preStart, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder))
+            {
+                foreach (var pre in ordered)
+                {
+                    this.mContractsHandlerMgr.RegisterMethodPreCondition(method, pre.Condition);
+                }
+            }
+        }
+
+        public void InstallObjectInvariants(List<BoxedExpression> objectInvariants, Type type)
+        {
+            Contract.Requires(objectInvariants != null);
+
+            if (objectInvariants.Count == 0)
+            {
+                return;
+            }
+            // Ordering by ToString should avoid in most of the cases the non-determinism problem we have 
+            // when the order of inferred invariants, causing the hash to change in the caching.
+            var ordered = objectInvariants.OrderBy(inv => inv.ToString()).ToList();
+
+
+            // TODO: COMMENT
+            Console.WriteLine("Installing the object invariants");
+            foreach (var e in ordered)
+            {
+                Console.WriteLine("   {0}", e);
+            }
+            // END TODO
+
+            var seq = BoxedExpression.Sequence(ordered);
+            var pc = new BoxedExpression.PC(seq, 0);
+            if (this.MethodCache.AddInvariant(type, pc, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder))
+            {
+                foreach (var inv in ordered)
+                {
+                    this.mContractsHandlerMgr.RegisterClassInvariant(type, inv);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Responsibility to make sure the assume can be properly decoded lies with the serializer/deserializer.
+        /// The SER/DES should have enough detail and checks to make sure a deserialized expression can be decoded without
+        /// failing due to stack mismatch or failed type assumptions.
+        /// </summary>
+        public void InstallCalleeAssumes(ICFG cfg, IEnumerable<Pair<BoxedExpression, Method>> inferredAssumes, Method method)
+        {
+            Contract.Requires(inferredAssumes != null);
+
+#if false
+            if (!inferredAssumes.Any())
+                return;
+            //this.Output.WriteLine("Trying to install {0} inferred assumes.", inferredAssumes.Count);
+
+            // We lookup by name
+            var locs = this.MetaDataDecoder.Locals(method).Enumerate().Select(local => this.MetaDataDecoder.Name(local));
+            var paramz = this.MetaDataDecoder.Parameters(method).Enumerate().Select(parameter => this.MetaDataDecoder.Name(parameter));
+            var fields = this.MetaDataDecoder.Fields(this.MetaDataDecoder.DeclaringType(method)).Select(m => this.MetaDataDecoder.Name(method));
+#endif
+            // TODO: can the name / expr matching get mixed up during deserialization?
+            foreach (var inferredAssume in inferredAssumes)
+            {
+                var assume = inferredAssume.One;
+                //this.Output.WriteLine("Installing assume " + assume);
+#if false
+                #region Ensure that all var's in the assume expression still exist in the new version of the function
+
+                // Check that the variables appearing in the assume to install exists in the scope.
+                // We use the name of the variables to make sure they are the same variable
+                var foundAllVariables = assume.Variables().TrueForAll(v =>
+                  {
+                      var vToString = v.ToString();
+
+              // check for var in locs
+              var found = locs.Any(loc => vToString == loc);
+
+              // check for var in params
+              found = found || paramz.Any(param => vToString == param);
+              //string paramStr = this.MetaDataDecoder.ParameterType(paramz[j]) + " " + v.ToString(); // create str with same format as parameter string; hacky, but needed
+
+              // check for var in fields
+              found = found || fields.Any(fName =>
+              {
+                        return vToString == fName // "normal" case
+                    || vToString == String.Format("this.{0}", fName); // case where field prefixed with "this"
             });
 
-            return found;
-          });
-        if (!foundAllVariables)
+                      return found;
+                  });
+                if (!foundAllVariables)
+                {
+                    continue;
+                }
+                #endregion
+                // found all locals, going to try to install this assume
+#endif
+                var dummyAPC = cfg.Entry; // TODO: do something better here! we don't know the APC yet, so we just pick some legitimate APC to avoid null ptr deref when looking up src context
+                Provenance provenance = null;
+                var be = new BoxedExpression.AssumeExpression(assume, "assume", dummyAPC, provenance, assume.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type)));
+                var pc = new BoxedExpression.PC(be, 0);
+
+                var calleeName = inferredAssume.Two;
+
+                this.MethodCache.AddCalleeAssumeAsPostCondition(cfg, method, calleeName, pc, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder);
+            }
+        }
+
+        public void InstallEntryAssumes(ICFG cfg, IEnumerable<Pair<BoxedExpression, Method>> inferredAssumes, Method method)
         {
-          continue;
+            Contract.Requires(inferredAssumes != null);
+
+            foreach (var inferredAssume in inferredAssumes)
+            {
+                var assume = inferredAssume.One;
+                var dummyAPC = cfg.Entry; // TODO: do something better here! we don't know the APC yet, so we just pick some legitimate APC to avoid null ptr deref when looking up src context
+                Provenance provenance = null;
+                var be = new BoxedExpression.AssumeExpression(assume, "assume", dummyAPC, provenance, assume.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type)));
+                var pc = new BoxedExpression.PC(be, 0);
+
+                this.MethodCache.AddEntryAssume(cfg, method, pc, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder);
+            }
+        }
+
+
+        public void RemoveInferredPrecondition(Method method)
+        {
+            this.MethodCache.RemovePreCondition(method);
+        }
+
+        public void RemoveContractsFor(Method method)
+        {
+            this.MethodCache.RemoveContractsFor(method);
+        }
+
+        public abstract IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> MethodDriver(
+          Method method,
+          IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> classDriver,
+          bool removeInferredPrecondition = false);
+
+        #region Class driver
+        public IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ClassDriver(Type type, bool inferInvariantsJustForReadonlyFields = true)
+        {
+            WeakReference reference;
+            CDriver result;
+            if (mCDrivers.TryGetValue(type, out reference) && reference != null && reference.IsAlive)
+            {
+                result = reference.Target as CDriver;
+                return result;
+            }
+            else
+            {
+                if (!inferInvariantsJustForReadonlyFields || this.MetaDataDecoder.Fields(type).Where(this.MetaDataDecoder.IsReadonly).Any())
+                {
+                    var cd = new CDriver(this, MetaDataDecoder, type);
+                    mCDrivers[type] = new WeakReference(cd);
+                    this.mMaxClassDriversCount = Math.Max(mCDriversCount, this.mMaxClassDriversCount);
+
+#if DEBUG && false
+                    var old = Console.ForegroundColor;
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine("-- ADD CLASS DRIVER -- Max Class Drivers Count is: {0} ; class drivers count is: {1}", this.mMaxClassDriversCount, mCDriversCount); // DEBUG
+                    Console.ForegroundColor = old;
+#endif
+
+                    return cd;
+                }
+                else
+                {
+#if DEBUG && false
+                    this.Output.WriteLine("The type {0} does not contain any readonly field. As a consequence we do not need a class driver", MetaDataDecoder.Name(type));
+#endif
+                    return null;
+                }
+            }
+        }
+
+        public int MaxClassDriversCount { get { return mMaxClassDriversCount; } }
+
+        public void RemoveClassDriver(IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> cdriver)
+        {
+            Contract.Requires(cdriver != null);
+
+            mCDrivers[cdriver.ClassType] = null; // don't need the class driver anymore, but don't need to actually rebuild it anymore either
+
+#if DEBUG && false
+            ConsoleColor old = Console.ForegroundColor; // DEBUG
+            Console.ForegroundColor = ConsoleColor.Yellow; // DEBUG
+            Console.WriteLine("-- REMOVE CLASS DRIVER -- Max Class Drivers Count is: {0} ; class drivers count is: {1}", this.mMaxClassDriversCount, mCDriversCount); // DEBUG
+            Console.ForegroundColor = old; // DEBUG
+#endif
         }
         #endregion
-        // found all locals, going to try to install this assume
-#endif
-        var dummyAPC = cfg.Entry; // TODO: do something better here! we don't know the APC yet, so we just pick some legitimate APC to avoid null ptr deref when looking up src context
-        Provenance provenance = null;
-        var be = new BoxedExpression.AssumeExpression(assume, "assume", dummyAPC, provenance, assume.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type)));
-        var pc = new BoxedExpression.PC(be, 0);
 
-        var calleeName = inferredAssume.Two;
-
-        this.MethodCache.AddCalleeAssumeAsPostCondition(cfg, method, calleeName, pc, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder);   
-      }
-    }
-
-    public void InstallEntryAssumes(ICFG cfg, IEnumerable<Pair<BoxedExpression, Method>> inferredAssumes, Method method)
-    {
-      Contract.Requires(inferredAssumes != null);
-
-      foreach (var inferredAssume in inferredAssumes)
-      {
-        var assume = inferredAssume.One;
-        var dummyAPC = cfg.Entry; // TODO: do something better here! we don't know the APC yet, so we just pick some legitimate APC to avoid null ptr deref when looking up src context
-        Provenance provenance = null;
-        var be = new BoxedExpression.AssumeExpression(assume, "assume", dummyAPC, provenance, assume.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type)));
-        var pc = new BoxedExpression.PC(be, 0);
-
-        this.MethodCache.AddEntryAssume(cfg, method, pc, ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>.Decoder);
-      }
-    }
-
-
-    public void RemoveInferredPrecondition(Method method)
-    {
-      this.MethodCache.RemovePreCondition(method);
-    }
-
-    public void RemoveContractsFor(Method method)
-    {
-      this.MethodCache.RemoveContractsFor(method);
-    }
-
-    public abstract IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> MethodDriver(
-      Method method,
-      IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> classDriver,
-      bool removeInferredPrecondition = false);
-
-    #region Class driver
-    public IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ClassDriver(Type type, bool inferInvariantsJustForReadonlyFields = true)
-    {
-      WeakReference reference;
-      CDriver result;
-      if (mCDrivers.TryGetValue(type, out reference) && reference != null && reference.IsAlive)
-      {
-        result = reference.Target as CDriver;
-        return result;
-      }
-      else
-      {
-        if (!inferInvariantsJustForReadonlyFields || this.MetaDataDecoder.Fields(type).Where(this.MetaDataDecoder.IsReadonly).Any())
+        ///////////////////////////////////////////
+        // CDriver
+        ///////////////////////////////////////////
+        protected class CDriver : IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
         {
+            #region Privates
+            public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; private set; }
 
-          var cd = new CDriver(this, MetaDataDecoder, type);
-          mCDrivers[type] = new WeakReference(cd);
-          this.mMaxClassDriversCount = Math.Max(mCDriversCount, this.mMaxClassDriversCount);
+            public Type ClassType { get; private set; }
+            public LogOptions Options { get; private set; }
 
-#if DEBUG && false
-          var old = Console.ForegroundColor; 
-          Console.ForegroundColor = ConsoleColor.Red; 
-          Console.WriteLine("-- ADD CLASS DRIVER -- Max Class Drivers Count is: {0} ; class drivers count is: {1}", this.mMaxClassDriversCount, mCDriversCount); // DEBUG
-          Console.ForegroundColor = old; 
-#endif
-
-          return cd;
-        }
-        else
-        {
-#if DEBUG && false
-          this.Output.WriteLine("The type {0} does not contain any readonly field. As a consequence we do not need a class driver", MetaDataDecoder.Name(type));
-#endif
-          return null;
-        }
-      }
-    }
-
-    public int MaxClassDriversCount { get { return mMaxClassDriversCount; } }
-
-    public void RemoveClassDriver(IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> cdriver)
-    {
-      Contract.Requires(cdriver != null);
-
-      mCDrivers[cdriver.ClassType] = null; // don't need the class driver anymore, but don't need to actually rebuild it anymore either
-
-#if DEBUG && false
-      ConsoleColor old = Console.ForegroundColor; // DEBUG
-      Console.ForegroundColor = ConsoleColor.Yellow; // DEBUG
-      Console.WriteLine("-- REMOVE CLASS DRIVER -- Max Class Drivers Count is: {0} ; class drivers count is: {1}", this.mMaxClassDriversCount, mCDriversCount); // DEBUG
-      Console.ForegroundColor = old; // DEBUG
-#endif
-    }
-    #endregion
-
-    ///////////////////////////////////////////
-    // CDriver
-    ///////////////////////////////////////////
-    protected class CDriver : IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    {
-      #region Privates
-      public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; private set; }
-
-      public Type ClassType { get; private set; }
-      public LogOptions Options { get; private set; }
-
-      private List<BoxedExpression> mInvariants;
+            private List<BoxedExpression> mInvariants;
 #if false
-      private List<WeakReference> weakConstructors; // weak references to Method
+            private List<WeakReference> weakConstructors; // weak references to Method
 #endif
-      public List<Method> Constructors { get; private set; }
+            public List<Method> Constructors { get; private set; }
 #if false
-      private readonly Dictionary<Method, MethodInfo> mConstructorsInfo;
+            private readonly Dictionary<Method, MethodInfo> mConstructorsInfo;
 #endif
-      private int mMethodsCount;
-      private int mAnalyzedMethodsCount;
-      /// <summary>
-      /// Stores all the information about the analysis of each the class method
-      /// </summary>
-      private readonly Dictionary<Method, MethodAnalysisStatus> mMass;
+            private int mMethodsCount;
+            private int mAnalyzedMethodsCount;
+            /// <summary>
+            /// Stores all the information about the analysis of each the class method
+            /// </summary>
+            private readonly Dictionary<Method, MethodAnalysisStatus> mMass;
 
-      public IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ConstructorsStatus { get; private set; }
-      #endregion
+            public IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ConstructorsStatus { get; private set; }
+            #endregion
 
-      public CDriver(AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> parent, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Type type)
-      {
-        Contract.Requires(mdDecoder != null);
-
-        this.ParentDriver = parent;
-        this.MetaDataDecoder = mdDecoder;
-        this.mInvariants = new List<BoxedExpression>();
-        this.ClassType = type;
-        
-        var nonStaticMethods = mdDecoder.Methods(type).Where(m => !mdDecoder.IsStatic(m));
-        this.mMethodsCount = nonStaticMethods.Count();
-        this.Constructors = nonStaticMethods.Where(mdDecoder.IsConstructor).ToList();
-        var constructorsCount = this.Constructors.Count();
-
-        this.mAnalyzedMethodsCount = 0;
-#if false
-        this.mConstructorsInfo = new Dictionary<Method, MethodInfo>(capacity: constructorsCount);
-#endif
-        this.ConstructorsStatus = new ConstructorsAnalysisStatus(type, constructorsCount);
-        this.mMass = new Dictionary<Method, AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>.MethodAnalysisStatus>();
-      }
-
-      public AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ParentDriver { get; private set; }
-
-#if false
-      public List<Method> Constructors
-      {
-        get
-        {
-          List<Method> result = new List<Method>();
-          if (this.weakConstructors != null)
-          {
-            foreach (var wm in this.weakConstructors)
+            public CDriver(AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> parent, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Type type)
             {
-              var m = wm.Target;
-              if (m == null)
-                break;
-              result.Add((Method)m);
+                Contract.Requires(mdDecoder != null);
+
+                this.ParentDriver = parent;
+                this.MetaDataDecoder = mdDecoder;
+                mInvariants = new List<BoxedExpression>();
+                this.ClassType = type;
+
+                var nonStaticMethods = mdDecoder.Methods(type).Where(m => !mdDecoder.IsStatic(m));
+                mMethodsCount = nonStaticMethods.Count();
+                this.Constructors = nonStaticMethods.Where(mdDecoder.IsConstructor).ToList();
+                var constructorsCount = this.Constructors.Count();
+
+                mAnalyzedMethodsCount = 0;
+#if false
+                mConstructorsInfo = new Dictionary<Method, MethodInfo>(capacity: constructorsCount);
+#endif
+                this.ConstructorsStatus = new ConstructorsAnalysisStatus(type, constructorsCount);
+                mMass = new Dictionary<Method, AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>.MethodAnalysisStatus>();
             }
-            if (result.Count == this.weakConstructors.Count)
-              return result;
-            this.weakConstructors.Clear();
-          }
-          else
-          {
-            this.weakConstructors = new List<WeakReference>();
-          }
-          result.Clear();
-          foreach (var m in this.MetaDataDecoder.Methods(this.ClassType))
-            if (this.MetaDataDecoder.IsConstructor(m) && !this.MetaDataDecoder.IsStatic(m))
+
+            public AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ParentDriver { get; private set; }
+
+#if false
+            public List<Method> Constructors
             {
-              result.Add(m);
-              this.weakConstructors.Add(new WeakReference(m));
+                get
+                {
+                    List<Method> result = new List<Method>();
+                    if (weakConstructors != null)
+                    {
+                        foreach (var wm in weakConstructors)
+                        {
+                            var m = wm.Target;
+                            if (m == null)
+                                break;
+                            result.Add((Method)m);
+                        }
+                        if (result.Count == weakConstructors.Count)
+                            return result;
+                        weakConstructors.Clear();
+                    }
+                    else
+                    {
+                        weakConstructors = new List<WeakReference>();
+                    }
+                    result.Clear();
+                    foreach (var m in this.MetaDataDecoder.Methods(this.ClassType))
+                        if (this.MetaDataDecoder.IsConstructor(m) && !this.MetaDataDecoder.IsStatic(m))
+                        {
+                            result.Add(m);
+                            weakConstructors.Add(new WeakReference(m));
+                        }
+                    return result;
+                }
             }
-          return result;
-        }
-      }
 #endif
 
-      public bool IsExistingInvariant(string invariantString)
-      {
-        foreach (var be in mInvariants)
-        {
-          if (be.ToString() == invariantString)
-            return true;
-        }
-        return false;
-      }
+            public bool IsExistingInvariant(string invariantString)
+            {
+                foreach (var be in mInvariants)
+                {
+                    if (be.ToString() == invariantString)
+                        return true;
+                }
+                return false;
+            }
 
-      public bool AddInvariant(BoxedExpression boxedExpression)
-      {
-        if (CanAddInvariants() && !IsExistingInvariant(boxedExpression.ToString()))
-        {
-          mInvariants.Add(boxedExpression);
-          return true;
-        }
-        return false;
-      }
+            public bool AddInvariant(BoxedExpression boxedExpression)
+            {
+                if (CanAddInvariants() && !IsExistingInvariant(boxedExpression.ToString()))
+                {
+                    mInvariants.Add(boxedExpression);
+                    return true;
+                }
+                return false;
+            }
 
-      public bool CanAddInvariants()
-      {
-        return MetaDataDecoder.IsClass(ClassType);
-      }
+            public bool CanAddInvariants()
+            {
+                return MetaDataDecoder.IsClass(ClassType);
+            }
 
-      public bool InstallInvariantsAsConstructorPostconditions(Parameter methodThis, IEnumerable<Pair<BoxedExpression, Provenance>> boxedExpressions, Method method)
-      {
-        if (boxedExpressions == null)
-          return false;
-        var beArray = boxedExpressions.ToArray();
-        if (beArray.Length == 0)
-          return true;
-        var result = true;
-        foreach (var constructor in this.Constructors)
-        {
-          var ctorThis = this.MetaDataDecoder.This(constructor);
-          var pc = this.NormalExitPC(constructor);
-          // We need to replace any 'this' occuring in the expression by the 'this' of the constructor
-          var postConditions = beArray
-            .Select(be => {
-              var exp = this.SubstituteThis(be.One, methodThis, ctorThis);
-              var definingMethod = this.MetaDataDecoder.Name(method);
-              return new BoxedExpression.AssertExpression(exp, "invariant", pc, be.Two ?? new List<ProofObligation>() { new FakeProofObligationForAssertionFromTheCache(be.One, definingMethod, null) },
-                exp.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type)));
-            }) // We use  trick or returning a non-empty proof obligation to signal that the assertion has been inferred, even if we lost the context 
-            .ToList();
-          //          var postConditions = beArray.Select(be => new BoxedExpression.AssertExpression(this.SubstituteThis(be.One, methodThis, ctorThis), "ensures", pc, be.Two)).ToList();
-          this.ParentDriver.InstallPostconditions(postConditions, constructor);
-        }
-        return result;
-      }
+            public bool InstallInvariantsAsConstructorPostconditions(Parameter methodThis, IEnumerable<Pair<BoxedExpression, Provenance>> boxedExpressions, Method method)
+            {
+                if (boxedExpressions == null)
+                    return false;
+                var beArray = boxedExpressions.ToArray();
+                if (beArray.Length == 0)
+                    return true;
+                var result = true;
+                foreach (var constructor in this.Constructors)
+                {
+                    var ctorThis = this.MetaDataDecoder.This(constructor);
+                    var pc = this.NormalExitPC(constructor);
+                    // We need to replace any 'this' occuring in the expression by the 'this' of the constructor
+                    var postConditions = beArray
+                      .Select(be =>
+                      {
+                          var exp = this.SubstituteThis(be.One, methodThis, ctorThis);
+                          var definingMethod = this.MetaDataDecoder.Name(method);
+                          return new BoxedExpression.AssertExpression(exp, "invariant", pc, be.Two ?? new List<ProofObligation>() { new FakeProofObligationForAssertionFromTheCache(be.One, definingMethod, null) },
+                  exp.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type)));
+                      }) // We use  trick or returning a non-empty proof obligation to signal that the assertion has been inferred, even if we lost the context 
+                      .ToList();
+                    //          var postConditions = beArray.Select(be => new BoxedExpression.AssertExpression(this.SubstituteThis(be.One, methodThis, ctorThis), "ensures", pc, be.Two)).ToList();
+                    this.ParentDriver.InstallPostconditions(postConditions, constructor);
+                }
+                return result;
+            }
 
-      [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification="Bug in Clousot")]
-      private PathElement[] SubstituteThis(PathElement[] path, Parameter from, Parameter to)
-      {
-        PathElement[] result = null;
-        for (int i = 0; i < path.Length; i++)
-        {
-          var pathElement = path[i];
+            [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification = "Bug in Clousot")]
+            private PathElement[] SubstituteThis(PathElement[] path, Parameter from, Parameter to)
+            {
+                PathElement[] result = null;
+                for (int i = 0; i < path.Length; i++)
+                {
+                    var pathElement = path[i];
 
-          Contract.Assume(pathElement != null);
+                    Contract.Assume(pathElement != null);
 
-          var subst = pathElement.SubstituteElement(from, to);
-          if (subst != pathElement) {
-            if (result == null)
-              path.CopyTo(result = new PathElement[path.Length], 0);
-            result[i] = subst;
-          }
-        }
-        return result ?? path;
-      }
+                    var subst = pathElement.SubstituteElement(from, to);
+                    if (subst != pathElement)
+                    {
+                        if (result == null)
+                            path.CopyTo(result = new PathElement[path.Length], 0);
+                        result[i] = subst;
+                    }
+                }
+                return result ?? path;
+            }
 
-      private BoxedExpression SubstituteThis(BoxedExpression be, Parameter from, Parameter to)
-      {
-        return be.Substitute<object>((_, variableExpression) =>
-          {
-            var accessPath = SubstituteThis(variableExpression.AccessPath, from, to);
-            if (accessPath == variableExpression.AccessPath)
-              return variableExpression;
-            BoxedExpression writableBytes;
-            object type;
-            if (!variableExpression.TryGetType(out type))
-              type = null;
-            if (variableExpression.TryGetAssociatedInfo(AssociatedInfo.WritableBytes, out writableBytes))
-              return new BoxedExpression.VariableExpression(variableExpression.UnderlyingVariable, accessPath, writableBytes, type);
-            return new BoxedExpression.VariableExpression(variableExpression.UnderlyingVariable, accessPath, type);
-          });
-      }
+            private BoxedExpression SubstituteThis(BoxedExpression be, Parameter from, Parameter to)
+            {
+                return be.Substitute<object>((_, variableExpression) =>
+                  {
+                      var accessPath = SubstituteThis(variableExpression.AccessPath, from, to);
+                      if (accessPath == variableExpression.AccessPath)
+                          return variableExpression;
+                      BoxedExpression writableBytes;
+                      object type;
+                      if (!variableExpression.TryGetType(out type))
+                          type = null;
+                      if (variableExpression.TryGetAssociatedInfo(AssociatedInfo.WritableBytes, out writableBytes))
+                          return new BoxedExpression.VariableExpression(variableExpression.UnderlyingVariable, accessPath, writableBytes, type);
+                      return new BoxedExpression.VariableExpression(variableExpression.UnderlyingVariable, accessPath, type);
+                  });
+            }
 
-      public void MethodHasBeenAnalyzed(
-        string analyze_name,
-        MethodResult result,
-        Method method)
-      {
-        MethodAnalysisStatus mas;
-        if (!mMass.TryGetValue(method, out mas))
-        {
-          mas = new MethodAnalysisStatus(method);
-          mMass.Add(method, mas);
-        }
-        else
-        {
-          Contract.Assume(mas != null);
-        }
-        mas.AddMethodResult(analyze_name, result);
-      }
+            public void MethodHasBeenAnalyzed(
+              string analyze_name,
+              MethodResult result,
+              Method method)
+            {
+                MethodAnalysisStatus mas;
+                if (!mMass.TryGetValue(method, out mas))
+                {
+                    mas = new MethodAnalysisStatus(method);
+                    mMass.Add(method, mas);
+                }
+                else
+                {
+                    Contract.Assume(mas != null);
+                }
+                mas.AddMethodResult(analyze_name, result);
+            }
 
-      public void MethodHasBeenFullyAnalyzed(Method method)
-      {
-        var isStatic = this.MetaDataDecoder.IsStatic(method);
-        var isConstructor = this.MetaDataDecoder.IsConstructor(method) && !isStatic;
+            public void MethodHasBeenFullyAnalyzed(Method method)
+            {
+                var isStatic = this.MetaDataDecoder.IsStatic(method);
+                var isConstructor = this.MetaDataDecoder.IsConstructor(method) && !isStatic;
 
-        if (!isStatic)
-          this.mAnalyzedMethodsCount++;
+                if (!isStatic)
+                    mAnalyzedMethodsCount++;
 
-        if (!mMass.ContainsKey(method))
-          return; // don't have any info about this method! shouldn't happen
+                if (!mMass.ContainsKey(method))
+                    return; // don't have any info about this method! shouldn't happen
 
-        if (isConstructor)
-          ConstructorsStatus.ConstructorAnalyzed(mMass[method]);
-      }
+                if (isConstructor)
+                    ConstructorsStatus.ConstructorAnalyzed(mMass[method]);
+            }
 
 #if false
-      class MethodInfo
-      {
-        public readonly APC NormalExit;
-        public readonly PathElement This;
+            class MethodInfo
+            {
+                public readonly APC NormalExit;
+                public readonly PathElement This;
 
-        public MethodInfo(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver)
-        {
-          Contract.Requires(mdriver != null);
+                public MethodInfo(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver)
+                {
+                    Contract.Requires(mdriver != null);
 
-          this.NormalExit = mdriver.CFG.NormalExit;
+                    this.NormalExit = mdriver.CFG.NormalExit;
 
-          var entryAfterRequires = mdriver.CFG.EntryAfterRequires;
-          var parameterThis = mdriver.MetaDataDecoder.This(mdriver.CurrentMethod);
-          Variable symbolicThis;
-          if (mdriver.Context.ValueContext.TryParameterValue(entryAfterRequires, parameterThis, out symbolicThis))
-          {
-            var pathThis = mdriver.Context.ValueContext.AccessPathList(mdriver.CFG.EntryAfterRequires, symbolicThis, false, false);
-            if (pathThis != null)
-              this.This = pathThis.Head;
-          }
-        }
-      }
+                    var entryAfterRequires = mdriver.CFG.EntryAfterRequires;
+                    var parameterThis = mdriver.MetaDataDecoder.This(mdriver.CurrentMethod);
+                    Variable symbolicThis;
+                    if (mdriver.Context.ValueContext.TryParameterValue(entryAfterRequires, parameterThis, out symbolicThis))
+                    {
+                        var pathThis = mdriver.Context.ValueContext.AccessPathList(mdriver.CFG.EntryAfterRequires, symbolicThis, false, false);
+                        if (pathThis != null)
+                            this.This = pathThis.Head;
+                    }
+                }
+            }
 #endif
-      private APC NormalExitPC(Method method)
-      {
-          var cfg = this.ParentDriver.MethodCache.GetCFG(method);
-          return cfg.NormalExit;
-      }
+            private APC NormalExitPC(Method method)
+            {
+                var cfg = this.ParentDriver.MethodCache.GetCFG(method);
+                return cfg.NormalExit;
+            }
 
 #if false
-      private MethodInfo GetConstructorInfo(Method method)
-      {
-        MethodInfo result;
-        if (this.mConstructorsInfo.TryGetValue(method, out result))
-          return result;
-        var mdriver = this.ParentDriver.MethodDriver(method, this);
-        mdriver.RunHeapAndExpressionAnalyses();
-        result = new MethodInfo(mdriver);
-        this.mConstructorsInfo.Add(method, result);
-        return result;
-      }
+            private MethodInfo GetConstructorInfo(Method method)
+            {
+                MethodInfo result;
+                if (mConstructorsInfo.TryGetValue(method, out result))
+                    return result;
+                var mdriver = this.ParentDriver.MethodDriver(method, this);
+                mdriver.RunHeapAndExpressionAnalyses();
+                result = new MethodInfo(mdriver);
+                mConstructorsInfo.Add(method, result);
+                return result;
+            }
 #endif
 
-      public int PendingConstructors { get { return ConstructorsStatus.Pending; } }
+            public int PendingConstructors { get { return ConstructorsStatus.Pending; } }
 
-      public bool IsClassFullyAnalyzed()
-      {
-        return this.mAnalyzedMethodsCount == this.mMethodsCount;
-      }
-    }
-
-    public class ConstructorsAnalysisStatus
-      : IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    {
-      [ContractInvariantMethod]
-      [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.AnalysesResults != null);
-      }
-
-
-      public ConstructorsAnalysisStatus(Type type, int totalnb)
-      {
-        this.ClassType = type;
-        Pending = totalnb;
-        TotalNb = totalnb;
-        AnalysesResults = new Dictionary<Method, IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>>();
-      }
-
-      /// <summary>
-      /// Decrease the count of pending constructors to analyze by one
-      /// </summary>
-      /// <returns>The new pending count (maybe 0)</returns>
-      private int DecreasePendingCount()
-      {
-        return --Pending;
-      }
-
-      public void ConstructorAnalyzed(IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mas)
-      {
-        if (!AnalysesResults.ContainsKey(mas.MethodObj)) // protect in case we analyze twice the same method
-        {
-          AnalysesResults.Add(mas.MethodObj, mas);
-          DecreasePendingCount(); // a constructor was analyzed
+            public bool IsClassFullyAnalyzed()
+            {
+                return mAnalyzedMethodsCount == mMethodsCount;
+            }
         }
-      }
 
-      public Type ClassType { get; private set; }
-      public int Pending { get; private set; } /// number of constructors left to analyze before starting the ObjectInvariant analysis
-      public int TotalNb { get; private set; } /// total number of constructors for this type
-      public Dictionary<Method, IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>> AnalysesResults { get; private set; }
+        public class ConstructorsAnalysisStatus
+          : IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
+        {
+            [ContractInvariantMethod]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.AnalysesResults != null);
+            }
+
+
+            public ConstructorsAnalysisStatus(Type type, int totalnb)
+            {
+                this.ClassType = type;
+                Pending = totalnb;
+                TotalNb = totalnb;
+                AnalysesResults = new Dictionary<Method, IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>>();
+            }
+
+            /// <summary>
+            /// Decrease the count of pending constructors to analyze by one
+            /// </summary>
+            /// <returns>The new pending count (maybe 0)</returns>
+            private int DecreasePendingCount()
+            {
+                return --Pending;
+            }
+
+            public void ConstructorAnalyzed(IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mas)
+            {
+                if (!AnalysesResults.ContainsKey(mas.MethodObj)) // protect in case we analyze twice the same method
+                {
+                    AnalysesResults.Add(mas.MethodObj, mas);
+                    DecreasePendingCount(); // a constructor was analyzed
+                }
+            }
+
+            public Type ClassType { get; private set; }
+            public int Pending { get; private set; } /// number of constructors left to analyze before starting the ObjectInvariant analysis
+            public int TotalNb { get; private set; } /// total number of constructors for this type
+            public Dictionary<Method, IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>> AnalysesResults { get; private set; }
+        }
+
+
+        public class MethodAnalysisStatus
+          : IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
+        {
+            #region Object invariant
+
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.Results != null);
+            }
+            #endregion
+
+            public MethodAnalysisStatus(
+              Method method)
+            {
+                this.MethodObj = method;
+                Results = new Dictionary<string, MethodResult>();
+            }
+
+            public void AddMethodResult(string analyze_name, MethodResult result)
+            {
+                if (!Results.ContainsKey(analyze_name))
+                    Results.Add(analyze_name, result);
+            }
+
+            public Method MethodObj { get; private set; }
+            public Dictionary<string, MethodResult> Results { get; private set; }
+        }
+
+
+        #region delegate IBasicAnalysisDriver<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly,LogOptions> Members
+
+        public LogOptions Options
+        {
+            get { return basicDriver.Options; }
+        }
+
+        public MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache
+        {
+            get
+            {
+                return basicDriver.MethodCache;
+            }
+        }
+
+        public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
+        {
+            get
+            {
+                return basicDriver.MetaDataDecoder;
+            }
+        }
+
+        public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
+        {
+            get { return basicDriver.ContractDecoder; }
+        }
+
+        public IOutput Output { get { return basicDriver.Output; } }
+
+        #endregion
     }
-
-
-    public class MethodAnalysisStatus
-      : IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    {
-
-      #region Object invariant
-      
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.Results != null);
-      }
-      #endregion
-
-      public MethodAnalysisStatus(
-        Method method)
-      {
-        this.MethodObj = method;
-        Results = new Dictionary<string, MethodResult>();
-      }
-
-      public void AddMethodResult(string analyze_name, MethodResult result)
-      {
-        if (!Results.ContainsKey(analyze_name))
-          Results.Add(analyze_name, result);
-      }
-
-      public Method MethodObj { get; private set; }
-      public Dictionary<string, MethodResult> Results { get; private set; }
-    }
-
-
-    #region delegate IBasicAnalysisDriver<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly,LogOptions> Members
-
-    public LogOptions Options
-    {
-      get { return basicDriver.Options; }
-    }
-
-    public MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache
-    {
-      get 
-      {
-        return basicDriver.MethodCache; 
-      }
-    }
-
-    public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
-    {
-      get {
-        return basicDriver.MetaDataDecoder; 
-      }
-    }
-
-    public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
-    {
-      get { return basicDriver.ContractDecoder; }
-    }
-
-    public IOutput Output { get { return basicDriver.Output; } }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/AnalysisInterfaces.cs
+++ b/Microsoft.Research/CodeAnalysis/AnalysisInterfaces.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -23,1993 +12,2021 @@ using StackTemp = System.Int32;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using Provenance = IEnumerable<ProofObligation>;
-  using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
-  using System.Diagnostics.Contracts;
+    using Provenance = IEnumerable<ProofObligation>;
+    using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
+    using System.Diagnostics.Contracts;
 
-  /// <summary>
-  /// Used to get the renamings at the exit point of a block
-  /// </summary>
-  public delegate IFunctionalMap<string, string> CrossBlockRenamings<Label>(Label blockEnd, Label blockTarget);
+    /// <summary>
+    /// Used to get the renamings at the exit point of a block
+    /// </summary>
+    public delegate IFunctionalMap<string, string> CrossBlockRenamings<Label>(Label blockEnd, Label blockTarget);
 
-  public delegate Set<string> RenamedVariables<Label>(Label blockEnd, Label blockTarget);
+    public delegate Set<string> RenamedVariables<Label>(Label blockEnd, Label blockTarget);
 
-  public delegate string AssumptionFinder<Label>(Label label);
+    public delegate string AssumptionFinder<Label>(Label label);
 
-  public delegate string InvariantQuery<Label>(Label label);
+    public delegate string InvariantQuery<Label>(Label label);
 
-  [ContractClass(typeof(IBasicAnalysisDriverContract<,,,,,,,,,>))]
-  public interface IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    LogOptions Options { get; }
-
-    MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache { get; }
-
-    IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; } 
-
-    IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get; }
-
-    IOutput Output { get; }
-
-  }
-
-  #region IBasicAnalysisDriver contract binding
-  [ContractClassFor(typeof(IBasicAnalysisDriver<,,,,,,,,,>))]
-  abstract class IBasicAnalysisDriverContract<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    : IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    #region IBasicAnalysisDriver<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly,LogOptions> Members
-
-    public LogOptions Options
+    [ContractClass(typeof(IBasicAnalysisDriverContract<,,,,,,,,,>))]
+    public interface IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-      get {
-        Contract.Ensures(Contract.Result<LogOptions>() != null);
-        throw new NotImplementedException();
-      }
+        LogOptions Options { get; }
+
+        MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache { get; }
+
+        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; }
+
+        IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get; }
+
+        IOutput Output { get; }
     }
 
-    public MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache
+    #region IBasicAnalysisDriver contract binding
+    [ContractClassFor(typeof(IBasicAnalysisDriver<,,,,,,,,,>))]
+    internal abstract class IBasicAnalysisDriverContract<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      : IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-      get {
-        Contract.Ensures(Contract.Result<MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>>() != null);
-        throw new NotImplementedException();
-      }
-    }
+        #region IBasicAnalysisDriver<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly,LogOptions> Members
 
-    public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
-    {
-      get {
-        Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
+        public LogOptions Options
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<LogOptions>() != null);
+                throw new NotImplementedException();
+            }
+        }
 
-    public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
-    {
-      get {
-        Contract.Ensures(Contract.Result<IDecodeContracts<Local, Parameter, Method, Field, Type>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
+        public MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>>() != null);
+                throw new NotImplementedException();
+            }
+        }
 
-    public IOutput Output
-    {
-      get {
-        Contract.Ensures(Contract.Result<IOutput>() != null); 
-        throw new NotImplementedException();
-      }
-    }
+        public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
+                throw new NotImplementedException();
+            }
+        }
 
+        public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IDecodeContracts<Local, Parameter, Method, Field, Type>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public IOutput Output
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IOutput>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion
+    }
     #endregion
-  }
-  #endregion
 
-  public interface IVisitValueExprIL<Label, Type, Expression, SymbolicValue, Data, Result> : IVisitExprIL<Label, Type, Expression, SymbolicValue, Data, Result>
-  {
-    /// <summary>
-    /// Base case for expression visitor when no more information about the symbolic constant is available
-    /// </summary>
-    Result SymbolicConstant(Label pc, SymbolicValue symbol, Data data);
-  }
-
-  /// <summary>
-  /// A decoder instantiated to a particular data,result transformation.
-  /// </summary>
-  /// <typeparam name="Label">Type of underlying code points</typeparam>
-  /// <typeparam name="Data">Transformation argument type</typeparam>
-  /// <typeparam name="Result">Transformation result</typeparam>
-  /// <typeparam name="Visitor">The visitor that is dispatched to.</typeparam>
-  /// <param name="label">Dispatch according to code at this label</param>
-  /// <param name="data">Data to pass to visitor</param>
-  /// <param name="v">visitor being dispatched to</param>
-  /// <returns></returns>
-  public delegate Result ILDecoder<Label, Data, Result, Visitor>(Label label, Data data, Visitor v);
-
-  /// <summary>
-  /// The combination of an ILDecoder and a Visitor
-  /// </summary>
-  public delegate Result Transformer<Label, Data, Result>(Label label, Data data);
-
-
-  /// <summary>
-  /// A delegate representing a join operation
-  /// </summary>
-  public delegate AState Joiner<Label, AState>(Pair<Label, Label> edge, AState newState, AState prevState, out bool weaker, bool widen);
-  
-  /// <summary>
-  /// A delegate representing a converter that gets a chance to convert an abstract state when it is pushed
-  /// onto a block. This allows for instance renaming.
-  /// </summary>
-  public delegate AState EdgeConverter<Label, AState, EdgeData>(Label from, Label next, bool joinPoint, EdgeData data, AState newState);
-
-  /// <summary>
-  /// A delegate that can generate a constant of an abstract state
-  /// </summary>
-  /// <typeparam name="AState"></typeparam>
-  /// <returns></returns>
-  public delegate AState StateGenerator<AState>();
-
-  [ContractClass(typeof(IFixpointInfoContracts<,>))]
-  public interface IFixpointInfo<Label, AState>
-  {
-    /// <summary>
-    /// Returns true if state is found
-    /// </summary>
-    bool PreState(Label label, out AState ifFound);
-    /// <summary>
-    /// Returns true if state is found
-    /// </summary>
-    bool PostState(Label label, out AState ifFound);
-
-    /// <summary>
-    /// Try to get an abstract state which captures the postconditions of the method
-    /// </summary>
-    bool TryAStateForPostCondition(AState initialState, out AState exitState);
-
-    /// <summary>
-    /// Returns the set of cached subroutine contexts starting at this block
-    /// NOTE: slow, use only for debugging
-    /// </summary>
-    IEnumerable<SubroutineContext> CachedContexts(CFGBlock block);
-
-    /// <summary>
-    /// Push the given state as state on a possible exception edge originating
-    /// from the given pc.
-    /// </summary>
-    void PushExceptionState(Label atThrow, AState exceptionState);
-  }
-
-  #region Contracts for IFixpointInfo
-
-  [ContractClassFor(typeof(IFixpointInfo<,>))]
-  abstract class IFixpointInfoContracts<Label, AState>
-    : IFixpointInfo<Label, AState>
-  {
-    public bool PreState(Label label, out AState ifFound)
+    public interface IVisitValueExprIL<Label, Type, Expression, SymbolicValue, Data, Result> : IVisitExprIL<Label, Type, Expression, SymbolicValue, Data, Result>
     {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
-
-      throw new NotImplementedException(); 
+        /// <summary>
+        /// Base case for expression visitor when no more information about the symbolic constant is available
+        /// </summary>
+        Result SymbolicConstant(Label pc, SymbolicValue symbol, Data data);
     }
 
-    public bool PostState(Label label, out AState ifFound)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
-
-      throw new NotImplementedException();
-    }
-
-    public bool TryAStateForPostCondition(AState initialState, out AState exitState)
-    {
-      Contract.Requires(initialState != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out exitState) != null);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<SubroutineContext> CachedContexts(CFGBlock block)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<SubroutineContext>>() != null);
-
-      return null;
-    }
-
-    public void PushExceptionState(Label atThrow, AState exceptionState)
-    {
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
-
-  public interface IAbstractValue<T>
-  {
-
-    T Top { get; }
-    T Bottom { get; }
-
-    bool IsTop { get; }
-    bool IsBottom { get; }
-
     /// <summary>
-    /// Used by the underlying fixpoint computation to signal that the argument value will not be used
-    /// for transfer update any longer.
-    /// Useful for debugging. Usually, can be implemented as an identity function. But if the analysis 
-    /// does complicated sharing and updating, one might have to do something different.
+    /// A decoder instantiated to a particular data,result transformation.
     /// </summary>
-    /// <returns>A value that is guaranteed to not be modified by the analysis.</returns>
-    T ImmutableVersion();
+    /// <typeparam name="Label">Type of underlying code points</typeparam>
+    /// <typeparam name="Data">Transformation argument type</typeparam>
+    /// <typeparam name="Result">Transformation result</typeparam>
+    /// <typeparam name="Visitor">The visitor that is dispatched to.</typeparam>
+    /// <param name="label">Dispatch according to code at this label</param>
+    /// <param name="data">Data to pass to visitor</param>
+    /// <param name="v">visitor being dispatched to</param>
+    /// <returns></returns>
+    public delegate Result ILDecoder<Label, Data, Result, Visitor>(Label label, Data data, Visitor v);
 
     /// <summary>
-    /// Return a value equivalent to the argument value that can be updated by the transfer function.
-    ///
-    /// For purely functional states, this is an identity. For transfer functions that mutate the 
-    /// abstract value, this should be a clone.
+    /// The combination of an ILDecoder and a Visitor
     /// </summary>
-    T Clone();
+    public delegate Result Transformer<Label, Data, Result>(Label label, Data data);
+
 
     /// <summary>
-    /// Returns weaker==true if the result of the join is strictly more abstract than existingState (this)
-    /// i.e., !LessEqual(result, existingState). This can be true more often than necessary, unless widen
-    /// is true.
-    ///
-    /// If widen is true, operation must widen
+    /// A delegate representing a join operation
     /// </summary>
-    T Join(T newState, out bool weaker, bool widen);
+    public delegate AState Joiner<Label, AState>(Pair<Label, Label> edge, AState newState, AState prevState, out bool weaker, bool widen);
 
     /// <summary>
-    /// </summary>
-    T Meet(T that);
-
-    bool LessEqual(T that);
-
-    void Dump(TextWriter tw);
-
-  }
-
-
-  /// <summary>
-  /// An analysis driver encapsulates a complete analysis to be used by a fix point engine.
-  /// The structure allows generating stacks of drivers, where elements in the stack can 
-  /// adjust what higher level drivers see.
-  /// </summary>
-  /// <typeparam name="Label">Abstract PC type</typeparam>
-  /// <typeparam name="AState">Abstract state for analysis</typeparam>
-  /// <typeparam name="Interface">The visitor interface used by the analysis</typeparam>
-  /// <typeparam name="EdgeConversionData">Additional information on edges for transforming abstract state</typeparam>
-  public partial interface IAnalysis<Label, AState, Interface, EdgeConversionData>
-  {
-    /// <summary>
-    /// A converter that gets a chance to convert an abstract state when it is pushed
+    /// A delegate representing a converter that gets a chance to convert an abstract state when it is pushed
     /// onto a block. This allows for instance renaming.
-    /// 
-    /// The edgeData depends on the particular analysis layer and is optional.
     /// </summary>
-    AState EdgeConversion(Label from, Label next, bool joinPoint, EdgeConversionData edgeData, AState newState);
+    public delegate AState EdgeConverter<Label, AState, EdgeData>(Label from, Label next, bool joinPoint, EdgeData data, AState newState);
 
     /// <summary>
-    /// The join operation
+    /// A delegate that can generate a constant of an abstract state
     /// </summary>
+    /// <typeparam name="AState"></typeparam>
     /// <returns></returns>
-    AState Join(Pair<Label, Label> edge, AState newState, AState prevState, out bool weaker, bool widen);
+    public delegate AState StateGenerator<AState>();
 
-    /// <summary>
-    /// Obtain a mutable version of an abstract state (usually a clone)
-    /// </summary>
-    /// <returns></returns>
-    AState MutableVersion(AState state);
-
-    /// <summary>
-    /// Marks a state as no longer mutable. Mostly for debugging.
-    /// </summary>
-    /// <returns></returns>
-    AState ImmutableVersion(AState state);
-
-    /// <summary>
-    /// Dumps the abstract state
-    /// </summary>
-    /// <returns></returns>
-    void Dump(Pair<AState, TextWriter> pair);
-
-    /// <summary>
-    /// Evaluates to true on bottom states.
-    /// This instructs the fixpoint analysis to stop following paths.
-    /// </summary>
-    bool IsBottom(Label pc, AState state);
-
-    /// <summary>
-    /// Evaluates to true on top states.
-    /// </summary>
-    bool IsTop(Label pc, AState state);
-
-    /// <summary>
-    /// Must return a visitor that is used to construct the transfer function
-    /// </summary>
-    Interface Visitor();
-
-    /// <summary>
-    /// Called by underlying engine to provide a lookup method that can be used to find fixpoint states
-    /// after the fix point has been reached.
-    /// </summary>
-    /// <returns>Can return a predicate that informs the underlying DFA at which pc's to cache the state.
-    /// if null, no extra caching is done.</returns>
-    Predicate<Label> CacheStates(IFixpointInfo<Label, AState> fixpointInfo);
-  }
-
-  #region IAnalysis contract binding
-  [ContractClass(typeof(IAnalysisContract<,,,>))]
-  public partial interface IAnalysis<Label, AState, Interface, EdgeConversionData>  { }
-
-  [ContractClassFor(typeof(IAnalysis<,,,>))]
-  abstract class IAnalysisContract<Label, AState, Interface, EdgeConversionData> : IAnalysis<Label, AState, Interface, EdgeConversionData>
-  {
-    #region IAnalysis<Label,AState,Interface,EdgeConversionData> Members
-
-    public AState EdgeConversion(Label from, Label next, bool joinPoint, EdgeConversionData edgeData, AState newState)
+    [ContractClass(typeof(IFixpointInfoContracts<,>))]
+    public interface IFixpointInfo<Label, AState>
     {
-      throw new NotImplementedException();
+        /// <summary>
+        /// Returns true if state is found
+        /// </summary>
+        bool PreState(Label label, out AState ifFound);
+        /// <summary>
+        /// Returns true if state is found
+        /// </summary>
+        bool PostState(Label label, out AState ifFound);
+
+        /// <summary>
+        /// Try to get an abstract state which captures the postconditions of the method
+        /// </summary>
+        bool TryAStateForPostCondition(AState initialState, out AState exitState);
+
+        /// <summary>
+        /// Returns the set of cached subroutine contexts starting at this block
+        /// NOTE: slow, use only for debugging
+        /// </summary>
+        IEnumerable<SubroutineContext> CachedContexts(CFGBlock block);
+
+        /// <summary>
+        /// Push the given state as state on a possible exception edge originating
+        /// from the given pc.
+        /// </summary>
+        void PushExceptionState(Label atThrow, AState exceptionState);
     }
 
-    public AState Join(Pair<Label, Label> edge, AState newState, AState prevState, out bool weaker, bool widen)
+    #region Contracts for IFixpointInfo
+
+    [ContractClassFor(typeof(IFixpointInfo<,>))]
+    internal abstract class IFixpointInfoContracts<Label, AState>
+      : IFixpointInfo<Label, AState>
     {
-      throw new NotImplementedException();
-    }
+        public bool PreState(Label label, out AState ifFound)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
 
-    public AState MutableVersion(AState state)
-    {
-      throw new NotImplementedException();
-    }
+            throw new NotImplementedException();
+        }
 
-    public AState ImmutableVersion(AState state)
-    {
-      throw new NotImplementedException();
-    }
+        public bool PostState(Label label, out AState ifFound)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
 
-    public void Dump(Pair<AState, TextWriter> pair)
-    {
-      throw new NotImplementedException();
-    }
+            throw new NotImplementedException();
+        }
 
-    public bool IsBottom(Label pc, AState state)
-    {
-      throw new NotImplementedException();
-    }
+        public bool TryAStateForPostCondition(AState initialState, out AState exitState)
+        {
+            Contract.Requires(initialState != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out exitState) != null);
 
-    public bool IsTop(Label pc, AState state)
-    {
-      throw new NotImplementedException();
-    }
+            throw new NotImplementedException();
+        }
 
-    public Interface Visitor()
-    {
-      throw new NotImplementedException();
-    }
+        public IEnumerable<SubroutineContext> CachedContexts(CFGBlock block)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<SubroutineContext>>() != null);
 
-    public Predicate<Label> CacheStates(IFixpointInfo<Label, AState> fixpointInfo)
-    {
-      Contract.Requires(fixpointInfo != null);
-      throw new NotImplementedException();
-    }
+            return null;
+        }
 
-    #endregion
-  }
-  #endregion
-
-
-  public interface IEdgeVisit<Label, Local, Parameter, Method, Field, Type, Variable, State> : IVisitMSIL<Label,Local,Parameter,Method,Field,Type,Variable,Variable,State,State> {
-    /// <summary>
-    /// Called in backward edge visitor if the edge corresponds to a renaming
-    /// </summary>
-    /// <param name="from">Start of edge (in backward transfer this is the later pc)</param>
-    /// <param name="to">Target of edge (in backward transfer this is the earlier pc)</param>
-    State Rename(Label from, Label to, State state, IFunctionalMap<Variable,Variable> renaming);
-  }
-
-
-  [ContractClass(typeof(ICodeLayerContracts<, , , , , , , , , , , , >))]
-  public interface ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeConversionData>
-    where Type:IEquatable<Type>
-    where ContextData : IMethodContext<Field, Method>
-  {
-    IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; }
-    IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get; }
-
-    /// <summary>
-    /// Decode the instruction immediately following the label on a forward path.
-    /// </summary>
-    IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeConversionData> Decoder { get; }
-
-    /// <summary>
-    /// A converter from destinations (variables) to strings
-    /// </summary>
-    Converter<Variable, string> VariableToString { get; }
-
-    /// <summary>
-    /// A converter from sources (expressions) to strings
-    /// </summary>
-    Converter<Expression, string> ExpressionToString { get; }
-
-    /// <summary>
-    /// A printer for IL at this abstraction level
-    /// </summary>
-    ILPrinter<APC> Printer { get; }
-
-    /// <summary>
-    /// Returns true if v1 is newer than v2
-    /// </summary>
-    bool NewerThan(Variable v1, Variable v2);
-
-    /// <summary>
-    /// Creates a forward analysis with the given IL visitor.
-    /// </summary>
-    /// <typeparam name="AnalysisState">Abstract state of analysis</typeparam>
-    /// <param name="analysis">A visitor handling il at this layer</param>
-    /// <returns>A delegate that starts the fixpoint computation if provided an initial abstract value</returns>
-    Func<AnalysisState, IFixpointInfo<APC,AnalysisState>> CreateForward<AnalysisState>(
-      IAnalysis<APC, AnalysisState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, AnalysisState, AnalysisState>, EdgeConversionData> analysis,
-      DFAOptions options
-    );
-
-  }
-
-  #region ICodeLayerContracts
-
-  [ContractClassFor(typeof(ICodeLayer<, , , , , , , , , , , , >))]
-  abstract class ICodeLayerContracts<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeConversionData>
-    : ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeConversionData>
-    where Type : IEquatable<Type>
-    where ContextData : IMethodContext<Field, Method>
-  {
-    public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
-    {
-      get {
-        Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
-        throw new NotImplementedException(); }
-    }
-
-    public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeConversionData> Decoder
-    {
-      get {
-        Contract.Ensures(Contract.Result<IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeConversionData>>() != null);
-        throw new NotImplementedException(); }
-    }
-
-    public Converter<Variable, string> VariableToString
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Converter<Expression, string> ExpressionToString
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public ILPrinter<APC> Printer
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Func<AnalysisState, IFixpointInfo<APC, AnalysisState>> CreateForward<AnalysisState>(IAnalysis<APC, AnalysisState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, AnalysisState, AnalysisState>, EdgeConversionData> analysis, DFAOptions options)
-    {
-      Contract.Ensures(Contract.Result<Func<AnalysisState, IFixpointInfo<APC, AnalysisState>>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public bool NewerThan(Variable v1, Variable v2) {
-      throw new NotImplementedException();
-    }
-
-  }
-  
-  #endregion
-
-  #region IBasicMethodDriver contract binding
-  [ContractClass(typeof(IBasicMethodDriverContract<,,,,,,,,,>))]
-  public partial interface IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
-  {
-
-  }
-
-  [ContractClassFor(typeof(IBasicMethodDriver<,,,,,,,,,>))]
-  abstract class IBasicMethodDriverContract<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> : IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.RawLayer
-    {
-      get {
-        Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.StackLayer
-    {
-      get {
-        Contract.Ensures(Contract.Result< ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeRawLayer
-    {
-      get {
-        Contract.Ensures(Contract.Result< ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeStackLayer
-    {
-      get {
-        Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    LogOptions IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.Options
-    {
-      get {
-        Contract.Ensures(Contract.Result<LogOptions>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    ICFG IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeCFG
-    {
-      get {
-        Contract.Ensures(Contract.Result<ICFG>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    SyntacticComplexity IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.SyntacticComplexity
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AnalysisDriver
-    {
-      get {
-        Contract.Ensures(Contract.Result<IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-  }
-  #endregion
-
-  public partial interface IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    /// <summary>
-    /// The original IL code layer
-    /// </summary>
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>
-      RawLayer { get; }
-
-    /// <summary>
-    /// The stack code layer with stack temporary numbers and stack depth info
-    /// </summary>
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>
-      StackLayer { get; }
-
-    /// <summary>
-    /// The original IL code layer
-    /// </summary>
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>
-      ContractFreeRawLayer { get; }
-
-    /// <summary>
-    /// The stack code layer with stack temporary numbers and stack depth info
-    /// </summary>
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>
-      ContractFreeStackLayer { get; }
-
-    LogOptions Options { get; }
-
-    ICFG ContractFreeCFG { get; }
-
-    /// <summary>
-    /// The Syntactic complexity of the method
-    /// </summary>
-    SyntacticComplexity SyntacticComplexity { get; set; }
-
-    IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> AnalysisDriver { get; }
-  }
-
-  public interface IDisjunctiveExpressionRefiner<Variable, Expression>
-  {
-    bool TryRefineExpression(APC pc, Variable toRefine, out Expression refined);
-
-    bool TryApplyModusPonens(APC pc, Expression premise, Predicate<Expression> oracle, out List<Expression> consequences);
-  }
-
-  #region IBasicMethodDriverWithInference contract binding
-  [ContractClass(typeof(IBasicMethodDriverWithInferenceContract<,,,,,,,,,>))]
-  public partial interface IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
-  {
-
-
-  }
-
-  [ContractClassFor(typeof(IBasicMethodDriverWithInference<,,,,,,,,,>))]
-  abstract class IBasicMethodDriverWithInferenceContract<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> : IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    #region IBasicMethodDriverWithInference
-    bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddPreCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredPreConditions
-    {
-      get {
-        Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null);
-        throw new NotImplementedException(); 
-      }
-    }
-
-    bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddPostCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredPostConditions
-    {
-      get {
-        Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddObjectInvariant(BoxedExpression boxedExpression, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredObjectInvariants
-    {
-      get {
-        Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddCalleeAssume(BoxedExpression boxedExpression, object callee, APC pc, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<STuple<BoxedExpression, Provenance, Method>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredCalleeAssumes
-    {
-      get {
-        Contract.Ensures(Contract.Result<IEnumerable<STuple<BoxedExpression, Provenance, Method>>>() != null); 
-        throw new NotImplementedException();
-      }
-    }
-
-    bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddEntryAssume(BoxedExpression boxedExpression, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredEntryAssumes
-    {
-      get {
-        Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null); 
-        throw new NotImplementedException();
-      }
+        public void PushExceptionState(Label atThrow, AState exceptionState)
+        {
+            throw new NotImplementedException();
+        }
     }
     #endregion
 
-    #region Inherited
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.RawLayer
+    public interface IAbstractValue<T>
     {
-      get { throw new NotImplementedException(); }
+        T Top { get; }
+        T Bottom { get; }
+
+        bool IsTop { get; }
+        bool IsBottom { get; }
+
+        /// <summary>
+        /// Used by the underlying fixpoint computation to signal that the argument value will not be used
+        /// for transfer update any longer.
+        /// Useful for debugging. Usually, can be implemented as an identity function. But if the analysis 
+        /// does complicated sharing and updating, one might have to do something different.
+        /// </summary>
+        /// <returns>A value that is guaranteed to not be modified by the analysis.</returns>
+        T ImmutableVersion();
+
+        /// <summary>
+        /// Return a value equivalent to the argument value that can be updated by the transfer function.
+        ///
+        /// For purely functional states, this is an identity. For transfer functions that mutate the 
+        /// abstract value, this should be a clone.
+        /// </summary>
+        T Clone();
+
+        /// <summary>
+        /// Returns weaker==true if the result of the join is strictly more abstract than existingState (this)
+        /// i.e., !LessEqual(result, existingState). This can be true more often than necessary, unless widen
+        /// is true.
+        ///
+        /// If widen is true, operation must widen
+        /// </summary>
+        T Join(T newState, out bool weaker, bool widen);
+
+        /// <summary>
+        /// </summary>
+        T Meet(T that);
+
+        bool LessEqual(T that);
+
+        void Dump(TextWriter tw);
     }
 
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.StackLayer
+
+    /// <summary>
+    /// An analysis driver encapsulates a complete analysis to be used by a fix point engine.
+    /// The structure allows generating stacks of drivers, where elements in the stack can 
+    /// adjust what higher level drivers see.
+    /// </summary>
+    /// <typeparam name="Label">Abstract PC type</typeparam>
+    /// <typeparam name="AState">Abstract state for analysis</typeparam>
+    /// <typeparam name="Interface">The visitor interface used by the analysis</typeparam>
+    /// <typeparam name="EdgeConversionData">Additional information on edges for transforming abstract state</typeparam>
+    public partial interface IAnalysis<Label, AState, Interface, EdgeConversionData>
     {
-      get { throw new NotImplementedException(); }
+        /// <summary>
+        /// A converter that gets a chance to convert an abstract state when it is pushed
+        /// onto a block. This allows for instance renaming.
+        /// 
+        /// The edgeData depends on the particular analysis layer and is optional.
+        /// </summary>
+        AState EdgeConversion(Label from, Label next, bool joinPoint, EdgeConversionData edgeData, AState newState);
+
+        /// <summary>
+        /// The join operation
+        /// </summary>
+        /// <returns></returns>
+        AState Join(Pair<Label, Label> edge, AState newState, AState prevState, out bool weaker, bool widen);
+
+        /// <summary>
+        /// Obtain a mutable version of an abstract state (usually a clone)
+        /// </summary>
+        /// <returns></returns>
+        AState MutableVersion(AState state);
+
+        /// <summary>
+        /// Marks a state as no longer mutable. Mostly for debugging.
+        /// </summary>
+        /// <returns></returns>
+        AState ImmutableVersion(AState state);
+
+        /// <summary>
+        /// Dumps the abstract state
+        /// </summary>
+        /// <returns></returns>
+        void Dump(Pair<AState, TextWriter> pair);
+
+        /// <summary>
+        /// Evaluates to true on bottom states.
+        /// This instructs the fixpoint analysis to stop following paths.
+        /// </summary>
+        bool IsBottom(Label pc, AState state);
+
+        /// <summary>
+        /// Evaluates to true on top states.
+        /// </summary>
+        bool IsTop(Label pc, AState state);
+
+        /// <summary>
+        /// Must return a visitor that is used to construct the transfer function
+        /// </summary>
+        Interface Visitor();
+
+        /// <summary>
+        /// Called by underlying engine to provide a lookup method that can be used to find fixpoint states
+        /// after the fix point has been reached.
+        /// </summary>
+        /// <returns>Can return a predicate that informs the underlying DFA at which pc's to cache the state.
+        /// if null, no extra caching is done.</returns>
+        Predicate<Label> CacheStates(IFixpointInfo<Label, AState> fixpointInfo);
     }
 
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeRawLayer
-    {
-      get { throw new NotImplementedException(); }
-    }
+    #region IAnalysis contract binding
+    [ContractClass(typeof(IAnalysisContract<,,,>))]
+    public partial interface IAnalysis<Label, AState, Interface, EdgeConversionData> { }
 
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeStackLayer
+    [ContractClassFor(typeof(IAnalysis<,,,>))]
+    internal abstract class IAnalysisContract<Label, AState, Interface, EdgeConversionData> : IAnalysis<Label, AState, Interface, EdgeConversionData>
     {
-      get { throw new NotImplementedException(); }
-    }
+        #region IAnalysis<Label,AState,Interface,EdgeConversionData> Members
 
-    LogOptions IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.Options
-    {
-      get { throw new NotImplementedException(); }
-    }
+        public AState EdgeConversion(Label from, Label next, bool joinPoint, EdgeConversionData edgeData, AState newState)
+        {
+            throw new NotImplementedException();
+        }
 
-    ICFG IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeCFG
-    {
-      get { throw new NotImplementedException(); }
-    }
+        public AState Join(Pair<Label, Label> edge, AState newState, AState prevState, out bool weaker, bool widen)
+        {
+            throw new NotImplementedException();
+        }
 
-    SyntacticComplexity IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.SyntacticComplexity
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
+        public AState MutableVersion(AState state)
+        {
+            throw new NotImplementedException();
+        }
 
-    IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AnalysisDriver
-    {
-      get { throw new NotImplementedException(); }
+        public AState ImmutableVersion(AState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dump(Pair<AState, TextWriter> pair)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsBottom(Label pc, AState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsTop(Label pc, AState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Interface Visitor()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Predicate<Label> CacheStates(IFixpointInfo<Label, AState> fixpointInfo)
+        {
+            Contract.Requires(fixpointInfo != null);
+            throw new NotImplementedException();
+        }
+
+        #endregion
     }
     #endregion
 
 
-    public bool MayReturnNull
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-
-    public bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> postconditions)
-    {
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
-
-  public partial interface IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
-    : IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    /// <summary>
-    /// Returns true if pre-condition was added.
-    /// </summary>
-    bool AddPreCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance);
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> InferredPreConditions { get; }
-
-    bool AddPostCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance);
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> InferredPostConditions { get; }
-
-    bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> candidatePostconditions);
-
-
-    // TODO: make more generic, to collect a set of witnesses for the postconditions
-    bool MayReturnNull { get; set; }
-
-    bool AddObjectInvariant(BoxedExpression boxedExpression, Provenance provenance);
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> InferredObjectInvariants { get; }
-
-    bool AddCalleeAssume(BoxedExpression boxedExpression, object callee, APC pc, Provenance provenance);
-
-    IEnumerable<STuple<BoxedExpression, Provenance, Method>> InferredCalleeAssumes { get; }
-
-    bool AddEntryAssume(BoxedExpression boxedExpression, Provenance provenance);
-
-    IEnumerable<Pair<BoxedExpression, Provenance>> InferredEntryAssumes { get; }
-
-    }
-
-  [ContractClass(typeof(IMethodDriverContracts<,,,,,,,,,,,>))]
-  public interface IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, out LogOptions>
-    : IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type:IEquatable<Type>
-  {
-    /// <summary>
-    /// The Value Abstraction Layer
-    /// </summary>
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable,FList<Variable>>>
-      ValueLayer { get; }
-
-    /// <summary>
-    /// The expression layer
-    /// </summary>
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>, IFunctionalMap<Variable,FList<Variable>>>
-      ExpressionLayer { get; }
-
-    /// <summary>
-    /// Same as the Value Abstraction Layer except that the printer prints expressions (historical)
-    /// </summary>
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>
-      HybridLayer { get; }
-
-
-    /// <summary>
-    /// Same as ExpressionLayer.Decoder.Context
-    /// </summary>
-    IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context { get; }
-
-    /// <summary>
-    /// Same as XXXLayer.MetaDataDecoder (just temporary)
-    /// </summary>
-    IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; }
-
-    /// <summary>
-    /// Same as StackLayer.Decoder.Context.MethodContext.CFG
-    /// </summary>
-    ICFG CFG { get; }
-
-    /// <summary>
-    /// Same as StackLayer.Decoder.Context.MethodContext.CurrentMethod
-    /// </summary>
-    Method CurrentMethod { get; }
-
-    Converter<Variable,int> KeyNumber { get; }
-    Comparison<Variable> VariableComparer { get; }
-
-    /// <summary>
-    /// Dispatches on the transfer edge. Could be an instruction, or a renaming
-    /// </summary>
-    /// <param name="from">Starting point of backward edge</param>
-    /// <param name="to">Target of backward edge</param>
-    State BackwardTransfer<State,Visitor>(APC from, APC to, State state, Visitor visitor)
-      where Visitor : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, State>;
-
-    IFullExpressionDecoder<Type, Variable, Expression> ExpressionDecoder { get; }
-
-    /// <returns>
-    /// Returns true if we can add preconditions to the method
-    /// </returns>
-    bool CanAddRequires();
-
-    /// <returns>
-    /// Returns true if we can add postconditions to the method
-    /// </returns>
-    bool CanAddEnsures();
-
-    /// <summary>
-    /// Perform any pending actions on this method before moving on to the next such as pending AddRequires etc.
-    /// </summary>
-    void EndAnalysis();
-
-    void RunHeapAndExpressionAnalyses();
-
-    /// <summary>
-    /// Returns a query interface for truths about variables and reachable pc's independent of higher-level analysis,
-    /// just based on the value/expression analysis.
-    /// </summary>
-    IFactBase<Variable> BasicFacts { get; }
-
-    /// <summary>
-    /// Returns a query interface to enable refinement to disjunctive expressions.
-    /// It may return null.
-    /// </summary>
-    IDisjunctiveExpressionRefiner<Variable, BoxedExpression> DisjunctiveExpressionRefiner { get; set; }
-
-    SyntacticInformation<Method, Field, Variable> AdditionalSyntacticInformation { get; set; }
-
-    bool IsUnreachable(APC pc);
-  }
-
-  #region Contracts
-
-  [ContractClassFor(typeof(IMethodDriver<,,,,,,,,,,,>))]
-  abstract class IMethodDriverContracts<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> 
-    : IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type:IEquatable<Type>
-  {
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>
-      ValueLayer
-    {
-      get {
-        Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>>() != null);
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>, IFunctionalMap<Variable, FList<Variable>>>
-      ExpressionLayer
-    {
-      get {
-        Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>, IFunctionalMap<Variable, FList<Variable>>>>() != null);
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>
-      HybridLayer
-    {
-      get {
-        Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>>() != null);
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context
-    {
-      get {
-        Contract.Ensures(Contract.Result < IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>>() != null);
-        throw new NotImplementedException(); }
-    }
-
-    public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
-    {
-      get {
-        Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
-        throw new NotImplementedException(); }
-    }
-
-    public ICFG CFG
-    {
-      get {
-        Contract.Ensures(Contract.Result<ICFG>() != null);
-        throw new NotImplementedException(); }
-    }
-
-    public Method CurrentMethod
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Converter<Variable, StackTemp> KeyNumber
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Comparison<Variable> VariableComparer
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public State BackwardTransfer<State, Visitor>(APC from, APC to, State state, Visitor visitor) where Visitor : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, State>
-    {
-      throw new NotImplementedException();
-    }
-
-    public IFullExpressionDecoder<Type, Variable, Expression> ExpressionDecoder
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool CanAddRequires()
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool CanAddEnsures()
-    {
-      throw new NotImplementedException();
-    }
-
-    public void EndAnalysis()
-    {
-      throw new NotImplementedException();
-    }
-
-    public void RunHeapAndExpressionAnalyses()
-    {
-      throw new NotImplementedException();
-    }
-
-    public IFactBase<Variable> BasicFacts
-    {
-      get {
-        Contract.Ensures(Contract.Result<IFactBase<Variable>>() != null);
-        
-        throw new NotImplementedException(); }
-    }
-
-    public IDisjunctiveExpressionRefiner<Variable, BoxedExpression> DisjunctiveExpressionRefiner
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public SyntacticInformation<Method, Field, Variable> AdditionalSyntacticInformation
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public bool AddPreCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPreConditions
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool AddPostCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPostConditions
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool AddObjectInvariant(BoxedExpression boxedExpression, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredObjectInvariants
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool AddCalleeAssume(BoxedExpression boxedExpression, object callee, APC pc, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<STuple<BoxedExpression, Provenance, Method>> InferredCalleeAssumes
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> RawLayer
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> StackLayer
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> ContractFreeRawLayer
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> ContractFreeStackLayer
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public LogOptions Options
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public ICFG ContractFreeCFG
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public SyntacticComplexity SyntacticComplexity
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> AnalysisDriver
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool IsUnreachable(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-
-    public bool AddEntryAssume(BoxedExpression boxedExpression, Provenance provenance)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredEntryAssumes
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool MayReturnNull
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-
-    public bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> postconditions)
-    {
-      throw new NotImplementedException();
-    }
-  }
-
-  #endregion
-
-  public interface IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; }
-
-    Type ClassType { get; }
-    AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ParentDriver { get; }
-
-    List<Method> Constructors { get; }
-    LogOptions Options { get; }
-
-    IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event ,Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ConstructorsStatus { get; }
-    int PendingConstructors { get; }
-
-    /// <summary>
-    /// Returns true if invariant is implied by existing invariants of the class
-    /// </summary>
-    bool IsExistingInvariant(string preconditionString);
-
-    /// <summary>
-    /// Returns true if invariant was added.
-    /// </summary>
-    bool AddInvariant(BoxedExpression boxedExpression);
-
-    /// <returns>
-    /// Returns true if we can add invariants to the class
-    /// </returns>
-    bool CanAddInvariants();
-
-    /// <returns>
-    /// Returns true if the postcondition was added to all non-static constructors.
-    /// </returns>
-    bool InstallInvariantsAsConstructorPostconditions(Parameter thisOfInferringMethod, IEnumerable<Pair<BoxedExpression, Provenance>> boxedExpressions, Method method);
-
-    /// <summary>
-    /// Informs the class driver that this method has just been analyzed by an analyzer
-    /// </summary>
-    void MethodHasBeenAnalyzed(
-      string analyzer_name,
-      MethodResult result,
-      Method method
-      );
-
-    /// <summary>
-    /// Inform the class drivers that all the analyzers are done on this method
-    /// </summary>
-    void MethodHasBeenFullyAnalyzed(Method method);
-
-    /// <summary>
-    /// Returns true if MethodHasBeenFullyAnalyzed has been called at least once for each non-static method of the class
-    /// </summary>
-    bool IsClassFullyAnalyzed();
-  }
-
-  public interface IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    void ConstructorAnalyzed(IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mas);
-
-    Type ClassType { get; }
-    int Pending { get; } /// number of constructors left to analyze before starting the ObjectInvariant analysis
-    int TotalNb { get; } /// total number of constructors for this type
-    Dictionary<Method, IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>> AnalysesResults { get; }
-  }
-
-  public interface IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    Method MethodObj { get; }
-
-    /// <summary>
-    /// Results from the analysis called "Key"
-    /// </summary>
-    Dictionary<string, MethodResult> Results { get; }
-  }
-
-
-  #region Context providers for various analysis abstraction layers
-
-  [ContractClass(typeof(IValueContextContracts<,,,,,>))]
-  public interface IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue> : IStackContext<Field, Method>
-    where Type:IEquatable<Type>
-  {
-    IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext { get; }
-  }
-
-  #region Contracts for IValueContext
-
-  [ContractClassFor(typeof(IValueContext<, , , , , >))]
-  abstract class IValueContextContracts<Local, Parameter, Method, Field, Type, SymbolicValue> : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
-    where Type : IEquatable<Type>
-  {
-
-    public IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>>() != null);
-        return null;
-      }
-    }
-
-    public IStackContextData<Field, Method> StackContext
-    {
-      get { return null; }
-    }
-
-    public IMethodContextData<Field, Method> MethodContext
-    {
-      get { return null; }
-    }
-  }
-
-  #endregion
-
-  public partial interface IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> 
-    where Type : IEquatable<Type>
-  {
-    /// <summary>
-    /// Returns the value representing null
-    /// </summary>
-    [Pure]
-    bool TryZero(APC at, out SymbolicValue value);
-
-    /// <summary>
-    /// Returns the value representing null
-    /// </summary>
-    [Pure]
-    bool TryNull(APC at, out SymbolicValue value);
-
-    /// <summary>
-    /// Returns the type of the given symbolic value
-    /// </summary>
-    [Pure]
-    FlatDomain<Type> GetType(APC at, SymbolicValue v);
-
-    /// <summary>
-    /// Returns the array length of the given array or buffer value if known
-    /// </summary>
-    [Pure]
-    bool TryGetArrayLength(APC at, SymbolicValue array, out SymbolicValue length);
-
-    /// <summary>
-    /// Returns the writable bytes extent of a pointer if known
-    /// </summary>
-    [Pure]
-    bool TryGetWritableBytes(APC at, SymbolicValue pointer, out SymbolicValue writableBytes);
-
-    /// <summary>
-    /// Returns true if value is equivalent to 0 in all its forms (int32, int8, null, null pointers, etc).
-    /// </summary>
-    [Pure]
-    bool IsZero(APC at, SymbolicValue value);
-
-    /// <summary>
-    /// Returns true if the Symbolic value is not dummy
-    /// </summary>
-    [Pure]
-    bool IsValid(SymbolicValue value);
-
-    /// <summary>
-    /// Returns the symbolic value on the evaluation stack with the given index. 
-    /// The bottom of the stack is 0, the top given by the current stack depth at the given PC
-    /// </summary>
-    [Pure]
-    bool TryStackValue(APC at, int stackIndex, out SymbolicValue sv);
-
-    /// <summary>
-    /// Returns the value of the given local at the given pc
-    /// Should not be called if local is of type struct (unless it is a primitive numeric type).
-    /// </summary>
-    [Pure]
-    bool TryLocalValue(APC at, Local local, out SymbolicValue sv);
-
-    /// <summary>
-    /// Returns the value representing the address of the given local at the given pc
-    /// </summary>
-    [Pure]
-    bool TryLocalAddress(APC at, Local local, out SymbolicValue sv);
-
-    /// <summary>
-    /// Returns the value of the given parameter (which must be a parameter of the current method) at the given pc
-    /// Should not be called if parameter is of type struct (unless it is a primitive numeric type).
-    /// </summary>
-    [Pure]
-    bool TryParameterValue(APC at, Parameter parameter, out SymbolicValue sv);
-
-    /// <summary>
-    /// Returns the value representing the address of the given parameter 
-    /// (which must be a parameter of the current method) at the given pc
-    /// </summary>
-    [Pure]
-    bool TryParameterAddress(APC at, Parameter parameter, out SymbolicValue sv);
-
-    /// <summary>
-    /// Returns the symbolic value for the given field address if present.
-    /// </summary>
-    [Pure]
-    bool TryFieldAddress(APC at, SymbolicValue objectValue, Field field, out SymbolicValue fieldAddress);
-
-    /// <summary>
-    /// Returns the symbolic value stored in the given address if present.
-    /// </summary>
-    [Pure]
-    bool TryLoadIndirect(APC at, SymbolicValue address, out SymbolicValue value);
-
-    /// <summary>
-    /// Returns a symbolic value for the "result" of the method (for non-void methods) at the given PC
-    /// </summary>
-    [Pure]
-    bool TryResultValue(APC pc, out SymbolicValue value);
-
-
-    /// <summary>
-    /// Returns an access path for the symbolic value at the given program point.
-    /// The access path returned is preferably rooted in a parameter. If not possible, it is rooted in a local variable.
-    /// For symbolic values that are not reachable from locals/parameters, null is returned. 
-    ///
-    /// The access path may contain dereferences (*), field accesses .f, and Length accesses, as well as array index operations.
-    /// </summary>
-    /// <param name="at">PC at which access path holds</param>
-    /// <param name="value">Value for which we compute an access path</param>
-    /// <returns>null if no access path is found.</returns>
-    [Pure]
-    string AccessPath(APC at, SymbolicValue value);
-
-    /// <summary>
-    /// Returns an access path for the symbolic value at the given program point.
-    /// The access path returned is preferably rooted in a parameter. If not possible, it is rooted in a local variable.
-    /// For symbolic values that are not reachable from locals/parameters, null is returned. 
-    ///
-    /// The access path may contain dereferences (*), field accesses .f, and Length accesses, as well as array index operations.
-    /// </summary>
-    /// <param name="at">PC at which access path holds</param>
-    /// <param name="value">Value for which we compute an access path</param>
-    /// <param name="witness">list of symbolic values corrsponding to path</param>
-    /// <returns>null if no access path is found.</returns>
-    [Pure]
-    FList<PathElement> AccessPathListAndWitness(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, out FList<SymbolicValue> witness, Type allowReturnValueFromCall = default(Type));
-
-    /// <summary>
-    /// Returns an access path for the symbolic value at the given program point.
-    /// The access path returned is preferably rooted in a parameter. If not possible, it is rooted in a local variable.
-    /// For symbolic values that are not reachable from locals/parameters, null is returned. 
-    ///
-    /// The access path may contain dereferences (*), field accesses .f, and Length accesses, as well as array index operations.
-    /// </summary>
-    /// <param name="at">PC at which access path holds</param>
-    /// <param name="value">Value for which we compute an access path</param>
-    /// <returns>null if no access path is found.</returns>
-    [Pure]
-    FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall = default(Type));
-
-    /// <summary>
-    /// Returns all possible access paths at pc to given value.
-    /// </summary>
-    [Pure]
-    IEnumerable<FList<PathElement>> AccessPaths(APC at, SymbolicValue value, AccessPathFilter<Method, Type> filter);
-
-    /// <summary>
-    /// Create an access path to the given value, but only one that is visible from outside the
-    /// method in the pre state given the current method's visibility.
-    /// </summary>
-    /// <returns>null if no access path is found</returns>
-    [Pure]
-    FList<PathElement> VisibleAccessPathListFromPre(APC at, SymbolicValue value);
-
-    /// <summary>
-    /// Create an access path to the given value, but only one that is visible from outside the
-    /// method in the post state given the current method's visibility.
-    /// </summary>
-    /// <returns>null if no access path is found</returns>
-    [Pure]
-    FList<PathElement> VisibleAccessPathListFromPost(APC at, SymbolicValue value, bool allowReturnValue = true);
-
-
-    /// <summary>
-    /// Determines if the given access path at Label at is referring to the same value in the pre-state of the method.
-    /// </summary>
-    /// <param name="at">Label where path is valid</param>
-    /// <param name="path">Path</param>
-    /// <returns>true if same path refers to same value in pre-state of method.</returns>
-    [Pure]
-    bool PathUnmodifiedSinceEntry(APC at, FList<PathElement> path);
-
-    /// <summary>
-    /// Determines if the given access path is suitable as a pre conditions. Implies PathUnmodifiedSinceEntry,
-    /// and additionally filters out unwanted preconditions involving static getters.
-    /// </summary>
-    /// <param name="at">Label where path is valid</param>
-    /// <param name="path">Path</param>
-    [Pure]
-    bool PathSuitableInRequires(APC at, FList<PathElement> path);
-
-    /// <summary>
-    /// Determines if the given access path is suitable as a post conditions. Implies that if the location is not modified,
-    /// and additionally filters out unwanted postconditions involving static getters.
-    /// </summary>
-    /// <param name="at">Label where path is valid</param>
-    /// <param name="path">Path</param>
-    [Pure]
-    bool PathSuitableInEnsures(APC at, FList<PathElement> path, bool allowReturnValue);
-
-    /// <summary>
-    /// If known to be a constant, returns the type and value
-    /// </summary>
-    [Pure]
-    bool IsConstant(APC at, SymbolicValue sv, out Type type, out object value);
-
-    /// <summary>
-    /// Is the first element of the list a parameter?
-    /// </summary>
-    [Pure]
-    bool IsRootedInParameter(FList<PathElement> path);
-
-    /// <summary>
-    /// Is the first element return value?
-    /// </summary>
-    [Pure]
-    bool IsRootedInReturnValue(FList<PathElement> path);
-
-    /// <summary>
-    /// Computes information about how the given symbolic value is accesssible. It computes
-    /// whether any access paths exist where the value was reached from the return value of
-    /// a method call, or the read of an array element.
-    /// </summary>
-    /// <returns>All possible ways the value is accessible</returns>
-    [Pure]
-    PathContextFlags PathContexts(APC at, SymbolicValue value);
-
-    /// <summary>
-    /// Succeeds if the value is the result of a pure method call at that program point.
-    /// </summary>
-    [Pure]
-    bool IsPureFunctionCall(APC at, SymbolicValue value, out Method method, out SymbolicValue[] args);
-
-    /// <summary>
-    /// Returns true if the given symbolic value is a delegate value and the target function is known
-    /// </summary>
-    /// <param name="targetObject">Could be dummy in case of a static method. Don't use it in that case.</param>
-    /// <param name="targetMethod">The target method of the delegate</param>
-    [Pure]
-    bool IsDelegateValue(APC at, SymbolicValue delegateValue, out SymbolicValue targetObject, out Method targetMethod);
-
-    /// <summary>
-    /// For enumerables, attempt to obtain model array
-    /// </summary>
-    [Pure]
-    bool TryGetModelArray(APC at, SymbolicValue enumerable, out SymbolicValue modelArray);
-
-    /// <summary>
-    /// If given an object version id, we want to find the object value, use this method.
-    /// </summary>
-    [Pure]
-    bool TryGetObjectFromObjectVersion(APC at, SymbolicValue objectVersion, out SymbolicValue objectValue);
-
-    /// <summary>
-    /// If given address is the element address of an array, returns the corresponding array and index
-    /// </summary>
-    [Pure]
-    bool TryGetArrayFromElementAddress(APC at, SymbolicValue arrayElementAddress, out SymbolicValue arrayValue, out SymbolicValue index);
-
-    /// <summary>
-    /// Returns the static type corresponding to the given runtime type object if known.
-    /// </summary>
-    [Pure]
-    bool IsRuntimeType(APC at, SymbolicValue runtimeTypeObject, out Type type);
-
-    /// <summary>
-    /// If the given argument is a box, return the contents. This only works if the contents is primitive (not a struct with fields)
-    /// </summary>
-    [Pure]
-    bool TryUnbox(APC at, SymbolicValue box, out SymbolicValue content);
-  }
-
-  #region IValueContextData contract binding
-  [ContractClass(typeof(IValueContextDataContract<,,,,,>))]
-  public partial interface IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>
-    where Type : IEquatable<Type>
-  {
-
-  }
-
-  [ContractClassFor(typeof(IValueContextData<,,,,,>))]
-  abstract class IValueContextDataContract<Local, Parameter, Method, Field, Type, SymbolicValue> : IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>
-    where Type : IEquatable<Type> 
-  {
-    #region IValueContextData<Local,Parameter,Method,Field,Type,SymbolicValue> Members
-
-    public bool TryZero(APC at, out SymbolicValue value) {
-      throw new NotImplementedException();
-    }
-
-    public bool TryNull(APC at, out SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FlatDomain<Type> GetType(APC at, SymbolicValue v)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryGetArrayLength(APC at, SymbolicValue array, out SymbolicValue length)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryGetWritableBytes(APC at, SymbolicValue pointer, out SymbolicValue writableBytes)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsZero(APC at, SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsValid(SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryStackValue(APC at, StackTemp stackIndex, out SymbolicValue sv)
-    {
-      Contract.Requires(stackIndex >= 0);
-
-      throw new NotImplementedException();
-    }
-
-    public bool TryLocalValue(APC at, Local local, out SymbolicValue sv)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryLocalAddress(APC at, Local local, out SymbolicValue sv)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryParameterValue(APC at, Parameter parameter, out SymbolicValue sv)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryParameterAddress(APC at, Parameter parameter, out SymbolicValue sv)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryFieldAddress(APC at, SymbolicValue objectValue, Field field, out SymbolicValue fieldAddress)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryLoadIndirect(APC at, SymbolicValue address, out SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryResultValue(APC at, out SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public string AccessPath(APC at, SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall = default(Type))
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<FList<PathElement>> AccessPaths(APC at, SymbolicValue value, AccessPathFilter<Method, Type> filter)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FList<PathElement> VisibleAccessPathListFromPre(APC at, SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public FList<PathElement> VisibleAccessPathListFromPost(APC at, SymbolicValue value, bool allowReturnValue)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool PathUnmodifiedSinceEntry(APC at, FList<PathElement> path)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool PathSuitableInRequires(APC at, FList<PathElement> path)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool PathSuitableInEnsures(APC at, FList<PathElement> path, bool allowReturnValue)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsConstant(APC at, SymbolicValue sv, out Type type, out object value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsRootedInParameter(FList<PathElement> path)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsRootedInReturnValue(FList<PathElement> path)
-    {
-      throw new NotImplementedException();
-    }
-
-    public PathContextFlags PathContexts(APC at, SymbolicValue value)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPureFunctionCall(APC at, SymbolicValue value, out Method method, out SymbolicValue[] args)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsDelegateValue(APC at, SymbolicValue delegateValue, out SymbolicValue targetObject, out Method targetMethod)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryGetModelArray(APC at, SymbolicValue enumerable, out SymbolicValue modelArray)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryGetObjectFromObjectVersion(APC at, SymbolicValue objectVersion, out SymbolicValue objectValue)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryGetArrayFromElementAddress(APC at, SymbolicValue arrayElementAddress, out SymbolicValue arrayValue, out SymbolicValue index)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsRuntimeType(APC at, SymbolicValue runtimeTypeObject, out Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryUnbox(APC at, SymbolicValue box, out SymbolicValue content)
-    {
-      throw new NotImplementedException();
+    public interface IEdgeVisit<Label, Local, Parameter, Method, Field, Type, Variable, State> : IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Variable, Variable, State, State>
+    {
+        /// <summary>
+        /// Called in backward edge visitor if the edge corresponds to a renaming
+        /// </summary>
+        /// <param name="from">Start of edge (in backward transfer this is the later pc)</param>
+        /// <param name="to">Target of edge (in backward transfer this is the earlier pc)</param>
+        State Rename(Label from, Label to, State state, IFunctionalMap<Variable, Variable> renaming);
+    }
+
+
+    [ContractClass(typeof(ICodeLayerContracts<,,,,,,,,,,,,>))]
+    public interface ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeConversionData>
+      where Type : IEquatable<Type>
+      where ContextData : IMethodContext<Field, Method>
+    {
+        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; }
+        IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get; }
+
+        /// <summary>
+        /// Decode the instruction immediately following the label on a forward path.
+        /// </summary>
+        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeConversionData> Decoder { get; }
+
+        /// <summary>
+        /// A converter from destinations (variables) to strings
+        /// </summary>
+        Converter<Variable, string> VariableToString { get; }
+
+        /// <summary>
+        /// A converter from sources (expressions) to strings
+        /// </summary>
+        Converter<Expression, string> ExpressionToString { get; }
+
+        /// <summary>
+        /// A printer for IL at this abstraction level
+        /// </summary>
+        ILPrinter<APC> Printer { get; }
+
+        /// <summary>
+        /// Returns true if v1 is newer than v2
+        /// </summary>
+        bool NewerThan(Variable v1, Variable v2);
+
+        /// <summary>
+        /// Creates a forward analysis with the given IL visitor.
+        /// </summary>
+        /// <typeparam name="AnalysisState">Abstract state of analysis</typeparam>
+        /// <param name="analysis">A visitor handling il at this layer</param>
+        /// <returns>A delegate that starts the fixpoint computation if provided an initial abstract value</returns>
+        Func<AnalysisState, IFixpointInfo<APC, AnalysisState>> CreateForward<AnalysisState>(
+          IAnalysis<APC, AnalysisState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, AnalysisState, AnalysisState>, EdgeConversionData> analysis,
+          DFAOptions options
+        );
+    }
+
+    #region ICodeLayerContracts
+
+    [ContractClassFor(typeof(ICodeLayer<,,,,,,,,,,,,>))]
+    internal abstract class ICodeLayerContracts<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeConversionData>
+      : ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeConversionData>
+      where Type : IEquatable<Type>
+      where ContextData : IMethodContext<Field, Method>
+    {
+        public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeConversionData> Decoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeConversionData>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public Converter<Variable, string> VariableToString
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Converter<Expression, string> ExpressionToString
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ILPrinter<APC> Printer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Func<AnalysisState, IFixpointInfo<APC, AnalysisState>> CreateForward<AnalysisState>(IAnalysis<APC, AnalysisState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, AnalysisState, AnalysisState>, EdgeConversionData> analysis, DFAOptions options)
+        {
+            Contract.Ensures(Contract.Result<Func<AnalysisState, IFixpointInfo<APC, AnalysisState>>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public bool NewerThan(Variable v1, Variable v2)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     #endregion
 
-
-    public FList<PathElement> AccessPathListAndWitness(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, out FList<SymbolicValue> witness, Type allowReturnValueFromCall = default(Type))
+    #region IBasicMethodDriver contract binding
+    [ContractClass(typeof(IBasicMethodDriverContract<,,,,,,,,,>))]
+    public partial interface IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
     {
-      Contract.Ensures(Contract.Result<FList<PathElement>>() == null || Contract.ValueAtReturn(out witness) != null);
-      throw new NotImplementedException();
     }
-  }
 
-  #endregion
+    [ContractClassFor(typeof(IBasicMethodDriver<,,,,,,,,,>))]
+    internal abstract class IBasicMethodDriverContract<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> : IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.RawLayer
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>>() != null);
+                throw new NotImplementedException();
+            }
+        }
 
-  [Flags]
-  public enum PathContextFlags
-  {
-    None = 0,
-    ViaMethodReturn = 1,
-    ViaArray = 2,
-    ViaField = 4,
-    ViaPureMethodReturn = 8,
-    ViaCast = 16,
-    ViaOutParameter = 32,
-    ViaCallThisHavoc = 64,
-    ViaOldValue = 128,
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.StackLayer
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>>() != null);
+                throw new NotImplementedException();
+            }
+        }
 
-    /// <summary>
-    /// Complete bitmask
-    /// </summary>
-    All = 255,
-  }
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeRawLayer
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>>() != null);
+                throw new NotImplementedException();
+            }
+        }
 
-  [ContractClass(typeof(IExpressionContextContracts<,,,,,,>))]
-  public interface IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> 
-    : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeStackLayer
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        LogOptions IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.Options
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<LogOptions>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        ICFG IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeCFG
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICFG>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        SyntacticComplexity IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.SyntacticComplexity
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AnalysisDriver
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+    }
+    #endregion
+
+    public partial interface IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        /// <summary>
+        /// The original IL code layer
+        /// </summary>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>
+          RawLayer
+        { get; }
+
+        /// <summary>
+        /// The stack code layer with stack temporary numbers and stack depth info
+        /// </summary>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>
+          StackLayer
+        { get; }
+
+        /// <summary>
+        /// The original IL code layer
+        /// </summary>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit>
+          ContractFreeRawLayer
+        { get; }
+
+        /// <summary>
+        /// The stack code layer with stack temporary numbers and stack depth info
+        /// </summary>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>
+          ContractFreeStackLayer
+        { get; }
+
+        LogOptions Options { get; }
+
+        ICFG ContractFreeCFG { get; }
+
+        /// <summary>
+        /// The Syntactic complexity of the method
+        /// </summary>
+        SyntacticComplexity SyntacticComplexity { get; set; }
+
+        IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> AnalysisDriver { get; }
+    }
+
+    public interface IDisjunctiveExpressionRefiner<Variable, Expression>
+    {
+        bool TryRefineExpression(APC pc, Variable toRefine, out Expression refined);
+
+        bool TryApplyModusPonens(APC pc, Expression premise, Predicate<Expression> oracle, out List<Expression> consequences);
+    }
+
+    #region IBasicMethodDriverWithInference contract binding
+    [ContractClass(typeof(IBasicMethodDriverWithInferenceContract<,,,,,,,,,>))]
+    public partial interface IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
+    {
+    }
+
+    [ContractClassFor(typeof(IBasicMethodDriverWithInference<,,,,,,,,,>))]
+    internal abstract class IBasicMethodDriverWithInferenceContract<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> : IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        #region IBasicMethodDriverWithInference
+        bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddPreCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredPreConditions
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddPostCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredPostConditions
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddObjectInvariant(BoxedExpression boxedExpression, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredObjectInvariants
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddCalleeAssume(BoxedExpression boxedExpression, object callee, APC pc, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<STuple<BoxedExpression, Provenance, Method>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredCalleeAssumes
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<STuple<BoxedExpression, Provenance, Method>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        bool IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AddEntryAssume(BoxedExpression boxedExpression, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.InferredEntryAssumes
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Pair<BoxedExpression, Provenance>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+        #endregion
+
+        #region Inherited
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.RawLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.StackLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeRawLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeStackLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        LogOptions IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.Options
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        ICFG IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.ContractFreeCFG
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        SyntacticComplexity IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.SyntacticComplexity
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>.AnalysisDriver
+        {
+            get { throw new NotImplementedException(); }
+        }
+        #endregion
+
+
+        public bool MayReturnNull
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+
+        public bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> postconditions)
+        {
+            throw new NotImplementedException();
+        }
+    }
+    #endregion
+
+    public partial interface IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, out LogOptions>
+      : IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        /// <summary>
+        /// Returns true if pre-condition was added.
+        /// </summary>
+        bool AddPreCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance);
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> InferredPreConditions { get; }
+
+        bool AddPostCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance);
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> InferredPostConditions { get; }
+
+        bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> candidatePostconditions);
+
+
+        // TODO: make more generic, to collect a set of witnesses for the postconditions
+        bool MayReturnNull { get; set; }
+
+        bool AddObjectInvariant(BoxedExpression boxedExpression, Provenance provenance);
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> InferredObjectInvariants { get; }
+
+        bool AddCalleeAssume(BoxedExpression boxedExpression, object callee, APC pc, Provenance provenance);
+
+        IEnumerable<STuple<BoxedExpression, Provenance, Method>> InferredCalleeAssumes { get; }
+
+        bool AddEntryAssume(BoxedExpression boxedExpression, Provenance provenance);
+
+        IEnumerable<Pair<BoxedExpression, Provenance>> InferredEntryAssumes { get; }
+    }
+
+    [ContractClass(typeof(IMethodDriverContracts<,,,,,,,,,,,>))]
+    public interface IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, out LogOptions>
+      : IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        /// <summary>
+        /// The Value Abstraction Layer
+        /// </summary>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>
+          ValueLayer
+        { get; }
+
+        /// <summary>
+        /// The expression layer
+        /// </summary>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>, IFunctionalMap<Variable, FList<Variable>>>
+          ExpressionLayer
+        { get; }
+
+        /// <summary>
+        /// Same as the Value Abstraction Layer except that the printer prints expressions (historical)
+        /// </summary>
+        ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>
+          HybridLayer
+        { get; }
+
+
+        /// <summary>
+        /// Same as ExpressionLayer.Decoder.Context
+        /// </summary>
+        IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context { get; }
+
+        /// <summary>
+        /// Same as XXXLayer.MetaDataDecoder (just temporary)
+        /// </summary>
+        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; }
+
+        /// <summary>
+        /// Same as StackLayer.Decoder.Context.MethodContext.CFG
+        /// </summary>
+        ICFG CFG { get; }
+
+        /// <summary>
+        /// Same as StackLayer.Decoder.Context.MethodContext.CurrentMethod
+        /// </summary>
+        Method CurrentMethod { get; }
+
+        Converter<Variable, int> KeyNumber { get; }
+        Comparison<Variable> VariableComparer { get; }
+
+        /// <summary>
+        /// Dispatches on the transfer edge. Could be an instruction, or a renaming
+        /// </summary>
+        /// <param name="from">Starting point of backward edge</param>
+        /// <param name="to">Target of backward edge</param>
+        State BackwardTransfer<State, Visitor>(APC from, APC to, State state, Visitor visitor)
+          where Visitor : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, State>;
+
+        IFullExpressionDecoder<Type, Variable, Expression> ExpressionDecoder { get; }
+
+        /// <returns>
+        /// Returns true if we can add preconditions to the method
+        /// </returns>
+        bool CanAddRequires();
+
+        /// <returns>
+        /// Returns true if we can add postconditions to the method
+        /// </returns>
+        bool CanAddEnsures();
+
+        /// <summary>
+        /// Perform any pending actions on this method before moving on to the next such as pending AddRequires etc.
+        /// </summary>
+        void EndAnalysis();
+
+        void RunHeapAndExpressionAnalyses();
+
+        /// <summary>
+        /// Returns a query interface for truths about variables and reachable pc's independent of higher-level analysis,
+        /// just based on the value/expression analysis.
+        /// </summary>
+        IFactBase<Variable> BasicFacts { get; }
+
+        /// <summary>
+        /// Returns a query interface to enable refinement to disjunctive expressions.
+        /// It may return null.
+        /// </summary>
+        IDisjunctiveExpressionRefiner<Variable, BoxedExpression> DisjunctiveExpressionRefiner { get; set; }
+
+        SyntacticInformation<Method, Field, Variable> AdditionalSyntacticInformation { get; set; }
+
+        bool IsUnreachable(APC pc);
+    }
+
+    #region Contracts
+
+    [ContractClassFor(typeof(IMethodDriver<,,,,,,,,,,,>))]
+    internal abstract class IMethodDriverContracts<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+      : IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>
+          ValueLayer
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>, IFunctionalMap<Variable, FList<Variable>>>
+          ExpressionLayer
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>, IFunctionalMap<Variable, FList<Variable>>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>
+          HybridLayer
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable, Variable, IValueContext<Local, Parameter, Method, Field, Type, Variable>, IFunctionalMap<Variable, FList<Variable>>>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICFG CFG
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICFG>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public Method CurrentMethod
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Converter<Variable, StackTemp> KeyNumber
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Comparison<Variable> VariableComparer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public State BackwardTransfer<State, Visitor>(APC from, APC to, State state, Visitor visitor) where Visitor : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, State>
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFullExpressionDecoder<Type, Variable, Expression> ExpressionDecoder
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool CanAddRequires()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CanAddEnsures()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void EndAnalysis()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RunHeapAndExpressionAnalyses()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFactBase<Variable> BasicFacts
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IFactBase<Variable>>() != null);
+
+                throw new NotImplementedException();
+            }
+        }
+
+        public IDisjunctiveExpressionRefiner<Variable, BoxedExpression> DisjunctiveExpressionRefiner
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public SyntacticInformation<Method, Field, Variable> AdditionalSyntacticInformation
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool AddPreCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPreConditions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool AddPostCondition(BoxedExpression boxedExpression, APC pc, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPostConditions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool AddObjectInvariant(BoxedExpression boxedExpression, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredObjectInvariants
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool AddCalleeAssume(BoxedExpression boxedExpression, object callee, APC pc, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<STuple<BoxedExpression, Provenance, Method>> InferredCalleeAssumes
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> RawLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> StackLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> ContractFreeRawLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> ContractFreeStackLayer
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public LogOptions Options
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ICFG ContractFreeCFG
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public SyntacticComplexity SyntacticComplexity
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> AnalysisDriver
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool IsUnreachable(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public bool AddEntryAssume(BoxedExpression boxedExpression, Provenance provenance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredEntryAssumes
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool MayReturnNull
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+
+        public bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> postconditions)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    #endregion
+
+    public interface IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get; }
+
+        Type ClassType { get; }
+        AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ParentDriver { get; }
+
+        List<Method> Constructors { get; }
+        LogOptions Options { get; }
+
+        IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> ConstructorsStatus { get; }
+        int PendingConstructors { get; }
+
+        /// <summary>
+        /// Returns true if invariant is implied by existing invariants of the class
+        /// </summary>
+        bool IsExistingInvariant(string preconditionString);
+
+        /// <summary>
+        /// Returns true if invariant was added.
+        /// </summary>
+        bool AddInvariant(BoxedExpression boxedExpression);
+
+        /// <returns>
+        /// Returns true if we can add invariants to the class
+        /// </returns>
+        bool CanAddInvariants();
+
+        /// <returns>
+        /// Returns true if the postcondition was added to all non-static constructors.
+        /// </returns>
+        bool InstallInvariantsAsConstructorPostconditions(Parameter thisOfInferringMethod, IEnumerable<Pair<BoxedExpression, Provenance>> boxedExpressions, Method method);
+
+        /// <summary>
+        /// Informs the class driver that this method has just been analyzed by an analyzer
+        /// </summary>
+        void MethodHasBeenAnalyzed(
+          string analyzer_name,
+          MethodResult result,
+          Method method
+          );
+
+        /// <summary>
+        /// Inform the class drivers that all the analyzers are done on this method
+        /// </summary>
+        void MethodHasBeenFullyAnalyzed(Method method);
+
+        /// <summary>
+        /// Returns true if MethodHasBeenFullyAnalyzed has been called at least once for each non-static method of the class
+        /// </summary>
+        bool IsClassFullyAnalyzed();
+    }
+
+    public interface IConstructorsAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        void ConstructorAnalyzed(IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mas);
+
+        Type ClassType { get; }
+        int Pending { get; } /// number of constructors left to analyze before starting the ObjectInvariant analysis
+        int TotalNb { get; } /// total number of constructors for this type
+        Dictionary<Method, IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>> AnalysesResults { get; }
+    }
+
+    public interface IMethodAnalysisStatus<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
+    {
+        Method MethodObj { get; }
+
+        /// <summary>
+        /// Results from the analysis called "Key"
+        /// </summary>
+        Dictionary<string, MethodResult> Results { get; }
+    }
+
+
+    #region Context providers for various analysis abstraction layers
+
+    [ContractClass(typeof(IValueContextContracts<,,,,,>))]
+    public interface IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue> : IStackContext<Field, Method>
+      where Type : IEquatable<Type>
+    {
+        IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext { get; }
+    }
+
+    #region Contracts for IValueContext
+
+    [ContractClassFor(typeof(IValueContext<,,,,,>))]
+    internal abstract class IValueContextContracts<Local, Parameter, Method, Field, Type, SymbolicValue> : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
+      where Type : IEquatable<Type>
+    {
+        public IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>>() != null);
+                return null;
+            }
+        }
+
+        public IStackContextData<Field, Method> StackContext
+        {
+            get { return null; }
+        }
+
+        public IMethodContextData<Field, Method> MethodContext
+        {
+            get { return null; }
+        }
+    }
+
+    #endregion
+
+    public partial interface IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>
+      where Type : IEquatable<Type>
+    {
+        /// <summary>
+        /// Returns the value representing null
+        /// </summary>
+        [Pure]
+        bool TryZero(APC at, out SymbolicValue value);
+
+        /// <summary>
+        /// Returns the value representing null
+        /// </summary>
+        [Pure]
+        bool TryNull(APC at, out SymbolicValue value);
+
+        /// <summary>
+        /// Returns the type of the given symbolic value
+        /// </summary>
+        [Pure]
+        FlatDomain<Type> GetType(APC at, SymbolicValue v);
+
+        /// <summary>
+        /// Returns the array length of the given array or buffer value if known
+        /// </summary>
+        [Pure]
+        bool TryGetArrayLength(APC at, SymbolicValue array, out SymbolicValue length);
+
+        /// <summary>
+        /// Returns the writable bytes extent of a pointer if known
+        /// </summary>
+        [Pure]
+        bool TryGetWritableBytes(APC at, SymbolicValue pointer, out SymbolicValue writableBytes);
+
+        /// <summary>
+        /// Returns true if value is equivalent to 0 in all its forms (int32, int8, null, null pointers, etc).
+        /// </summary>
+        [Pure]
+        bool IsZero(APC at, SymbolicValue value);
+
+        /// <summary>
+        /// Returns true if the Symbolic value is not dummy
+        /// </summary>
+        [Pure]
+        bool IsValid(SymbolicValue value);
+
+        /// <summary>
+        /// Returns the symbolic value on the evaluation stack with the given index. 
+        /// The bottom of the stack is 0, the top given by the current stack depth at the given PC
+        /// </summary>
+        [Pure]
+        bool TryStackValue(APC at, int stackIndex, out SymbolicValue sv);
+
+        /// <summary>
+        /// Returns the value of the given local at the given pc
+        /// Should not be called if local is of type struct (unless it is a primitive numeric type).
+        /// </summary>
+        [Pure]
+        bool TryLocalValue(APC at, Local local, out SymbolicValue sv);
+
+        /// <summary>
+        /// Returns the value representing the address of the given local at the given pc
+        /// </summary>
+        [Pure]
+        bool TryLocalAddress(APC at, Local local, out SymbolicValue sv);
+
+        /// <summary>
+        /// Returns the value of the given parameter (which must be a parameter of the current method) at the given pc
+        /// Should not be called if parameter is of type struct (unless it is a primitive numeric type).
+        /// </summary>
+        [Pure]
+        bool TryParameterValue(APC at, Parameter parameter, out SymbolicValue sv);
+
+        /// <summary>
+        /// Returns the value representing the address of the given parameter 
+        /// (which must be a parameter of the current method) at the given pc
+        /// </summary>
+        [Pure]
+        bool TryParameterAddress(APC at, Parameter parameter, out SymbolicValue sv);
+
+        /// <summary>
+        /// Returns the symbolic value for the given field address if present.
+        /// </summary>
+        [Pure]
+        bool TryFieldAddress(APC at, SymbolicValue objectValue, Field field, out SymbolicValue fieldAddress);
+
+        /// <summary>
+        /// Returns the symbolic value stored in the given address if present.
+        /// </summary>
+        [Pure]
+        bool TryLoadIndirect(APC at, SymbolicValue address, out SymbolicValue value);
+
+        /// <summary>
+        /// Returns a symbolic value for the "result" of the method (for non-void methods) at the given PC
+        /// </summary>
+        [Pure]
+        bool TryResultValue(APC pc, out SymbolicValue value);
+
+
+        /// <summary>
+        /// Returns an access path for the symbolic value at the given program point.
+        /// The access path returned is preferably rooted in a parameter. If not possible, it is rooted in a local variable.
+        /// For symbolic values that are not reachable from locals/parameters, null is returned. 
+        ///
+        /// The access path may contain dereferences (*), field accesses .f, and Length accesses, as well as array index operations.
+        /// </summary>
+        /// <param name="at">PC at which access path holds</param>
+        /// <param name="value">Value for which we compute an access path</param>
+        /// <returns>null if no access path is found.</returns>
+        [Pure]
+        string AccessPath(APC at, SymbolicValue value);
+
+        /// <summary>
+        /// Returns an access path for the symbolic value at the given program point.
+        /// The access path returned is preferably rooted in a parameter. If not possible, it is rooted in a local variable.
+        /// For symbolic values that are not reachable from locals/parameters, null is returned. 
+        ///
+        /// The access path may contain dereferences (*), field accesses .f, and Length accesses, as well as array index operations.
+        /// </summary>
+        /// <param name="at">PC at which access path holds</param>
+        /// <param name="value">Value for which we compute an access path</param>
+        /// <param name="witness">list of symbolic values corrsponding to path</param>
+        /// <returns>null if no access path is found.</returns>
+        [Pure]
+        FList<PathElement> AccessPathListAndWitness(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, out FList<SymbolicValue> witness, Type allowReturnValueFromCall = default(Type));
+
+        /// <summary>
+        /// Returns an access path for the symbolic value at the given program point.
+        /// The access path returned is preferably rooted in a parameter. If not possible, it is rooted in a local variable.
+        /// For symbolic values that are not reachable from locals/parameters, null is returned. 
+        ///
+        /// The access path may contain dereferences (*), field accesses .f, and Length accesses, as well as array index operations.
+        /// </summary>
+        /// <param name="at">PC at which access path holds</param>
+        /// <param name="value">Value for which we compute an access path</param>
+        /// <returns>null if no access path is found.</returns>
+        [Pure]
+        FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall = default(Type));
+
+        /// <summary>
+        /// Returns all possible access paths at pc to given value.
+        /// </summary>
+        [Pure]
+        IEnumerable<FList<PathElement>> AccessPaths(APC at, SymbolicValue value, AccessPathFilter<Method, Type> filter);
+
+        /// <summary>
+        /// Create an access path to the given value, but only one that is visible from outside the
+        /// method in the pre state given the current method's visibility.
+        /// </summary>
+        /// <returns>null if no access path is found</returns>
+        [Pure]
+        FList<PathElement> VisibleAccessPathListFromPre(APC at, SymbolicValue value);
+
+        /// <summary>
+        /// Create an access path to the given value, but only one that is visible from outside the
+        /// method in the post state given the current method's visibility.
+        /// </summary>
+        /// <returns>null if no access path is found</returns>
+        [Pure]
+        FList<PathElement> VisibleAccessPathListFromPost(APC at, SymbolicValue value, bool allowReturnValue = true);
+
+
+        /// <summary>
+        /// Determines if the given access path at Label at is referring to the same value in the pre-state of the method.
+        /// </summary>
+        /// <param name="at">Label where path is valid</param>
+        /// <param name="path">Path</param>
+        /// <returns>true if same path refers to same value in pre-state of method.</returns>
+        [Pure]
+        bool PathUnmodifiedSinceEntry(APC at, FList<PathElement> path);
+
+        /// <summary>
+        /// Determines if the given access path is suitable as a pre conditions. Implies PathUnmodifiedSinceEntry,
+        /// and additionally filters out unwanted preconditions involving static getters.
+        /// </summary>
+        /// <param name="at">Label where path is valid</param>
+        /// <param name="path">Path</param>
+        [Pure]
+        bool PathSuitableInRequires(APC at, FList<PathElement> path);
+
+        /// <summary>
+        /// Determines if the given access path is suitable as a post conditions. Implies that if the location is not modified,
+        /// and additionally filters out unwanted postconditions involving static getters.
+        /// </summary>
+        /// <param name="at">Label where path is valid</param>
+        /// <param name="path">Path</param>
+        [Pure]
+        bool PathSuitableInEnsures(APC at, FList<PathElement> path, bool allowReturnValue);
+
+        /// <summary>
+        /// If known to be a constant, returns the type and value
+        /// </summary>
+        [Pure]
+        bool IsConstant(APC at, SymbolicValue sv, out Type type, out object value);
+
+        /// <summary>
+        /// Is the first element of the list a parameter?
+        /// </summary>
+        [Pure]
+        bool IsRootedInParameter(FList<PathElement> path);
+
+        /// <summary>
+        /// Is the first element return value?
+        /// </summary>
+        [Pure]
+        bool IsRootedInReturnValue(FList<PathElement> path);
+
+        /// <summary>
+        /// Computes information about how the given symbolic value is accesssible. It computes
+        /// whether any access paths exist where the value was reached from the return value of
+        /// a method call, or the read of an array element.
+        /// </summary>
+        /// <returns>All possible ways the value is accessible</returns>
+        [Pure]
+        PathContextFlags PathContexts(APC at, SymbolicValue value);
+
+        /// <summary>
+        /// Succeeds if the value is the result of a pure method call at that program point.
+        /// </summary>
+        [Pure]
+        bool IsPureFunctionCall(APC at, SymbolicValue value, out Method method, out SymbolicValue[] args);
+
+        /// <summary>
+        /// Returns true if the given symbolic value is a delegate value and the target function is known
+        /// </summary>
+        /// <param name="targetObject">Could be dummy in case of a static method. Don't use it in that case.</param>
+        /// <param name="targetMethod">The target method of the delegate</param>
+        [Pure]
+        bool IsDelegateValue(APC at, SymbolicValue delegateValue, out SymbolicValue targetObject, out Method targetMethod);
+
+        /// <summary>
+        /// For enumerables, attempt to obtain model array
+        /// </summary>
+        [Pure]
+        bool TryGetModelArray(APC at, SymbolicValue enumerable, out SymbolicValue modelArray);
+
+        /// <summary>
+        /// If given an object version id, we want to find the object value, use this method.
+        /// </summary>
+        [Pure]
+        bool TryGetObjectFromObjectVersion(APC at, SymbolicValue objectVersion, out SymbolicValue objectValue);
+
+        /// <summary>
+        /// If given address is the element address of an array, returns the corresponding array and index
+        /// </summary>
+        [Pure]
+        bool TryGetArrayFromElementAddress(APC at, SymbolicValue arrayElementAddress, out SymbolicValue arrayValue, out SymbolicValue index);
+
+        /// <summary>
+        /// Returns the static type corresponding to the given runtime type object if known.
+        /// </summary>
+        [Pure]
+        bool IsRuntimeType(APC at, SymbolicValue runtimeTypeObject, out Type type);
+
+        /// <summary>
+        /// If the given argument is a box, return the contents. This only works if the contents is primitive (not a struct with fields)
+        /// </summary>
+        [Pure]
+        bool TryUnbox(APC at, SymbolicValue box, out SymbolicValue content);
+    }
+
+    #region IValueContextData contract binding
+    [ContractClass(typeof(IValueContextDataContract<,,,,,>))]
+    public partial interface IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>
+      where Type : IEquatable<Type>
+    {
+    }
+
+    [ContractClassFor(typeof(IValueContextData<,,,,,>))]
+    internal abstract class IValueContextDataContract<Local, Parameter, Method, Field, Type, SymbolicValue> : IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>
+      where Type : IEquatable<Type>
+    {
+        #region IValueContextData<Local,Parameter,Method,Field,Type,SymbolicValue> Members
+
+        public bool TryZero(APC at, out SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryNull(APC at, out SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FlatDomain<Type> GetType(APC at, SymbolicValue v)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetArrayLength(APC at, SymbolicValue array, out SymbolicValue length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetWritableBytes(APC at, SymbolicValue pointer, out SymbolicValue writableBytes)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsZero(APC at, SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsValid(SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryStackValue(APC at, StackTemp stackIndex, out SymbolicValue sv)
+        {
+            Contract.Requires(stackIndex >= 0);
+
+            throw new NotImplementedException();
+        }
+
+        public bool TryLocalValue(APC at, Local local, out SymbolicValue sv)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryLocalAddress(APC at, Local local, out SymbolicValue sv)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryParameterValue(APC at, Parameter parameter, out SymbolicValue sv)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryParameterAddress(APC at, Parameter parameter, out SymbolicValue sv)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryFieldAddress(APC at, SymbolicValue objectValue, Field field, out SymbolicValue fieldAddress)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryLoadIndirect(APC at, SymbolicValue address, out SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryResultValue(APC at, out SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string AccessPath(APC at, SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall = default(Type))
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<FList<PathElement>> AccessPaths(APC at, SymbolicValue value, AccessPathFilter<Method, Type> filter)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FList<PathElement> VisibleAccessPathListFromPre(APC at, SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FList<PathElement> VisibleAccessPathListFromPost(APC at, SymbolicValue value, bool allowReturnValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool PathUnmodifiedSinceEntry(APC at, FList<PathElement> path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool PathSuitableInRequires(APC at, FList<PathElement> path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool PathSuitableInEnsures(APC at, FList<PathElement> path, bool allowReturnValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsConstant(APC at, SymbolicValue sv, out Type type, out object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRootedInParameter(FList<PathElement> path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRootedInReturnValue(FList<PathElement> path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public PathContextFlags PathContexts(APC at, SymbolicValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPureFunctionCall(APC at, SymbolicValue value, out Method method, out SymbolicValue[] args)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDelegateValue(APC at, SymbolicValue delegateValue, out SymbolicValue targetObject, out Method targetMethod)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetModelArray(APC at, SymbolicValue enumerable, out SymbolicValue modelArray)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetObjectFromObjectVersion(APC at, SymbolicValue objectVersion, out SymbolicValue objectValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetArrayFromElementAddress(APC at, SymbolicValue arrayElementAddress, out SymbolicValue arrayValue, out SymbolicValue index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRuntimeType(APC at, SymbolicValue runtimeTypeObject, out Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryUnbox(APC at, SymbolicValue box, out SymbolicValue content)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+
+        public FList<PathElement> AccessPathListAndWitness(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, out FList<SymbolicValue> witness, Type allowReturnValueFromCall = default(Type))
+        {
+            Contract.Ensures(Contract.Result<FList<PathElement>>() == null || Contract.ValueAtReturn(out witness) != null);
+            throw new NotImplementedException();
+        }
+    }
+
+    #endregion
+
+    [Flags]
+    public enum PathContextFlags
+    {
+        None = 0,
+        ViaMethodReturn = 1,
+        ViaArray = 2,
+        ViaField = 4,
+        ViaPureMethodReturn = 8,
+        ViaCast = 16,
+        ViaOutParameter = 32,
+        ViaCallThisHavoc = 64,
+        ViaOldValue = 128,
+
+        /// <summary>
+        /// Complete bitmask
+        /// </summary>
+        All = 255,
+    }
+
+    [ContractClass(typeof(IExpressionContextContracts<,,,,,,>))]
+    public interface IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue>
+      : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
+      where Type : IEquatable<Type>
+    {
+        IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> ExpressionContext { get; }
+    }
+
+    #region Contracts
+
+    [ContractClassFor(typeof(IExpressionContext<,,,,,,>))]
+    internal abstract class IExpressionContextContracts<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> : IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue>
     where Type : IEquatable<Type>
-  {
-    IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> ExpressionContext { get; }    
-  }
-
-  #region Contracts
-
-  [ContractClassFor(typeof(IExpressionContext<, , , , , , >))]
-  abstract class IExpressionContextContracts<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> : IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue>
-  where Type : IEquatable<Type>
-  {
-    public IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> ExpressionContext
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue>>() != null);
-   
-        throw new NotImplementedException();
-      }
+        public IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> ExpressionContext
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue>>() != null);
+
+                throw new NotImplementedException();
+            }
+        }
+
+        public IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IStackContextData<Field, Method> StackContext
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IMethodContextData<Field, Method> MethodContext
+        {
+            get { throw new NotImplementedException(); }
+        }
+    }
+    #endregion
+
+    public interface IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue>
+      where Type : IEquatable<Type>
+    {
+        /// <summary>
+        /// Refine a symbolic value into an expression at the given pc.
+        /// </summary>
+        /// <returns>A possible expression representing this value. In the future we might need to return all possible such expressions.</returns>
+        Expression Refine(APC pc, SymbolicValue value);
+
+        /// <summary>
+        /// Return the symbolic value representing this expression
+        /// </summary>
+        /// <returns>The name of the expression expr</returns>
+        SymbolicValue Unrefine(Expression expr);
+
+        /// <summary>
+        /// Decode an expression.
+        /// </summary>
+        Result Decode<Data, Result, Visitor>(Expression expr, Visitor visitor, Data data)
+          where Visitor : IVisitValueExprIL<Expression, Type, Expression, SymbolicValue, Data, Result>;
+
+        /// <summary>
+        /// Get the type of an expression
+        /// </summary>
+        FlatDomain<Type> GetType(Expression expr);
+
+        /// <summary>
+        /// Returns the label at which the expression is captured
+        /// </summary>
+        APC GetPC(Expression expr);
+
+        /// <summary>
+        /// Returns an expression for the symbolic value
+        /// </summary>
+        Expression For(SymbolicValue value);
+
+        /// <summary>
+        /// Returns true if an expression is equivalent to 0, null, (int16)0, (int8)0, etc.
+        /// </summary>
+        bool IsZero(Expression exp);
+
+        /// <summary>
+        /// Returns the array length of the given array or buffer value if known
+        /// </summary>
+        bool TryGetArrayLength(Expression array, out Expression length);
+
+        /// <summary>
+        /// Returns the writable bytes extent of a pointer if known
+        /// </summary>
+        bool TryGetWritableBytes(Expression pointer, out Expression writableBytes);
+    }
+    #endregion
+
+
+    /// <summary>
+    /// Implements an IAnalysis for fixpoint computation along with some extra operations to manipulate the abstract domain values.
+    /// </summary>
+    public interface IAbstractAnalysis<Local, Parameter, Method, Field, Property, Type, Expression, Attribute, Assembly, MyDomain, Variable>
+      : IAnalysis<APC,
+                  MyDomain,
+                  IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Variable, Variable, MyDomain, MyDomain>,
+                  IFunctionalMap<Variable, FList<Variable>>
+                 >
+      where Type : IEquatable<Type>
+    {
+        /// <summary>
+        /// The initial abstract state.
+        /// </summary>
+        MyDomain GetTopValue();
+
+        /// <summary>
+        /// The bottom abstract state.
+        /// </summary>
+        MyDomain GetBottomValue();
+
+        /// <summary>
+        /// Extract facts from the fixpoint  
+        /// </summary>
+        /// <returns></returns>
+        IFactQuery<BoxedExpression, Variable> FactQuery(IFixpointInfo<APC, MyDomain> fixpoint);
     }
 
-    public IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext
+    public interface IFactQuery<Expression, Variable> : IFactBase<Variable>
     {
-      get { throw new NotImplementedException(); }
+        ProofOutcome IsNull(APC pc, Expression expr);
+        ProofOutcome IsNonNull(APC pc, Expression expr);
+
+        ProofOutcome IsTrue(APC pc, Expression condition);
+
+        ProofOutcome IsTrue(APC pc, Question question);
+
+        /// <summary>
+        /// Check if "posAssumptions && negAssumptions ==> goal" at program point pc
+        /// </summary>
+        ProofOutcome IsTrueImply(APC pc, FList<Expression> posAssumptions, FList<Expression> negAssumptions, Expression goal);
+
+        ProofOutcome IsGreaterEqualToZero(APC pc, Expression expr);
+        ProofOutcome IsLessThan(APC pc, Expression left, Expression right);
+        ProofOutcome IsNonZero(APC pc, Expression condition);
+
+        /// <summary>
+        /// Do left and right have the same concrete floating point type?
+        /// </summary>
+        ProofOutcome HaveSameFloatType(APC pc, Expression left, Expression right);
+
+        /// <summary>
+        /// Try to get a definite floating point type for exp
+        /// </summary>
+        bool TryGetFloatType(APC pc, Expression exp, out ConcreteFloat type);
+
+        /// <summary>
+        /// Provide variables that lower-bound the expression numerically
+        /// </summary>
+        IEnumerable<Variable> LowerBounds(APC pc, Expression exp, bool strict);
+
+        /// <summary>
+        /// Provide variables that upper-bound the expression numerically
+        /// </summary>
+        IEnumerable<Variable> UpperBounds(APC pc, Expression exp, bool strict);
+
+        /// <summary>
+        /// Provide expressions that lower-bound the expression numerically
+        /// </summary>
+        IEnumerable<Expression> LowerBoundsAsExpressions(APC pc, Expression exp, bool strict);
+
+        /// <summary>
+        /// Provide expressions that upper-bound the expression numerically
+        /// </summary>
+        IEnumerable<Expression> UpperBoundsAsExpressions(APC pc, Expression exp, bool strict);
+
+        /// <summary>
+        /// An interval for the expression <code>exp</code> at program point pc
+        /// </summary>
+        Pair<long, long> BoundsFor(APC pc, Expression exp);
+
+        ProofOutcome IsVariableDefinedForType(APC pc, Variable v, object type);
     }
 
-    public IStackContextData<Field, Method> StackContext
+    public interface IFactQueryForOverflow<Expression>
     {
-      get { throw new NotImplementedException(); }
+        bool CanOverflow(APC pc, Expression exp);
+        bool CanUnderflow(APC pc, Expression exp);
     }
 
-    public IMethodContextData<Field, Method> MethodContext
+    public delegate IEnumerable<IFixpointInfo<Label, AState>> FixpointEnum<Label, AState>();
+
+    public interface IFact
     {
-      get { throw new NotImplementedException(); }
-    }
-  }
-  #endregion
-
-  public interface IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> 
-    where Type:IEquatable<Type>
-  {
-    /// <summary>
-    /// Refine a symbolic value into an expression at the given pc.
-    /// </summary>
-    /// <returns>A possible expression representing this value. In the future we might need to return all possible such expressions.</returns>
-    Expression Refine(APC pc, SymbolicValue value);
-
-    /// <summary>
-    /// Return the symbolic value representing this expression
-    /// </summary>
-    /// <returns>The name of the expression expr</returns>
-    SymbolicValue Unrefine(Expression expr);
-
-    /// <summary>
-    /// Decode an expression.
-    /// </summary>
-    Result Decode<Data, Result, Visitor>(Expression expr, Visitor visitor, Data data)
-      where Visitor : IVisitValueExprIL<Expression, Type, Expression, SymbolicValue, Data, Result>;
-
-    /// <summary>
-    /// Get the type of an expression
-    /// </summary>
-    FlatDomain<Type> GetType(Expression expr);
-
-    /// <summary>
-    /// Returns the label at which the expression is captured
-    /// </summary>
-    APC GetPC(Expression expr);
-
-    /// <summary>
-    /// Returns an expression for the symbolic value
-    /// </summary>
-    Expression For(SymbolicValue value);
-
-    /// <summary>
-    /// Returns true if an expression is equivalent to 0, null, (int16)0, (int8)0, etc.
-    /// </summary>
-    bool IsZero(Expression exp);
-
-    /// <summary>
-    /// Returns the array length of the given array or buffer value if known
-    /// </summary>
-    bool TryGetArrayLength(Expression array, out Expression length);
-
-    /// <summary>
-    /// Returns the writable bytes extent of a pointer if known
-    /// </summary>
-    bool TryGetWritableBytes(Expression pointer, out Expression writableBytes);
-
-  }
-  #endregion
-
-  
-  /// <summary>
-  /// Implements an IAnalysis for fixpoint computation along with some extra operations to manipulate the abstract domain values.
-  /// </summary>
-  public interface IAbstractAnalysis<Local, Parameter, Method, Field, Property, Type, Expression, Attribute, Assembly, MyDomain, Variable>
-    : IAnalysis<APC, 
-                MyDomain, 
-                IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Variable, Variable, MyDomain, MyDomain>,
-                IFunctionalMap<Variable,FList<Variable>>
-               >
-    where Type : IEquatable<Type>
-  {
-    /// <summary>
-    /// The initial abstract state.
-    /// </summary>
-    MyDomain GetTopValue();
-
-    /// <summary>
-    /// The bottom abstract state.
-    /// </summary>
-    MyDomain GetBottomValue();
-
-    /// <summary>
-    /// Extract facts from the fixpoint  
-    /// </summary>
-    /// <returns></returns>
-    IFactQuery<BoxedExpression, Variable> FactQuery(IFixpointInfo<APC, MyDomain> fixpoint);
-
-  }
-
-  public interface IFactQuery<Expression, Variable> : IFactBase<Variable>
-  {
-    ProofOutcome IsNull(APC pc, Expression expr);
-    ProofOutcome IsNonNull(APC pc, Expression expr);
-
-    ProofOutcome IsTrue(APC pc, Expression condition);
-
-    ProofOutcome IsTrue(APC pc, Question question);
-
-    /// <summary>
-    /// Check if "posAssumptions && negAssumptions ==> goal" at program point pc
-    /// </summary>
-    ProofOutcome IsTrueImply(APC pc, FList<Expression> posAssumptions, FList<Expression> negAssumptions, Expression goal);
-
-    ProofOutcome IsGreaterEqualToZero(APC pc, Expression expr);
-    ProofOutcome IsLessThan(APC pc, Expression left, Expression right);
-    ProofOutcome IsNonZero(APC pc, Expression condition);
-
-    /// <summary>
-    /// Do left and right have the same concrete floating point type?
-    /// </summary>
-    ProofOutcome HaveSameFloatType(APC pc, Expression left, Expression right);
-
-    /// <summary>
-    /// Try to get a definite floating point type for exp
-    /// </summary>
-    bool TryGetFloatType(APC pc, Expression exp, out ConcreteFloat type);
-
-    /// <summary>
-    /// Provide variables that lower-bound the expression numerically
-    /// </summary>
-    IEnumerable<Variable> LowerBounds(APC pc, Expression exp, bool strict);
-
-    /// <summary>
-    /// Provide variables that upper-bound the expression numerically
-    /// </summary>
-    IEnumerable<Variable> UpperBounds(APC pc, Expression exp, bool strict);
-
-    /// <summary>
-    /// Provide expressions that lower-bound the expression numerically
-    /// </summary>
-    IEnumerable<Expression> LowerBoundsAsExpressions(APC pc, Expression exp, bool strict);
-
-    /// <summary>
-    /// Provide expressions that upper-bound the expression numerically
-    /// </summary>
-    IEnumerable<Expression> UpperBoundsAsExpressions(APC pc, Expression exp, bool strict);
-
-    /// <summary>
-    /// An interval for the expression <code>exp</code> at program point pc
-    /// </summary>
-    Pair<long, long> BoundsFor(APC pc, Expression exp);
-
-    ProofOutcome IsVariableDefinedForType(APC pc, Variable v, object type);
-
-   }
-
-  public interface IFactQueryForOverflow<Expression>
-  {
-    bool CanOverflow(APC pc, Expression exp);
-    bool CanUnderflow(APC pc, Expression exp);
-  }
-
-  public delegate IEnumerable<IFixpointInfo<Label,AState>> FixpointEnum<Label,AState>();
-
-  public interface IFact
-  {
-  }
-
-  public interface IFactBase<Variable> : IFact
-  {
-    ProofOutcome IsNull(APC pc, Variable value);
-    ProofOutcome IsNonNull(APC pc, Variable value);
-
-    /// <summary>
-    /// Returns true if the pc is definitely unreachable.
-    /// </summary>
-    bool IsUnreachable(APC pc);
-
-    FList<BoxedExpression> InvariantAt(APC pc, FList<Variable> variables = null, bool replaceVarsWithAccessPaths = true);
-  }
-
-  public class Question
-  {
-    public class IsPureArray<Variable> 
-      : Question
-    {
-      public readonly Variable array;
-
-      public IsPureArray(Variable var)
-      {
-        this.array = var;
-      }
-    }
-  }
-
-  public class QuestionVisitor<Variable, Expression>
-  {
-    public ProofOutcome Visit(Question q)
-    {
-      var pureArray = q as Question.IsPureArray<Variable>;
-      if(pureArray != null)
-      {
-        return VisitIsPureArray(pureArray.array);
-      }
-
-      return ProofOutcome.Top;
     }
 
-    virtual protected ProofOutcome VisitIsPureArray(Variable array)
+    public interface IFactBase<Variable> : IFact
     {
-      return ProofOutcome.Top;
+        ProofOutcome IsNull(APC pc, Variable value);
+        ProofOutcome IsNonNull(APC pc, Variable value);
+
+        /// <summary>
+        /// Returns true if the pc is definitely unreachable.
+        /// </summary>
+        bool IsUnreachable(APC pc);
+
+        FList<BoxedExpression> InvariantAt(APC pc, FList<Variable> variables = null, bool replaceVarsWithAccessPaths = true);
     }
-  }
+
+    public class Question
+    {
+        public class IsPureArray<Variable>
+          : Question
+        {
+            public readonly Variable array;
+
+            public IsPureArray(Variable var)
+            {
+                this.array = var;
+            }
+        }
+    }
+
+    public class QuestionVisitor<Variable, Expression>
+    {
+        public ProofOutcome Visit(Question q)
+        {
+            var pureArray = q as Question.IsPureArray<Variable>;
+            if (pureArray != null)
+            {
+                return VisitIsPureArray(pureArray.array);
+            }
+
+            return ProofOutcome.Top;
+        }
+
+        virtual protected ProofOutcome VisitIsPureArray(Variable array)
+        {
+            return ProofOutcome.Top;
+        }
+    }
 }
 

--- a/Microsoft.Research/CodeAnalysis/BasicMethodDriver.cs
+++ b/Microsoft.Research/CodeAnalysis/BasicMethodDriver.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,344 +9,343 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using Provenance = IEnumerable<ProofObligation>;
-  using StackTemp = System.Int32;
+    using Provenance = IEnumerable<ProofObligation>;
+    using StackTemp = System.Int32;
 
-  class BasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    : IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-
-    #region Object invariant
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
+    internal class BasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      : IBasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-      Contract.Invariant(this.parent != null);
-    }
-
-    #endregion
-
-    private readonly ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> rawLayer;
-    private readonly ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> stackLayer;
-    protected readonly IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> parent;
-    protected readonly Method method;
-
-    private ICFG contractFreeCFG; // computed on demand
-
-    protected BasicMethodDriver(
-      Method method,
-      IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> parent
-    )
-    {
-      Contract.Requires(parent != null);
-
-      this.method = method;
-      this.parent = parent;
-      var rawCFG = this.parent.MethodCache.GetCFG(method);
-
-      // Here we build our stack of adapters.
-      //
-      //  StackDepth    (Temp decoder for APC)
-      //  CFG           (Unit decoder for APC, including Assume)
-      //  cciilprovider (Unit decoder for PC)
-      //
-
-      this.rawLayer = CodeLayerFactory.Create(
-        rawCFG.GetDecoder(parent.MetaDataDecoder),
-        parent.MetaDataDecoder,
-        parent.ContractDecoder,
-        (unit) => "",
-        (unit) => "",
-        (v1, v2) => false);
-
-      if (PrintIL)
-      {
-        Console.WriteLine("-----------------APC based CFG---------------------");
-        this.RawLayer.Decoder.AssumeNotNull().Context.MethodContext.CFG.Print(Console.Out, this.RawLayer.Printer, null, null, null);
-      }
-
-      this.stackLayer = CodeLayerFactory.Create(
-          StackDepthFactory.Create(
-            this.RawLayer.Decoder,
-            this.RawLayer.MetaDataDecoder),
-          this.RawLayer.MetaDataDecoder,
-          this.RawLayer.ContractDecoder,
-          delegate(int i) { return "s" + i.ToString(); },
-          delegate(int i) { return "s" + i.ToString(); },
-          (s1, s2) => false
-          );
-
-      if (PrintIL)
-      {
-        Console.WriteLine("-----------------Stack based CFG---------------------");
-        this.StackLayer.Decoder.AssumeNotNull().Context.MethodContext.CFG.Print(Console.Out, StackLayer.Printer, null, null, null);
-      }
-
-      // set static wp tracing option
-      WeakestPreconditionProver.Trace = parent.Options.TraceWP;
-      WeakestPreconditionProver.EmitSMT2Formula = parent.Options.EmitSMT2Formula;
-    }
-
-    public SyntacticComplexity SyntacticComplexity { get; set; }
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> RawLayer { get { return this.rawLayer; } }
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> StackLayer { get { return this.stackLayer; } }
-
-    private ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> contractFreeRawLayer;
-
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> ContractFreeRawLayer
-    {
-      get
-      {
-        if (this.contractFreeRawLayer == null)
+        #region Object invariant
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
         {
-          this.contractFreeRawLayer =
-            CodeLayerFactory.Create(
-              ContractFreeCFG.GetDecoder(parent.MetaDataDecoder),
-              RawLayer.MetaDataDecoder,
-              RawLayer.ContractDecoder,
-              RawLayer.ExpressionToString,
-              RawLayer.VariableToString,
-              RawLayer.Printer,
-              RawLayer.NewerThan);
+            Contract.Invariant(this.parent != null);
         }
-        return this.contractFreeRawLayer;
-      }
 
-    }
+        #endregion
 
-    private ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> contractFreeStackLayer;
+        private readonly ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> rawLayer;
+        private readonly ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> stackLayer;
+        protected readonly IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> parent;
+        protected readonly Method method;
 
-    public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> ContractFreeStackLayer
-    {
-      get
-      {
-        if (this.contractFreeStackLayer == null)
+        private ICFG contractFreeCFG; // computed on demand
+
+        protected BasicMethodDriver(
+          Method method,
+          IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> parent
+        )
         {
-          this.contractFreeStackLayer = CodeLayerFactory.Create(
-            StackDepthFactory.Create(
-              this.ContractFreeRawLayer.Decoder,
-              this.ContractFreeRawLayer.MetaDataDecoder),
-            this.ContractFreeRawLayer.MetaDataDecoder,
-            this.ContractFreeRawLayer.ContractDecoder,
-            this.StackLayer.ExpressionToString,
-            this.StackLayer.VariableToString,
-            this.StackLayer.Printer,
-            this.StackLayer.NewerThan);
-        }
-        return this.contractFreeStackLayer;
-      }
-    }
+            Contract.Requires(parent != null);
 
-    protected bool PrintIL { get { return this.parent.Options.PrintIL; } }
+            this.method = method;
+            this.parent = parent;
+            var rawCFG = this.parent.MethodCache.GetCFG(method);
+
+            // Here we build our stack of adapters.
+            //
+            //  StackDepth    (Temp decoder for APC)
+            //  CFG           (Unit decoder for APC, including Assume)
+            //  cciilprovider (Unit decoder for PC)
+            //
+
+            rawLayer = CodeLayerFactory.Create(
+              rawCFG.GetDecoder(parent.MetaDataDecoder),
+              parent.MetaDataDecoder,
+              parent.ContractDecoder,
+              (unit) => "",
+              (unit) => "",
+              (v1, v2) => false);
+
+            if (PrintIL)
+            {
+                Console.WriteLine("-----------------APC based CFG---------------------");
+                this.RawLayer.Decoder.AssumeNotNull().Context.MethodContext.CFG.Print(Console.Out, this.RawLayer.Printer, null, null, null);
+            }
+
+            stackLayer = CodeLayerFactory.Create(
+                StackDepthFactory.Create(
+                  this.RawLayer.Decoder,
+                  this.RawLayer.MetaDataDecoder),
+                this.RawLayer.MetaDataDecoder,
+                this.RawLayer.ContractDecoder,
+                delegate (int i) { return "s" + i.ToString(); },
+                delegate (int i) { return "s" + i.ToString(); },
+                (s1, s2) => false
+                );
+
+            if (PrintIL)
+            {
+                Console.WriteLine("-----------------Stack based CFG---------------------");
+                this.StackLayer.Decoder.AssumeNotNull().Context.MethodContext.CFG.Print(Console.Out, StackLayer.Printer, null, null, null);
+            }
+
+            // set static wp tracing option
+            WeakestPreconditionProver.Trace = parent.Options.TraceWP;
+            WeakestPreconditionProver.EmitSMT2Formula = parent.Options.EmitSMT2Formula;
+        }
+
+        public SyntacticComplexity SyntacticComplexity { get; set; }
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> RawLayer { get { return rawLayer; } }
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> StackLayer { get { return stackLayer; } }
+
+        private ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> contractFreeRawLayer;
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Unit, Unit, IMethodContext<Field, Method>, Unit> ContractFreeRawLayer
+        {
+            get
+            {
+                if (contractFreeRawLayer == null)
+                {
+                    contractFreeRawLayer =
+                      CodeLayerFactory.Create(
+                        ContractFreeCFG.GetDecoder(parent.MetaDataDecoder),
+                        RawLayer.MetaDataDecoder,
+                        RawLayer.ContractDecoder,
+                        RawLayer.ExpressionToString,
+                        RawLayer.VariableToString,
+                        RawLayer.Printer,
+                        RawLayer.NewerThan);
+                }
+                return contractFreeRawLayer;
+            }
+        }
+
+        private ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> contractFreeStackLayer;
+
+        public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, StackTemp, StackTemp, IStackContext<Field, Method>, Unit> ContractFreeStackLayer
+        {
+            get
+            {
+                if (contractFreeStackLayer == null)
+                {
+                    contractFreeStackLayer = CodeLayerFactory.Create(
+                      StackDepthFactory.Create(
+                        this.ContractFreeRawLayer.Decoder,
+                        this.ContractFreeRawLayer.MetaDataDecoder),
+                      this.ContractFreeRawLayer.MetaDataDecoder,
+                      this.ContractFreeRawLayer.ContractDecoder,
+                      this.StackLayer.ExpressionToString,
+                      this.StackLayer.VariableToString,
+                      this.StackLayer.Printer,
+                      this.StackLayer.NewerThan);
+                }
+                return contractFreeStackLayer;
+            }
+        }
+
+        protected bool PrintIL { get { return this.parent.Options.PrintIL; } }
 
 #if false
-      public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, IStackContext<Field, Method>> StackDecoder
-      {
-        get { return stackDecoder; }
-      }
+        public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, IStackContext<Field, Method>> StackDecoder
+        {
+            get { return stackDecoder; }
+        }
 
-      public Func<AState, IFixpointInfo<APC,AState>> CreateForward<AState>(IAnalysisDriver<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, AState, AState>, IMethodContext<Field, Method>> analysis)
-      {
-        var solver = ForwardAnalysisSolver<AState, Type>.Make(apcDecoder, analysis, apcRawPrinter);
-        solver.Trace = this.parent.Options.TraceDFA;
-        solver.TraceTimePerInstruction = this.parent.Options.TraceTimings;
+        public Func<AState, IFixpointInfo<APC, AState>> CreateForward<AState>(IAnalysisDriver<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, AState, AState>, IMethodContext<Field, Method>> analysis)
+        {
+            var solver = ForwardAnalysisSolver<AState, Type>.Make(apcDecoder, analysis, apcRawPrinter);
+            solver.Trace = this.parent.Options.TraceDFA;
+            solver.TraceTimePerInstruction = this.parent.Options.TraceTimings;
 
-        return (initialState) => { solver.Run(initialState); return solver; };
-      }
+            return (initialState) => { solver.Run(initialState); return solver; };
+        }
 
-      public Func<AState, IFixpointInfo<APC,AState>> CreateForward<AState>(IAnalysisDriver<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, AState, AState>, IStackContext<Field, Method>> analysis)
-      {
-        var solver = ForwardAnalysisSolver<AState, Type>.Make(stackDecoder, analysis, apcStackPrinter);
-        solver.Trace = this.parent.Options.TraceDFA;
-        return (initialState) => { solver.Run(initialState); return solver; };
-      }
+        public Func<AState, IFixpointInfo<APC, AState>> CreateForward<AState>(IAnalysisDriver<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, AState, AState>, IStackContext<Field, Method>> analysis)
+        {
+            var solver = ForwardAnalysisSolver<AState, Type>.Make(stackDecoder, analysis, apcStackPrinter);
+            solver.Trace = this.parent.Options.TraceDFA;
+            return (initialState) => { solver.Run(initialState); return solver; };
+        }
 
-      public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get { return this.parent.MetaDataDecoder; } }
+        public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get { return this.parent.MetaDataDecoder; } }
 #endif
 
-    public LogOptions Options { get { return this.parent.Options; } }
+        public LogOptions Options { get { return this.parent.Options; } }
 
-    public ICFG ContractFreeCFG
-    {
-      get
-      {
-
-        if (this.contractFreeCFG == null)
+        public ICFG ContractFreeCFG
         {
-          var decoder = this.RawLayer.Decoder;
-          Contract.Assert(decoder != null);
-          this.contractFreeCFG = new ContractFilteredCFG(decoder.Context.MethodContext.CFG);
-          if (PrintIL)
-          {
-            Console.WriteLine("-----------------raw contract-free CFG---------------------");
-            this.contractFreeCFG.Print(Console.Out, this.RawLayer.Printer, null, null, null);
-
-            var loopInfo = LoopAnalysis.ComputeContainingLoopMap(this.contractFreeCFG);
-            Console.WriteLine("  --- loop info ---");
-            foreach (var block in loopInfo.Keys)
+            get
             {
-              Console.Write("  Block {0}.{1} is inside loop heads ", block.Subroutine.Id, block.Index);
-              var loops = loopInfo[block].AssumeNotNull();
-              foreach (var loophead in loops)
-              {
-                Console.Write("{0}.{1} ", loophead.Subroutine.Id, loophead.Index);
-              }
-              Console.WriteLine();
+                if (contractFreeCFG == null)
+                {
+                    var decoder = this.RawLayer.Decoder;
+                    Contract.Assert(decoder != null);
+                    contractFreeCFG = new ContractFilteredCFG(decoder.Context.MethodContext.CFG);
+                    if (PrintIL)
+                    {
+                        Console.WriteLine("-----------------raw contract-free CFG---------------------");
+                        contractFreeCFG.Print(Console.Out, this.RawLayer.Printer, null, null, null);
+
+                        var loopInfo = LoopAnalysis.ComputeContainingLoopMap(contractFreeCFG);
+                        Console.WriteLine("  --- loop info ---");
+                        foreach (var block in loopInfo.Keys)
+                        {
+                            Console.Write("  Block {0}.{1} is inside loop heads ", block.Subroutine.Id, block.Index);
+                            var loops = loopInfo[block].AssumeNotNull();
+                            foreach (var loophead in loops)
+                            {
+                                Console.Write("{0}.{1} ", loophead.Subroutine.Id, loophead.Index);
+                            }
+                            Console.WriteLine();
+                        }
+                    }
+                }
+                return contractFreeCFG;
             }
-          }
         }
-        return this.contractFreeCFG;
-      }
+
+        public IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> AnalysisDriver
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+
+        public ICFG CFG
+        {
+            [ContractVerification(false)]
+            get
+            { return this.StackLayer.Decoder.Context.AssumeNotNull().MethodContext.CFG; }
+        }
+
+        public Method CurrentMethod { get { return this.method; } }
     }
 
-    public IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> AnalysisDriver
+    internal abstract class BasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      : BasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>,
+        IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-      get
-      {
-        return this.parent;
-      }
+        protected BasicMethodDriverWithInference(
+            Method method,
+            IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> parent
+          )
+          : base(method, parent)
+        { }
+
+        public abstract bool CanAddRequires();
+        public abstract bool CanAddEnsures();
+        protected abstract bool CanAddInvariants();
+        protected abstract bool CanAddAssumes();
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inferredPreconditions != null);
+            Contract.Invariant(inferredPostconditions != null);
+            Contract.Invariant(inferredObjectInvariants != null);
+            Contract.Invariant(inferredCalleeAssumes != null);
+            Contract.Invariant(inferredEntryAssumes != null);
+        }
+
+        protected readonly List<BoxedExpression.AssumeExpression> inferredPreconditions = new List<BoxedExpression.AssumeExpression>();
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPreConditions { get { return this.inferredPreconditions.Select(assert => Pair.For(assert.Condition, assert.Provenance)); } }
+
+        public bool AddPreCondition(BoxedExpression boxedExpression, APC apc, Provenance provenance)
+        {
+            if (!this.CanAddRequires())
+            {
+                this.AddEntryAssume(boxedExpression, provenance); // record it as assume instead
+                return false;
+            }
+            var pre = new BoxedExpression.AssumeExpression(boxedExpression, "requires", apc, provenance, boxedExpression.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.AnalysisDriver.MetaDataDecoder, type)));
+            this.inferredPreconditions.Add(pre);
+            return true;
+        }
+
+        protected readonly List<BoxedExpression.AssertExpression> inferredPostconditions = new List<BoxedExpression.AssertExpression>();
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPostConditions { get { return this.inferredPostconditions.Select(assert => Pair.For(assert.Condition, assert.Provenance)); } }
+
+        public bool AddPostCondition(BoxedExpression postcondition, APC pc, Provenance provenance)
+        {
+            if (!this.CanAddEnsures())
+            {
+                return false;
+            }
+            var post = new BoxedExpression.AssertExpression(postcondition, "ensures", pc, provenance, null);
+            this.inferredPostconditions.Add(post);
+            return true;
+        }
+
+        protected List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> otherPostconditions;
+        public bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> postconditions)
+        {
+            if (postconditions == null)
+            {
+                return false;
+            }
+
+            if (otherPostconditions == null)
+            {
+                otherPostconditions = postconditions;
+            }
+            else
+            {
+                otherPostconditions.AddRange(postconditions);
+            }
+
+            return true;
+        }
+
+        public bool MayReturnNull { get; set; }
+
+        // We do not box object invariants into Contract.Invariant because we want to use them as postconditions of constructors
+        protected readonly List<Pair<BoxedExpression, Provenance>> inferredEntryAssumes = new List<Pair<BoxedExpression, Provenance>>();
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredEntryAssumes { get { return this.inferredEntryAssumes; } }
+
+        // We do not box object invariants into Contract.Invariant because we want to use them as postconditions of constructors
+        protected readonly List<Pair<BoxedExpression, Provenance>> inferredObjectInvariants = new List<Pair<BoxedExpression, Provenance>>();
+
+        public IEnumerable<Pair<BoxedExpression, Provenance>> InferredObjectInvariants { get { return this.inferredObjectInvariants; } }
+
+        public bool AddObjectInvariant(BoxedExpression objinv, Provenance provenance)
+        {
+            if (!this.CanAddInvariants())
+            {
+                this.AddEntryAssume(objinv, provenance); // record as assume instead
+                return false;
+            }
+            this.inferredObjectInvariants.Add(new Pair<BoxedExpression, Provenance>(objinv, provenance));
+            return true;
+        }
+
+        protected readonly List<Pair<BoxedExpression.AssumeExpression, Method>> inferredCalleeAssumes = new List<Pair<BoxedExpression.AssumeExpression, Method>>();
+
+        public IEnumerable<STuple<BoxedExpression, Provenance, Method>> InferredCalleeAssumes { get { return this.inferredCalleeAssumes.Select(p => STuple.For(p.One.Condition, p.One.Provenance, p.Two)); } }
+
+        public bool AddCalleeAssume(BoxedExpression assumeExpression, object callee, APC apc, Provenance provenance)
+        {
+            Contract.Assume(callee != null);
+
+            if (!this.CanAddAssumes())
+            {
+                return false;
+            }
+            // TODO: collect context info
+            var assume = new BoxedExpression.AssumeExpression(assumeExpression, "assume", apc, provenance, assumeExpression.ToString());
+            //var assumePostCond = new BoxedExpression.AssumeAsPostConditionExpression(assumeExpression, null, callee, calleeName, "assume", apc, provenance);
+            //var assume = new BoxedExpression.AssumeExpression(boxedExpression, "assume", apc, provenance);
+            this.inferredCalleeAssumes.Add(Pair.For(assume, (Method)callee));
+            return true;
+        }
+
+        public bool AddEntryAssume(BoxedExpression assumeExpression, Provenance provenance)
+        {
+            if (!this.CanAddAssumes())
+            {
+                return false;
+            }
+            this.inferredEntryAssumes.Add(new Pair<BoxedExpression, Provenance>(assumeExpression, provenance));
+            return true;
+        }
     }
-
-    public ICFG CFG { 
-      [ContractVerification(false)]
-      get { return this.StackLayer.Decoder.Context.AssumeNotNull().MethodContext.CFG; } }
-
-    public Method CurrentMethod { get { return this.method; } }
-  }
-
-  abstract class BasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    : BasicMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>,
-      IBasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    protected BasicMethodDriverWithInference(
-        Method method,
-        IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> parent
-      )
-      : base(method, parent)
-    { }
-
-    public abstract bool CanAddRequires();
-    public abstract bool CanAddEnsures();
-    protected abstract bool CanAddInvariants();
-    protected abstract bool CanAddAssumes();
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(inferredPreconditions != null);
-      Contract.Invariant(inferredPostconditions != null);
-      Contract.Invariant(inferredObjectInvariants != null);
-      Contract.Invariant(inferredCalleeAssumes != null);
-      Contract.Invariant(inferredEntryAssumes != null);
-    }
-
-    protected readonly List<BoxedExpression.AssumeExpression> inferredPreconditions = new List<BoxedExpression.AssumeExpression>();
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPreConditions { get { return this.inferredPreconditions.Select(assert => Pair.For(assert.Condition, assert.Provenance)); } }
-
-    public bool AddPreCondition(BoxedExpression boxedExpression, APC apc, Provenance provenance)
-    {
-      if (!this.CanAddRequires())
-      {
-        this.AddEntryAssume(boxedExpression, provenance); // record it as assume instead
-        return false;
-      }
-      var pre = new BoxedExpression.AssumeExpression(boxedExpression, "requires", apc, provenance, boxedExpression.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.AnalysisDriver.MetaDataDecoder, type)));
-      this.inferredPreconditions.Add(pre);
-      return true;
-    }
-
-    protected readonly List<BoxedExpression.AssertExpression> inferredPostconditions = new List<BoxedExpression.AssertExpression>();
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredPostConditions { get { return this.inferredPostconditions.Select(assert => Pair.For(assert.Condition, assert.Provenance)); } }
-
-    public bool AddPostCondition(BoxedExpression postcondition, APC pc, Provenance provenance)
-    {
-      if (!this.CanAddEnsures())
-      {
-        return false;
-      }
-      var post = new BoxedExpression.AssertExpression(postcondition, "ensures", pc, provenance, null);
-      this.inferredPostconditions.Add(post);
-      return true;
-    }
-
-    protected List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> otherPostconditions;
-    public bool AddPostConditionsForAutoProperties(List<Tuple<Method, BoxedExpression.AssertExpression, Provenance>> postconditions)
-    {
-      if(postconditions == null)
-      {
-        return false;
-      }
-
-      if (otherPostconditions == null)
-      {
-        otherPostconditions = postconditions;
-      }
-      else
-      {
-        otherPostconditions.AddRange(postconditions);
-      }
-
-      return true;
-    }
-
-    public bool MayReturnNull { get; set; }
-
-    // We do not box object invariants into Contract.Invariant because we want to use them as postconditions of constructors
-    protected readonly List<Pair<BoxedExpression, Provenance>> inferredEntryAssumes = new List<Pair<BoxedExpression, Provenance>>();
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredEntryAssumes { get { return this.inferredEntryAssumes; } }
-
-    // We do not box object invariants into Contract.Invariant because we want to use them as postconditions of constructors
-    protected readonly List<Pair<BoxedExpression, Provenance>> inferredObjectInvariants = new List<Pair<BoxedExpression, Provenance>>();
-
-    public IEnumerable<Pair<BoxedExpression, Provenance>> InferredObjectInvariants { get { return this.inferredObjectInvariants; } }
-
-    public bool AddObjectInvariant(BoxedExpression objinv, Provenance provenance)
-    {
-      if (!this.CanAddInvariants())
-      {
-        this.AddEntryAssume(objinv, provenance); // record as assume instead
-        return false;
-      }
-      this.inferredObjectInvariants.Add(new Pair<BoxedExpression, Provenance>(objinv, provenance));
-      return true;
-    }
-
-    protected readonly List<Pair<BoxedExpression.AssumeExpression, Method>> inferredCalleeAssumes = new List<Pair<BoxedExpression.AssumeExpression, Method>>();
-
-    public IEnumerable<STuple<BoxedExpression, Provenance, Method>> InferredCalleeAssumes { get { return this.inferredCalleeAssumes.Select(p => STuple.For(p.One.Condition, p.One.Provenance, p.Two)); } }
-
-    public bool AddCalleeAssume(BoxedExpression assumeExpression, object callee, APC apc, Provenance provenance)
-    {
-      Contract.Assume(callee != null);
-
-      if (!this.CanAddAssumes())
-      {
-        return false;
-      }
-      // TODO: collect context info
-      var assume = new BoxedExpression.AssumeExpression(assumeExpression, "assume", apc, provenance, assumeExpression.ToString());
-      //var assumePostCond = new BoxedExpression.AssumeAsPostConditionExpression(assumeExpression, null, callee, calleeName, "assume", apc, provenance);
-      //var assume = new BoxedExpression.AssumeExpression(boxedExpression, "assume", apc, provenance);
-      this.inferredCalleeAssumes.Add(Pair.For(assume, (Method)callee));
-      return true;
-    }
-
-    public bool AddEntryAssume(BoxedExpression assumeExpression, Provenance provenance)
-    {
-      if (!this.CanAddAssumes())
-      {
-        return false;
-      }
-      this.inferredEntryAssumes.Add(new Pair<BoxedExpression, Provenance>(assumeExpression, provenance));
-      return true;
-    }
-
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Benigni.cs
+++ b/Microsoft.Research/CodeAnalysis/Benigni.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if false
 using System;
@@ -22,923 +11,923 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  class BenigniMain
-  {
-    internal const string BLOCKPREFIX = "b";
-    internal const string SEPPARAM = ", ";
-    internal const string TRANS = " -> ";
-    internal const string EMPTY = " ";
-    internal const string INITIAL = "(INITIAL {0})";
-    internal const string VARS = "(VAR {0})";
-    internal const string BEGIN_RULES = "(RULES ";
-    internal const string END_RULES = ")";
-
-    public static void EmitTheEquations(EquationBlock entryPoint, List<EquationBlock> equations, TextWriter where, InvariantQuery<APC>  invariantDB)
+    class BenigniMain
     {
-      Set<string> vars = new Set<string>();
-      foreach(EquationBlock b in equations)
-      {
-        vars.AddRange(b.FormalParameters);
-      }
-      List<string> allVars = new List<string>(vars);
-      allVars.Sort();
+        internal const string BLOCKPREFIX = "b";
+        internal const string SEPPARAM = ", ";
+        internal const string TRANS = " -> ";
+        internal const string EMPTY = " ";
+        internal const string INITIAL = "(INITIAL {0})";
+        internal const string VARS = "(VAR {0})";
+        internal const string BEGIN_RULES = "(RULES ";
+        internal const string END_RULES = ")";
 
-      where.WriteLine(Vars(allVars));
+        public static void EmitTheEquations(EquationBlock entryPoint, List<EquationBlock> equations, TextWriter where, InvariantQuery<APC> invariantDB)
+        {
+            Set<string> vars = new Set<string>();
+            foreach (EquationBlock b in equations)
+            {
+                vars.AddRange(b.FormalParameters);
+            }
+            List<string> allVars = new List<string>(vars);
+            allVars.Sort();
 
-      where.WriteLine(Initial(entryPoint));
-      
+            where.WriteLine(Vars(allVars));
 
-      where.WriteLine(BEGIN_RULES);
-      foreach (EquationBlock b in equations)
-      {
-        b.EmitEquations(where, invariantDB);
-      }
-      where.WriteLine(END_RULES);
+            where.WriteLine(Initial(entryPoint));
+
+
+            where.WriteLine(BEGIN_RULES);
+            foreach (EquationBlock b in equations)
+            {
+                b.EmitEquations(where, invariantDB);
+            }
+            where.WriteLine(END_RULES);
+        }
+
+        private static string Initial(EquationBlock entry)
+        {
+            return SanitizeString(String.Format(INITIAL, entry.Head()));
+        }
+
+        private static string Vars(List<string> vars)
+        {
+            return SanitizeString(String.Format(VARS, FormalParametersAsString(vars)));
+        }
+
+        public static string FormalParametersAsString(List<string> listOfVariables)
+        {
+            StringBuilder tmp = new StringBuilder();
+
+            foreach (string p in listOfVariables)
+            {
+                tmp.Append(p + SEPPARAM);
+            }
+
+            if (tmp.Length > SEPPARAM.Length)
+            {
+                tmp.Remove(tmp.Length - SEPPARAM.Length, SEPPARAM.Length);  // remove the last ", "
+            }
+            else
+            {
+                tmp.Append(BenigniMain.EMPTY);
+            }
+
+            return tmp.ToString();
+        }
+        /// <summary>
+        /// Replace "svXXX (YYY)" with "svXXX_(YYY)"
+        /// </summary>
+        public static string SanitizeString(string s)
+        {
+            char[] sAsChar = s.ToCharArray();
+            char[] result = new char[sAsChar.Length];
+
+            for (int i = 0, j = 0; i < sAsChar.Length;)
+            {
+                if (i < sAsChar.Length - 1 && sAsChar[i] == 's' && sAsChar[i + 1] == 'v')
+                {
+                    result[j++] = sAsChar[i++]; // copy 's'
+                    result[j++] = sAsChar[i++]; // copy 'v'
+                    while (Char.IsDigit(sAsChar[i]))
+                    {
+                        result[j++] = sAsChar[i++];
+                    }
+                    while (Char.IsWhiteSpace(sAsChar[i]))
+                    {
+                        result[j++] = '_';
+                        i++;
+                    }
+                    if (sAsChar[i] == '(')   // Skip left parenthesis
+                    {
+                        i++;
+                    }
+                    while (Char.IsDigit(sAsChar[i]))
+                    {
+                        result[j++] = sAsChar[i++];
+                    }
+                    if (sAsChar[i] == ')')
+                    {
+                        i++;
+                    }
+                }
+
+                result[j++] = sAsChar[i++];
+            }
+
+            return new String(result);
+        }
+
     }
 
-    private static string Initial(EquationBlock entry)
-    {
-      return SanitizeString(String.Format(INITIAL, entry.Head()));
-    }
-
-    private static string Vars(List<string> vars)
-    {
-      return SanitizeString(String.Format(VARS, FormalParametersAsString(vars)));
-    }
-
-    public static string FormalParametersAsString(List<string> listOfVariables)
-    {
-      StringBuilder tmp = new StringBuilder();
-
-      foreach (string p in listOfVariables)
-      {
-        tmp.Append(p + SEPPARAM);
-      }
-
-      if (tmp.Length > SEPPARAM.Length)
-      {
-        tmp.Remove(tmp.Length - SEPPARAM.Length, SEPPARAM.Length);  // remove the last ", "
-      }
-      else
-      {
-        tmp.Append(BenigniMain.EMPTY);
-      }
-
-      return tmp.ToString();
-    }
     /// <summary>
-    /// Replace "svXXX (YYY)" with "svXXX_(YYY)"
+    /// Represent the equations for a block 
     /// </summary>
-    public static string SanitizeString(string s)
+    class EquationBlock
     {
-      char[] sAsChar = s.ToCharArray();
-      char[] result = new char[sAsChar.Length];
+        private CFGBlock id;
+        private List<string> formalParameters; // We want to keep it sorted...
+        private List<EquationBody> bodies;
 
-      for (int i = 0, j = 0; i < sAsChar.Length; )
-      {
-        if (i < sAsChar.Length - 1 && sAsChar[i] == 's' && sAsChar[i + 1] == 'v')
+        private string/*?*/ condition;
+
+
+        public List<string> FormalParameters
         {
-          result[j++] = sAsChar[i++]; // copy 's'
-          result[j++] = sAsChar[i++]; // copy 'v'
-          while (Char.IsDigit(sAsChar[i]))
-          {
-            result[j++] = sAsChar[i++];
-          }
-          while (Char.IsWhiteSpace(sAsChar[i]))
-          {
-            result[j++] = '_';
-            i++;
-          }
-          if (sAsChar[i] == '(')   // Skip left parenthesis
-          {
-            i++;
-          }
-          while (Char.IsDigit(sAsChar[i]))
-          {
-            result[j++] = sAsChar[i++];
-          }
-          if (sAsChar[i] == ')')
-          {
-            i++;
-          }
+            get
+            {
+                Contract.Ensures(Contract.Result<List<string>>() != null);
+
+                if (formalParameters.Count == 0)
+                {
+                    this.InferParameters(new Set<EquationBlock>());
+                }
+
+                return formalParameters;
+            }
         }
 
-        result[j++] = sAsChar[i++];
-      }
-
-      return new String(result);
-    }
-
-  }
-
-  /// <summary>
-  /// Represent the equations for a block 
-  /// </summary>
-  class EquationBlock
-  {
-    private CFGBlock id;
-    private List<string> formalParameters; // We want to keep it sorted...
-    private List<EquationBody> bodies;
-
-    private string/*?*/ condition;
-
-
-    public List<string> FormalParameters
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<List<string>>() != null);
-
-        if (this.formalParameters.Count == 0)
+        public CFGBlock Block
         {
-          this.InferParameters(new Set<EquationBlock>());
+            get
+            {
+                return id;
+            }
         }
 
-        return this.formalParameters;
-      }
-    }
-
-    public CFGBlock Block
-    {
-      get
-      {
-        return this.id;
-      }
-    }
-
-    public EquationBlock(CFGBlock ID)
-    {
-      this.id = ID;
-      this.formalParameters = new List<string>();
-      this.bodies = new List<EquationBody>();
-      this.condition = null;
-    }
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(this.formalParameters != null);
-    }
-
-    public void AddBody(EquationBody toAdd)
-    {
-      this.bodies.Add(toAdd);
-    }
-
-    public void AddParameters(Set<string> vars)
-    {
-      formalParameters.AddRange(vars);
-      formalParameters.Sort(); // we keep the parameters sorted
-    }
-
-    public void EmitEquations(TextWriter where, InvariantQuery<APC> invariantDB)
-    {
-      foreach (EquationBody body in this.bodies)
-      {
-        body.EmitEquation(where, invariantDB);
-      }
-    }
-
-    public string Condition
-    {
-      set
-      {
-        if (value != null && value.Length != 0)
-          this.condition = value;
-        else
-          this.condition = null;
-      }
-      get
-      {
-        return this.condition;
-      }
-    }
-
-    internal string Head()
-    {
-      return string.Format("{0}{1} ({2})", BenigniMain.BLOCKPREFIX, this.id.Index, BenigniMain.FormalParametersAsString(this.FormalParameters));
-    }
-
-    private void InferParameters(Set<EquationBlock> visited)
-    {
-      // Console.WriteLine("Visiting {0}", this.Block.Index);
-      if (visited.Contains(this))
-        return;
-
-      visited.Add(this);
-
-      var newParameters = new Set<string>(this.formalParameters);
-      foreach (EquationBody succ in this.bodies)
-      {
-        succ.To.InferParameters(visited);
-        newParameters.AddRange(succ.To.formalParameters);
-      }
-
-      List<string> asList = new List<string>(newParameters);
-      asList.Sort();
-      this.formalParameters = asList;
-    }
-  }
-
-  class EquationBody
-  {
-    private EquationBlock parent;
-    private EquationBlock to;
-    private IFunctionalMap<string, string> renamings;
-
-    internal EquationBlock To
-    {
-      get
-      {
-        return this.to;
-      }
-    }
-
-    public EquationBody(EquationBlock parent, EquationBlock to, IFunctionalMap<string, string> renamings)
-    {
-      this.parent = parent;
-      this.to = to;
-      this.renamings = renamings;
-    }
-
-    public void EmitEquation(TextWriter where, InvariantQuery<APC> invariantDB)
-    {
-      string head = this.parent.Head(); // bn(... )
-
-      StringBuilder bodyAsString = new StringBuilder();
-
-      foreach (string s in this.to.FormalParameters)
-      {
-        string actualParameter = this.renamings[s];
-
-        if (actualParameter == null)
-          actualParameter = s;  // if it is not there, it means that it is not renamed, i.e. it is the identity
-
-        bodyAsString.Append(actualParameter + BenigniMain.SEPPARAM);
-      }
-
-      if (bodyAsString.Length > BenigniMain.SEPPARAM.Length)
-      {
-        bodyAsString.Remove(bodyAsString.Length - BenigniMain.SEPPARAM.Length, BenigniMain.SEPPARAM.Length);  // remove the last ", "
-      }
-      else if(this.parent.Condition != null)
-      { // no successors, so I just write down the parameters, 
-        bodyAsString.Append(BenigniMain.FormalParametersAsString(this.parent.FormalParameters));
-      }
-      else
-      {
-        bodyAsString.Append(BenigniMain.EMPTY);
-      }
-
-      string succ = BenigniMain.BLOCKPREFIX + this.To.Block.Index;
-
-      string result = String.Format("{0} {1} {2}( {3} ) ", head, BenigniMain.TRANS, succ, bodyAsString.ToString());
-
-      string postState = invariantDB(this.To.Block.First);
-
-      if (this.parent.Condition != null)  // Is there a condition on the rewriting rule?
-      {
-        result = String.Format("{0} | {1} -> 1", result, this.parent.Condition);
- 
-        if (postState != null && postState.Length > 0)
+        public EquationBlock(CFGBlock ID)
         {
-          result += string.Format(", {0}", postState); 
+            id = ID;
+            formalParameters = new List<string>();
+            bodies = new List<EquationBody>();
+            condition = null;
         }
-      }
-      else if (postState != null && postState.Length > 0)
-      {
-        result = String.Format("{0} | {1}", result, postState);
-      }
 
-      result = BenigniMain.SanitizeString(result);
+        [ContractInvariantMethod]
+        void ObjectInvariant()
+        {
+            Contract.Invariant(formalParameters != null);
+        }
 
-      // Here we output the equation
-      where.WriteLine(result);
+        public void AddBody(EquationBody toAdd)
+        {
+            bodies.Add(toAdd);
+        }
+
+        public void AddParameters(Set<string> vars)
+        {
+            formalParameters.AddRange(vars);
+            formalParameters.Sort(); // we keep the parameters sorted
+        }
+
+        public void EmitEquations(TextWriter where, InvariantQuery<APC> invariantDB)
+        {
+            foreach (EquationBody body in bodies)
+            {
+                body.EmitEquation(where, invariantDB);
+            }
+        }
+
+        public string Condition
+        {
+            set
+            {
+                if (value != null && value.Length != 0)
+                    condition = value;
+                else
+                    condition = null;
+            }
+            get
+            {
+                return condition;
+            }
+        }
+
+        internal string Head()
+        {
+            return string.Format("{0}{1} ({2})", BenigniMain.BLOCKPREFIX, id.Index, BenigniMain.FormalParametersAsString(this.FormalParameters));
+        }
+
+        private void InferParameters(Set<EquationBlock> visited)
+        {
+            // Console.WriteLine("Visiting {0}", this.Block.Index);
+            if (visited.Contains(this))
+                return;
+
+            visited.Add(this);
+
+            var newParameters = new Set<string>(formalParameters);
+            foreach (EquationBody succ in bodies)
+            {
+                succ.To.InferParameters(visited);
+                newParameters.AddRange(succ.To.formalParameters);
+            }
+
+            List<string> asList = new List<string>(newParameters);
+            asList.Sort();
+            formalParameters = asList;
+        }
     }
-  }
 
-  #region Expression visitors
-  /// <summary>
-  /// The crawler used by Benigni to find which variables are used in a block
-  /// </summary>
-  public class BenigniVariableCrawler
-  {
-    class Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>
-      : IVisitValueExprIL<ExternalExpression<Label, SymbolicValue>, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue, Set<string>, Set<string>>
-      where SymbolicValue : IEquatable<SymbolicValue>
-      where Type: IEquatable<Type>
+    class EquationBody
     {
-      IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder;
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+        private EquationBlock parent;
+        private EquationBlock to;
+        private IFunctionalMap<string, string> renamings;
 
-      public Decoder(
-        IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-      {
-        this.decoder = decoder;
-        this.mdDecoder = mdDecoder;
-      }
+        internal EquationBlock To
+        {
+            get
+            {
+                return to;
+            }
+        }
 
-      public Set<string> Variables(ExternalExpression<Label, SymbolicValue> expr)
-      {
-        Set<string> emptySet = new Set<string>();
-        return Recurse(emptySet, expr);
-      }
+        public EquationBody(EquationBlock parent, EquationBlock to, IFunctionalMap<string, string> renamings)
+        {
+            this.parent = parent;
+            this.to = to;
+            this.renamings = renamings;
+        }
 
-      #region IVisitExprIL<Label,Type,ExternalExpression,SymbolicValue,StringBuilder,Unit> Members
+        public void EmitEquation(TextWriter where, InvariantQuery<APC> invariantDB)
+        {
+            string head = parent.Head(); // bn(... )
 
-      Set<string> Recurse(Set<string> input, ExternalExpression<Label, SymbolicValue> expr)
-      {
-        return decoder.ExpressionContext.Decode<Set<string>, Set<string>, Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>>(expr, this, input);
-      }
+            StringBuilder bodyAsString = new StringBuilder();
 
-      public Set<string> Binary(ExternalExpression<Label, SymbolicValue> pc, BinaryOperator op, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> s1, ExternalExpression<Label, SymbolicValue> s2, Set<string> data)
-      {
+            foreach (string s in to.FormalParameters)
+            {
+                string actualParameter = renamings[s];
 
-        data = Recurse(data, s1);
-        data = Recurse(data, s2);
+                if (actualParameter == null)
+                    actualParameter = s;  // if it is not there, it means that it is not renamed, i.e. it is the identity
 
-        return data;
-      }
+                bodyAsString.Append(actualParameter + BenigniMain.SEPPARAM);
+            }
 
-      public Set<string> Isinst(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> obj, Set<string> data)
-      {
-        return Recurse(data, obj);
-      }
+            if (bodyAsString.Length > BenigniMain.SEPPARAM.Length)
+            {
+                bodyAsString.Remove(bodyAsString.Length - BenigniMain.SEPPARAM.Length, BenigniMain.SEPPARAM.Length);  // remove the last ", "
+            }
+            else if (parent.Condition != null)
+            { // no successors, so I just write down the parameters, 
+                bodyAsString.Append(BenigniMain.FormalParametersAsString(parent.FormalParameters));
+            }
+            else
+            {
+                bodyAsString.Append(BenigniMain.EMPTY);
+            }
 
-      public Set<string> Ldconst(ExternalExpression<Label, SymbolicValue> pc, object constant, Type type, SymbolicValue dest, Set<string> data)
-      {
-        return data;
-      }
+            string succ = BenigniMain.BLOCKPREFIX + this.To.Block.Index;
 
-      public Set<string> Ldnull(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue dest, Set<string> data)
-      {
-        return data;
-      }
+            string result = String.Format("{0} {1} {2}( {3} ) ", head, BenigniMain.TRANS, succ, bodyAsString.ToString());
 
-      public Set<string> Sizeof(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, Set<string> data)
-      {
-        return data;
-      }
+            string postState = invariantDB(this.To.Block.First);
 
-      public Set<string> Unary(ExternalExpression<Label, SymbolicValue> pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> source, Set<string> data)
-      {
-        return Recurse(data, source);
-      }
+            if (parent.Condition != null)  // Is there a condition on the rewriting rule?
+            {
+                result = String.Format("{0} | {1} -> 1", result, parent.Condition);
 
-      public Set<string> SymbolicConstant(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue symbol, Set<string> data)
-      {
-        data.Add(symbol.ToString());
-        return data;
-      }
+                if (postState != null && postState.Length > 0)
+                {
+                    result += string.Format(", {0}", postState);
+                }
+            }
+            else if (postState != null && postState.Length > 0)
+            {
+                result = String.Format("{0} | {1}", result, postState);
+            }
 
-      #endregion
+            result = BenigniMain.SanitizeString(result);
+
+            // Here we output the equation
+            where.WriteLine(result);
+        }
     }
 
-    public static Converter<ExternalExpression<Label, SymbolicValue>, Set<string>> Crawler<Label, Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue>(
-      IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-      where SymbolicValue : IEquatable<SymbolicValue>
-      where Type:IEquatable<Type>
+    #region Expression visitors
+    /// <summary>
+    /// The crawler used by Benigni to find which variables are used in a block
+    /// </summary>
+    public class BenigniVariableCrawler
     {
-      Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly> expr = new Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>(decoder, mdDecoder);
-      return expr.Variables;
-    }
-  }
+        class Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>
+          : IVisitValueExprIL<ExternalExpression<Label, SymbolicValue>, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue, Set<string>, Set<string>>
+          where SymbolicValue : IEquatable<SymbolicValue>
+          where Type : IEquatable<Type>
+        {
+            IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder;
+            IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
 
-  /// <summary>
-  /// The printer for expressions used by Benigni
-  /// </summary>
-  public class BenigniExprPrinter
-  {
-    class Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>
-      : IVisitValueExprIL<ExternalExpression<Label, SymbolicValue>, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue, StringBuilder, Unit>
-      where SymbolicValue : IEquatable<SymbolicValue>
-      where Type:IEquatable<Type>
+            public Decoder(
+              IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+            )
+            {
+                this.decoder = decoder;
+                this.mdDecoder = mdDecoder;
+            }
+
+            public Set<string> Variables(ExternalExpression<Label, SymbolicValue> expr)
+            {
+                Set<string> emptySet = new Set<string>();
+                return Recurse(emptySet, expr);
+            }
+
+            #region IVisitExprIL<Label,Type,ExternalExpression,SymbolicValue,StringBuilder,Unit> Members
+
+            Set<string> Recurse(Set<string> input, ExternalExpression<Label, SymbolicValue> expr)
+            {
+                return decoder.ExpressionContext.Decode<Set<string>, Set<string>, Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>>(expr, this, input);
+            }
+
+            public Set<string> Binary(ExternalExpression<Label, SymbolicValue> pc, BinaryOperator op, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> s1, ExternalExpression<Label, SymbolicValue> s2, Set<string> data)
+            {
+
+                data = Recurse(data, s1);
+                data = Recurse(data, s2);
+
+                return data;
+            }
+
+            public Set<string> Isinst(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> obj, Set<string> data)
+            {
+                return Recurse(data, obj);
+            }
+
+            public Set<string> Ldconst(ExternalExpression<Label, SymbolicValue> pc, object constant, Type type, SymbolicValue dest, Set<string> data)
+            {
+                return data;
+            }
+
+            public Set<string> Ldnull(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue dest, Set<string> data)
+            {
+                return data;
+            }
+
+            public Set<string> Sizeof(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, Set<string> data)
+            {
+                return data;
+            }
+
+            public Set<string> Unary(ExternalExpression<Label, SymbolicValue> pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> source, Set<string> data)
+            {
+                return Recurse(data, source);
+            }
+
+            public Set<string> SymbolicConstant(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue symbol, Set<string> data)
+            {
+                data.Add(symbol.ToString());
+                return data;
+            }
+
+            #endregion
+        }
+
+        public static Converter<ExternalExpression<Label, SymbolicValue>, Set<string>> Crawler<Label, Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue>(
+          IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+          where SymbolicValue : IEquatable<SymbolicValue>
+          where Type : IEquatable<Type>
+        {
+            Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly> expr = new Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>(decoder, mdDecoder);
+            return expr.Variables;
+        }
+    }
+
+    /// <summary>
+    /// The printer for expressions used by Benigni
+    /// </summary>
+    public class BenigniExprPrinter
     {
-      IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder;
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+        class Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>
+          : IVisitValueExprIL<ExternalExpression<Label, SymbolicValue>, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue, StringBuilder, Unit>
+          where SymbolicValue : IEquatable<SymbolicValue>
+          where Type : IEquatable<Type>
+        {
+            IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder;
+            IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
 
-      public Decoder(
-        IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-      {
-        this.decoder = decoder;
-        this.mdDecoder = mdDecoder;
-      }
+            public Decoder(
+              IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+            )
+            {
+                this.decoder = decoder;
+                this.mdDecoder = mdDecoder;
+            }
 
-      public string ToString(ExternalExpression<Label, SymbolicValue> expr)
-      {
-        StringBuilder sb = new StringBuilder();
-        Recurse(sb, expr);
-        return sb.ToString();
-      }
+            public string ToString(ExternalExpression<Label, SymbolicValue> expr)
+            {
+                StringBuilder sb = new StringBuilder();
+                Recurse(sb, expr);
+                return sb.ToString();
+            }
 
-      #region IVisitExprIL<Label,Type,ExternalExpression,SymbolicValue,StringBuilder,Unit> Members
+            #region IVisitExprIL<Label,Type,ExternalExpression,SymbolicValue,StringBuilder,Unit> Members
 
-      void Recurse(StringBuilder tw, ExternalExpression<Label, SymbolicValue> expr)
-      {
-        decoder.ExpressionContext.Decode<StringBuilder, Unit, Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>>(expr, this, tw);
-      }
+            void Recurse(StringBuilder tw, ExternalExpression<Label, SymbolicValue> expr)
+            {
+                decoder.ExpressionContext.Decode<StringBuilder, Unit, Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>>(expr, this, tw);
+            }
 
-      public Unit Binary(ExternalExpression<Label, SymbolicValue> pc, BinaryOperator op, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> s1, ExternalExpression<Label, SymbolicValue> s2, StringBuilder data)
-      {
-        data.Append(op.ToString());
-        data.Append('(');
-        Recurse(data, s1);
-        data.Append(", ");
-        Recurse(data, s2);
-        data.Append(')');
-        return Unit.Value;
-      }
+            public Unit Binary(ExternalExpression<Label, SymbolicValue> pc, BinaryOperator op, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> s1, ExternalExpression<Label, SymbolicValue> s2, StringBuilder data)
+            {
+                data.Append(op.ToString());
+                data.Append('(');
+                Recurse(data, s1);
+                data.Append(", ");
+                Recurse(data, s2);
+                data.Append(')');
+                return Unit.Value;
+            }
 
-      public Unit Isinst(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> obj, StringBuilder data)
-      {
-        data.AppendFormat("IsInst({0}) ", mdDecoder.FullName(type));
-        Recurse(data, obj);
-        return Unit.Value;
-      }
+            public Unit Isinst(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> obj, StringBuilder data)
+            {
+                data.AppendFormat("IsInst({0}) ", mdDecoder.FullName(type));
+                Recurse(data, obj);
+                return Unit.Value;
+            }
 
-      public Unit Ldconst(ExternalExpression<Label, SymbolicValue> pc, object constant, Type type, SymbolicValue dest, StringBuilder data)
-      {
-        data.Append(constant.ToString());
-        return Unit.Value;
-      }
+            public Unit Ldconst(ExternalExpression<Label, SymbolicValue> pc, object constant, Type type, SymbolicValue dest, StringBuilder data)
+            {
+                data.Append(constant.ToString());
+                return Unit.Value;
+            }
 
-      public Unit Ldnull(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue dest, StringBuilder data)
-      {
-        data.Append("null");
-        return Unit.Value;
-      }
+            public Unit Ldnull(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue dest, StringBuilder data)
+            {
+                data.Append("null");
+                return Unit.Value;
+            }
 
-      public Unit Sizeof(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, StringBuilder data)
-      {
-        data.AppendFormat("sizeof({0})", mdDecoder.FullName(type));
-        return Unit.Value;
-      }
+            public Unit Sizeof(ExternalExpression<Label, SymbolicValue> pc, Type type, SymbolicValue dest, StringBuilder data)
+            {
+                data.AppendFormat("sizeof({0})", mdDecoder.FullName(type));
+                return Unit.Value;
+            }
 
-      public Unit Unary(ExternalExpression<Label, SymbolicValue> pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> source, StringBuilder data)
-      {
-        data.AppendFormat("{0}(", op.ToString());
-        Recurse(data, source);
-        data.AppendFormat(")");
-        return Unit.Value;
-      }
+            public Unit Unary(ExternalExpression<Label, SymbolicValue> pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, ExternalExpression<Label, SymbolicValue> source, StringBuilder data)
+            {
+                data.AppendFormat("{0}(", op.ToString());
+                Recurse(data, source);
+                data.AppendFormat(")");
+                return Unit.Value;
+            }
 
-      public Unit SymbolicConstant(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue symbol, StringBuilder data)
-      {
-        data.Append(symbol.ToString());
-        return Unit.Value;
-      }
+            public Unit SymbolicConstant(ExternalExpression<Label, SymbolicValue> pc, SymbolicValue symbol, StringBuilder data)
+            {
+                data.Append(symbol.ToString());
+                return Unit.Value;
+            }
 
-      #endregion
+            #endregion
+        }
+
+        public static Converter<ExternalExpression<Label, SymbolicValue>, string> Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue>(
+          IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+          where SymbolicValue : IEquatable<SymbolicValue>
+          where Type : IEquatable<Type>
+        {
+            var exprPrinter = new Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>(decoder, mdDecoder);
+            return exprPrinter.ToString;
+        }
     }
+    #endregion
 
-    public static Converter<ExternalExpression<Label, SymbolicValue>, string> Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue>(
-      IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<Label, SymbolicValue>, SymbolicValue> decoder,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-      where SymbolicValue : IEquatable<SymbolicValue>
-      where Type:IEquatable<Type>
+    #region Instruction visitor
+    public static class BenigniConditionCrawler
     {
-      var exprPrinter = new Decoder<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly>(decoder, mdDecoder);
-      return exprPrinter.ToString;
-    }
-  }
-  #endregion
-
-  #region Instruction visitor
-  public static class BenigniConditionCrawler
-  {
-
-    public static AssumptionFinder<Label> Create<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(
-      IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      Converter<Source, string> sourceName,
-      Converter<Dest, string> destName
-    )
-    {
-      return  new SearchAssumptions<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(ilDecoder, mdDecoder, sourceName, destName).SearchAssumptionAt;
-    }
-
-    private class SearchAssumptions<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData> :
-      IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, string, string>
-    {
-      IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder;
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-      Converter<Source, string> sourceName;
-      Converter<Dest, string> destName;
-
-      public SearchAssumptions(
-        IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-        Converter<Source, string> sourceName,
-        Converter<Dest, string> destName
-      )
-      {
-        this.ilDecoder = ilDecoder;
-        this.mdDecoder = mdDecoder;
-        this.sourceName = sourceName;
-        this.destName = destName;
-      }
-
-      public string SearchAssumptionAt(Label label)
-      {
-        return this.ilDecoder.ForwardDecode<string, string, SearchAssumptions<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>>(label, this, null);
-      }
-
-      #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,Source,Dest,string,string> Members
-
-      private string/*?*/ SourceName(Source src)
-      {
-        if (this.sourceName != null) { return this.sourceName(src); }
-        return null;
-      }
-
-      private string/*?*/ DestName(Dest dest)
-      {
-        if (this.destName != null) { return this.destName(dest); }
-        return null;
-      }
-
-      public string Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, string data)
-      {
-        return data;
-      }
-
-      public string Assert(Label pc, string tag, Source s, string data)
-      {
- //       tw.WriteLine("{0}assert({1}) {2}", prefix, tag, SourceName(s));
-        return data;
-      }
-
-      public string Assume(Label pc, string tag, Source s, string data)
-      {
-//        tw.WriteLine("{0}assume({1}) {2}", prefix, tag, SourceName(s));
-
-        if (data != null)
-          return null;
-        else if (tag.Equals("true"))
-          return SourceName(s);
-        else
-          return "not(" + SourceName(s) + ")";
-      }
-
-      public string Arglist(Label pc, Dest d, string data)
-      {
-        return data;
-      }
-
-      public string BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, string data)
-      {
-        return data;
-      }
-
-      public string BranchTrue(Label pc, Label target, Source cond, string data)
-      {
-        return data;
-      }
-
-      public string BranchFalse(Label pc, Label target, Source cond, string data)
-      {
-        return data;
-      }
-
-      public string Branch(Label pc, Label target, bool leave, string data)
-      {
-        return data;
-      }
-
-      public string Break(Label pc, string data)
-      {
-        return data;
-      }
-
-      public string Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, string data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        return data;
-      }
-
-      public string Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, string data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        return data;
-      }
-
-      public string Ckfinite(Label pc, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Unary(Label pc, UnaryOperator op, bool ovf, bool unsigned, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, string data)
-      {
-        return data;
-      }
-
-      public string Endfilter(Label pc, Source condition, string data)
-      {
-        return data;
-      }
-
-      public string Endfinally(Label pc, string data)
-      {
-        return data;
-      }
-
-      public string Entry(Label pc, Method method, string data)
-      {
-        return data;
-      }
-
-      public string Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, string data)
-      {
-        return data;
-      }
-
-      public string Jmp(Label pc, Method method, string data)
-      {
-        return data;
-      }
-
-      public string Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldconst(Label pc, object constant, Type type, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldnull(Label pc, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldftn(Label pc, Method method, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, string data)
-      {
-        return data;
-      }
-
-      public string Ldloc(Label pc, Local local, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldloca(Label pc, Local local, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldresult(Label pc, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Ldstack(Label pc, int offset, Dest dest, Source s, bool isOld, string data)
-      {
-        return data;
-      }
-
-      public string Ldstacka(Label pc, int offset, Dest dest, Source s, Type type, bool isOld, string data)
-      {
-        return data;
-      }
-
-      public string Localloc(Label pc, Dest dest, Source size, string data)
-      {
-        return data;
-      }
-
-
-      public string Nop(Label pc, string data)
-      {
-        return data;
-      }
-
-      public string Pop(Label pc, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Return(Label pc, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Starg(Label pc, Parameter argument, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Stloc(Label pc, Local local, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Switch(Label pc, Type type, IEnumerable<Pair<object,Label>> cases, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Box(Label pc, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, string data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        return data;
-      }
-
-      public string Castclass(Label pc, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Cpobj(Label pc, Type type, Source destptr, Source srcptr, string data)
-      {
-        return data;
-      }
-
-      public string Initobj(Label pc, Type type, Source ptr, string data)
-      {
-        return data;
-      }
-
-      public string Isinst(Label pc, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Ldelem(Label pc, Type type, Dest dest, Source array, Source index, string data)
-      {
-        return data;
-      }
-
-      public string Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, string data)
-      {
-        return data;
-      }
-
-      public string Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source ptr, string data)
-      {
-        return data;
-      }
-
-      public string Ldflda(Label pc, Field field, Dest dest, Source ptr, string data)
-      {
-        return data;
-      }
-
-      public string Ldlen(Label pc, Dest dest, Source array, string data)
-      {
-        return data;
-      }
-
-      public string Ldsfld(Label pc, Field field, bool @volatile, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldsflda(Label pc, Field field, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldtypetoken(Label pc, Type type, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldfieldtoken(Label pc, Field field, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldmethodtoken(Label pc, Method method, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Ldvirtftn(Label pc, Method method, Dest dest, Source obj, string data)
-      {
-        return data;
-      }
-
-      public string Mkrefany(Label pc, Type type, Dest dest, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList lengths, string data)
-        where ArgList : IIndexable<Source>
-      {
-        return data;
-      }
-
-      public string Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, string data)
-        where ArgList : IIndexable<Source>
-      {
-        return data;
-      }
-
-      public string Refanytype(Label pc, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Refanyval(Label pc, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Rethrow(Label pc, string data)
-      {
-        return data;
-      }
-
-      public string Sizeof(Label pc, Type type, Dest dest, string data)
-      {
-        return data;
-      }
-
-      public string Stelem(Label pc, Type type, Source array, Source index, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Stfld(Label pc, Field field, bool @volatile, Source ptr, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Stsfld(Label pc, Field field, bool @volatile, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Throw(Label pc, Source value, string data)
-      {
-        return data;
-      }
-
-      public string Unbox(Label pc, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      public string Unboxany(Label pc, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      #endregion
-
-      #region IVisitSynthIL<Label,Method,Source,Dest,TextWriter,Unit> Members
-
-
-      public string BeginOld(Label pc, Label matchingEnd, string data)
-      {
-        return data;
-      }
-
-      public string EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, string data)
-      {
-        return data;
-      }
-
-      #endregion
+
+        public static AssumptionFinder<Label> Create<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(
+          IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          Converter<Source, string> sourceName,
+          Converter<Dest, string> destName
+        )
+        {
+            return new SearchAssumptions<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(ilDecoder, mdDecoder, sourceName, destName).SearchAssumptionAt;
+        }
+
+        private class SearchAssumptions<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData> :
+          IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, string, string>
+        {
+            IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder;
+            IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+            Converter<Source, string> sourceName;
+            Converter<Dest, string> destName;
+
+            public SearchAssumptions(
+              IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+              Converter<Source, string> sourceName,
+              Converter<Dest, string> destName
+            )
+            {
+                this.ilDecoder = ilDecoder;
+                this.mdDecoder = mdDecoder;
+                this.sourceName = sourceName;
+                this.destName = destName;
+            }
+
+            public string SearchAssumptionAt(Label label)
+            {
+                return ilDecoder.ForwardDecode<string, string, SearchAssumptions<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>>(label, this, null);
+            }
+
+            #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,Source,Dest,string,string> Members
+
+            private string/*?*/ SourceName(Source src)
+            {
+                if (sourceName != null) { return sourceName(src); }
+                return null;
+            }
+
+            private string/*?*/ DestName(Dest dest)
+            {
+                if (destName != null) { return destName(dest); }
+                return null;
+            }
+
+            public string Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, string data)
+            {
+                return data;
+            }
+
+            public string Assert(Label pc, string tag, Source s, string data)
+            {
+                //       tw.WriteLine("{0}assert({1}) {2}", prefix, tag, SourceName(s));
+                return data;
+            }
+
+            public string Assume(Label pc, string tag, Source s, string data)
+            {
+                //        tw.WriteLine("{0}assume({1}) {2}", prefix, tag, SourceName(s));
+
+                if (data != null)
+                    return null;
+                else if (tag.Equals("true"))
+                    return SourceName(s);
+                else
+                    return "not(" + SourceName(s) + ")";
+            }
+
+            public string Arglist(Label pc, Dest d, string data)
+            {
+                return data;
+            }
+
+            public string BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, string data)
+            {
+                return data;
+            }
+
+            public string BranchTrue(Label pc, Label target, Source cond, string data)
+            {
+                return data;
+            }
+
+            public string BranchFalse(Label pc, Label target, Source cond, string data)
+            {
+                return data;
+            }
+
+            public string Branch(Label pc, Label target, bool leave, string data)
+            {
+                return data;
+            }
+
+            public string Break(Label pc, string data)
+            {
+                return data;
+            }
+
+            public string Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, string data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                return data;
+            }
+
+            public string Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, string data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                return data;
+            }
+
+            public string Ckfinite(Label pc, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Unary(Label pc, UnaryOperator op, bool ovf, bool unsigned, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, string data)
+            {
+                return data;
+            }
+
+            public string Endfilter(Label pc, Source condition, string data)
+            {
+                return data;
+            }
+
+            public string Endfinally(Label pc, string data)
+            {
+                return data;
+            }
+
+            public string Entry(Label pc, Method method, string data)
+            {
+                return data;
+            }
+
+            public string Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, string data)
+            {
+                return data;
+            }
+
+            public string Jmp(Label pc, Method method, string data)
+            {
+                return data;
+            }
+
+            public string Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldconst(Label pc, object constant, Type type, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldnull(Label pc, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldftn(Label pc, Method method, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, string data)
+            {
+                return data;
+            }
+
+            public string Ldloc(Label pc, Local local, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldloca(Label pc, Local local, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldresult(Label pc, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Ldstack(Label pc, int offset, Dest dest, Source s, bool isOld, string data)
+            {
+                return data;
+            }
+
+            public string Ldstacka(Label pc, int offset, Dest dest, Source s, Type type, bool isOld, string data)
+            {
+                return data;
+            }
+
+            public string Localloc(Label pc, Dest dest, Source size, string data)
+            {
+                return data;
+            }
+
+
+            public string Nop(Label pc, string data)
+            {
+                return data;
+            }
+
+            public string Pop(Label pc, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Return(Label pc, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Starg(Label pc, Parameter argument, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Stloc(Label pc, Local local, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Box(Label pc, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, string data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                return data;
+            }
+
+            public string Castclass(Label pc, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Cpobj(Label pc, Type type, Source destptr, Source srcptr, string data)
+            {
+                return data;
+            }
+
+            public string Initobj(Label pc, Type type, Source ptr, string data)
+            {
+                return data;
+            }
+
+            public string Isinst(Label pc, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Ldelem(Label pc, Type type, Dest dest, Source array, Source index, string data)
+            {
+                return data;
+            }
+
+            public string Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, string data)
+            {
+                return data;
+            }
+
+            public string Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source ptr, string data)
+            {
+                return data;
+            }
+
+            public string Ldflda(Label pc, Field field, Dest dest, Source ptr, string data)
+            {
+                return data;
+            }
+
+            public string Ldlen(Label pc, Dest dest, Source array, string data)
+            {
+                return data;
+            }
+
+            public string Ldsfld(Label pc, Field field, bool @volatile, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldsflda(Label pc, Field field, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldtypetoken(Label pc, Type type, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldfieldtoken(Label pc, Field field, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldmethodtoken(Label pc, Method method, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Ldvirtftn(Label pc, Method method, Dest dest, Source obj, string data)
+            {
+                return data;
+            }
+
+            public string Mkrefany(Label pc, Type type, Dest dest, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList lengths, string data)
+              where ArgList : IIndexable<Source>
+            {
+                return data;
+            }
+
+            public string Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, string data)
+              where ArgList : IIndexable<Source>
+            {
+                return data;
+            }
+
+            public string Refanytype(Label pc, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Refanyval(Label pc, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Rethrow(Label pc, string data)
+            {
+                return data;
+            }
+
+            public string Sizeof(Label pc, Type type, Dest dest, string data)
+            {
+                return data;
+            }
+
+            public string Stelem(Label pc, Type type, Source array, Source index, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Stfld(Label pc, Field field, bool @volatile, Source ptr, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Stsfld(Label pc, Field field, bool @volatile, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Throw(Label pc, Source value, string data)
+            {
+                return data;
+            }
+
+            public string Unbox(Label pc, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            public string Unboxany(Label pc, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            #endregion
+
+            #region IVisitSynthIL<Label,Method,Source,Dest,TextWriter,Unit> Members
+
+
+            public string BeginOld(Label pc, Label matchingEnd, string data)
+            {
+                return data;
+            }
+
+            public string EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, string data)
+            {
+                return data;
+            }
+
+            #endregion
+        }
+
     }
 
-  }
-
-  #endregion
+    #endregion
 }
 #endif

--- a/Microsoft.Research/CodeAnalysis/BooleanExpressionRefiner.cs
+++ b/Microsoft.Research/CodeAnalysis/BooleanExpressionRefiner.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,724 +11,722 @@ using System.Diagnostics;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-
-  public static class BooleanExpressionRefiner
-  {
-    public static bool TryRefine<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
-      (APC pc, Variable goal, bool tryRefineToMethodEntry,
-      IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
-      out BoxedExpression result)
-      where Expression : IEquatable<Expression>
-      where Variable : IEquatable<Variable>
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
+    public static class BooleanExpressionRefiner
     {
-      Contract.Requires(mdriver != null);
+        public static bool TryRefine<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+          (APC pc, Variable goal, bool tryRefineToMethodEntry,
+          IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
+          out BoxedExpression result)
+          where Expression : IEquatable<Expression>
+          where Variable : IEquatable<Variable>
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(mdriver != null);
 
-      var goalExp = BoxedExpression.Convert(mdriver.ExpressionLayer.Decoder.Context.AssumeNotNull().ExpressionContext.Refine(pc, goal), mdriver.ExpressionDecoder, Int32.MaxValue);
+            var goalExp = BoxedExpression.Convert(mdriver.ExpressionLayer.Decoder.Context.AssumeNotNull().ExpressionContext.Refine(pc, goal), mdriver.ExpressionDecoder, Int32.MaxValue);
 
-      return TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.TryRefineInternal(pc, goalExp, tryRefineToMethodEntry, mdriver, out result);
+            return TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.TryRefineInternal(pc, goalExp, tryRefineToMethodEntry, mdriver, out result);
+        }
+
+        public static class TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+          where Expression : IEquatable<Expression>
+          where Variable : IEquatable<Variable>
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
+        {
+            [ThreadStatic]
+            static private bool Trace = false;
+
+            private const int MaxVisitDepth = 100;
+
+            static internal bool TryRefineInternal(APC pc, BoxedExpression goal, bool tryRefineToMethodEntry, IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver, out BoxedExpression result)
+            {
+                var refiner = new Refiner(pc, mdriver);
+
+                var visitDept = 0;
+
+                bool isVisitAborted;
+                result = refiner.Refine(pc, goal, tryRefineToMethodEntry, ref visitDept, out isVisitAborted);
+
+                Log("Result of the refinement {0}", result != null ? result.ToString() : "<null>");
+
+                return result != null;
+            }
+
+
+            private class Refiner : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, BoxedExpression>
+            {
+                #region Object invariant
+                [ContractInvariantMethod]
+                [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+                private void ObjectInvariant()
+                {
+                    Contract.Invariant(mdriver != null);
+                }
+
+                #endregion
+
+                readonly private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver;
+                readonly private Subroutine subroutine;
+                readonly private BoxedExpression False;
+
+
+                public Refiner(APC pc, IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver)
+                {
+                    Contract.Requires(mdriver != null);
+
+                    this.mdriver = mdriver;
+                    subroutine = pc.Block.Subroutine;
+                    Contract.Assert(mdriver.MetaDataDecoder != null);
+                    False = BoxedExpression.ConstBool(0, mdriver.MetaDataDecoder);
+                }
+
+                public BoxedExpression Refine(APC pc, BoxedExpression goal, bool tryRefineToMethodEntry, ref int visitDepth, out bool isVisitAborted)
+                {
+                    Log("Visiting {0} with {1}", pc.ToString(), goal != null ? goal.ToString() : "<null>");
+
+                    if (visitDepth > MaxVisitDepth)
+                    {
+                        Log("Too depth in the visit. Aborting");
+
+                        isVisitAborted = true;
+                        return null;
+                    }
+
+                    isVisitAborted = false;
+                    if (goal == null)
+                    {
+                        Log("Null goal ({0})", pc.ToString());
+
+                        return null;
+                    }
+
+                    if (!tryRefineToMethodEntry && pc.Block.Subroutine != subroutine)
+                    {
+                        Log("Hit Subroutine boundaries ({0}) with {1}", pc.ToString(), goal.ToString());
+
+                        // We give one last shot to try to decompile a ForAll/Exists.
+                        // This may happen as we cannot decompile it at this point
+
+                        Variable var;
+                        if (goal.IsVariable && goal.TryGetFrameworkVariable(out var))
+                        {
+                            var tryForall = mdriver.AsForAllIndexed(pc, var);
+                            if (tryForall != null)
+                            {
+                                Log("We were able to refine {0} into {1}", goal.ToString(), tryForall.ToString());
+                                return tryForall;
+                            }
+                        }
+                        return goal;
+                    }
+
+                    var result = (BoxedExpression)null;
+                    var currExp = goal;
+                    var md = mdriver;
+
+                    if (md.CFG.IsForwardBackEdgeTarget(pc))
+                    {
+                        Log("Hit target of a backedge: we give up");
+                        return null;
+                    }
+
+                    foreach (var pred in md.StackLayer.Decoder.Context.MethodContext.CFG.Predecessors(pc))
+                    {
+                        if (md.BasicFacts.IsUnreachable(pred))
+                        {
+                            continue;
+                        }
+
+                        var refined = md.BackwardTransfer(pc, pred, currExp, this);
+
+                        visitDepth++;
+
+                        var r = Refine(pred, refined, tryRefineToMethodEntry, ref visitDepth, out isVisitAborted);
+
+                        visitDepth--;
+
+                        if (isVisitAborted)
+                        {
+                            return null;
+                        }
+
+                        if (r != null)
+                        {
+                            if (r.UnderlyingVariable is Variable) // just a sanity check
+                            {
+                                var asForAll = md.AsForAllIndexed(pc.Post(), (Variable)r.UnderlyingVariable);
+                                if (asForAll != null)
+                                {
+                                    r = asForAll;
+                                }
+                            }
+
+                            if (result == null)
+                            {
+                                result = r;
+                            }
+                            else
+                            {
+                                result = BoxedExpression.BinaryLogicalOr(r, result);
+                            }
+                        }
+                        else
+                        {
+                            result = result == null ? goal : result;
+                        }
+                    }
+
+                    return result;
+                }
+
+                #region IEdgeVisit<APC,Local,Parameter,Method,Field,Type,Variable,BoxedExpression> Members
+
+                public BoxedExpression Rename(APC from, APC to, BoxedExpression state, IFunctionalMap<Variable, Variable> renaming)
+                {
+                    if (state != null)
+                    {
+                        Variable v;
+                        if (state.TryGetFrameworkVariable(out v))
+                        {
+                            if (renaming.Contains(v))
+                            {
+                                var newVar = renaming[v];
+
+                                var result = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(to, newVar), mdriver.ExpressionDecoder);
+
+                                Log("Renaming {0} to {1}", state.ToString(), result != null ? result.ToString() : "<null>");
+
+                                // We use the heuristic of reading variables in the prestate, to get their name at the point we are interested in.
+                                // We may lose information because of it, and unable to decompile more complex expressions
+                                if (result != null && !result.IsVariable)
+                                {
+                                    return ReadInPostState(result, renaming);
+                                }
+
+                                return result;
+                            }
+                        }
+                        int k;
+                        if (state.IsConstantInt(out k))
+                        {
+                            return state;
+                        }
+                    }
+
+                    return null;
+                }
+
+                public BoxedExpression Assume(APC pc, string tag, Variable condition, object provenance, BoxedExpression data)
+                {
+                    var mdd = mdriver.MetaDataDecoder;
+                    var cond = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, condition), mdriver.ExpressionDecoder);
+
+                    Log("Hit Assume ({0}) : {1}", tag.ToString(), cond != null ? cond.ToString() : "<null>");
+
+                    if (cond == null)
+                    {
+                        Log("Aborting as we found a null condition for assume");
+                        return null;
+                    }
+
+                    // We do not add the assumptions already checked somewhere else
+                    if (tag == "requires" || tag == "invariant")
+                    {
+                        return data;
+                    }
+
+                    if (tag == "true")
+                    {
+                        if (cond.IsVariable)
+                        {
+                            var liftedtype = mdriver.Context.ValueContext.GetType(pc, condition);
+                            if (liftedtype.IsNormal)
+                            {
+                                var type = liftedtype.Value;
+                                if (mdd.System_Boolean.Equals(type))
+                                {
+                                    // do nothing
+                                }
+                                else if (mdd.IsReferenceType(type))
+                                {
+                                    // build cond != null
+                                    cond = BoxedExpression.Binary(BinaryOperator.Cne_Un, cond, BoxedExpression.Const(null, type, mdd));
+                                }
+                                else
+                                {
+                                    // build cond != 0
+                                    cond = BoxedExpression.Binary(BinaryOperator.Cne_Un, cond, BoxedExpression.Const(0, type, mdd));
+                                }
+                            }
+                        }
+                    }
+                    else if (tag == "false")
+                    {
+                        UnaryOperator uop;
+                        BoxedExpression inner;
+
+                        // !(!inner) ? ---> inner != null
+                        if (cond.IsUnaryExpression(out uop, out inner) && uop == UnaryOperator.Not)
+                        {
+                            cond = BoxedExpression.Binary(BinaryOperator.Cne_Un, inner, BoxedExpression.Const(null, mdd.System_Object, mdd));
+                        }
+                        else
+                        {
+                            cond = BoxedExpression.Unary(UnaryOperator.Not, cond);
+                        }
+                    }
+
+                    bool B;
+                    if (cond.IsTrivialCondition(out B))
+                    {
+                        return B ? data : BoxedExpression.ConstBool(false, mdriver.MetaDataDecoder);
+                    }
+
+
+                    return BoxedExpression.BinaryLogicalAnd(cond, data);
+                }
+
+                protected BoxedExpression ReadInPostState(BoxedExpression candidate, IFunctionalMap<Variable, Variable> renaming)
+                {
+                    Contract.Requires(candidate != null);
+
+                    Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+                    if (candidate.IsVariable)
+                    {
+                        Variable v;
+                        if (candidate.TryGetFrameworkVariable(out v))
+                        {
+                            // F: bad bad way of doing reverse lookup. This should be changed (by now it is balanced by the fact that we cache the reconstructed expressions)
+                            foreach (var key in renaming.Keys)
+                            {
+                                var val = renaming[key];
+                                if (v.Equals(val))
+                                {
+                                    return BoxedExpression.Var(key);
+                                }
+                            }
+                        }
+
+                        return candidate;
+                    }
+                    if (candidate.IsUnary)
+                    {
+                        return BoxedExpression.Unary(candidate.UnaryOp, ReadInPostState(candidate.UnaryArgument, renaming));
+                    }
+
+                    BinaryOperator bop;
+                    BoxedExpression left, right;
+                    if (candidate.IsBinaryExpression(out bop, out left, out right))
+                    {
+                        return BoxedExpression.Binary(bop, ReadInPostState(left, renaming), ReadInPostState(right, renaming));
+                    }
+                    return candidate;
+                }
+
+                #endregion
+
+                #region Utils to simplify expressions
+
+
+                #endregion
+
+                #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Variable,Variable,BoxedExpression,BoxedExpression> Members
+
+                public BoxedExpression Arglist(APC pc, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression BranchCond(APC pc, APC target, BranchOperator bop, Variable value1, Variable value2, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression BranchTrue(APC pc, APC target, Variable cond, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression BranchFalse(APC pc, APC target, Variable cond, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Branch(APC pc, APC target, bool leave, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Break(APC pc, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Variable dest, ArgList args, BoxedExpression data)
+                  where TypeList : Microsoft.Research.DataStructures.IIndexable<Type>
+                  where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
+                {
+                    return data;
+                }
+
+                public BoxedExpression Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Variable dest, Variable fp, ArgList args, BoxedExpression data)
+                  where TypeList : Microsoft.Research.DataStructures.IIndexable<Type>
+                  where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ckfinite(APC pc, Variable dest, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Cpblk(APC pc, bool @volatile, Variable destaddr, Variable srcaddr, Variable len, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Endfilter(APC pc, Variable decision, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Endfinally(APC pc, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Initblk(APC pc, bool @volatile, Variable destaddr, Variable value, Variable len, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Jmp(APC pc, Method method, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldarg(APC pc, Parameter argument, bool isOld, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldarga(APC pc, Parameter argument, bool isOld, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldftn(APC pc, Method method, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldind(APC pc, Type type, bool @volatile, Variable dest, Variable ptr, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldloc(APC pc, Local local, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldloca(APC pc, Local local, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Localloc(APC pc, Variable dest, Variable size, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Nop(APC pc, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Pop(APC pc, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Return(APC pc, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Starg(APC pc, Parameter argument, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Stind(APC pc, Type type, bool @volatile, Variable ptr, Variable value, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Stloc(APC pc, Local local, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Switch(APC pc, Type type, IEnumerable<Microsoft.Research.DataStructures.Pair<object, APC>> cases, Variable value, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Box(APC pc, Type type, Variable dest, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Variable dest, ArgList args, BoxedExpression data)
+                  where TypeList : Microsoft.Research.DataStructures.IIndexable<Type>
+                  where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
+                {
+                    return data;
+                }
+
+                public BoxedExpression Castclass(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Cpobj(APC pc, Type type, Variable destptr, Variable srcptr, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Initobj(APC pc, Type type, Variable ptr, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldelem(APC pc, Type type, Variable dest, Variable array, Variable index, BoxedExpression data)
+                {
+                    Log("Hit ldelem {0} = {1}[{2}] with {3}", dest, array, index, data);
+
+                    if (data != null)
+                    {
+                        return data.Substitute(delegate (Variable v, BoxedExpression be)
+                        {
+                            if (dest.Equals(v))
+                            {
+                                var context = mdriver.Context.ExpressionContext;
+                                var arrayExp = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, array), mdriver.ExpressionDecoder);
+                                var indexExp = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, index), mdriver.ExpressionDecoder);
+                                if (arrayExp != null && indexExp != null)
+                                {
+                                    return new BoxedExpression.ArrayIndexExpression<Type>(arrayExp, indexExp, type);
+                                }
+                            }
+                            return be;
+                        });
+                    }
+
+                    return data;
+                }
+
+                public BoxedExpression Ldelema(APC pc, Type type, bool @readonly, Variable dest, Variable array, Variable index, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldfld(APC pc, Field field, bool @volatile, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldflda(APC pc, Field field, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldlen(APC pc, Variable dest, Variable array, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldsfld(APC pc, Field field, bool @volatile, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldsflda(APC pc, Field field, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldtypetoken(APC pc, Type type, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldfieldtoken(APC pc, Field field, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldmethodtoken(APC pc, Method method, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldvirtftn(APC pc, Method method, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Mkrefany(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Newarray<ArgList>(APC pc, Type type, Variable dest, ArgList len, BoxedExpression data) where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
+                {
+                    return data;
+                }
+
+                public BoxedExpression Newobj<ArgList>(APC pc, Method ctor, Variable dest, ArgList args, BoxedExpression data) where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
+                {
+                    return data;
+                }
+
+                public BoxedExpression Refanytype(APC pc, Variable dest, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Refanyval(APC pc, Type type, Variable dest, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Rethrow(APC pc, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Stelem(APC pc, Type type, Variable array, Variable index, Variable value, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Stfld(APC pc, Field field, bool @volatile, Variable obj, Variable value, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Stsfld(APC pc, Field field, bool @volatile, Variable value, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Throw(APC pc, Variable exn, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Unbox(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Unboxany(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                #endregion
+
+                #region IVisitSynthIL<APC,Method,Type,Variable,Variable,BoxedExpression,BoxedExpression> Members
+
+                public BoxedExpression Entry(APC pc, Method method, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Assert(APC pc, string tag, Variable condition, object provenance, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldstack(APC pc, int offset, Variable dest, Variable source, bool isOld, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldstacka(APC pc, int offset, Variable dest, Variable source, Type origParamType, bool isOld, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldresult(APC pc, Type type, Variable dest, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression BeginOld(APC pc, APC matchingEnd, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression EndOld(APC pc, APC matchingBegin, Type type, Variable dest, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                #endregion
+
+                #region IVisitExprIL<APC,Type,Variable,Variable,BoxedExpression,BoxedExpression> Members
+
+                public BoxedExpression Binary(APC pc, BinaryOperator op, Variable dest, Variable s1, Variable s2, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Isinst(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldconst(APC pc, object constant, Type type, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Ldnull(APC pc, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Sizeof(APC pc, Type type, Variable dest, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                public BoxedExpression Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Variable source, BoxedExpression data)
+                {
+                    return data;
+                }
+
+                #endregion
+            }
+
+            #region Logging
+            [Conditional("DEBUG")]
+            static private void Log(string format, params object[] args)
+            {
+                if (Trace)
+                {
+                    Console.WriteLine(format, args);
+                }
+            }
+            #endregion
+        }
     }
-
-    public static class TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
-      where Expression : IEquatable<Expression>
-      where Variable : IEquatable<Variable>
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
-    {
-      [ThreadStatic]
-      static private bool Trace = false;
-
-      private const int MaxVisitDepth = 100;
-
-      static internal bool TryRefineInternal(APC pc, BoxedExpression goal, bool tryRefineToMethodEntry, IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver, out BoxedExpression result)
-      {
-        var refiner = new Refiner(pc, mdriver);
-
-        var visitDept = 0;
-
-        bool isVisitAborted;
-        result = refiner.Refine(pc, goal, tryRefineToMethodEntry, ref visitDept, out isVisitAborted);
-
-        Log("Result of the refinement {0}", result != null ? result.ToString() : "<null>");
-
-        return result != null;
-      }
-
-
-      class Refiner : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, BoxedExpression>
-      {
-
-        #region Object invariant
-        [ContractInvariantMethod]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-        private void ObjectInvariant()
-        {
-          Contract.Invariant(this.mdriver != null);
-        }
-        
-        #endregion
-
-        readonly private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver;
-        readonly private Subroutine subroutine;
-        readonly private BoxedExpression False;
-
-
-        public Refiner(APC pc, IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver)
-        {
-          Contract.Requires(mdriver != null);
-
-          this.mdriver = mdriver;
-          this.subroutine = pc.Block.Subroutine;
-          Contract.Assert(mdriver.MetaDataDecoder != null);
-          this.False = BoxedExpression.ConstBool(0, mdriver.MetaDataDecoder);
-        }
-
-        public BoxedExpression Refine(APC pc, BoxedExpression goal, bool tryRefineToMethodEntry, ref int visitDepth, out bool isVisitAborted)
-        {
-          Log("Visiting {0} with {1}", pc.ToString(), goal != null ? goal.ToString() : "<null>");
-
-          if (visitDepth > MaxVisitDepth)
-          {
-            Log("Too depth in the visit. Aborting");
-
-            isVisitAborted = true;
-            return null;
-          }
-
-          isVisitAborted = false;
-          if (goal == null)
-          {
-            Log("Null goal ({0})", pc.ToString());
-
-            return null;
-          }
-
-          if (!tryRefineToMethodEntry && pc.Block.Subroutine != this.subroutine)
-          {
-            Log("Hit Subroutine boundaries ({0}) with {1}", pc.ToString(), goal.ToString());
-
-            // We give one last shot to try to decompile a ForAll/Exists.
-            // This may happen as we cannot decompile it at this point
-
-            Variable var;
-            if (goal.IsVariable && goal.TryGetFrameworkVariable(out var))
-            {
-              var tryForall = this.mdriver.AsForAllIndexed(pc, var);
-              if (tryForall != null)
-              {
-                Log("We were able to refine {0} into {1}", goal.ToString(), tryForall.ToString());
-                return tryForall;
-              }
-            }
-            return goal;
-          }
-
-          var result = (BoxedExpression)null;
-          var currExp = goal;
-          var md = this.mdriver;
-
-          if (md.CFG.IsForwardBackEdgeTarget(pc))
-          {
-            Log("Hit target of a backedge: we give up");
-            return null;
-          }
-
-          foreach (var pred in md.StackLayer.Decoder.Context.MethodContext.CFG.Predecessors(pc))
-          {
-            if (md.BasicFacts.IsUnreachable(pred))
-            {
-              continue;
-            }
-
-            var refined = md.BackwardTransfer(pc, pred, currExp, this);
-
-            visitDepth++;
-
-            var r = Refine(pred, refined, tryRefineToMethodEntry, ref visitDepth, out isVisitAborted);
-
-            visitDepth--;
-
-            if (isVisitAborted)
-            {
-              return null;
-            }
-
-            if (r != null)
-            {
-              if (r.UnderlyingVariable is Variable) // just a sanity check
-              {
-                var asForAll = md.AsForAllIndexed(pc.Post(), (Variable)r.UnderlyingVariable);
-                if (asForAll != null)
-                {
-                  r = asForAll;
-                }
-              }
-
-              if (result == null)
-              {
-                result = r;
-              }
-              else
-              {
-                result = BoxedExpression.BinaryLogicalOr(r, result);
-              }
-            }
-            else
-            {
-              result = result == null ? goal : result;
-            }
-          }
-
-          return result;
-        }
-
-        #region IEdgeVisit<APC,Local,Parameter,Method,Field,Type,Variable,BoxedExpression> Members
-
-        public BoxedExpression Rename(APC from, APC to, BoxedExpression state, IFunctionalMap<Variable, Variable> renaming)
-        {
-          if (state != null)
-          {
-            Variable v;
-            if (state.TryGetFrameworkVariable(out v))
-            {
-              if (renaming.Contains(v))
-              {
-                var newVar = renaming[v];
-
-                var result = BoxedExpression.Convert(this.mdriver.Context.ExpressionContext.Refine(to, newVar), this.mdriver.ExpressionDecoder);
-
-                Log("Renaming {0} to {1}", state.ToString(), result != null? result.ToString(): "<null>");
-
-                // We use the heuristic of reading variables in the prestate, to get their name at the point we are interested in.
-                // We may lose information because of it, and unable to decompile more complex expressions
-                if (result != null && !result.IsVariable)
-                {
-                  return ReadInPostState(result, renaming);
-                }
-
-                return result;
-              }
-            }
-            int k;
-            if (state.IsConstantInt(out k))
-            {
-              return state;
-            }
-          }
-
-          return null;
-        }
-
-        public BoxedExpression Assume(APC pc, string tag, Variable condition, object provenance, BoxedExpression data)
-        {
-          var mdd = mdriver.MetaDataDecoder;
-          var cond = BoxedExpression.Convert(this.mdriver.Context.ExpressionContext.Refine(pc, condition), this.mdriver.ExpressionDecoder);
-
-          Log("Hit Assume ({0}) : {1}", tag.ToString(), cond != null ? cond.ToString() : "<null>");
-
-          if (cond == null)
-          {
-            Log("Aborting as we found a null condition for assume");
-            return null;
-          }
-
-          // We do not add the assumptions already checked somewhere else
-          if (tag == "requires" || tag == "invariant")
-          {
-            return data;
-          }
-
-          if (tag == "true")
-          {
-            if (cond.IsVariable)
-            {
-              var liftedtype = mdriver.Context.ValueContext.GetType(pc, condition);
-              if (liftedtype.IsNormal)
-              {
-                var type = liftedtype.Value;
-                if (mdd.System_Boolean.Equals(type))
-                {
-                  // do nothing
-                }
-                else if (mdd.IsReferenceType(type))
-                {
-                  // build cond != null
-                  cond = BoxedExpression.Binary(BinaryOperator.Cne_Un, cond, BoxedExpression.Const(null, type, mdd));
-                }
-                else
-                {
-                  // build cond != 0
-                  cond = BoxedExpression.Binary(BinaryOperator.Cne_Un, cond, BoxedExpression.Const(0, type, mdd));
-                }
-              }
-            }
-          }
-          else if (tag == "false")
-          {
-            UnaryOperator uop;
-            BoxedExpression inner;
-
-            // !(!inner) ? ---> inner != null
-            if (cond.IsUnaryExpression(out uop, out inner) && uop == UnaryOperator.Not)
-            {
-              cond = BoxedExpression.Binary(BinaryOperator.Cne_Un, inner, BoxedExpression.Const(null, mdd.System_Object, mdd));
-            }
-            else
-            {
-              cond = BoxedExpression.Unary(UnaryOperator.Not, cond);
-            }
-          }
-
-          bool B;
-          if(cond.IsTrivialCondition(out B))
-          {
-            return B ? data : BoxedExpression.ConstBool(false, this.mdriver.MetaDataDecoder);
-          }
-
-
-          return BoxedExpression.BinaryLogicalAnd(cond, data);
-        }
-
-        protected BoxedExpression ReadInPostState(BoxedExpression candidate, IFunctionalMap<Variable, Variable> renaming)
-        {
-          Contract.Requires(candidate != null);
-
-          Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-          if (candidate.IsVariable)
-          {
-            Variable v;
-            if (candidate.TryGetFrameworkVariable(out v))
-            {
-              // F: bad bad way of doing reverse lookup. This should be changed (by now it is balanced by the fact that we cache the reconstructed expressions)
-              foreach (var key in renaming.Keys)
-              {
-                var val = renaming[key];
-                if (v.Equals(val))
-                {
-                  return BoxedExpression.Var(key);
-                }
-              }
-            }
-
-            return candidate;
-          }
-          if (candidate.IsUnary)
-          {
-            return BoxedExpression.Unary(candidate.UnaryOp, ReadInPostState(candidate.UnaryArgument, renaming));
-          }
-
-          BinaryOperator bop;
-          BoxedExpression left, right;
-          if (candidate.IsBinaryExpression(out bop, out left, out right))
-          {
-            return BoxedExpression.Binary(bop, ReadInPostState(left, renaming), ReadInPostState(right, renaming));
-          }
-          return candidate;
-        }
-
-        #endregion
-
-        #region Utils to simplify expressions
-
-
-        #endregion
-
-        #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Variable,Variable,BoxedExpression,BoxedExpression> Members
-
-        public BoxedExpression Arglist(APC pc, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression BranchCond(APC pc, APC target, BranchOperator bop, Variable value1, Variable value2, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression BranchTrue(APC pc, APC target, Variable cond, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression BranchFalse(APC pc, APC target, Variable cond, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Branch(APC pc, APC target, bool leave, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Break(APC pc, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Variable dest, ArgList args, BoxedExpression data)
-          where TypeList : Microsoft.Research.DataStructures.IIndexable<Type>
-          where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
-        {
-          return data;
-        }
-
-        public BoxedExpression Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Variable dest, Variable fp, ArgList args, BoxedExpression data)
-          where TypeList : Microsoft.Research.DataStructures.IIndexable<Type>
-          where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
-        {
-          return data;
-        }
-
-        public BoxedExpression Ckfinite(APC pc, Variable dest, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Cpblk(APC pc, bool @volatile, Variable destaddr, Variable srcaddr, Variable len, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Endfilter(APC pc, Variable decision, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Endfinally(APC pc, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Initblk(APC pc, bool @volatile, Variable destaddr, Variable value, Variable len, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Jmp(APC pc, Method method, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldarg(APC pc, Parameter argument, bool isOld, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldarga(APC pc, Parameter argument, bool isOld, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldftn(APC pc, Method method, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldind(APC pc, Type type, bool @volatile, Variable dest, Variable ptr, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldloc(APC pc, Local local, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldloca(APC pc, Local local, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Localloc(APC pc, Variable dest, Variable size, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Nop(APC pc, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Pop(APC pc, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Return(APC pc, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Starg(APC pc, Parameter argument, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Stind(APC pc, Type type, bool @volatile, Variable ptr, Variable value, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Stloc(APC pc, Local local, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Switch(APC pc, Type type, IEnumerable<Microsoft.Research.DataStructures.Pair<object, APC>> cases, Variable value, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Box(APC pc, Type type, Variable dest, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Variable dest, ArgList args, BoxedExpression data)
-          where TypeList : Microsoft.Research.DataStructures.IIndexable<Type>
-          where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
-        {
-          return data;
-        }
-
-        public BoxedExpression Castclass(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Cpobj(APC pc, Type type, Variable destptr, Variable srcptr, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Initobj(APC pc, Type type, Variable ptr, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldelem(APC pc, Type type, Variable dest, Variable array, Variable index, BoxedExpression data)
-        {
-          Log("Hit ldelem {0} = {1}[{2}] with {3}", dest, array, index, data);
-
-          if (data != null)
-          {
-            return data.Substitute(delegate(Variable v, BoxedExpression be)
-            {
-              if (dest.Equals(v))
-              {
-                var context = this.mdriver.Context.ExpressionContext;
-                var arrayExp = BoxedExpression.Convert(this.mdriver.Context.ExpressionContext.Refine(pc, array), this.mdriver.ExpressionDecoder);
-                var indexExp = BoxedExpression.Convert(this.mdriver.Context.ExpressionContext.Refine(pc, index), this.mdriver.ExpressionDecoder);
-                if (arrayExp != null && indexExp != null)
-                {
-                  return new BoxedExpression.ArrayIndexExpression<Type>(arrayExp, indexExp, type);
-                }
-              }
-              return be;
-            });
-          }
-
-          return data;
-        }
-
-        public BoxedExpression Ldelema(APC pc, Type type, bool @readonly, Variable dest, Variable array, Variable index, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldfld(APC pc, Field field, bool @volatile, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldflda(APC pc, Field field, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldlen(APC pc, Variable dest, Variable array, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldsfld(APC pc, Field field, bool @volatile, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldsflda(APC pc, Field field, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldtypetoken(APC pc, Type type, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldfieldtoken(APC pc, Field field, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldmethodtoken(APC pc, Method method, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldvirtftn(APC pc, Method method, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Mkrefany(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Newarray<ArgList>(APC pc, Type type, Variable dest, ArgList len, BoxedExpression data) where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
-        {
-          return data;
-        }
-
-        public BoxedExpression Newobj<ArgList>(APC pc, Method ctor, Variable dest, ArgList args, BoxedExpression data) where ArgList : Microsoft.Research.DataStructures.IIndexable<Variable>
-        {
-          return data;
-        }
-
-        public BoxedExpression Refanytype(APC pc, Variable dest, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Refanyval(APC pc, Type type, Variable dest, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Rethrow(APC pc, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Stelem(APC pc, Type type, Variable array, Variable index, Variable value, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Stfld(APC pc, Field field, bool @volatile, Variable obj, Variable value, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Stsfld(APC pc, Field field, bool @volatile, Variable value, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Throw(APC pc, Variable exn, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Unbox(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Unboxany(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        #endregion
-
-        #region IVisitSynthIL<APC,Method,Type,Variable,Variable,BoxedExpression,BoxedExpression> Members
-
-        public BoxedExpression Entry(APC pc, Method method, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Assert(APC pc, string tag, Variable condition, object provenance, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldstack(APC pc, int offset, Variable dest, Variable source, bool isOld, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldstacka(APC pc, int offset, Variable dest, Variable source, Type origParamType, bool isOld, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldresult(APC pc, Type type, Variable dest, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression BeginOld(APC pc, APC matchingEnd, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression EndOld(APC pc, APC matchingBegin, Type type, Variable dest, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        #endregion
-
-        #region IVisitExprIL<APC,Type,Variable,Variable,BoxedExpression,BoxedExpression> Members
-
-        public BoxedExpression Binary(APC pc, BinaryOperator op, Variable dest, Variable s1, Variable s2, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Isinst(APC pc, Type type, Variable dest, Variable obj, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldconst(APC pc, object constant, Type type, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Ldnull(APC pc, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Sizeof(APC pc, Type type, Variable dest, BoxedExpression data)
-        {
-          return data;
-        }
-
-        public BoxedExpression Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Variable source, BoxedExpression data)
-        {
-          return data;
-        }
-
-        #endregion
-      }
-
-      #region Logging
-      [Conditional("DEBUG")]
-      static private void Log(string format, params object[] args)
-      {
-        if (Trace)
-        {
-          Console.WriteLine(format, args);
-        }
-      }
-      #endregion
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/CodeLayer.cs
+++ b/Microsoft.Research/CodeAnalysis/CodeLayer.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,134 +9,133 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using StackTemp = System.Int32;
-  public static class CodeLayerFactory
-  {
-    public static ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
-      Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
-        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder, 
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, 
-        IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
-        Converter<Expression,string> expression2String,
-        Converter<Variable,string> variable2String,
-        Func<Variable,Variable,bool> newerThan
-      )
-      where Type : IEquatable<Type>
-      where ContextData : IMethodContext<Field,Method>
+    using StackTemp = System.Int32;
+    public static class CodeLayerFactory
     {
-      return new CodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
-        ildecoder, mdDecoder, ctDecoder,
-        expression2String, variable2String,
-        newerThan
-        );
+        public static ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
+          Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
+            IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder,
+            IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+            IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
+            Converter<Expression, string> expression2String,
+            Converter<Variable, string> variable2String,
+            Func<Variable, Variable, bool> newerThan
+          )
+          where Type : IEquatable<Type>
+          where ContextData : IMethodContext<Field, Method>
+        {
+            return new CodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
+              ildecoder, mdDecoder, ctDecoder,
+              expression2String, variable2String,
+              newerThan
+              );
+        }
+
+        public static ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
+        Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
+          IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
+          Converter<Expression, string> expression2String,
+          Converter<Variable, string> variable2String,
+          ILPrinter<APC> printer,
+          Func<Variable, Variable, bool> newerThan
+        )
+          where Type : IEquatable<Type>
+          where ContextData : IMethodContext<Field, Method>
+        {
+            return new CodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
+              ildecoder, mdDecoder, ctDecoder,
+              expression2String, variable2String,
+              printer, newerThan
+              );
+        }
     }
 
-    public static ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
-    Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
-      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
-      Converter<Expression, string> expression2String,
-      Converter<Variable, string> variable2String,
-      ILPrinter<APC> printer,
-      Func<Variable,Variable,bool> newerThan
-    )
+    internal class CodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
+          : ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
       where Type : IEquatable<Type>
       where ContextData : IMethodContext<Field, Method>
     {
-      return new CodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>(
-        ildecoder, mdDecoder, ctDecoder,
-        expression2String, variable2String,
-        printer, newerThan
-        );
-    }
+        private IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder;
+        private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+        private IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder;
+        private Converter<Expression, string> expression2String;
+        private Converter<Variable, string> variable2String;
+        private ILPrinter<APC> printer;
+        private Func<Variable, Variable, bool> newerThan;
 
-  }
-
-  class CodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
-        : ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData>
-    where Type : IEquatable<Type>
-    where ContextData : IMethodContext<Field, Method>
-  {
-    private IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder;
-    private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-    private IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder;
-    private Converter<Expression, string> expression2String;
-    private Converter<Variable, string> variable2String;
-    private ILPrinter<APC> printer;
-    private Func<Variable, Variable, bool> newerThan;
-
-    public CodeLayer(IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
-      Converter<Expression, string> expression2String, Converter<Variable, string> variable2String,
-      Func<Variable,Variable,bool> newerThan)
-    {
-      this.ildecoder = ildecoder;
-      this.mdDecoder = mdDecoder;
-      this.ctDecoder = ctDecoder;
-      this.expression2String = expression2String;
-      this.variable2String = variable2String;
-      this.newerThan = newerThan;
-    }
-
-    public CodeLayer(IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
-      Converter<Expression, string> expression2String, Converter<Variable, string> variable2String,
-      ILPrinter<APC> printer, Func<Variable, Variable, bool> newerThan)
-      : this(ildecoder, mdDecoder, ctDecoder, expression2String, variable2String, newerThan)
-    {
-      this.printer = printer;
-    }
-
-
-    #region ICodeLayer<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly,LogOptions,Expression,Variable,ContextData> Members
-
-    public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
-    {
-      get { return this.mdDecoder; }
-    }
-
-    public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
-    {
-      get { return this.ctDecoder; }
-    }
-
-    public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> Decoder
-    {
-      get { return this.ildecoder; }
-    }
-
-    public Converter<Variable, string> VariableToString
-    {
-      get { return this.variable2String; }
-    }
-
-    public Converter<Expression, string> ExpressionToString
-    {
-      get { return this.expression2String; }
-    }
-
-    public ILPrinter<APC> Printer
-    {
-      get {
-        if (printer == null)
+        public CodeLayer(IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
+          Converter<Expression, string> expression2String, Converter<Variable, string> variable2String,
+          Func<Variable, Variable, bool> newerThan)
         {
-          printer = PrinterFactory.Create(this.ildecoder, this.mdDecoder, this.expression2String, this.variable2String);
+            this.ildecoder = ildecoder;
+            this.mdDecoder = mdDecoder;
+            this.ctDecoder = ctDecoder;
+            this.expression2String = expression2String;
+            this.variable2String = variable2String;
+            this.newerThan = newerThan;
         }
-        return printer;
-      }
+
+        public CodeLayer(IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> ildecoder, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> ctDecoder,
+          Converter<Expression, string> expression2String, Converter<Variable, string> variable2String,
+          ILPrinter<APC> printer, Func<Variable, Variable, bool> newerThan)
+          : this(ildecoder, mdDecoder, ctDecoder, expression2String, variable2String, newerThan)
+        {
+            this.printer = printer;
+        }
+
+
+        #region ICodeLayer<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly,LogOptions,Expression,Variable,ContextData> Members
+
+        public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
+        {
+            get { return mdDecoder; }
+        }
+
+        public IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder
+        {
+            get { return ctDecoder; }
+        }
+
+        public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> Decoder
+        {
+            get { return ildecoder; }
+        }
+
+        public Converter<Variable, string> VariableToString
+        {
+            get { return variable2String; }
+        }
+
+        public Converter<Expression, string> ExpressionToString
+        {
+            get { return expression2String; }
+        }
+
+        public ILPrinter<APC> Printer
+        {
+            get
+            {
+                if (printer == null)
+                {
+                    printer = PrinterFactory.Create(ildecoder, mdDecoder, expression2String, variable2String);
+                }
+                return printer;
+            }
+        }
+
+        public bool NewerThan(Variable v1, Variable v2) { return newerThan(v1, v2); }
+
+        public Func<AnalysisState, IFixpointInfo<APC, AnalysisState>> CreateForward<AnalysisState>(
+          IAnalysis<APC, AnalysisState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, AnalysisState, AnalysisState>, EdgeData> analysis,
+          DFAOptions options)
+        {
+            var solver = ForwardAnalysisSolver<AnalysisState, Type, EdgeData>.Make(ildecoder, analysis, this.Printer);
+            solver.Options = options;
+            return (initialState) => { solver.Run(initialState); return solver; };
+        }
+
+        #endregion
     }
-
-    public bool NewerThan(Variable v1, Variable v2) { return this.newerThan(v1, v2); }
-
-    public Func<AnalysisState, IFixpointInfo<APC, AnalysisState>> CreateForward<AnalysisState>(
-      IAnalysis<APC, AnalysisState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, AnalysisState, AnalysisState>, EdgeData> analysis,
-      DFAOptions options)
-    {
-      var solver = ForwardAnalysisSolver<AnalysisState, Type, EdgeData>.Make(this.ildecoder, analysis, this.Printer);
-      solver.Options = options;
-      return (initialState) => { solver.Run(initialState); return solver; };
-    }
-
-    #endregion
-
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/ConcreteFloatingPointTypes.cs
+++ b/Microsoft.Research/CodeAnalysis/ConcreteFloatingPointTypes.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,34 +9,33 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// Define the concrete floating point types
-  /// </summary>
-  public enum ConcreteFloat
-  {
-    Float32, Float64, Float80, Uncompatible
-  }
-
-  public static class ConcreteFloatsExtensions
-  {
-    public static string ToCastString(this ConcreteFloat f)
+    /// <summary>
+    /// Define the concrete floating point types
+    /// </summary>
+    public enum ConcreteFloat
     {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      switch (f)
-      {
-        case ConcreteFloat.Float32:
-          return "(float)";
-
-        case ConcreteFloat.Float64:
-          return "(double)";
-
-        case ConcreteFloat.Float80:
-        case ConcreteFloat.Uncompatible:
-        default:
-          return "";
-      }
+        Float32, Float64, Float80, Uncompatible
     }
 
-  }
+    public static class ConcreteFloatsExtensions
+    {
+        public static string ToCastString(this ConcreteFloat f)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            switch (f)
+            {
+                case ConcreteFloat.Float32:
+                    return "(float)";
+
+                case ConcreteFloat.Float64:
+                    return "(double)";
+
+                case ConcreteFloat.Float80:
+                case ConcreteFloat.Uncompatible:
+                default:
+                    return "";
+            }
+        }
+    }
 }

--- a/Microsoft.Research/CodeAnalysis/DFA.cs
+++ b/Microsoft.Research/CodeAnalysis/DFA.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,1496 +11,1535 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
-  using System.Diagnostics.Contracts;
-  using System.Threading;
+    using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
+    using System.Diagnostics.Contracts;
+    using System.Threading;
 
-  public class DFAOptions
-  {
-    public bool Trace { get; set; }
-    public bool TraceTimePerInstruction { get; set; }
-    public bool TraceMemoryPerInstruction { get; set; }
-
-    /// <summary>
-    /// How many exact joins we do before applying the widening operator?
-    /// </summary>
-    public int IterationsBeforeWidening { get; set; }
-    public bool EnforceFairJoin { get; set; }
-    /// <summary>
-    /// Timeout expressed in minutes for the fixpoint computation
-    /// </summary>
-    public int Timeout { get; set; }
-
-    public DFAOptions()
+    public class DFAOptions
     {
-      Timeout = Int32.MaxValue;
-    }
+        public bool Trace { get; set; }
+        public bool TraceTimePerInstruction { get; set; }
+        public bool TraceMemoryPerInstruction { get; set; }
 
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(Timeout >= 0);
-    }
+        /// <summary>
+        /// How many exact joins we do before applying the widening operator?
+        /// </summary>
+        public int IterationsBeforeWidening { get; set; }
+        public bool EnforceFairJoin { get; set; }
+        /// <summary>
+        /// Timeout expressed in minutes for the fixpoint computation
+        /// </summary>
+        public int Timeout { get; set; }
 
-  }
-
-  [ContractVerification(true)]
-  public abstract class DFARoot
-  {
-
-    #region Constants
-    
-    public const int DefaultTimeOut = 180;
-
-    #endregion
-
-    #region TimeOut
-    static public TimeOutChecker StartTimeOut(int time, CancellationToken cancellationToken)
-    {
-      Contract.Requires(time > 0);
-
-      Contract.Ensures(Contract.Result<TimeOutChecker>() != null);
-
-      timeout = new TimeOutChecker(time, cancellationToken);
-
-      return timeout;
-    }
-
-    [ThreadStatic]
-    static private TimeOutChecker timeout;
-
-    static public TimeOutChecker TimeOut
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<TimeOutChecker>() != null);
-
-        // just to make the code more robust
-        if (timeout == null)
+        public DFAOptions()
         {
-          timeout = new TimeOutChecker(DefaultTimeOut, new CancellationToken());
+            Timeout = Int32.MaxValue;
         }
 
-        return timeout;
-      }
-    }
-    #endregion
-
-    #region Object invariant
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.timeCounter != null);
-    }
-
-
-    #endregion
-
-    #region Time Counter
-
-    protected readonly TimeCounter timeCounter;
-
-    #endregion
-
-    #region Constructor
-
-    protected DFARoot()
-    {
-      this.timeCounter = new TimeCounter();
-    }
-
-    #endregion
-
-  }
-
-  #region DFARoot<AState, Type> contract binding
-  [ContractClass(typeof(DFARootContract<, >))]
-  public abstract partial class DFARoot<AState, Type>
-  {
-
-  }
-
-  [ContractClassFor(typeof(DFARoot<,>))]
-  abstract class DFARootContract <AState, Type> : DFARoot<AState, Type>
-  {
-    protected DFARootContract(ICFG cfg) : base(cfg) {}
-
-    protected override int Comparer(APC o1, APC o2)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override bool RequiresJoining(APC apc)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override bool IsBackEdge(APC from, APC to)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override bool HasSingleSuccessor(APC current, out APC next)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override IEnumerable<APC> Successors(APC current)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override AState ImmutableVersion(AState state, APC at)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override AState MutableVersion(AState state, APC at)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override bool Join(Pair<APC, APC> edge, AState newState, AState existingState, out AState joinedState, bool widen)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override AState Transfer(APC pc, AState state)
-    {
-      Contract.Ensures(Contract.Result<AState>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    protected override bool IsBottom(APC pc, AState state)
-    {
-      throw new NotImplementedException();
-    }
-
-    protected override bool IsTop(APC pc, AState state)
-    {
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
-
-  [ContractVerification(true)]
-  public abstract partial class DFARoot<AState, Type> : DFARoot, IEqualityComparer<APC>
-  {
-    #region Object invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.pending != null);
-      Contract.Invariant(this.joinState != null);
-    }
-
-    #endregion
-
-    private DFAOptions options;
-    public DFAOptions Options
-    {
-      get
-      {
-        if (options == null)
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          this.options = new DFAOptions();
+            Contract.Invariant(Timeout >= 0);
         }
-        return this.options;
-      }
-      set
-      {
-        this.options = value;
-      }
-    }
-    private IWidenStrategy widenStrategy;
-
-    /// <summary>
-    /// Predicate indicating to fixpoint computation where to cache intermediate state.
-    /// </summary>
-    private Predicate<APC> cachePolicy;
-
-    public Predicate<APC> CachePolicy {
-      set
-      {
-        this.cachePolicy = value;
-      }
     }
 
-    protected bool CacheThisPC(APC pc)
+    [ContractVerification(true)]
+    public abstract class DFARoot
     {
-      if (cachePolicy != null) return cachePolicy(pc);
-      return false;
-    }
+        #region Constants
 
-    protected ICFG cfg;
+        public const int DefaultTimeOut = 180;
 
-    /// <summary>
-    /// Maintains the summmary abstract state at a join point, which is the join/widening of all incoming edges
-    /// NOTE: states may also be cached at APCs other than join points.
-    /// </summary>
-    readonly private Dictionary<APC, AState> joinState;
+        #endregion
 
-    public IEnumerable<KeyValuePair<APC, AState>> JoinStates() {
-      return joinState;
-    }
+        #region TimeOut
+        static public TimeOutChecker StartTimeOut(int time, CancellationToken cancellationToken)
+        {
+            Contract.Requires(time > 0);
 
-    public bool TryJoinState(APC apc, out AState value)
-    {
-      return this.joinState.TryGetValue(apc, out value);
-    }
+            Contract.Ensures(Contract.Result<TimeOutChecker>() != null);
 
-    /// <summary>
-    /// An abstract pc is in this set if it needs to be (re)analyzed.
-    /// </summary>
-    readonly protected PriorityQueue<APC> pending;
+            timeout = new TimeOutChecker(time, cancellationToken);
 
-    protected DFARoot(ICFG cfg) {
-      this.cfg = cfg;
-      this.pending = new PriorityQueue<APC>(this.Comparer);
-
-      this.widenStrategy = null; // Will be set later
-      this.joinState = new Dictionary<APC, AState>(this);
-    }
-
-    /// <summary>
-    /// State state must be immutable.
-    /// </summary>
-    protected void Seed(APC startPC, AState startState) {
-      joinState.Add(startPC, startState);
-      pending.Add(startPC);
-    }
-
-    /// <summary>
-    /// Called whenever we have a new state at the beginning of a block
-    /// This method decides whether
-    /// a) it is a join point and requires a join
-    /// b) whether to just cache the state
-    /// </summary>
-    public virtual void PushState(APC current, APC next, AState state)
-    {
-      // since we store this away, we need to get an immutable version
-      state = ImmutableVersion(state, next);
-
-      if (RequiresJoining(next)) {
-        Pair<APC, APC> edge = new Pair<APC, APC>(current, next);
-        if (JoinStateAtBlock(edge, state)) {
-          this.pending.Add(next);
+            return timeout;
         }
-      }
-      else {
-        // don't join if no join is required, just store pending state and add to pending list
-        this.joinState[next] = state;
-        this.pending.Add(next);
-      }
+
+        [ThreadStatic]
+        static private TimeOutChecker timeout;
+
+        static public TimeOutChecker TimeOut
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<TimeOutChecker>() != null);
+
+                // just to make the code more robust
+                if (timeout == null)
+                {
+                    timeout = new TimeOutChecker(DefaultTimeOut, new CancellationToken());
+                }
+
+                return timeout;
+            }
+        }
+        #endregion
+
+        #region Object invariant
+
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.timeCounter != null);
+        }
+
+
+        #endregion
+
+        #region Time Counter
+
+        protected readonly TimeCounter timeCounter;
+
+        #endregion
+
+        #region Constructor
+
+        protected DFARoot()
+        {
+            this.timeCounter = new TimeCounter();
+        }
+
+        #endregion
     }
 
-    /// <summary>
-    /// Called by the TryGetAStateForPostcondition to rename a state
-    /// </summary>
-    protected virtual bool TryRename(APC lastPC, APC aPC, AState currState, out AState renamed)
+    #region DFARoot<AState, Type> contract binding
+    [ContractClass(typeof(DFARootContract<,>))]
+    public abstract partial class DFARoot<AState, Type>
     {
-      Contract.Ensures(Contract.ValueAtReturn(out renamed) != null || !Contract.Result<bool>());
-
-      renamed = currState;
-      return false;
     }
 
+    [ContractClassFor(typeof(DFARoot<,>))]
+    internal abstract class DFARootContract<AState, Type> : DFARoot<AState, Type>
+    {
+        protected DFARootContract(ICFG cfg) : base(cfg) { }
 
-    #region Edge state not needed for now
+        protected override int Comparer(APC o1, APC o2)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override bool RequiresJoining(APC apc)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override bool IsBackEdge(APC from, APC to)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override bool HasSingleSuccessor(APC current, out APC next)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override IEnumerable<APC> Successors(APC current)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override AState ImmutableVersion(AState state, APC at)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override AState MutableVersion(AState state, APC at)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override bool Join(Pair<APC, APC> edge, AState newState, AState existingState, out AState joinedState, bool widen)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override AState Transfer(APC pc, AState state)
+        {
+            Contract.Ensures(Contract.Result<AState>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        protected override bool IsBottom(APC pc, AState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override bool IsTop(APC pc, AState state)
+        {
+            throw new NotImplementedException();
+        }
+    }
+    #endregion
+
+    [ContractVerification(true)]
+    public abstract partial class DFARoot<AState, Type> : DFARoot, IEqualityComparer<APC>
+    {
+        #region Object invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.pending != null);
+            Contract.Invariant(joinState != null);
+        }
+
+        #endregion
+
+        private DFAOptions options;
+        public DFAOptions Options
+        {
+            get
+            {
+                if (options == null)
+                {
+                    options = new DFAOptions();
+                }
+                return options;
+            }
+            set
+            {
+                options = value;
+            }
+        }
+        private IWidenStrategy widenStrategy;
+
+        /// <summary>
+        /// Predicate indicating to fixpoint computation where to cache intermediate state.
+        /// </summary>
+        private Predicate<APC> cachePolicy;
+
+        public Predicate<APC> CachePolicy
+        {
+            set
+            {
+                cachePolicy = value;
+            }
+        }
+
+        protected bool CacheThisPC(APC pc)
+        {
+            if (cachePolicy != null) return cachePolicy(pc);
+            return false;
+        }
+
+        protected ICFG cfg;
+
+        /// <summary>
+        /// Maintains the summmary abstract state at a join point, which is the join/widening of all incoming edges
+        /// NOTE: states may also be cached at APCs other than join points.
+        /// </summary>
+        readonly private Dictionary<APC, AState> joinState;
+
+        public IEnumerable<KeyValuePair<APC, AState>> JoinStates()
+        {
+            return joinState;
+        }
+
+        public bool TryJoinState(APC apc, out AState value)
+        {
+            return joinState.TryGetValue(apc, out value);
+        }
+
+        /// <summary>
+        /// An abstract pc is in this set if it needs to be (re)analyzed.
+        /// </summary>
+        readonly protected PriorityQueue<APC> pending;
+
+        protected DFARoot(ICFG cfg)
+        {
+            this.cfg = cfg;
+            this.pending = new PriorityQueue<APC>(this.Comparer);
+
+            widenStrategy = null; // Will be set later
+            joinState = new Dictionary<APC, AState>(this);
+        }
+
+        /// <summary>
+        /// State state must be immutable.
+        /// </summary>
+        protected void Seed(APC startPC, AState startState)
+        {
+            joinState.Add(startPC, startState);
+            pending.Add(startPC);
+        }
+
+        /// <summary>
+        /// Called whenever we have a new state at the beginning of a block
+        /// This method decides whether
+        /// a) it is a join point and requires a join
+        /// b) whether to just cache the state
+        /// </summary>
+        public virtual void PushState(APC current, APC next, AState state)
+        {
+            // since we store this away, we need to get an immutable version
+            state = ImmutableVersion(state, next);
+
+            if (RequiresJoining(next))
+            {
+                Pair<APC, APC> edge = new Pair<APC, APC>(current, next);
+                if (JoinStateAtBlock(edge, state))
+                {
+                    this.pending.Add(next);
+                }
+            }
+            else
+            {
+                // don't join if no join is required, just store pending state and add to pending list
+                joinState[next] = state;
+                this.pending.Add(next);
+            }
+        }
+
+        /// <summary>
+        /// Called by the TryGetAStateForPostcondition to rename a state
+        /// </summary>
+        protected virtual bool TryRename(APC lastPC, APC aPC, AState currState, out AState renamed)
+        {
+            Contract.Ensures(Contract.ValueAtReturn(out renamed) != null || !Contract.Result<bool>());
+
+            renamed = currState;
+            return false;
+        }
+
+
+        #region Edge state not needed for now
 #if false
-    bool PushStateOntoEdge(Pair<APC, APC> edge, AState state)
-    {
-      AState existing;
-      if (this.edgeState.TryGetValue(edge, out existing)) {
-        AState joined;
-        bool changed = Join(edge, state, existing, out joined, false);
-        if (changed) {
-          this.edgeState[edge] = joined;
+        bool PushStateOntoEdge(Pair<APC, APC> edge, AState state)
+        {
+            AState existing;
+            if (this.edgeState.TryGetValue(edge, out existing))
+            {
+                AState joined;
+                bool changed = Join(edge, state, existing, out joined, false);
+                if (changed)
+                {
+                    this.edgeState[edge] = joined;
+                }
+                return changed;
+            }
+            else
+            {
+                this.edgeState.Add(edge, state);
+                return true;
+            }
         }
-        return changed;
-      }
-      else {
-        this.edgeState.Add(edge, state);
-        return true;
-      }
-    }
 #endif
-    #endregion
+        #endregion
 
-    protected virtual bool JoinStateAtBlock(Pair<APC, APC> edge, AState state) 
-    {
-      AState/*?*/ existing;
-
-      if (this.joinState.TryGetValue(edge.Two, out existing)) 
-      {
-        AState joined;
-
-        Contract.Assume(this.widenStrategy != null, "At this point, the widening strategy has already been set");
-        bool widen = this.widenStrategy.WantToWiden(edge.One, edge.Two, this.IsBackEdge(edge.One, edge.Two));
-
-        bool changed = Join(edge, state, existing, out joined, widen);
-        
-        if (changed)
+        protected virtual bool JoinStateAtBlock(Pair<APC, APC> edge, AState state)
         {
-          this.joinState[edge.Two] = this.ImmutableVersion(joined, edge.Two);
-        }
-        return changed;
-      }
-      else {
-        this.joinState.Add(edge.Two, state);
-        return true;
-      }
-    }
+            AState/*?*/ existing;
 
-    /// <summary>
-    /// Print the states at join points
-    /// </summary>
-    public void PrintStatesAtJoinPoints(TextWriter output)
-    {
-      // It's just logging
-      if(output == null)
-      {
-        return;
-      }
+            if (joinState.TryGetValue(edge.Two, out existing))
+            {
+                AState joined;
 
-      foreach (APC apc in this.joinState.Keys)
-      {
-        string stateAsStr = this.joinState[apc].ToString().Replace(Environment.NewLine, Environment.NewLine + "  ");
+                Contract.Assume(widenStrategy != null, "At this point, the widening strategy has already been set");
+                bool widen = widenStrategy.WantToWiden(edge.One, edge.Two, this.IsBackEdge(edge.One, edge.Two));
 
-        output.WriteLine("Block {0}, PC {1}: {2}", apc.Block.ToString(), apc.Index.ToString(), stateAsStr);
-      }
-    }
+                bool changed = Join(edge, state, existing, out joined, widen);
 
-    private AState Cache(APC pc, AState state)
-    {
-      state = ImmutableVersion(state, pc);
-      if (this.Options.Trace)
-      {
-        Console.WriteLine("Caching at {0}", pc);
-        this.Dump(state);
-      }
-      this.joinState[pc] = state;
-      return MutableVersion(state, pc);
-    }
-
-
-    protected virtual void ComputeFixpoint()
-    {
-      var timeout = TimeOut;
-
-      if (this.Options.EnforceFairJoin)
-      {
-        this.widenStrategy = new EdgeBasedWidening(this.Options.IterationsBeforeWidening);
-      }
-      else
-      {
-        this.widenStrategy = new BlockBasedWidening(this.Options.IterationsBeforeWidening);
-      }
-
-      while (pending.Count > 0)
-      {
-        var next = pending.Pull();
-        var state = MutableVersion(joinState[next], next);
-        var alreadyCached = true;
-        APC current;
-
-        if (Options.Trace)
-        {
-          Console.WriteLine("State before {0}", next);
-          Dump(state);
+                if (changed)
+                {
+                    joinState[edge.Two] = this.ImmutableVersion(joined, edge.Two);
+                }
+                return changed;
+            }
+            else
+            {
+                joinState.Add(edge.Two, state);
+                return true;
+            }
         }
 
-        if (this.Options.TraceTimePerInstruction)
+        /// <summary>
+        /// Print the states at join points
+        /// </summary>
+        public void PrintStatesAtJoinPoints(TextWriter output)
         {
-          this.timeCounter.Start();
+            // It's just logging
+            if (output == null)
+            {
+                return;
+            }
+
+            foreach (APC apc in joinState.Keys)
+            {
+                string stateAsStr = joinState[apc].ToString().Replace(Environment.NewLine, Environment.NewLine + "  ");
+
+                output.WriteLine("Block {0}, PC {1}: {2}", apc.Block.ToString(), apc.Index.ToString(), stateAsStr);
+            }
         }
 
-        do
+        private AState Cache(APC pc, AState state)
         {
-          current = next;
-
-          if (IsBottom(current, state))
-          {
-            goto nextPending;
-          }
-
-          if (!alreadyCached && this.CacheThisPC(current))
-          {
-            state = this.Cache(current, state);
-          }
-
-          state = Transfer(current, state);
-
-          if (Options.Trace)
-          {
-            Console.WriteLine("State after {0}", current);
-            Dump(state);
-          }
-
-          if (this.Options.TraceTimePerInstruction)
-          {
-            this.timeCounter.Stop();
-            Console.WriteLine("Elapsed time for {0} : {1}", current, timeCounter);
-          }
-
-          this.TraceMemoryUsageIfEnabled("after instruction", current);
-
-          // The transfer function of some abstract domains can take *really* a lot of time, this is the reason why we check the timeout here
-          timeout.CheckTimeOut("fixpoint computation");
-
-          alreadyCached = false;
-        } while (this.HasSingleSuccessor(current, out next) && !RequiresJoining(next));
-
-
-        foreach (APC succ in this.Successors(current).AssumeNotNull())
-        {
-          if (IsBottom(succ, state)) continue;
-
-          PushState(current, succ, state);
+            state = ImmutableVersion(state, pc);
+            if (this.Options.Trace)
+            {
+                Console.WriteLine("Caching at {0}", pc);
+                this.Dump(state);
+            }
+            joinState[pc] = state;
+            return MutableVersion(state, pc);
         }
-        timeout.CheckTimeOut("fixpoint computation");
 
-      nextPending:
-        ;
-      }
 
-      if (Options.Trace)
-      {
-        Console.WriteLine("DFA done");
-      }
-    }
+        protected virtual void ComputeFixpoint()
+        {
+            var timeout = TimeOut;
 
-    #region Directional abstractions
+            if (this.Options.EnforceFairJoin)
+            {
+                widenStrategy = new EdgeBasedWidening(this.Options.IterationsBeforeWidening);
+            }
+            else
+            {
+                widenStrategy = new BlockBasedWidening(this.Options.IterationsBeforeWidening);
+            }
 
-    protected abstract int Comparer(APC o1, APC o2);
+            while (pending.Count > 0)
+            {
+                var next = pending.Pull();
+                var state = MutableVersion(joinState[next], next);
+                var alreadyCached = true;
+                APC current;
 
-    protected abstract bool RequiresJoining(APC apc);
+                if (Options.Trace)
+                {
+                    Console.WriteLine("State before {0}", next);
+                    Dump(state);
+                }
 
-    protected abstract bool IsBackEdge(APC from, APC to);
+                if (this.Options.TraceTimePerInstruction)
+                {
+                    this.timeCounter.Start();
+                }
 
-    protected abstract bool HasSingleSuccessor(APC current, out APC next);
+                do
+                {
+                    current = next;
 
-    protected abstract IEnumerable<APC> Successors(APC current);
+                    if (IsBottom(current, state))
+                    {
+                        goto nextPending;
+                    }
 
-    #endregion
+                    if (!alreadyCached && this.CacheThisPC(current))
+                    {
+                        state = this.Cache(current, state);
+                    }
 
-    #region Client abstractions
+                    state = Transfer(current, state);
 
-    /// <summary>
-    /// Called by framework prior to storing a state as a temporary fixpoint.
-    /// This is useful for a client to know in that it can no longer modify that 
-    /// state, or the analysis is meaningless.
-    /// </summary>
-    protected abstract AState ImmutableVersion(AState state, APC at);
+                    if (Options.Trace)
+                    {
+                        Console.WriteLine("State after {0}", current);
+                        Dump(state);
+                    }
 
-    /// <summary>
-    /// Called by the framework whenever it picks up interpretation from a temporary
-    /// fixpoint. The result of this call is passed to the transfer function, which
-    /// is free to modify it in place (if it is mutable at all).
-    /// </summary>
-    protected abstract AState MutableVersion(AState state, APC at);
+                    if (this.Options.TraceTimePerInstruction)
+                    {
+                        this.timeCounter.Stop();
+                        Console.WriteLine("Elapsed time for {0} : {1}", current, timeCounter);
+                    }
 
-    protected abstract bool Join(Pair<APC, APC> edge, AState newState, AState existingState, out AState joinedState, bool widen);
+                    this.TraceMemoryUsageIfEnabled("after instruction", current);
 
-    /// <summary>
-    /// Apply instruction at the given pc to the abstract state.
-    /// Should be side effect free as transfer is called during recomputation of intermediate states.
-    /// </summary>
-    /// <param name="pc"></param>
-    /// <param name="state"></param>
-    /// <returns></returns>
-    protected abstract AState Transfer(APC pc, AState state);
+                    // The transfer function of some abstract domains can take *really* a lot of time, this is the reason why we check the timeout here
+                    timeout.CheckTimeOut("fixpoint computation");
 
-    /// <summary>
-    /// Must be asked in the pre-state
-    /// </summary>
-    protected abstract bool IsBottom(APC pc, AState state);
+                    alreadyCached = false;
+                } while (this.HasSingleSuccessor(current, out next) && !RequiresJoining(next));
 
-    /// <summary>
-    /// Must be asked in the pre-state
-    /// </summary>
-    protected abstract bool IsTop(APC pc, AState state);
 
-    protected virtual void Dump(AState state) { }
+                foreach (APC succ in this.Successors(current).AssumeNotNull())
+                {
+                    if (IsBottom(succ, state)) continue;
 
-    #endregion
+                    PushState(current, succ, state);
+                }
+                timeout.CheckTimeOut("fixpoint computation");
 
-    #region IEqualityComparer<APC> Members
+            nextPending:
+                ;
+            }
 
-    bool IEqualityComparer<APC>.Equals(APC x, APC y)
-    {
-      return x.Equals(y);
-    }
+            if (Options.Trace)
+            {
+                Console.WriteLine("DFA done");
+            }
+        }
 
-    int IEqualityComparer<APC>.GetHashCode(APC obj)
-    {
-      return obj.GetHashCode();
-    }
+        #region Directional abstractions
 
-    #endregion
+        protected abstract int Comparer(APC o1, APC o2);
 
-    #region Printing helpers
+        protected abstract bool RequiresJoining(APC apc);
 
-    public void TraceMemoryUsageIfEnabled(string where, APC? apc)
-    {
+        protected abstract bool IsBackEdge(APC from, APC to);
+
+        protected abstract bool HasSingleSuccessor(APC current, out APC next);
+
+        protected abstract IEnumerable<APC> Successors(APC current);
+
+        #endregion
+
+        #region Client abstractions
+
+        /// <summary>
+        /// Called by framework prior to storing a state as a temporary fixpoint.
+        /// This is useful for a client to know in that it can no longer modify that 
+        /// state, or the analysis is meaningless.
+        /// </summary>
+        protected abstract AState ImmutableVersion(AState state, APC at);
+
+        /// <summary>
+        /// Called by the framework whenever it picks up interpretation from a temporary
+        /// fixpoint. The result of this call is passed to the transfer function, which
+        /// is free to modify it in place (if it is mutable at all).
+        /// </summary>
+        protected abstract AState MutableVersion(AState state, APC at);
+
+        protected abstract bool Join(Pair<APC, APC> edge, AState newState, AState existingState, out AState joinedState, bool widen);
+
+        /// <summary>
+        /// Apply instruction at the given pc to the abstract state.
+        /// Should be side effect free as transfer is called during recomputation of intermediate states.
+        /// </summary>
+        /// <param name="pc"></param>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        protected abstract AState Transfer(APC pc, AState state);
+
+        /// <summary>
+        /// Must be asked in the pre-state
+        /// </summary>
+        protected abstract bool IsBottom(APC pc, AState state);
+
+        /// <summary>
+        /// Must be asked in the pre-state
+        /// </summary>
+        protected abstract bool IsTop(APC pc, AState state);
+
+        protected virtual void Dump(AState state) { }
+
+        #endregion
+
+        #region IEqualityComparer<APC> Members
+
+        bool IEqualityComparer<APC>.Equals(APC x, APC y)
+        {
+            return x.Equals(y);
+        }
+
+        int IEqualityComparer<APC>.GetHashCode(APC obj)
+        {
+            return obj.GetHashCode();
+        }
+
+        #endregion
+
+        #region Printing helpers
+
+        public void TraceMemoryUsageIfEnabled(string where, APC? apc)
+        {
 #if DEBUG && false
-      var currmem = System.GC.GetTotalMemory(false) / (1024 * 1024);
-      if (currmem > 4000)
-      {
-        //System.Diagnostics.Debugger.Break();
-        Console.WriteLine("Used more than 4GBytes of mem");
-      }
+            var currmem = System.GC.GetTotalMemory(false) / (1024 * 1024);
+            if (currmem > 4000)
+            {
+                //System.Diagnostics.Debugger.Break();
+                Console.WriteLine("Used more than 4GBytes of mem");
+            }
 #endif
-      if (this.Options.TraceMemoryPerInstruction)
-      {
-        var mem = System.GC.GetTotalMemory(false) / (1024 * 1024);
-        Console.WriteLine("mem: {0}Mbytes @ {1} {2}", mem, where, apc.HasValue? apc.Value.ToString() : "");
-      }
-    }
-    
-    #endregion
-  }
-
-  
-  public abstract class ForwardDFA<AState, Type> : DFARoot<AState, Type>
-  {
-    /// <summary>
-    /// Assumes that exception edges always target join points, so we never need to reach
-    /// backwards across a throw edges.
-    /// </summary>
-    public bool GetPreState(APC apc, out AState/*?*/ ifFound)
-    {      
-      bool noInfo;
-      ifFound = GetPreState(apc, default(AState), out noInfo);
-      return !noInfo;
-    }
-
-
-    public AState/*?*/ GetPreStateWithDefault(APC apc, AState/*?*/ ifMissing)
-    {
-      bool noInfo;
-      AState ifFound = GetPreState(apc, default(AState), out noInfo);
-      if (noInfo) return ifMissing;
-      return ifFound;
-    }
-
-    OnDemandCache<APC, AState> preStateCache = new OnDemandCache<APC, AState> { Capacity = 1000 };
-
-    virtual protected bool TryPreStateCache(APC apc, out AState value)
-    {
-      if (this.TryJoinState(apc, out value)) return true;
-      return preStateCache.TryGetValue(apc, out value);
-    }
-
-    virtual protected void CachePreState(APC apc, AState value)
-    {
-      this.preStateCache.Add(apc, value);
-    }
-
-    /// <summary>
-    /// Assumes that exception edges always target join points, so we never need to reach
-    /// backwards across a throw edges.
-    /// </summary>
-    /// <param name="apc"></param>
-    /// <param name="ifMissing"></param>
-    /// <returns></returns>
-    public AState/*?*/ GetPreState(APC apc, AState/*?*/ ifMissing, out bool noInfo) {
-      // Find closest preceeding cached point
-      // Keep a list of program points we visit backward so we can take the
-      // same path forward.
-      FList<APC>/*?*/ path = null;
-      APC current = apc;
-      APC pred;
-      AState/*?*/ state;
-      bool found;
-      while (!(found = this.TryPreStateCache(current, out state)) && !RequiresJoining(current) && !this.CacheThisPC(current) && this.cfg.HasSinglePredecessor(current, out pred))
-      {
-        current = pred;
-        path = path.Cons(current);
-      }
-      if (!found) {
-        noInfo = true;
-        return ifMissing; // unreachable
-      }
-      bool nonTrivialPath = path != null;
-      // Now forward simulate and cache
-      while (path != null) {
-        if (IsBottom(path.Head, state))
-        {
-          noInfo = true; // equate no info with bottom since we cannot manufacture bottom here
-          return state;
+            if (this.Options.TraceMemoryPerInstruction)
+            {
+                var mem = System.GC.GetTotalMemory(false) / (1024 * 1024);
+                Console.WriteLine("mem: {0}Mbytes @ {1} {2}", mem, where, apc.HasValue ? apc.Value.ToString() : "");
+            }
         }
-        // must get a mutable version if we are going to change it.
-        state = MutableVersion(state, path.Head);
-        state = Transfer(path.Head, state);
-        if (IsBottom(path.Head, state))
-        {
-          noInfo = false;
-          return state;
-        }
-        path = path.Tail;
-        if (path != null)
-        {
-          // cache on next
-          this.CachePreState(path.Head, ImmutableVersion(state, path.Head));
-          // this.joinState.Add(path.Head, state);
-        }
-      }
-      // cache on lookedup up apc
-      if (nonTrivialPath) {
-        this.CachePreState(apc, ImmutableVersion(state, apc));
-        // this.joinState.Add(apc, state);
-      }
-      noInfo = false;
-      return state;
+
+        #endregion
     }
+
+
+    public abstract class ForwardDFA<AState, Type> : DFARoot<AState, Type>
+    {
+        /// <summary>
+        /// Assumes that exception edges always target join points, so we never need to reach
+        /// backwards across a throw edges.
+        /// </summary>
+        public bool GetPreState(APC apc, out AState/*?*/ ifFound)
+        {
+            bool noInfo;
+            ifFound = GetPreState(apc, default(AState), out noInfo);
+            return !noInfo;
+        }
+
+
+        public AState/*?*/ GetPreStateWithDefault(APC apc, AState/*?*/ ifMissing)
+        {
+            bool noInfo;
+            AState ifFound = GetPreState(apc, default(AState), out noInfo);
+            if (noInfo) return ifMissing;
+            return ifFound;
+        }
+
+        private OnDemandCache<APC, AState> preStateCache = new OnDemandCache<APC, AState> { Capacity = 1000 };
+
+        virtual protected bool TryPreStateCache(APC apc, out AState value)
+        {
+            if (this.TryJoinState(apc, out value)) return true;
+            return preStateCache.TryGetValue(apc, out value);
+        }
+
+        virtual protected void CachePreState(APC apc, AState value)
+        {
+            preStateCache.Add(apc, value);
+        }
+
+        /// <summary>
+        /// Assumes that exception edges always target join points, so we never need to reach
+        /// backwards across a throw edges.
+        /// </summary>
+        /// <param name="apc"></param>
+        /// <param name="ifMissing"></param>
+        /// <returns></returns>
+        public AState/*?*/ GetPreState(APC apc, AState/*?*/ ifMissing, out bool noInfo)
+        {
+            // Find closest preceeding cached point
+            // Keep a list of program points we visit backward so we can take the
+            // same path forward.
+            FList<APC>/*?*/ path = null;
+            APC current = apc;
+            APC pred;
+            AState/*?*/ state;
+            bool found;
+            while (!(found = this.TryPreStateCache(current, out state)) && !RequiresJoining(current) && !this.CacheThisPC(current) && this.cfg.HasSinglePredecessor(current, out pred))
+            {
+                current = pred;
+                path = path.Cons(current);
+            }
+            if (!found)
+            {
+                noInfo = true;
+                return ifMissing; // unreachable
+            }
+            bool nonTrivialPath = path != null;
+            // Now forward simulate and cache
+            while (path != null)
+            {
+                if (IsBottom(path.Head, state))
+                {
+                    noInfo = true; // equate no info with bottom since we cannot manufacture bottom here
+                    return state;
+                }
+                // must get a mutable version if we are going to change it.
+                state = MutableVersion(state, path.Head);
+                state = Transfer(path.Head, state);
+                if (IsBottom(path.Head, state))
+                {
+                    noInfo = false;
+                    return state;
+                }
+                path = path.Tail;
+                if (path != null)
+                {
+                    // cache on next
+                    this.CachePreState(path.Head, ImmutableVersion(state, path.Head));
+                    // this.joinState.Add(path.Head, state);
+                }
+            }
+            // cache on lookedup up apc
+            if (nonTrivialPath)
+            {
+                this.CachePreState(apc, ImmutableVersion(state, apc));
+                // this.joinState.Add(apc, state);
+            }
+            noInfo = false;
+            return state;
+        }
 
 #if false
-    public bool TryAStateForPostCondition(AState initialState, out AState exitState)
-    {
-      APC currPC = default(APC);  // just to please the compiler
-      int paths = 0;
-
-      if (this.Options.Trace)
-      {
-        Console.WriteLine("Looking for a state for the postcondition filtering");
-      }
-
-      var currState = initialState;
-
-      foreach (var prevBlock in this.cfg.NormalExit.Block.Subroutine.PredecessorBlocks(this.cfg.NormalExit.Block))
-      {
-        if(this.Options.Trace)
+        public bool TryAStateForPostCondition(AState initialState, out AState exitState)
         {
-          Console.WriteLine("Starting analysis of predecessor #{0} (Block {1})", paths, prevBlock.ToString());        
-        }
+            APC currPC = default(APC);  // just to please the compiler
+            int paths = 0;
 
-        APC prevPC, lastPC; 
-        prevPC = lastPC = currPC = prevBlock.Last;
-        currState = initialState;
-
-        // F: this is a rough strategy. A subroutine may contain loops. In this case we just gave up 
-        // (I do not want to compute a fixpoint here to avoid slowing down the inference of posts)
-        while (currPC.Block != this.cfg.NormalExit.Block && this.cfg.HasSingleSuccessor(currPC, out currPC))
-        {
-          if (currPC.Block.First.Equals(currPC))
-          {
-            int preds = 0;
-            foreach (var p in this.cfg.Predecessors(currPC))
-            {
-              preds++;
-            }
-
-            if (preds > 1 && currPC.Block != this.cfg.NormalExit.Block)
-            {
-              exitState = initialState;
-              return false;
-            }
-          }
-
-          currState = Transfer(currPC, currState);
-
-          if (IsBottom(currPC, currState))
-          {
             if (this.Options.Trace)
             {
-              Console.WriteLine("Found bottom, giving up");
+                Console.WriteLine("Looking for a state for the postcondition filtering");
             }
 
-            exitState = initialState;
-            return false;
-          }
+            var currState = initialState;
 
-          prevPC = lastPC;
-          lastPC = currPC;
+            foreach (var prevBlock in this.cfg.NormalExit.Block.Subroutine.PredecessorBlocks(this.cfg.NormalExit.Block))
+            {
+                if (this.Options.Trace)
+                {
+                    Console.WriteLine("Starting analysis of predecessor #{0} (Block {1})", paths, prevBlock.ToString());
+                }
+
+                APC prevPC, lastPC;
+                prevPC = lastPC = currPC = prevBlock.Last;
+                currState = initialState;
+
+                // F: this is a rough strategy. A subroutine may contain loops. In this case we just gave up 
+                // (I do not want to compute a fixpoint here to avoid slowing down the inference of posts)
+                while (currPC.Block != this.cfg.NormalExit.Block && this.cfg.HasSingleSuccessor(currPC, out currPC))
+                {
+                    if (currPC.Block.First.Equals(currPC))
+                    {
+                        int preds = 0;
+                        foreach (var p in this.cfg.Predecessors(currPC))
+                        {
+                            preds++;
+                        }
+
+                        if (preds > 1 && currPC.Block != this.cfg.NormalExit.Block)
+                        {
+                            exitState = initialState;
+                            return false;
+                        }
+                    }
+
+                    currState = Transfer(currPC, currState);
+
+                    if (IsBottom(currPC, currState))
+                    {
+                        if (this.Options.Trace)
+                        {
+                            Console.WriteLine("Found bottom, giving up");
+                        }
+
+                        exitState = initialState;
+                        return false;
+                    }
+
+                    prevPC = lastPC;
+                    lastPC = currPC;
+                }
+
+                if (this.Options.Trace)
+                {
+                    Console.WriteLine("Trying to apply the renaming: {0} --> {1}", prevPC, lastPC.Block.First);
+                }
+
+
+                AState renamed;
+                if (!this.IsTop(prevPC, currState) // Inferring good postconditions is based on a heuristic. We do not want the renaming to add more information 
+                  && this.TryRename(prevPC, lastPC.Block.First, currState, out renamed))
+                {
+                    currState = renamed;
+                }
+
+                if (this.Options.Trace)
+                {
+                    Console.WriteLine("Found state\n{0}", currState);
+                }
+
+                paths++;
+                if (paths == 1)
+                {
+                    break;
+                }
+            }
+
+            if (paths == 0)
+            {
+                exitState = initialState;
+                return false;
+            }
+
+            exitState = currState;
+            return true;
         }
-
-        if (this.Options.Trace)
-        {
-          Console.WriteLine("Trying to apply the renaming: {0} --> {1}", prevPC, lastPC.Block.First);
-        }
-
-
-        AState renamed;
-        if (!this.IsTop(prevPC, currState) // Inferring good postconditions is based on a heuristic. We do not want the renaming to add more information 
-          && this.TryRename(prevPC, lastPC.Block.First, currState, out renamed))
-        {
-          currState = renamed;
-        }
-        
-        if (this.Options.Trace)
-        {
-          Console.WriteLine("Found state\n{0}", currState);
-        }
-
-        paths++;
-        if (paths == 1)
-        {
-          break;
-        }
-      }
-
-      if (paths == 0)
-      {
-        exitState = initialState;
-        return false;
-      }
-
-      exitState = currState;
-      return true;
-    }
 #endif
 
-    /// <summary>
-    /// Maintains the abstract post state for given apc's that have join successors. Computed on demand
-    /// </summary>
-    protected OnDemandMap<APC, AState> postState;
-    
-    public bool GetPostState(APC apc, out AState/*?*/ result)
-    {
-      if (postState.TryGetValue(apc, out result)) {
-        return true;
-      }
-      APC succ;
-      if (apc.Block.Count <= apc.Index)
-      {
-        // this is already the post program point in this block, so pre==post state here
-        return GetPreState(apc, out result);
-      }
-      if (cfg.HasSingleSuccessor(apc, out succ) && !RequiresJoining(succ)) {
-        return GetPreState(succ, out result);
-      }
-      else {
-        // recompute from pre-state
-        AState preState;
-        if (!GetPreState(apc, out preState)) {
-          return false;
-        }
-        result = MutableVersion(preState, apc);
-        result = this.Transfer(apc, result);
-      }
-      // cache
-      postState.Add(apc, result);
-      return true;
-    }
-
-    protected ForwardDFA(ICFG cfg)
-      : base(cfg) 
-    {
-    }
-
-    /// <summary>
-    /// State state must be immutable.
-    /// </summary>
-    public void Run(AState startState) {
-      Seed(cfg.Entry, startState);
-
-      ComputeFixpoint();
-    }
-
-    #region Forward specific overrides
-
-    protected override int Comparer(APC o1, APC o2) {
-      return o2.Block.ReversePostOrderIndex - o1.Block.ReversePostOrderIndex;
-    }
-
-    protected override bool RequiresJoining(APC apc) {
-      return this.cfg.IsJoinPoint(apc);
-    }
-
-    protected override bool IsBackEdge(APC from, APC to) {
-      return cfg.IsForwardBackEdge(from, to);
-    }
-    protected override bool HasSingleSuccessor(APC current, out APC next) {
-      return this.cfg.HasSingleSuccessor(current, out next);
-    }
-
-    protected override IEnumerable<APC> Successors(APC current) {
-      return this.cfg.Successors(current);
-    }
-
-    #endregion
-
-  }
-
-  public abstract class BackwardDFA<AState, Type> : DFARoot<AState, Type>
-  {
-    private bool skipContracts;
-    public AState GetPostState(APC apc, AState ifMissing) {
-      if (cfg.IsSplitPoint(apc)) {
-        AState/*?*/ result;
-        if (this.TryJoinState(apc, out result)) {
-          return result;
-        }
-        else {
-          return ifMissing;
-        }
-      }
-      throw new NotImplementedException("non split point recomputation not implemented yet");
-    }
-
-    protected BackwardDFA(ICFG cfg, bool skipContracts)
-      : base(cfg) {
-
-        this.skipContracts = skipContracts;
-    }
-
-    /// <summary>
-    /// State state must be immutable.
-    /// </summary>
-    public void Run(AState normalExit, AState exceptionExit) {
-      base.Seed(cfg.NormalExit, normalExit);
-      base.Seed(cfg.ExceptionExit, exceptionExit);
-
-      ComputeFixpoint();
-    }
-
-    #region Backward specific overrides
-
-    protected override int Comparer(APC o1, APC o2) {
-      return o1.Block.Index - o2.Block.Index;
-    }
-
-    protected override bool RequiresJoining(APC apc) {
-      return this.cfg.IsSplitPoint(apc);
-    }
-
-    protected override bool IsBackEdge(APC from, APC to) {
-      return cfg.IsBackwardBackEdge(from, to);
-    }
-    protected override bool HasSingleSuccessor(APC current, out APC next) {
-      return this.cfg.HasSinglePredecessor(current, out next, this.skipContracts);
-    }
-
-    protected override IEnumerable<APC> Successors(APC current) {
-      return this.cfg.Predecessors(current, this.skipContracts);
-    }
-
-    #endregion
-
-  }
-
-  public class ForwardAnalysisSolver<AState, Type, EdgeData> : ForwardDFA<AState, Type>, IFixpointInfo<APC, AState>
-  {
-    #region Privates
-
-    private int joinCount = 0;      // For debugging
-
-    readonly Transformer<APC, AState, AState> transfer;
-    readonly EdgeConverter<APC, AState, EdgeData> edgeConverter;
-    readonly Joiner<APC, AState> joiner;
-    readonly Converter<AState, AState> immutableVersion;
-    readonly Converter<AState, AState> mutableVersion;
-    readonly Action<Pair<AState, TextWriter>> dumper;
-    readonly Func<APC, AState, bool> isBottom;
-    readonly Func<APC, AState, bool> isTop;
-    readonly ILPrinter<APC>/*?*/ printer;
-    readonly Printer<EdgeData> edgeDataPrinter;
-    readonly Func<APC, APC, EdgeData> edgeDataGetter;
-
-    public ForwardAnalysisSolver(
-      ICFG cfg,
-      Transformer<APC, AState, AState> transfer,
-      EdgeConverter<APC, AState, EdgeData> edgeConverter,
-      Joiner<APC, AState> joiner,
-      Converter<AState, AState> immutableVersion,
-      Converter<AState, AState> mutableVersion,
-      Action<Pair<AState,TextWriter>> dumper,
-      Func<APC,AState,bool> isBottom,
-      Func<APC, AState, bool> isTop,
-      ILPrinter<APC> printer,
-      Printer<EdgeData> edgeDataPrinter,
-      Func<APC, APC, EdgeData> edgeDataGetter
-    )
-      : base(cfg) {
-        Contract.Requires(transfer != null);
-        Contract.Requires(immutableVersion != null);
-        Contract.Requires(isBottom != null);
-        Contract.Requires(isTop != null);
-        Contract.Requires(joiner != null);
-        Contract.Requires(mutableVersion != null);
-        Contract.Requires(edgeConverter != null);
-        Contract.Requires(edgeDataGetter != null);
-
-      this.transfer = transfer;
-      this.edgeConverter = edgeConverter;
-      this.joiner = joiner;
-      this.immutableVersion = immutableVersion;
-      this.mutableVersion = mutableVersion;
-      this.dumper = dumper;
-      this.isBottom = isBottom;
-      this.isTop = isTop;
-      this.printer = printer;
-      this.edgeDataPrinter = edgeDataPrinter;
-      this.edgeDataGetter = edgeDataGetter;
-    }
-
-    protected override void Dump(AState state)
-    {
-      if (this.dumper != null)
-      {
-        this.dumper(new Pair<AState, TextWriter>(state, Console.Out));
-      }
-    }
-
-    #endregion
-
-    public static ForwardAnalysisSolver<AState, Type, EdgeData> Make<Local, Parameter, Method, Field, Source, Dest, Context>(
-      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> decoder,
-      IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Source, Dest, AState, AState>, EdgeData> driver,
-      ILPrinter<APC> printer
-    )
-      where Context : IMethodContext<Field, Method>
-    {
-      Contract.Requires(decoder != null);
-      Contract.Requires(driver != null);
-
-      IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Source,Dest,AState,AState> visitor = driver.Visitor();
-      var result = new ForwardAnalysisSolver<AState, Type, EdgeData>(
-        decoder.Context.MethodContext.CFG,
-        delegate(APC pc, AState state) { return decoder.ForwardDecode<AState, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Source, Dest, AState, AState>>(pc, visitor, state); },
-        driver.EdgeConversion,
-        driver.Join,
-        driver.ImmutableVersion,
-        driver.MutableVersion,
-        driver.Dump,
-        delegate(APC pc, AState state) { return (decoder.IsUnreachable(pc) || driver.IsBottom(pc, state)); },
-        delegate(APC pc, AState state) { return (driver.IsTop(pc, state)); },
-        printer,
-        decoder.Display,
-        decoder.EdgeData
-      );
-      result.CachePolicy = driver.CacheStates(result);
-      return result;
-    }
-
-    #region Overrides
-
-    /// <summary>
-    /// Gives us a chance to let client rename variables prior to storing away the state
-    /// </summary>
-    /// <param name="edge"></param>
-    /// <param name="state"></param>
-    /// <returns></returns>
-    public override void PushState(APC pc, APC next, AState state) {
-      var edgeData = this.edgeDataGetter(pc, next);
-      if (this.Options.Trace)
-      {
-        Console.WriteLine("------EdgeConversion from {0} to {1}", pc, next);
-        this.edgeDataPrinter(Console.Out, "  ", edgeData);
-        Console.WriteLine("------EdgeConversion data end-----------");
-      }
-      if (this.Options.TraceTimePerInstruction)
-      {
-        timeCounter.Start();
-      }
-      this.TraceMemoryUsageIfEnabled("before renaming", pc);
-
-      var transformed = edgeConverter(pc, next, this.RequiresJoining(next), edgeData, state);
-      
-      
-      if (this.Options.TraceTimePerInstruction)
-      {
-        timeCounter.Stop();
-        Console.WriteLine("Time elapsed to perform EdgeConversion: {0}", timeCounter);
-      }
-      if (this.Options.Trace)
-      {
-        Console.WriteLine("Edge converted state:");
-        this.Dump(transformed);
-      }
-      this.TraceMemoryUsageIfEnabled("after renaming", null);
-
-      base.PushState(pc, next, transformed);
-    }
-
-    protected override bool TryRename(APC prev, APC next, AState currState, out AState renamed)
-    {
-      var edgeData = this.edgeDataGetter(prev, next);
-
-      if (this.Options.Trace)
-      {
-        if (edgeData != null)
-          Console.WriteLine("Found a remaing");
-        else
-          Console.WriteLine("No renaming found");
-      }
-
-      renamed = this.edgeConverter(prev, next, false, edgeData, currState);
-      Contract.Assume(renamed != null);
-
-      return true;
-    }
-
-
-
-    protected override AState ImmutableVersion(AState state, APC at) {
-      return this.immutableVersion(state);
-    }
-
-    protected override AState MutableVersion(AState state, APC at) {
-      return this.mutableVersion(state);
-    }
-
-    protected override bool Join(Pair<APC, APC> edge, AState newState, AState existingState, out AState joinedState, bool widen) {
-      bool weaker;
-      if (this.Options.Trace) {
-        Console.WriteLine("---: --Joining #{2} on {0} (widen={1})", edge.ToString(), widen, joinCount++);
-        Console.WriteLine("-------Existing state");
-        Dump(existingState);
-        Console.WriteLine("-------New state");
-        Dump(newState);
-      }
-
-      if (this.Options.TraceTimePerInstruction)
-      {
-        this.timeCounter.Start();
-      }
-
-      this.TraceMemoryUsageIfEnabled("before join", edge.One);
-
-      joinedState = joiner(edge, newState, existingState, out weaker, widen);
-      if (Options.Trace) {
-        Console.WriteLine("-------Result state: changed {0} (widen = {1})", weaker, widen);
-        Dump(joinedState);
-      }
-
-      if (this.Options.TraceTimePerInstruction)
-      {
-        this.timeCounter.Stop();
-        Console.WriteLine("Elapsed time for the join {0} : {1}", edge.ToString(), timeCounter);
-      }
-
-      this.TraceMemoryUsageIfEnabled("after join", null);
-
-      return weaker;
-    }
-
-    protected override AState Transfer(APC pc, AState state) {
-      if (Options.Trace) {
-        Console.WriteLine("State before {0}", pc);
-        Dump(state);
-        if (printer != null) printer(pc, "---: ", Console.Out);
-      }
-
-      if (this.Options.TraceTimePerInstruction)
-      {
-        this.timeCounter.Start();
-      }
-
-      this.TraceMemoryUsageIfEnabled("before instruction", pc);
-
-      var postState = this.transfer(pc, state);
-      Contract.Assume(postState != null);
-
-      if (this.Options.TraceTimePerInstruction)
-      {
-        this.timeCounter.Stop();
-
-        Console.WriteLine("Elapsed time for the transfer function of {0} : {1}", pc, this.timeCounter);
-      }
-
-      this.TraceMemoryUsageIfEnabled("after instruction", pc);
-
-      return postState;
-    }
-
-    protected override bool IsBottom(APC pc, AState state) {
-      return this.isBottom(pc, state);
-    }
-
-    protected override bool IsTop(APC pc, AState state)
-    {
-      return this.isTop(pc, state);
-    }
-
-    #endregion
-
-
-    #region IFixpointInfo<APC,AState> Members
-
-    [ContractVerification(false)]
-    public bool PreState(APC label, out AState ifFound)
-    {
-      return this.GetPreState(label, out ifFound);
-    }
-
-    [ContractVerification(false)]
-    public bool PostState(APC label, out AState ifFound)
-    {
-      return this.GetPostState(label, out ifFound);
-    }
-
-    public IEnumerable<SubroutineContext> CachedContexts(CFGBlock block)
-    {
-      foreach (KeyValuePair<APC, AState> kv in this.JoinStates())
-      {
-        if (kv.Key.Index == 0 && kv.Key.Block == block) yield return kv.Key.SubroutineContext;
-      }
-    }
-
-    public void PushExceptionState(APC atThrow, AState state) {
-      foreach (APC target in this.cfg.ExceptionHandlers<Type, object>(atThrow, null, null))
-      {
-        PushState(atThrow, target, state);
-      }
-    }
-
-    public bool TryAStateForPostCondition(AState initialState, out AState exitState)
-    {
-      APC currPC = default(APC);  // just to please the compiler
-      int paths = 0;
-
-      if (this.Options.Trace)
-      {
-        Console.WriteLine("Looking for a state for the postcondition filtering");
-      }
-
-      var currState = initialState;
-
-      var normalExit = this.cfg.NormalExit.Block;
-      Contract.Assume(normalExit != null);
-      foreach (var prevBlock in normalExit.Subroutine.PredecessorBlocks(this.cfg.NormalExit.Block))
-      {
-        if (this.Options.Trace)
+        /// <summary>
+        /// Maintains the abstract post state for given apc's that have join successors. Computed on demand
+        /// </summary>
+        protected OnDemandMap<APC, AState> postState;
+
+        public bool GetPostState(APC apc, out AState/*?*/ result)
         {
-          Console.WriteLine("Starting analysis of predecessor #{0} (Block {1})", paths, prevBlock.ToString());
+            if (postState.TryGetValue(apc, out result))
+            {
+                return true;
+            }
+            APC succ;
+            if (apc.Block.Count <= apc.Index)
+            {
+                // this is already the post program point in this block, so pre==post state here
+                return GetPreState(apc, out result);
+            }
+            if (cfg.HasSingleSuccessor(apc, out succ) && !RequiresJoining(succ))
+            {
+                return GetPreState(succ, out result);
+            }
+            else
+            {
+                // recompute from pre-state
+                AState preState;
+                if (!GetPreState(apc, out preState))
+                {
+                    return false;
+                }
+                result = MutableVersion(preState, apc);
+                result = this.Transfer(apc, result);
+            }
+            // cache
+            postState.Add(apc, result);
+            return true;
         }
 
-        APC prevPC, lastPC;
-        prevPC = lastPC = currPC = prevBlock.Last;
-        currState = initialState;
-
-        // F: this is a rough strategy. A subroutine may contain loops. In this case we just gave up 
-        // (I do not want to compute a fixpoint here to avoid slowing down the inference of posts)
-        while (currPC.Block != this.cfg.NormalExit.Block && this.cfg.HasSingleSuccessor(currPC, out currPC))
+        protected ForwardDFA(ICFG cfg)
+          : base(cfg)
         {
-          if (currPC.Block.First.Equals(currPC))
-          {
-            int preds = 0;
-            foreach (var p in this.cfg.Predecessors(currPC))
+        }
+
+        /// <summary>
+        /// State state must be immutable.
+        /// </summary>
+        public void Run(AState startState)
+        {
+            Seed(cfg.Entry, startState);
+
+            ComputeFixpoint();
+        }
+
+        #region Forward specific overrides
+
+        protected override int Comparer(APC o1, APC o2)
+        {
+            return o2.Block.ReversePostOrderIndex - o1.Block.ReversePostOrderIndex;
+        }
+
+        protected override bool RequiresJoining(APC apc)
+        {
+            return this.cfg.IsJoinPoint(apc);
+        }
+
+        protected override bool IsBackEdge(APC from, APC to)
+        {
+            return cfg.IsForwardBackEdge(from, to);
+        }
+        protected override bool HasSingleSuccessor(APC current, out APC next)
+        {
+            return this.cfg.HasSingleSuccessor(current, out next);
+        }
+
+        protected override IEnumerable<APC> Successors(APC current)
+        {
+            return this.cfg.Successors(current);
+        }
+
+        #endregion
+    }
+
+    public abstract class BackwardDFA<AState, Type> : DFARoot<AState, Type>
+    {
+        private bool skipContracts;
+        public AState GetPostState(APC apc, AState ifMissing)
+        {
+            if (cfg.IsSplitPoint(apc))
             {
-              preds++;
+                AState/*?*/ result;
+                if (this.TryJoinState(apc, out result))
+                {
+                    return result;
+                }
+                else
+                {
+                    return ifMissing;
+                }
             }
+            throw new NotImplementedException("non split point recomputation not implemented yet");
+        }
 
-            if (preds > 1 && currPC.Block != this.cfg.NormalExit.Block)
+        protected BackwardDFA(ICFG cfg, bool skipContracts)
+          : base(cfg)
+        {
+            this.skipContracts = skipContracts;
+        }
+
+        /// <summary>
+        /// State state must be immutable.
+        /// </summary>
+        public void Run(AState normalExit, AState exceptionExit)
+        {
+            base.Seed(cfg.NormalExit, normalExit);
+            base.Seed(cfg.ExceptionExit, exceptionExit);
+
+            ComputeFixpoint();
+        }
+
+        #region Backward specific overrides
+
+        protected override int Comparer(APC o1, APC o2)
+        {
+            return o1.Block.Index - o2.Block.Index;
+        }
+
+        protected override bool RequiresJoining(APC apc)
+        {
+            return this.cfg.IsSplitPoint(apc);
+        }
+
+        protected override bool IsBackEdge(APC from, APC to)
+        {
+            return cfg.IsBackwardBackEdge(from, to);
+        }
+        protected override bool HasSingleSuccessor(APC current, out APC next)
+        {
+            return this.cfg.HasSinglePredecessor(current, out next, skipContracts);
+        }
+
+        protected override IEnumerable<APC> Successors(APC current)
+        {
+            return this.cfg.Predecessors(current, skipContracts);
+        }
+
+        #endregion
+    }
+
+    public class ForwardAnalysisSolver<AState, Type, EdgeData> : ForwardDFA<AState, Type>, IFixpointInfo<APC, AState>
+    {
+        #region Privates
+
+        private int joinCount = 0;      // For debugging
+
+        private readonly Transformer<APC, AState, AState> transfer;
+        private readonly EdgeConverter<APC, AState, EdgeData> edgeConverter;
+        private readonly Joiner<APC, AState> joiner;
+        private readonly Converter<AState, AState> immutableVersion;
+        private readonly Converter<AState, AState> mutableVersion;
+        private readonly Action<Pair<AState, TextWriter>> dumper;
+        private readonly Func<APC, AState, bool> isBottom;
+        private readonly Func<APC, AState, bool> isTop;
+        private readonly ILPrinter<APC>/*?*/ printer;
+        private readonly Printer<EdgeData> edgeDataPrinter;
+        private readonly Func<APC, APC, EdgeData> edgeDataGetter;
+
+        public ForwardAnalysisSolver(
+          ICFG cfg,
+          Transformer<APC, AState, AState> transfer,
+          EdgeConverter<APC, AState, EdgeData> edgeConverter,
+          Joiner<APC, AState> joiner,
+          Converter<AState, AState> immutableVersion,
+          Converter<AState, AState> mutableVersion,
+          Action<Pair<AState, TextWriter>> dumper,
+          Func<APC, AState, bool> isBottom,
+          Func<APC, AState, bool> isTop,
+          ILPrinter<APC> printer,
+          Printer<EdgeData> edgeDataPrinter,
+          Func<APC, APC, EdgeData> edgeDataGetter
+        )
+          : base(cfg)
+        {
+            Contract.Requires(transfer != null);
+            Contract.Requires(immutableVersion != null);
+            Contract.Requires(isBottom != null);
+            Contract.Requires(isTop != null);
+            Contract.Requires(joiner != null);
+            Contract.Requires(mutableVersion != null);
+            Contract.Requires(edgeConverter != null);
+            Contract.Requires(edgeDataGetter != null);
+
+            this.transfer = transfer;
+            this.edgeConverter = edgeConverter;
+            this.joiner = joiner;
+            this.immutableVersion = immutableVersion;
+            this.mutableVersion = mutableVersion;
+            this.dumper = dumper;
+            this.isBottom = isBottom;
+            this.isTop = isTop;
+            this.printer = printer;
+            this.edgeDataPrinter = edgeDataPrinter;
+            this.edgeDataGetter = edgeDataGetter;
+        }
+
+        protected override void Dump(AState state)
+        {
+            if (dumper != null)
             {
-              exitState = initialState;
-              return false;
+                dumper(new Pair<AState, TextWriter>(state, Console.Out));
             }
-          }
+        }
 
-          currState = Transfer(currPC, currState);
+        #endregion
 
-          if (IsBottom(currPC, currState))
-          {
+        public static ForwardAnalysisSolver<AState, Type, EdgeData> Make<Local, Parameter, Method, Field, Source, Dest, Context>(
+          IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> decoder,
+          IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Source, Dest, AState, AState>, EdgeData> driver,
+          ILPrinter<APC> printer
+        )
+          where Context : IMethodContext<Field, Method>
+        {
+            Contract.Requires(decoder != null);
+            Contract.Requires(driver != null);
+
+            IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Source, Dest, AState, AState> visitor = driver.Visitor();
+            var result = new ForwardAnalysisSolver<AState, Type, EdgeData>(
+              decoder.Context.MethodContext.CFG,
+              delegate (APC pc, AState state) { return decoder.ForwardDecode<AState, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Source, Dest, AState, AState>>(pc, visitor, state); },
+              driver.EdgeConversion,
+              driver.Join,
+              driver.ImmutableVersion,
+              driver.MutableVersion,
+              driver.Dump,
+              delegate (APC pc, AState state) { return (decoder.IsUnreachable(pc) || driver.IsBottom(pc, state)); },
+              delegate (APC pc, AState state) { return (driver.IsTop(pc, state)); },
+              printer,
+              decoder.Display,
+              decoder.EdgeData
+            );
+            result.CachePolicy = driver.CacheStates(result);
+            return result;
+        }
+
+        #region Overrides
+
+        /// <summary>
+        /// Gives us a chance to let client rename variables prior to storing away the state
+        /// </summary>
+        /// <param name="edge"></param>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        public override void PushState(APC pc, APC next, AState state)
+        {
+            var edgeData = edgeDataGetter(pc, next);
             if (this.Options.Trace)
             {
-              Console.WriteLine("Found bottom, giving up");
+                Console.WriteLine("------EdgeConversion from {0} to {1}", pc, next);
+                edgeDataPrinter(Console.Out, "  ", edgeData);
+                Console.WriteLine("------EdgeConversion data end-----------");
+            }
+            if (this.Options.TraceTimePerInstruction)
+            {
+                timeCounter.Start();
+            }
+            this.TraceMemoryUsageIfEnabled("before renaming", pc);
+
+            var transformed = edgeConverter(pc, next, this.RequiresJoining(next), edgeData, state);
+
+
+            if (this.Options.TraceTimePerInstruction)
+            {
+                timeCounter.Stop();
+                Console.WriteLine("Time elapsed to perform EdgeConversion: {0}", timeCounter);
+            }
+            if (this.Options.Trace)
+            {
+                Console.WriteLine("Edge converted state:");
+                this.Dump(transformed);
+            }
+            this.TraceMemoryUsageIfEnabled("after renaming", null);
+
+            base.PushState(pc, next, transformed);
+        }
+
+        protected override bool TryRename(APC prev, APC next, AState currState, out AState renamed)
+        {
+            var edgeData = edgeDataGetter(prev, next);
+
+            if (this.Options.Trace)
+            {
+                if (edgeData != null)
+                    Console.WriteLine("Found a remaing");
+                else
+                    Console.WriteLine("No renaming found");
             }
 
-            exitState = initialState;
-            return false;
-          }
+            renamed = edgeConverter(prev, next, false, edgeData, currState);
+            Contract.Assume(renamed != null);
 
-          prevPC = lastPC;
-          lastPC = currPC;
+            return true;
         }
 
-        if (this.Options.Trace)
+
+
+        protected override AState ImmutableVersion(AState state, APC at)
         {
-          Console.WriteLine("Trying to apply the renaming: {0} --> {1}", prevPC, lastPC.Block.First);
+            return immutableVersion(state);
         }
 
-
-        AState renamed;
-        if (!this.IsTop(prevPC, currState) // Inferring good postconditions is based on a heuristic. We do not want the renaming to add more information 
-          && this.TryRename(prevPC, lastPC.Block.First, currState, out renamed))
+        protected override AState MutableVersion(AState state, APC at)
         {
-          currState = renamed;
+            return mutableVersion(state);
         }
 
-        if (this.Options.Trace)
+        protected override bool Join(Pair<APC, APC> edge, AState newState, AState existingState, out AState joinedState, bool widen)
         {
-          Console.WriteLine("Found state\n{0}", currState);
+            bool weaker;
+            if (this.Options.Trace)
+            {
+                Console.WriteLine("---: --Joining #{2} on {0} (widen={1})", edge.ToString(), widen, joinCount++);
+                Console.WriteLine("-------Existing state");
+                Dump(existingState);
+                Console.WriteLine("-------New state");
+                Dump(newState);
+            }
+
+            if (this.Options.TraceTimePerInstruction)
+            {
+                this.timeCounter.Start();
+            }
+
+            this.TraceMemoryUsageIfEnabled("before join", edge.One);
+
+            joinedState = joiner(edge, newState, existingState, out weaker, widen);
+            if (Options.Trace)
+            {
+                Console.WriteLine("-------Result state: changed {0} (widen = {1})", weaker, widen);
+                Dump(joinedState);
+            }
+
+            if (this.Options.TraceTimePerInstruction)
+            {
+                this.timeCounter.Stop();
+                Console.WriteLine("Elapsed time for the join {0} : {1}", edge.ToString(), timeCounter);
+            }
+
+            this.TraceMemoryUsageIfEnabled("after join", null);
+
+            return weaker;
         }
 
-        paths++;
-        if (paths == 1)
+        protected override AState Transfer(APC pc, AState state)
         {
-          break;
+            if (Options.Trace)
+            {
+                Console.WriteLine("State before {0}", pc);
+                Dump(state);
+                if (printer != null) printer(pc, "---: ", Console.Out);
+            }
+
+            if (this.Options.TraceTimePerInstruction)
+            {
+                this.timeCounter.Start();
+            }
+
+            this.TraceMemoryUsageIfEnabled("before instruction", pc);
+
+            var postState = transfer(pc, state);
+            Contract.Assume(postState != null);
+
+            if (this.Options.TraceTimePerInstruction)
+            {
+                this.timeCounter.Stop();
+
+                Console.WriteLine("Elapsed time for the transfer function of {0} : {1}", pc, this.timeCounter);
+            }
+
+            this.TraceMemoryUsageIfEnabled("after instruction", pc);
+
+            return postState;
         }
-      }
 
-      if (paths == 0)
-      {
-        exitState = initialState;
-        return false;
-      }
+        protected override bool IsBottom(APC pc, AState state)
+        {
+            return isBottom(pc, state);
+        }
 
-      exitState = currState;
-      return true;
+        protected override bool IsTop(APC pc, AState state)
+        {
+            return isTop(pc, state);
+        }
+
+        #endregion
+
+
+        #region IFixpointInfo<APC,AState> Members
+
+        [ContractVerification(false)]
+        public bool PreState(APC label, out AState ifFound)
+        {
+            return this.GetPreState(label, out ifFound);
+        }
+
+        [ContractVerification(false)]
+        public bool PostState(APC label, out AState ifFound)
+        {
+            return this.GetPostState(label, out ifFound);
+        }
+
+        public IEnumerable<SubroutineContext> CachedContexts(CFGBlock block)
+        {
+            foreach (KeyValuePair<APC, AState> kv in this.JoinStates())
+            {
+                if (kv.Key.Index == 0 && kv.Key.Block == block) yield return kv.Key.SubroutineContext;
+            }
+        }
+
+        public void PushExceptionState(APC atThrow, AState state)
+        {
+            foreach (APC target in this.cfg.ExceptionHandlers<Type, object>(atThrow, null, null))
+            {
+                PushState(atThrow, target, state);
+            }
+        }
+
+        public bool TryAStateForPostCondition(AState initialState, out AState exitState)
+        {
+            APC currPC = default(APC);  // just to please the compiler
+            int paths = 0;
+
+            if (this.Options.Trace)
+            {
+                Console.WriteLine("Looking for a state for the postcondition filtering");
+            }
+
+            var currState = initialState;
+
+            var normalExit = this.cfg.NormalExit.Block;
+            Contract.Assume(normalExit != null);
+            foreach (var prevBlock in normalExit.Subroutine.PredecessorBlocks(this.cfg.NormalExit.Block))
+            {
+                if (this.Options.Trace)
+                {
+                    Console.WriteLine("Starting analysis of predecessor #{0} (Block {1})", paths, prevBlock.ToString());
+                }
+
+                APC prevPC, lastPC;
+                prevPC = lastPC = currPC = prevBlock.Last;
+                currState = initialState;
+
+                // F: this is a rough strategy. A subroutine may contain loops. In this case we just gave up 
+                // (I do not want to compute a fixpoint here to avoid slowing down the inference of posts)
+                while (currPC.Block != this.cfg.NormalExit.Block && this.cfg.HasSingleSuccessor(currPC, out currPC))
+                {
+                    if (currPC.Block.First.Equals(currPC))
+                    {
+                        int preds = 0;
+                        foreach (var p in this.cfg.Predecessors(currPC))
+                        {
+                            preds++;
+                        }
+
+                        if (preds > 1 && currPC.Block != this.cfg.NormalExit.Block)
+                        {
+                            exitState = initialState;
+                            return false;
+                        }
+                    }
+
+                    currState = Transfer(currPC, currState);
+
+                    if (IsBottom(currPC, currState))
+                    {
+                        if (this.Options.Trace)
+                        {
+                            Console.WriteLine("Found bottom, giving up");
+                        }
+
+                        exitState = initialState;
+                        return false;
+                    }
+
+                    prevPC = lastPC;
+                    lastPC = currPC;
+                }
+
+                if (this.Options.Trace)
+                {
+                    Console.WriteLine("Trying to apply the renaming: {0} --> {1}", prevPC, lastPC.Block.First);
+                }
+
+
+                AState renamed;
+                if (!this.IsTop(prevPC, currState) // Inferring good postconditions is based on a heuristic. We do not want the renaming to add more information 
+                  && this.TryRename(prevPC, lastPC.Block.First, currState, out renamed))
+                {
+                    currState = renamed;
+                }
+
+                if (this.Options.Trace)
+                {
+                    Console.WriteLine("Found state\n{0}", currState);
+                }
+
+                paths++;
+                if (paths == 1)
+                {
+                    break;
+                }
+            }
+
+            if (paths == 0)
+            {
+                exitState = initialState;
+                return false;
+            }
+
+            exitState = currState;
+            return true;
+        }
+
+        #endregion
     }
-
-    #endregion
-
-  }
 
     /// <summary>
-  /// A small class to check timeouts
-  /// </summary>
-  [ContractVerification(true)]
-  public class TimeOutChecker
-  {
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.stopWatch != null);
-    }
-
-
-    #region Private state
-
-    enum State { Stopped, Running }
-
-private readonly Stopwatch stopWatch;
-  private TimeSpan totalElapsed;
-    readonly CancellationToken cancellationToken;
-    readonly private int timeout;                                    // The seconds for the timeout
-    private TimeoutExceptionFixpointComputation exception;  // We want to throw one exception per TimeOutChecker instance
-    private State state;
-
-    #endregion
-
-    public TimeOutChecker(int seconds, bool start = true)
-      : this(seconds, new CancellationToken(), start)
-    {
-      Contract.Requires(seconds >= 0);
-    }
-
-    /// <param name="seconds"> The timeout in seconds</param>    
-    public TimeOutChecker(int seconds, CancellationToken cancellationToken, bool start = true)
-    {
-      Contract.Requires(seconds >= 0);
-
-      this.stopWatch = new Stopwatch();
-      this.totalElapsed = new TimeSpan();
-      if (start)
-      {
-        this.stopWatch.Start();
-        this.state = State.Running;
-      }
-      else
-      {
-        this.state = State.Stopped;
-      }
-      this.timeout = seconds;
-      this.cancellationToken = cancellationToken;
-      this.exception = null;
-    }
-
-    public void Start()
-    {
-      switch (this.state)
-      {
-        case State.Stopped:
-          {
-            this.state = State.Running;
-            this.stopWatch.Start();
-          }
-          break;
-
-        case State.Running:
-          {
-          }
-          break;
-
-        default:
-          {
-            Contract.Assert(false);
-            break;
-          }
-      }
-    }
-
-    public void Stop()
-    {
-      switch (this.state)
-      {
-        case State.Running:
-          {
-            this.state = State.Stopped;
-
-            this.stopWatch.Stop();
-            totalElapsed += this.stopWatch.Elapsed;
-            this.stopWatch.Reset();
-          }
-          break;
-
-        case State.Stopped:
-          {
-          }
-          break;
-
-        default:
-          {
-            Contract.Assert(false);
-            break;
-          }
-      }
-    }
-
-    public bool HasAlreadyTimeOut
-    {
-      get
-      {
-        return this.exception != null;
-      }
-    }
-
-    /// <summary>
-    /// Check that we did not timed out.
-    /// If the timeout was not started, starts it
+    /// A small class to check timeouts
     /// </summary>
-    public void CheckTimeOut(string reason = "")
+    [ContractVerification(true)]
+    public class TimeOutChecker
     {
-      this.Start();
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(stopWatch != null);
+        }
 
-      this.stopWatch.Stop();
 
-      this.totalElapsed += this.stopWatch.Elapsed;
+        #region Private state
 
-      this.stopWatch.Reset();
-      this.stopWatch.Start();
+        private enum State { Stopped, Running }
 
-      // If we've reached a timeout, we throw an exception, and we abort the fixpoint computation
-      if (this.totalElapsed.TotalSeconds >= this.timeout
+        private readonly Stopwatch stopWatch;
+        private TimeSpan totalElapsed;
+        private readonly CancellationToken cancellationToken;
+        readonly private int timeout;                                    // The seconds for the timeout
+        private TimeoutExceptionFixpointComputation exception;  // We want to throw one exception per TimeOutChecker instance
+        private State state;
+
+        #endregion
+
+        public TimeOutChecker(int seconds, bool start = true)
+          : this(seconds, new CancellationToken(), start)
+        {
+            Contract.Requires(seconds >= 0);
+        }
+
+        /// <param name="seconds"> The timeout in seconds</param>    
+        public TimeOutChecker(int seconds, CancellationToken cancellationToken, bool start = true)
+        {
+            Contract.Requires(seconds >= 0);
+
+            stopWatch = new Stopwatch();
+            totalElapsed = new TimeSpan();
+            if (start)
+            {
+                stopWatch.Start();
+                state = State.Running;
+            }
+            else
+            {
+                state = State.Stopped;
+            }
+            timeout = seconds;
+            this.cancellationToken = cancellationToken;
+            exception = null;
+        }
+
+        public void Start()
+        {
+            switch (state)
+            {
+                case State.Stopped:
+                    {
+                        state = State.Running;
+                        stopWatch.Start();
+                    }
+                    break;
+
+                case State.Running:
+                    {
+                    }
+                    break;
+
+                default:
+                    {
+                        Contract.Assert(false);
+                        break;
+                    }
+            }
+        }
+
+        public void Stop()
+        {
+            switch (state)
+            {
+                case State.Running:
+                    {
+                        state = State.Stopped;
+
+                        stopWatch.Stop();
+                        totalElapsed += stopWatch.Elapsed;
+                        stopWatch.Reset();
+                    }
+                    break;
+
+                case State.Stopped:
+                    {
+                    }
+                    break;
+
+                default:
+                    {
+                        Contract.Assert(false);
+                        break;
+                    }
+            }
+        }
+
+        public bool HasAlreadyTimeOut
+        {
+            get
+            {
+                return exception != null;
+            }
+        }
+
+        /// <summary>
+        /// Check that we did not timed out.
+        /// If the timeout was not started, starts it
+        /// </summary>
+        public void CheckTimeOut(string reason = "")
+        {
+            this.Start();
+
+            stopWatch.Stop();
+
+            totalElapsed += stopWatch.Elapsed;
+
+            stopWatch.Reset();
+            stopWatch.Start();
+
+            // If we've reached a timeout, we throw an exception, and we abort the fixpoint computation
+            if (totalElapsed.TotalSeconds >= timeout
 #if DEBUG
  && !System.Diagnostics.Debugger.IsAttached
 #endif
 )
-      {
+            {
 #if DEBUG
-        if (!String.IsNullOrEmpty(reason))
-        {
-          Console.WriteLine("Timeout hit: Reason {0}", reason);
-        }
+                if (!String.IsNullOrEmpty(reason))
+                {
+                    Console.WriteLine("Timeout hit: Reason {0}", reason);
+                }
 #endif
-        if (this.exception == null)
-        {
-          this.exception = new TimeoutExceptionFixpointComputation();
+                if (exception == null)
+                {
+                    exception = new TimeoutExceptionFixpointComputation();
+                }
+                throw exception;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
         }
-        throw this.exception;
-      }
-
-      cancellationToken.ThrowIfCancellationRequested();
     }
-  }
-
-  /// <summary>
-  /// Exception raised if the fixpoint computation is taking too long
-  /// </summary>
-  public class TimeoutExceptionFixpointComputation : TimeoutException
-  {
-    [ThreadStatic]
-    private static uint count;
-
-    static public uint ThrownExceptions
-    {
-      get
-      {
-        return count;
-      }
-    }
-
-    public TimeoutExceptionFixpointComputation()
-    {
-      count++;
-    }
-  }
-
-  public interface IWidenStrategy
-  {    
-    bool WantToWiden(APC from, APC to, bool isBackEdge);
-  }
-
-  public abstract class StepWidening<Index> : IWidenStrategy
-  {
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.widenCounter != null);
-    }
-
 
     /// <summary>
-    /// Mantains a count of the times we've seen each widen point, so that we can decide if we perform widening or join
+    /// Exception raised if the fixpoint computation is taking too long
     /// </summary>
-    readonly private Dictionary<Index, int> widenCounter;
-    readonly private int N;
-
-    protected StepWidening(int n)
+    public class TimeoutExceptionFixpointComputation : TimeoutException
     {
-      this.widenCounter = new Dictionary<Index, int>();
-      this.N = n;
-    }
+        [ThreadStatic]
+        private static uint count;
 
-    abstract protected Index MakeIndex(APC from, APC to);
-
-    #region IWidenStrategy Members
-
-    public bool WantToWiden(APC from, APC to, bool IsBackEdge)
-    {
-      if (!IsBackEdge)
-      {
-        return false;
-      }
-      else
-      {
-        var index = MakeIndex(from, to);
-        if (this.widenCounter.ContainsKey(index))
+        static public uint ThrownExceptions
         {
-          this.widenCounter[index]++;
-        }
-        else
-        {
-          this.widenCounter[index] = 1;
+            get
+            {
+                return count;
+            }
         }
 
-        return this.N < this.widenCounter[index];
-      }
+        public TimeoutExceptionFixpointComputation()
+        {
+            count++;
+        }
     }
 
-    #endregion
-  }
-
-  public class BlockBasedWidening : StepWidening<APC>
-  {
-    public BlockBasedWidening(int n)
-      : base(n)
-    { }
-
-    protected override APC MakeIndex(APC from, APC to)
+    public interface IWidenStrategy
     {
-      return to;
+        bool WantToWiden(APC from, APC to, bool isBackEdge);
     }
-  }
 
-  public class EdgeBasedWidening : StepWidening<Pair<APC, APC>>
-  {
-    public EdgeBasedWidening(int n)
-      : base(n)
-    { }
-
-    protected override Pair<APC, APC> MakeIndex(APC from, APC to)
+    public abstract class StepWidening<Index> : IWidenStrategy
     {
-      return new Pair<APC, APC>(from, to);
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(widenCounter != null);
+        }
+
+
+        /// <summary>
+        /// Mantains a count of the times we've seen each widen point, so that we can decide if we perform widening or join
+        /// </summary>
+        readonly private Dictionary<Index, int> widenCounter;
+        readonly private int N;
+
+        protected StepWidening(int n)
+        {
+            widenCounter = new Dictionary<Index, int>();
+            N = n;
+        }
+
+        abstract protected Index MakeIndex(APC from, APC to);
+
+        #region IWidenStrategy Members
+
+        public bool WantToWiden(APC from, APC to, bool IsBackEdge)
+        {
+            if (!IsBackEdge)
+            {
+                return false;
+            }
+            else
+            {
+                var index = MakeIndex(from, to);
+                if (widenCounter.ContainsKey(index))
+                {
+                    widenCounter[index]++;
+                }
+                else
+                {
+                    widenCounter[index] = 1;
+                }
+
+                return N < widenCounter[index];
+            }
+        }
+
+        #endregion
     }
-  }
+
+    public class BlockBasedWidening : StepWidening<APC>
+    {
+        public BlockBasedWidening(int n)
+          : base(n)
+        { }
+
+        protected override APC MakeIndex(APC from, APC to)
+        {
+            return to;
+        }
+    }
+
+    public class EdgeBasedWidening : StepWidening<Pair<APC, APC>>
+    {
+        public EdgeBasedWidening(int n)
+          : base(n)
+        { }
+
+        protected override Pair<APC, APC> MakeIndex(APC from, APC to)
+        {
+            return new Pair<APC, APC>(from, to);
+        }
+    }
 }

--- a/Microsoft.Research/CodeAnalysis/Decoders.cs
+++ b/Microsoft.Research/CodeAnalysis/Decoders.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The decoder (implemented as visitors for the IL)
 
@@ -22,711 +11,710 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// The wrapper for the analysis, so to share some code (in particular the decoder)
-  /// </summary>
-  public static class ExternalExpressionDecoder
-  {
-    public static IFullExpressionDecoder<Type, Variable, Expression> Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context
-    )
-      where Expression : IEquatable<Expression>
-      where Variable : IEquatable<Variable>
-      where Type: IEquatable<Type>
+    /// <summary>
+    /// The wrapper for the analysis, so to share some code (in particular the decoder)
+    /// </summary>
+    public static class ExternalExpressionDecoder
     {
-      Contract.Requires(context != null);
-
-      return new TypeBindings<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>.Decoder(context, mdDecoder);
-    }
-
-    // This class is just to provide bindings to type parameters
-    public static partial class TypeBindings<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>
-      where Variable : IEquatable<Variable>
-      where Expression : IEquatable<Expression>
-      where Type:IEquatable<Type>
-    {
-      #region Expression decoder, implementation and helper visitors
-      /// <summary>
-      /// The decoder for the expressions
-      /// </summary>
-      public class Decoder : IFullExpressionDecoder<Type, Variable, Expression>
-      {
-        #region Private environment
-        protected IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context;
-        protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> decoderForMetaData;
-
-        private VisitorForIsBinaryExpression visitorForIsBinaryExpression;
-        private VisitorForIsUnaryExpression visitorForIsUnaryExpression;
-        private VisitorForVariablesIn visitorForVariablesIn;
-        private VisitorForValueOf visitorForValueOf;
-        private VisitorForIsNull visitorForIsNull;
-        private VisitorForSizeOf visitorForSizeOf;
-        private VisitorForIsInst visitorForIsInst;
-        private VisitorForVariable visitorForVariable;
-        private VisitorForUnderlyingVariable visitorForUnderlyingVariable;
-        private VisitorForDispatch visitorForDispatch;
-        #endregion
-
-        #region Getters
-
-        public IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context
+        public static IFullExpressionDecoder<Type, Variable, Expression> Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context
+        )
+          where Expression : IEquatable<Expression>
+          where Variable : IEquatable<Variable>
+          where Type : IEquatable<Type>
         {
-          get
-          {
-            Contract.Ensures(Contract.Result<IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>>() != null);
+            Contract.Requires(context != null);
 
-            return this.context;
-          }
+            return new TypeBindings<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>.Decoder(context, mdDecoder);
         }
 
-        #endregion
-
-        public Decoder(IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
-          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> decoderForMetaData)
+        // This class is just to provide bindings to type parameters
+        public static partial class TypeBindings<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>
+          where Variable : IEquatable<Variable>
+          where Expression : IEquatable<Expression>
+          where Type : IEquatable<Type>
         {
-          Contract.Requires(context != null);
-
-          this.context = context;
-          this.decoderForMetaData = decoderForMetaData;
-
-          this.visitorForIsUnaryExpression = new VisitorForIsUnaryExpression();
-          this.visitorForIsBinaryExpression = new VisitorForIsBinaryExpression();
-          this.visitorForVariablesIn = new VisitorForVariablesIn(context);
-          this.visitorForValueOf = new VisitorForValueOf();
-          this.visitorForSizeOf = new VisitorForSizeOf();
-          this.visitorForIsNull = new VisitorForIsNull();
-          this.visitorForVariable = new VisitorForVariable();
-          this.visitorForIsInst = new VisitorForIsInst();
-          this.visitorForUnderlyingVariable = new VisitorForUnderlyingVariable();
-          this.visitorForDispatch = new VisitorForDispatch(this);
-        }
-
-        #region IFullExpressionDecoder<Type,Field,Expression> Members
-
-        public bool IsVariable(Expression exp, out object variable)
-        {
-          Variable var;
-          bool result = VisitorForVariable.IsVariable(exp, out var, this);
-          variable = var;
-          return result;
-        }
-
-        public Variable UnderlyingVariable(Expression exp)
-        {
-          return VisitorForUnderlyingVariable.UnderlyingVariable(exp, this);
-        }
-
-        public bool IsConstant(Expression exp, out object value, out Type type)
-        {
-          return VisitorForValueOf.IsConstant(exp, out value, out type, this);
-        }
-
-        public bool IsSizeOf(Expression exp, out Type type)
-        {
-          return VisitorForSizeOf.IsSizeOf(exp, out type, this);
-        }
-
-        public bool IsInst(Expression exp, out Expression arg, out Type type)
-        {
-          return VisitorForIsInst.IsIsInst(exp, out type, out arg, this);
-        }
-
-        public bool IsUnaryOperator(Expression exp, out UnaryOperator op, out Expression arg)
-        {
-          return VisitorForIsUnaryExpression.IsUnary(exp, out op, out arg, this);
-        }
-
-        public bool IsBinaryOperator(Expression exp, out BinaryOperator op, out Expression left, out Expression right)
-        {
-          return VisitorForIsBinaryExpression.IsBinary(exp, out op, out left, out right, this);
-        }
-
-        public FList<PathElement> GetVariableAccessPath(Expression exp)
-        {
-          return this.context.ValueContext.AccessPathList(this.context.ExpressionContext.GetPC(exp), this.context.ExpressionContext.Unrefine(exp), true, false);
-        }
-
-        public void AddFreeVariables(Expression exp, Microsoft.Research.DataStructures.IMutableSet<Expression> set)
-        {
-          VisitorForVariablesIn.AddFreeVariables(exp, set, this);
-        }
-
-        public bool TryGetType(Expression exp, out object type)
-        {
-          var liftedType = this.context.ExpressionContext.GetType(exp);
-          if(liftedType.IsNormal)
-          {
-            type = liftedType.Value;
-            return true;
-          }
-
-          type = default(object);
-          return false;
-        }
-
-        #endregion
-
-        #region The visitors
-
-        protected abstract class QueryVisitor 
-            : IVisitValueExprIL<Expression, Type, Expression, Variable, Unit, bool>
-        {
-          protected static bool Decode<Visitor>(Expression exp, Visitor v, Decoder decoder) where Visitor : QueryVisitor
-          {
-            Contract.Requires(decoder != null);
-
-            return decoder.Context.ExpressionContext.Decode<Unit, bool, Visitor>(exp, v, Unit.Value);
-          }
-
-          #region IVisitValueExprIL<Expression,Type,ExternalExpression,Variable,Unit,bool> Members
-
-          public virtual bool SymbolicConstant(Expression pc, Variable symbol, Unit data)
-          {
-            return false;
-          }
-
-          #endregion
-
-          #region IVisitExprIL<Expression,Type,ExternalExpression,Variable,Unit,bool> Members
-
-          public virtual bool Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
-          {
-            return false;
-          }
-
-          public virtual bool Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
-          {
-            return false;
-          }
-
-          public virtual bool Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
-          {
-            return false;
-          }
-
-          public virtual bool Ldnull(Expression pc, Variable dest, Unit data)
-          {
-            return false;
-          }
-
-          public virtual bool Sizeof(Expression pc, Type type, Variable dest, Unit data)
-          {
-            return false;
-          }
-
-          public virtual bool Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
-          {
-            return false;
-          }
-
-          public virtual bool Box(Expression pc, Type type, Variable dest, Expression source, Unit data)
-          {
-              return false;
-          }
-
-          #endregion
-        }
-
-        private class VisitorForVariable : QueryVisitor
-        {
-          Variable Variable;
-
-          public static bool IsVariable(Expression exp, out Variable var, Decoder decoder)
-          {
-            VisitorForVariable visitor = decoder.visitorForVariable;
-            bool result = Decode(exp, visitor, decoder);
-            var = visitor.Variable;
-            return result;
-          }
-
-          public override bool SymbolicConstant(Expression pc, Variable symbol, Unit data)
-          {
-            this.Variable = symbol;
-            return true;
-          }
-        }
-
-        private class VisitorForUnderlyingVariable : QueryVisitor
-        {
-          Variable Variable;
-
-          public static Variable UnderlyingVariable(Expression exp, Decoder decoder)
-          {
-            var visitor = decoder.visitorForUnderlyingVariable;
-            var dummy = Decode(exp, visitor, decoder);
-
-            return visitor.Variable;
-          }
-
-          public override bool Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
-          {
-            this.Variable = dest; 
-            return true;
-          }
-
-          public override bool Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
-          {
-            this.Variable = dest;
-            return true;
-          }
-
-          public override bool Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
-          {
-            this.Variable = dest;
-            return true;
-          }
-
-          public override bool Ldnull(Expression pc, Variable dest, Unit data)
-          {
-            this.Variable = dest;
-            return true;
-          }
-
-          public override bool Sizeof(Expression pc, Type type, Variable dest, Unit data)
-          {
-            this.Variable = dest;
-            return true;
-          }
-
-          public override bool SymbolicConstant(Expression pc, Variable symbol, Unit data)
-          {
-            this.Variable = symbol;
-            return true;
-          }
-
-          public override bool Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
-          {
-            this.Variable = dest;
-            return true;
-          }
-        }
-
-
-        private class VisitorForIsUnaryExpression : QueryVisitor
-        {
-          private UnaryOperator Operator;
-          private Expression Argument;
-
-          public static bool IsUnary(Expression exp, out UnaryOperator op, out Expression arg,
-            Decoder decoder)
-          {
-            VisitorForIsUnaryExpression visitor = decoder.visitorForIsUnaryExpression;
-            bool result = Decode(exp, visitor, decoder);
-            op = visitor.Operator;
-            arg = visitor.Argument;
-            return result;
-          }
-
-          public override bool Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
-          {
-            this.Argument = source;
-            this.Operator = op;
-            return true;
-          }
-        }
-
-        private class VisitorForIsBinaryExpression : QueryVisitor
-        {
-          BinaryOperator Operator;
-          Expression Left;
-          Expression Right;
-
-          public static bool IsBinary(Expression exp, out BinaryOperator op, out Expression left, out Expression right, Decoder decoder)
-          {
-            VisitorForIsBinaryExpression visitor = decoder.visitorForIsBinaryExpression;
-            bool result = Decode(exp, visitor, decoder);
-            op = visitor.Operator;
-            left = visitor.Left;
-            right = visitor.Right;
-            return result;
-          }
-
-          public override bool Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
-          {
-            this.Operator = op;
-            this.Left = s1;
-            this.Right = s2;
-            return true;
-          }
-        }
-
-        private class VisitorForVariablesIn
-          : IVisitValueExprIL<Expression, Type, Expression, Variable, Microsoft.Research.DataStructures.IMutableSet<Expression>, Unit>
-        {
-          #region Private state
-          private IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context;
-          #endregion
-
-          public VisitorForVariablesIn(IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>/*!*/ context)
-          {
-            this.context = context;
-          }
-
-          public static void AddFreeVariables(Expression exp,
-                                              Microsoft.Research.DataStructures.IMutableSet<Expression> set, Decoder decoder)
-          {
-            decoder.visitorForVariablesIn.Recurse(exp, set);
-          }
-
-          private void Recurse(Expression exp, Microsoft.Research.DataStructures.IMutableSet<Expression> set)
-          {
-            context.ExpressionContext.Decode<Microsoft.Research.DataStructures.IMutableSet<Expression>, Unit, VisitorForVariablesIn>(exp, this, set);
-          }
-
-          #region IVisitValueExprIL<Expression,Type,Expression,Variable,Generics.Set<Variable>,Generics.Set<Variable>> Members
-
-          public Unit SymbolicConstant(Expression pc, Variable symbol, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
-          {
-            data.Add(pc);
-            return Unit.Value;
-          }
-
-          #endregion
-
-          #region IVisitExprIL<Expression,Type,Expression,Variable,Generics.Set<Expression>,Microsoft.Research.DataStructures.ISet<Expression>> Members
-
-          public Unit Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
-          {
-            Recurse(s1, data);
-            Recurse(s2, data);
-
-            return Unit.Value;
-          }
-
-          public Unit Isinst(Expression pc, Type type, Variable dest, Expression obj, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
-          {
-            data.Add(pc); // TODO: figure out who depends on this! This should not be treated as a free variable!
-
-            return Unit.Value;
-          }
-
-          public Unit Ldconst(Expression pc, object constant, Type type, Variable dest, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
-          {
-            return Unit.Value;
-          }
-
-          public Unit Ldnull(Expression pc, Variable dest, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
-          {
-            return Unit.Value;
-          }
-
-          public Unit Sizeof(Expression pc, Type type, Variable dest, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
-          {
-            // Why is this used here? TODO: figure out what depends on this!
-            data.Add(pc);
-            return Unit.Value;
-          }
-
-          public Unit Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
-          {
-            Recurse(source, data);
-            return Unit.Value;
-          }
-
-          public Unit Box(Expression pc, Type type, Variable dest, Expression source, IMutableSet<Expression> data)
-          {
-              Recurse(source, data);
-              return Unit.Value;
-          }
-
-          #endregion
-        }
-
-        private class VisitorForValueOf : QueryVisitor
-        {
-          #region Private state
-          Type Type;
-          object Value;
-          #endregion
-
-          public static bool IsConstant(Expression exp, out object value, out Type type, Decoder decoder)
-          {
-            VisitorForValueOf visitor = decoder.visitorForValueOf;
-            bool result = Decode(exp, visitor, decoder);
-            value = visitor.Value;
-            type = visitor.Type;
-            return result;
-          }
-
-          public override bool Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
-          {
-            this.Type = type;
-            this.Value = constant;
-            return true;
-          }
-          public override bool Ldnull(Expression pc, Variable dest, Unit data)
-          {
-            this.Type = default(Type);
-            this.Value = null;
-            return true;
-          }
-        }
-
-        private class VisitorForSizeOf : QueryVisitor
-        {
-          #region Constructor
-          #endregion
-
-          private Type Type;
-
-          public static bool IsSizeOf(Expression exp, out Type type, Decoder decoder)
-          {
-            VisitorForSizeOf visitor = decoder.visitorForSizeOf;
-            bool result = Decode(exp, visitor, decoder);
-            type = visitor.Type;
-            return result;
-          }
-
-          public override bool Sizeof(Expression pc, Type type, Variable dest, Unit data)
-          {
-            Type = type;
-            return true;
-          }
-        }
-
-        private class VisitorForIsInst : QueryVisitor
-        {
-          #region Constructor
-          #endregion
-
-          private Type Type;
-          private Expression Argument;
-
-          public static bool IsIsInst(Expression exp, out Type type, out Expression arg, Decoder decoder)
-          {
-            VisitorForIsInst visitor = decoder.visitorForIsInst;
-            bool result = Decode(exp, visitor, decoder);
-            type = visitor.Type;
-            arg = visitor.Argument;
-            return result;
-          }
-
-          public override bool Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
-          {
-            this.Type = type;
-            this.Argument = obj;
-            return true;
-          }
-        }
+            #region Expression decoder, implementation and helper visitors
+            /// <summary>
+            /// The decoder for the expressions
+            /// </summary>
+            public class Decoder : IFullExpressionDecoder<Type, Variable, Expression>
+            {
+                #region Private environment
+                protected IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context;
+                protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> decoderForMetaData;
+
+                private VisitorForIsBinaryExpression visitorForIsBinaryExpression;
+                private VisitorForIsUnaryExpression visitorForIsUnaryExpression;
+                private VisitorForVariablesIn visitorForVariablesIn;
+                private VisitorForValueOf visitorForValueOf;
+                private VisitorForIsNull visitorForIsNull;
+                private VisitorForSizeOf visitorForSizeOf;
+                private VisitorForIsInst visitorForIsInst;
+                private VisitorForVariable visitorForVariable;
+                private VisitorForUnderlyingVariable visitorForUnderlyingVariable;
+                private VisitorForDispatch visitorForDispatch;
+                #endregion
+
+                #region Getters
+
+                public IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context
+                {
+                    get
+                    {
+                        Contract.Ensures(Contract.Result<IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>>() != null);
+
+                        return this.context;
+                    }
+                }
+
+                #endregion
+
+                public Decoder(IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
+                  IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> decoderForMetaData)
+                {
+                    Contract.Requires(context != null);
+
+                    this.context = context;
+                    this.decoderForMetaData = decoderForMetaData;
+
+                    visitorForIsUnaryExpression = new VisitorForIsUnaryExpression();
+                    visitorForIsBinaryExpression = new VisitorForIsBinaryExpression();
+                    visitorForVariablesIn = new VisitorForVariablesIn(context);
+                    visitorForValueOf = new VisitorForValueOf();
+                    visitorForSizeOf = new VisitorForSizeOf();
+                    visitorForIsNull = new VisitorForIsNull();
+                    visitorForVariable = new VisitorForVariable();
+                    visitorForIsInst = new VisitorForIsInst();
+                    visitorForUnderlyingVariable = new VisitorForUnderlyingVariable();
+                    visitorForDispatch = new VisitorForDispatch(this);
+                }
+
+                #region IFullExpressionDecoder<Type,Field,Expression> Members
+
+                public bool IsVariable(Expression exp, out object variable)
+                {
+                    Variable var;
+                    bool result = VisitorForVariable.IsVariable(exp, out var, this);
+                    variable = var;
+                    return result;
+                }
+
+                public Variable UnderlyingVariable(Expression exp)
+                {
+                    return VisitorForUnderlyingVariable.UnderlyingVariable(exp, this);
+                }
+
+                public bool IsConstant(Expression exp, out object value, out Type type)
+                {
+                    return VisitorForValueOf.IsConstant(exp, out value, out type, this);
+                }
+
+                public bool IsSizeOf(Expression exp, out Type type)
+                {
+                    return VisitorForSizeOf.IsSizeOf(exp, out type, this);
+                }
+
+                public bool IsInst(Expression exp, out Expression arg, out Type type)
+                {
+                    return VisitorForIsInst.IsIsInst(exp, out type, out arg, this);
+                }
+
+                public bool IsUnaryOperator(Expression exp, out UnaryOperator op, out Expression arg)
+                {
+                    return VisitorForIsUnaryExpression.IsUnary(exp, out op, out arg, this);
+                }
+
+                public bool IsBinaryOperator(Expression exp, out BinaryOperator op, out Expression left, out Expression right)
+                {
+                    return VisitorForIsBinaryExpression.IsBinary(exp, out op, out left, out right, this);
+                }
+
+                public FList<PathElement> GetVariableAccessPath(Expression exp)
+                {
+                    return this.context.ValueContext.AccessPathList(this.context.ExpressionContext.GetPC(exp), this.context.ExpressionContext.Unrefine(exp), true, false);
+                }
+
+                public void AddFreeVariables(Expression exp, Microsoft.Research.DataStructures.IMutableSet<Expression> set)
+                {
+                    VisitorForVariablesIn.AddFreeVariables(exp, set, this);
+                }
+
+                public bool TryGetType(Expression exp, out object type)
+                {
+                    var liftedType = this.context.ExpressionContext.GetType(exp);
+                    if (liftedType.IsNormal)
+                    {
+                        type = liftedType.Value;
+                        return true;
+                    }
+
+                    type = default(object);
+                    return false;
+                }
+
+                #endregion
+
+                #region The visitors
+
+                protected abstract class QueryVisitor
+                    : IVisitValueExprIL<Expression, Type, Expression, Variable, Unit, bool>
+                {
+                    protected static bool Decode<Visitor>(Expression exp, Visitor v, Decoder decoder) where Visitor : QueryVisitor
+                    {
+                        Contract.Requires(decoder != null);
+
+                        return decoder.Context.ExpressionContext.Decode<Unit, bool, Visitor>(exp, v, Unit.Value);
+                    }
+
+                    #region IVisitValueExprIL<Expression,Type,ExternalExpression,Variable,Unit,bool> Members
+
+                    public virtual bool SymbolicConstant(Expression pc, Variable symbol, Unit data)
+                    {
+                        return false;
+                    }
+
+                    #endregion
+
+                    #region IVisitExprIL<Expression,Type,ExternalExpression,Variable,Unit,bool> Members
+
+                    public virtual bool Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
+                    {
+                        return false;
+                    }
+
+                    public virtual bool Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
+                    {
+                        return false;
+                    }
+
+                    public virtual bool Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
+                    {
+                        return false;
+                    }
+
+                    public virtual bool Ldnull(Expression pc, Variable dest, Unit data)
+                    {
+                        return false;
+                    }
+
+                    public virtual bool Sizeof(Expression pc, Type type, Variable dest, Unit data)
+                    {
+                        return false;
+                    }
+
+                    public virtual bool Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
+                    {
+                        return false;
+                    }
+
+                    public virtual bool Box(Expression pc, Type type, Variable dest, Expression source, Unit data)
+                    {
+                        return false;
+                    }
+
+                    #endregion
+                }
+
+                private class VisitorForVariable : QueryVisitor
+                {
+                    private Variable Variable;
+
+                    public static bool IsVariable(Expression exp, out Variable var, Decoder decoder)
+                    {
+                        VisitorForVariable visitor = decoder.visitorForVariable;
+                        bool result = Decode(exp, visitor, decoder);
+                        var = visitor.Variable;
+                        return result;
+                    }
+
+                    public override bool SymbolicConstant(Expression pc, Variable symbol, Unit data)
+                    {
+                        Variable = symbol;
+                        return true;
+                    }
+                }
+
+                private class VisitorForUnderlyingVariable : QueryVisitor
+                {
+                    private Variable Variable;
+
+                    public static Variable UnderlyingVariable(Expression exp, Decoder decoder)
+                    {
+                        var visitor = decoder.visitorForUnderlyingVariable;
+                        var dummy = Decode(exp, visitor, decoder);
+
+                        return visitor.Variable;
+                    }
+
+                    public override bool Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
+                    {
+                        Variable = dest;
+                        return true;
+                    }
+
+                    public override bool Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
+                    {
+                        Variable = dest;
+                        return true;
+                    }
+
+                    public override bool Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
+                    {
+                        Variable = dest;
+                        return true;
+                    }
+
+                    public override bool Ldnull(Expression pc, Variable dest, Unit data)
+                    {
+                        Variable = dest;
+                        return true;
+                    }
+
+                    public override bool Sizeof(Expression pc, Type type, Variable dest, Unit data)
+                    {
+                        Variable = dest;
+                        return true;
+                    }
+
+                    public override bool SymbolicConstant(Expression pc, Variable symbol, Unit data)
+                    {
+                        Variable = symbol;
+                        return true;
+                    }
+
+                    public override bool Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
+                    {
+                        Variable = dest;
+                        return true;
+                    }
+                }
+
+
+                private class VisitorForIsUnaryExpression : QueryVisitor
+                {
+                    private UnaryOperator Operator;
+                    private Expression Argument;
+
+                    public static bool IsUnary(Expression exp, out UnaryOperator op, out Expression arg,
+                      Decoder decoder)
+                    {
+                        VisitorForIsUnaryExpression visitor = decoder.visitorForIsUnaryExpression;
+                        bool result = Decode(exp, visitor, decoder);
+                        op = visitor.Operator;
+                        arg = visitor.Argument;
+                        return result;
+                    }
+
+                    public override bool Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
+                    {
+                        Argument = source;
+                        Operator = op;
+                        return true;
+                    }
+                }
+
+                private class VisitorForIsBinaryExpression : QueryVisitor
+                {
+                    private BinaryOperator Operator;
+                    private Expression Left;
+                    private Expression Right;
+
+                    public static bool IsBinary(Expression exp, out BinaryOperator op, out Expression left, out Expression right, Decoder decoder)
+                    {
+                        VisitorForIsBinaryExpression visitor = decoder.visitorForIsBinaryExpression;
+                        bool result = Decode(exp, visitor, decoder);
+                        op = visitor.Operator;
+                        left = visitor.Left;
+                        right = visitor.Right;
+                        return result;
+                    }
+
+                    public override bool Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
+                    {
+                        Operator = op;
+                        Left = s1;
+                        Right = s2;
+                        return true;
+                    }
+                }
+
+                private class VisitorForVariablesIn
+                  : IVisitValueExprIL<Expression, Type, Expression, Variable, Microsoft.Research.DataStructures.IMutableSet<Expression>, Unit>
+                {
+                    #region Private state
+                    private IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context;
+                    #endregion
+
+                    public VisitorForVariablesIn(IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>/*!*/ context)
+                    {
+                        this.context = context;
+                    }
+
+                    public static void AddFreeVariables(Expression exp,
+                                                        Microsoft.Research.DataStructures.IMutableSet<Expression> set, Decoder decoder)
+                    {
+                        decoder.visitorForVariablesIn.Recurse(exp, set);
+                    }
+
+                    private void Recurse(Expression exp, Microsoft.Research.DataStructures.IMutableSet<Expression> set)
+                    {
+                        context.ExpressionContext.Decode<Microsoft.Research.DataStructures.IMutableSet<Expression>, Unit, VisitorForVariablesIn>(exp, this, set);
+                    }
+
+                    #region IVisitValueExprIL<Expression,Type,Expression,Variable,Generics.Set<Variable>,Generics.Set<Variable>> Members
+
+                    public Unit SymbolicConstant(Expression pc, Variable symbol, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
+                    {
+                        data.Add(pc);
+                        return Unit.Value;
+                    }
+
+                    #endregion
+
+                    #region IVisitExprIL<Expression,Type,Expression,Variable,Generics.Set<Expression>,Microsoft.Research.DataStructures.ISet<Expression>> Members
+
+                    public Unit Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
+                    {
+                        Recurse(s1, data);
+                        Recurse(s2, data);
+
+                        return Unit.Value;
+                    }
+
+                    public Unit Isinst(Expression pc, Type type, Variable dest, Expression obj, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
+                    {
+                        data.Add(pc); // TODO: figure out who depends on this! This should not be treated as a free variable!
+
+                        return Unit.Value;
+                    }
+
+                    public Unit Ldconst(Expression pc, object constant, Type type, Variable dest, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
+                    {
+                        return Unit.Value;
+                    }
+
+                    public Unit Ldnull(Expression pc, Variable dest, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
+                    {
+                        return Unit.Value;
+                    }
+
+                    public Unit Sizeof(Expression pc, Type type, Variable dest, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
+                    {
+                        // Why is this used here? TODO: figure out what depends on this!
+                        data.Add(pc);
+                        return Unit.Value;
+                    }
+
+                    public Unit Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Microsoft.Research.DataStructures.IMutableSet<Expression> data)
+                    {
+                        Recurse(source, data);
+                        return Unit.Value;
+                    }
+
+                    public Unit Box(Expression pc, Type type, Variable dest, Expression source, IMutableSet<Expression> data)
+                    {
+                        Recurse(source, data);
+                        return Unit.Value;
+                    }
+
+                    #endregion
+                }
+
+                private class VisitorForValueOf : QueryVisitor
+                {
+                    #region Private state
+                    private Type Type;
+                    private object Value;
+                    #endregion
+
+                    public static bool IsConstant(Expression exp, out object value, out Type type, Decoder decoder)
+                    {
+                        VisitorForValueOf visitor = decoder.visitorForValueOf;
+                        bool result = Decode(exp, visitor, decoder);
+                        value = visitor.Value;
+                        type = visitor.Type;
+                        return result;
+                    }
+
+                    public override bool Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
+                    {
+                        Type = type;
+                        Value = constant;
+                        return true;
+                    }
+                    public override bool Ldnull(Expression pc, Variable dest, Unit data)
+                    {
+                        Type = default(Type);
+                        Value = null;
+                        return true;
+                    }
+                }
+
+                private class VisitorForSizeOf : QueryVisitor
+                {
+                    #region Constructor
+                    #endregion
+
+                    private Type Type;
+
+                    public static bool IsSizeOf(Expression exp, out Type type, Decoder decoder)
+                    {
+                        VisitorForSizeOf visitor = decoder.visitorForSizeOf;
+                        bool result = Decode(exp, visitor, decoder);
+                        type = visitor.Type;
+                        return result;
+                    }
+
+                    public override bool Sizeof(Expression pc, Type type, Variable dest, Unit data)
+                    {
+                        Type = type;
+                        return true;
+                    }
+                }
+
+                private class VisitorForIsInst : QueryVisitor
+                {
+                    #region Constructor
+                    #endregion
+
+                    private Type Type;
+                    private Expression Argument;
+
+                    public static bool IsIsInst(Expression exp, out Type type, out Expression arg, Decoder decoder)
+                    {
+                        VisitorForIsInst visitor = decoder.visitorForIsInst;
+                        bool result = Decode(exp, visitor, decoder);
+                        type = visitor.Type;
+                        arg = visitor.Argument;
+                        return result;
+                    }
+
+                    public override bool Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
+                    {
+                        Type = type;
+                        Argument = obj;
+                        return true;
+                    }
+                }
 
 #if false
-        private class VisitorForNameOf : IVisitValueExprIL<Expression, Type, Expression, Variable, Unit, string>
-        {
-          #region Private state
-          private IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context;
-          #endregion
+                private class VisitorForNameOf : IVisitValueExprIL<Expression, Type, Expression, Variable, Unit, string>
+                {
+                    #region Private state
+                    private IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context;
+                    #endregion
 
-          #region Constructor
-          public VisitorForNameOf(IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context)
-          {
-            this.context = context;
-          }
-          #endregion
+                    #region Constructor
+                    public VisitorForNameOf(IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context)
+                    {
+                        this.context = context;
+                    }
+                    #endregion
 
-          #region IVisitValueExprIL<Expression,Type,Expression,Variable,Unit,string> Members
+                    #region IVisitValueExprIL<Expression,Type,Expression,Variable,Unit,string> Members
 
-          public string SymbolicConstant(Expression aPC, Variable symbol, Unit data)
-          {
-            return symbol.ToString();
-          }
+                    public string SymbolicConstant(Expression aPC, Variable symbol, Unit data)
+                    {
+                        return symbol.ToString();
+                    }
 
-          #endregion
+                    #endregion
 
-          #region IVisitExprIL<Expression,Type,Expression,Variable,Unit,string> Members
+                    #region IVisitExprIL<Expression,Type,Expression,Variable,Unit,string> Members
 
-          public string Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
-          {
-            return null;
-          }
+                    public string Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, Unit data)
+                    {
+                        return null;
+                    }
 
-          public string Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
-          {
-            return null;
-          }
+                    public string Isinst(Expression pc, Type type, Variable dest, Expression obj, Unit data)
+                    {
+                        return null;
+                    }
 
-          public string Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
-          {
-            return "Constant(" + constant.ToString() + ")";
-          }
+                    public string Ldconst(Expression pc, object constant, Type type, Variable dest, Unit data)
+                    {
+                        return "Constant(" + constant.ToString() + ")";
+                    }
 
-          public string Ldnull(Expression pc, Variable dest, Unit data)
-          {
-            return null;
-          }
+                    public string Ldnull(Expression pc, Variable dest, Unit data)
+                    {
+                        return null;
+                    }
 
-          public string Sizeof(Expression pc, Type type, Variable dest, Unit data)
-          {
-            return null;
-          }
+                    public string Sizeof(Expression pc, Type type, Variable dest, Unit data)
+                    {
+                        return null;
+                    }
 
-          public string Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
-          {
-            return null;
-          }
+                    public string Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, Unit data)
+                    {
+                        return null;
+                    }
 
-          #endregion
-        }
+                    #endregion
+                }
 #endif
-        private class VisitorForIsNull : QueryVisitor
-        {
-          public static bool IsNull(Expression exp, Decoder decoder)
-          {
-            return Decode(exp, decoder.visitorForIsNull, decoder);
-          }
+                private class VisitorForIsNull : QueryVisitor
+                {
+                    public static bool IsNull(Expression exp, Decoder decoder)
+                    {
+                        return Decode(exp, decoder.visitorForIsNull, decoder);
+                    }
 
-          public override bool Ldnull(Expression pc, Variable dest, Unit data)
-          {
-            return true;
-          }
-        }
+                    public override bool Ldnull(Expression pc, Variable dest, Unit data)
+                    {
+                        return true;
+                    }
+                }
 
-        private class VisitorForDispatch : IVisitValueExprIL<Expression, Type, Expression, Variable, IBoxedExpressionVisitor, Unit>
-        {
-          private Decoder decoder;
+                private class VisitorForDispatch : IVisitValueExprIL<Expression, Type, Expression, Variable, IBoxedExpressionVisitor, Unit>
+                {
+                    private Decoder decoder;
 
-          public VisitorForDispatch(Decoder decoder)
-          {
-            Contract.Requires(decoder != null);
+                    public VisitorForDispatch(Decoder decoder)
+                    {
+                        Contract.Requires(decoder != null);
 
-            this.decoder = decoder;
-          }
+                        this.decoder = decoder;
+                    }
 
-          public Unit SymbolicConstant(Expression pc, Variable symbol, IBoxedExpressionVisitor data)
-          {
-            data.Variable(symbol, null, null);
-            return Unit.Value;
-          }
+                    public Unit SymbolicConstant(Expression pc, Variable symbol, IBoxedExpressionVisitor data)
+                    {
+                        data.Variable(symbol, null, null);
+                        return Unit.Value;
+                    }
 
-          public Unit Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, IBoxedExpressionVisitor data)
-          {
-            data.Binary(op, BoxedExpression.For(s1, this.decoder), BoxedExpression.For(s2, this.decoder), null);
-            return Unit.Value;
-          }
+                    public Unit Binary(Expression pc, BinaryOperator op, Variable dest, Expression s1, Expression s2, IBoxedExpressionVisitor data)
+                    {
+                        data.Binary(op, BoxedExpression.For(s1, decoder), BoxedExpression.For(s2, decoder), null);
+                        return Unit.Value;
+                    }
 
-          public Unit Isinst(Expression pc, Type type, Variable dest, Expression obj, IBoxedExpressionVisitor data)
-          {
-            data.IsInst(type, BoxedExpression.For(obj, this.decoder), null); 
-            return Unit.Value;
-          }
+                    public Unit Isinst(Expression pc, Type type, Variable dest, Expression obj, IBoxedExpressionVisitor data)
+                    {
+                        data.IsInst(type, BoxedExpression.For(obj, decoder), null);
+                        return Unit.Value;
+                    }
 
-          public Unit Ldconst(Expression pc, object constant, Type type, Variable dest, IBoxedExpressionVisitor data)
-          {
-            data.Constant(type, constant, null);
-            return Unit.Value;
-          }
+                    public Unit Ldconst(Expression pc, object constant, Type type, Variable dest, IBoxedExpressionVisitor data)
+                    {
+                        data.Constant(type, constant, null);
+                        return Unit.Value;
+                    }
 
-          public Unit Ldnull(Expression pc, Variable dest, IBoxedExpressionVisitor data)
-          {
-            data.Constant<Type>(default(Type), null, null);
-            return Unit.Value;
-          }
+                    public Unit Ldnull(Expression pc, Variable dest, IBoxedExpressionVisitor data)
+                    {
+                        data.Constant<Type>(default(Type), null, null);
+                        return Unit.Value;
+                    }
 
-          public Unit Sizeof(Expression pc, Type type, Variable dest, IBoxedExpressionVisitor data)
-          {
-            int size;
-            if (!this.decoder.TrySizeOfAsConstant(pc, out size)) {
-              size = 0;
+                    public Unit Sizeof(Expression pc, Type type, Variable dest, IBoxedExpressionVisitor data)
+                    {
+                        int size;
+                        if (!decoder.TrySizeOfAsConstant(pc, out size))
+                        {
+                            size = 0;
+                        }
+                        data.SizeOf(type, size, null);
+                        return Unit.Value;
+                    }
+
+                    public Unit Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, IBoxedExpressionVisitor data)
+                    {
+                        data.Unary(op, BoxedExpression.For(source, decoder), null);
+                        return Unit.Value;
+                    }
+
+                    public Unit Box(Expression pc, Type type, Variable dest, Expression source, IBoxedExpressionVisitor data)
+                    {
+                        // TODO: dispatch to box, once we have BOX in BoxedExpressions
+                        return Unit.Value;
+                    }
+
+                    internal void Dispatch(Expression exp, IBoxedExpressionVisitor visitor)
+                    {
+                        var expContext = decoder.Context.ExpressionContext;
+
+                        expContext.Decode<IBoxedExpressionVisitor, Unit, VisitorForDispatch>(exp, this, visitor);
+                    }
+                }
+                #endregion
+
+                #region IFullExpressionDecoder<Type,Field,Expression> Members
+
+                public Type System_Int32 { get { return this.decoderForMetaData.System_Int32; } }
+
+                public bool IsReferenceType(Type type)
+                {
+                    return this.decoderForMetaData.IsReferenceType(type);
+                }
+
+                public bool TrySizeOfAsConstant(Expression exp, out int value)
+                {
+                    return TrySizeOf(exp, out value);
+                }
+
+                public bool TrySizeOf(Expression exp, out int value)
+                {
+                    Type type;
+                    if (VisitorForSizeOf.IsSizeOf(exp, out type, this))
+                    {
+                        int size = this.decoderForMetaData.TypeSize(type);
+                        if (size != -1)
+                        {
+                            value = size;
+                            return true;
+                        }
+                        else
+                        {
+                            value = -1;
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        value = -1;
+                        return false;
+                    }
+                }
+
+                public bool IsNull(Expression exp)
+                {
+                    return this.context.ExpressionContext.IsZero(exp);
+                    // return this.context.Decode<Unit, bool, VisitorForIsNull>(exp, this.visitorForIsNull, Unit.Value);
+                }
+
+                public bool TryGetAssociatedExpression(APC pc, Expression e, AssociatedInfo infoKind, out Expression info)
+                {
+                    Variable var = this.context.ExpressionContext.Unrefine(e);
+                    return TryGetAssociatedExpression(this.context.ExpressionContext.Refine(pc, var), infoKind, out info);
+                }
+
+                public bool TryGetAssociatedExpression(Expression e, AssociatedInfo infoKind, out Expression info)
+                {
+                    switch (infoKind)
+                    {
+                        case AssociatedInfo.WritableBytes:
+                            return this.context.ExpressionContext.TryGetWritableBytes(e, out info);
+                        case AssociatedInfo.ArrayLength:
+                            return this.context.ExpressionContext.TryGetArrayLength(e, out info);
+                        default:
+                            info = default(Expression);
+                            return false;
+                    }
+                }
+
+                public void Dispatch(Expression exp, IBoxedExpressionVisitor visitor)
+                {
+                    visitorForDispatch.Dispatch(exp, visitor);
+                }
+                #endregion
             }
-            data.SizeOf(type, size, null);
-            return Unit.Value;
-          }
 
-          public Unit Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Expression source, IBoxedExpressionVisitor data)
-          {
-            data.Unary(op, BoxedExpression.For(source, this.decoder), null);
-            return Unit.Value;
-          }
-
-          public Unit Box(Expression pc, Type type, Variable dest, Expression source, IBoxedExpressionVisitor data)
-          {
-              // TODO: dispatch to box, once we have BOX in BoxedExpressions
-              return Unit.Value;
-          }
-
-          internal void Dispatch(Expression exp, IBoxedExpressionVisitor visitor)
-          {
-            var expContext = this.decoder.Context.ExpressionContext;
-
-            expContext.Decode<IBoxedExpressionVisitor, Unit, VisitorForDispatch>(exp, this, visitor);
-          }
-
-
+            #endregion
         }
-        #endregion
-
-        #region IFullExpressionDecoder<Type,Field,Expression> Members
-
-        public Type System_Int32 { get { return this.decoderForMetaData.System_Int32; } }
-
-        public bool IsReferenceType(Type type)
-        {
-          return this.decoderForMetaData.IsReferenceType(type);
-        }
-
-        public bool TrySizeOfAsConstant(Expression exp, out int value)
-        {
-          return TrySizeOf(exp, out value);
-        }
-
-        public bool TrySizeOf(Expression exp, out int value)
-        {
-          Type type;
-          if (VisitorForSizeOf.IsSizeOf(exp, out type, this))
-          {
-            int size = this.decoderForMetaData.TypeSize(type);
-            if (size != -1)
-            {
-              value = size;
-              return true;
-            }
-            else
-            {
-              value = -1;
-              return false;
-            }
-          }
-          else
-          {
-            value = -1;
-            return false;
-          }
-        }
-
-        public bool IsNull(Expression exp)
-        {
-          return this.context.ExpressionContext.IsZero(exp);
-          // return this.context.Decode<Unit, bool, VisitorForIsNull>(exp, this.visitorForIsNull, Unit.Value);
-        }
-
-        public bool TryGetAssociatedExpression(APC pc, Expression e, AssociatedInfo infoKind, out Expression info)
-        {
-          Variable var = this.context.ExpressionContext.Unrefine(e);
-          return TryGetAssociatedExpression(this.context.ExpressionContext.Refine(pc, var), infoKind, out info);
-        }
-
-        public bool TryGetAssociatedExpression(Expression e, AssociatedInfo infoKind, out Expression info)
-        {
-          switch (infoKind)
-          {
-            case AssociatedInfo.WritableBytes:
-              return this.context.ExpressionContext.TryGetWritableBytes(e, out info);
-            case AssociatedInfo.ArrayLength:
-              return this.context.ExpressionContext.TryGetArrayLength(e, out info);
-            default:
-              info = default(Expression);
-              return false;
-          }
-        }
-
-        public void Dispatch(Expression exp, IBoxedExpressionVisitor visitor)
-        {
-          this.visitorForDispatch.Dispatch(exp, visitor);
-        }
-        #endregion
-      }
-
-      #endregion
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Driver.cs
+++ b/Microsoft.Research/CodeAnalysis/Driver.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,327 +9,327 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using EdgeData = IFunctionalMap<SymbolicValue, FList<SymbolicValue>>;
+    using EdgeData = IFunctionalMap<SymbolicValue, FList<SymbolicValue>>;
 
-  public class OldAnalysisDriver<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly,LogOptions, MethodResult> 
-    : AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC,SymbolicValue>, SymbolicValue, LogOptions, MethodResult>
-    where LogOptions:IFrameworkLogOptions 
-    where Type:IEquatable<Type>
-  {
-
-    public OldAnalysisDriver(
-      IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> basicDriver
-    ) : base (basicDriver)
+    public class OldAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions, MethodResult>
+      : AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-    }
-
-    public override IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions> MethodDriver(
-      Method method,
-      IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> classDriver,
-      bool removeInferredPrecondition = false)
-    {
-      return new MDriver(method, this, classDriver, removeInferredPrecondition);
-    }
-
-    private class MDriver
-      : BasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
-      , IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions>
-      , IFactBase<SymbolicValue>
-    {
-      private OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> optimisticHeapAnalysis;
-      private Converter<ExternalExpression<APC, SymbolicValue>, string> expr2String;
-      private IFullExpressionDecoder<Type, SymbolicValue, ExternalExpression<APC, SymbolicValue>> expressionDecoder;
-      private readonly IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> classDriver;
-      private readonly AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> specializedParent;
-      private readonly bool RemoveInferredPreconditions;
-
-      public IDisjunctiveExpressionRefiner<SymbolicValue, BoxedExpression> DisjunctiveExpressionRefiner { get; set; }
-
-      public SyntacticInformation<Method, Field, SymbolicValue> AdditionalSyntacticInformation { get; set; }
-
-      public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
-        ValueLayer { get; private set; }
-
-      public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>, EdgeData>
-        ExpressionLayer { get; private set; }
-
-      public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
-        HybridLayer { get; protected set; }
-
-      public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
-        { get { return this.RawLayer.MetaDataDecoder; } }
-
-      public MDriver(
-        Method method,
-        OldAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions, MethodResult> parent,
-        IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> classDriver,
-        bool removeInferredPrecondition
-      )
-        : base(method, parent)
-      {
-        this.specializedParent = parent;
-        // Here we build our stack of adapters.
-        //
-        //  Expr          (expressions)
-        //  Heap          (symbolic values)
-        //  StackDepth    (Temp decoder for APC)
-        //  CFG           (Unit decoder for APC, including Assume)
-        //  cciilprovider (Unit decoder for PC)
-        //
-        // The base class already built the first 3
-        // The last two are built on demand
-
-        this.classDriver = classDriver;
-        this.RemoveInferredPreconditions = removeInferredPrecondition;
-      }
-
-      public IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> Context { get { return this.ExpressionLayer.Decoder.AssumeNotNull().Context; } }
-
-      public Converter<SymbolicValue, int> KeyNumber { get { return SymbolicValue.GetUniqueKey; } }
-      public Comparison<SymbolicValue> VariableComparer { get { return SymbolicValue.Compare; } }
-
-      public void RunHeapAndExpressionAnalyses()
-      {
-        if (optimisticHeapAnalysis != null) return;
-
-        optimisticHeapAnalysis = new OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(this.StackLayer, this.Options.TraceEGraph);
-        optimisticHeapAnalysis.TurnArgumentExceptionThrowsIntoAssertFalse = this.Options.TurnArgumentExceptionThrowsIntoAssertFalse;
-        optimisticHeapAnalysis.IgnoreExplicitAssumptions = this.Options.IgnoreExplicitAssumptions;
-        optimisticHeapAnalysis.TraceAssumptions = this.Options.TraceAssumptions;
-        var heapsolver = this.StackLayer.CreateForward(optimisticHeapAnalysis,
-                            new DFAOptions { Trace = this.Options.TraceHeapAnalysis });
-
-        heapsolver(optimisticHeapAnalysis.InitialValue());
-
-        this.ValueLayer = CodeLayerFactory.Create(optimisticHeapAnalysis.GetDecoder(this.StackLayer.Decoder),
-                                                  this.StackLayer.MetaDataDecoder, 
-                                                  this.StackLayer.ContractDecoder, 
-                                                  delegate(SymbolicValue source) { return source.ToString(); },
-                                                  delegate(SymbolicValue dest) { return dest.ToString(); },
-                                                  (v1, v2) => v1.symbol.GlobalId>v2.symbol.GlobalId
-        );
-
-        if (this.PrintIL)
+        public OldAnalysisDriver(
+          IBasicAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions> basicDriver
+        ) : base(basicDriver)
         {
-          Console.WriteLine("-----------------Value based CFG---------------------");
-          this.ValueLayer.Decoder.Context.MethodContext.CFG.Print(Console.Out, this.ValueLayer.Printer, optimisticHeapAnalysis.GetEdgePrinter(),
-                    (block) => optimisticHeapAnalysis.GetContexts(block),
-                    null);
-        }
-        var exprAnalysis = new ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>(
-          this.ValueLayer,
-          this.Options,
-          optimisticHeapAnalysis.IsUnreachable
-          );
-        var exprsolver = this.ValueLayer.CreateForward(exprAnalysis.CreateExpressionAnalyzer(),
-                                                       new DFAOptions { Trace = this.Options.TraceExpressionAnalysis });
-
-        exprsolver(exprAnalysis.InitialValue(SymbolicValue.GetUniqueKey));
-
-        var exprDecoder = exprAnalysis.GetDecoder(this.ValueLayer.Decoder);
-        this.expr2String = ExprPrinter.Printer(exprDecoder.Context, this);
-
-        this.ExpressionLayer = CodeLayerFactory.Create(
-          exprDecoder,
-          this.ValueLayer.MetaDataDecoder,
-          this.ValueLayer.ContractDecoder,
-          expr2String,
-          this.ValueLayer.VariableToString,
-          (v1, v2) => v1.symbol.GlobalId > v2.symbol.GlobalId
-          );
-        
-
-        if (this.PrintIL)
-        {
-          Console.WriteLine("-----------------Expression based CFG---------------------");
-          this.ExpressionLayer.Decoder.Context.MethodContext.CFG.Print(Console.Out, this.ExpressionLayer.Printer, exprAnalysis.GetBlockPrinter(expr2String),
-                    (block) => exprAnalysis.GetContexts(block),
-                    null);
         }
 
-        this.HybridLayer = CodeLayerFactory.Create(
-          this.ValueLayer.Decoder,
-          this.ValueLayer.MetaDataDecoder,
-          this.ValueLayer.ContractDecoder,
-          this.ValueLayer.ExpressionToString,
-          this.ValueLayer.VariableToString,
-          this.ExpressionLayer.Printer,
-          this.ExpressionLayer.NewerThan
-          );
-
-        if (Options.TraceAssumptions)
+        public override IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions> MethodDriver(
+          Method method,
+          IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> classDriver,
+          bool removeInferredPrecondition = false)
         {
-          #region Produce trace output to extract implicit assumptions. Please don't remove this code!
+            return new MDriver(method, this, classDriver, removeInferredPrecondition);
+        }
 
-          Console.WriteLine("<assumptions>");
-          Console.WriteLine(@"<subroutine id=""{0}"" methodName=""{1}"">", HybridLayer.Decoder.Context.MethodContext.CFG.Subroutine.Id, HybridLayer.Decoder.Context.MethodContext.CFG.Subroutine.Name);
+        private class MDriver
+          : BasicMethodDriverWithInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions>
+          , IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions>
+          , IFactBase<SymbolicValue>
+        {
+            private OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> optimisticHeapAnalysis;
+            private Converter<ExternalExpression<APC, SymbolicValue>, string> expr2String;
+            private IFullExpressionDecoder<Type, SymbolicValue, ExternalExpression<APC, SymbolicValue>> expressionDecoder;
+            private readonly IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> classDriver;
+            private readonly AnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> specializedParent;
+            private readonly bool RemoveInferredPreconditions;
 
-          foreach (var b in HybridLayer.Decoder.Context.MethodContext.CFG.Subroutine.Blocks)
-          {
-            Console.WriteLine(@"<block index=""{0}"">", b.Index);
+            public IDisjunctiveExpressionRefiner<SymbolicValue, BoxedExpression> DisjunctiveExpressionRefiner { get; set; }
 
-            foreach (var apc in b.APCs())
+            public SyntacticInformation<Method, Field, SymbolicValue> AdditionalSyntacticInformation { get; set; }
+
+            public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
+              ValueLayer
+            { get; private set; }
+
+            public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>, EdgeData>
+              ExpressionLayer
+            { get; private set; }
+
+            public ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
+              HybridLayer
+            { get; protected set; }
+
+            public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder
+            { get { return this.RawLayer.MetaDataDecoder; } }
+
+            public MDriver(
+              Method method,
+              OldAnalysisDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, LogOptions, MethodResult> parent,
+              IClassDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions, MethodResult> classDriver,
+              bool removeInferredPrecondition
+            )
+              : base(method, parent)
             {
-              Console.WriteLine(@"<apc name=""{0}"" index=""{1}"" ilOffset=""{2}"" primarySourceContext=""{3}"" sourceContext=""{4}"">",
-                apc.ToString(), apc.Index, apc.ILOffset, apc.PrimarySourceContext(), HybridLayer.Decoder.Context.MethodContext.SourceContext(apc));
-              
-              Console.WriteLine("<code>");
-              HybridLayer.Printer(apc, "", Console.Out);
-              Console.WriteLine("</code>");
+                specializedParent = parent;
+                // Here we build our stack of adapters.
+                //
+                //  Expr          (expressions)
+                //  Heap          (symbolic values)
+                //  StackDepth    (Temp decoder for APC)
+                //  CFG           (Unit decoder for APC, including Assume)
+                //  cciilprovider (Unit decoder for PC)
+                //
+                // The base class already built the first 3
+                // The last two are built on demand
 
-              optimisticHeapAnalysis.Dump(apc);
-
-              Console.WriteLine("</apc>");
+                this.classDriver = classDriver;
+                RemoveInferredPreconditions = removeInferredPrecondition;
             }
 
-            Console.WriteLine("</block>");
-          }
+            public IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> Context { get { return this.ExpressionLayer.Decoder.AssumeNotNull().Context; } }
 
-          Console.WriteLine("</subroutine>");
-          Console.WriteLine("</assumptions>");
+            public Converter<SymbolicValue, int> KeyNumber { get { return SymbolicValue.GetUniqueKey; } }
+            public Comparison<SymbolicValue> VariableComparer { get { return SymbolicValue.Compare; } }
 
-          #endregion
+            public void RunHeapAndExpressionAnalyses()
+            {
+                if (optimisticHeapAnalysis != null) return;
+
+                optimisticHeapAnalysis = new OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(this.StackLayer, this.Options.TraceEGraph);
+                optimisticHeapAnalysis.TurnArgumentExceptionThrowsIntoAssertFalse = this.Options.TurnArgumentExceptionThrowsIntoAssertFalse;
+                optimisticHeapAnalysis.IgnoreExplicitAssumptions = this.Options.IgnoreExplicitAssumptions;
+                optimisticHeapAnalysis.TraceAssumptions = this.Options.TraceAssumptions;
+                var heapsolver = this.StackLayer.CreateForward(optimisticHeapAnalysis,
+                                    new DFAOptions { Trace = this.Options.TraceHeapAnalysis });
+
+                heapsolver(optimisticHeapAnalysis.InitialValue());
+
+                this.ValueLayer = CodeLayerFactory.Create(optimisticHeapAnalysis.GetDecoder(this.StackLayer.Decoder),
+                                                          this.StackLayer.MetaDataDecoder,
+                                                          this.StackLayer.ContractDecoder,
+                                                          delegate (SymbolicValue source) { return source.ToString(); },
+                                                          delegate (SymbolicValue dest) { return dest.ToString(); },
+                                                          (v1, v2) => v1.symbol.GlobalId > v2.symbol.GlobalId
+                );
+
+                if (this.PrintIL)
+                {
+                    Console.WriteLine("-----------------Value based CFG---------------------");
+                    this.ValueLayer.Decoder.Context.MethodContext.CFG.Print(Console.Out, this.ValueLayer.Printer, optimisticHeapAnalysis.GetEdgePrinter(),
+                              (block) => optimisticHeapAnalysis.GetContexts(block),
+                              null);
+                }
+                var exprAnalysis = new ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>(
+                  this.ValueLayer,
+                  this.Options,
+                  optimisticHeapAnalysis.IsUnreachable
+                  );
+                var exprsolver = this.ValueLayer.CreateForward(exprAnalysis.CreateExpressionAnalyzer(),
+                                                               new DFAOptions { Trace = this.Options.TraceExpressionAnalysis });
+
+                exprsolver(exprAnalysis.InitialValue(SymbolicValue.GetUniqueKey));
+
+                var exprDecoder = exprAnalysis.GetDecoder(this.ValueLayer.Decoder);
+                expr2String = ExprPrinter.Printer(exprDecoder.Context, this);
+
+                this.ExpressionLayer = CodeLayerFactory.Create(
+                  exprDecoder,
+                  this.ValueLayer.MetaDataDecoder,
+                  this.ValueLayer.ContractDecoder,
+                  expr2String,
+                  this.ValueLayer.VariableToString,
+                  (v1, v2) => v1.symbol.GlobalId > v2.symbol.GlobalId
+                  );
+
+
+                if (this.PrintIL)
+                {
+                    Console.WriteLine("-----------------Expression based CFG---------------------");
+                    this.ExpressionLayer.Decoder.Context.MethodContext.CFG.Print(Console.Out, this.ExpressionLayer.Printer, exprAnalysis.GetBlockPrinter(expr2String),
+                              (block) => exprAnalysis.GetContexts(block),
+                              null);
+                }
+
+                this.HybridLayer = CodeLayerFactory.Create(
+                  this.ValueLayer.Decoder,
+                  this.ValueLayer.MetaDataDecoder,
+                  this.ValueLayer.ContractDecoder,
+                  this.ValueLayer.ExpressionToString,
+                  this.ValueLayer.VariableToString,
+                  this.ExpressionLayer.Printer,
+                  this.ExpressionLayer.NewerThan
+                  );
+
+                if (Options.TraceAssumptions)
+                {
+                    #region Produce trace output to extract implicit assumptions. Please don't remove this code!
+
+                    Console.WriteLine("<assumptions>");
+                    Console.WriteLine(@"<subroutine id=""{0}"" methodName=""{1}"">", HybridLayer.Decoder.Context.MethodContext.CFG.Subroutine.Id, HybridLayer.Decoder.Context.MethodContext.CFG.Subroutine.Name);
+
+                    foreach (var b in HybridLayer.Decoder.Context.MethodContext.CFG.Subroutine.Blocks)
+                    {
+                        Console.WriteLine(@"<block index=""{0}"">", b.Index);
+
+                        foreach (var apc in b.APCs())
+                        {
+                            Console.WriteLine(@"<apc name=""{0}"" index=""{1}"" ilOffset=""{2}"" primarySourceContext=""{3}"" sourceContext=""{4}"">",
+                              apc.ToString(), apc.Index, apc.ILOffset, apc.PrimarySourceContext(), HybridLayer.Decoder.Context.MethodContext.SourceContext(apc));
+
+                            Console.WriteLine("<code>");
+                            HybridLayer.Printer(apc, "", Console.Out);
+                            Console.WriteLine("</code>");
+
+                            optimisticHeapAnalysis.Dump(apc);
+
+                            Console.WriteLine("</apc>");
+                        }
+
+                        Console.WriteLine("</block>");
+                    }
+
+                    Console.WriteLine("</subroutine>");
+                    Console.WriteLine("</assumptions>");
+
+                    #endregion
+                }
+            }
+
+            public Converter<ExternalExpression<APC, SymbolicValue>, string> ExpressionToString { get { return expr2String; } }
+
+            public State BackwardTransfer<State, Visitor>(APC from, APC to, State state, Visitor visitor)
+              where Visitor : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, SymbolicValue, State>
+            {
+                if (this.IsUnreachable(to)) { throw new InvalidOperationException("Can not transfer to unreachable point"); }
+
+                if (from.Block != to.Block)
+                {
+                    var renaming = optimisticHeapAnalysis.BackwardEdgeRenaming(from, to);
+                    if (renaming != null)
+                    {
+                        return visitor.Rename(from, to, state, renaming);
+                    }
+                    else
+                    {
+                        return state;
+                    }
+                }
+                return this.ValueLayer.Decoder.ForwardDecode<State, State, Visitor>(to, visitor, state);
+            }
+
+
+            #region IMethodDriver<APC,Local,Parameter,Method,Field,Type,Attribute,Assembly,ExternalExpression<APC,SymbolicValue>,SymbolicValue,LogOptions> Members
+
+
+            public IFullExpressionDecoder<Type, SymbolicValue, ExternalExpression<APC, SymbolicValue>> ExpressionDecoder
+            {
+                get
+                {
+                    if (expressionDecoder == null)
+                    {
+                        Contract.Assert(this.Context != null);
+                        expressionDecoder = ExternalExpressionDecoder.Create(this.MetaDataDecoder, this.Context);
+                    }
+                    return expressionDecoder;
+                }
+            }
+
+            public IFactBase<SymbolicValue> BasicFacts { get { return this; } }
+
+            public override bool CanAddRequires()
+            {
+                return this.CanAddContracts();
+            }
+
+            public override bool CanAddEnsures()
+            {
+                return !this.MetaDataDecoder.IsVirtual(this.Context.MethodContext.CurrentMethod) && this.CanAddContracts();
+            }
+
+            protected override bool CanAddInvariants()
+            {
+                if (classDriver == null)
+                    return false;
+                return classDriver.CanAddInvariants();
+            }
+
+            protected override bool CanAddAssumes()
+            {
+                return this.Options.InferAssumesForBaseLining;
+            }
+
+            private bool CanAddContracts()
+            {
+                return !this.MetaDataDecoder.IsCompilerGenerated(this.Context.MethodContext.CurrentMethod) &&
+                       (!this.MetaDataDecoder.IsVirtual(this.Context.MethodContext.CurrentMethod) ||
+                        this.MetaDataDecoder.OverriddenAndImplementedMethods(this.method).AsIndexable(1).Count == 0);
+            }
+
+            public void EndAnalysis()
+            {
+                if (RemoveInferredPreconditions)
+                {
+                    // we are done validating the inferred preconditions, so we can remove them from the method cache
+                    specializedParent.RemoveInferredPrecondition(this.method);
+                }
+                else
+                {
+                    specializedParent.InstallPreconditions(this.inferredPreconditions, this.method);
+                }
+                specializedParent.InstallPostconditions(this.inferredPostconditions, this.method);
+
+                // Let's add the witness
+                specializedParent.MethodCache.AddWitness(this.method, this.MayReturnNull);
+
+                // Install postconditons for other methods
+                if (otherPostconditions != null)
+                {
+                    foreach (var tuple in otherPostconditions.GroupBy(t => t.Item1))
+                    {
+                        Contract.Assume(tuple.Any());
+                        specializedParent.InstallPostconditions(tuple.Select(t => t.Item2).ToList(), tuple.First().Item1);
+                    }
+                }
+
+                if (classDriver != null)
+                {
+                    var methodThis = this.MetaDataDecoder.This(this.method);
+                    classDriver.InstallInvariantsAsConstructorPostconditions(methodThis, this.inferredObjectInvariants, this.method);
+
+                    // Really install object invariants. TODO: readonly fields only
+                    // Missing something... how do I build a Contract.Invariant(...)?
+
+                    var asAssume = this.inferredObjectInvariants.Select(be => (new BoxedExpression.AssumeExpression(be.One, "invariant", this.CFG.EntryAfterRequires, be.Two, be.One.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type))))).Cast<BoxedExpression>();
+                    specializedParent.InstallObjectInvariants(asAssume.ToList(), classDriver.ClassType);
+                }
+            }
+
+            #endregion
+
+
+            #region IFactBase<SymbolicValue> Members
+
+            public ProofOutcome IsNull(APC pc, SymbolicValue value)
+            {
+                return ProofOutcome.Top;
+                //this.ValueLayer.Decoder.Context.ValueContext.IsZero(pc, value);
+            }
+
+            public ProofOutcome IsNonNull(APC pc, SymbolicValue value)
+            {
+                return ProofOutcome.Top;
+                //this.ValueLayer.Decoder.Context.ValueContext.IsZero(pc, value);
+            }
+
+            public FList<BoxedExpression> InvariantAt(APC pc, FList<SymbolicValue> filter, bool replaceVarsWithAccessPath = true)
+            {
+                return FList<BoxedExpression>.Empty;
+            }
+
+            public bool IsUnreachable(APC pc)
+            {
+                return optimisticHeapAnalysis.IsUnreachable(pc);
+            }
+            #endregion
         }
-      }
-
-      public Converter<ExternalExpression<APC, SymbolicValue>, string> ExpressionToString { get { return expr2String; } }
-
-      public State BackwardTransfer<State, Visitor>(APC from, APC to, State state, Visitor visitor)
-        where Visitor : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, SymbolicValue, State>
-      {
-        if (this.IsUnreachable(to)) { throw new InvalidOperationException("Can not transfer to unreachable point"); }
-
-        if (from.Block != to.Block)
-        {
-          var renaming = this.optimisticHeapAnalysis.BackwardEdgeRenaming(from, to);
-          if (renaming != null)
-          {
-            return visitor.Rename(from, to, state, renaming);
-          }
-          else
-          {
-            return state;
-          }
-        }
-        return this.ValueLayer.Decoder.ForwardDecode<State, State, Visitor>(to, visitor, state);
-      }
-
-
-      #region IMethodDriver<APC,Local,Parameter,Method,Field,Type,Attribute,Assembly,ExternalExpression<APC,SymbolicValue>,SymbolicValue,LogOptions> Members
-
-
-      public IFullExpressionDecoder<Type, SymbolicValue, ExternalExpression<APC, SymbolicValue>> ExpressionDecoder
-      {
-        get
-        {
-          if (this.expressionDecoder == null)
-          {
-            Contract.Assert(this.Context != null);
-            this.expressionDecoder = ExternalExpressionDecoder.Create(this.MetaDataDecoder, this.Context);
-          }
-          return this.expressionDecoder;
-        }
-      }
-
-      public IFactBase<SymbolicValue> BasicFacts { get { return this; } }
-
-      public override bool CanAddRequires()
-      {
-        return this.CanAddContracts();
-      }
-
-      public override bool CanAddEnsures()
-      {
-        return !this.MetaDataDecoder.IsVirtual(this.Context.MethodContext.CurrentMethod) && this.CanAddContracts();
-      }
-
-      protected override bool CanAddInvariants()
-      {
-        if (this.classDriver == null)
-          return false;
-        return this.classDriver.CanAddInvariants();
-      }
-
-      protected override bool CanAddAssumes()
-      {
-          return this.Options.InferAssumesForBaseLining;
-      }
-
-      private bool CanAddContracts()
-      {
-        return !this.MetaDataDecoder.IsCompilerGenerated(this.Context.MethodContext.CurrentMethod) &&
-               (!this.MetaDataDecoder.IsVirtual(this.Context.MethodContext.CurrentMethod) ||
-                this.MetaDataDecoder.OverriddenAndImplementedMethods(this.method).AsIndexable(1).Count == 0);
-
-      }
-
-      public void EndAnalysis()
-      {
-        if (this.RemoveInferredPreconditions)
-        {
-          // we are done validating the inferred preconditions, so we can remove them from the method cache
-          this.specializedParent.RemoveInferredPrecondition(this.method);
-        }
-        else
-        {
-          this.specializedParent.InstallPreconditions(this.inferredPreconditions, this.method);
-        }
-        this.specializedParent.InstallPostconditions(this.inferredPostconditions, this.method);
-
-        // Let's add the witness
-        this.specializedParent.MethodCache.AddWitness(this.method, this.MayReturnNull);
-
-        // Install postconditons for other methods
-        if (otherPostconditions != null)
-        {
-          foreach (var tuple in otherPostconditions.GroupBy(t => t.Item1))
-          {
-            Contract.Assume(tuple.Any());
-            this.specializedParent.InstallPostconditions(tuple.Select(t => t.Item2).ToList(), tuple.First().Item1);
-          }
-        }
-
-        if (this.classDriver != null)
-        {
-          var methodThis = this.MetaDataDecoder.This(this.method);
-          this.classDriver.InstallInvariantsAsConstructorPostconditions(methodThis, this.inferredObjectInvariants, this.method);
-
-          // Really install object invariants. TODO: readonly fields only
-          // Missing something... how do I build a Contract.Invariant(...)?
-
-          var asAssume = this.inferredObjectInvariants.Select(be => (new BoxedExpression.AssumeExpression(be.One, "invariant", this.CFG.EntryAfterRequires, be.Two, be.One.ToString<Type>(type => OutputPrettyCS.TypeHelper.TypeFullName(this.MetaDataDecoder, type))))).Cast<BoxedExpression>();
-          this.specializedParent.InstallObjectInvariants(asAssume.ToList(), this.classDriver.ClassType);
-        }
-      }
-
-      #endregion
-
-
-      #region IFactBase<SymbolicValue> Members
-
-      public ProofOutcome IsNull(APC pc, SymbolicValue value)
-      {
-        return ProofOutcome.Top;
-          //this.ValueLayer.Decoder.Context.ValueContext.IsZero(pc, value);
-      }
-
-      public ProofOutcome IsNonNull(APC pc, SymbolicValue value)
-      {
-        return ProofOutcome.Top;
-        //this.ValueLayer.Decoder.Context.ValueContext.IsZero(pc, value);
-      }
-
-      public FList<BoxedExpression> InvariantAt(APC pc, FList<SymbolicValue> filter, bool replaceVarsWithAccessPath = true)
-      {
-        return FList<BoxedExpression>.Empty;
-      }
-
-      public bool IsUnreachable(APC pc)
-      {
-        return this.optimisticHeapAnalysis.IsUnreachable(pc);
-      }
-      #endregion
     }
-
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/EGraph.cs
+++ b/Microsoft.Research/CodeAnalysis/EGraph.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #define ALLOW_MANIFESTATION
 
@@ -27,2725 +16,2871 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-
-  public struct EGraphTerm<T> : IEquatable<EGraphTerm<T>> where T:IEquatable<T> {
-    public readonly T Function;
-    public readonly ESymValue[] Args;
-
-    public EGraphTerm(T fun, params ESymValue[] args) {
-      this.Function = fun;
-      this.Args = args;
-    }
-
-    #region IEquatable<EGraphTerm<T>> Members
-
-    public bool Equals(EGraphTerm<T> that)
+    public struct EGraphTerm<T> : IEquatable<EGraphTerm<T>> where T : IEquatable<T>
     {
-      if (!this.Function.Equals(that.Function)) return false;
-      if (this.Args.Length != that.Args.Length) return false;
-      for (int i = 0; i < this.Args.Length; i++) {
-        if (!this.Args[i].Equals(that.Args[i])) return false;
-      }
-      return true;
+        public readonly T Function;
+        public readonly ESymValue[] Args;
+
+        public EGraphTerm(T fun, params ESymValue[] args)
+        {
+            this.Function = fun;
+            this.Args = args;
+        }
+
+        #region IEquatable<EGraphTerm<T>> Members
+
+        public bool Equals(EGraphTerm<T> that)
+        {
+            if (!this.Function.Equals(that.Function)) return false;
+            if (this.Args.Length != that.Args.Length) return false;
+            for (int i = 0; i < this.Args.Length; i++)
+            {
+                if (!this.Args[i].Equals(that.Args[i])) return false;
+            }
+            return true;
+        }
+
+        #endregion
     }
 
-    #endregion
-  }
-
-  public interface IAbstractValueForEGraph<ADomain> : IAbstractValue<ADomain>
-  {
-    bool HasAllBottomFields { get; }
-
-    /// <summary>
-    /// Returns a correct Top approximation for a manifested field at a join point,
-    /// where the other side has "this" abstract value
-    /// For some domains, this allows recovering information, such as type information
-    /// (that has to agree on branches).
-    /// </summary>
-    ADomain ForManifestedField();
-
-  }
-
-  public interface IConstantInfo
-  {
-    /// <summary>
-    /// True if this contant should be maintained when joining bottom
-    /// </summary>
-    bool KeepAsBottomField { get; }
-    /// <summary>
-    /// True if this constant should be maintained when joining top
-    /// </summary>
-    bool ManifestField { get; }
-  }
-
-  public interface IEGraph<Constant, ADomain, T> : IAbstractValue<T> where ADomain : IAbstractValueForEGraph<ADomain> where Constant : IEquatable<Constant>, IConstantInfo
-  {
-    /// <summary>
-    /// getter returns sv, such that sv == function(arg)
-    /// 
-    /// setter sets function(arg) == value, is equivalent to Eliminate(f, arg), followed by
-    /// assume (f(arg) == value)
-    /// </summary>
-    /// <param name="function"></param>
-    /// <param name="args"></param>
-    ESymValue this[Constant function, ESymValue arg] {
-      get;
-      set;
-    }
-
-    ESymValue this[Constant function] {
-      get;
-      set;
-    }
-
-    /// <summary>
-    /// returns sv, such that sv == function(arg), or null if not mapped
-    /// </summary>
-    ESymValue TryLookup(Constant function, ESymValue arg);
-
-    /// <summary>
-    /// returns sv, such that sv == function, or null if not mapped
-    /// </summary>
-    ESymValue TryLookup(Constant function);
-
-    /// <summary>
-    /// Assumes v1 == v2
-    /// </summary>
-    void AssumeEqual(ESymValue v1, ESymValue v2);
-
-    /// <summary>
-    /// Returns true if v1 == v2
-    /// </summary>
-    bool IsEqual(ESymValue v1, ESymValue v2);
-    
-    /// <summary>
-    /// Removes the mapping from the egraph. Semantically equivalent to setting 
-    /// the corresponding term to a Fresh symbolic value.
-    /// </summary>
-    void Eliminate(Constant function, ESymValue arg);
-
-    /// <summary>
-    /// Removes the mapping from the egraph. Semantically equivalent to setting 
-    /// the corresponding term to a Fresh symbolic value.
-    /// </summary>
-    void Eliminate(Constant function);
-
-    /// <summary>
-    /// Removes all mappings from the egraph of the form g(from).
-    /// </summary>
-    void EliminateAll(ESymValue from);
-    
-    /// <summary>
-    /// Create a fresh symbol
-    /// </summary>
-    /// <returns></returns>
-    ESymValue FreshSymbol();
-
-    /// <summary>
-    /// Associates symval with an abstract value.
-    /// 
-    /// getter returns current association or Top
-    /// setter sets current association (forgetting old association)
-    /// </summary>
-    ADomain this[ESymValue symval] { get; set; }
-    
-    /// <summary>
-    /// Merge two EGraphs. Result is null if result is no different than this.
-    /// MergeInfo provides the mapping of symbolic values in the result to values in the
-    /// two incoming branches.
-    /// </summary>
-    T Join(T incoming, out IMergeInfo mergeInfo, bool widen);
-
-
-    /// <summary>
-    /// return the set of constant function symbols in this egraph
-    /// </summary>
-    IEnumerable<Constant> Constants { get; }
-
-    /// <summary>
-    /// return the set of unary function symbols f, such that f(symval) = sv' exists in
-    /// the egraph.
-    /// </summary>
-    /// <param name="symval"></param>
-    IEnumerable<Constant> Functions(ESymValue symval);
-
-    /// <summary>
-    /// Returns the set of defined symbolic values in the egraph that have outgoing edges.
-    /// </summary>
-    IEnumerable<ESymValue> SymbolicValues { get; }
-
-    /// <summary>
-    /// Return set of equivalent terms to this symbolic value
-    /// </summary>
-    IEnumerable<EGraphTerm<Constant>> EqTerms(ESymValue symval);
-
-    /// <summary>
-    /// Returns true if this egraph contains as much information as the given argument egraph.
-    /// </summary>
-    /// <returns>if true, the map out parameter contains a mapping from symbolic variables in this egraph to corresponding
-    /// values in the other egraph. Equivalent (id) mappings are also present.</returns>
-    bool LessEqual(T that,
-                   out IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward,
-                   out IFunctionalMap<ESymValue, ESymValue>/*?*/ backward);
-
-  }
-
-
-  public interface IMergeInfo {
-
-    IEnumerable<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, ESymValue>> MergeTriples { get; }
-
-    bool IsCommon(ESymValue sv);
-
-    /// <summary>
-    /// Returns true if result is different from G1
-    /// </summary>
-    bool Changed { get; }
-
-    bool IsResult<Constant, ADomain>(EGraph<Constant, ADomain> egraph)
-      where Constant : IEquatable<Constant>, IConstantInfo
-      where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>;
-
-    bool IsGraph1<Constant, ADomain>(EGraph<Constant, ADomain> egraph)
-      where Constant : IEquatable<Constant>, IConstantInfo
-      where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>;
-
-    bool IsGraph2<Constant, ADomain>(EGraph<Constant, ADomain> egraph)
-      where Constant : IEquatable<Constant>, IConstantInfo
-      where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>;
-
-    /// <summary>
-    /// Returns substitution from result to G1
-    /// </summary>
-    IFunctionalMap<ESymValue, ESymValue> BackwardG1Map { get; }
-    /// <summary>
-    /// Returns substitution from result to G2
-    /// </summary>
-    IFunctionalMap<ESymValue, ESymValue> BackwardG2Map { get; }
-
-    /// <summary>
-    /// Returns substitution from G1 to result
-    /// </summary>
-    IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG1Map { get; }
-    /// <summary>
-    /// Returns substitution from G2 to result
-    /// </summary>
-    IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG2Map { get; }
-
-  }
-
-  public sealed class ESymValue : IEquatable<ESymValue>, IComparable<ESymValue>, IComparable {
-
-    private static int globalNumber;
-
-    public static int GetUniqueKey(ESymValue sv)
+    public interface IAbstractValueForEGraph<ADomain> : IAbstractValue<ADomain>
     {
-      Contract.Requires(sv != null);
+        bool HasAllBottomFields { get; }
 
-      return sv.GlobalId; 
-    } 
+        /// <summary>
+        /// Returns a correct Top approximation for a manifested field at a join point,
+        /// where the other side has "this" abstract value
+        /// For some domains, this allows recovering information, such as type information
+        /// (that has to agree on branches).
+        /// </summary>
+        ADomain ForManifestedField();
+    }
 
-    public readonly int UniqueId;
-    public readonly int GlobalId;
+    public interface IConstantInfo
+    {
+        /// <summary>
+        /// True if this contant should be maintained when joining bottom
+        /// </summary>
+        bool KeepAsBottomField { get; }
+        /// <summary>
+        /// True if this constant should be maintained when joining top
+        /// </summary>
+        bool ManifestField { get; }
+    }
 
-    internal ESymValue(int id) {
-      this.UniqueId = id;
-      this.GlobalId = ++globalNumber;
+    public interface IEGraph<Constant, ADomain, T> : IAbstractValue<T> where ADomain : IAbstractValueForEGraph<ADomain> where Constant : IEquatable<Constant>, IConstantInfo
+    {
+        /// <summary>
+        /// getter returns sv, such that sv == function(arg)
+        /// 
+        /// setter sets function(arg) == value, is equivalent to Eliminate(f, arg), followed by
+        /// assume (f(arg) == value)
+        /// </summary>
+        /// <param name="function"></param>
+        /// <param name="args"></param>
+        ESymValue this[Constant function, ESymValue arg]
+        {
+            get;
+            set;
+        }
+
+        ESymValue this[Constant function]
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// returns sv, such that sv == function(arg), or null if not mapped
+        /// </summary>
+        ESymValue TryLookup(Constant function, ESymValue arg);
+
+        /// <summary>
+        /// returns sv, such that sv == function, or null if not mapped
+        /// </summary>
+        ESymValue TryLookup(Constant function);
+
+        /// <summary>
+        /// Assumes v1 == v2
+        /// </summary>
+        void AssumeEqual(ESymValue v1, ESymValue v2);
+
+        /// <summary>
+        /// Returns true if v1 == v2
+        /// </summary>
+        bool IsEqual(ESymValue v1, ESymValue v2);
+
+        /// <summary>
+        /// Removes the mapping from the egraph. Semantically equivalent to setting 
+        /// the corresponding term to a Fresh symbolic value.
+        /// </summary>
+        void Eliminate(Constant function, ESymValue arg);
+
+        /// <summary>
+        /// Removes the mapping from the egraph. Semantically equivalent to setting 
+        /// the corresponding term to a Fresh symbolic value.
+        /// </summary>
+        void Eliminate(Constant function);
+
+        /// <summary>
+        /// Removes all mappings from the egraph of the form g(from).
+        /// </summary>
+        void EliminateAll(ESymValue from);
+
+        /// <summary>
+        /// Create a fresh symbol
+        /// </summary>
+        /// <returns></returns>
+        ESymValue FreshSymbol();
+
+        /// <summary>
+        /// Associates symval with an abstract value.
+        /// 
+        /// getter returns current association or Top
+        /// setter sets current association (forgetting old association)
+        /// </summary>
+        ADomain this[ESymValue symval] { get; set; }
+
+        /// <summary>
+        /// Merge two EGraphs. Result is null if result is no different than this.
+        /// MergeInfo provides the mapping of symbolic values in the result to values in the
+        /// two incoming branches.
+        /// </summary>
+        T Join(T incoming, out IMergeInfo mergeInfo, bool widen);
+
+
+        /// <summary>
+        /// return the set of constant function symbols in this egraph
+        /// </summary>
+        IEnumerable<Constant> Constants { get; }
+
+        /// <summary>
+        /// return the set of unary function symbols f, such that f(symval) = sv' exists in
+        /// the egraph.
+        /// </summary>
+        /// <param name="symval"></param>
+        IEnumerable<Constant> Functions(ESymValue symval);
+
+        /// <summary>
+        /// Returns the set of defined symbolic values in the egraph that have outgoing edges.
+        /// </summary>
+        IEnumerable<ESymValue> SymbolicValues { get; }
+
+        /// <summary>
+        /// Return set of equivalent terms to this symbolic value
+        /// </summary>
+        IEnumerable<EGraphTerm<Constant>> EqTerms(ESymValue symval);
+
+        /// <summary>
+        /// Returns true if this egraph contains as much information as the given argument egraph.
+        /// </summary>
+        /// <returns>if true, the map out parameter contains a mapping from symbolic variables in this egraph to corresponding
+        /// values in the other egraph. Equivalent (id) mappings are also present.</returns>
+        bool LessEqual(T that,
+                       out IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward,
+                       out IFunctionalMap<ESymValue, ESymValue>/*?*/ backward);
     }
 
 
-    //^ [Confined]
-    public override string ToString() {
+    public interface IMergeInfo
+    {
+        IEnumerable<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, ESymValue>> MergeTriples { get; }
+
+        bool IsCommon(ESymValue sv);
+
+        /// <summary>
+        /// Returns true if result is different from G1
+        /// </summary>
+        bool Changed { get; }
+
+        bool IsResult<Constant, ADomain>(EGraph<Constant, ADomain> egraph)
+          where Constant : IEquatable<Constant>, IConstantInfo
+          where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>;
+
+        bool IsGraph1<Constant, ADomain>(EGraph<Constant, ADomain> egraph)
+          where Constant : IEquatable<Constant>, IConstantInfo
+          where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>;
+
+        bool IsGraph2<Constant, ADomain>(EGraph<Constant, ADomain> egraph)
+          where Constant : IEquatable<Constant>, IConstantInfo
+          where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>;
+
+        /// <summary>
+        /// Returns substitution from result to G1
+        /// </summary>
+        IFunctionalMap<ESymValue, ESymValue> BackwardG1Map { get; }
+        /// <summary>
+        /// Returns substitution from result to G2
+        /// </summary>
+        IFunctionalMap<ESymValue, ESymValue> BackwardG2Map { get; }
+
+        /// <summary>
+        /// Returns substitution from G1 to result
+        /// </summary>
+        IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG1Map { get; }
+        /// <summary>
+        /// Returns substitution from G2 to result
+        /// </summary>
+        IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG2Map { get; }
+    }
+
+    public sealed class ESymValue : IEquatable<ESymValue>, IComparable<ESymValue>, IComparable
+    {
+        private static int globalNumber;
+
+        public static int GetUniqueKey(ESymValue sv)
+        {
+            Contract.Requires(sv != null);
+
+            return sv.GlobalId;
+        }
+
+        public readonly int UniqueId;
+        public readonly int GlobalId;
+
+        internal ESymValue(int id)
+        {
+            this.UniqueId = id;
+            this.GlobalId = ++globalNumber;
+        }
+
+
+        //^ [Confined]
+        public override string ToString()
+        {
 #if true
-      return String.Format("sv{0} ({1})", this.UniqueId.ToString(), this.GlobalId.ToString());
+            return String.Format("sv{0} ({1})", this.UniqueId.ToString(), this.GlobalId.ToString());
 #else
-      return String.Format("sv{0}", this.UniqueId.ToString());
+            return String.Format("sv{0}", this.UniqueId.ToString());
 #endif
 
-    }
-
-
-    #region IEquatable<SymbolicValue> Members
-
-    //^ [StateIndependent]
-    public bool Equals(ESymValue other) {
-      return this == other;
-    }
-
-    #endregion
-
-    #region IComparable<ESymValue> Members
-
-    public int CompareTo(ESymValue other) {
-      return this.UniqueId - other.UniqueId;
-    }
-
-    #endregion
-
-    #region IComparable Members
-
-    public int CompareTo(object obj) {
-      ESymValue that = obj as ESymValue;
-      if (that == null) return 1;
-      
-      return this.UniqueId - that.UniqueId;
-    }
-
-    #endregion
-  }
-
-  public static class EGraphStats
-  {
-    #region global flags
-    [ThreadStatic]
-    public static bool IncrementalJoin = false;
-    #endregion
-
-    #region Statistics
-    [ThreadStatic]
-    internal static long Joins;
-    [ThreadStatic]
-    internal static long FullJoins;
-    [ThreadStatic]
-    internal static long IncrementalJoins;
-    [ThreadStatic]
-    internal static long FullJoinTicks;
-    [ThreadStatic]
-    internal static long IncrementalJoinTicks;
-
-    private static float Average(long tickCount, float count)
-    {
-      float avg = (float)tickCount / count;
-      return avg;
-    }
-
-    public static void PrintStats(ISimpleLineWriter tw)
-    {
-      Contract.Requires(tw != null);
-
-      tw.WriteLine("EGraph Joins {0}", Joins);
-      tw.WriteLine("  full       {0}", FullJoins);
-      tw.WriteLine("  incr       {0}", IncrementalJoins);
-      tw.WriteLine("Time         {0} ms", FullJoinTicks + IncrementalJoinTicks);
-      tw.WriteLine("  full       {0} ms", FullJoinTicks);
-      tw.WriteLine("  incr       {0} ms", IncrementalJoinTicks);
-      tw.WriteLine("Avg Time     {0,3:F1} ms", Average(FullJoinTicks + IncrementalJoinTicks, Joins));
-      tw.WriteLine("  full       {0,3:F1} ms", Average(FullJoinTicks, FullJoins));
-      tw.WriteLine("  incr       {0,3:F1} ms", Average(IncrementalJoinTicks, IncrementalJoins));
-    }
-    #endregion
-  }
-
-  public class EGraph<Constant, AbstractValue> : IEGraph<Constant, AbstractValue, EGraph<Constant, AbstractValue>>
-    where AbstractValue : IAbstractValueForEGraph<AbstractValue>, IEquatable<AbstractValue>
-    where Constant : IEquatable<Constant>, IConstantInfo
-  {
-    #region Object invariant
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.constRoot != null);
-      Contract.Invariant(this.forwMap != null);
-      Contract.Invariant(this.eqTermMap != null);
-    }
-    #endregion
-
-    #region Privates
-
-    int idCounter = 0;
-
-    private static int egraphIdGen = 0;
-    int egraphId;
-
-    private ESymValue FreshSymbolicValue() {
-      if (this.IsConstant)
-      {
-        Contract.Assume(false, "modifying a locked down egraph");
-      }
-      ESymValue v = new ESymValue(++idCounter);
-      return v;
-    }
-
-
-    private readonly ESymValue constRoot;
-
-    /// <summary>
-    /// Used as a dummy node when joining graphs with allfieldbottomvalues as a placeholder for the
-    /// non-represented fields.
-    /// </summary>
-    private readonly ESymValue bottomPlaceHolder;
-
-    public ESymValue BottomPlaceHolder { get { return this.bottomPlaceHolder; } }
-
-    private DoubleFunctionalMap<ESymValue, Constant, ESymValue> termMap;
-
-    /// <summary>
-    /// Used to represent multi-argument terms x = f(x1..xn). They are represented by individual
-    /// edges  xi -[f,i]-> [x ,...]
-    ///
-    /// </summary>
-    private DoubleFunctionalMap<ESymValue, MultiEdge, FList<ESymValue>> multiTermMap;
-
-    private IFunctionalMap<ESymValue, AbstractValue> absMap;
-
-    /// <summary>
-    /// Used to represent equalities among symbolic values
-    /// </summary>
-    private IFunctionalMap<ESymValue, ESymValue> forwMap;
-
-    private IFunctionalMap<ESymValue, FList<EGraphTerm<Constant>>> eqTermMap;
-
-    /// <summary>
-    /// The unique reverse map for x = f(x1..xn)
-    /// </summary>
-    private IFunctionalMap<ESymValue, EGraphTerm<Constant>> eqMultiTermMap;
-
-    [Pure]
-    private ESymValue Find(ESymValue v)
-    {
-      ESymValue result = this.forwMap[v];
-      if (result == null) return v;
-      return Find(result);
-    }
-
-    internal bool IsConstant { get { return this.constant; } }
-    private bool constant; // once we make a copy of this, we set it to true to prevent further updates
-    private readonly EGraph<Constant, AbstractValue>/*?*/ parent;
-    private readonly EGraph<Constant, AbstractValue>/*?*/ root;
-    private readonly int historySize;
-    private readonly AbstractValue underlyingTopValue;
-    private readonly AbstractValue underlyingBottomValue;
-
-    private FList<Update>/*?*/ updates;
-
-
-    /// <summary>
-    /// Used to initialize the bottom egraph value
-    /// </summary>
-    private EGraph(AbstractValue topValue, AbstractValue bottomValue, bool dummy)
-    {
-      Contract.Requires(bottomValue.HasAllBottomFields);
-      this.egraphId = egraphIdGen++;
-      this.constRoot = FreshSymbolicValue();
-      this.termMap = DoubleFunctionalMap<ESymValue, Constant, ESymValue>.Empty(ESymValue.GetUniqueKey);
-      this.multiTermMap = DoubleFunctionalMap<ESymValue, MultiEdge, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
-      this.absMap = FunctionalIntKeyMap<ESymValue, AbstractValue>.Empty(ESymValue.GetUniqueKey);
-      this.forwMap = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
-      this.eqTermMap = FunctionalIntKeyMap<ESymValue, FList<EGraphTerm<Constant>>>.Empty(ESymValue.GetUniqueKey);
-      this.eqMultiTermMap = FunctionalIntKeyMap<ESymValue, EGraphTerm<Constant>>.Empty(ESymValue.GetUniqueKey);
-      this.bottomPlaceHolder = this.FreshSymbol();
-      this.absMap = this.absMap.Add(this.bottomPlaceHolder, bottomValue);
-      this.constant = false;
-      this.parent = null;
-      this.root = this;
-      this.historySize = 1;
-      this.updates = null;
-      this.underlyingTopValue = topValue;
-      this.underlyingBottomValue = bottomValue;
-    }
-    /// <summary>
-    /// Requires: bottomValue.HasAllBottomFields
-    /// </summary>
-    /// <param name="topValue">top value for underlying abstract values associated with each symbolic value</param>
-    /// <param name="bottomValue">bottom value for underlying abstract values associated with each symbolic value</param>
-    public EGraph(AbstractValue topValue, AbstractValue bottomValue)
-      : this(topValue, bottomValue, false)
-    {
-      // Initialize BottomValue
-      if (BottomValue == null)
-      {
-        BottomValue = new EGraph<Constant, AbstractValue>(topValue, bottomValue, true);
-      }
-    }
-
-    /// <summary>
-    /// Copy constructor
-    /// </summary>
-    /// <param name="from"></param>
-    private EGraph(EGraph<Constant, AbstractValue> from) {
-      Contract.Requires(!from.IsBottom);
-      this.egraphId = egraphIdGen++;
-      this.constRoot = from.constRoot;
-      this.bottomPlaceHolder = from.bottomPlaceHolder;
-      this.termMap = from.termMap;
-      this.multiTermMap = from.multiTermMap;
-      this.idCounter = from.idCounter;
-      this.absMap = from.absMap;
-      this.forwMap = from.forwMap;
-      this.eqTermMap = from.eqTermMap;
-      this.eqMultiTermMap = from.eqMultiTermMap;
-      this.underlyingTopValue = from.underlyingTopValue;
-      this.underlyingBottomValue = from.underlyingBottomValue;
-
-      // keep history
-      this.updates = from.updates;
-      this.parent = from;
-      this.root = from.root;
-      this.historySize = from.historySize + 1;
-
-      // set from to constant
-      from.LockDown();
-    }
-
-    /// <summary>
-    /// Partial copy constructor. Keeps history and id's, but empties all the maps. Used when recomputing join from scratch
-    /// </summary>
-    private EGraph(EGraph<Constant, AbstractValue> from, bool partialDummy)
-    {
-      Contract.Requires(!from.IsBottom);
-      this.egraphId = egraphIdGen++;
-      this.constRoot = from.constRoot;
-      this.bottomPlaceHolder = from.bottomPlaceHolder;
-      this.idCounter = from.idCounter;
-      this.underlyingTopValue = from.underlyingTopValue;
-      this.underlyingBottomValue = from.underlyingBottomValue;
-
-      // fresh maps
-      this.termMap = DoubleFunctionalMap<ESymValue, Constant, ESymValue>.Empty(ESymValue.GetUniqueKey);
-      this.multiTermMap = DoubleFunctionalMap<ESymValue, MultiEdge, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
-      this.absMap = FunctionalIntKeyMap<ESymValue, AbstractValue>.Empty(ESymValue.GetUniqueKey);
-      this.forwMap = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
-      this.eqTermMap = FunctionalIntKeyMap<ESymValue, FList<EGraphTerm<Constant>>>.Empty(ESymValue.GetUniqueKey);
-      this.eqMultiTermMap = FunctionalIntKeyMap<ESymValue, EGraphTerm<Constant>>.Empty(ESymValue.GetUniqueKey);
-
-      this.absMap = this.absMap.Add(this.bottomPlaceHolder, from.underlyingBottomValue);
-
-      // keep history
-      this.updates = from.updates;
-      this.parent = from;
-      this.root = from.root;
-      this.historySize = from.historySize + 1;
-
-      // set from to constant
-      from.LockDown();
-    }
-
-    private int LastSymbolId {
-      get {
-        Contract.Requires(this.constant, "LastSymbolId only makes sense on locked down egraphs");
-        return this.idCounter;
-      }
-    }
-
-    private bool IsOldSymbol(ESymValue sv) {
-      EGraph<Constant,AbstractValue> parent = this.parent;
-      if (parent == null) return false;
-      return (sv.UniqueId <= parent.LastSymbolId);
-    }
-
-    private void AddEdgeUpdate(ESymValue from, Constant function) {
-      if (IsOldSymbol(from)) {
-        AddUpdate(new MergeState.EdgeUpdate(from, function));
-      }
-    }
-
-    private void AddMultiEdgeUpdate(ESymValue[] from, Constant function)
-    {
-      for (int i = 0; i < from.Length; i++)
-      {
-        if (!IsOldSymbol(from[i])) return;
-      }
-      AddUpdate(new MergeState.MultiEdgeUpdate(from, function));
-    }
-
-    private void AddAValUpdate(ESymValue sv)
-    {
-      if (IsOldSymbol(sv)) {
-        AddUpdate(new MergeState.AValUpdate(sv));
-      }
-    }
-
-    private void AddEqualityUpdate(ESymValue sv1, ESymValue sv2) {
-      if (IsOldSymbol(sv1) && IsOldSymbol(sv2)) {
-        AddUpdate(new MergeState.EqualityUpdate(sv1, sv2));
-      }
-    }
-
-    private void AddEliminateEdgeUpdate(ESymValue from, Constant function) {
-      if (IsOldSymbol(from)) {
-        AddUpdate(new MergeState.EliminateEdgeUpdate(from, function));
-      }
-    }
-
-    private void AddEliminateAllUpdate(ESymValue from) {
-      if (IsOldSymbol(from)) {
-        foreach (Constant function in this.termMap.Keys2(from)) {
-          AddUpdate(new MergeState.EliminateEdgeUpdate(from, function));
         }
-      }
-    }
 
-    [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!this.IsConstant (modification of locked down egraph)")]
-    private void AddUpdate(Update upd) {
-      Contract.Requires(!this.IsConstant, "modification of locked down egraph");
-      this.updates = this.updates.Cons(upd);
-    }
 
-    private abstract class Update {
-      /// <summary>
-      /// Replay update on merge state
-      /// </summary>
-      public abstract void Replay(MergeState merge);
+        #region IEquatable<SymbolicValue> Members
 
-      public abstract void ReplayElimination(MergeState merge);
-
-      Update/*?*/ next; // during reversal
-
-      public static Update Reverse(FList<Update> updates, FList<Update> common) {
-        Update/*?*/ oldest = null;
-        while (updates != common) {
-          Update current = updates.Head;
-          current.next = oldest;
-          oldest = current;
-          updates = updates.Tail;
-        }
-        return oldest;
-      }
-
-      public Update Next {
-        get {
-          Update next = this.next;
-          //this.next = null;
-          return next;
-        }
-      }
-    }
-
-    [ThreadStatic]
-    private static bool debug;
-    [ThreadStatic]
-    private static bool statistics;
-    
-    #endregion
-
-    #region Debugging
-    public static bool DoDebug { get { return debug; } set { debug = value; statistics = true; } }
-    public static bool Statistics { get { return statistics; } set { statistics = value; } }
-    #endregion
-
-    public ESymValue FreshSymbol() {
-      return this.FreshSymbolicValue();
-    }
-
-    [Pure]
-    public bool HasAllBottomFields(ESymValue sv)
-    {
-      if (sv == null) return false;
-      return this[sv].HasAllBottomFields;
-    }
-
-    public AbstractValue this[ESymValue sym] {
-      get {
-        sym = Find(sym);
-        if (this.absMap.Contains(sym)) {
-          AbstractValue v = this.absMap[sym];
-          return v;
-        }
-        return this.underlyingTopValue;
-      }
-
-      set {
-        ESymValue sv = Find(sym);
-        AbstractValue old = this[sym];
-        if (!old.Equals(value)) {
-          AddAValUpdate(sv);
-          if (value.IsTop) {
-            this.absMap = this.absMap.Remove(sv);
-          }
-          else {
-            this.absMap = this.absMap.Add(sv, value);
-          }
-        }
-      }
-    }
-
-    public ESymValue Root { get { return this.constRoot; } }
-
-    public ESymValue LookupOrManifest(Constant function, ESymValue arg, out bool fresh)
-    {
-      int oldIdCount = this.idCounter;
-      ESymValue result = this[function, arg];
-      fresh = (oldIdCount < this.idCounter);
-      return result;
-    }
-
-    public ESymValue TryLookup(Constant function, ESymValue arg) 
-    {
-      return LookupWithoutManifesting(arg, function);
-    }
-
-    public ESymValue TryLookup(Constant function) {
-      return LookupWithoutManifesting(this.constRoot, function);
-    }
-
-    public ESymValue TryLookup(Constant function, params ESymValue[] args)
-    {
-      Contract.Requires(args != null);
-      if (args.Length == 0)
-      {
-        return LookupWithoutManifesting(this.constRoot, function);
-      }
-      if (args.Length == 1)
-      {
-        return LookupWithoutManifesting(args[0], function);
-      }
-      return LookupWithoutManifesting(args, function);
-    }
-
-    private ESymValue LookupWithoutManifesting(ESymValue arg, Constant function)
-    {
-      if (arg == null) return null; // possible when manifesting during join
-      arg = Find(arg);
-      ESymValue v = this.termMap[arg, function];
-      if (v == null) return v;
-      return Find(v);
-    }
-
-    private ESymValue LookupOrBottomPlaceHolder(ESymValue arg, Constant function)
-    {
-      bool dummy;
-      return LookupOrBottomPlaceHolder(arg, function, out dummy);
-    }
-
-    private ESymValue LookupOrBottomPlaceHolder(ESymValue arg, Constant function, out bool isPlaceholder)
-    {
-      var result = LookupWithoutManifesting(arg, function);
-      if (result == null)
-      {
-        isPlaceholder = true;
-        return this.bottomPlaceHolder;
-      }
-      isPlaceholder = false;
-      return result;
-    }
-
-    [Pure]
-    private ESymValue LookupWithoutManifesting(ESymValue[] args, Constant function)
-    {
-      Contract.Requires(args.Length > 1);
-
-      int arity = args.Length;
-      Debug.Assert(arity > 1);
-      for (int i = 0; i < arity; i++)
-      {
-        args[i] = Find(args[i]);
-      }
-      // lookup first argument and reverse map and compare arguments
-      var candidate = FindCandidate(args, function);
-      return candidate;
-    }
-
-    private ESymValue this[ESymValue arg, Constant function] {
-      get {
-        arg = Find(arg);
-        ESymValue v = this.termMap[arg, function];
-
-        if (v == null) {
-          v = FreshSymbolicValue();
-          this.termMap = this.termMap.Add(arg, function, v);
-          this.eqTermMap = this.eqTermMap.Add(v, FList<EGraphTerm<Constant>>.Cons(new EGraphTerm<Constant>(function, arg), null));
-          this.AddEdgeUpdate(arg, function);
-        }
-        else {
-          v = Find(v);
-        }
-        return v;
-      }
-
-      set {
-        arg = Find(arg);
-        value = Find(value);
-        this.termMap = this.termMap.Add(arg, function, value);
-        var existing = this.eqTermMap[value];
-        if (existing != null && existing.Head.Function.Equals(function) && existing.Head.Args[0] == arg)
+        //^ [StateIndependent]
+        public bool Equals(ESymValue other)
         {
-          // already present.
+            return this == other;
         }
-        else {
-          this.eqTermMap = this.eqTermMap.Add(value, existing.Cons(new EGraphTerm<Constant>(function, arg)));
+
+        #endregion
+
+        #region IComparable<ESymValue> Members
+
+        public int CompareTo(ESymValue other)
+        {
+            return this.UniqueId - other.UniqueId;
         }
-        this.AddEdgeUpdate(arg, function);
-      }
+
+        #endregion
+
+        #region IComparable Members
+
+        public int CompareTo(object obj)
+        {
+            ESymValue that = obj as ESymValue;
+            if (that == null) return 1;
+
+            return this.UniqueId - that.UniqueId;
+        }
+
+        #endregion
     }
 
-    private ESymValue this[ESymValue[] args, Constant function]
+    public static class EGraphStats
     {
-      get
-      {
-        Contract.Requires(args.Length > 1); // F: Added from Clousot precondition suggestion
+        #region global flags
+        [ThreadStatic]
+        public static bool IncrementalJoin = false;
+        #endregion
 
-        int arity = args.Length;
-        Debug.Assert(arity > 1);
-        for (int i = 0; i < arity; i++)
-        {
-          args[i] = Find(args[i]);
-        }
-        // lookup first argument and reverse map and compare arguments
-        var candidate = FindCandidate(args, function);
-        if (candidate != null) return candidate;
-        // create fresh one
-        var fresh = FreshSymbolicValue();
-        for (int i = 0; i < arity; i++)
-        {
-          MultiEdge edge = new MultiEdge(function, i, arity);
-          this.multiTermMap = this.multiTermMap.Add(args[i],edge, this.multiTermMap[args[i], edge].Cons(fresh));
-        }
-        this.eqMultiTermMap = this.eqMultiTermMap.Add(fresh, new EGraphTerm<Constant>(function, args));
-        this.AddMultiEdgeUpdate(args, function);
-        return fresh;
-      }
+        #region Statistics
+        [ThreadStatic]
+        internal static long Joins;
+        [ThreadStatic]
+        internal static long FullJoins;
+        [ThreadStatic]
+        internal static long IncrementalJoins;
+        [ThreadStatic]
+        internal static long FullJoinTicks;
+        [ThreadStatic]
+        internal static long IncrementalJoinTicks;
 
-      set
-      {
-        Contract.Requires(args.Length > 1); // F: Added from Clousot precondition suggestion
-
-        int arity = args.Length;
-        Debug.Assert(arity > 1);
-        for (int i = 0; i < arity; i++)
+        private static float Average(long tickCount, float count)
         {
-          args[i] = Find(args[i]);
+            float avg = (float)tickCount / count;
+            return avg;
         }
-        // check if this is already present
-        bool alreadyExisting = true;
-        var term = this.eqMultiTermMap[value];
-        if (term.Args != null)
+
+        public static void PrintStats(ISimpleLineWriter tw)
         {
-          for (int i = 0; i < arity; i++)
-          {
-            if (term.Args[i] != args[i])
+            Contract.Requires(tw != null);
+
+            tw.WriteLine("EGraph Joins {0}", Joins);
+            tw.WriteLine("  full       {0}", FullJoins);
+            tw.WriteLine("  incr       {0}", IncrementalJoins);
+            tw.WriteLine("Time         {0} ms", FullJoinTicks + IncrementalJoinTicks);
+            tw.WriteLine("  full       {0} ms", FullJoinTicks);
+            tw.WriteLine("  incr       {0} ms", IncrementalJoinTicks);
+            tw.WriteLine("Avg Time     {0,3:F1} ms", Average(FullJoinTicks + IncrementalJoinTicks, Joins));
+            tw.WriteLine("  full       {0,3:F1} ms", Average(FullJoinTicks, FullJoins));
+            tw.WriteLine("  incr       {0,3:F1} ms", Average(IncrementalJoinTicks, IncrementalJoins));
+        }
+        #endregion
+    }
+
+    public class EGraph<Constant, AbstractValue> : IEGraph<Constant, AbstractValue, EGraph<Constant, AbstractValue>>
+      where AbstractValue : IAbstractValueForEGraph<AbstractValue>, IEquatable<AbstractValue>
+      where Constant : IEquatable<Constant>, IConstantInfo
+    {
+        #region Object invariant
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(constRoot != null);
+            Contract.Invariant(forwMap != null);
+            Contract.Invariant(eqTermMap != null);
+        }
+        #endregion
+
+        #region Privates
+
+        private int idCounter = 0;
+
+        private static int egraphIdGen = 0;
+        private int egraphId;
+
+        private ESymValue FreshSymbolicValue()
+        {
+            if (this.IsConstant)
             {
-              alreadyExisting = false;
-              break;
+                Contract.Assume(false, "modifying a locked down egraph");
             }
-          }
+            ESymValue v = new ESymValue(++idCounter);
+            return v;
         }
-        for (int i = 0; i < arity; i++)
+
+
+        private readonly ESymValue constRoot;
+
+        /// <summary>
+        /// Used as a dummy node when joining graphs with allfieldbottomvalues as a placeholder for the
+        /// non-represented fields.
+        /// </summary>
+        private readonly ESymValue bottomPlaceHolder;
+
+        public ESymValue BottomPlaceHolder { get { return bottomPlaceHolder; } }
+
+        private DoubleFunctionalMap<ESymValue, Constant, ESymValue> termMap;
+
+        /// <summary>
+        /// Used to represent multi-argument terms x = f(x1..xn). They are represented by individual
+        /// edges  xi -[f,i]-> [x ,...]
+        ///
+        /// </summary>
+        private DoubleFunctionalMap<ESymValue, MultiEdge, FList<ESymValue>> multiTermMap;
+
+        private IFunctionalMap<ESymValue, AbstractValue> absMap;
+
+        /// <summary>
+        /// Used to represent equalities among symbolic values
+        /// </summary>
+        private IFunctionalMap<ESymValue, ESymValue> forwMap;
+
+        private IFunctionalMap<ESymValue, FList<EGraphTerm<Constant>>> eqTermMap;
+
+        /// <summary>
+        /// The unique reverse map for x = f(x1..xn)
+        /// </summary>
+        private IFunctionalMap<ESymValue, EGraphTerm<Constant>> eqMultiTermMap;
+
+        [Pure]
+        private ESymValue Find(ESymValue v)
         {
-          MultiEdge edge = new MultiEdge(function, i, arity);
-          var existing = this.multiTermMap[args[i], edge];
-          if (alreadyExisting && !existing.Contains(value)) {
-            // check for existing map
-            alreadyExisting = false;
-          }
-          if (!alreadyExisting)
-          {
-            this.multiTermMap = this.multiTermMap.Add(args[i], edge, existing.Cons(value));
-          }
+            ESymValue result = forwMap[v];
+            if (result == null) return v;
+            return Find(result);
         }
-        if (!alreadyExisting)
+
+        internal bool IsConstant { get { return constant; } }
+        private bool constant; // once we make a copy of this, we set it to true to prevent further updates
+        private readonly EGraph<Constant, AbstractValue>/*?*/ parent;
+        private readonly EGraph<Constant, AbstractValue>/*?*/ root;
+        private readonly int historySize;
+        private readonly AbstractValue underlyingTopValue;
+        private readonly AbstractValue underlyingBottomValue;
+
+        private FList<Update>/*?*/ updates;
+
+
+        /// <summary>
+        /// Used to initialize the bottom egraph value
+        /// </summary>
+        private EGraph(AbstractValue topValue, AbstractValue bottomValue, bool dummy)
         {
-          this.eqMultiTermMap = this.eqMultiTermMap.Add(value, new EGraphTerm<Constant>(function, args));
-          this.AddMultiEdgeUpdate(args, function);
+            Contract.Requires(bottomValue.HasAllBottomFields);
+            egraphId = egraphIdGen++;
+            constRoot = FreshSymbolicValue();
+            termMap = DoubleFunctionalMap<ESymValue, Constant, ESymValue>.Empty(ESymValue.GetUniqueKey);
+            multiTermMap = DoubleFunctionalMap<ESymValue, MultiEdge, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
+            absMap = FunctionalIntKeyMap<ESymValue, AbstractValue>.Empty(ESymValue.GetUniqueKey);
+            forwMap = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
+            eqTermMap = FunctionalIntKeyMap<ESymValue, FList<EGraphTerm<Constant>>>.Empty(ESymValue.GetUniqueKey);
+            eqMultiTermMap = FunctionalIntKeyMap<ESymValue, EGraphTerm<Constant>>.Empty(ESymValue.GetUniqueKey);
+            bottomPlaceHolder = this.FreshSymbol();
+            absMap = absMap.Add(bottomPlaceHolder, bottomValue);
+            constant = false;
+            parent = null;
+            root = this;
+            historySize = 1;
+            updates = null;
+            underlyingTopValue = topValue;
+            underlyingBottomValue = bottomValue;
         }
-      }
-    }
-
-    private ESymValue FindCandidate(ESymValue[] args, Constant function)
-    {
-      int arity = args.Length;
-      MultiEdge edge = new MultiEdge(function, 0, arity);
-      var candidates = this.multiTermMap[args[0], edge];
-      for (; candidates != null; candidates = candidates.Tail)
-      {
-        var term = eqMultiTermMap[candidates.Head];
-        if (term.Args.Length != arity) continue;
-        for (int i = 0; i < arity; i++)
+        /// <summary>
+        /// Requires: bottomValue.HasAllBottomFields
+        /// </summary>
+        /// <param name="topValue">top value for underlying abstract values associated with each symbolic value</param>
+        /// <param name="bottomValue">bottom value for underlying abstract values associated with each symbolic value</param>
+        public EGraph(AbstractValue topValue, AbstractValue bottomValue)
+          : this(topValue, bottomValue, false)
         {
-          if (Find(term.Args[i]) != args[i]) goto continueOuter;
+            // Initialize BottomValue
+            if (BottomValue == null)
+            {
+                BottomValue = new EGraph<Constant, AbstractValue>(topValue, bottomValue, true);
+            }
         }
-        return candidates.Head;
-      continueOuter:
-        ;
-      }
-      return null;
-    }
 
-    public ESymValue this[Constant function] {
-      get {
-        return this[this.constRoot, function];
-      }
-      set {
-        this[this.constRoot, function] = value;
-      }
-    }
-    public ESymValue this[Constant function, ESymValue arg] {
-      get {
-        return this[arg, function];
-      }
-
-      set {
-        this[arg, function] = value;
-      }
-    }
-    public ESymValue this[Constant function, params ESymValue[] args]
-    {
-      get
-      {
-        Contract.Requires(args != null);
-        Contract.Requires(args.Length > 1);
-
-        return this[args, function];
-      }
-    }
-
-    public void Eliminate(Constant function, ESymValue arg) {
-      ESymValue sv = Find(arg);
-      var newTermMap = this.termMap.Remove(sv, function);
-      if (newTermMap == this.termMap) return; // no change
-      this.termMap = newTermMap;
-      this.AddEliminateEdgeUpdate(sv, function);
-    }
-
-    public void Eliminate(Constant function) {
-      this.termMap = this.termMap.Remove(this.constRoot, function);
-      this.AddEliminateEdgeUpdate(this.constRoot, function);
-    }
-
-    public void EliminateAll(ESymValue arg) {
-      ESymValue sv = Find(arg);
-      this.AddEliminateAllUpdate(sv); // must be before RemoveAll, as it reads termMap
-      this.termMap = this.termMap.RemoveAll(sv);
-      this[arg] = underlyingTopValue;
-    }
-
-    internal struct MultiEdge : IEquatable<MultiEdge>
-    {
-      public readonly Constant Function;
-      public readonly int Index;
-      public readonly int Arity;
-
-      public MultiEdge(Constant func, int index, int arity)
-      {
-        this.Function = func;
-        this.Index = index;
-        this.Arity = arity;
-      }
-
-      #region IEquatable<MultiArityEdge> Members
-
-      public bool Equals(MultiEdge other)
-      {
-        return this.Index == other.Index && this.Arity == other.Arity && this.Function.Equals(other.Function);
-      }
-
-      public override bool Equals(object obj)
-      {
-        if (obj is MultiEdge)
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="from"></param>
+        private EGraph(EGraph<Constant, AbstractValue> from)
         {
-          MultiEdge that = (MultiEdge)obj;
-          return Equals(that);
-        }
-        return false;
-      }
+            Contract.Requires(!from.IsBottom);
+            egraphId = egraphIdGen++;
+            constRoot = from.constRoot;
+            bottomPlaceHolder = from.bottomPlaceHolder;
+            termMap = from.termMap;
+            multiTermMap = from.multiTermMap;
+            idCounter = from.idCounter;
+            absMap = from.absMap;
+            forwMap = from.forwMap;
+            eqTermMap = from.eqTermMap;
+            eqMultiTermMap = from.eqMultiTermMap;
+            underlyingTopValue = from.underlyingTopValue;
+            underlyingBottomValue = from.underlyingBottomValue;
 
-      public override int GetHashCode()
-      {
-        return Arity + Index;
-      }
+            // keep history
+            updates = from.updates;
+            parent = from;
+            root = from.root;
+            historySize = from.historySize + 1;
 
-      public override string ToString()
-      {
-        return String.Format("[{0}:{1}]", Function.ToString(), Index);
-      }
-      #endregion
-    }
-
-    private struct EqPair : IEquatable<EqPair> {
-      public readonly ESymValue v1;
-      public readonly ESymValue v2;
-
-      public EqPair(ESymValue v1, ESymValue v2) {
-        this.v1 = v1;
-        this.v2 = v2;
-      }
-
-      public override int GetHashCode()
-      {
-        return GetV1HashCode() + v2.GlobalId;
-      }
-
-      private int GetV1HashCode()
-      {
-        if (v1 == null) return 1;
-        return v1.GlobalId;
-      }
-
-      public bool Equals(EqPair that)
-      {
-        return this.v1 == that.v1 && this.v2 == that.v2;
-      }
-
-    }
-
-    private void PushEquality(WorkList<EqPair> wl, ESymValue v1, ESymValue v2) {
-      if (v1 == v2) return;
-      wl.Add(new EqPair(v1, v2));
-    }
-
-
-    public void AssumeEqual(ESymValue v1, ESymValue v2) {
-
-      WorkList<EqPair> wl = new WorkList<EqPair>();
-      ESymValue v1rep = Find(v1);
-      ESymValue v2rep = Find(v2);
-      PushEquality(wl, v1rep, v2rep);
-
-      if (!wl.IsEmpty) {
-        // TODO: there's an opportunity for optimizing the number
-        // of necessary updates that we need to record, since the induced
-        // updates of the equality may end up as duplicates.
-        AddEqualityUpdate(v1rep, v2rep);
-      }
-      DrainEqualityWorkList(wl);
-    }
-
-    private void DrainEqualityWorkList(WorkList<EqPair> wl) {
-      while ( ! wl.IsEmpty ) {
-
-        var eqpair = (EqPair)wl.Pull();
-        var v1rep = Find(eqpair.v1);
-        var v2rep = Find(eqpair.v2);
-        if (v1rep == v2rep) continue;
-
-        // always map new to older var
-        if (v1rep.UniqueId < v2rep.UniqueId) {
-          ESymValue temp = v1rep;
-          v1rep = v2rep;
-          v2rep = temp;
+            // set from to constant
+            from.LockDown();
         }
 
-        // perform congruence closure here:
-        foreach(Constant f in this.Functions(v1rep)) {
-          ESymValue target = this.LookupWithoutManifesting(v2rep, f);
-          if (target == null) {
-            this[v2rep, f] = this[v1rep,f];
-          }
-          else {
-            PushEquality(wl, this[v1rep,f], target);
-          }
-        }
-        AbstractValue av1 = this[v1rep];
-        AbstractValue av2 = this[v2rep];
-        // merge term map of v1 into v2
-        foreach(EGraphTerm<Constant> eterm in this.eqTermMap[v1rep].GetEnumerable()) {
-          this.eqTermMap = this.eqTermMap.Add(v2rep, this.eqTermMap[v2rep].Cons(eterm));
-        }
-        this.forwMap = this.forwMap.Add(v1rep, v2rep);
-        this[v2rep] = av1.Meet(av2);
-      }
-    }
-
-
-    public bool IsEqual(ESymValue v1, ESymValue v2) {
-      return  (Find(v1) == Find(v2));
-    }
-
-    public IEnumerable<Constant> Constants {
-      get { return this.termMap.Keys2(this.constRoot); }
-    }
-
-
-    public IEnumerable<Constant> Functions(ESymValue sv) {
-      Contract.Ensures(Contract.Result<IEnumerable<Constant>>() != null);
-      
-      return this.termMap.Keys2(Find(sv));
-    }
-
-    internal IEnumerable<MultiEdge> MultiEdges(ESymValue sv)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<MultiEdge>>() != null);
-     
-      return this.multiTermMap.Keys2(Find(sv));
-    }
-
-    public IEnumerable<ESymValue> SymbolicValues
-    {
-      get { return this.termMap.Keys1; }
-    }
-
-    public IEnumerable<EGraphTerm<Constant>> EqTerms(ESymValue sv) {
-      Contract.Ensures(Contract.Result<IEnumerable<EGraphTerm<Constant>>>() != null);
-      
-      foreach (EGraphTerm<Constant> eterm in this.eqTermMap[Find(sv)].GetEnumerable()) {
-        // test if it is valid
-        if (this.TryLookup(eterm.Function, eterm.Args) == sv) {
-          yield return eterm;
-        }
-      }
-    }
-
-    public IEnumerable<EGraphTerm<Constant>> EqMultiTerms(ESymValue sv)
-    {
-      // for now this can only be 0 or 1
-      var term = this.eqMultiTermMap[sv];
-      if (term.Args != null)
-      {
-        if (IsValidMultiTerm(term))
+        /// <summary>
+        /// Partial copy constructor. Keeps history and id's, but empties all the maps. Used when recomputing join from scratch
+        /// </summary>
+        private EGraph(EGraph<Constant, AbstractValue> from, bool partialDummy)
         {
-          yield return term;
+            Contract.Requires(!from.IsBottom);
+            egraphId = egraphIdGen++;
+            constRoot = from.constRoot;
+            bottomPlaceHolder = from.bottomPlaceHolder;
+            idCounter = from.idCounter;
+            underlyingTopValue = from.underlyingTopValue;
+            underlyingBottomValue = from.underlyingBottomValue;
+
+            // fresh maps
+            termMap = DoubleFunctionalMap<ESymValue, Constant, ESymValue>.Empty(ESymValue.GetUniqueKey);
+            multiTermMap = DoubleFunctionalMap<ESymValue, MultiEdge, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
+            absMap = FunctionalIntKeyMap<ESymValue, AbstractValue>.Empty(ESymValue.GetUniqueKey);
+            forwMap = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
+            eqTermMap = FunctionalIntKeyMap<ESymValue, FList<EGraphTerm<Constant>>>.Empty(ESymValue.GetUniqueKey);
+            eqMultiTermMap = FunctionalIntKeyMap<ESymValue, EGraphTerm<Constant>>.Empty(ESymValue.GetUniqueKey);
+
+            absMap = absMap.Add(bottomPlaceHolder, from.underlyingBottomValue);
+
+            // keep history
+            updates = from.updates;
+            parent = from;
+            root = from.root;
+            historySize = from.historySize + 1;
+
+            // set from to constant
+            from.LockDown();
         }
-      }
-    }
 
-
-    public EGraph<Constant,AbstractValue> Clone() {
-      Contract.Ensures(Contract.Result<EGraph<Constant, AbstractValue>>() != null);
-
-      return new EGraph<Constant,AbstractValue>(this);
-    }
-
-    #region Join on EGraphs
-
-    public EGraph<Constant, AbstractValue> Join(EGraph<Constant, AbstractValue> eg2, out bool weaker, bool widen) {
-      EGraph<Constant, AbstractValue> eg1 = this;
-      IMergeInfo info;
-      EGraph<Constant, AbstractValue> result = eg1.Join(eg2, out info, widen);
-      weaker = info.Changed;
-      return result;
-    }
-    
-    public EGraph<Constant,AbstractValue> Join(EGraph<Constant,AbstractValue> eg2, out IMergeInfo mergeInfo, bool widen) 
-    {
-      Contract.Ensures(Contract.ValueAtReturn(out mergeInfo) != null);
-      Contract.Ensures(Contract.Result<EGraph<Constant, AbstractValue>>() != null);
-
-      EGraphStats.Joins++;
-
-      EGraph<Constant, AbstractValue> eg1 = this;
-
-      int updateSize;
-      EGraph<Constant,AbstractValue> common = ComputeCommonTail(eg1, eg2, out updateSize);
-
-      bool doReplay = true;
-
-      if (common == null) {
-        doReplay = false;
-      }
-      if (Statistics) {
-        Console.WriteLine("G1({5}):{0},{1} G2({6}):{2},{3} UpdateSize:{4}", eg1.historySize, eg1.LastSymbolId, eg2.historySize, eg2.LastSymbolId, updateSize, eg1.egraphId, eg2.egraphId);
-        Console.WriteLine("  G1 Updates {0}", eg1.updates.Length());
-        Console.WriteLine("  G2 Updates {0}", eg2.updates.Length());
-
-        if (common != null)
+        private int LastSymbolId
         {
-          Console.WriteLine("Common id:{0} updates {1}", common.egraphId, common.updates.Length());
+            get
+            {
+                Contract.Requires(constant, "LastSymbolId only makes sense on locked down egraphs");
+                return idCounter;
+            }
         }
-      }
 
-      MergeState ms;
-
-      // Heuristic for using Replay vs. full update
-      doReplay &= (common != eg1.root);
-
-      //doReplay &= (eg1.historySize > 3);
-      //doReplay &= (eg2.historySize > 3);
-
-      // Heuristic 1
-      //doReplay &= (eg1.historySize - common.historySize < eg1.idCounter) && (eg2.historySize - common.historySize < eg2.idCounter);
-
-      // Heuristic 2
-      //doReplay &= (eg1.idCounter - common.idCounter <= common.idCounter);
-      //doReplay &= (eg2.idCounter - common.idCounter <= common.idCounter);
-
-      // Heuristic 3
-      //doReplay &= (updateSize < 400);
-
-      // Heuristic 4
-      //   - the incremental list after merging is effectively tail.size + updateSize and the cost is updateSize
-      //   - whereas a join will be proportional to the smaller egraph (idCounter) and cost in proportion to it
-      //var incrCostSmaller = updateSize < eg1.idCounter && updateSize < eg2.idCounter;
-
-      //var incrSizeCost = ((float)(common.idCounter + updateSize)) / Math.Min(eg1.idCounter, eg2.idCounter);
-      //doReplay &= (incrSizeCost < 2.0);
-
-      doReplay &= !widen;
-
-      // No Incremental
-      //common = eg1.root;
-      //doReplay = false;
-
-      doReplay &= EGraphStats.IncrementalJoin;
-
-      if (DoDebug) {
-        if (widen) {
-          Console.WriteLine("EGraph widen");
-        }
-        else {
-          Console.WriteLine("EGraph join");
-        }
-        Console.WriteLine("  Last common symbol: {0}", common.idCounter);
-        if (doReplay) {
-          Console.WriteLine("  Doing incremental join");
-        }
-        else {
-          Console.WriteLine("  Doing full join");
-        }
-      }
-      EGraph<Constant, AbstractValue> result;
-      long replayTime;
-      long fullTime;
-      if (doReplay) {
-        long startTime = Environment.TickCount;
-        EGraphStats.IncrementalJoins++;
-        result = new EGraph<Constant, AbstractValue>(common);
-        ms = new MergeState(result, eg1, eg2, widen);
-        ms.Replay(common);
-        ms.Commit();
-        // the incremental join computes a changed bit that is conservative (may say changed too often)
-        // For widening, that is not acceptable, thus we compute a LessEqual here in that case.
-        if (widen && ms.Changed) {
-          ms.Changed = !result.LessEqual(eg1);
-          if (DoDebug && ms.Changed)
-          {
-            Console.WriteLine("---EGraph changed due to LessEqual check on Widen");
-          }
-        }
-        replayTime = Environment.TickCount - startTime;
-        EGraphStats.IncrementalJoinTicks += replayTime;
-      }
-      else { // (!doReplay)
-        long startTime = Environment.TickCount;
-        EGraphStats.FullJoins++;
-        result = new EGraph<Constant, AbstractValue>(common); // keep history, clear maps
-        ms = new MergeState(result, eg1, eg2, widen);
-        // need to eliminate things from common that were eliminated since
-        if (DoDebug)
+        private bool IsOldSymbol(ESymValue sv)
         {
-          Console.WriteLine("  Start Replay Elimination: result update size now {0}", result.updates.Length());
+            EGraph<Constant, AbstractValue> parent = this.parent;
+            if (parent == null) return false;
+            return (sv.UniqueId <= parent.LastSymbolId);
         }
-        
-        // not needed if we use root.
-        ms.ReplayEliminations(common); 
 
-        ms.AddMapping(eg1.constRoot, eg2.constRoot, result.constRoot);
-        if (DoDebug)
+        private void AddEdgeUpdate(ESymValue from, Constant function)
         {
-          Console.WriteLine("  Start Join of roots: result update size now {0}", result.updates.Length());
+            if (IsOldSymbol(from))
+            {
+                AddUpdate(new MergeState.EdgeUpdate(from, function));
+            }
         }
-        ms.JoinSymbolicValue(eg1.constRoot, eg2.constRoot, result.constRoot);
-        ms.Commit();
-        fullTime = Environment.TickCount - startTime;
-        EGraphStats.FullJoinTicks += fullTime;
-      }
-      // Log((fullTime < replayTime), common, eg1, eg2, widen);
 
-      mergeInfo = ms;
-      if (DoDebug)
-      {
-        Console.WriteLine("  Result update size {0}", result.updates.Length());
-        Console.WriteLine("Done with Egraph join: changed = {0}", mergeInfo.Changed);
+        private void AddMultiEdgeUpdate(ESymValue[] from, Constant function)
+        {
+            for (int i = 0; i < from.Length; i++)
+            {
+                if (!IsOldSymbol(from[i])) return;
+            }
+            AddUpdate(new MergeState.MultiEdgeUpdate(from, function));
+        }
 
-        Contract.Assume(this.LessEqual(result));
-        Contract.Assume(eg2 != null);
-        Contract.Assume(eg2.LessEqual(result));
-      }
-      return result;
-    }
+        private void AddAValUpdate(ESymValue sv)
+        {
+            if (IsOldSymbol(sv))
+            {
+                AddUpdate(new MergeState.AValUpdate(sv));
+            }
+        }
+
+        private void AddEqualityUpdate(ESymValue sv1, ESymValue sv2)
+        {
+            if (IsOldSymbol(sv1) && IsOldSymbol(sv2))
+            {
+                AddUpdate(new MergeState.EqualityUpdate(sv1, sv2));
+            }
+        }
+
+        private void AddEliminateEdgeUpdate(ESymValue from, Constant function)
+        {
+            if (IsOldSymbol(from))
+            {
+                AddUpdate(new MergeState.EliminateEdgeUpdate(from, function));
+            }
+        }
+
+        private void AddEliminateAllUpdate(ESymValue from)
+        {
+            if (IsOldSymbol(from))
+            {
+                foreach (Constant function in termMap.Keys2(from))
+                {
+                    AddUpdate(new MergeState.EliminateEdgeUpdate(from, function));
+                }
+            }
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!this.IsConstant (modification of locked down egraph)")]
+        private void AddUpdate(Update upd)
+        {
+            Contract.Requires(!this.IsConstant, "modification of locked down egraph");
+            updates = updates.Cons(upd);
+        }
+
+        private abstract class Update
+        {
+            /// <summary>
+            /// Replay update on merge state
+            /// </summary>
+            public abstract void Replay(MergeState merge);
+
+            public abstract void ReplayElimination(MergeState merge);
+
+            private Update/*?*/ next; // during reversal
+
+            public static Update Reverse(FList<Update> updates, FList<Update> common)
+            {
+                Update/*?*/ oldest = null;
+                while (updates != common)
+                {
+                    Update current = updates.Head;
+                    current.next = oldest;
+                    oldest = current;
+                    updates = updates.Tail;
+                }
+                return oldest;
+            }
+
+            public Update Next
+            {
+                get
+                {
+                    Update next = this.next;
+                    //this.next = null;
+                    return next;
+                }
+            }
+        }
+
+        [ThreadStatic]
+        private static bool debug;
+        [ThreadStatic]
+        private static bool statistics;
+
+        #endregion
+
+        #region Debugging
+        public static bool DoDebug { get { return debug; } set { debug = value; statistics = true; } }
+        public static bool Statistics { get { return statistics; } set { statistics = value; } }
+        #endregion
+
+        public ESymValue FreshSymbol()
+        {
+            return this.FreshSymbolicValue();
+        }
+
+        [Pure]
+        public bool HasAllBottomFields(ESymValue sv)
+        {
+            if (sv == null) return false;
+            return this[sv].HasAllBottomFields;
+        }
+
+        public AbstractValue this[ESymValue sym]
+        {
+            get
+            {
+                sym = Find(sym);
+                if (absMap.Contains(sym))
+                {
+                    AbstractValue v = absMap[sym];
+                    return v;
+                }
+                return underlyingTopValue;
+            }
+
+            set
+            {
+                ESymValue sv = Find(sym);
+                AbstractValue old = this[sym];
+                if (!old.Equals(value))
+                {
+                    AddAValUpdate(sv);
+                    if (value.IsTop)
+                    {
+                        absMap = absMap.Remove(sv);
+                    }
+                    else
+                    {
+                        absMap = absMap.Add(sv, value);
+                    }
+                }
+            }
+        }
+
+        public ESymValue Root { get { return constRoot; } }
+
+        public ESymValue LookupOrManifest(Constant function, ESymValue arg, out bool fresh)
+        {
+            int oldIdCount = idCounter;
+            ESymValue result = this[function, arg];
+            fresh = (oldIdCount < idCounter);
+            return result;
+        }
+
+        public ESymValue TryLookup(Constant function, ESymValue arg)
+        {
+            return LookupWithoutManifesting(arg, function);
+        }
+
+        public ESymValue TryLookup(Constant function)
+        {
+            return LookupWithoutManifesting(constRoot, function);
+        }
+
+        public ESymValue TryLookup(Constant function, params ESymValue[] args)
+        {
+            Contract.Requires(args != null);
+            if (args.Length == 0)
+            {
+                return LookupWithoutManifesting(constRoot, function);
+            }
+            if (args.Length == 1)
+            {
+                return LookupWithoutManifesting(args[0], function);
+            }
+            return LookupWithoutManifesting(args, function);
+        }
+
+        private ESymValue LookupWithoutManifesting(ESymValue arg, Constant function)
+        {
+            if (arg == null) return null; // possible when manifesting during join
+            arg = Find(arg);
+            ESymValue v = termMap[arg, function];
+            if (v == null) return v;
+            return Find(v);
+        }
+
+        private ESymValue LookupOrBottomPlaceHolder(ESymValue arg, Constant function)
+        {
+            bool dummy;
+            return LookupOrBottomPlaceHolder(arg, function, out dummy);
+        }
+
+        private ESymValue LookupOrBottomPlaceHolder(ESymValue arg, Constant function, out bool isPlaceholder)
+        {
+            var result = LookupWithoutManifesting(arg, function);
+            if (result == null)
+            {
+                isPlaceholder = true;
+                return bottomPlaceHolder;
+            }
+            isPlaceholder = false;
+            return result;
+        }
+
+        [Pure]
+        private ESymValue LookupWithoutManifesting(ESymValue[] args, Constant function)
+        {
+            Contract.Requires(args.Length > 1);
+
+            int arity = args.Length;
+            Debug.Assert(arity > 1);
+            for (int i = 0; i < arity; i++)
+            {
+                args[i] = Find(args[i]);
+            }
+            // lookup first argument and reverse map and compare arguments
+            var candidate = FindCandidate(args, function);
+            return candidate;
+        }
+
+        private ESymValue this[ESymValue arg, Constant function]
+        {
+            get
+            {
+                arg = Find(arg);
+                ESymValue v = termMap[arg, function];
+
+                if (v == null)
+                {
+                    v = FreshSymbolicValue();
+                    termMap = termMap.Add(arg, function, v);
+                    eqTermMap = eqTermMap.Add(v, FList<EGraphTerm<Constant>>.Cons(new EGraphTerm<Constant>(function, arg), null));
+                    this.AddEdgeUpdate(arg, function);
+                }
+                else
+                {
+                    v = Find(v);
+                }
+                return v;
+            }
+
+            set
+            {
+                arg = Find(arg);
+                value = Find(value);
+                termMap = termMap.Add(arg, function, value);
+                var existing = eqTermMap[value];
+                if (existing != null && existing.Head.Function.Equals(function) && existing.Head.Args[0] == arg)
+                {
+                    // already present.
+                }
+                else
+                {
+                    eqTermMap = eqTermMap.Add(value, existing.Cons(new EGraphTerm<Constant>(function, arg)));
+                }
+                this.AddEdgeUpdate(arg, function);
+            }
+        }
+
+        private ESymValue this[ESymValue[] args, Constant function]
+        {
+            get
+            {
+                Contract.Requires(args.Length > 1); // F: Added from Clousot precondition suggestion
+
+                int arity = args.Length;
+                Debug.Assert(arity > 1);
+                for (int i = 0; i < arity; i++)
+                {
+                    args[i] = Find(args[i]);
+                }
+                // lookup first argument and reverse map and compare arguments
+                var candidate = FindCandidate(args, function);
+                if (candidate != null) return candidate;
+                // create fresh one
+                var fresh = FreshSymbolicValue();
+                for (int i = 0; i < arity; i++)
+                {
+                    MultiEdge edge = new MultiEdge(function, i, arity);
+                    multiTermMap = multiTermMap.Add(args[i], edge, multiTermMap[args[i], edge].Cons(fresh));
+                }
+                eqMultiTermMap = eqMultiTermMap.Add(fresh, new EGraphTerm<Constant>(function, args));
+                this.AddMultiEdgeUpdate(args, function);
+                return fresh;
+            }
+
+            set
+            {
+                Contract.Requires(args.Length > 1); // F: Added from Clousot precondition suggestion
+
+                int arity = args.Length;
+                Debug.Assert(arity > 1);
+                for (int i = 0; i < arity; i++)
+                {
+                    args[i] = Find(args[i]);
+                }
+                // check if this is already present
+                bool alreadyExisting = true;
+                var term = eqMultiTermMap[value];
+                if (term.Args != null)
+                {
+                    for (int i = 0; i < arity; i++)
+                    {
+                        if (term.Args[i] != args[i])
+                        {
+                            alreadyExisting = false;
+                            break;
+                        }
+                    }
+                }
+                for (int i = 0; i < arity; i++)
+                {
+                    MultiEdge edge = new MultiEdge(function, i, arity);
+                    var existing = multiTermMap[args[i], edge];
+                    if (alreadyExisting && !existing.Contains(value))
+                    {
+                        // check for existing map
+                        alreadyExisting = false;
+                    }
+                    if (!alreadyExisting)
+                    {
+                        multiTermMap = multiTermMap.Add(args[i], edge, existing.Cons(value));
+                    }
+                }
+                if (!alreadyExisting)
+                {
+                    eqMultiTermMap = eqMultiTermMap.Add(value, new EGraphTerm<Constant>(function, args));
+                    this.AddMultiEdgeUpdate(args, function);
+                }
+            }
+        }
+
+        private ESymValue FindCandidate(ESymValue[] args, Constant function)
+        {
+            int arity = args.Length;
+            MultiEdge edge = new MultiEdge(function, 0, arity);
+            var candidates = multiTermMap[args[0], edge];
+            for (; candidates != null; candidates = candidates.Tail)
+            {
+                var term = eqMultiTermMap[candidates.Head];
+                if (term.Args.Length != arity) continue;
+                for (int i = 0; i < arity; i++)
+                {
+                    if (Find(term.Args[i]) != args[i]) goto continueOuter;
+                }
+                return candidates.Head;
+            continueOuter:
+                ;
+            }
+            return null;
+        }
+
+        public ESymValue this[Constant function]
+        {
+            get
+            {
+                return this[constRoot, function];
+            }
+            set
+            {
+                this[constRoot, function] = value;
+            }
+        }
+        public ESymValue this[Constant function, ESymValue arg]
+        {
+            get
+            {
+                return this[arg, function];
+            }
+
+            set
+            {
+                this[arg, function] = value;
+            }
+        }
+        public ESymValue this[Constant function, params ESymValue[] args]
+        {
+            get
+            {
+                Contract.Requires(args != null);
+                Contract.Requires(args.Length > 1);
+
+                return this[args, function];
+            }
+        }
+
+        public void Eliminate(Constant function, ESymValue arg)
+        {
+            ESymValue sv = Find(arg);
+            var newTermMap = termMap.Remove(sv, function);
+            if (newTermMap == termMap) return; // no change
+            termMap = newTermMap;
+            this.AddEliminateEdgeUpdate(sv, function);
+        }
+
+        public void Eliminate(Constant function)
+        {
+            termMap = termMap.Remove(constRoot, function);
+            this.AddEliminateEdgeUpdate(constRoot, function);
+        }
+
+        public void EliminateAll(ESymValue arg)
+        {
+            ESymValue sv = Find(arg);
+            this.AddEliminateAllUpdate(sv); // must be before RemoveAll, as it reads termMap
+            termMap = termMap.RemoveAll(sv);
+            this[arg] = underlyingTopValue;
+        }
+
+        internal struct MultiEdge : IEquatable<MultiEdge>
+        {
+            public readonly Constant Function;
+            public readonly int Index;
+            public readonly int Arity;
+
+            public MultiEdge(Constant func, int index, int arity)
+            {
+                this.Function = func;
+                this.Index = index;
+                this.Arity = arity;
+            }
+
+            #region IEquatable<MultiArityEdge> Members
+
+            public bool Equals(MultiEdge other)
+            {
+                return this.Index == other.Index && this.Arity == other.Arity && this.Function.Equals(other.Function);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is MultiEdge)
+                {
+                    MultiEdge that = (MultiEdge)obj;
+                    return Equals(that);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return Arity + Index;
+            }
+
+            public override string ToString()
+            {
+                return String.Format("[{0}:{1}]", Function.ToString(), Index);
+            }
+            #endregion
+        }
+
+        private struct EqPair : IEquatable<EqPair>
+        {
+            public readonly ESymValue v1;
+            public readonly ESymValue v2;
+
+            public EqPair(ESymValue v1, ESymValue v2)
+            {
+                this.v1 = v1;
+                this.v2 = v2;
+            }
+
+            public override int GetHashCode()
+            {
+                return GetV1HashCode() + v2.GlobalId;
+            }
+
+            private int GetV1HashCode()
+            {
+                if (v1 == null) return 1;
+                return v1.GlobalId;
+            }
+
+            public bool Equals(EqPair that)
+            {
+                return this.v1 == that.v1 && this.v2 == that.v2;
+            }
+        }
+
+        private void PushEquality(WorkList<EqPair> wl, ESymValue v1, ESymValue v2)
+        {
+            if (v1 == v2) return;
+            wl.Add(new EqPair(v1, v2));
+        }
+
+
+        public void AssumeEqual(ESymValue v1, ESymValue v2)
+        {
+            WorkList<EqPair> wl = new WorkList<EqPair>();
+            ESymValue v1rep = Find(v1);
+            ESymValue v2rep = Find(v2);
+            PushEquality(wl, v1rep, v2rep);
+
+            if (!wl.IsEmpty)
+            {
+                // TODO: there's an opportunity for optimizing the number
+                // of necessary updates that we need to record, since the induced
+                // updates of the equality may end up as duplicates.
+                AddEqualityUpdate(v1rep, v2rep);
+            }
+            DrainEqualityWorkList(wl);
+        }
+
+        private void DrainEqualityWorkList(WorkList<EqPair> wl)
+        {
+            while (!wl.IsEmpty)
+            {
+                var eqpair = (EqPair)wl.Pull();
+                var v1rep = Find(eqpair.v1);
+                var v2rep = Find(eqpair.v2);
+                if (v1rep == v2rep) continue;
+
+                // always map new to older var
+                if (v1rep.UniqueId < v2rep.UniqueId)
+                {
+                    ESymValue temp = v1rep;
+                    v1rep = v2rep;
+                    v2rep = temp;
+                }
+
+                // perform congruence closure here:
+                foreach (Constant f in this.Functions(v1rep))
+                {
+                    ESymValue target = this.LookupWithoutManifesting(v2rep, f);
+                    if (target == null)
+                    {
+                        this[v2rep, f] = this[v1rep, f];
+                    }
+                    else
+                    {
+                        PushEquality(wl, this[v1rep, f], target);
+                    }
+                }
+                AbstractValue av1 = this[v1rep];
+                AbstractValue av2 = this[v2rep];
+                // merge term map of v1 into v2
+                foreach (EGraphTerm<Constant> eterm in eqTermMap[v1rep].GetEnumerable())
+                {
+                    eqTermMap = eqTermMap.Add(v2rep, eqTermMap[v2rep].Cons(eterm));
+                }
+                forwMap = forwMap.Add(v1rep, v2rep);
+                this[v2rep] = av1.Meet(av2);
+            }
+        }
+
+
+        public bool IsEqual(ESymValue v1, ESymValue v2)
+        {
+            return (Find(v1) == Find(v2));
+        }
+
+        public IEnumerable<Constant> Constants
+        {
+            get { return termMap.Keys2(constRoot); }
+        }
+
+
+        public IEnumerable<Constant> Functions(ESymValue sv)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Constant>>() != null);
+
+            return termMap.Keys2(Find(sv));
+        }
+
+        internal IEnumerable<MultiEdge> MultiEdges(ESymValue sv)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<MultiEdge>>() != null);
+
+            return multiTermMap.Keys2(Find(sv));
+        }
+
+        public IEnumerable<ESymValue> SymbolicValues
+        {
+            get { return termMap.Keys1; }
+        }
+
+        public IEnumerable<EGraphTerm<Constant>> EqTerms(ESymValue sv)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<EGraphTerm<Constant>>>() != null);
+
+            foreach (EGraphTerm<Constant> eterm in eqTermMap[Find(sv)].GetEnumerable())
+            {
+                // test if it is valid
+                if (this.TryLookup(eterm.Function, eterm.Args) == sv)
+                {
+                    yield return eterm;
+                }
+            }
+        }
+
+        public IEnumerable<EGraphTerm<Constant>> EqMultiTerms(ESymValue sv)
+        {
+            // for now this can only be 0 or 1
+            var term = eqMultiTermMap[sv];
+            if (term.Args != null)
+            {
+                if (IsValidMultiTerm(term))
+                {
+                    yield return term;
+                }
+            }
+        }
+
+
+        public EGraph<Constant, AbstractValue> Clone()
+        {
+            Contract.Ensures(Contract.Result<EGraph<Constant, AbstractValue>>() != null);
+
+            return new EGraph<Constant, AbstractValue>(this);
+        }
+
+        #region Join on EGraphs
+
+        public EGraph<Constant, AbstractValue> Join(EGraph<Constant, AbstractValue> eg2, out bool weaker, bool widen)
+        {
+            EGraph<Constant, AbstractValue> eg1 = this;
+            IMergeInfo info;
+            EGraph<Constant, AbstractValue> result = eg1.Join(eg2, out info, widen);
+            weaker = info.Changed;
+            return result;
+        }
+
+        public EGraph<Constant, AbstractValue> Join(EGraph<Constant, AbstractValue> eg2, out IMergeInfo mergeInfo, bool widen)
+        {
+            Contract.Ensures(Contract.ValueAtReturn(out mergeInfo) != null);
+            Contract.Ensures(Contract.Result<EGraph<Constant, AbstractValue>>() != null);
+
+            EGraphStats.Joins++;
+
+            EGraph<Constant, AbstractValue> eg1 = this;
+
+            int updateSize;
+            EGraph<Constant, AbstractValue> common = ComputeCommonTail(eg1, eg2, out updateSize);
+
+            bool doReplay = true;
+
+            if (common == null)
+            {
+                doReplay = false;
+            }
+            if (Statistics)
+            {
+                Console.WriteLine("G1({5}):{0},{1} G2({6}):{2},{3} UpdateSize:{4}", eg1.historySize, eg1.LastSymbolId, eg2.historySize, eg2.LastSymbolId, updateSize, eg1.egraphId, eg2.egraphId);
+                Console.WriteLine("  G1 Updates {0}", eg1.updates.Length());
+                Console.WriteLine("  G2 Updates {0}", eg2.updates.Length());
+
+                if (common != null)
+                {
+                    Console.WriteLine("Common id:{0} updates {1}", common.egraphId, common.updates.Length());
+                }
+            }
+
+            MergeState ms;
+
+            // Heuristic for using Replay vs. full update
+            doReplay &= (common != eg1.root);
+
+            //doReplay &= (eg1.historySize > 3);
+            //doReplay &= (eg2.historySize > 3);
+
+            // Heuristic 1
+            //doReplay &= (eg1.historySize - common.historySize < eg1.idCounter) && (eg2.historySize - common.historySize < eg2.idCounter);
+
+            // Heuristic 2
+            //doReplay &= (eg1.idCounter - common.idCounter <= common.idCounter);
+            //doReplay &= (eg2.idCounter - common.idCounter <= common.idCounter);
+
+            // Heuristic 3
+            //doReplay &= (updateSize < 400);
+
+            // Heuristic 4
+            //   - the incremental list after merging is effectively tail.size + updateSize and the cost is updateSize
+            //   - whereas a join will be proportional to the smaller egraph (idCounter) and cost in proportion to it
+            //var incrCostSmaller = updateSize < eg1.idCounter && updateSize < eg2.idCounter;
+
+            //var incrSizeCost = ((float)(common.idCounter + updateSize)) / Math.Min(eg1.idCounter, eg2.idCounter);
+            //doReplay &= (incrSizeCost < 2.0);
+
+            doReplay &= !widen;
+
+            // No Incremental
+            //common = eg1.root;
+            //doReplay = false;
+
+            doReplay &= EGraphStats.IncrementalJoin;
+
+            if (DoDebug)
+            {
+                if (widen)
+                {
+                    Console.WriteLine("EGraph widen");
+                }
+                else
+                {
+                    Console.WriteLine("EGraph join");
+                }
+                Console.WriteLine("  Last common symbol: {0}", common.idCounter);
+                if (doReplay)
+                {
+                    Console.WriteLine("  Doing incremental join");
+                }
+                else
+                {
+                    Console.WriteLine("  Doing full join");
+                }
+            }
+            EGraph<Constant, AbstractValue> result;
+            long replayTime;
+            long fullTime;
+            if (doReplay)
+            {
+                long startTime = Environment.TickCount;
+                EGraphStats.IncrementalJoins++;
+                result = new EGraph<Constant, AbstractValue>(common);
+                ms = new MergeState(result, eg1, eg2, widen);
+                ms.Replay(common);
+                ms.Commit();
+                // the incremental join computes a changed bit that is conservative (may say changed too often)
+                // For widening, that is not acceptable, thus we compute a LessEqual here in that case.
+                if (widen && ms.Changed)
+                {
+                    ms.Changed = !result.LessEqual(eg1);
+                    if (DoDebug && ms.Changed)
+                    {
+                        Console.WriteLine("---EGraph changed due to LessEqual check on Widen");
+                    }
+                }
+                replayTime = Environment.TickCount - startTime;
+                EGraphStats.IncrementalJoinTicks += replayTime;
+            }
+            else
+            { // (!doReplay)
+                long startTime = Environment.TickCount;
+                EGraphStats.FullJoins++;
+                result = new EGraph<Constant, AbstractValue>(common); // keep history, clear maps
+                ms = new MergeState(result, eg1, eg2, widen);
+                // need to eliminate things from common that were eliminated since
+                if (DoDebug)
+                {
+                    Console.WriteLine("  Start Replay Elimination: result update size now {0}", result.updates.Length());
+                }
+
+                // not needed if we use root.
+                ms.ReplayEliminations(common);
+
+                ms.AddMapping(eg1.constRoot, eg2.constRoot, result.constRoot);
+                if (DoDebug)
+                {
+                    Console.WriteLine("  Start Join of roots: result update size now {0}", result.updates.Length());
+                }
+                ms.JoinSymbolicValue(eg1.constRoot, eg2.constRoot, result.constRoot);
+                ms.Commit();
+                fullTime = Environment.TickCount - startTime;
+                EGraphStats.FullJoinTicks += fullTime;
+            }
+            // Log((fullTime < replayTime), common, eg1, eg2, widen);
+
+            mergeInfo = ms;
+            if (DoDebug)
+            {
+                Console.WriteLine("  Result update size {0}", result.updates.Length());
+                Console.WriteLine("Done with Egraph join: changed = {0}", mergeInfo.Changed);
+
+                Contract.Assume(this.LessEqual(result));
+                Contract.Assume(eg2 != null);
+                Contract.Assume(eg2.LessEqual(result));
+            }
+            return result;
+        }
 
 #if EGRAPH_LOG
-    static TextWriter tw = new StreamWriter(@"c:\tmp\egraph.log");
-    static void Log(bool fullFaster, EGraph<Constant, Label, AbstractValue> common, EGraph<Constant, Label, AbstractValue> eg1, EGraph<Constant, Label, AbstractValue> eg2, bool widen)
-    {
-      tw.WriteLine("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}",
-                    fullFaster, common.idCounter, common.historySize, eg1.idCounter, eg1.historySize, eg2.idCounter, eg2.historySize, widen);
-    }
+        static TextWriter tw = new StreamWriter(@"c:\tmp\egraph.log");
+        static void Log(bool fullFaster, EGraph<Constant, Label, AbstractValue> common, EGraph<Constant, Label, AbstractValue> eg1, EGraph<Constant, Label, AbstractValue> eg2, bool widen)
+        {
+            tw.WriteLine("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}",
+                          fullFaster, common.idCounter, common.historySize, eg1.idCounter, eg1.historySize, eg2.idCounter, eg2.historySize, widen);
+        }
 #endif
 
-    [Pure]
-    [ContractVerification(false)]
-    private static EGraph<Constant,AbstractValue>/*?*/ ComputeCommonTail(EGraph<Constant,AbstractValue> g1, EGraph<Constant,AbstractValue> g2, out int updateSize) {
-
-      EGraph<Constant,AbstractValue>/*?*/ current1 = g1;
-      EGraph<Constant,AbstractValue>/*?*/ current2 = g2;
+        [Pure]
+        [ContractVerification(false)]
+        private static EGraph<Constant, AbstractValue>/*?*/ ComputeCommonTail(EGraph<Constant, AbstractValue> g1, EGraph<Constant, AbstractValue> g2, out int updateSize)
+        {
+            EGraph<Constant, AbstractValue>/*?*/ current1 = g1;
+            EGraph<Constant, AbstractValue>/*?*/ current2 = g2;
 
 #if false
-      if (g1.historySize <= 3 && g2.historySize > 100) { 
-        updateSize = g1.historySize + g2.historySize;
-        if (g1.root == g2.root) {
-          return g1.root; 
-        }
-        return null;
-      }
-      if (g2.historySize <= 3 && g1.historySize > 100) { 
-        updateSize = g1.historySize + g2.historySize;
-        if (g1.root == g2.root) {
-          return g1.root; 
-        }
-        return null;
-      }
+            if (g1.historySize <= 3 && g2.historySize > 100)
+            {
+                updateSize = g1.historySize + g2.historySize;
+                if (g1.root == g2.root)
+                {
+                    return g1.root;
+                }
+                return null;
+            }
+            if (g2.historySize <= 3 && g1.historySize > 100)
+            {
+                updateSize = g1.historySize + g2.historySize;
+                if (g1.root == g2.root)
+                {
+                    return g1.root;
+                }
+                return null;
+            }
 #endif
 
-      while (current1 != current2) {
-        if (current1 == null) {
-          // no common tail
-          current2 = null; break;
-        }
-        if (current2 == null) {
-          // no common tail
-          current1 = null; break;
-        }
-        if (current1.historySize > current2.historySize) {
-          current1 = current1.parent; continue;
-        }
-        if (current2.historySize > current1.historySize) {
-          current2 = current2.parent; continue;
-        }
-        // they have equal size
-        current1 = current1.parent;
-        current2 = current2.parent;
-      }
-      // now current1 == current2 == tail
-      EGraph<Constant,AbstractValue> tail = current1;
-      int tailSize = (tail != null)?tail.historySize:0;
-      updateSize = g1.historySize + g2.historySize - tailSize - tailSize;
-      return tail;
-    }
-
-    private class MergeState : IMergeInfo {
-
-      public readonly EGraph<Constant, AbstractValue> Result;
-      public readonly EGraph<Constant, AbstractValue> G1;
-      public readonly EGraph<Constant, AbstractValue> G2;
-      private DoubleFunctionalMap<ESymValue, ESymValue, ESymValue> Map;
-      private OnDemandSet<ESymValue> manifested;
-
-      /// <summary>
-      /// Used for targets of multivariable functions 
-      /// x0 = f(x1..xn) and y0 = f(y0..yn)
-      /// Maps (x0,y0) to count of how many arg mappings (0..n) we've seen so far.
-      /// When the count reaches n, we have a matching pair.
-      /// </summary>
-      private DoubleTable<ESymValue, ESymValue, int> PendingCounts;
-      //private DoubleFunctionalMap<ESymValue, ESymValue, int> PendingCounts;
-
-      private OnDemandSet<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, MultiEdge>> VisitedMultiEdges;
-
-      /// <summary>
-      /// Returns true if the arity is reached.
-      /// </summary>
-      bool UpdatePendingCount(ESymValue xi, ESymValue yi, int arity)
-      {
-        int oldCount = 0;
-        PendingCounts.TryGetValue(xi, yi, out oldCount);
-        var newCount = oldCount + 1;
-        PendingCounts[xi, yi] = newCount;
-        if (newCount == arity)
-        {
-          return true;
-        }
-        return false;
-      }
-
-      /// <summary>
-      /// These tuples may have a null in one of the two first args if they are a result of 
-      /// materializing nodes during joins.
-      /// Additionally, the list contains all triples in the Map above
-      /// </summary>
-      private FList<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, ESymValue>> tuples;
-      /// <summary>
-      /// Used for manifest tuples (key1,null,result) that don't show up in the Map
-      /// </summary>
-      private IFunctionalSet<ESymValue> visitedKey1;
-
-      private bool widen;
-      private bool changed;
-      public bool Changed {
-        get { return this.changed; }
-        set {
-          this.changed = value;
-        }
-      }
-
-      int lastCommonVariable;
-
-      public bool IsCommon(ESymValue sv) {
-        return (sv.UniqueId <= lastCommonVariable);
-      }
-
-      public bool AreCommon(ESymValue[] svs)
-      {
-        foreach (var sv in svs)
-        {
-          if (!IsCommon(sv)) return false;
-        }
-        return true;
-      }
-
-      public MergeState(EGraph<Constant, AbstractValue> result, EGraph<Constant, AbstractValue> g1, EGraph<Constant, AbstractValue> g2, bool widen)
-      {
-        this.Result = result;
-        this.G1 = g1;
-        this.G2 = g2;
-        this.Map = DoubleFunctionalMap<ESymValue,ESymValue,ESymValue>.Empty(ESymValue.GetUniqueKey);
-        //this.PendingCounts = DoubleFunctionalMap<ESymValue, ESymValue, int>.Empty(ESymValue.GetUniqueKey);
-        this.PendingCounts = new DoubleTable<ESymValue, ESymValue, int>();
-        this.visitedKey1 = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-        this.changed = false;
-        // capture the idCounter before we update the result structure.
-        this.lastCommonVariable = result.idCounter;
-        this.widen = widen;
-      }
-
-      /// <summary>
-      /// It is possible that v1 or v2 are null. This happens when we manifest trees at join
-      /// </summary>
-      public void JoinSymbolicValue(ESymValue v1, ESymValue v2, ESymValue r) {
-        // Contract.Requires(v1 != null);
-        // Contract.Requires(v2 != null); // It can be null
-        
-        if (DoDebug) {
-          Console.WriteLine("JoinSymbolicValue: [{0},{1}] -> {2}", v1, v2, r);
-        }
-
-        if (G2.HasAllBottomFields(v2))
-        {
-          // retain all fields of v1 in G1 and result is not changed
-          if (v1 != null)
-          {
-            foreach (Constant function in G1.termMap.Keys2(v1))
+            while (current1 != current2)
             {
-              bool isPlaceHolder;
-              ESymValue v1target = G1.LookupWithoutManifesting(v1, function);
-              ESymValue v2target = G2.LookupOrBottomPlaceHolder(v2, function, out isPlaceHolder);
-
-              if (isPlaceHolder && !function.KeepAsBottomField) continue;
-
-              ESymValue rtarget = AddJointEdge(v1target, v2target, function, r);
-
-              if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
+                if (current1 == null)
+                {
+                    // no common tail
+                    current2 = null; break;
+                }
+                if (current2 == null)
+                {
+                    // no common tail
+                    current1 = null; break;
+                }
+                if (current1.historySize > current2.historySize)
+                {
+                    current1 = current1.parent; continue;
+                }
+                if (current2.historySize > current1.historySize)
+                {
+                    current2 = current2.parent; continue;
+                }
+                // they have equal size
+                current1 = current1.parent;
+                current2 = current2.parent;
             }
-          }
+            // now current1 == current2 == tail
+            EGraph<Constant, AbstractValue> tail = current1;
+            int tailSize = (tail != null) ? tail.historySize : 0;
+            updateSize = g1.historySize + g2.historySize - tailSize - tailSize;
+            return tail;
         }
-        else if (!widen && G1.HasAllBottomFields(v1))
+
+        private class MergeState : IMergeInfo
         {
-          // retain all fields of v2 in G2, but result graph is changed, as result is not a AllFieldsBottom symbol
-          if (DoDebug)
-          {
-            Console.WriteLine("---EGraph changed due to an all bottom field value in G1 changing to non-bottom");
-          }
-          this.Changed = true;
-          if (v2 != null)
-          {
-            foreach (Constant function in G2.termMap.Keys2(v2).AssumeNotNull())
+            public readonly EGraph<Constant, AbstractValue> Result;
+            public readonly EGraph<Constant, AbstractValue> G1;
+            public readonly EGraph<Constant, AbstractValue> G2;
+            private DoubleFunctionalMap<ESymValue, ESymValue, ESymValue> Map;
+            private OnDemandSet<ESymValue> manifested;
+
+            /// <summary>
+            /// Used for targets of multivariable functions 
+            /// x0 = f(x1..xn) and y0 = f(y0..yn)
+            /// Maps (x0,y0) to count of how many arg mappings (0..n) we've seen so far.
+            /// When the count reaches n, we have a matching pair.
+            /// </summary>
+            private DoubleTable<ESymValue, ESymValue, int> PendingCounts;
+            //private DoubleFunctionalMap<ESymValue, ESymValue, int> PendingCounts;
+
+            private OnDemandSet<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, MultiEdge>> VisitedMultiEdges;
+
+            /// <summary>
+            /// Returns true if the arity is reached.
+            /// </summary>
+            private bool UpdatePendingCount(ESymValue xi, ESymValue yi, int arity)
             {
-              bool isPlaceHolder;
-              ESymValue v1target = G1.LookupOrBottomPlaceHolder(v1, function, out isPlaceHolder);
-              ESymValue v2target = G2.LookupWithoutManifesting(v2, function);
-
-              if (isPlaceHolder && !function.KeepAsBottomField) continue;
-
-              ESymValue rtarget = AddJointEdge(v1target, v2target, function, r);
-
-              if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
+                int oldCount = 0;
+                PendingCounts.TryGetValue(xi, yi, out oldCount);
+                var newCount = oldCount + 1;
+                PendingCounts[xi, yi] = newCount;
+                if (newCount == arity)
+                {
+                    return true;
+                }
+                return false;
             }
-          }
-        }
-        else
-        {
-          IEnumerable<Constant> keys;
-          bool extraManifest;
+
+            /// <summary>
+            /// These tuples may have a null in one of the two first args if they are a result of 
+            /// materializing nodes during joins.
+            /// Additionally, the list contains all triples in the Map above
+            /// </summary>
+            private FList<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, ESymValue>> tuples;
+            /// <summary>
+            /// Used for manifest tuples (key1,null,result) that don't show up in the Map
+            /// </summary>
+            private IFunctionalSet<ESymValue> visitedKey1;
+
+            private bool widen;
+            private bool changed;
+            public bool Changed
+            {
+                get { return changed; }
+                set
+                {
+                    changed = value;
+                }
+            }
+
+            private int lastCommonVariable;
+
+            public bool IsCommon(ESymValue sv)
+            {
+                return (sv.UniqueId <= lastCommonVariable);
+            }
+
+            public bool AreCommon(ESymValue[] svs)
+            {
+                foreach (var sv in svs)
+                {
+                    if (!IsCommon(sv)) return false;
+                }
+                return true;
+            }
+
+            public MergeState(EGraph<Constant, AbstractValue> result, EGraph<Constant, AbstractValue> g1, EGraph<Constant, AbstractValue> g2, bool widen)
+            {
+                this.Result = result;
+                this.G1 = g1;
+                this.G2 = g2;
+                Map = DoubleFunctionalMap<ESymValue, ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
+                //this.PendingCounts = DoubleFunctionalMap<ESymValue, ESymValue, int>.Empty(ESymValue.GetUniqueKey);
+                PendingCounts = new DoubleTable<ESymValue, ESymValue, int>();
+                visitedKey1 = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+                changed = false;
+                // capture the idCounter before we update the result structure.
+                lastCommonVariable = result.idCounter;
+                this.widen = widen;
+            }
+
+            /// <summary>
+            /// It is possible that v1 or v2 are null. This happens when we manifest trees at join
+            /// </summary>
+            public void JoinSymbolicValue(ESymValue v1, ESymValue v2, ESymValue r)
+            {
+                // Contract.Requires(v1 != null);
+                // Contract.Requires(v2 != null); // It can be null
+
+                if (DoDebug)
+                {
+                    Console.WriteLine("JoinSymbolicValue: [{0},{1}] -> {2}", v1, v2, r);
+                }
+
+                if (G2.HasAllBottomFields(v2))
+                {
+                    // retain all fields of v1 in G1 and result is not changed
+                    if (v1 != null)
+                    {
+                        foreach (Constant function in G1.termMap.Keys2(v1))
+                        {
+                            bool isPlaceHolder;
+                            ESymValue v1target = G1.LookupWithoutManifesting(v1, function);
+                            ESymValue v2target = G2.LookupOrBottomPlaceHolder(v2, function, out isPlaceHolder);
+
+                            if (isPlaceHolder && !function.KeepAsBottomField) continue;
+
+                            ESymValue rtarget = AddJointEdge(v1target, v2target, function, r);
+
+                            if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
+                        }
+                    }
+                }
+                else if (!widen && G1.HasAllBottomFields(v1))
+                {
+                    // retain all fields of v2 in G2, but result graph is changed, as result is not a AllFieldsBottom symbol
+                    if (DoDebug)
+                    {
+                        Console.WriteLine("---EGraph changed due to an all bottom field value in G1 changing to non-bottom");
+                    }
+                    this.Changed = true;
+                    if (v2 != null)
+                    {
+                        foreach (Constant function in G2.termMap.Keys2(v2).AssumeNotNull())
+                        {
+                            bool isPlaceHolder;
+                            ESymValue v1target = G1.LookupOrBottomPlaceHolder(v1, function, out isPlaceHolder);
+                            ESymValue v2target = G2.LookupWithoutManifesting(v2, function);
+
+                            if (isPlaceHolder && !function.KeepAsBottomField) continue;
+
+                            ESymValue rtarget = AddJointEdge(v1target, v2target, function, r);
+
+                            if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
+                        }
+                    }
+                }
+                else
+                {
+                    IEnumerable<Constant> keys;
+                    bool extraManifest;
 #if ALLOW_MANIFESTATION
-          extraManifest = true;
+                    extraManifest = true;
 #else
-          extraManifest = false;
+                    extraManifest = false;
 #endif
-          if (!extraManifest || this.widen)
-          {
-            if (G1.termMap.Keys2Count(v1) <= G2.termMap.Keys2Count(v2))
-            {
-              keys = G1.termMap.Keys2(v1);
-            }
-            else
-            {
-              keys = G2.termMap.Keys2(v2);
-              if (DoDebug)
-              {
-                Console.WriteLine("---EGraph changed because G2 has fewer keys for {0} than {1} in G1", v2, v1);
-              }
-              this.Changed = true; // since we have fewer keys in output
-            }
-          }
-          else
-          {
-            // use larger key set to manifest fields: this won't guarantee that we manifest all as we would have to
-            // take the union of left and write.
-            if (G1.termMap.Keys2Count(v1) < G2.termMap.Keys2Count(v2))
-            {
-              keys = G2.termMap.Keys2(v2);
-              if (DoDebug)
-              {
-                Console.WriteLine("---EGraph changed because G1 has fewer keys for {0} than {1} in G2", v1, v2);
-              }
-              this.Changed = true;
-            }
-            else
-            {
-              keys = G1.termMap.Keys2(v1);
-            }
-          }
-          Contract.Assume(keys != null);
-          foreach (Constant function in keys)
-          {
-            ESymValue v1target = G1.LookupWithoutManifesting(v1, function);
-            ESymValue v2target = G2.LookupWithoutManifesting(v2, function);
+                    if (!extraManifest || widen)
+                    {
+                        if (G1.termMap.Keys2Count(v1) <= G2.termMap.Keys2Count(v2))
+                        {
+                            keys = G1.termMap.Keys2(v1);
+                        }
+                        else
+                        {
+                            keys = G2.termMap.Keys2(v2);
+                            if (DoDebug)
+                            {
+                                Console.WriteLine("---EGraph changed because G2 has fewer keys for {0} than {1} in G1", v2, v1);
+                            }
+                            this.Changed = true; // since we have fewer keys in output
+                        }
+                    }
+                    else
+                    {
+                        // use larger key set to manifest fields: this won't guarantee that we manifest all as we would have to
+                        // take the union of left and write.
+                        if (G1.termMap.Keys2Count(v1) < G2.termMap.Keys2Count(v2))
+                        {
+                            keys = G2.termMap.Keys2(v2);
+                            if (DoDebug)
+                            {
+                                Console.WriteLine("---EGraph changed because G1 has fewer keys for {0} than {1} in G2", v1, v2);
+                            }
+                            this.Changed = true;
+                        }
+                        else
+                        {
+                            keys = G1.termMap.Keys2(v1);
+                        }
+                    }
+                    Contract.Assume(keys != null);
+                    foreach (Constant function in keys)
+                    {
+                        ESymValue v1target = G1.LookupWithoutManifesting(v1, function);
+                        ESymValue v2target = G2.LookupWithoutManifesting(v2, function);
 
-            if (v1target == null)
-            {
+                        if (v1target == null)
+                        {
 #if ALLOW_MANIFESTATION
-              if (!this.widen && function.ManifestField)
-              {
-                // pretend that G1 has an unshared tree at v1,function with all top
-                // mirroring the spanning tree rooted at v2,function.
-                // Create such a tree in the result and map G2', nodes to the fresh
-                // result nodes.
+                            if (!widen && function.ManifestField)
+                            {
+                                // pretend that G1 has an unshared tree at v1,function with all top
+                                // mirroring the spanning tree rooted at v2,function.
+                                // Create such a tree in the result and map G2', nodes to the fresh
+                                // result nodes.
 
-                // Result changed over G1 (not semantically, but representationally)
+                                // Result changed over G1 (not semantically, but representationally)
+                                if (DoDebug)
+                                {
+                                    Console.WriteLine("---EGraph changed due to manifestation of a top edge in G1");
+                                }
+                                this.Changed = true;
+                                // v1target == null is allowed in the remaining code
+                            }
+                            else
+#endif
+                            {
+                                // no change in output over G1
+                                continue;
+                            }
+                        }
+                        if (v2target == null)
+                        {
+                            // absence considered Top.
+#if ALLOW_MANIFESTATION
+                            if (!widen && function.ManifestField)
+                            {
+                                // manifest the value in G2
+                                // v2target == null is allowed in the remaining code
+                            }
+                            else
+#endif
+                            {
+                                if (DoDebug)
+                                {
+                                    Console.WriteLine("---EGraph changed due to absence of map {0}-{1}-> in G2", v2, function.ToString());
+                                }
+                                this.Changed = true;
+                                continue;
+                            }
+                        }
+
+                        ESymValue rtarget = AddJointEdge(v1target, v2target, function, r);
+
+                        if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
+                    }
+                }
+
+                #region Handle multi-variable function slices
+                JoinMultiEdges(v1, v2);
+                #endregion
+            }
+
+            private void JoinMultiEdges(ESymValue v1, ESymValue v2)
+            {
+                if (v1 != null && v2 != null)
+                {
+                    // not manifesting v1 or v2
+                    int keysG1 = G1.multiTermMap.Keys2Count(v1);
+                    int keysG2 = G2.multiTermMap.Keys2Count(v2);
+                    IEnumerable<MultiEdge> multiKeys;
+                    if (keysG1 <= keysG2)
+                    {
+                        multiKeys = G1.multiTermMap.Keys2(v1);
+                    }
+                    else
+                    {
+                        multiKeys = G2.multiTermMap.Keys2(v2);
+                    }
+
+                    foreach (var slice in multiKeys)
+                    {
+                        JoinMultiEdge(v1, v2, slice);
+                    }
+                }
+            }
+
+            private void JoinMultiEdge(ESymValue v1, ESymValue v2, MultiEdge slice)
+            {
+                // SUPER important:
+                // For each v1, v2, and slice, we can only execute this once per merge or else (boom)
+                // This is an issue when we perform incremental joins.
+                var mark = new Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, MultiEdge>(v1, v2, slice);
+                if (VisitedMultiEdges.Contains(mark)) return;
+                VisitedMultiEdges.Add(mark);
+
+                FList<ESymValue> v1candidateList = G1.multiTermMap[v1, slice];
+                FList<ESymValue> v2candidateList = G2.multiTermMap[v2, slice];
+
+                // for pair of candidates, we update the triggers
+                if (v2candidateList != null)
+                {
+                    for (var v1candidates = v1candidateList; v1candidates != null; v1candidates = v1candidates.Tail)
+                    {
+                        for (var v2candidates = v2candidateList; v2candidates != null; v2candidates = v2candidates.Tail)
+                        {
+                            var v1target = v1candidates.Head;
+                            var v2target = v2candidates.Head;
+
+                            if (UpdatePendingCount(v1target, v2target, slice.Arity))
+                            {
+                                // found matching functions
+                                var term1 = G1.eqMultiTermMap[v1target];
+                                var term2 = G2.eqMultiTermMap[v2target];
+
+                                if (term1.Args == null || term2.Args == null)
+                                {
+                                    // Debugger.Break();
+                                    break;
+                                }
+
+                                // it must be the case that the pairwise args are related already: find them
+                                Contract.Assume(term1.Args.Length > 1); // F: added as required below
+                                var resultArgs = new ESymValue[term1.Args.Length];
+                                for (int index = 0; index < resultArgs.Length; index++)
+                                {
+                                    var resultArg = Map[term1.Args[index], term2.Args[index]];
+                                    Contract.Assume(resultArg != null);
+                                    resultArgs[index] = resultArg;
+                                }
+                                var rtarget = AddJointEdge(v1target, v2target, slice.Function, resultArgs);
+                                if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
+                            }
+                        }
+                    }
+                }
+            }
+
+            private ESymValue/*?*/ AddJointEdge(ESymValue v1target, ESymValue v2target, Constant function, ESymValue[] resultRoots)
+            {
+                Contract.Requires(resultRoots.Length > 1); // F: Clousot does not suggest it because of some "return null"
+
+                ESymValue rtarget = LookupMap(v1target, v2target);
+                bool newBinding = false;
+                if (rtarget == null)
+                {
+                    // if we have visited v1target before, then the result graph is not isomorphic to G1
+                    if (VisitedKey1(v1target, v2target))
+                    {
+                        if (DoDebug)
+                        {
+                            Console.WriteLine("---Egraph changed due to pre-existing mapping in G1 of {0}", v1target);
+                        }
+                        this.Changed = true;
+
+                        if (v1target == null) return null; // manifesting
+                        if (v2target == null) return null; // manifesting
+                    }
+                    newBinding = true;
+                    if (v1target != null && v1target.UniqueId <= lastCommonVariable && v1target == v2target)
+                    {
+                        rtarget = v1target; // reuse old symbol
+                    }
+                    else
+                    {
+                        rtarget = Result.FreshSymbolicValue();
+                    }
+                    this.AddMapping(v1target, v2target, rtarget);
+                }
+                else
+                {
+                    // See if info is already present
+                    ESymValue oldTarget = Result.LookupWithoutManifesting(resultRoots, function);
+                    if (oldTarget == rtarget)
+                    {
+                        // no change, don't record or change anything
+                        return null;
+                    }
+                }
+                Result[resultRoots, function] = rtarget;
+
+                AbstractValue aval1 = G1AbstractValue(v1target);
+                AbstractValue aval2 = G2AbstractValue(v2target);
+                bool weaker;
+                AbstractValue aresult = aval1.Join(aval2, out weaker, widen);
+                Result[rtarget] = aresult;
+                if (weaker)
+                {
+                    if (DoDebug)
+                    {
+                        Console.WriteLine("-----EGraph changed due to join of aval of [{0},{1}] (prev {2}, new {3}, join {4})",
+                          v1target, v2target, aval1.ToString(), aval2.ToString(), aresult.ToString());
+                    }
+                    this.Changed = true;
+                }
+
                 if (DoDebug)
                 {
-                  Console.WriteLine("---EGraph changed due to manifestation of a top edge in G1");
+                    Console.WriteLine("AddJointEdge: ({0}) -{1}-> [{2},{3},{4}]",
+                      resultRoots.ToString(", "), Function2String(function), v1target, v2target, rtarget);
                 }
-                this.Changed = true;
-                // v1target == null is allowed in the remaining code
-              }
-              else
-#endif
-              {
-                // no change in output over G1
-                continue;
-              }
+                return (newBinding) ? rtarget : null;
             }
-            if (v2target == null)
+
+            /// <summary>
+            /// Note that either v1target or v2target may be null in order to allow manifestation on joins
+            /// </summary>
+            private ESymValue/*?*/ AddJointEdge(ESymValue v1target, ESymValue v2target, Constant function, ESymValue resultRoot)
             {
-              // absence considered Top.
-#if ALLOW_MANIFESTATION
-              if (!this.widen && function.ManifestField)
-              {
-                // manifest the value in G2
-                // v2target == null is allowed in the remaining code
-              }
-              else
-#endif
-              {
+                ESymValue rtarget = LookupMap(v1target, v2target);
+                bool newBinding = false;
+                if (rtarget == null)
+                {
+                    // if we have visited v1target before, then the result graph is not isomorphic to G1
+                    if (VisitedKey1(v1target, v2target))
+                    {
+                        if (DoDebug)
+                        {
+                            Console.WriteLine("---Egraph changed due to pre-existing mapping in G1 of {0}", v1target);
+                        }
+                        this.Changed = true;
+
+                        if (v1target == null)
+                        {
+                            if (manifested.Contains(v2target))
+                            {
+                                return null; // can only manifest once
+                            }
+                            manifested.Add(v2target);
+                        }
+                        if (v2target == null)
+                        {
+                            if (manifested.Contains(v1target))
+                            {
+                                return null; // manifesting
+                            }
+                            manifested.Add(v1target);
+                        }
+                    }
+                    newBinding = true;
+                    if (v1target != null && v1target.UniqueId <= lastCommonVariable && v1target == v2target)
+                    {
+                        rtarget = v1target; // reuse old symbol
+                    }
+                    else
+                    {
+                        rtarget = Result.FreshSymbolicValue();
+                    }
+                    this.AddMapping(v1target, v2target, rtarget);
+                }
+                else
+                {
+                    // See if info is already present
+                    ESymValue oldTarget = Result.LookupWithoutManifesting(resultRoot, function);
+                    if (oldTarget == rtarget)
+                    {
+                        // no change, don't record or change anything
+                        return null;
+                    }
+                }
+                Result[resultRoot, function] = rtarget;
+
+                AbstractValue aval1 = G1AbstractValue(v1target);
+                AbstractValue aval2 = G2AbstractValue(v2target);
+                bool weaker;
+                AbstractValue aresult = aval1.Join(aval2, out weaker, widen);
+                Result[rtarget] = aresult;
+                if (weaker)
+                {
+                    if (DoDebug)
+                    {
+                        Console.WriteLine("-----EGraph changed due to join of aval of [{0},{1}] (prev {2}, new {3}, join {4})",
+                          v1target, v2target, aval1.ToString(), aval2.ToString(), aresult.ToString());
+                    }
+                    this.Changed = true;
+                }
+
                 if (DoDebug)
                 {
-                  Console.WriteLine("---EGraph changed due to absence of map {0}-{1}-> in G2", v2, function.ToString());
+                    Console.WriteLine("AddJointEdge: {0} -{1}-> [{2},{3},{4}]",
+                      resultRoot, Function2String(function), v1target, v2target, rtarget);
                 }
-                this.Changed = true;
-                continue;
-              }
+                return (newBinding) ? rtarget : null;
             }
 
-            ESymValue rtarget = AddJointEdge(v1target, v2target, function, r);
-
-            if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
-          }
-        }
-
-        #region Handle multi-variable function slices
-        JoinMultiEdges(v1, v2);
-        #endregion
-      }
-
-       private void JoinMultiEdges(ESymValue v1, ESymValue v2)
-      {
-        if (v1 != null && v2 != null)
-        {
-          // not manifesting v1 or v2
-          int keysG1 = G1.multiTermMap.Keys2Count(v1);
-          int keysG2 = G2.multiTermMap.Keys2Count(v2);
-          IEnumerable<MultiEdge> multiKeys;
-          if (keysG1 <= keysG2)
-          {
-            multiKeys = G1.multiTermMap.Keys2(v1);
-          }
-          else
-          {
-            multiKeys = G2.multiTermMap.Keys2(v2);
-          }
-
-          foreach (var slice in multiKeys)
-          {
-            JoinMultiEdge(v1, v2, slice);
-          }
-        }
-      }
-
-      private void JoinMultiEdge(ESymValue v1, ESymValue v2, MultiEdge slice)
-      {
-        // SUPER important:
-        // For each v1, v2, and slice, we can only execute this once per merge or else (boom)
-        // This is an issue when we perform incremental joins.
-        var mark = new Microsoft.Research.DataStructures.STuple<ESymValue,ESymValue,MultiEdge>(v1,v2,slice);
-        if (VisitedMultiEdges.Contains(mark)) return;
-        VisitedMultiEdges.Add(mark);
-
-        FList<ESymValue> v1candidateList = G1.multiTermMap[v1, slice];
-        FList<ESymValue> v2candidateList = G2.multiTermMap[v2, slice];
-
-        // for pair of candidates, we update the triggers
-        if (v2candidateList != null)
-        {
-          for (var v1candidates = v1candidateList; v1candidates != null; v1candidates = v1candidates.Tail)
-          {
-            for (var v2candidates = v2candidateList; v2candidates != null; v2candidates = v2candidates.Tail)
+            private ESymValue LookupMap(ESymValue v1target, ESymValue v2target)
             {
-              var v1target = v1candidates.Head;
-              var v2target = v2candidates.Head;
+                if (v1target == null || v2target == null) return null;
+                return Map[v1target, v2target];
+            }
 
-              if (UpdatePendingCount(v1target, v2target, slice.Arity))
-              {
-                // found matching functions
-                var term1 = G1.eqMultiTermMap[v1target];
-                var term2 = G2.eqMultiTermMap[v2target];
+            private AbstractValue G2AbstractValue(ESymValue v2target)
+            {
+                if (v2target == null) return G2.underlyingTopValue.ForManifestedField();
+                return G2[v2target];
+            }
 
-                if (term1.Args == null || term2.Args == null)
+            private AbstractValue G1AbstractValue(ESymValue v1target)
+            {
+                if (v1target == null) return G1.underlyingTopValue.ForManifestedField();
+                return G1[v1target];
+            }
+
+            private bool VisitedKey1(ESymValue v1target, ESymValue v2target)
+            {
+                if (v1target == null)
                 {
-                  // Debugger.Break();
-                  break;
+                    // use visitedKey1 as a recursion breaker for v2target as well
+                    return visitedKey1.Contains(v2target);
                 }
+                return visitedKey1.Contains(v1target) || Map.ContainsKey1(v1target);
+            }
 
-                // it must be the case that the pairwise args are related already: find them
-                Contract.Assume(term1.Args.Length > 1); // F: added as required below
-                var resultArgs = new ESymValue[term1.Args.Length];
-                for (int index = 0; index < resultArgs.Length; index++)
+            public void AddMapping(ESymValue v1, ESymValue v2, ESymValue result)
+            {
+                if (v2 == null)
                 {
-                  var resultArg = Map[term1.Args[index], term2.Args[index]];
-                  Contract.Assume(resultArg != null);
-                  resultArgs[index] = resultArg;
+                    // record the fact that we use v1
+                    visitedKey1 = visitedKey1.Add(v1);
                 }
-                var rtarget = AddJointEdge(v1target, v2target, slice.Function, resultArgs);
-                if (rtarget != null) { JoinSymbolicValue(v1target, v2target, rtarget); }
-              }
+                else
+                {
+                    if (v1 != null)
+                    {
+                        Map = Map.Add(v1, v2, result);
+                    }
+                    else
+                    {
+                        // add recursion breaker v2
+                        visitedKey1 = visitedKey1.Add(v2);
+                    }
+                }
+                this.AddTuple(v1, v2, result);
             }
-          }
-        }
-      }
 
-      private ESymValue/*?*/ AddJointEdge(ESymValue v1target, ESymValue v2target, Constant function, ESymValue[] resultRoots)
-      {
-        Contract.Requires(resultRoots.Length > 1); // F: Clousot does not suggest it because of some "return null"
-
-        ESymValue rtarget = LookupMap(v1target, v2target);
-        bool newBinding = false;
-        if (rtarget == null)
-        {
-          // if we have visited v1target before, then the result graph is not isomorphic to G1
-          if (VisitedKey1(v1target, v2target))
-          {
-            if (DoDebug)
+            private void AddTuple(ESymValue s1, ESymValue s2, ESymValue result)
             {
-              Console.WriteLine("---Egraph changed due to pre-existing mapping in G1 of {0}", v1target);
+                tuples = tuples.Cons(new Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, ESymValue>(s1, s2, result));
             }
-            this.Changed = true;
 
-            if (v1target == null) return null; // manifesting
-            if (v2target == null) return null; // manifesting
-          }
-          newBinding = true;
-          if (v1target != null && v1target.UniqueId <= lastCommonVariable && v1target == v2target)
-          {
-            rtarget = v1target; // reuse old symbol
-          }
-          else
-          {
-            rtarget = Result.FreshSymbolicValue();
-          }
-          this.AddMapping(v1target, v2target, rtarget);
-        }
-        else
-        {
-          // See if info is already present
-          ESymValue oldTarget = Result.LookupWithoutManifesting(resultRoots, function);
-          if (oldTarget == rtarget)
-          {
-            // no change, don't record or change anything
-            return null;
-          }
-        }
-        Result[resultRoots, function] = rtarget;
-
-        AbstractValue aval1 = G1AbstractValue(v1target);
-        AbstractValue aval2 = G2AbstractValue(v2target);
-        bool weaker;
-        AbstractValue aresult = aval1.Join(aval2, out weaker, widen);
-        Result[rtarget] = aresult;
-        if (weaker)
-        {
-          if (DoDebug)
-          {
-            Console.WriteLine("-----EGraph changed due to join of aval of [{0},{1}] (prev {2}, new {3}, join {4})",
-              v1target, v2target, aval1.ToString(), aval2.ToString(), aresult.ToString());
-          }
-          this.Changed = true;
-        }
-
-        if (DoDebug)
-        {
-          Console.WriteLine("AddJointEdge: ({0}) -{1}-> [{2},{3},{4}]",
-            resultRoots.ToString(", "), Function2String(function), v1target, v2target, rtarget);
-        }
-        return (newBinding) ? rtarget : null;
-      }
-
-      /// <summary>
-      /// Note that either v1target or v2target may be null in order to allow manifestation on joins
-      /// </summary>
-      private ESymValue/*?*/ AddJointEdge(ESymValue v1target, ESymValue v2target, Constant function, ESymValue resultRoot) {
-        ESymValue rtarget = LookupMap(v1target, v2target);
-        bool newBinding = false;
-        if (rtarget == null) {
-          // if we have visited v1target before, then the result graph is not isomorphic to G1
-          if (VisitedKey1(v1target, v2target))
-          {
-            if (DoDebug)
+            public void Replay(EGraph<Constant, AbstractValue> common)
             {
-              Console.WriteLine("---Egraph changed due to pre-existing mapping in G1 of {0}", v1target);
+                PrimeMapWithCommon();
+                Replay(this.G1.updates, common.updates);
+                Replay(this.G2.updates, common.updates);
             }
-            this.Changed = true;
 
-            if (v1target == null)
+            public void ReplayEliminations(EGraph<Constant, AbstractValue> common)
             {
-              if (manifested.Contains(v2target))
-              {
-                return null; // can only manifest once
-              }
-              manifested.Add(v2target);
+                ReplayEliminations(this.G1.updates, common.updates);
+                ReplayEliminations(this.G2.updates, common.updates);
             }
-            if (v2target == null)
+
+            /// <summary>
+            /// Must add to map entries for (sv,sv) -> sv for all common variables sv that are
+            /// present in both G1 and G2
+            /// </summary>
+            private void PrimeMapWithCommon()
             {
-              if (manifested.Contains(v1target))
-              {
-                return null; // manifesting
-              }
-              manifested.Add(v1target);
+                FList<ESymValue> triggers = null;
+                foreach (ESymValue sv in G1.eqTermMap.Keys)
+                {
+                    if (!IsCommon(sv)) continue;
+                    if (!(G2.eqTermMap.Contains(sv) || G2.eqMultiTermMap.Contains(sv))) continue;
+                    // common one
+                    if (G1.multiTermMap.ContainsKey1(sv)) triggers = triggers.Cons(sv);
+                    this.AddMapping(sv, sv, sv);
+                }
+                foreach (var sv in G1.eqMultiTermMap.Keys)
+                {
+                    if (!IsCommon(sv)) continue;
+                    if (!(G2.eqTermMap.Contains(sv) || G2.eqMultiTermMap.Contains(sv))) continue;
+                    // common one
+                    if (Map[sv, sv] != null) continue;
+                    if (G1.multiTermMap.ContainsKey1(sv)) triggers = triggers.Cons(sv);
+                    this.AddMapping(sv, sv, sv);
+                }
+                while (triggers != null)
+                {
+                    var trigger = triggers.Head;
+                    triggers = triggers.Tail;
+                    foreach (var slice in G1.multiTermMap.Keys2(trigger))
+                    {
+                        JoinMultiEdge(trigger, trigger, slice);
+                    }
+                }
             }
-          }
-          newBinding = true;
-          if (v1target != null && v1target.UniqueId <= lastCommonVariable && v1target == v2target) {
-            rtarget = v1target; // reuse old symbol
-          }
-          else {
-            rtarget = Result.FreshSymbolicValue();
-          }
-          this.AddMapping(v1target, v2target, rtarget);
-        }
-        else {
-          // See if info is already present
-          ESymValue oldTarget = Result.LookupWithoutManifesting(resultRoot, function);
-          if (oldTarget == rtarget) {
-            // no change, don't record or change anything
-            return null;
-          }
-        }
-        Result[resultRoot, function] = rtarget;
 
-        AbstractValue aval1 = G1AbstractValue(v1target);
-        AbstractValue aval2 = G2AbstractValue(v2target);
-        bool weaker;
-        AbstractValue aresult =  aval1.Join(aval2, out weaker, widen);
-        Result[rtarget] = aresult;
-        if (weaker)
-        {
-          if (DoDebug)
-          {
-            Console.WriteLine("-----EGraph changed due to join of aval of [{0},{1}] (prev {2}, new {3}, join {4})",
-              v1target, v2target, aval1.ToString(), aval2.ToString(), aresult.ToString());
-          }
-          this.Changed = true;
-        }
-
-        if (DoDebug) {
-          Console.WriteLine("AddJointEdge: {0} -{1}-> [{2},{3},{4}]",
-            resultRoot, Function2String(function), v1target, v2target, rtarget); 
-        }
-        return (newBinding)?rtarget:null;
-      }
-
-      private ESymValue LookupMap(ESymValue v1target, ESymValue v2target)
-      {
-        if (v1target == null || v2target == null) return null;
-        return Map[v1target, v2target];
-      }
-
-      private AbstractValue G2AbstractValue(ESymValue v2target)
-      {
-        if (v2target == null) return G2.underlyingTopValue.ForManifestedField();
-        return G2[v2target];
-      }
-
-      private AbstractValue G1AbstractValue(ESymValue v1target)
-      {
-        if (v1target == null) return G1.underlyingTopValue.ForManifestedField();
-        return G1[v1target];
-      }
-
-      private bool VisitedKey1(ESymValue v1target, ESymValue v2target)
-      {
-        if (v1target == null)
-        {
-          // use visitedKey1 as a recursion breaker for v2target as well
-          return visitedKey1.Contains(v2target);
-        }
-        return visitedKey1.Contains(v1target) || Map.ContainsKey1(v1target);
-      }
-
-      public void AddMapping(ESymValue v1, ESymValue v2, ESymValue result)
-      {
-        if (v2 == null)
-        {
-          // record the fact that we use v1
-          this.visitedKey1 = this.visitedKey1.Add(v1);
-        }
-        else
-        {
-          if (v1 != null)
-          {
-            this.Map = this.Map.Add(v1, v2, result);
-          }
-          else
-          {
-            // add recursion breaker v2
-            this.visitedKey1 = this.visitedKey1.Add(v2);
-          }
-        }
-        this.AddTuple(v1, v2, result);
-      }
-
-      void AddTuple(ESymValue s1, ESymValue s2, ESymValue result)
-      {
-        this.tuples = this.tuples.Cons(new Microsoft.Research.DataStructures.STuple<ESymValue,ESymValue,ESymValue>(s1,s2,result));
-      }
-
-      public void Replay(EGraph<Constant,AbstractValue> common) {
-        PrimeMapWithCommon();
-        Replay(this.G1.updates, common.updates);
-        Replay(this.G2.updates, common.updates);
-      }
-
-      public void ReplayEliminations(EGraph<Constant, AbstractValue> common)
-      {
-        ReplayEliminations(this.G1.updates, common.updates);
-        ReplayEliminations(this.G2.updates, common.updates);
-      }
-
-      /// <summary>
-      /// Must add to map entries for (sv,sv) -> sv for all common variables sv that are
-      /// present in both G1 and G2
-      /// </summary>
-      private void PrimeMapWithCommon() {
-        FList<ESymValue> triggers = null;
-        foreach (ESymValue sv in G1.eqTermMap.Keys) {
-          if (!IsCommon(sv)) continue;
-          if (!(G2.eqTermMap.Contains(sv) || G2.eqMultiTermMap.Contains(sv))) continue;
-          // common one
-          if (G1.multiTermMap.ContainsKey1(sv)) triggers = triggers.Cons(sv);
-          this.AddMapping(sv, sv, sv);
-        }
-        foreach (var sv in G1.eqMultiTermMap.Keys) {
-          if (!IsCommon(sv)) continue;
-          if (!(G2.eqTermMap.Contains(sv) || G2.eqMultiTermMap.Contains(sv))) continue;
-          // common one
-          if (this.Map[sv, sv] != null) continue;
-          if (G1.multiTermMap.ContainsKey1(sv)) triggers = triggers.Cons(sv);
-          this.AddMapping(sv, sv, sv);
-        }
-        while (triggers != null)
-        {
-          var trigger = triggers.Head;
-          triggers = triggers.Tail;
-          foreach (var slice in G1.multiTermMap.Keys2(trigger))
-          {
-            JoinMultiEdge(trigger, trigger, slice);
-          }
-        }
-      }
-
-      private void Replay(FList<Update> updates, FList<Update> common) {
-        // First reverse updates.
-        Update oldest = Update.Reverse(updates, common);
-        while (oldest != null) {
-          oldest.Replay(this);
-          oldest = oldest.Next;
-        }
-      }
-
-      private void ReplayEliminations(FList<Update> updates, FList<Update> common)
-      {
-        // First reverse updates.
-        Update oldest = Update.Reverse(updates, common);
-        while (oldest != null) {
-          oldest.ReplayElimination(this);
-          oldest = oldest.Next;
-        }
-      }
-
-
-      #region Updates
-
-      public class EdgeUpdate : Update {
-        readonly ESymValue from;
-        readonly Constant function;
-
-        public EdgeUpdate(ESymValue from, Constant function) {
-          this.from = from;
-          this.function = function;
-        }
-
-        public override void ReplayElimination(MergeState merge)
-        {
-          // nothing to do
-          return;
-        }
-
-        /// <summary>
-        /// This replay actually throws away information in the following case.
-        /// If from is not common, but is related to another
-        /// variable in G2. This can happen as follows:
-        /// Both graphs perform an edge update from a common variable c to b1 (b2) respectively. 
-        /// These edge updates will be properly
-        /// captured in this replay and b1 will be related to b2, mapping to b3 in the new graph.
-        /// If both graphs further contain an edge update b1 (b2) -> c1 (c2), then the replay code below will throw it 
-        /// away, even though it would make sense to map b3 -> c3 in the new graph, relating c1,c2 -> c3.
-        /// </summary>
-        public override void Replay(MergeState merge) {
-          if (!merge.IsCommon(from)) return;
-
-          ESymValue v1target = merge.G1.LookupWithoutManifesting(from,function);
-          ESymValue v2target = merge.G2.LookupWithoutManifesting(from,function);
-
-          if (DoDebug) {
-            Console.WriteLine("Replay edge update: {0} -{3}-> [ {1}, {2} ]", from.ToString(), v1target, v2target, function);
-          }
-
-          if (v1target == null) {
-            // not in G1
-            if (function.KeepAsBottomField && merge.G1.HasAllBottomFields(from))
+            private void Replay(FList<Update> updates, FList<Update> common)
             {
-              // allowed to maintain this edge
-              v1target = merge.G1.bottomPlaceHolder;
+                // First reverse updates.
+                Update oldest = Update.Reverse(updates, common);
+                while (oldest != null)
+                {
+                    oldest.Replay(this);
+                    oldest = oldest.Next;
+                }
             }
+
+            private void ReplayEliminations(FList<Update> updates, FList<Update> common)
+            {
+                // First reverse updates.
+                Update oldest = Update.Reverse(updates, common);
+                while (oldest != null)
+                {
+                    oldest.ReplayElimination(this);
+                    oldest = oldest.Next;
+                }
+            }
+
+
+            #region Updates
+
+            public class EdgeUpdate : Update
+            {
+                private readonly ESymValue from;
+                private readonly Constant function;
+
+                public EdgeUpdate(ESymValue from, Constant function)
+                {
+                    this.from = from;
+                    this.function = function;
+                }
+
+                public override void ReplayElimination(MergeState merge)
+                {
+                    // nothing to do
+                    return;
+                }
+
+                /// <summary>
+                /// This replay actually throws away information in the following case.
+                /// If from is not common, but is related to another
+                /// variable in G2. This can happen as follows:
+                /// Both graphs perform an edge update from a common variable c to b1 (b2) respectively. 
+                /// These edge updates will be properly
+                /// captured in this replay and b1 will be related to b2, mapping to b3 in the new graph.
+                /// If both graphs further contain an edge update b1 (b2) -> c1 (c2), then the replay code below will throw it 
+                /// away, even though it would make sense to map b3 -> c3 in the new graph, relating c1,c2 -> c3.
+                /// </summary>
+                public override void Replay(MergeState merge)
+                {
+                    if (!merge.IsCommon(from)) return;
+
+                    ESymValue v1target = merge.G1.LookupWithoutManifesting(from, function);
+                    ESymValue v2target = merge.G2.LookupWithoutManifesting(from, function);
+
+                    if (DoDebug)
+                    {
+                        Console.WriteLine("Replay edge update: {0} -{3}-> [ {1}, {2} ]", from.ToString(), v1target, v2target, function);
+                    }
+
+                    if (v1target == null)
+                    {
+                        // not in G1
+                        if (function.KeepAsBottomField && merge.G1.HasAllBottomFields(from))
+                        {
+                            // allowed to maintain this edge
+                            v1target = merge.G1.bottomPlaceHolder;
+                        }
 #if ALLOW_MANIFESTATION
-            // can we manifest it?
-            else if (v2target != null && !merge.widen && function.ManifestField)
-            {
-              // manifest in G1
-              // Result changed over G1 (not semantically, but representationally)
-              if (DoDebug)
-              {
-                Console.WriteLine("---EGraph changed due to manifestation of a top edge in G1");
-              }
-              merge.Changed = true;
+                        // can we manifest it?
+                        else if (v2target != null && !merge.widen && function.ManifestField)
+                        {
+                            // manifest in G1
+                            // Result changed over G1 (not semantically, but representationally)
+                            if (DoDebug)
+                            {
+                                Console.WriteLine("---EGraph changed due to manifestation of a top edge in G1");
+                            }
+                            merge.Changed = true;
 
-              // leave v1target == null and let it be manifested in AddJointEdge
-            }
-            else
+                            // leave v1target == null and let it be manifested in AddJointEdge
+                        }
+                        else
 #endif
-            {
-              // no longer in G1
-              return;
-            }
-          }
-          if (v2target == null) {
-            if (function.KeepAsBottomField && merge.G2.HasAllBottomFields(from))
-            {
-              // allowed to maintain this edge
-              v2target = merge.G2.bottomPlaceHolder;
-            }
+                        {
+                            // no longer in G1
+                            return;
+                        }
+                    }
+                    if (v2target == null)
+                    {
+                        if (function.KeepAsBottomField && merge.G2.HasAllBottomFields(from))
+                        {
+                            // allowed to maintain this edge
+                            v2target = merge.G2.bottomPlaceHolder;
+                        }
 #if ALLOW_MANIFESTATION
-            else if (!merge.widen && function.ManifestField)
-            {
-              // manifest in G2
-              // leave v2target == null and let it be manifested in AddJointEdge
-            }
+                        else if (!merge.widen && function.ManifestField)
+                        {
+                            // manifest in G2
+                            // leave v2target == null and let it be manifested in AddJointEdge
+                        }
 #endif
-            else
+                        else
+                        {
+                            // no longer in G2
+                            if (DoDebug)
+                            {
+                                Console.WriteLine("---EGraph changed during EdgeUpdate due to missing target in G2");
+                            }
+                            merge.Changed = true; // no longer in result.
+                            return;
+                        }
+                    }
+
+                    ESymValue rtarget = merge.AddJointEdge(v1target, v2target, function, from);
+
+                    if (rtarget != null && rtarget.UniqueId > merge.lastCommonVariable)
+                    {
+                        merge.JoinSymbolicValue(v1target, v2target, rtarget);
+                    }
+                }
+            }
+
+            public class MultiEdgeUpdate : Update
             {
-              // no longer in G2
-              if (DoDebug)
-              {
-                Console.WriteLine("---EGraph changed during EdgeUpdate due to missing target in G2");
-              }
-              merge.Changed = true; // no longer in result.
-              return;
+                private readonly ESymValue[] from;
+                private readonly Constant function;
+
+                public MultiEdgeUpdate(ESymValue[] from, Constant function)
+                {
+                    this.from = from;
+                    this.function = function;
+                }
+
+                public override void ReplayElimination(MergeState merge)
+                {
+                    // nothing to do
+                    return;
+                }
+
+                /// <summary>
+                /// </summary>
+                public override void Replay(MergeState merge)
+                {
+                    int arity = from.Length;
+                    for (int i = 0; i < arity; i++)
+                    {
+                        var arg = from[i];
+                        if (!merge.IsCommon(arg)) continue;
+
+                        merge.JoinMultiEdge(arg, arg, new MultiEdge(function, i, arity));
+                    }
+                }
             }
-          }
-        
-          ESymValue rtarget = merge.AddJointEdge(v1target, v2target, function, from);
 
-          if (rtarget != null && rtarget.UniqueId > merge.lastCommonVariable) {
-            merge.JoinSymbolicValue(v1target, v2target, rtarget); 
-          }
-        }
-      }
-
-      public class MultiEdgeUpdate : Update
-      {
-        readonly ESymValue[] from;
-        readonly Constant function;
-
-        public MultiEdgeUpdate(ESymValue[] from, Constant function)
-        {
-          this.from = from;
-          this.function = function;
-        }
-
-        public override void ReplayElimination(MergeState merge)
-        {
-          // nothing to do
-          return;
-        }
-
-        /// <summary>
-        /// </summary>
-        public override void Replay(MergeState merge)
-        {
-          int arity = from.Length;
-          for (int i = 0; i < arity; i++)
-          {
-            var arg = from[i];
-            if (!merge.IsCommon(arg)) continue;
-
-            merge.JoinMultiEdge(arg, arg, new MultiEdge(function, i, arity));
-          }
-        }
-      }
-
-      public class AValUpdate : Update
-      {
-        readonly ESymValue sv;
-
-        public AValUpdate(ESymValue sv) {
-          this.sv = sv;
-        }
-
-        public override void ReplayElimination(MergeState merge)
-        {
-          if (!merge.IsCommon(this.sv)) return;
-          AbstractValue av1 = merge.G1[this.sv];
-          if (av1.IsTop) {
-            merge.Result[this.sv] = av1;
-            return;
-          }
-          AbstractValue av2 = merge.G2[this.sv];
-          if (av2.IsTop) {
-            merge.Result[this.sv] = av2;
-          }
-          return;
-        }
-
-        public override void Replay(MergeState merge) {
-          if (!merge.IsCommon(this.sv)) return;
-
-          AbstractValue av1 = merge.G1[this.sv];
-          AbstractValue av2 = merge.G2[this.sv];
-
-          AbstractValue old = merge.Result[this.sv];
-
-          bool weaker;
-          AbstractValue join = av1.Join(av2, out weaker, merge.widen);
-          if (weaker)
-          {
-            if (DoDebug)
+            public class AValUpdate : Update
             {
-              Console.WriteLine("----EGraph changed during AValUpdate of {3} due to weaker aval join (prev {0}, new {1}, result {2})", av1.ToString(), av2.ToString(), join.ToString(), this.sv.ToString());
+                private readonly ESymValue sv;
+
+                public AValUpdate(ESymValue sv)
+                {
+                    this.sv = sv;
+                }
+
+                public override void ReplayElimination(MergeState merge)
+                {
+                    if (!merge.IsCommon(sv)) return;
+                    AbstractValue av1 = merge.G1[sv];
+                    if (av1.IsTop)
+                    {
+                        merge.Result[sv] = av1;
+                        return;
+                    }
+                    AbstractValue av2 = merge.G2[sv];
+                    if (av2.IsTop)
+                    {
+                        merge.Result[sv] = av2;
+                    }
+                    return;
+                }
+
+                public override void Replay(MergeState merge)
+                {
+                    if (!merge.IsCommon(sv)) return;
+
+                    AbstractValue av1 = merge.G1[sv];
+                    AbstractValue av2 = merge.G2[sv];
+
+                    AbstractValue old = merge.Result[sv];
+
+                    bool weaker;
+                    AbstractValue join = av1.Join(av2, out weaker, merge.widen);
+                    if (weaker)
+                    {
+                        if (DoDebug)
+                        {
+                            Console.WriteLine("----EGraph changed during AValUpdate of {3} due to weaker aval join (prev {0}, new {1}, result {2})", av1.ToString(), av2.ToString(), join.ToString(), sv.ToString());
+                        }
+                        merge.Changed = true;
+                    }
+
+                    if (!join.Equals(old))
+                    {
+                        merge.Result[sv] = join;
+                    }
+                }
             }
-            merge.Changed = true;
-          }
 
-          if (!join.Equals(old)) {
-            merge.Result[this.sv] = join;
-          }
-        }
-      }
+            public class EqualityUpdate : Update
+            {
+                private readonly ESymValue sv1;
+                private readonly ESymValue sv2;
 
-      public class EqualityUpdate : Update {
-        readonly ESymValue sv1;
-        readonly ESymValue sv2;
+                public EqualityUpdate(ESymValue sv1, ESymValue sv2)
+                {
+                    this.sv1 = sv1;
+                    this.sv2 = sv2;
+                }
 
-        public EqualityUpdate(ESymValue sv1, ESymValue sv2) {
-          this.sv1 = sv1;
-          this.sv2 = sv2;
-        }
+                public override void ReplayElimination(MergeState merge)
+                {
+                    return; // nothing to do
+                }
 
-        public override void ReplayElimination(MergeState merge)
-        {
-          return; // nothing to do
-        }
+                public override void Replay(MergeState merge)
+                {
+                    if (!merge.IsCommon(sv1)) return;
+                    if (!merge.IsCommon(sv2)) return;
 
-        public override void Replay(MergeState merge) {
-          if (!merge.IsCommon(this.sv1)) return;
-          if (!merge.IsCommon(this.sv2)) return;
-
-          if (merge.G1.IsEqual(this.sv1, this.sv2)) {
-            if (merge.Result.IsEqual(this.sv1, this.sv2)) {
-              // already present
-              return;
+                    if (merge.G1.IsEqual(sv1, sv2))
+                    {
+                        if (merge.Result.IsEqual(sv1, sv2))
+                        {
+                            // already present
+                            return;
+                        }
+                        if (merge.G2.IsEqual(sv1, sv2))
+                        {
+                            // add equality
+                            merge.Result.AssumeEqual(sv1, sv2);
+                        }
+                        else
+                        {
+                            // Changed vs G1 (since not present in output)
+                            if (DoDebug)
+                            {
+                                Console.WriteLine("---Egraph changed during EqualityUpdate, as equality ({0},{1}) is missing in new", sv1.ToString(), sv2.ToString());
+                            }
+                            merge.Changed = true;
+                        }
+                    }
+                }
             }
-            if (merge.G2.IsEqual(this.sv1, this.sv2)) {
-              // add equality
-              merge.Result.AssumeEqual(this.sv1, this.sv2);
+
+            public class EliminateEdgeUpdate : Update
+            {
+                private readonly ESymValue from;
+                private readonly Constant function;
+
+                public EliminateEdgeUpdate(ESymValue from, Constant function)
+                {
+                    this.from = from;
+                    this.function = function;
+                }
+
+                public override void ReplayElimination(MergeState merge)
+                {
+                    if (!merge.IsCommon(from)) return;
+                    merge.Result.Eliminate(function, from);
+                }
+
+                public override void Replay(MergeState merge)
+                {
+                    if (!merge.IsCommon(from)) return;
+                    ESymValue v1target = merge.G1.LookupWithoutManifesting(from, function);
+                    ESymValue v2target = merge.G2.LookupWithoutManifesting(from, function);
+
+                    if (v1target != null && v2target != null)
+                    {
+                        // outdated
+                        return;
+                    }
+
+                    if (v1target != null)
+                    {
+                        if (DoDebug)
+                        {
+                            Console.WriteLine("---Egraph changed due to EliminateEdgeUpdate {0}-{1}-> that is only in G2", from.ToString(), function.ToString());
+                        }
+                        merge.Changed = true;
+                    }
+                    ESymValue rtarget = merge.Result.LookupWithoutManifesting(from, function);
+                    if (rtarget == null)
+                    {
+                        // redundant
+                        return;
+                    }
+                    merge.Result.Eliminate(function, from);
+                }
             }
-            else {
-              // Changed vs G1 (since not present in output)
-              if (DoDebug) {
-                Console.WriteLine("---Egraph changed during EqualityUpdate, as equality ({0},{1}) is missing in new", this.sv1.ToString(), this.sv2.ToString());
-              }
-              merge.Changed = true;
-            }
-          }
-        }
-      }
 
-      public class EliminateEdgeUpdate : Update {
-        readonly ESymValue from;
-        readonly Constant function;
+            #endregion
 
-        public EliminateEdgeUpdate(ESymValue from, Constant function) {
-          this.from = from;
-          this.function = function;
-        }
+            #region IMergeInfo members
 
-        public override void ReplayElimination(MergeState merge)
-        {
-          if (!merge.IsCommon(this.from)) return;
-          merge.Result.Eliminate(this.function, this.from);
-        }
-
-        public override void Replay(MergeState merge) {
-          if (!merge.IsCommon(this.from)) return;
-          ESymValue v1target = merge.G1.LookupWithoutManifesting(this.from, this.function);
-          ESymValue v2target = merge.G2.LookupWithoutManifesting(this.from, this.function);
-
-          if (v1target != null && v2target != null) { 
-            // outdated
-            return;
-          }
-
-          if (v1target != null) {
-            if (DoDebug) {
-              Console.WriteLine("---Egraph changed due to EliminateEdgeUpdate {0}-{1}-> that is only in G2", this.from.ToString(), this.function.ToString());
-            }
-            merge.Changed = true;
-          }
-          ESymValue rtarget = merge.Result.LookupWithoutManifesting(this.from, this.function);
-          if (rtarget == null) {
-            // redundant
-            return;
-          }
-          merge.Result.Eliminate(this.function, this.from);
-        }
-      }
-
-      #endregion
-
-      #region IMergeInfo members
-
-      public IEnumerable<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, ESymValue>> MergeTriples
-      {
-        get
-        {
+            public IEnumerable<Microsoft.Research.DataStructures.STuple<ESymValue, ESymValue, ESymValue>> MergeTriples
+            {
+                get
+                {
 #if false
-          foreach (ESymValue s1 in this.Map.Keys1)
-          {
-            foreach (ESymValue s2 in this.Map.Keys2(s1))
-            {
-              yield return new Tuple<ESymValue, ESymValue, ESymValue>(s1, s2, this.Map[s1, s2]);
-            }
-          }
+                    foreach (ESymValue s1 in Map.Keys1)
+                    {
+                        foreach (ESymValue s2 in Map.Keys2(s1))
+                        {
+                            yield return new Tuple<ESymValue, ESymValue, ESymValue>(s1, s2, Map[s1, s2]);
+                        }
+                    }
 #endif
-          var tups = this.tuples;
-          while (tups != null)
-          {
-            yield return tups.Head;
-            tups = tups.Tail;
-          }
-        }
-      }
-
-      public bool IsResult<C, ADomain>(EGraph<C, ADomain> egraph)
-        where C : IEquatable<C>, IConstantInfo
-        where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>
-      {
-        return (object)egraph == this.Result;
-      }
-
-      public bool IsGraph1<C, ADomain>(EGraph<C, ADomain> egraph)
-        where C : IEquatable<C>, IConstantInfo
-        where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>
-      {
-        if ((object)egraph == this.G1) return true;
-        if (this.G1.parent == (object)egraph && this.G1.updates == (object)egraph.updates) return true;
-        return false;
-      }
-
-      public bool IsGraph2<C, ADomain>(EGraph<C, ADomain> egraph)
-        where C : IEquatable<C>, IConstantInfo
-        where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>
-      {
-        if ((object)egraph == this.G2) return true;
-        if (this.G2.parent == (object)egraph && this.G2.updates == (object)egraph.updates) return true;
-        return false;
-      }
-
-      public IFunctionalMap<ESymValue, ESymValue> BackwardG1Map
-      {
-        get { throw new NotImplementedException(); }
-      }
-
-      public IFunctionalMap<ESymValue, ESymValue> BackwardG2Map
-      {
-        get { throw new NotImplementedException(); }
-      }
-
-      public IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG1Map
-      {
-        get
-        {
-          IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
-          for (var tups = this.tuples; tups != null; tups = tups.Tail)
-          {
-            var tuple = tups.Head;
-            var key1 = tuple.One;
-            if (key1 != null)
-            {
-              forward = forward.Add(key1, forward[key1].Cons(tuple.Three));
-            }
-          }
-          return forward;
-        }
-      }
-
-      public IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG2Map
-      {
-        get
-        {
-          IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
-          for (var tups = this.tuples; tups != null; tups = tups.Tail)
-          {
-            var tuple = tups.Head;
-            var key2 = tuple.Two;
-            if (key2 != null)
-            {
-              forward = forward.Add(key2, forward[key2].Cons(tuple.Three));
-            }
-          }
-          return forward;
-        }        
-      }
-
-      #endregion
-
-      /// <summary>
-      /// Performs additional check to see if Result == G1 for multiargument functions
-      /// </summary>
-      internal void Commit()
-      {
-        // we can only make Changed more true in this code.
-        if (this.Changed) return;
-
-        // check for each "valid" term in G1 whether we have the corresponding term in G2.
-        // NOTE that some valid terms are actually unreachable and we need to consider that
-        // as well.
-        //
-        foreach (var pair in this.G1.ValidMultiTerms)
-        {
-          var term = pair.Two;
-          Contract.Assume(term.Args.Length > 1); // F: Added because of the precondition below
-          ESymValue[] resultArgs = new ESymValue[term.Args.Length];
-          Contract.Assert(term.Args.Length > 1, "Help Clousot");
-          for (int i = 0; i < resultArgs.Length; i++)
-          {
-            var key1 = term.Args[i];
-            if (!this.VisitedKey1(key1, null))
-            {
-              // key1 not reached. There are 2 cases:
-              // 1) not reachable via normal edges in G1. Thus garbage.
-              // 2) reachable via a multi-edge. In this case, there is another multiterm that we will
-              //    find.
-              // In either case, we can disregard this term.
-              goto ContinueOuter;
-            }
-            int count = 0;
-            foreach (var key2 in this.Map.Keys2(key1))
-            {
-              count++;
-              if (count != 1) { goto Changed; }
-              resultArgs[i] = Map[key1, key2];
-              if (resultArgs[i] == null) { goto Changed; }
-            }
-            if (count != 1) { goto Changed; }
-          }
-          {
-            var result = Result.LookupWithoutManifesting(resultArgs, term.Function);
-            if (result == null) { goto Changed; }
-            var target1 = pair.One;
-            int count = 0;
-            foreach (var target2 in this.Map.Keys2(target1).AssumeNotNull())
-            {
-              count++;
-              if (count != 1) { goto Changed; }
-              var target = Map[target1, target2];
-              if (target != result) { goto Changed; }
-            }
-            if (count != 1) { goto Changed; }
-          }
-        ContinueOuter: ;
-
-        }
-        return; // ok
-      Changed:
-        this.Changed = true;
-        return; 
-      }
-    }  
-
-
-    #endregion
-
-
-
-    [Pure]
-    public void Dump(TextWriter tw) 
-    {
-      if(tw == null)
-      {
-        return;
-      }
-
-      var seen = new Set<ESymValue>();
-      var wl = new WorkList<ESymValue>();
-      var triggers = FunctionalIntKeyMap<ESymValue, int>.Empty(ESymValue.GetUniqueKey);
-    
-      Console.WriteLine("EGraphId:{0}", this.egraphId);
-      Console.WriteLine("LastSymbolId:{0}", this.idCounter);
-      foreach (Constant function in this.termMap.Keys2(this.constRoot))
-      {
-        ESymValue target = this[this.constRoot, function];
-
-        tw.WriteLine("{0} = {1}", Function2String(function), target);
-
-        wl.Add(target);
-      }
-
-      while (!wl.IsEmpty)
-      {
-        ESymValue v = wl.Pull();
-        if (!seen.AddQ(v)) continue;
-
-        foreach (var function in this.termMap.Keys2(v).AssumeNotNull())
-        {
-          ESymValue target = this[v, function];
-          tw.WriteLine("{0}({2}) = {1}", Function2String(function), target, v);
-
-          wl.Add(target);
-        }
-        foreach (var multiEdge in this.multiTermMap.Keys2(v))
-        {
-          for (var candidates = this.multiTermMap[v, multiEdge]; candidates != null; candidates = candidates.Tail)
-          {
-            if (UpdateTrigger(candidates.Head, multiEdge, ref triggers))
-            {
-              var target = candidates.Head;
-              var mterm = this.eqMultiTermMap[target];
-              if (mterm.Args != null)
-              {
-                // should always be valid, but let's not crash
-                tw.Write("{0}(", Function2String(multiEdge.Function));
-                for (int i = 0; i < mterm.Args.Length; i++)
-                {
-                  if (i > 0) { tw.Write(", "); }
-                  tw.Write("{0}", mterm.Args[i]);
+                    var tups = tuples;
+                    while (tups != null)
+                    {
+                        yield return tups.Head;
+                        tups = tups.Tail;
+                    }
                 }
-                tw.WriteLine(") = {0}", target);
+            }
+
+            public bool IsResult<C, ADomain>(EGraph<C, ADomain> egraph)
+              where C : IEquatable<C>, IConstantInfo
+              where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>
+            {
+                return (object)egraph == this.Result;
+            }
+
+            public bool IsGraph1<C, ADomain>(EGraph<C, ADomain> egraph)
+              where C : IEquatable<C>, IConstantInfo
+              where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>
+            {
+                if ((object)egraph == this.G1) return true;
+                if (this.G1.parent == (object)egraph && this.G1.updates == (object)egraph.updates) return true;
+                return false;
+            }
+
+            public bool IsGraph2<C, ADomain>(EGraph<C, ADomain> egraph)
+              where C : IEquatable<C>, IConstantInfo
+              where ADomain : IAbstractValueForEGraph<ADomain>, IEquatable<ADomain>
+            {
+                if ((object)egraph == this.G2) return true;
+                if (this.G2.parent == (object)egraph && this.G2.updates == (object)egraph.updates) return true;
+                return false;
+            }
+
+            public IFunctionalMap<ESymValue, ESymValue> BackwardG1Map
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public IFunctionalMap<ESymValue, ESymValue> BackwardG2Map
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG1Map
+            {
+                get
+                {
+                    IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
+                    for (var tups = tuples; tups != null; tups = tups.Tail)
+                    {
+                        var tuple = tups.Head;
+                        var key1 = tuple.One;
+                        if (key1 != null)
+                        {
+                            forward = forward.Add(key1, forward[key1].Cons(tuple.Three));
+                        }
+                    }
+                    return forward;
+                }
+            }
+
+            public IFunctionalMap<ESymValue, FList<ESymValue>> ForwardG2Map
+            {
+                get
+                {
+                    IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
+                    for (var tups = tuples; tups != null; tups = tups.Tail)
+                    {
+                        var tuple = tups.Head;
+                        var key2 = tuple.Two;
+                        if (key2 != null)
+                        {
+                            forward = forward.Add(key2, forward[key2].Cons(tuple.Three));
+                        }
+                    }
+                    return forward;
+                }
+            }
+
+            #endregion
+
+            /// <summary>
+            /// Performs additional check to see if Result == G1 for multiargument functions
+            /// </summary>
+            internal void Commit()
+            {
+                // we can only make Changed more true in this code.
+                if (this.Changed) return;
+
+                // check for each "valid" term in G1 whether we have the corresponding term in G2.
+                // NOTE that some valid terms are actually unreachable and we need to consider that
+                // as well.
+                //
+                foreach (var pair in this.G1.ValidMultiTerms)
+                {
+                    var term = pair.Two;
+                    Contract.Assume(term.Args.Length > 1); // F: Added because of the precondition below
+                    ESymValue[] resultArgs = new ESymValue[term.Args.Length];
+                    Contract.Assert(term.Args.Length > 1, "Help Clousot");
+                    for (int i = 0; i < resultArgs.Length; i++)
+                    {
+                        var key1 = term.Args[i];
+                        if (!this.VisitedKey1(key1, null))
+                        {
+                            // key1 not reached. There are 2 cases:
+                            // 1) not reachable via normal edges in G1. Thus garbage.
+                            // 2) reachable via a multi-edge. In this case, there is another multiterm that we will
+                            //    find.
+                            // In either case, we can disregard this term.
+                            goto ContinueOuter;
+                        }
+                        int count = 0;
+                        foreach (var key2 in Map.Keys2(key1))
+                        {
+                            count++;
+                            if (count != 1) { goto Changed; }
+                            resultArgs[i] = Map[key1, key2];
+                            if (resultArgs[i] == null) { goto Changed; }
+                        }
+                        if (count != 1) { goto Changed; }
+                    }
+                    {
+                        var result = Result.LookupWithoutManifesting(resultArgs, term.Function);
+                        if (result == null) { goto Changed; }
+                        var target1 = pair.One;
+                        int count = 0;
+                        foreach (var target2 in Map.Keys2(target1).AssumeNotNull())
+                        {
+                            count++;
+                            if (count != 1) { goto Changed; }
+                            var target = Map[target1, target2];
+                            if (target != result) { goto Changed; }
+                        }
+                        if (count != 1) { goto Changed; }
+                    }
+                ContinueOuter:;
+                }
+                return; // ok
+            Changed:
+                this.Changed = true;
+                return;
+            }
+        }
+
+
+        #endregion
+
+
+
+        [Pure]
+        public void Dump(TextWriter tw)
+        {
+            if (tw == null)
+            {
+                return;
+            }
+
+            var seen = new Set<ESymValue>();
+            var wl = new WorkList<ESymValue>();
+            var triggers = FunctionalIntKeyMap<ESymValue, int>.Empty(ESymValue.GetUniqueKey);
+
+            Console.WriteLine("EGraphId:{0}", egraphId);
+            Console.WriteLine("LastSymbolId:{0}", idCounter);
+            foreach (Constant function in termMap.Keys2(constRoot))
+            {
+                ESymValue target = this[constRoot, function];
+
+                tw.WriteLine("{0} = {1}", Function2String(function), target);
+
                 wl.Add(target);
-              }
             }
-          }
-        }
-      }
-      tw.WriteLine("**Abstract value map");
-      foreach (ESymValue v in seen) {
-        AbstractValue aval = this[v];
-        if (!aval.IsTop) {
-          tw.WriteLine("{0} -> {1}", v, aval);
-      }
-      }
-    }
 
-    IEnumerable<Pair<ESymValue, EGraphTerm<Constant>>> ValidMultiTerms
-    {
-      get
-      {
-        foreach (var key in this.eqMultiTermMap.Keys)
-        {
-          var term = this.eqMultiTermMap[key];
-          if (IsValidMultiTerm(term))
-          {
-            yield return new Pair<ESymValue,EGraphTerm<Constant>>(key, term);
-          }
-        }        
-      }
-    }
+            while (!wl.IsEmpty)
+            {
+                ESymValue v = wl.Pull();
+                if (!seen.AddQ(v)) continue;
 
-    bool IsValidMultiTerm(EGraphTerm<Constant> term)
-    {
-      Contract.Requires(term.Args.Length > 1); // F: Added precondition suggested by Clousot
+                foreach (var function in termMap.Keys2(v).AssumeNotNull())
+                {
+                    ESymValue target = this[v, function];
+                    tw.WriteLine("{0}({2}) = {1}", Function2String(function), target, v);
 
-      return (this.LookupWithoutManifesting(term.Args, term.Function) != null);
-    }
-
-    public static string Function2String(Constant function) 
-    {
-      return function.ToString();
-    }
-
-    #region IAbstractValueDomain<EGraph<Constant,Label,AbstractValue>> Members
-
-    public EGraph<Constant, AbstractValue> Top {
-      get { return new EGraph<Constant, AbstractValue>(this.underlyingTopValue, this.underlyingBottomValue); }
-    }
-
-    [ThreadStatic] // Because it depends on the analysis driver
-    private static EGraph<Constant, AbstractValue> BottomValue;
-
-    public EGraph<Constant, AbstractValue> Bottom {
-      get {
-        if (BottomValue == null) {
-          BottomValue = new EGraph<Constant, AbstractValue>(this.underlyingTopValue, this.underlyingBottomValue);
-          BottomValue.LockDown();
-        }
-        return BottomValue;
-      }
-    }
-
-    public bool IsTop {
-      get {
-        return this.termMap.Keys2Count(this.constRoot) == 0;
-      }
-    }
-
-    public bool IsBottom {
-      get {
-        return this == BottomValue;
-      }
-    }
-
-    public EGraph<Constant, AbstractValue> ImmutableVersion() {
-      LockDown();
-      
-      return this;
-    }
-
-    private void LockDown()
-    {
-      this.constant = true; // prevents future mods
-    }
-
-    public EGraph<Constant, AbstractValue> Meet(EGraph<Constant, AbstractValue> that) {
-      Contract.Ensures(Contract.Result<EGraph<Constant, AbstractValue>>() != null);
-      
-      if (this == that) return this;
-
-      if (this.IsBottom) return this;
-      if (that.IsBottom) return that;
-      if (this.IsTop) return that;
-      if (that.IsTop) return this;
-      return this; // not very smart
-    }
-
-    #endregion
-
-    #region IEGraph<Constant,Label,AbstractValue,EGraph<Constant,Label,AbstractValue>> Members
-
-    static bool VisitedBefore(ESymValue s2,
-      IFunctionalSet<ESymValue> backwardManifested,
-      IFunctionalMap<ESymValue, ESymValue> backward, out ESymValue s1)
-    {
-      s1 = backward[s2];
-      if (s1 == null)
-      {
-        return backwardManifested.Contains(s2);
-      }
-      return true;
-    }
-
-
-    /// <summary>
-    /// Null maps signify identity mappings
-    /// </summary>
-    public bool LessEqual(EGraph<Constant, AbstractValue> that,
-                          out IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forwardMap,
-                          out IFunctionalMap<ESymValue, ESymValue>/*?*/ backwardMap
-                         )
-    {
-      if (this.IsSameEGraph(that))
-      {
-        forwardMap = null;
-        backwardMap = null;
-        return true;
-        //return this.LessEqualIdentityMaps(that, out forwardMap, out backwardMap);
-      }
-
-      return InternalLessEqual(this, that, out forwardMap, out backwardMap);
-    }
-
-    private static bool InternalLessEqual(EGraph<Constant,AbstractValue> thisG, EGraph<Constant, AbstractValue> that, out IFunctionalMap<ESymValue, FList<ESymValue>> forwardMap, out IFunctionalMap<ESymValue, ESymValue> backwardMap)
-    {
-      int dummy;
-      var common = ComputeCommonTail(thisG, that, out dummy);
-
-      // we need to manifest things in thisG to check properly. Make sure we have a copy or a mutable graph
-      if (thisG.IsConstant) { thisG = thisG.Clone(); }
-
-      ContractHelpers.AssumeInvariant(thisG);
-
-      WorkList<EqPair> workList = new WorkList<EqPair>();
-      workList.Add(new EqPair(thisG.constRoot, that.constRoot));
-
-      // The backward graph is our evidence. We have to compute mappings even for manifested values, but not include them
-      // in the result. Thus, we use an extra set for those.
-      IFunctionalSet<ESymValue> backwardManifested = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-      IFunctionalMap<ESymValue, ESymValue> backward = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
-      IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
-      IFunctionalMap<ESymValue, int> triggers = FunctionalIntKeyMap<ESymValue, int>.Empty(ESymValue.GetUniqueKey);
-
-      if (debug)
-      {
-        Console.WriteLine("-----LessEqual");
-        Console.WriteLine("-------this--");
-        thisG.Dump(Console.Out);
-        Console.WriteLine("-------that--");
-        that.Dump(Console.Out);
-      }
-      while (!workList.IsEmpty)
-      {
-        EqPair pair = workList.Pull();
-        ESymValue source1 = pair.v1;
-        ESymValue source2 = pair.v2;
-        if (debug)
-        {
-          Console.WriteLine(" Considering {0} <= {1}", source1, source2);
-        }
-        ESymValue corresponding;
-        if (VisitedBefore(source2, backwardManifested, backward, out corresponding))
-        {
-          // visited source2 before. Makesure corresponding is equal to source1 && source1 is not null.
-          if (corresponding != null)
-          {
-            if (corresponding == source1) continue; // already in relation
-          }
-          // graphs don't match
-          if (debug)
-          {
-            Console.WriteLine("---LessEqual fails due to pre-existing relation: {0} <- {1}", corresponding, source2);
-          }
-          forwardMap = null;
-          backwardMap = null;
-          return false;
+                    wl.Add(target);
+                }
+                foreach (var multiEdge in multiTermMap.Keys2(v))
+                {
+                    for (var candidates = multiTermMap[v, multiEdge]; candidates != null; candidates = candidates.Tail)
+                    {
+                        if (UpdateTrigger(candidates.Head, multiEdge, ref triggers))
+                        {
+                            var target = candidates.Head;
+                            var mterm = eqMultiTermMap[target];
+                            if (mterm.Args != null)
+                            {
+                                // should always be valid, but let's not crash
+                                tw.Write("{0}(", Function2String(multiEdge.Function));
+                                for (int i = 0; i < mterm.Args.Length; i++)
+                                {
+                                    if (i > 0) { tw.Write(", "); }
+                                    tw.Write("{0}", mterm.Args[i]);
+                                }
+                                tw.WriteLine(") = {0}", target);
+                                wl.Add(target);
+                            }
+                        }
+                    }
+                }
+            }
+            tw.WriteLine("**Abstract value map");
+            foreach (ESymValue v in seen)
+            {
+                AbstractValue aval = this[v];
+                if (!aval.IsTop)
+                {
+                    tw.WriteLine("{0} -> {1}", v, aval);
+                }
+            }
         }
 
-        // check abstract value implication
-        AbstractValue a1 = (source1 == null) ? thisG.underlyingTopValue.ForManifestedField() : thisG[source1];
-        AbstractValue a2 = that[source2];
-
-        if (!a1.LessEqual(a2))
+        private IEnumerable<Pair<ESymValue, EGraphTerm<Constant>>> ValidMultiTerms
         {
-          // graphs differ
-          if (debug)
-          {
-            Console.WriteLine("---LessEqual fails due to abstract values: !({0} <= {1})", a1, a2);
-          }
-          forwardMap = null;
-          backwardMap = null;
-          return false;
+            get
+            {
+                foreach (var key in eqMultiTermMap.Keys)
+                {
+                    var term = eqMultiTermMap[key];
+                    if (IsValidMultiTerm(term))
+                    {
+                        yield return new Pair<ESymValue, EGraphTerm<Constant>>(key, term);
+                    }
+                }
+            }
         }
 
-        // add to relation
-        if (source1 != null)
+        private bool IsValidMultiTerm(EGraphTerm<Constant> term)
         {
-          backward = backward.Add(source2, source1);
-          // add inverse relation
-          forward = forward.Add(source1, forward[source1].Cons(source2));
+            Contract.Requires(term.Args.Length > 1); // F: Added precondition suggested by Clousot
+
+            return (this.LookupWithoutManifesting(term.Args, term.Function) != null);
         }
-        else
+
+        public static string Function2String(Constant function)
         {
-          backwardManifested = backwardManifested.Add(source2);
+            return function.ToString();
         }
-        // before relating the fields, check whether source1 is a bottom field value
-        if (!thisG.HasAllBottomFields(source1))
+
+        #region IAbstractValueDomain<EGraph<Constant,Label,AbstractValue>> Members
+
+        public EGraph<Constant, AbstractValue> Top
         {
-          if (that.HasAllBottomFields(source2))
-          {
-            // means source1 does not have bottom fields, but source2 has, meaning
-            // the relation does not hold.
+            get { return new EGraph<Constant, AbstractValue>(underlyingTopValue, underlyingBottomValue); }
+        }
+
+        [ThreadStatic] // Because it depends on the analysis driver
+        private static EGraph<Constant, AbstractValue> BottomValue;
+
+        public EGraph<Constant, AbstractValue> Bottom
+        {
+            get
+            {
+                if (BottomValue == null)
+                {
+                    BottomValue = new EGraph<Constant, AbstractValue>(underlyingTopValue, underlyingBottomValue);
+                    BottomValue.LockDown();
+                }
+                return BottomValue;
+            }
+        }
+
+        public bool IsTop
+        {
+            get
+            {
+                return termMap.Keys2Count(constRoot) == 0;
+            }
+        }
+
+        public bool IsBottom
+        {
+            get
+            {
+                return this == BottomValue;
+            }
+        }
+
+        public EGraph<Constant, AbstractValue> ImmutableVersion()
+        {
+            LockDown();
+
+            return this;
+        }
+
+        private void LockDown()
+        {
+            constant = true; // prevents future mods
+        }
+
+        public EGraph<Constant, AbstractValue> Meet(EGraph<Constant, AbstractValue> that)
+        {
+            Contract.Ensures(Contract.Result<EGraph<Constant, AbstractValue>>() != null);
+
+            if (this == that) return this;
+
+            if (this.IsBottom) return this;
+            if (that.IsBottom) return that;
+            if (this.IsTop) return that;
+            if (that.IsTop) return this;
+            return this; // not very smart
+        }
+
+        #endregion
+
+        #region IEGraph<Constant,Label,AbstractValue,EGraph<Constant,Label,AbstractValue>> Members
+
+        private static bool VisitedBefore(ESymValue s2,
+          IFunctionalSet<ESymValue> backwardManifested,
+          IFunctionalMap<ESymValue, ESymValue> backward, out ESymValue s1)
+        {
+            s1 = backward[s2];
+            if (s1 == null)
+            {
+                return backwardManifested.Contains(s2);
+            }
+            return true;
+        }
+
+
+        /// <summary>
+        /// Null maps signify identity mappings
+        /// </summary>
+        public bool LessEqual(EGraph<Constant, AbstractValue> that,
+                              out IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forwardMap,
+                              out IFunctionalMap<ESymValue, ESymValue>/*?*/ backwardMap
+                             )
+        {
+            if (this.IsSameEGraph(that))
+            {
+                forwardMap = null;
+                backwardMap = null;
+                return true;
+                //return this.LessEqualIdentityMaps(that, out forwardMap, out backwardMap);
+            }
+
+            return InternalLessEqual(this, that, out forwardMap, out backwardMap);
+        }
+
+        private static bool InternalLessEqual(EGraph<Constant, AbstractValue> thisG, EGraph<Constant, AbstractValue> that, out IFunctionalMap<ESymValue, FList<ESymValue>> forwardMap, out IFunctionalMap<ESymValue, ESymValue> backwardMap)
+        {
+            int dummy;
+            var common = ComputeCommonTail(thisG, that, out dummy);
+
+            // we need to manifest things in thisG to check properly. Make sure we have a copy or a mutable graph
+            if (thisG.IsConstant) { thisG = thisG.Clone(); }
+
+            ContractHelpers.AssumeInvariant(thisG);
+
+            WorkList<EqPair> workList = new WorkList<EqPair>();
+            workList.Add(new EqPair(thisG.constRoot, that.constRoot));
+
+            // The backward graph is our evidence. We have to compute mappings even for manifested values, but not include them
+            // in the result. Thus, we use an extra set for those.
+            IFunctionalSet<ESymValue> backwardManifested = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+            IFunctionalMap<ESymValue, ESymValue> backward = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
+            IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
+            IFunctionalMap<ESymValue, int> triggers = FunctionalIntKeyMap<ESymValue, int>.Empty(ESymValue.GetUniqueKey);
+
             if (debug)
             {
-              Console.WriteLine("---LessEqual fails due to bottom field difference");
+                Console.WriteLine("-----LessEqual");
+                Console.WriteLine("-------this--");
+                thisG.Dump(Console.Out);
+                Console.WriteLine("-------that--");
+                that.Dump(Console.Out);
             }
-            forwardMap = null;
-            backwardMap = null;
+            while (!workList.IsEmpty)
+            {
+                EqPair pair = workList.Pull();
+                ESymValue source1 = pair.v1;
+                ESymValue source2 = pair.v2;
+                if (debug)
+                {
+                    Console.WriteLine(" Considering {0} <= {1}", source1, source2);
+                }
+                ESymValue corresponding;
+                if (VisitedBefore(source2, backwardManifested, backward, out corresponding))
+                {
+                    // visited source2 before. Makesure corresponding is equal to source1 && source1 is not null.
+                    if (corresponding != null)
+                    {
+                        if (corresponding == source1) continue; // already in relation
+                    }
+                    // graphs don't match
+                    if (debug)
+                    {
+                        Console.WriteLine("---LessEqual fails due to pre-existing relation: {0} <- {1}", corresponding, source2);
+                    }
+                    forwardMap = null;
+                    backwardMap = null;
+                    return false;
+                }
+
+                // check abstract value implication
+                AbstractValue a1 = (source1 == null) ? thisG.underlyingTopValue.ForManifestedField() : thisG[source1];
+                AbstractValue a2 = that[source2];
+
+                if (!a1.LessEqual(a2))
+                {
+                    // graphs differ
+                    if (debug)
+                    {
+                        Console.WriteLine("---LessEqual fails due to abstract values: !({0} <= {1})", a1, a2);
+                    }
+                    forwardMap = null;
+                    backwardMap = null;
+                    return false;
+                }
+
+                // add to relation
+                if (source1 != null)
+                {
+                    backward = backward.Add(source2, source1);
+                    // add inverse relation
+                    forward = forward.Add(source1, forward[source1].Cons(source2));
+                }
+                else
+                {
+                    backwardManifested = backwardManifested.Add(source2);
+                }
+                // before relating the fields, check whether source1 is a bottom field value
+                if (!thisG.HasAllBottomFields(source1))
+                {
+                    if (that.HasAllBottomFields(source2))
+                    {
+                        // means source1 does not have bottom fields, but source2 has, meaning
+                        // the relation does not hold.
+                        if (debug)
+                        {
+                            Console.WriteLine("---LessEqual fails due to bottom field difference");
+                        }
+                        forwardMap = null;
+                        backwardMap = null;
+                        return false;
+                    }
+                    foreach (Constant c in that.Functions(source2))
+                    {
+                        // ESymValue target1 = thisG.TryLookup(c, source1);
+                        ESymValue target1 = thisG[c, source1]; // lookup or manifest
+                        ESymValue target2 = that[c, source2]; // must be present
+                        if (debug)
+                        {
+                            Console.WriteLine("    {0}-{1}->{2} <=? {3}-{4}->{5}", source1, c, target1, source2, c, target2);
+                        }
+                        workList.Add(new EqPair(target1, target2));
+                    }
+                    foreach (MultiEdge e in that.MultiEdges(source2))
+                    {
+                        for (var candidates = that.multiTermMap[source2, e]; candidates != null; candidates = candidates.Tail)
+                        {
+                            var target2 = candidates.Head;
+                            if (UpdateTrigger(target2, e, ref triggers))
+                            {
+                                var term2 = that.eqMultiTermMap[target2];
+                                Contract.Assume(term2.Args != null);
+                                // map args to this
+                                Contract.Assume(term2.Args.Length > 1); // F: Added because of precondition of LookUpWithoutManifesting below
+                                ESymValue[] thisArgs = new ESymValue[term2.Args.Length];
+                                for (int i = 0; i < thisArgs.Length; i++)
+                                {
+                                    thisArgs[i] = backward[term2.Args[i]];
+                                    Contract.Assume(thisArgs[i] != null);
+                                }
+                                // lookup term in this
+                                var target1 = thisG.LookupWithoutManifesting(thisArgs, e.Function);
+                                if (target1 == null)
+                                {
+                                    // term does not exist in this graph, so LessEqual does not hold.
+                                    if (debug)
+                                    {
+                                        Console.WriteLine("---LessEqual fails due to missing multi term {0}({1})", e.Function, term2.Args.ToString(", "));
+                                    }
+                                    forwardMap = null;
+                                    backwardMap = null;
+                                    return false;
+                                }
+                                // add target1,target2 to work list
+                                workList.Add(new EqPair(target1, target2));
+                            }
+                        }
+                    }
+                }
+            }
+            // made it here means that all edges in that graph are also in this graph.
+            forwardMap = forward;
+
+            Contract.Assume(common != null, "Making the assumption explicit");
+
+            backwardMap = CompleteWithCommon(backward, thisG, that, common.idCounter);
+            return true;
+        }
+
+        private static IFunctionalMap<ESymValue, ESymValue> CompleteWithCommon(IFunctionalMap<ESymValue, ESymValue> map, EGraph<Constant, AbstractValue> G1, EGraph<Constant, AbstractValue> G2, int lastCommonId)
+        {
+            Contract.Requires(map != null);
+
+            foreach (ESymValue sv in G1.eqTermMap.Keys)
+            {
+                if (!IsCommon(sv, lastCommonId)) continue;
+                if (map.Contains(sv)) continue;
+                map = map.Add(sv, sv);
+            }
+            foreach (var sv in G1.eqMultiTermMap.Keys)
+            {
+                if (!IsCommon(sv, lastCommonId)) continue;
+                if (map.Contains(sv)) continue;
+                map = map.Add(sv, sv);
+            }
+            return map;
+        }
+
+        private static bool IsCommon(ESymValue sv, int lastCommonId)
+        {
+            return sv.UniqueId <= lastCommonId;
+        }
+
+        private static bool UpdateTrigger(ESymValue source2, MultiEdge e, ref IFunctionalMap<ESymValue, int> triggers)
+        {
+            Contract.Ensures(triggers != null);
+
+            var newCount = triggers[source2] + 1;
+            triggers = triggers.Add(source2, newCount);
+
+            Contract.Assert(triggers != null);
+
+            if (newCount == e.Arity)
+            {
+                return true;
+            }
             return false;
-          }
-          foreach (Constant c in that.Functions(source2))
-          {
-            // ESymValue target1 = thisG.TryLookup(c, source1);
-            ESymValue target1 = thisG[c, source1]; // lookup or manifest
-            ESymValue target2 = that[c, source2]; // must be present
-            if (debug)
-            {
-              Console.WriteLine("    {0}-{1}->{2} <=? {3}-{4}->{5}", source1, c, target1, source2, c, target2);
-            }
-            workList.Add(new EqPair(target1, target2));
-          }
-          foreach (MultiEdge e in that.MultiEdges(source2))
-          {
-            for (var candidates = that.multiTermMap[source2, e]; candidates != null; candidates = candidates.Tail)
-            {
-              var target2 = candidates.Head;
-              if (UpdateTrigger(target2, e, ref triggers))
-              {
-                var term2 = that.eqMultiTermMap[target2];
-                Contract.Assume(term2.Args != null);
-                // map args to this
-                Contract.Assume(term2.Args.Length > 1); // F: Added because of precondition of LookUpWithoutManifesting below
-                ESymValue[] thisArgs = new ESymValue[term2.Args.Length];
-                for (int i = 0; i < thisArgs.Length; i++)
-                {
-                  thisArgs[i] = backward[term2.Args[i]];
-                  Contract.Assume(thisArgs[i] != null);
-                }
-                // lookup term in this
-                var target1 = thisG.LookupWithoutManifesting(thisArgs, e.Function);
-                if (target1 == null)
-                {
-                  // term does not exist in this graph, so LessEqual does not hold.
-                  if (debug)
-                  {
-                    Console.WriteLine("---LessEqual fails due to missing multi term {0}({1})", e.Function, term2.Args.ToString(", "));
-                  }
-                  forwardMap = null;
-                  backwardMap = null;
-                  return false;
-                }
-                // add target1,target2 to work list
-                workList.Add(new EqPair(target1, target2));
-              }
-            }
-          }
         }
-      }
-      // made it here means that all edges in that graph are also in this graph.
-      forwardMap = forward;
 
-      Contract.Assume(common != null, "Making the assumption explicit");
-
-      backwardMap = CompleteWithCommon(backward, thisG, that, common.idCounter);
-      return true;
-    }
-
-    private static IFunctionalMap<ESymValue,ESymValue> CompleteWithCommon(IFunctionalMap<ESymValue,ESymValue> map, EGraph<Constant, AbstractValue> G1, EGraph<Constant, AbstractValue> G2, int lastCommonId)
-    {
-      Contract.Requires(map != null);
-
-      foreach (ESymValue sv in G1.eqTermMap.Keys)
-      {
-        if (!IsCommon(sv, lastCommonId)) continue;
-        if (map.Contains(sv)) continue;
-        map = map.Add(sv, sv);
-      }
-      foreach (var sv in G1.eqMultiTermMap.Keys)
-      {
-        if (!IsCommon(sv, lastCommonId)) continue;
-        if (map.Contains(sv)) continue;
-        map = map.Add(sv, sv);
-      }
-      return map;
-    }
-
-    private static bool IsCommon(ESymValue sv, int lastCommonId)
-    {
-      return sv.UniqueId <= lastCommonId;
-    }
-
-    private static bool UpdateTrigger(ESymValue source2, MultiEdge e, ref IFunctionalMap<ESymValue, int> triggers)
-    {
-      Contract.Ensures(triggers != null);
-
-      var newCount = triggers[source2] + 1;
-      triggers = triggers.Add(source2, newCount);
-
-      Contract.Assert(triggers != null);
-
-      if (newCount == e.Arity)
-      {
-        return true;
-      }
-      return false;
-    }
-
-    private int EqTermCount(ESymValue target)
-    {
-      int count = 0;
-      foreach (EGraphTerm<Constant> eterm in this.eqTermMap[Find(target)].GetEnumerable())
-      {
-        // test if it is valid
-        if (this.TryLookup(eterm.Function, eterm.Args) == target)
+        private int EqTermCount(ESymValue target)
         {
-          count++;
+            int count = 0;
+            foreach (EGraphTerm<Constant> eterm in eqTermMap[Find(target)].GetEnumerable())
+            {
+                // test if it is valid
+                if (this.TryLookup(eterm.Function, eterm.Args) == target)
+                {
+                    count++;
+                }
+            }
+            return count;
         }
-      }
-      return count;
+
+        private bool IsSameEGraph(EGraph<Constant, AbstractValue> that)
+        {
+            if (this == that) return true;
+            return (that.parent == this && that.updates == updates);
+        }
+
+        private bool LessEqualIdentityMaps(EGraph<Constant, AbstractValue> that, out IFunctionalMap<ESymValue, FList<ESymValue>> forwardMap, out IFunctionalMap<ESymValue, ESymValue> backwardMap)
+        {
+            IFunctionalMap<ESymValue, ESymValue> backward = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
+            IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
+
+            foreach (ESymValue sv in eqTermMap.Keys.Union(eqMultiTermMap.Keys))
+            {
+                backward = backward.Add(sv, sv);
+                forward = forward.Add(sv, FList<ESymValue>.Cons(sv, null));
+            }
+            backwardMap = backward;
+            forwardMap = forward;
+            return true;
+        }
+
+        public IFunctionalMap<ESymValue, FList<ESymValue>> GetForwardIdentityMap()
+        {
+            IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
+
+            foreach (ESymValue sv in eqTermMap.Keys.Union(eqMultiTermMap.Keys))
+            {
+                forward = forward.Add(sv, FList<ESymValue>.Cons(sv, null));
+            }
+            return forward;
+        }
+
+        #endregion
+
+        #region IAbstractValue<EGraph<Constant,Label,AbstractValue>> Members
+
+
+        public bool LessEqual(EGraph<Constant, AbstractValue> that)
+        {
+            IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
+            IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
+            return this.LessEqual(that, out forward, out backward);
+        }
+
+        #endregion
+
+        internal bool IsValidSymbolc(ESymValue sv)
+        {
+            return (eqTermMap.Contains(sv));
+        }
     }
-
-    private bool IsSameEGraph(EGraph<Constant, AbstractValue> that)
-    {
-      if (this == that) return true;
-      return (that.parent == this && that.updates == this.updates);
-    }
-
-    private bool LessEqualIdentityMaps(EGraph<Constant, AbstractValue> that, out IFunctionalMap<ESymValue, FList<ESymValue>> forwardMap, out IFunctionalMap<ESymValue, ESymValue> backwardMap)
-    {
-      IFunctionalMap<ESymValue, ESymValue> backward = FunctionalIntKeyMap<ESymValue, ESymValue>.Empty(ESymValue.GetUniqueKey);
-      IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
-
-      foreach (ESymValue sv in this.eqTermMap.Keys.Union(this.eqMultiTermMap.Keys))
-      {
-        backward = backward.Add(sv, sv);
-        forward = forward.Add(sv, FList<ESymValue>.Cons(sv, null));
-      }
-      backwardMap = backward;
-      forwardMap = forward;
-      return true;
-    }
-
-    public IFunctionalMap<ESymValue, FList<ESymValue>> GetForwardIdentityMap()
-    {
-      IFunctionalMap<ESymValue, FList<ESymValue>> forward = FunctionalIntKeyMap<ESymValue, FList<ESymValue>>.Empty(ESymValue.GetUniqueKey);
-
-      foreach (ESymValue sv in this.eqTermMap.Keys.Union(this.eqMultiTermMap.Keys))
-      {
-        forward = forward.Add(sv, FList<ESymValue>.Cons(sv, null));
-      }
-      return forward;
-    }
-    
-    #endregion
-
-    #region IAbstractValue<EGraph<Constant,Label,AbstractValue>> Members
-
-
-    public bool LessEqual(EGraph<Constant, AbstractValue> that) {
-      IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
-      IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
-      return this.LessEqual(that, out forward, out backward);
-    }
-
-    #endregion
-
-    internal bool IsValidSymbolc(ESymValue sv)
-    {
-      return (this.eqTermMap.Contains(sv));
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Expression.cs
+++ b/Microsoft.Research/CodeAnalysis/Expression.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using Generics = System.Collections.Generic;
@@ -26,5146 +15,5142 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using Provenance = IEnumerable<ProofObligation>;
-  using System.Diagnostics.CodeAnalysis;
-
-  /// <summary>
-  /// Used to associated other info with an expression
-  /// </summary>
-  public enum AssociatedInfo
-  {
-    /// <summary>
-    /// Writable byte extent for pointers
-    /// </summary>
-    WritableBytes,
+    using Provenance = IEnumerable<ProofObligation>;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
-    /// Element count of an array
+    /// Used to associated other info with an expression
     /// </summary>
-    ArrayLength
-  }
-
-  /// <summary>
-  /// An expression is either
-  ///   IsNull
-  ///   IsVariable
-  ///   IsConstant
-  ///   IsSizeOf
-  ///   IsUnary
-  ///   IsBinary
-  ///   IsIsInst
-  ///
-  /// In each case, further access to data stored in that case is possible.
-  /// </summary>
-  [ContractClass(typeof(BoxedExpressionContracts))]
-  [Serializable]
-  public abstract class BoxedExpression
-  {
-    #region Protected fields
-    protected const int HashCodeUnSet = 0x5f5f5f5f;
-    private int hashCodeCache = HashCodeUnSet;
-
-    protected abstract int ComputeHashCode();
-
-    #endregion
-
-    #region Constants
-
-    public const int MaxDepthInConverting = Int32.MaxValue;
-
-    public const int DefaultDepthInConverting = 16; // some small number
-
-    #endregion
-
-    #region Statics 
-
-    // We use True/False too often, and creating them each time requires bringing around the metadatadecoder, and hence all the templates..
-    [ThreadStatic]
-    private static BoxedExpression constTrue, constFalse;
-
-    public static BoxedExpression ConstTrue
+    public enum AssociatedInfo
     {
-      get
-      {
-        return constTrue;
-      }
-      set
-      {
-        constTrue = value;
-      }
+        /// <summary>
+        /// Writable byte extent for pointers
+        /// </summary>
+        WritableBytes,
+
+        /// <summary>
+        /// Element count of an array
+        /// </summary>
+        ArrayLength
     }
 
-    public static BoxedExpression ConstFalse
+    /// <summary>
+    /// An expression is either
+    ///   IsNull
+    ///   IsVariable
+    ///   IsConstant
+    ///   IsSizeOf
+    ///   IsUnary
+    ///   IsBinary
+    ///   IsIsInst
+    ///
+    /// In each case, further access to data stored in that case is possible.
+    /// </summary>
+    [ContractClass(typeof(BoxedExpressionContracts))]
+    [Serializable]
+    public abstract class BoxedExpression
     {
-      get
-      {
-        return constFalse;
-      }
-      set
-      {
-        constFalse = value;
-      }
-    }
+        #region Protected fields
+        protected const int HashCodeUnSet = 0x5f5f5f5f;
+        private int hashCodeCache = HashCodeUnSet;
 
-    #endregion
+        protected abstract int ComputeHashCode();
 
-    #region Factory methods
+        #endregion
 
-    private static IEqualityComparer<BoxedExpression> equalityComparerCache; // Thread-safe
-    public static IEqualityComparer<BoxedExpression> EqualityComparer
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEqualityComparer<BoxedExpression>>() != null);
+        #region Constants
 
-        if (equalityComparerCache == null)
+        public const int MaxDepthInConverting = Int32.MaxValue;
+
+        public const int DefaultDepthInConverting = 16; // some small number
+
+        #endregion
+
+        #region Statics 
+
+        // We use True/False too often, and creating them each time requires bringing around the metadatadecoder, and hence all the templates..
+        [ThreadStatic]
+        private static BoxedExpression constTrue, constFalse;
+
+        public static BoxedExpression ConstTrue
         {
-          equalityComparerCache = new BoxedExpressionsEqualityComparer();
+            get
+            {
+                return constTrue;
+            }
+            set
+            {
+                constTrue = value;
+            }
         }
-        return equalityComparerCache;
-      }
-    }
 
-    private static IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> equalityPairComparerCache; // Thread-safe
-    public static IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> EqualityPairComparer
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>>() != null);
-
-        if (equalityPairComparerCache == null)
+        public static BoxedExpression ConstFalse
         {
-          equalityPairComparerCache = new BoxedExpressionKeyEqualityComparer();
+            get
+            {
+                return constFalse;
+            }
+            set
+            {
+                constFalse = value;
+            }
         }
-        return equalityPairComparerCache;
-      }
-    }
 
+        #endregion
 
-    /// <summary>
-    /// Create an External box, i.e., a subtree holding on to an ExternalExpression but that can be viewed as
-    /// an ordinary Expression
-    /// </summary>
-    public static BoxedExpression For<Type, Variable, Expression>(Expression external, IFullExpressionDecoder<Type, Variable, Expression> decoder)
-      where Expression : IEquatable<Expression>
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+        #region Factory methods
 
-      return new ClousotExpression<Type>.ExternalBox<Variable, Expression>(external, decoder);
-    }
-
-    /// <summary>
-    /// Create an ordinary Expression from the given external expression by converting it completely.
-    /// </summary>
-    /// <returns>It may return null, if the expression is too big!</returns>
-    public static BoxedExpression Convert<Type, V, T>(T exp, IFullExpressionDecoder<Type, V, T> decoder, 
-      int MAXDEPTH = DefaultDepthInConverting, bool trySimplify = true, bool replaceConstants = true, bool replaceNull=true,
-      Func<V, FList<PathElement>> accessPaths = null) 
-      where T : IEquatable<T>
-    {     
-      BoxedExpression result;
-
-      if(ClousotExpression<Type>.TryConvert(exp, decoder, MAXDEPTH, trySimplify, replaceConstants, replaceNull, accessPaths, out result))
-      {
-        return result;
-      }
-      return null;
-    }
-
-    public static BoxedExpression Var(object var)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new VariableExpression(var);
-    }
-
-    public static BoxedExpression Var(object var, FList<PathElement> path)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new VariableExpression(var, path);
-    }
-
-
-    public static BoxedExpression Var(object var, PathElement[]  path)
-    {
-        Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-        return new VariableExpression(var, path);
-    }
-
-    public static BoxedExpression Var(object var, FList<PathElement> path, object type)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new VariableExpression(var, path, type);
-    }
-
-    public static BoxedExpression VarBoundedInQuantifier(string name)
-    {
-      Contract.Requires(name != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new VariableExpression(name, true);
-    }
-
-    public static BoxedExpression VarCast<Type>(object var, PathElement[] path, Type type, Type CastTo)
-      where Type : IEquatable<Type>
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.CastExpression(new VariableExpression(var, path, (object)type), null, CastTo, false);
-    }
-
-    public static BoxedExpression VarCastUnchecked<Type>(object var, PathElement[] path, Type type, Type CastTo)
-      where Type : IEquatable<Type>
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.CastExpression(new VariableExpression(var, path, (object)type), null, CastTo, true);
-    }
-
-    public static BoxedExpression Binary(BinaryOperator op, BoxedExpression left, BoxedExpression right, object frameworkVar = null)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);      
-
-      return new BinaryExpression(op, left, right, frameworkVar);
-    }
-
-    public static BoxedExpression BinaryLogicalAnd(BoxedExpression left, BoxedExpression right)
-    {
-      if (left == null || right == null)
-        return null;
-
-      if (Object.ReferenceEquals(left, right))
-        return left;
-
-      int k;
-      if (left.IsConstantInt(out k))
-      {
-        return k == 0 ? left : right;
-      }
-      if (right.IsConstantInt(out k))
-      {
-        return k == 0 ? right : left;
-      }
-
-      return BoxedExpression.Binary(BinaryOperator.LogicalAnd, left, right);
-    }
-
-    public static BoxedExpression BinaryLogicalOr(BoxedExpression left, BoxedExpression right)
-    {
-      if (left == null || right == null)
-        return null;
-
-      if (Object.ReferenceEquals(left, right))
-        return left;
-
-      int k;
-      if (left.IsConstantInt(out k))
-      {
-        return k != 0 ? left : right;
-      }
-      if (right.IsConstantInt(out k) && k == 0)
-      {
-        return k != 0 ? right : left;
-      }
-
-      // F: Should use LogicalOr
-      return BoxedExpression.Binary(BinaryOperator.LogicalOr, left, right);
-    }
-
-    public static BoxedExpression BinaryCast<Type>(BinaryOperator op, BoxedExpression left, BoxedExpression right, Type CastTo)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.CastExpression(new BinaryExpression(op, left, right), null, CastTo, false);
-    }
-
-    public static BoxedExpression BinaryMethodToCall(BinaryOperator op, BoxedExpression left, BoxedExpression right, string method_to_call)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new BinaryExpressionMethodCall(op, left, right, method_to_call);
-    }
-
-    public static BoxedExpression Unary(UnaryOperator op, BoxedExpression arg)
-    {
-      Contract.Requires(arg != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      // normalize negations
-
-      BinaryOperator bop;
-      BoxedExpression left, right;
-      if (arg.IsBinaryExpression(out bop, out left, out right))
-      {
-        switch (bop)
+        private static IEqualityComparer<BoxedExpression> equalityComparerCache; // Thread-safe
+        public static IEqualityComparer<BoxedExpression> EqualityComparer
         {
-          case BinaryOperator.Ceq:
-          case BinaryOperator.Cobjeq:
-            return new BinaryExpression(BinaryOperator.Cne_Un, left, right);
-          case BinaryOperator.Cne_Un:
-            return new BinaryExpression(BinaryOperator.Ceq, left, right);
-          default:
-            break;
+            get
+            {
+                Contract.Ensures(Contract.Result<IEqualityComparer<BoxedExpression>>() != null);
+
+                if (equalityComparerCache == null)
+                {
+                    equalityComparerCache = new BoxedExpressionsEqualityComparer();
+                }
+                return equalityComparerCache;
+            }
         }
-      }
-      return new UnaryExpression(op, arg, null);
-    }
 
-    public static BoxedExpression UnaryLogicalNot(BoxedExpression arg)
-    {
-      Contract.Requires(arg != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new UnaryExpression(UnaryOperator.Not, arg, null);
-    }
-
-    public static BoxedExpression UnaryCast<Type>(UnaryOperator op, BoxedExpression arg, Type CastTo)
-    {
-      Contract.Requires(arg != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.CastExpression(new UnaryExpression(op, arg, null), null, CastTo, false);
-    }
-
-    public static BoxedExpression UnaryCastUnchecked<Type>(UnaryOperator op, BoxedExpression arg, Type CastTo)
-    {
-      Contract.Requires(arg != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.CastExpression(new UnaryExpression(op, arg, null), null, CastTo, true);
-    }
-
-    public static BoxedExpression Const<Local,Parameter,Field,Property,Event,Method,Type,Attribute,Assembly>(object obj, Type type, IDecodeMetaData<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly> mdDecoder)
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      Contract.Assume(!mdDecoder.Equal(type, mdDecoder.System_Int32) || obj is Int32);
-      return new ClousotExpression<Type>.ConstantExpression(obj, type);
-    }
-
-    public static BoxedExpression ConstCast<Local, Parameter, Field, Property, Event, Method, Type, Attribute, Assembly>(object obj, string name, Type type, Type type_cast, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.CastExpression(Const(obj, type, mdDecoder), name, type_cast, false);
-    }
-
-    public static BoxedExpression ConstCastUnchecked<Local, Parameter, Field, Property, Event, Method, Type, Attribute, Assembly>(object obj, Type type, Type type_cast, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.CastExpression(Const(obj, type, mdDecoder), null, type_cast, true);
-    }
-
-    public static BoxedExpression ConstBool<Local, Parameter, Field, Property, Event, Method, Type, Attribute, Assembly>(object obj, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.ConstantExpression(obj, mdDecoder.System_Boolean, true);
-    }
-
-    public static BoxedExpression Result<Type>(Type type)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.ResultExpression(type);
-    }
-
-    public static BoxedExpression Old<Type>(BoxedExpression oldExpr, Type type)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.OldExpression(oldExpr, type);
-    }
-
-    public static BoxedExpression ValueAtReturn<Type>(BoxedExpression oldExpr, Type type)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.ValueAtReturnExpression(oldExpr, type);
-    }
-
-    #endregion
-
-    #region Public methods
-    public virtual bool IsVariable
-    {
-      get { return false; }
-    }
-
-    public virtual bool IsVariableBoundedInQuantifier
-    {
-      get { return false; }
-    }
-
-    public virtual bool IsBooleanTyped
-    {
-      get { return false; }
-    }
-
-    public virtual object UnderlyingVariable 
-    { 
-      get { return null; } 
-    }
-
-    public virtual PathElement[] AccessPath
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<PathElement[]>() == null || Contract.ForAll(Contract.Result<PathElement[]>(), p => p != null));
-        return null;
-      }
-    }
-
-    public virtual bool IsConstant
-    {
-      get { return false; }
-    }
-    public virtual object Constant { get { throw new InvalidOperationException(); } }
-    public virtual object ConstantType { get { throw new InvalidOperationException(); } }
-    public virtual bool IsSizeOf
-    {
-      get { return false; }
-    }
-    public virtual bool SizeOf(out int size) { size = 0; return false; }
-    public virtual bool SizeOf(out object type, out int size) { type = null;  size = 0; return false; }
-
-    public virtual bool IsUnary
-    {
-      get { return false; }
-    }
-    public virtual UnaryOperator UnaryOp { get { throw new InvalidOperationException(); } }
-    public virtual BoxedExpression UnaryArgument
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-        throw new InvalidOperationException();
-      }
-    }
-    
-    public virtual bool IsBinary
-    {
-      get { return false; }
-    }
-    public virtual bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out right) != null);
-
-      bop = BinaryOperator.Add; // dummy
-      left = null;
-      right = null;
-      return false;
-    }
-
-    public virtual bool IsUnaryExpression(out UnaryOperator uop, out BoxedExpression left)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
-
-      uop = default(UnaryOperator); // dummy
-      left = default(BoxedExpression);
-      return false;
-    }
-
-    public virtual bool IsIsInstExpression(out BoxedExpression exp, out object type)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out exp) != null);
-
-      exp = default(BoxedExpression);
-      type = default(object);
-      return false;
-    }
-
-    public virtual BinaryOperator BinaryOp { get { throw new InvalidOperationException(); } }
-
-    public virtual BoxedExpression BinaryLeft
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-        throw new InvalidOperationException();
-      }
-    }
-
-    public virtual BoxedExpression BinaryRight
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-        throw new InvalidOperationException();
-      }
-    }
-    
-    public virtual bool IsIsInst
-    {
-      get { return false; }
-    }
-    public virtual bool IsNull
-    {
-      get { return false; }
-    }
-
-    public virtual bool IsCast
-    {
-      get { return false; }
-    }
-
-    public virtual bool IsResult
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    public virtual bool IsParameterRef
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    public virtual bool IsArrayIndex
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    public virtual bool IsArrayIndexExpression(out BoxedExpression array, out BoxedExpression index, out object type)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out array) != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out index) != null);
-
-      array = index = null;
-      type = null;
-      return false;
-    }
-
-    public virtual bool IsQuantified
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    public virtual bool IsQuantifiedExpression(out bool isForAll, out BoxedExpression boundVar, out BoxedExpression lower, out BoxedExpression upper, out BoxedExpression body)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out boundVar) != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out lower) != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out upper) != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out body) != null);
-
-      isForAll = false;
-
-      boundVar = lower = upper = body = null;
-
-      return false;
-    }
-
-    abstract public BoxedExpression Negate();
-
-    public abstract void AddFreeVariables(Set<BoxedExpression> set);
-
-    /// <summary>
-    /// If expression has associated info, such as a pointer with associated writable byte information, then this operation
-    /// returns the expression representing the info.
-    /// </summary>
-    public virtual bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
-    {
-      info = null; 
-      return false;
-    }
-
-    /// <summary>
-    /// If expression has associated info, such as a pointer with associated writable byte information, then this operation
-    /// returns the expression representing the info.
-    /// The extra PC provides information about where the associated info should hold in case of a variable.
-    /// </summary>
-    public virtual bool TryGetAssociatedInfo(APC atPC, AssociatedInfo infoKind, out BoxedExpression info)
-    {
-      info = null; return false;
-    }
-
-    /// <summary>
-    /// Replaces the occurrences of what with newExp, converting external subtrees as they are found.
-    /// </summary>
-    public virtual BoxedExpression Substitute(BoxedExpression what, BoxedExpression newExp)
-    {
-      Contract.Requires(what != null);
-      Contract.Requires(newExp != null);
-
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      if (this == what || this.Equals(what)) return newExp;
-
-      return this.RecursiveSubstitute(what, newExp);
-    }
-
-    /// <summary>
-    /// Performs the given substitution of variables.
-    /// Returns null if the converter returns null
-    /// </summary>
-    public abstract BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map);
-
-    public abstract BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null);
-
-    protected virtual BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
-    {
-      Contract.Requires(what != null);
-      Contract.Requires(newExp != null);
-
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      // default
-      return this;
-    }
-
-    public abstract void Dispatch(IBoxedExpressionVisitor visitor);
-
-    public virtual bool TryGetType(out object type)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out type) != null);
-
-      type = null;
-      return false;
-    }
-
-
-      internal abstract Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      where Visitor : IVisitMSIL<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>;
-
-    #endregion
-
-    #region System.Object overrides
-    public abstract override bool Equals(object obj);
-
-    public sealed override int GetHashCode()
-    {
-      if (this.hashCodeCache == HashCodeUnSet)
-      {
-        this.hashCodeCache = ComputeHashCode();
-      }
-      return this.hashCodeCache;
-    }
-
-    public abstract override string ToString();
-    public virtual string ToString<Typ2>(Converter<Typ2, string> converter)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return ToString(); // Default behavior
-    }
-
-    #endregion
-
-    #region SimpleSyntacticEquals
-
-    public static bool SimpleSyntacticEquality(BoxedExpression left, BoxedExpression right)
-    {
-      if (left == null || right == null)
-      {
-        return left == right;
-      }
-
-      if (left.Equals(right))
-      {
-        return true;
-      }
-
-      BinaryOperator bopLeft, bopRight;
-      BoxedExpression left1, left2, right1, right2;
-      if (left.IsBinaryExpression(out bopLeft, out left1, out left2) && bopLeft.IsComparisonBinaryOperator()
-        && right.IsBinaryExpression(out bopRight, out right1, out right2) && bopRight.IsComparisonBinaryOperator())
-      {
-        // left1 bopLeft left2 && right2 bopleft right 1
-        BinaryOperator bopRightInverted;        
-        if (bopRight.TryInvert(out bopRightInverted) && bopLeft == bopRightInverted)
+        private static IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> equalityPairComparerCache; // Thread-safe
+        public static IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> EqualityPairComparer
         {
-          return BoxedExpression.SimpleSyntacticEquality(left1, right2) && BoxedExpression.SimpleSyntacticEquality(left2, right1);
+            get
+            {
+                Contract.Ensures(Contract.Result<IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>>() != null);
+
+                if (equalityPairComparerCache == null)
+                {
+                    equalityPairComparerCache = new BoxedExpressionKeyEqualityComparer();
+                }
+                return equalityPairComparerCache;
+            }
         }
-      }
 
-      return false;
-    }
 
-    #endregion
+        /// <summary>
+        /// Create an External box, i.e., a subtree holding on to an ExternalExpression but that can be viewed as
+        /// an ordinary Expression
+        /// </summary>
+        public static BoxedExpression For<Type, Variable, Expression>(Expression external, IFullExpressionDecoder<Type, Variable, Expression> decoder)
+          where Expression : IEquatable<Expression>
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
 
-    #region Actual Expression implementations
+            return new ClousotExpression<Type>.ExternalBox<Variable, Expression>(external, decoder);
+        }
+
+        /// <summary>
+        /// Create an ordinary Expression from the given external expression by converting it completely.
+        /// </summary>
+        /// <returns>It may return null, if the expression is too big!</returns>
+        public static BoxedExpression Convert<Type, V, T>(T exp, IFullExpressionDecoder<Type, V, T> decoder,
+          int MAXDEPTH = DefaultDepthInConverting, bool trySimplify = true, bool replaceConstants = true, bool replaceNull = true,
+          Func<V, FList<PathElement>> accessPaths = null)
+          where T : IEquatable<T>
+        {
+            BoxedExpression result;
+
+            if (ClousotExpression<Type>.TryConvert(exp, decoder, MAXDEPTH, trySimplify, replaceConstants, replaceNull, accessPaths, out result))
+            {
+                return result;
+            }
+            return null;
+        }
+
+        public static BoxedExpression Var(object var)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new VariableExpression(var);
+        }
+
+        public static BoxedExpression Var(object var, FList<PathElement> path)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new VariableExpression(var, path);
+        }
+
+
+        public static BoxedExpression Var(object var, PathElement[] path)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new VariableExpression(var, path);
+        }
+
+        public static BoxedExpression Var(object var, FList<PathElement> path, object type)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new VariableExpression(var, path, type);
+        }
+
+        public static BoxedExpression VarBoundedInQuantifier(string name)
+        {
+            Contract.Requires(name != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new VariableExpression(name, true);
+        }
+
+        public static BoxedExpression VarCast<Type>(object var, PathElement[] path, Type type, Type CastTo)
+          where Type : IEquatable<Type>
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.CastExpression(new VariableExpression(var, path, (object)type), null, CastTo, false);
+        }
+
+        public static BoxedExpression VarCastUnchecked<Type>(object var, PathElement[] path, Type type, Type CastTo)
+          where Type : IEquatable<Type>
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.CastExpression(new VariableExpression(var, path, (object)type), null, CastTo, true);
+        }
+
+        public static BoxedExpression Binary(BinaryOperator op, BoxedExpression left, BoxedExpression right, object frameworkVar = null)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new BinaryExpression(op, left, right, frameworkVar);
+        }
+
+        public static BoxedExpression BinaryLogicalAnd(BoxedExpression left, BoxedExpression right)
+        {
+            if (left == null || right == null)
+                return null;
+
+            if (Object.ReferenceEquals(left, right))
+                return left;
+
+            int k;
+            if (left.IsConstantInt(out k))
+            {
+                return k == 0 ? left : right;
+            }
+            if (right.IsConstantInt(out k))
+            {
+                return k == 0 ? right : left;
+            }
+
+            return BoxedExpression.Binary(BinaryOperator.LogicalAnd, left, right);
+        }
+
+        public static BoxedExpression BinaryLogicalOr(BoxedExpression left, BoxedExpression right)
+        {
+            if (left == null || right == null)
+                return null;
+
+            if (Object.ReferenceEquals(left, right))
+                return left;
+
+            int k;
+            if (left.IsConstantInt(out k))
+            {
+                return k != 0 ? left : right;
+            }
+            if (right.IsConstantInt(out k) && k == 0)
+            {
+                return k != 0 ? right : left;
+            }
+
+            // F: Should use LogicalOr
+            return BoxedExpression.Binary(BinaryOperator.LogicalOr, left, right);
+        }
+
+        public static BoxedExpression BinaryCast<Type>(BinaryOperator op, BoxedExpression left, BoxedExpression right, Type CastTo)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.CastExpression(new BinaryExpression(op, left, right), null, CastTo, false);
+        }
+
+        public static BoxedExpression BinaryMethodToCall(BinaryOperator op, BoxedExpression left, BoxedExpression right, string method_to_call)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new BinaryExpressionMethodCall(op, left, right, method_to_call);
+        }
+
+        public static BoxedExpression Unary(UnaryOperator op, BoxedExpression arg)
+        {
+            Contract.Requires(arg != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            // normalize negations
+
+            BinaryOperator bop;
+            BoxedExpression left, right;
+            if (arg.IsBinaryExpression(out bop, out left, out right))
+            {
+                switch (bop)
+                {
+                    case BinaryOperator.Ceq:
+                    case BinaryOperator.Cobjeq:
+                        return new BinaryExpression(BinaryOperator.Cne_Un, left, right);
+                    case BinaryOperator.Cne_Un:
+                        return new BinaryExpression(BinaryOperator.Ceq, left, right);
+                    default:
+                        break;
+                }
+            }
+            return new UnaryExpression(op, arg, null);
+        }
+
+        public static BoxedExpression UnaryLogicalNot(BoxedExpression arg)
+        {
+            Contract.Requires(arg != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new UnaryExpression(UnaryOperator.Not, arg, null);
+        }
+
+        public static BoxedExpression UnaryCast<Type>(UnaryOperator op, BoxedExpression arg, Type CastTo)
+        {
+            Contract.Requires(arg != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.CastExpression(new UnaryExpression(op, arg, null), null, CastTo, false);
+        }
+
+        public static BoxedExpression UnaryCastUnchecked<Type>(UnaryOperator op, BoxedExpression arg, Type CastTo)
+        {
+            Contract.Requires(arg != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.CastExpression(new UnaryExpression(op, arg, null), null, CastTo, true);
+        }
+
+        public static BoxedExpression Const<Local, Parameter, Field, Property, Event, Method, Type, Attribute, Assembly>(object obj, Type type, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(mdDecoder != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            Contract.Assume(!mdDecoder.Equal(type, mdDecoder.System_Int32) || obj is Int32);
+            return new ClousotExpression<Type>.ConstantExpression(obj, type);
+        }
+
+        public static BoxedExpression ConstCast<Local, Parameter, Field, Property, Event, Method, Type, Attribute, Assembly>(object obj, string name, Type type, Type type_cast, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(mdDecoder != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.CastExpression(Const(obj, type, mdDecoder), name, type_cast, false);
+        }
+
+        public static BoxedExpression ConstCastUnchecked<Local, Parameter, Field, Property, Event, Method, Type, Attribute, Assembly>(object obj, Type type, Type type_cast, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(mdDecoder != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.CastExpression(Const(obj, type, mdDecoder), null, type_cast, true);
+        }
+
+        public static BoxedExpression ConstBool<Local, Parameter, Field, Property, Event, Method, Type, Attribute, Assembly>(object obj, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(mdDecoder != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.ConstantExpression(obj, mdDecoder.System_Boolean, true);
+        }
+
+        public static BoxedExpression Result<Type>(Type type)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.ResultExpression(type);
+        }
+
+        public static BoxedExpression Old<Type>(BoxedExpression oldExpr, Type type)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.OldExpression(oldExpr, type);
+        }
+
+        public static BoxedExpression ValueAtReturn<Type>(BoxedExpression oldExpr, Type type)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.ValueAtReturnExpression(oldExpr, type);
+        }
+
+        #endregion
+
+        #region Public methods
+        public virtual bool IsVariable
+        {
+            get { return false; }
+        }
+
+        public virtual bool IsVariableBoundedInQuantifier
+        {
+            get { return false; }
+        }
+
+        public virtual bool IsBooleanTyped
+        {
+            get { return false; }
+        }
+
+        public virtual object UnderlyingVariable
+        {
+            get { return null; }
+        }
+
+        public virtual PathElement[] AccessPath
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<PathElement[]>() == null || Contract.ForAll(Contract.Result<PathElement[]>(), p => p != null));
+                return null;
+            }
+        }
+
+        public virtual bool IsConstant
+        {
+            get { return false; }
+        }
+        public virtual object Constant { get { throw new InvalidOperationException(); } }
+        public virtual object ConstantType { get { throw new InvalidOperationException(); } }
+        public virtual bool IsSizeOf
+        {
+            get { return false; }
+        }
+        public virtual bool SizeOf(out int size) { size = 0; return false; }
+        public virtual bool SizeOf(out object type, out int size) { type = null; size = 0; return false; }
+
+        public virtual bool IsUnary
+        {
+            get { return false; }
+        }
+        public virtual UnaryOperator UnaryOp { get { throw new InvalidOperationException(); } }
+        public virtual BoxedExpression UnaryArgument
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+                throw new InvalidOperationException();
+            }
+        }
+
+        public virtual bool IsBinary
+        {
+            get { return false; }
+        }
+        public virtual bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out right) != null);
+
+            bop = BinaryOperator.Add; // dummy
+            left = null;
+            right = null;
+            return false;
+        }
+
+        public virtual bool IsUnaryExpression(out UnaryOperator uop, out BoxedExpression left)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
+
+            uop = default(UnaryOperator); // dummy
+            left = default(BoxedExpression);
+            return false;
+        }
+
+        public virtual bool IsIsInstExpression(out BoxedExpression exp, out object type)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out exp) != null);
+
+            exp = default(BoxedExpression);
+            type = default(object);
+            return false;
+        }
+
+        public virtual BinaryOperator BinaryOp { get { throw new InvalidOperationException(); } }
+
+        public virtual BoxedExpression BinaryLeft
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+                throw new InvalidOperationException();
+            }
+        }
+
+        public virtual BoxedExpression BinaryRight
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+                throw new InvalidOperationException();
+            }
+        }
+
+        public virtual bool IsIsInst
+        {
+            get { return false; }
+        }
+        public virtual bool IsNull
+        {
+            get { return false; }
+        }
+
+        public virtual bool IsCast
+        {
+            get { return false; }
+        }
+
+        public virtual bool IsResult
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public virtual bool IsParameterRef
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public virtual bool IsArrayIndex
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public virtual bool IsArrayIndexExpression(out BoxedExpression array, out BoxedExpression index, out object type)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out array) != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out index) != null);
+
+            array = index = null;
+            type = null;
+            return false;
+        }
+
+        public virtual bool IsQuantified
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public virtual bool IsQuantifiedExpression(out bool isForAll, out BoxedExpression boundVar, out BoxedExpression lower, out BoxedExpression upper, out BoxedExpression body)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out boundVar) != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out lower) != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out upper) != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out body) != null);
+
+            isForAll = false;
+
+            boundVar = lower = upper = body = null;
+
+            return false;
+        }
+
+        abstract public BoxedExpression Negate();
+
+        public abstract void AddFreeVariables(Set<BoxedExpression> set);
+
+        /// <summary>
+        /// If expression has associated info, such as a pointer with associated writable byte information, then this operation
+        /// returns the expression representing the info.
+        /// </summary>
+        public virtual bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
+        {
+            info = null;
+            return false;
+        }
+
+        /// <summary>
+        /// If expression has associated info, such as a pointer with associated writable byte information, then this operation
+        /// returns the expression representing the info.
+        /// The extra PC provides information about where the associated info should hold in case of a variable.
+        /// </summary>
+        public virtual bool TryGetAssociatedInfo(APC atPC, AssociatedInfo infoKind, out BoxedExpression info)
+        {
+            info = null; return false;
+        }
+
+        /// <summary>
+        /// Replaces the occurrences of what with newExp, converting external subtrees as they are found.
+        /// </summary>
+        public virtual BoxedExpression Substitute(BoxedExpression what, BoxedExpression newExp)
+        {
+            Contract.Requires(what != null);
+            Contract.Requires(newExp != null);
+
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            if (this == what || this.Equals(what)) return newExp;
+
+            return this.RecursiveSubstitute(what, newExp);
+        }
+
+        /// <summary>
+        /// Performs the given substitution of variables.
+        /// Returns null if the converter returns null
+        /// </summary>
+        public abstract BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map);
+
+        public abstract BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null);
+
+        protected virtual BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
+        {
+            Contract.Requires(what != null);
+            Contract.Requires(newExp != null);
+
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            // default
+            return this;
+        }
+
+        public abstract void Dispatch(IBoxedExpressionVisitor visitor);
+
+        public virtual bool TryGetType(out object type)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out type) != null);
+
+            type = null;
+            return false;
+        }
+
+
+        internal abstract Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+        where Visitor : IVisitMSIL<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>;
+
+        #endregion
+
+        #region System.Object overrides
+        public abstract override bool Equals(object obj);
+
+        public sealed override int GetHashCode()
+        {
+            if (hashCodeCache == HashCodeUnSet)
+            {
+                hashCodeCache = ComputeHashCode();
+            }
+            return hashCodeCache;
+        }
+
+        public abstract override string ToString();
+        public virtual string ToString<Typ2>(Converter<Typ2, string> converter)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return ToString(); // Default behavior
+        }
+
+        #endregion
+
+        #region SimpleSyntacticEquals
+
+        public static bool SimpleSyntacticEquality(BoxedExpression left, BoxedExpression right)
+        {
+            if (left == null || right == null)
+            {
+                return left == right;
+            }
+
+            if (left.Equals(right))
+            {
+                return true;
+            }
+
+            BinaryOperator bopLeft, bopRight;
+            BoxedExpression left1, left2, right1, right2;
+            if (left.IsBinaryExpression(out bopLeft, out left1, out left2) && bopLeft.IsComparisonBinaryOperator()
+              && right.IsBinaryExpression(out bopRight, out right1, out right2) && bopRight.IsComparisonBinaryOperator())
+            {
+                // left1 bopLeft left2 && right2 bopleft right 1
+                BinaryOperator bopRightInverted;
+                if (bopRight.TryInvert(out bopRightInverted) && bopLeft == bopRightInverted)
+                {
+                    return BoxedExpression.SimpleSyntacticEquality(left1, right2) && BoxedExpression.SimpleSyntacticEquality(left2, right1);
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region Actual Expression implementations
 
 #pragma warning disable 659
-    [Serializable]
-    internal class VariableExpression : BoxedExpression
-    {
-      public readonly PathElement[] Path;
-      new public object Var { get; private set; } // not readonly because we need to assign it during serialization
-      [NonSerialized] private object _savedVar; // used in serialization only
-      public readonly object mType;
-      public readonly BoxedExpression WritableBytes/*?*/;
-      private readonly bool isBoundedVarInQuantifier = false;
-
-      // Just before the serialization, save the var, if needed            
-      [OnSerializing]
-      private void OnSerializing(StreamingContext context)
-      {
-        // keep Var in the serialized object only if it is a string
-        // use _savedVar to save Var during serialization and restore it afterwards
-        this._savedVar = this.Var;
-        if (!(this.Var is string))
+        [Serializable]
+        internal class VariableExpression : BoxedExpression
         {
-          if (this.Path == null)
-          {
-            // In this case the deserialized VariableExpression would have no sense
-            throw new NotSupportedException(String.Format("Trying to serialize a variable with Path == null and Var not string: {0}", this.ToString()));
-          }
-          this.Var = null;
-        }
-      }
+            public readonly PathElement[] Path;
+            new public object Var { get; private set; } // not readonly because we need to assign it during serialization
+            [NonSerialized]
+            private object _savedVar; // used in serialization only
+            public readonly object mType;
+            public readonly BoxedExpression WritableBytes/*?*/;
+            private readonly bool isBoundedVarInQuantifier = false;
 
-      // Just after the serialization, restore the value
-      [OnSerialized]
-      private void OnSerialized(StreamingContext context)
-      {
-        this.Var = this._savedVar;
-      }
-
-      public VariableExpression(object var)
-        : this(var, (PathElement[])null, (BoxedExpression)null, null)
-      { }
-
-      public VariableExpression(object var, PathElement[] path)
-        : this(var, path, (BoxedExpression)null, null)
-      { }
-
-      public VariableExpression(object var, FList<PathElement> path)
-        : this(var, path, (BoxedExpression)null, null)
-      { }
-
-      public VariableExpression(object var, PathElement[] path, object type)
-        : this(var, path, (BoxedExpression)null, type)
-      { }
-
-      public VariableExpression(object var, FList<PathElement> path, BoxedExpression wb)
-        : this(var, path, wb, null)
-      { }
-
-      public VariableExpression(object var, PathElement[] path, BoxedExpression wb)
-        : this(var, path, wb, null)
-      { }
-
-      public VariableExpression(object var, FList<PathElement> path, object type)
-        : this(var, path, (BoxedExpression)null, type)
-      { }
-
-      public VariableExpression(object var, FList<PathElement> path, BoxedExpression wb, object type)
-        : this(var, path == null ? null : path.ToArray(), wb, type)
-      { }
-
-      public VariableExpression(object var, PathElement[] path, BoxedExpression wb, object type)
-      {
-        this.Var = var;
-        this.Path = path;
-        this.WritableBytes = wb;
-        this.mType = type;
-      }
-
-      public VariableExpression(string name, bool p)
-      {
-        this.Var = name;
-        this.isBoundedVarInQuantifier = p;
-      }
-
-      public override bool TryGetType(out object type)
-      {
-        if (mType != null)
-        {
-          type = mType;
-          return true;
-        }
-        type = null;
-        return false;
-      }
-
-      public override bool IsVariable { get { return true; } }
-      //public override object Variable { get { return Var; } }
-
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          return Var;
-        }
-      }
-
-      public override bool IsVariableBoundedInQuantifier
-      {
-        get
-        {
-          return this.isBoundedVarInQuantifier;
-        }
-      }
-
-
-      public override PathElement[] AccessPath
-      {
-        get
-        {
-          return this.Path;
-        }
-      }
-
-      public override bool IsParameterRef
-      {
-        get
-        {
-          return this.Path != null && this.Path.Length > 0 && this.Path[0].AssumeNotNull().IsParameterRef;
-        }
-      }
-
-      public override bool IsBooleanTyped
-      {
-        get
-        {
-          return (Path != null && Path[Path.Length - 1].AssumeNotNull().IsBooleanTyped);
-        }
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        set.Add(this);
-        if (this.WritableBytes != null) this.WritableBytes.AddFreeVariables(set);
-      }
-
-      public override bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
-      {
-        switch (infoKind)
-        {
-          case AssociatedInfo.WritableBytes:
-            if (this.WritableBytes != null) { info = this.WritableBytes; return true; }
-            break;
-        }
-        info = null;
-        return false;
-      }
-
-      public override bool TryGetAssociatedInfo(APC atPC, AssociatedInfo infoKind, out BoxedExpression info)
-      {
-        // We don't have pc specific info here
-        return this.TryGetAssociatedInfo(infoKind, out info);
-      }
-
-      protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
-      {
-        // F: this causes a stack overflow has when we visit WB(s), we visit the argument s, and then s.Wb, i.e. WB(s) ...
-        /*
-        if (this.WritableBytes != null)
-        {
-          BoxedExpression subst = this.WritableBytes.Substitute(what, newExp);
-          if (subst == this.WritableBytes) return this;
-          return new VariableExpression(this.Var, this.Path, subst);
-        }
-        */
-
-        var whatAsVariableExpression = what as VariableExpression;
-        if (whatAsVariableExpression != null)
-        {
-          if (whatAsVariableExpression.Var.Equals(this.Var))
-          {
-            return newExp;
-          }
-        }
-
-        return this;
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
-
-      #region System.Object overrides
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
-        BoxedExpression that = obj as BoxedExpression;
-        if(that != null)
-        {
-        if (this.Var != null && that.IsVariable) { return this.Var.Equals(that.UnderlyingVariable); }
-
-          // compare the accessPaths
-          if (this.Var == null && that.UnderlyingVariable == null)
-        {
-          var thisPath = this.AccessPath;
-          var thatPath = that.AccessPath;
-          if (thisPath != null && thatPath != null && thisPath.Length == thatPath.Length)
-          {
-            Contract.Assume(Contract.ForAll(thisPath, p => p != null));
-
-            for (var i = 0; i < thisPath.Length; i++ )
+            // Just before the serialization, save the var, if needed            
+            [OnSerializing]
+            private void OnSerializing(StreamingContext context)
             {
-              // ToString is brittle or too expensive? We should use something else?
-              if (thisPath[i].ToString() != thatPath[i].ToString())
-              {
+                // keep Var in the serialized object only if it is a string
+                // use _savedVar to save Var during serialization and restore it afterwards
+                _savedVar = this.Var;
+                if (!(this.Var is string))
+                {
+                    if (this.Path == null)
+                    {
+                        // In this case the deserialized VariableExpression would have no sense
+                        throw new NotSupportedException(String.Format("Trying to serialize a variable with Path == null and Var not string: {0}", this.ToString()));
+                    }
+                    this.Var = null;
+                }
+            }
+
+            // Just after the serialization, restore the value
+            [OnSerialized]
+            private void OnSerialized(StreamingContext context)
+            {
+                this.Var = _savedVar;
+            }
+
+            public VariableExpression(object var)
+              : this(var, (PathElement[])null, (BoxedExpression)null, null)
+            { }
+
+            public VariableExpression(object var, PathElement[] path)
+              : this(var, path, (BoxedExpression)null, null)
+            { }
+
+            public VariableExpression(object var, FList<PathElement> path)
+              : this(var, path, (BoxedExpression)null, null)
+            { }
+
+            public VariableExpression(object var, PathElement[] path, object type)
+              : this(var, path, (BoxedExpression)null, type)
+            { }
+
+            public VariableExpression(object var, FList<PathElement> path, BoxedExpression wb)
+              : this(var, path, wb, null)
+            { }
+
+            public VariableExpression(object var, PathElement[] path, BoxedExpression wb)
+              : this(var, path, wb, null)
+            { }
+
+            public VariableExpression(object var, FList<PathElement> path, object type)
+              : this(var, path, (BoxedExpression)null, type)
+            { }
+
+            public VariableExpression(object var, FList<PathElement> path, BoxedExpression wb, object type)
+              : this(var, path == null ? null : path.ToArray(), wb, type)
+            { }
+
+            public VariableExpression(object var, PathElement[] path, BoxedExpression wb, object type)
+            {
+                this.Var = var;
+                this.Path = path;
+                this.WritableBytes = wb;
+                this.mType = type;
+            }
+
+            public VariableExpression(string name, bool p)
+            {
+                this.Var = name;
+                isBoundedVarInQuantifier = p;
+            }
+
+            public override bool TryGetType(out object type)
+            {
+                if (mType != null)
+                {
+                    type = mType;
+                    return true;
+                }
+                type = null;
                 return false;
-              }
             }
-            return true;
-          }
-        }
-        }
-        return false;
-      }
 
-      protected override int ComputeHashCode()
-      {
-        if (this.Var != null) return this.Var.GetHashCode();
-        if (this.Path != null) return this.Path.GetHashCode();
+            public override bool IsVariable { get { return true; } }
+            //public override object Variable { get { return Var; } }
 
-        //Contract.Assert(false, "Var && Paths are null!!!");
-
-        // Some of michael's code creates a variable where Var and Paths are both null
-        return -1;
-      }
-
-      public override string ToString()
-      {
-        if (this.Path != null)
-        {
-          return this.Path.ToCodeString();
-        }
-        if (this.Var != null)
-        {
-#if DEBUG
-          if (System.Diagnostics.Debugger.IsAttached)
-          {
-            return Var.ToString();
-          }
-#endif          
-          var fullName = Var.ToString();
-          var length = fullName.IndexOf('(');
-          return fullName.Substring(0, length < 0? fullName.Length: length);
-        }
-        return "Path & Var are null!!"; // should not happen
-      }
-
-      #endregion
-
-      /// <summary>
-      /// For variables, the access path is decoded prior to getting here. The final op is a nop.
-      /// </summary>
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      {
-        return visitor.Nop(pc, data);
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        Variable v;
-        if (this.TryGetFrameworkVariable(out v))
-        {
-          var result = map(v, this);
-          return result;
-        }
-        return this;
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        Variable v;
-        if (this.TryGetFrameworkVariable(out v))
-        {
-          if (renaming.Contains(v))
-          {
-            if (refiner != null)
+            public override object UnderlyingVariable
             {
-              return refiner(renaming[v]);
+                get
+                {
+                    return Var;
+                }
             }
 
-            return BoxedExpression.Var(renaming[v]);
-          }
-          else
-          {
-            return null;
-          }
-        }
-        return this; // REVIEW: if variable is null or not the right type, we leave it.
-      }
+            public override bool IsVariableBoundedInQuantifier
+            {
+                get
+                {
+                    return isBoundedVarInQuantifier;
+                }
+            }
 
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Variable(this.Var, this.Path, this);
-      }
+
+            public override PathElement[] AccessPath
+            {
+                get
+                {
+                    return this.Path;
+                }
+            }
+
+            public override bool IsParameterRef
+            {
+                get
+                {
+                    return this.Path != null && this.Path.Length > 0 && this.Path[0].AssumeNotNull().IsParameterRef;
+                }
+            }
+
+            public override bool IsBooleanTyped
+            {
+                get
+                {
+                    return (Path != null && Path[Path.Length - 1].AssumeNotNull().IsBooleanTyped);
+                }
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                set.Add(this);
+                if (this.WritableBytes != null) this.WritableBytes.AddFreeVariables(set);
+            }
+
+            public override bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
+            {
+                switch (infoKind)
+                {
+                    case AssociatedInfo.WritableBytes:
+                        if (this.WritableBytes != null) { info = this.WritableBytes; return true; }
+                        break;
+                }
+                info = null;
+                return false;
+            }
+
+            public override bool TryGetAssociatedInfo(APC atPC, AssociatedInfo infoKind, out BoxedExpression info)
+            {
+                // We don't have pc specific info here
+                return this.TryGetAssociatedInfo(infoKind, out info);
+            }
+
+            protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
+            {
+                // F: this causes a stack overflow has when we visit WB(s), we visit the argument s, and then s.Wb, i.e. WB(s) ...
+                /*
+                if (this.WritableBytes != null)
+                {
+                  BoxedExpression subst = this.WritableBytes.Substitute(what, newExp);
+                  if (subst == this.WritableBytes) return this;
+                  return new VariableExpression(this.Var, this.Path, subst);
+                }
+                */
+
+                var whatAsVariableExpression = what as VariableExpression;
+                if (whatAsVariableExpression != null)
+                {
+                    if (whatAsVariableExpression.Var.Equals(this.Var))
+                    {
+                        return newExp;
+                    }
+                }
+
+                return this;
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
+
+            #region System.Object overrides
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+                BoxedExpression that = obj as BoxedExpression;
+                if (that != null)
+                {
+                    if (this.Var != null && that.IsVariable) { return this.Var.Equals(that.UnderlyingVariable); }
+
+                    // compare the accessPaths
+                    if (this.Var == null && that.UnderlyingVariable == null)
+                    {
+                        var thisPath = this.AccessPath;
+                        var thatPath = that.AccessPath;
+                        if (thisPath != null && thatPath != null && thisPath.Length == thatPath.Length)
+                        {
+                            Contract.Assume(Contract.ForAll(thisPath, p => p != null));
+
+                            for (var i = 0; i < thisPath.Length; i++)
+                            {
+                                // ToString is brittle or too expensive? We should use something else?
+                                if (thisPath[i].ToString() != thatPath[i].ToString())
+                                {
+                                    return false;
+                                }
+                            }
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                if (this.Var != null) return this.Var.GetHashCode();
+                if (this.Path != null) return this.Path.GetHashCode();
+
+                //Contract.Assert(false, "Var && Paths are null!!!");
+
+                // Some of michael's code creates a variable where Var and Paths are both null
+                return -1;
+            }
+
+            public override string ToString()
+            {
+                if (this.Path != null)
+                {
+                    return this.Path.ToCodeString();
+                }
+                if (this.Var != null)
+                {
+#if DEBUG
+                    if (System.Diagnostics.Debugger.IsAttached)
+                    {
+                        return Var.ToString();
+                    }
+#endif
+                    var fullName = Var.ToString();
+                    var length = fullName.IndexOf('(');
+                    return fullName.Substring(0, length < 0 ? fullName.Length : length);
+                }
+                return "Path & Var are null!!"; // should not happen
+            }
+
+            #endregion
+
+            /// <summary>
+            /// For variables, the access path is decoded prior to getting here. The final op is a nop.
+            /// </summary>
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+            {
+                return visitor.Nop(pc, data);
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                Variable v;
+                if (this.TryGetFrameworkVariable(out v))
+                {
+                    var result = map(v, this);
+                    return result;
+                }
+                return this;
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                Variable v;
+                if (this.TryGetFrameworkVariable(out v))
+                {
+                    if (renaming.Contains(v))
+                    {
+                        if (refiner != null)
+                        {
+                            return refiner(renaming[v]);
+                        }
+
+                        return BoxedExpression.Var(renaming[v]);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+                return this; // REVIEW: if variable is null or not the right type, we leave it.
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Variable(this.Var, this.Path, this);
+            }
+        }
+
+        [Serializable]
+        public /* Mic: public for convenience of use in OutputPrettyCs, temporary until BoxedExpression are cleaned up to include type information */
+          class BinaryExpression : BoxedExpression
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.Left != null);
+                Contract.Invariant(this.Right != null);
+            }
+
+
+            public readonly BinaryOperator Op;
+            public readonly BoxedExpression Left;
+            public readonly BoxedExpression Right;
+
+            [NonSerialized]
+            private readonly object frameworkVar;
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return frameworkVar;
+                }
+            }
+
+            public BinaryExpression(BinaryOperator op, BoxedExpression left, BoxedExpression right, object frameworkVar = null)
+            {
+                Contract.Requires(left != null);
+                Contract.Requires(right != null);
+
+                this.Op = op;
+                this.Left = left;
+                this.Right = right;
+                this.frameworkVar = frameworkVar;
+            }
+
+            public override bool IsBinary
+            {
+                get { return true; }
+            }
+
+            [ContractVerification(false)]
+            public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
+            {
+                bop = this.Op;
+                left = this.Left;
+                right = this.Right;
+                return true;
+            }
+
+            public override BoxedExpression BinaryLeft
+            {
+                get { return Left; }
+            }
+
+            public override BoxedExpression BinaryRight
+            {
+                get { return Right; }
+            }
+
+            public override BinaryOperator BinaryOp
+            {
+                get { return Op; }
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                this.Left.AddFreeVariables(set);
+                this.Right.AddFreeVariables(set);
+            }
+
+            protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
+            {
+                BoxedExpression left = this.Left.Substitute(what, newExp);
+                BoxedExpression right = this.Right.Substitute(what, newExp);
+
+                if (left == this.Left && right == this.Right) return this;
+                return new BinaryExpression(this.Op, left, right);
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+            {
+                if (this.BinaryOp == BinaryOperator.LogicalOr || this.BinaryOp == BinaryOperator.LogicalAnd)
+                {
+                    // is decoded as shortcut evaluation and final operation is a nop.
+                    return visitor.Nop(pc, data);
+                }
+                return visitor.Binary(pc, this.BinaryOp, Unit.Value, Unit.Value, Unit.Value, data);
+            }
+
+            private bool IsEqualityOp(BinaryOperator op)
+            {
+                return op == BinaryOperator.Ceq || op == BinaryOperator.Cobjeq;
+            }
+
+            #region System.Object overrides
+
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+                BinaryExpression that = obj as BinaryExpression;
+                if (that != null)
+                {
+                    return this.Op == that.Op && this.Left.Equals(that.Left) && this.Right.Equals(that.Right);
+                }
+                // TODO: equality with external expressions?
+                return false;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return (int)Op + this.Left.GetHashCode() + this.Right.GetHashCode();
+            }
+
+            private string GetFormatString()
+            {
+                // TODO: improve
+                // Do some pretty printing
+                string format = null;
+                string formatLeft, formatRight;
+
+                switch (this.Op)
+                {
+                    case BinaryOperator.Add:
+                    case BinaryOperator.Add_Ovf:
+                    case BinaryOperator.Add_Ovf_Un:
+                        format = "{0} {1} {2}";
+                        break;
+
+                    case BinaryOperator.Sub:
+                    case BinaryOperator.Sub_Ovf:
+                    case BinaryOperator.Sub_Ovf_Un:
+                        if (!this.Right.IsBinary)
+                            format = "{0} {1} {2}";
+                        else
+                            format = "({0} {1} {2})";
+                        break;
+
+                    case BinaryOperator.And:
+                    case BinaryOperator.Or:
+                    case BinaryOperator.Rem:
+                    case BinaryOperator.Rem_Un:
+                    case BinaryOperator.Shl:
+                    case BinaryOperator.Shr:
+                    case BinaryOperator.Shr_Un:
+                    case BinaryOperator.LogicalAnd:
+                    case BinaryOperator.LogicalOr:
+                    case BinaryOperator.Xor:
+                        format = "({0} {1} {2})";
+                        break;
+
+                    case BinaryOperator.Ceq:
+                        {
+                            int cval;
+
+                            if (Left.IsBooleanTyped && Right.IsConstantInt(out cval) && cval == 0)
+                            {
+                                format = this.Left.IsBinary ? "!({0})" : "!{0}";
+                            }
+                            else
+                            {
+                                formatLeft = this.Left.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Left.BinaryOp) ? "({0})" : "{0}";
+                                formatRight = this.Right.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Right.BinaryOp) ? "({2})" : "{2}";
+
+                                format = formatLeft + " {1} " + formatRight;
+                            }
+                            break;
+                        }
+                    case BinaryOperator.Cne_Un:
+                        {
+                            int cval;
+
+                            if (Left.IsBooleanTyped && Right.IsConstantInt(out cval) && cval == 0)
+                            {
+                                format = "{0}";
+                            }
+                            else
+                            {
+                                formatLeft = this.Left.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Left.BinaryOp) ? "({0})" : "{0}";
+                                formatRight = this.Right.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Right.BinaryOp) ? "({2})" : "{2}";
+
+                                format = formatLeft + " {1} " + formatRight;
+                            }
+                            break;
+                        }
+
+                    case BinaryOperator.Mul:
+                    case BinaryOperator.Mul_Ovf:
+                    case BinaryOperator.Mul_Ovf_Un:
+                    case BinaryOperator.Div:
+                    case BinaryOperator.Div_Un:
+
+                    case BinaryOperator.Cge:
+                    case BinaryOperator.Cge_Un:
+                    case BinaryOperator.Cgt:
+                    case BinaryOperator.Cgt_Un:
+                    case BinaryOperator.Cle:
+                    case BinaryOperator.Cle_Un:
+                    case BinaryOperator.Clt:
+                    case BinaryOperator.Clt_Un:
+                        formatLeft = this.Left.IsBinary ? "({0})" : "{0}";
+                        formatRight = this.Right.IsBinary ? "({2})" : "{2}";
+
+                        format = formatLeft + " {1} " + formatRight;
+                        break;
+
+                    case BinaryOperator.Cobjeq:
+                        formatLeft = this.Left.IsBinary ? "({0})" : "{0}";
+                        format = formatLeft + ".Equals({2})";
+                        break;
+                }
+
+                return format;
+            }
+
+            private bool CanAvoidParenthesesInPrettyPrintingBinary(BinaryOperator binaryOperator)
+            {
+                switch (binaryOperator)
+                {
+                    case BinaryOperator.Add:
+                    case BinaryOperator.Add_Ovf:
+                    case BinaryOperator.Add_Ovf_Un:
+
+                    case BinaryOperator.Div:
+                    case BinaryOperator.Div_Un:
+                    case BinaryOperator.Mul:
+                    case BinaryOperator.Mul_Ovf:
+                    case BinaryOperator.Mul_Ovf_Un:
+                    case BinaryOperator.Rem:
+                    case BinaryOperator.Rem_Un:
+                    case BinaryOperator.Sub:
+                    case BinaryOperator.Sub_Ovf:
+                    case BinaryOperator.Sub_Ovf_Un:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+
+            public override string ToString()
+            {
+                string opString;
+                // Special case to handle the code generated by the C# compiler for "o is A", when A is a interface
+                // The compiler generates: "(o as A) >_un null"
+                if (this.Op == BinaryOperator.Cgt_Un && this.Right.IsNull)
+                {
+                    opString = BinaryOperator.Cne_Un.ToCodeString();
+                }
+                else
+                {
+                    opString = this.Op.ToCodeString();
+                }
+
+                return string.Format(GetFormatString(), this.Left.ToString(), opString, this.Right.ToString());
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                return string.Format(GetFormatString(), this.Left.ToString(converter), this.Op.ToCodeString(), this.Right.ToString(converter));
+            }
+
+
+
+            #endregion
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var left = this.Left.Substitute(map);
+                if (left == null) return null;
+                var right = this.Right.Substitute(map);
+                if (right == null) return null;
+                if (this.Left == left && this.Right == right) return this;
+                return new BinaryExpression(this.Op, left, right);
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var left = this.Left.Rename(renaming, refiner);
+                if (left == null) return null;
+                var right = this.Right.Rename(renaming, refiner);
+                if (right == null) return null;
+                if (this.Left == left && this.Right == right) return this;
+                return new BinaryExpression(this.Op, left, right);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                switch (this.Op)
+                {
+                    case BinaryOperator.Ceq:
+                        return new BinaryExpression(BinaryOperator.Cne_Un, this.Left, this.Right);
+
+                    case BinaryOperator.Cge:
+                        return new BinaryExpression(BinaryOperator.Clt, this.Left, this.Right);
+
+                    case BinaryOperator.Cge_Un:
+                        return new BinaryExpression(BinaryOperator.Clt_Un, this.Left, this.Right);
+
+                    case BinaryOperator.Cgt:
+                        return new BinaryExpression(BinaryOperator.Cle, this.Left, this.Right);
+
+                    case BinaryOperator.Cgt_Un:
+                        return new BinaryExpression(BinaryOperator.Cle_Un, this.Left, this.Right);
+
+                    case BinaryOperator.Cle:
+                        return new BinaryExpression(BinaryOperator.Cgt, this.Left, this.Right);
+
+                    case BinaryOperator.Cle_Un:
+                        return new BinaryExpression(BinaryOperator.Cgt_Un, this.Left, this.Right);
+
+                    case BinaryOperator.Clt:
+                        return new BinaryExpression(BinaryOperator.Cge, this.Left, this.Right);
+
+                    case BinaryOperator.Clt_Un:
+                        return new BinaryExpression(BinaryOperator.Cge_Un, this.Left, this.Right);
+
+                    case BinaryOperator.Cne_Un:
+                        return new BinaryExpression(BinaryOperator.Ceq, this.Left, this.Right);
+
+                    case BinaryOperator.Cobjeq:
+                        return new BinaryExpression(BinaryOperator.Cne_Un, this.Left, this.Right);
+
+                    default:
+                        return BoxedExpression.UnaryLogicalNot(this);
+                }
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Binary(this.Op, this.Left, this.Right, this);
+            }
+        }
+
+        /// <summary>
+        /// Allows to output expressions such as "Left.method_to_call (Right)"
+        /// </summary>
+        [Serializable]
+        public /* Mic: idem */ class BinaryExpressionMethodCall : BinaryExpression
+        {
+            /// <summary>
+            /// create Left."methodCall"()
+            /// </summary>
+            public BinaryExpressionMethodCall(BinaryOperator dummy, BoxedExpression left, string methodToCall, object frameworkVar = null)
+              : this(dummy, left, BoxedExpression.Var(null), methodToCall, frameworkVar)
+            {
+                Contract.Requires(left != null);
+            }
+
+            public BinaryExpressionMethodCall(BinaryOperator op, BoxedExpression left, BoxedExpression right, string method_to_call, object frameworkVar = null)
+              : base(op, left, right, frameworkVar)
+            {
+                Contract.Requires(left != null);
+                Contract.Requires(right != null);
+
+                mMethodToCall = method_to_call;
+            }
+
+            public override string ToString()
+            {
+                var right = "";
+                if (Right.IsVariable && (Right.UnderlyingVariable != null || Right.AccessPath != null))
+                {
+                    right = Right.ToString();
+                }
+                return string.Format("{0}.{1}({2})", Left.ToString(), mMethodToCall, right);
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                return string.Format("{0}.{1}({2})", Left.ToString(converter), mMethodToCall, Right.ToString(converter));
+            }
+
+            readonly private string mMethodToCall;
+            public string MethodToCall { get { return mMethodToCall; } }
+        }
+
+        [Serializable]
+        internal class UnaryExpression : BoxedExpression
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.Argument != null);
+            }
+
+            public readonly UnaryOperator Op;
+            public readonly BoxedExpression Argument;
+
+            [NonSerialized]
+            private readonly object frameworkVar;
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return frameworkVar;
+                }
+            }
+
+            public UnaryExpression(UnaryOperator op, BoxedExpression arg, object frameworkVar)
+            {
+                Contract.Requires(arg != null);
+
+                this.Op = op;
+                this.Argument = arg;
+                this.frameworkVar = frameworkVar;
+            }
+
+            public override bool IsUnary { get { return true; } }
+            public override BoxedExpression UnaryArgument { get { return Argument; } }
+            public override UnaryOperator UnaryOp { get { return Op; } }
+
+            public override bool IsUnaryExpression(out UnaryOperator uop, out BoxedExpression left)
+            {
+                uop = this.Op;
+                left = this.Argument;
+
+                return true;
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                this.Argument.AddFreeVariables(set);
+            }
+
+            protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
+            {
+                BoxedExpression nested = this.Argument.Substitute(what, newExp);
+                if (nested == this.Argument)
+                {
+                    return this;
+                }
+                return new UnaryExpression(this.Op, nested, null);
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+            {
+                return visitor.Unary(pc, this.UnaryOp, false, false, Unit.Value, Unit.Value, data);
+            }
+
+            #region System.Object overrides
+
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+                UnaryExpression that = obj as UnaryExpression;
+                if (that != null)
+                {
+                    return this.Op == that.Op && this.Argument.Equals(that.Argument);
+                }
+                // TODO: handle equality with external expressions
+                return false;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return (int)Op + this.Argument.GetHashCode();
+            }
+
+            virtual protected string OpCodeString
+            {
+                get
+                {
+                    return this.Op.ToCodeString();
+                }
+            }
+
+            public override string ToString()
+            {
+                // Mic: we don't want to make some "(UIntPtr)" casts, because they interfere
+                // with contracts output. The solution we came up with is to simply ignore the Conv_u casts.
+                if (this.UnaryOp == UnaryOperator.Conv_u)
+                    return this.Argument.ToString();
+
+                string format = "{0}" + /*(this.Argument.IsConstant ? "{1}" : */"({1})"/*)*/; // Mic: always parentheses, for example conv with negative constants
+                return string.Format(format, this.OpCodeString, this.Argument.ToString());
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                // Mic: we don't want to make some "(UIntPtr)" casts, because they interfere
+                // with contracts output. The solution we came up with is to simply ignore the Conv_u casts.
+                if (this.UnaryOp == UnaryOperator.Conv_u)
+                    return this.Argument.ToString(converter);
+
+                string format = "{0}" + /*(this.Argument.IsConstant ? "{1}" : */"({1})"/*)*/; // Mic: always parentheses, for example conv with negative constants
+                return string.Format(format, this.OpCodeString, this.Argument.ToString(converter));
+            }
+
+            #endregion
+
+            public override BoxedExpression Negate()
+            {
+                switch (this.Op)
+                {
+                    case UnaryOperator.Not:
+                        return this.Argument;
+
+                    default:
+                        return BoxedExpression.UnaryLogicalNot(this);
+                }
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var arg = this.Argument.Substitute(map);
+                if (arg == this.Argument) { return this; }
+                if (arg == null) return null;
+                return new UnaryExpression(this.Op, arg, null);
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var arg = this.Argument.Rename(renaming, refiner);
+                if (arg == this.Argument) { return this; }
+                if (arg == null) return null;
+                return new UnaryExpression(this.Op, arg, null);
+            }
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Unary(this.Op, this.Argument, this);
+            }
+        }
+
+        [Serializable]
+        public abstract class ContractExpression : BoxedExpression
+        {
+            public readonly string Tag;
+            public readonly BoxedExpression Condition;
+            public readonly APC Apc;
+            /// <summary>
+            /// An object encoding where this contract comes from. Can be null.
+            /// </summary>
+            public readonly Provenance Provenance;
+            public readonly string SourceCondition;
+
+            public ContractExpression(BoxedExpression cond, string tag, APC apc, Provenance provenance, string sourceCondition)
+            {
+                // Contract.Assume(apc.Block != null, "It should be a precondition");
+
+                this.Tag = tag;
+                this.Condition = cond;
+                this.Apc = apc;
+                this.Provenance = provenance;
+                this.SourceCondition = sourceCondition;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return Condition.GetHashCode();
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                this.Condition.AddFreeVariables(set);
+            }
+
+            internal abstract override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data);
+
+            public abstract override bool Equals(object obj);
+
+            public abstract override string ToString();
+
+            public bool HasSourceContext
+            {
+                get
+                {
+                    var block = this.Apc.Block;
+                    return block != null && block.SourceDocument(this.Apc) != null;
+                }
+            }
+            public string SourceAssertionCondition
+            {
+                get
+                {
+                    if (this.SourceCondition != null) return this.SourceCondition;
+                    Contract.Assume(this.Apc.Block != null);
+                    return this.Apc.Block.SourceAssertionCondition(this.Apc);
+                }
+            }
+            public string SourceDocument { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceDocument(this.Apc); } }
+            public int SourceStartLine { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceStartLine(this.Apc); } }
+            public int SourceStartColumn { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceStartColumn(this.Apc); } }
+            public int SourceEndLine { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceEndLine(this.Apc); } }
+            public int SourceEndColumn { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceEndColumn(this.Apc); } }
+            public int SourceStartIndex { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceStartIndex(this.Apc); } }
+            public int SourceLength { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceLength(this.Apc); } }
+            public int ILOffset { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.ILOffset(this.Apc); } }
+            public abstract override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map);
+        }
+
+        [Serializable]
+        public class AssertExpression : ContractExpression
+        {
+            public AssertExpression(BoxedExpression cond, string tag, APC apc, Provenance provenance, string sourceCondition)
+              : base(cond, tag, apc, provenance, sourceCondition)
+            {
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                return visitor.Assert(pc, this.Tag, Unit.Value, this.Provenance, data);
+            }
+
+            public override bool Equals(object obj)
+            {
+                var that = obj as AssertExpression;
+                if (that == null) return false;
+                return this.Condition.Equals(that.Condition);
+            }
+
+            public override string ToString()
+            {
+                return "assert(" + this.Tag + ") " + Condition.ToString();
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                return "assert(" + this.Tag + ") " + Condition.ToString(converter);
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var cond = this.Condition.Substitute(map);
+                if (cond == this.Condition) return this;
+                if (cond == null) return null;
+                return new AssertExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var cond = this.Condition.Rename(renaming, refiner);
+                if (cond == this.Condition) return this;
+                if (cond == null) return null;
+                return new AssertExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Assert(this.Condition, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return new AssertExpression(this.Condition.Negate(), this.Tag, this.Apc, this.Provenance, this.SourceCondition);
+            }
+        }
+
+#if false
+        // special kind of assume used to add context- and path-sensitive postconditions to a method (needed for semantic baselining)
+        [Serializable]
+        public class AssumeAsPostConditionExpression : ContractExpression
+        {
+            // holds information about the path on which this assume is to be placed
+            public readonly Set<BoxedExpression> PathContext;
+            public readonly string CalleeName;
+            public object Callee;
+
+            // for the code:
+            // if (x > 10) foo(); assume e
+            // we want assume (x > 10 => e); we write store this as cond = e, pathContext = [x > 10], calleeName = foo
+
+            // TODO: actually, just want return value instruction?
+            public AssumeAsPostConditionExpression(BoxedExpression cond, Set<BoxedExpression> pathContext, object callee, string calleeName, string tag, APC apc, Provenance provenance)
+              : base(cond, tag, apc, provenance, null)
+            {
+                Contract.Requires(cond != null);
+                this.PathContext = pathContext;
+                this.Callee = callee;
+                this.CalleeName = calleeName;
+            }
+
+            // return pathContext => cond
+            private BoxedExpression GetImplicationForm()
+            {
+                // will this use the first element as the seed as desired?
+                var left = PathContext.Aggregate((acc, cur) => BoxedExpression.BinaryLogicalAnd(acc, cur));
+                return BoxedExpression.BinaryLogicalOr(left.Negate(), Condition);
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                //  SHB: just copied this over from ordinary assume, but Unit.Value seems a bit odd (depending on what ForwardDecode is used for I suppose...)
+                return visitor.Assume(pc, this.Tag, Unit.Value, this.Provenance, data);
+            }
+
+            #region System.Object overrides
+
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+                AssumeAsPostConditionExpression that = obj as AssumeAsPostConditionExpression;
+                if (that != null)
+                {
+                    return this.GetImplicationForm().Equals(that.GetImplicationForm()) && this.CalleeName.Equals(that.CalleeName);
+                }
+                return false;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return base.ComputeHashCode() + this.CalleeName.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return "assume(" + this.Tag + ") !(" + GetImplicationForm().ToString() + ") || " + Condition.ToString();
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                return "assume(" + this.Tag + ") !(" + GetImplicationForm().ToString() + ") || " + Condition.ToString(converter);
+            }
+            #endregion
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                Contract.Assume(false, "untested");
+                var cond = this.Condition.Substitute(map);
+                if (cond == this.Condition) return this;
+                if (cond == null) return null;
+                // TODO: is this ok?
+                var substituted = PathContext.Select(x => Substitute(map)) as Set<BoxedExpression>;
+                return new AssumeAsPostConditionExpression(cond, substituted, this.Callee, this.CalleeName, this.Tag, this.Apc, this.Provenance);
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                Contract.Assume(false, "untested");
+                var cond = this.Condition.Rename(renaming, refiner);
+                if (cond == this.Condition) return this;
+                if (cond == null) return null;
+                // TODO: is this ok?
+                return new AssumeAsPostConditionExpression(cond, substituted, this.Callee, this.CalleeName, this.Tag, this.Apc, this.Provenance);
+            }
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Assume(GetImplicationForm(), this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return new AssumeExpression(GetImplicationForm().Negate(), this.Tag, this.Apc, this.Provenance, null);
+            }
+        }
+#endif
+
+        [Serializable]
+        public class AssumeExpression : ContractExpression
+        {
+            public AssumeExpression(BoxedExpression cond, string tag, APC apc, Provenance provenance, string sourceCondition)
+              : base(cond, tag, apc, provenance, sourceCondition)
+            {
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                return visitor.Assume(pc, this.Tag, Unit.Value, this.Provenance, data);
+            }
+
+            public override bool Equals(object obj)
+            {
+                var that = obj as AssumeExpression;
+                if (that == null) return false;
+                return this.Condition.Equals(that.Condition);
+            }
+
+            public override string ToString()
+            {
+                return "assume(" + this.Tag + ") " + Condition.ToString();
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                return "assume(" + this.Tag + ") " + Condition.ToString(converter);
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var cond = this.Condition.Substitute(map);
+                if (cond == this.Condition) return this;
+                if (cond == null) return null;
+                return new AssumeExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
+            }
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var cond = this.Condition.Rename(renaming, refiner);
+                if (cond == this.Condition) return this;
+                if (cond == null) return null;
+                return new AssumeExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
+            }
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Assume(this.Condition, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return new AssumeExpression(this.Condition.Negate(), this.Tag, this.Apc, this.Provenance, null);
+            }
+        }
+
+        [Serializable]
+        public class ArrayIndexExpression<Typ> : BoxedExpression
+        {
+            public BoxedExpression Array { get; private set; }
+            public BoxedExpression Index { get; private set; }
+            public readonly Typ Type;
+
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(Array != null);
+                Contract.Invariant(Index != null);
+            }
+
+            public ArrayIndexExpression(BoxedExpression array, BoxedExpression index, Typ type)
+            {
+                Contract.Requires(array != null);
+                Contract.Requires(index != null);
+
+                this.Array = array;
+                this.Index = index;
+                this.Type = type;
+            }
+
+            #region System.Object overrides
+
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+                ArrayIndexExpression<Typ> that = obj as ArrayIndexExpression<Typ>;
+                if (that != null)
+                {
+                    return this.Array.Equals(that.Array) && this.Index.Equals(that.Index);
+                }
+                return false;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return this.Array.GetHashCode() + this.Index.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return String.Format("{0}[{1}]", Array, Index);
+            }
+            #endregion
+
+            public override bool IsArrayIndex
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override bool IsArrayIndexExpression(out BoxedExpression array, out BoxedExpression index, out object type)
+            {
+                array = this.Array;
+                index = this.Index;
+                type = this.Type;
+
+                return true;
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                // TODO
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var array = this.Array.Substitute(map);
+                if (array == null) return null;
+                var index = this.Index.Substitute(map);
+                if (index == null) return null;
+                if (this.Array == array && this.Index == index) return this;
+                return new ArrayIndexExpression<Typ>(array, index, this.Type);
+            }
+
+            override public BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var array = this.Array.Rename(renaming, refiner);
+                if (array == null) return null;
+                var index = this.Index.Rename(renaming, refiner);
+                if (index == null) return null;
+                if (this.Array == array && this.Index == index) return this;
+                return new ArrayIndexExpression<Typ>(array, index, this.Type);
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                if (this.Type is Type)
+                {
+                    return visitor.Ldelem(pc, (Type)(object)this.Type, Unit.Value, Unit.Value, Unit.Value, data);
+                }
+                return visitor.Nop(pc, data);
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.ArrayIndex(this.Type, this.Array, this.Index, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
+        }
+
+        [Serializable]
+        public class StatementSequence : BoxedExpression
+        {
+            private readonly IIndexable<BoxedExpression> seq;
+
+            public int Count { get { return seq.Count; } }
+            public BoxedExpression this[int index]
+            {
+                get
+                {
+                    Contract.Requires(index >= 0);
+                    Contract.Requires(index < Count);
+                    return seq[index];
+                }
+            }
+
+            public StatementSequence(IEnumerable<BoxedExpression> seq)
+            {
+                this.seq = seq.AsIndexable();
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return seq.Count;
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                foreach (var b in seq.Enumerate()) { b.AddFreeVariables(set); }
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                return new StatementSequence(seq.Enumerate().AsIndexable(b => b.Substitute(map)));
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var distinct = false;
+                var belist = new List<BoxedExpression>();
+                for (int i = 0; i < seq.Count; i++)
+                {
+                    var elem = seq[i];
+                    Contract.Assume(elem != null);
+                    var newElem = elem.Rename(renaming, refiner);
+                    if (newElem == null) return null;
+                    if (newElem != elem) { distinct = true; }
+                    belist.Add(newElem);
+                }
+                if (!distinct) return this;
+                return new StatementSequence(belist);
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                return visitor.Nop(pc, data);
+            }
+
+            public override bool Equals(object obj)
+            {
+                StatementSequence other = obj as StatementSequence;
+                if (other == null) return false;
+                return seq.Equals(other.seq);
+            }
+
+            public override string ToString()
+            {
+                return "StatementSequence";
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.StatementSequence(seq, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return new StatementSequence(seq.Enumerate().AsIndexable(b => b.Negate()));
+            }
+        }
+        #endregion
+
+        #region BoxedExpression proxy for deserialization
+        [Serializable]
+        protected class BoxedExpressionProxy : ISerializable, IObjectReference
+        {
+            private readonly BoxedExpression be;
+
+            private BoxedExpressionProxy(SerializationInfo info, StreamingContext context)
+            {
+                be = (BoxedExpression)info.GetValue("BE", typeof(BoxedExpression));
+            }
+
+            object IObjectReference.GetRealObject(StreamingContext context)
+            {
+                return be;
+            }
+
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                throw new NotSupportedException("Trying to serialize a BoxedExpressionProxy");
+            }
+        }
+        #endregion
+
+        public struct PC
+        {
+            public readonly BoxedExpression Node;
+            public readonly int Index;
+
+            public PC(BoxedExpression exp, int index)
+            {
+                Contract.Requires(exp != null);
+
+                this.Node = exp;
+                this.Index = index;
+            }
+
+            public override string ToString()
+            {
+                Contract.Assume(this.Node != null);
+                return string.Format("PC({0}, {1})", this.Node.ToString(), Index);
+            }
+        }
+
+        public static BoxedExpression SizeOf<Type>(Type type, int sizeAsConstant)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ClousotExpression<Type>.SizeOfExpression(type, sizeAsConstant);
+        }
+
+        internal static BoxedExpression Sequence(IEnumerable<BoxedExpression> list)
+        {
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new BoxedExpression.StatementSequence(list);
+        }
+
+        internal static BoxedExpression ArrayIndex<Typ>(BoxedExpression arrayExpr, BoxedExpression indexExpr, Typ type)
+        {
+            Contract.Requires(arrayExpr != null);
+            Contract.Requires(indexExpr != null);
+
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return new ArrayIndexExpression<Typ>(arrayExpr, indexExpr, type);
+        }
+
+
+        private class BoxedExpressionsEqualityComparer : IEqualityComparer<BoxedExpression>
+        {
+            public bool Equals(BoxedExpression x, BoxedExpression y)
+            {
+                if (x == null)
+                {
+                    return y == null;
+                }
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.Equals(y);
+            }
+
+            public int GetHashCode(BoxedExpression obj)
+            {
+                if (obj != null)
+                    return obj.GetHashCode();
+
+                return Int32.MinValue;
+            }
+        }
+
+        private class BoxedExpressionKeyEqualityComparer : IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>
+        {
+            public bool Equals(KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>> px, KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>> py)
+            {
+                var x = px.Key;
+                var y = py.Key;
+
+                if (x == null)
+                {
+                    return y == null;
+                }
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.Equals(y);
+            }
+
+            public int GetHashCode(KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>> pobj)
+            {
+                var obj = pobj.Key;
+                if (obj != null)
+                    return obj.GetHashCode();
+
+                return Int32.MinValue;
+            }
+        }
     }
 
-    [Serializable]
-    public /* Mic: public for convenience of use in OutputPrettyCs, temporary until BoxedExpression are cleaned up to include type information */
-      class BinaryExpression : BoxedExpression
+    [ContractClassFor(typeof(BoxedExpression))]
+    internal abstract class BoxedExpressionContracts
+      : BoxedExpression
     {
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.Left != null);
-        Contract.Invariant(this.Right != null);
-      }
-
-
-      public readonly BinaryOperator Op;
-      public readonly BoxedExpression Left;
-      public readonly BoxedExpression Right;
-
-      [NonSerialized] private readonly object frameworkVar;
-      public override object UnderlyingVariable
-      {
-        get
+        #region Contracts
+        public override BoxedExpression Negate()
         {
-          return this.frameworkVar;
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return null;
         }
-      }
+        #endregion
 
-      public BinaryExpression(BinaryOperator op, BoxedExpression left, BoxedExpression right, object frameworkVar = null)
-      {
-        Contract.Requires(left != null);
-        Contract.Requires(right != null);
+        #region
 
-        this.Op = op;
-        this.Left = left;
-        this.Right = right;
-        this.frameworkVar = frameworkVar;
-      }
-
-      public override bool IsBinary
-      {
-        get { return true; }
-      }
-      
-      [ContractVerification(false)]
-      public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
-      {
-        bop = this.Op;
-        left = this.Left;
-        right = this.Right;
-        return true;
-      }
-
-      public override BoxedExpression BinaryLeft
-      {
-        get { return Left; }
-      }
-
-      public override BoxedExpression BinaryRight
-      {
-        get { return Right; }
-      }
-
-      public override BinaryOperator BinaryOp
-      {
-        get { return Op; }
-      }   
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        this.Left.AddFreeVariables(set);
-        this.Right.AddFreeVariables(set);
-      }
-
-      protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
-      {
-        BoxedExpression left = this.Left.Substitute(what, newExp);
-        BoxedExpression right = this.Right.Substitute(what, newExp);
-
-        if (left == this.Left && right == this.Right) return this;
-        return new BinaryExpression(this.Op, left, right);
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      {
-        if (this.BinaryOp == BinaryOperator.LogicalOr || this.BinaryOp == BinaryOperator.LogicalAnd)
+        protected override int ComputeHashCode()
         {
-          // is decoded as shortcut evaluation and final operation is a nop.
-          return visitor.Nop(pc, data);
-        }
-        return visitor.Binary(pc, this.BinaryOp, Unit.Value, Unit.Value, Unit.Value, data);
-      }
-
-      bool IsEqualityOp(BinaryOperator op)
-      {
-        return op == BinaryOperator.Ceq || op == BinaryOperator.Cobjeq;
-      }
-
-      #region System.Object overrides
-
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
-        BinaryExpression that = obj as BinaryExpression;
-        if (that != null)
-        {
-          return this.Op == that.Op && this.Left.Equals(that.Left) && this.Right.Equals(that.Right);
-        }
-        // TODO: equality with external expressions?
-        return false;
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return (int)Op + this.Left.GetHashCode() + this.Right.GetHashCode();
-      }
-
-      private string GetFormatString()
-      {
-        // TODO: improve
-        // Do some pretty printing
-        string format = null;
-        string formatLeft, formatRight;
-
-        switch (this.Op)
-        {
-          case BinaryOperator.Add:
-          case BinaryOperator.Add_Ovf:
-          case BinaryOperator.Add_Ovf_Un:  
-              format = "{0} {1} {2}";
-            break;
-
-          case BinaryOperator.Sub:
-          case BinaryOperator.Sub_Ovf:
-          case BinaryOperator.Sub_Ovf_Un:
-            if (!this.Right.IsBinary)
-              format = "{0} {1} {2}";
-            else
-              format = "({0} {1} {2})";
-            break;
-
-          case BinaryOperator.And:
-          case BinaryOperator.Or:
-          case BinaryOperator.Rem:
-          case BinaryOperator.Rem_Un:
-          case BinaryOperator.Shl:
-          case BinaryOperator.Shr:
-          case BinaryOperator.Shr_Un:
-          case BinaryOperator.LogicalAnd:
-          case BinaryOperator.LogicalOr:
-          case BinaryOperator.Xor:
-            format = "({0} {1} {2})";
-            break;
-
-          case BinaryOperator.Ceq:
-            {
-              int cval;
-
-              if (Left.IsBooleanTyped && Right.IsConstantInt(out cval) && cval == 0)
-              {
-                format = this.Left.IsBinary ? "!({0})" : "!{0}";
-              }
-              else
-              {
-                formatLeft = this.Left.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Left.BinaryOp)? "({0})" : "{0}";
-                formatRight = this.Right.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Right.BinaryOp)? "({2})" : "{2}";
-
-                format = formatLeft + " {1} " + formatRight;
-              }
-              break;
-            }
-          case BinaryOperator.Cne_Un:
-            {
-              int cval;
-
-              if (Left.IsBooleanTyped && Right.IsConstantInt(out cval) && cval == 0)
-              {
-                format = "{0}";
-              }
-              else
-              {
-                formatLeft = this.Left.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Left.BinaryOp) ? "({0})" : "{0}";
-                formatRight = this.Right.IsBinary && !CanAvoidParenthesesInPrettyPrintingBinary(this.Right.BinaryOp) ? "({2})" : "{2}";
-
-                format = formatLeft + " {1} " + formatRight;
-              }
-              break;
-            }
-
-          case BinaryOperator.Mul:
-          case BinaryOperator.Mul_Ovf:
-          case BinaryOperator.Mul_Ovf_Un:
-          case BinaryOperator.Div:
-          case BinaryOperator.Div_Un:
-
-          case BinaryOperator.Cge:
-          case BinaryOperator.Cge_Un:
-          case BinaryOperator.Cgt:
-          case BinaryOperator.Cgt_Un:
-          case BinaryOperator.Cle:
-          case BinaryOperator.Cle_Un:
-          case BinaryOperator.Clt:
-          case BinaryOperator.Clt_Un:
-            formatLeft = this.Left.IsBinary? "({0})" : "{0}";
-            formatRight = this.Right.IsBinary ? "({2})" : "{2}";
-
-            format = formatLeft +  " {1} " + formatRight;
-            break;  
-
-          case BinaryOperator.Cobjeq:
-            formatLeft = this.Left.IsBinary ? "({0})" : "{0}";
-            format = formatLeft + ".Equals({2})";
-            break;
+            throw new NotImplementedException();
         }
 
-        return format;
-      }
 
-      private bool CanAvoidParenthesesInPrettyPrintingBinary(BinaryOperator binaryOperator)
-      {
-        switch (binaryOperator)
+        public override void AddFreeVariables(Set<BoxedExpression> set)
         {
-          case BinaryOperator.Add:
-          case BinaryOperator.Add_Ovf:
-          case BinaryOperator.Add_Ovf_Un:
-
-          case BinaryOperator.Div:
-          case BinaryOperator.Div_Un:
-          case BinaryOperator.Mul:
-          case BinaryOperator.Mul_Ovf:
-          case BinaryOperator.Mul_Ovf_Un:
-          case BinaryOperator.Rem:
-          case BinaryOperator.Rem_Un:
-          case BinaryOperator.Sub:
-          case BinaryOperator.Sub_Ovf:
-          case BinaryOperator.Sub_Ovf_Un:
-            return true;
-
-          default:
-            return false;
-        }
-      }
-
-      public override string  ToString()
-      {
-        string opString;
-        // Special case to handle the code generated by the C# compiler for "o is A", when A is a interface
-        // The compiler generates: "(o as A) >_un null"
-        if (this.Op == BinaryOperator.Cgt_Un && this.Right.IsNull)
-        {
-          opString = BinaryOperator.Cne_Un.ToCodeString();
-        }
-        else
-        {
-          opString = this.Op.ToCodeString();
+            throw new NotImplementedException();
         }
 
-        return string.Format(GetFormatString(), this.Left.ToString(), opString, this.Right.ToString());
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        return string.Format(GetFormatString(), this.Left.ToString(converter), this.Op.ToCodeString(), this.Right.ToString(converter));
-      }
-
-
-
-      #endregion
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var left = this.Left.Substitute(map);
-        if (left == null) return null;
-        var right = this.Right.Substitute(map);
-        if (right == null) return null;
-        if (this.Left == left && this.Right == right) return this;
-        return new BinaryExpression(this.Op, left, right);
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var left = this.Left.Rename(renaming, refiner);
-        if (left == null) return null;
-        var right = this.Right.Rename(renaming, refiner);
-        if (right == null) return null;
-        if (this.Left == left && this.Right == right) return this;
-        return new BinaryExpression(this.Op, left, right);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        switch (this.Op)
+        public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
         {
-          case BinaryOperator.Ceq:
-            return new BinaryExpression(BinaryOperator.Cne_Un, this.Left, this.Right);
-
-          case BinaryOperator.Cge:
-            return new BinaryExpression(BinaryOperator.Clt, this.Left, this.Right);
-            
-          case BinaryOperator.Cge_Un:
-            return new BinaryExpression(BinaryOperator.Clt_Un, this.Left, this.Right);
-
-          case BinaryOperator.Cgt:
-            return new BinaryExpression(BinaryOperator.Cle, this.Left, this.Right);
-
-          case BinaryOperator.Cgt_Un:
-            return new BinaryExpression(BinaryOperator.Cle_Un, this.Left, this.Right);
-
-          case BinaryOperator.Cle:
-            return new BinaryExpression(BinaryOperator.Cgt, this.Left, this.Right);
-
-          case BinaryOperator.Cle_Un:
-            return new BinaryExpression(BinaryOperator.Cgt_Un, this.Left, this.Right);
-
-          case BinaryOperator.Clt:
-            return new BinaryExpression(BinaryOperator.Cge, this.Left, this.Right);
-
-          case BinaryOperator.Clt_Un:
-            return new BinaryExpression(BinaryOperator.Cge_Un, this.Left, this.Right);
-
-          case BinaryOperator.Cne_Un:
-            return new BinaryExpression(BinaryOperator.Ceq, this.Left, this.Right);
-
-          case BinaryOperator.Cobjeq:
-            return new BinaryExpression(BinaryOperator.Cne_Un, this.Left, this.Right);
-
-          default:
-            return BoxedExpression.UnaryLogicalNot(this);
+            throw new NotImplementedException();
         }
-      }
 
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Binary(this.Op, this.Left, this.Right, this);
-      }
+        public override void Dispatch(IBoxedExpressionVisitor visitor)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Equals(object obj)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
     }
 
     /// <summary>
-    /// Allows to output expressions such as "Left.method_to_call (Right)"
+    /// The bound variable is represented by a variable node whose variable is the contant int32 0.
+    /// </summary>
+    [ContractVerification(true)]
+    [ContractClass(typeof(QuantifiedIndexedExpressionContracts))]
+    [Serializable]
+    public abstract class QuantifiedIndexedExpression
+      : BoxedExpression
+    {
+        #region To be Overridden
+
+        abstract protected string Name { get; }
+        abstract protected BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object var = null);
+
+        #endregion
+
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.BoundVariable != null);
+            Contract.Invariant(this.LowerBound != null);
+            Contract.Invariant(this.UpperBound != null);
+            Contract.Invariant(this.Body != null);
+        }
+
+        #endregion
+
+        #region State
+
+        public readonly BoxedExpression BoundVariable;
+        public readonly BoxedExpression LowerBound;
+        public readonly BoxedExpression UpperBound;
+        public readonly BoxedExpression Body;
+
+        private readonly object var;
+
+        #endregion
+
+        #region Constructor
+
+        protected QuantifiedIndexedExpression(object value, BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
+        {
+            Contract.Requires(lowerBound != null);
+            Contract.Requires(upperBound != null);
+            Contract.Requires(bodyDecoded != null);
+            Contract.Requires(boundVariable != null);
+
+            var = value;
+            this.BoundVariable = boundVariable;
+            this.LowerBound = lowerBound;
+            this.UpperBound = upperBound;
+            this.Body = bodyDecoded;
+        }
+
+        #endregion
+
+        #region Implementation of abstract methods
+
+        public override string ToString()
+        {
+            return String.Format("Contract.{0}({1}, {2}, {3} => {4})", Name, LowerBound, UpperBound, BoundVariable, Body);
+        }
+
+        protected override int ComputeHashCode()
+        {
+            return BoundVariable.GetHashCode() + LowerBound.GetHashCode() + UpperBound.GetHashCode() + Body.GetHashCode();
+        }
+
+        public override void AddFreeVariables(Set<BoxedExpression> set)
+        {
+            // REVIEW: this looks wrong. It should compute the free variables and then remove the bound variable.
+        }
+
+        public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+        {
+            var newLowerBound = this.LowerBound.Substitute(map);
+            var newUpperBound = this.UpperBound.Substitute(map);
+            // bound variable is not substituted, so modify the map for the recursion body
+
+            Func<Variable, BoxedExpression, BoxedExpression> mapModified = (var, orig) => (orig == this.BoundVariable) ? orig : map(var, orig);
+
+            var newBody = this.Body.Substitute(mapModified);
+
+            if (newLowerBound == null || newUpperBound == null || newBody == null)
+                return null;
+
+            if (newLowerBound == this.LowerBound
+              && newUpperBound == this.UpperBound && newBody == this.Body)
+                return this;
+
+            return this.Factory(this.BoundVariable, newLowerBound, newUpperBound, newBody);
+        }
+
+        public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+        {
+            // if (this.BoundVariable == null) return null;
+            // don't rename bound variables
+            var newLowerBound = this.LowerBound.Rename(renaming, refiner);
+            var newUpperBound = this.UpperBound.Rename(renaming, refiner);
+
+            BoxedExpression newBody;
+
+            Variable underlyingBound;
+            if (this.BoundVariable.TryGetFrameworkVariable(out underlyingBound))
+            {
+                // have to remove it.
+                var modifiedMap = renaming.Remove(underlyingBound);
+                newBody = this.Body.Rename(modifiedMap, refiner);
+            }
+            else
+            {
+                newBody = this.Body.Rename(renaming, refiner);
+            }
+            if (newLowerBound == null || newUpperBound == null || newBody == null)
+                return null;
+
+            if (newLowerBound == this.LowerBound
+              && newUpperBound == this.UpperBound && newBody == this.Body)
+                return this;
+
+            return this.Factory(this.BoundVariable, newLowerBound, newUpperBound, newBody);
+        }
+        public override BoxedExpression Substitute(BoxedExpression what, BoxedExpression newExp)
+        {
+            var boundVarSub = this.BoundVariable.Substitute(what, newExp);
+            //     if (boundVarSub != null)
+            {
+                var lowerBoundSub = this.LowerBound.Substitute(what, newExp);
+                //       if (lowerBoundSub != null)
+                {
+                    var upperBoundSub = this.UpperBound.Substitute(what, newExp);
+                    //         if (upperBoundSub != null)
+                    {
+                        var bodySub = this.Body.Substitute(what, newExp);
+                        return this.Factory(boundVarSub, lowerBoundSub, upperBoundSub, bodySub);
+                    }
+                }
+            }
+            //     return null;
+        }
+
+        public override void Dispatch(IBoxedExpressionVisitor visitor)
+        {
+            visitor.ForAll(this.BoundVariable, this.LowerBound, this.UpperBound, this.Body, this);
+        }
+
+        internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+        {
+            return visitor.Nop(pc, data);
+        }
+
+        public override bool Equals(object obj)
+        {
+            var that = obj as QuantifiedIndexedExpression;
+            if (that == null)
+                return false;
+
+            return this.Name.Equals(that.Name) &&
+              this.BoundVariable.Equals(that.BoundVariable) && this.LowerBound.Equals(that.LowerBound)
+              && this.UpperBound.Equals(that.UpperBound) && this.Body.Equals(that.Body);
+        }
+
+        #endregion
+
+        #region Implementation of virtuals 
+
+        public override bool IsQuantified
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override bool IsQuantifiedExpression(out bool isForAll, out BoxedExpression boundVar, out BoxedExpression lower, out BoxedExpression upper, out BoxedExpression body)
+        {
+            isForAll = this is ForAllIndexedExpression;
+            boundVar = this.BoundVariable;
+            lower = this.LowerBound;
+            upper = this.UpperBound;
+            body = this.Body;
+
+            return true;
+        }
+
+        public override object UnderlyingVariable
+        {
+            get
+            {
+                return var;
+            }
+        }
+
+        #endregion
+    }
+
+    [ContractVerification(true)]
+    [Serializable]
+    public class ForAllIndexedExpression : QuantifiedIndexedExpression
+    {
+        public ForAllIndexedExpression(object value, BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
+          : base(value, boundVariable, lowerBound, upperBound, bodyDecoded)
+        {
+            Contract.Requires(boundVariable != null);
+            Contract.Requires(lowerBound != null);
+            Contract.Requires(upperBound != null);
+            Contract.Requires(bodyDecoded != null);
+        }
+
+        protected override string Name
+        {
+            get { return "ForAll"; }
+        }
+
+        protected override BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object variable = null)
+        {
+            return new ForAllIndexedExpression(variable, boundVar, lowerBound, upperBound, newBody);
+        }
+
+        public override BoxedExpression Negate()
+        {
+            return new ExistsIndexedExpression(null, this.BoundVariable, this.LowerBound, this.UpperBound, this.Body.Negate());
+        }
+    }
+
+    [ContractVerification(true)]
+    [Serializable]
+    public class ExistsIndexedExpression : QuantifiedIndexedExpression
+    {
+        public ExistsIndexedExpression(object value, BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
+          : base(value, boundVariable, lowerBound, upperBound, bodyDecoded)
+        {
+            Contract.Requires(boundVariable != null);
+            Contract.Requires(lowerBound != null);
+            Contract.Requires(upperBound != null);
+            Contract.Requires(bodyDecoded != null);
+        }
+
+        protected override string Name
+        {
+            get { return "Exists"; }
+        }
+
+        protected override BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object variable = null)
+        {
+            return new ExistsIndexedExpression(variable, boundVar, lowerBound, upperBound, newBody);
+        }
+
+        public override BoxedExpression Negate()
+        {
+            return new ForAllIndexedExpression(null, this.BoundVariable, this.LowerBound, this.UpperBound, this.Body.Negate());
+        }
+    }
+
+    #region Contracts for QuantifiedIndexedExpression
+    [ContractClassFor(typeof(QuantifiedIndexedExpression))]
+    internal abstract class QuantifiedIndexedExpressionContracts : QuantifiedIndexedExpression
+    {
+        protected override string Name
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<string>() != null);
+
+                return default(string);
+            }
+        }
+
+        protected override BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object var = null)
+        {
+            Contract.Requires(boundVar != null);
+            Contract.Requires(lowerBound != null);
+            Contract.Requires(upperBound != null);
+            Contract.Requires(newBody != null);
+
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            return default(BoxedExpression);
+        }
+
+        // To make the complier happy
+        private QuantifiedIndexedExpressionContracts(BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
+          : base(null, boundVariable, lowerBound, upperBound, bodyDecoded)
+        {
+        }
+    }
+    #endregion
+
+    /// <summary>
+    /// A ClousotExpression contains OR an expression created outside the analyzer (i.e. an ExternalExpression) OR an expression created by the analyzer (i.e. an InternalExpression)
     /// </summary>
     [Serializable]
-    public /* Mic: idem */ class BinaryExpressionMethodCall : BinaryExpression
+    public abstract class ClousotExpression<Typ> : BoxedExpression
     {
-      /// <summary>
-      /// create Left."methodCall"()
-      /// </summary>
-      public BinaryExpressionMethodCall(BinaryOperator dummy, BoxedExpression left, string methodToCall, object frameworkVar = null)
-        : this(dummy, left, BoxedExpression.Var(null), methodToCall, frameworkVar)
-      {
-        Contract.Requires(left != null);
-      }
+        #region Factories
 
-      public BinaryExpressionMethodCall(BinaryOperator op, BoxedExpression left, BoxedExpression right, string method_to_call, object frameworkVar = null)
-        : base(op, left, right, frameworkVar)
-      {
-        Contract.Requires(left != null);
-        Contract.Requires(right != null);
-
-        this.mMethodToCall = method_to_call;
-      }
-
-      public override string ToString()
-      {
-        var right = "";
-        if(Right.IsVariable && (Right.UnderlyingVariable != null || Right.AccessPath != null))
+        public static BoxedExpression MakeIsInst(Typ type, BoxedExpression arg)
         {
-          right = Right.ToString();
-        }
-        return string.Format("{0}.{1}({2})", Left.ToString(), mMethodToCall, right);
-      }
+            Contract.Requires(arg != null);
 
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        return string.Format("{0}.{1}({2})", Left.ToString(converter), mMethodToCall, Right.ToString(converter));
-      }
-
-      readonly private string mMethodToCall;
-      public string MethodToCall { get { return mMethodToCall; } }
-    }
-
-    [Serializable]
-    internal class UnaryExpression : BoxedExpression
-    {
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.Argument != null);
-      }
-
-      public readonly UnaryOperator Op;
-      public readonly BoxedExpression Argument;
-
-      [NonSerialized] private readonly object frameworkVar;
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          return this.frameworkVar;
-        }
-      }
-
-      public UnaryExpression(UnaryOperator op, BoxedExpression arg, object frameworkVar)
-      {
-        Contract.Requires(arg != null);
-
-        this.Op = op;
-        this.Argument = arg;
-        this.frameworkVar = frameworkVar;
-      }
-
-      public override bool IsUnary { get { return true; } }
-      public override BoxedExpression UnaryArgument { get { return Argument; } }
-      public override UnaryOperator UnaryOp { get { return Op; } }
-
-      public override bool IsUnaryExpression(out UnaryOperator uop, out BoxedExpression left)
-      {
-        uop = this.Op;
-        left = this.Argument;
-
-        return true;
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        this.Argument.AddFreeVariables(set);
-      }
-
-      protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
-      {
-        BoxedExpression nested = this.Argument.Substitute(what, newExp);
-        if (nested == this.Argument)
-        {
-          return this;
-        }
-        return new UnaryExpression(this.Op, nested, null);
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      {
-        return visitor.Unary(pc, this.UnaryOp, false, false, Unit.Value, Unit.Value, data);
-      }
-
-      #region System.Object overrides
-
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
-        UnaryExpression that = obj as UnaryExpression;
-        if (that != null)
-        {
-          return this.Op == that.Op && this.Argument.Equals(that.Argument);
-        }
-        // TODO: handle equality with external expressions
-        return false;
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return (int)Op + this.Argument.GetHashCode();
-      }
-
-      virtual protected string OpCodeString
-      {
-        get
-        {
-          return this.Op.ToCodeString();
-        }
-      }
-
-      public override string ToString()
-      {
-        // Mic: we don't want to make some "(UIntPtr)" casts, because they interfere
-        // with contracts output. The solution we came up with is to simply ignore the Conv_u casts.
-        if (this.UnaryOp == UnaryOperator.Conv_u)
-          return this.Argument.ToString();
-
-        string format = "{0}" + /*(this.Argument.IsConstant ? "{1}" : */"({1})"/*)*/; // Mic: always parentheses, for example conv with negative constants
-        return string.Format(format, this.OpCodeString, this.Argument.ToString());
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        // Mic: we don't want to make some "(UIntPtr)" casts, because they interfere
-        // with contracts output. The solution we came up with is to simply ignore the Conv_u casts.
-        if (this.UnaryOp == UnaryOperator.Conv_u)
-          return this.Argument.ToString(converter);
-
-        string format = "{0}" + /*(this.Argument.IsConstant ? "{1}" : */"({1})"/*)*/; // Mic: always parentheses, for example conv with negative constants
-        return string.Format(format, this.OpCodeString, this.Argument.ToString(converter));
-      }
-
-      #endregion
-
-      public override BoxedExpression Negate()
-      {
-        switch (this.Op)
-        {
-          case UnaryOperator.Not:
-            return this.Argument;
-
-          default:
-            return BoxedExpression.UnaryLogicalNot(this);
-        }
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var arg = this.Argument.Substitute(map);
-        if (arg == this.Argument) { return this; }
-        if (arg == null) return null;
-        return new UnaryExpression(this.Op, arg, null);
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var arg = this.Argument.Rename(renaming, refiner);
-        if (arg == this.Argument) { return this; }
-        if (arg == null) return null;
-        return new UnaryExpression(this.Op, arg, null);
-      }
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Unary(this.Op, this.Argument, this);
-      }
-    }
-
-    [Serializable]
-    public abstract class ContractExpression : BoxedExpression
-    {
-      public readonly string Tag;
-      public readonly BoxedExpression Condition;
-      public readonly APC Apc;
-      /// <summary>
-      /// An object encoding where this contract comes from. Can be null.
-      /// </summary>
-      public readonly Provenance Provenance;
-      public readonly string SourceCondition;
-
-      public ContractExpression(BoxedExpression cond, string tag, APC apc, Provenance provenance, string sourceCondition)
-      {
-        // Contract.Assume(apc.Block != null, "It should be a precondition");
-
-        this.Tag = tag;
-        this.Condition = cond;
-        this.Apc = apc;
-        this.Provenance = provenance;
-        this.SourceCondition = sourceCondition;
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return Condition.GetHashCode();
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        this.Condition.AddFreeVariables(set);
-      }
-
-      internal abstract override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data);
-
-      public abstract override bool Equals(object obj);
-
-      public abstract override string ToString();
-
-      public bool HasSourceContext
-      {
-        get
-        {
-          var block = this.Apc.Block;
-          return block != null && block.SourceDocument(this.Apc) != null;
-        }
-      }
-      public string SourceAssertionCondition
-      {
-        get
-        {
-          if (this.SourceCondition != null) return this.SourceCondition;
-          Contract.Assume(this.Apc.Block != null);
-          return this.Apc.Block.SourceAssertionCondition(this.Apc);
-        }
-      }
-      public string SourceDocument { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceDocument(this.Apc); } }
-      public int SourceStartLine { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceStartLine(this.Apc); } }
-      public int SourceStartColumn { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceStartColumn(this.Apc); } }
-      public int SourceEndLine { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceEndLine(this.Apc); } }
-      public int SourceEndColumn { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceEndColumn(this.Apc); } }
-      public int SourceStartIndex { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceStartIndex(this.Apc); } }
-      public int SourceLength { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.SourceLength(this.Apc); } }
-      public int ILOffset { get { Contract.Assume(this.Apc.Block != null); return this.Apc.Block.ILOffset(this.Apc); } }
-      public abstract override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map);
-    }
-
-    [Serializable]
-    public class AssertExpression : ContractExpression
-    {
-      public AssertExpression(BoxedExpression cond, string tag, APC apc, Provenance provenance, string sourceCondition)
-        : base(cond, tag, apc, provenance, sourceCondition)
-      {
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        return visitor.Assert(pc, this.Tag, Unit.Value, this.Provenance, data);
-      }
-
-      public override bool Equals(object obj)
-      {
-        var that = obj as AssertExpression;
-        if (that == null) return false;
-        return this.Condition.Equals(that.Condition);
-      }
-
-      public override string ToString()
-      {
-        return "assert(" + this.Tag + ") " + Condition.ToString();
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        return "assert(" + this.Tag + ") " + Condition.ToString(converter);
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var cond = this.Condition.Substitute(map);
-        if (cond == this.Condition) return this;
-        if (cond == null) return null;
-        return new AssertExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var cond = this.Condition.Rename(renaming, refiner);
-        if (cond == this.Condition) return this;
-        if (cond == null) return null;
-        return new AssertExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Assert(this.Condition, this);
-      }
-      
-      public override BoxedExpression Negate()
-      {
-        return new AssertExpression(this.Condition.Negate(), this.Tag, this.Apc, this.Provenance, this.SourceCondition);
-      }
-    }
-
-#if false
-    // special kind of assume used to add context- and path-sensitive postconditions to a method (needed for semantic baselining)
-    [Serializable]
-    public class AssumeAsPostConditionExpression : ContractExpression
-    {
-      // holds information about the path on which this assume is to be placed
-      public readonly Set<BoxedExpression> PathContext;
-      public readonly string CalleeName;
-      public object Callee;
-
-      // for the code:
-      // if (x > 10) foo(); assume e
-      // we want assume (x > 10 => e); we write store this as cond = e, pathContext = [x > 10], calleeName = foo
-
-      // TODO: actually, just want return value instruction?
-      public AssumeAsPostConditionExpression(BoxedExpression cond, Set<BoxedExpression> pathContext, object callee, string calleeName, string tag, APC apc, Provenance provenance)
-        : base(cond, tag, apc, provenance, null)
-      {
-        Contract.Requires(cond != null);
-        this.PathContext = pathContext;
-        this.Callee = callee;
-        this.CalleeName = calleeName;
-      }
-
-      // return pathContext => cond
-      private BoxedExpression GetImplicationForm() {
-        // will this use the first element as the seed as desired?
-        var left = PathContext.Aggregate((acc, cur) => BoxedExpression.BinaryLogicalAnd(acc, cur));
-        return BoxedExpression.BinaryLogicalOr(left.Negate(), Condition);
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        //  SHB: just copied this over from ordinary assume, but Unit.Value seems a bit odd (depending on what ForwardDecode is used for I suppose...)
-        return visitor.Assume(pc, this.Tag, Unit.Value, this.Provenance, data);
-      }
-
-      #region System.Object overrides
-
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
-        AssumeAsPostConditionExpression that = obj as AssumeAsPostConditionExpression;
-        if (that != null)
-        {
-          return this.GetImplicationForm().Equals(that.GetImplicationForm()) && this.CalleeName.Equals(that.CalleeName);
-        }
-        return false;
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return base.ComputeHashCode() + this.CalleeName.GetHashCode();
-      }
-
-      public override string ToString()
-      {
-        return "assume(" + this.Tag + ") !(" + GetImplicationForm().ToString() + ") || " + Condition.ToString();
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        return "assume(" + this.Tag + ") !(" + GetImplicationForm().ToString() + ") || " + Condition.ToString(converter);
-      }
-      #endregion
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        Contract.Assume(false, "untested"); 
-        var cond = this.Condition.Substitute(map);
-        if (cond == this.Condition) return this;
-        if (cond == null) return null;
-        // TODO: is this ok?
-        var substituted = PathContext.Select(x => Substitute(map)) as Set<BoxedExpression>;
-        return new AssumeAsPostConditionExpression(cond, substituted, this.Callee, this.CalleeName, this.Tag, this.Apc, this.Provenance);      
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        Contract.Assume(false, "untested");
-        var cond = this.Condition.Rename(renaming, refiner);
-        if (cond == this.Condition) return this;
-        if (cond == null) return null;
-        // TODO: is this ok?
-        return new AssumeAsPostConditionExpression(cond, substituted, this.Callee, this.CalleeName, this.Tag, this.Apc, this.Provenance);
-      }
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Assume(GetImplicationForm(), this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return new AssumeExpression(GetImplicationForm().Negate(), this.Tag, this.Apc, this.Provenance, null);
-      }     
-    }
-#endif
-
-    [Serializable]
-    public class AssumeExpression : ContractExpression
-    {
-      public AssumeExpression(BoxedExpression cond, string tag, APC apc, Provenance provenance, string sourceCondition)
-        : base(cond, tag, apc, provenance, sourceCondition)
-      {
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        return visitor.Assume(pc, this.Tag, Unit.Value, this.Provenance, data);
-      }
-
-      public override bool Equals(object obj)
-      {
-        var that = obj as AssumeExpression;
-        if (that == null) return false;
-        return this.Condition.Equals(that.Condition);
-      }
-
-      public override string ToString()
-      {
-        return "assume(" + this.Tag + ") " + Condition.ToString();
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        return "assume(" + this.Tag + ") " + Condition.ToString(converter);
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var cond = this.Condition.Substitute(map);
-        if (cond == this.Condition) return this;
-        if (cond == null) return null;
-        return new AssumeExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
-      }
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var cond = this.Condition.Rename(renaming, refiner);
-        if (cond == this.Condition) return this;
-        if (cond == null) return null;
-        return new AssumeExpression(cond, this.Tag, this.Apc, this.Provenance, this.SourceCondition);
-      }
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Assume(this.Condition, this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return new AssumeExpression(this.Condition.Negate(), this.Tag, this.Apc, this.Provenance, null);
-      }
-
-    }
-
-    [Serializable]
-    public class ArrayIndexExpression<Typ> : BoxedExpression
-    {
-      public BoxedExpression Array { get; private set; }
-      public BoxedExpression Index { get; private set; }
-      public readonly Typ Type;
-
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(Array != null);
-        Contract.Invariant(Index != null);
-      }
-
-      public ArrayIndexExpression(BoxedExpression array, BoxedExpression index, Typ type)
-      {
-        Contract.Requires(array != null);
-        Contract.Requires(index != null);
-
-        this.Array = array;
-        this.Index = index;
-        this.Type = type;
-      }
-
-      #region System.Object overrides
-
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
-        ArrayIndexExpression<Typ> that = obj as ArrayIndexExpression<Typ>;
-        if (that != null)
-        {
-          return this.Array.Equals(that.Array) && this.Index.Equals(that.Index);
-        }
-        return false;
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return this.Array.GetHashCode() + this.Index.GetHashCode();
-      }
-
-      public override string ToString()
-      {
-        return String.Format("{0}[{1}]", Array, Index);
-      }
-      #endregion
-
-      public override bool IsArrayIndex
-      {
-        get
-        {
-          return true;
-        }
-      }
-
-      public override bool IsArrayIndexExpression(out BoxedExpression array, out BoxedExpression index, out object type)
-      {
-        array = this.Array;
-        index = this.Index;
-        type = this.Type;
-
-        return true;
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        // TODO
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var array = this.Array.Substitute(map);
-        if (array == null) return null;
-        var index = this.Index.Substitute(map);
-        if (index == null) return null;
-        if (this.Array == array && this.Index == index) return this;
-        return new ArrayIndexExpression<Typ>(array, index, this.Type);
-      }
-
-      override public BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var array = this.Array.Rename(renaming, refiner);
-        if (array == null) return null;
-        var index = this.Index.Rename(renaming, refiner);
-        if (index == null) return null;
-        if (this.Array == array && this.Index == index) return this;
-        return new ArrayIndexExpression<Typ>(array, index, this.Type);
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        if (this.Type is Type)
-        {
-          return visitor.Ldelem(pc, (Type)(object)this.Type, Unit.Value, Unit.Value, Unit.Value, data);
-        }
-        return visitor.Nop(pc, data);
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.ArrayIndex(this.Type, this.Array, this.Index, this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
-    }
-
-    [Serializable]
-    public class StatementSequence : BoxedExpression
-    {
-      readonly IIndexable<BoxedExpression> seq;
-
-      public int Count { get { return this.seq.Count; } }
-      public BoxedExpression this[int index]
-      {
-        get
-        {
-          Contract.Requires(index >= 0);
-          Contract.Requires(index < Count);
-          return this.seq[index];
-        }
-      }
-
-      public StatementSequence(IEnumerable<BoxedExpression> seq)
-      {
-        this.seq = seq.AsIndexable();
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return this.seq.Count;
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        foreach (var b in this.seq.Enumerate()) { b.AddFreeVariables(set); }
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        return new StatementSequence(this.seq.Enumerate().AsIndexable(b => b.Substitute(map)));
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var distinct = false;
-        var belist = new List<BoxedExpression>();
-        for (int i = 0; i < this.seq.Count; i++)
-        {
-          var elem = this.seq[i];
-          Contract.Assume(elem != null);
-          var newElem = elem.Rename(renaming, refiner);
-          if (newElem == null) return null;
-          if (newElem != elem) { distinct = true; }
-          belist.Add(newElem);
-        }
-        if (!distinct) return this;
-        return new StatementSequence(belist);
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        return visitor.Nop(pc, data);
-      }
-
-      public override bool Equals(object obj)
-      {
-        StatementSequence other = obj as StatementSequence;
-        if (other == null) return false;
-        return this.seq.Equals(other.seq);
-      }
-
-      public override string ToString()
-      {
-        return "StatementSequence";
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.StatementSequence(this.seq, this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return new StatementSequence(this.seq.Enumerate().AsIndexable(b => b.Negate()));
-      }
-    }
-    #endregion
-
-    #region BoxedExpression proxy for deserialization
-    [Serializable]
-    protected class BoxedExpressionProxy : ISerializable, IObjectReference
-    {
-      private readonly BoxedExpression be;
-
-      private BoxedExpressionProxy(SerializationInfo info, StreamingContext context)
-      {
-        this.be = (BoxedExpression)info.GetValue("BE", typeof(BoxedExpression));
-      }
-
-      object IObjectReference.GetRealObject(StreamingContext context)
-      {
-        return this.be;
-      }
-
-      void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
-      {
-        throw new NotSupportedException("Trying to serialize a BoxedExpressionProxy");
-      }
-    }
-    #endregion
-
-    public struct PC
-    {
-      public readonly BoxedExpression Node;
-      public readonly int Index;
-
-      public PC(BoxedExpression exp, int index)
-      {
-        Contract.Requires(exp != null);
-
-        this.Node = exp;
-        this.Index = index;
-      }
-
-      public override string ToString()
-      {
-        Contract.Assume(this.Node != null);
-        return string.Format("PC({0}, {1})", this.Node.ToString(), Index);
-      }
-    }
-
-    public static BoxedExpression SizeOf<Type>(Type type, int sizeAsConstant)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ClousotExpression<Type>.SizeOfExpression(type, sizeAsConstant);
-    }
-
-    internal static BoxedExpression Sequence(IEnumerable<BoxedExpression> list)
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new BoxedExpression.StatementSequence(list);
-    }
-
-    internal static BoxedExpression ArrayIndex<Typ>(BoxedExpression arrayExpr, BoxedExpression indexExpr, Typ type)
-    {
-      Contract.Requires(arrayExpr != null);
-      Contract.Requires(indexExpr != null);
-
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return new ArrayIndexExpression<Typ>(arrayExpr, indexExpr, type);
-    }
-
-
-    class BoxedExpressionsEqualityComparer : IEqualityComparer<BoxedExpression>
-    {
-      public bool Equals(BoxedExpression x, BoxedExpression y)
-      {
-        if (x == null)
-        {
-          return y == null;
-        }
-        if (y == null)
-        {
-          return x == null;
+            return new IsInstExpression(arg, type, null);
         }
 
-        return x.Equals(y);
-      }
-
-      public int GetHashCode(BoxedExpression obj)
-      {
-        if (obj != null)
-          return obj.GetHashCode();
-
-        return Int32.MinValue;
-      }
-    }
-
-    class BoxedExpressionKeyEqualityComparer : IEqualityComparer<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>
-    {
-      public bool Equals(KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>> px, KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>> py)
-      {
-        var x = px.Key;
-        var y = py.Key;
-
-        if (x == null)
+        public static BoxedExpression MakeSizeOf(Typ type, int sizeAsConst)
         {
-          return y == null;
-        }
-        if (y == null)
-        {
-          return x == null;
+            return new SizeOfExpression(type, sizeAsConst);
         }
 
-        return x.Equals(y);
-      }
-
-      public int GetHashCode(KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>> pobj)
-      {
-        var obj = pobj.Key;
-        if (obj != null)
-          return obj.GetHashCode();
-
-        return Int32.MinValue;
-      }
-    }
-
-  }
-
-  [ContractClassFor(typeof(BoxedExpression))]
-  abstract class BoxedExpressionContracts 
-    : BoxedExpression
-  {
-
-    #region Contracts
-    public override BoxedExpression Negate()
-    {
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return null;
-    }
-    #endregion
-
-    #region
-
-    protected override int ComputeHashCode()
-    {
-      throw new NotImplementedException();
-    }
-
-
-    public override void AddFreeVariables(Set<BoxedExpression> set)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override void Dispatch(IBoxedExpressionVisitor visitor)
-    {
-      throw new NotImplementedException();
-    }
-
-    internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override bool Equals(object obj)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override string ToString()
-    {
-      throw new NotImplementedException();
-    }
-    #endregion
-  }
-
-  /// <summary>
-  /// The bound variable is represented by a variable node whose variable is the contant int32 0.
-  /// </summary>
-  [ContractVerification(true)]
-  [ContractClass(typeof(QuantifiedIndexedExpressionContracts))]
-  [Serializable]
-  public abstract class QuantifiedIndexedExpression
-    : BoxedExpression
-  {
-    #region To be Overridden
-    
-    abstract protected string Name { get; }
-    abstract protected BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object var = null);
-    
-    #endregion
-
-    #region Object invariant
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.BoundVariable != null);
-      Contract.Invariant(this.LowerBound != null);
-      Contract.Invariant(this.UpperBound != null);
-      Contract.Invariant(this.Body != null);
-    }
-
-    #endregion
-
-    #region State
-
-    public readonly BoxedExpression BoundVariable;
-    public readonly BoxedExpression LowerBound;
-    public readonly BoxedExpression UpperBound;
-    public readonly BoxedExpression Body;
-
-    private readonly object var;
-
-    #endregion
-
-    #region Constructor
-    
-    protected QuantifiedIndexedExpression(object value, BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
-    {
-      Contract.Requires(lowerBound != null);
-      Contract.Requires(upperBound != null);
-      Contract.Requires(bodyDecoded != null);
-      Contract.Requires(boundVariable != null);
-
-      this.var = value;
-      this.BoundVariable = boundVariable;
-      this.LowerBound = lowerBound;
-      this.UpperBound = upperBound;
-      this.Body = bodyDecoded;
-    }
-
-    #endregion
-
-    #region Implementation of abstract methods
-
-    public override string ToString()
-    {
-      return String.Format("Contract.{0}({1}, {2}, {3} => {4})", Name, LowerBound, UpperBound, BoundVariable, Body);
-    }
-
-    protected override int ComputeHashCode()
-    {
-      return BoundVariable.GetHashCode() + LowerBound.GetHashCode() + UpperBound.GetHashCode() + Body.GetHashCode();
-    }
-
-    public override void AddFreeVariables(Set<BoxedExpression> set)
-    {
-      // REVIEW: this looks wrong. It should compute the free variables and then remove the bound variable.
-    }
-
-    public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-    {
-      var newLowerBound = this.LowerBound.Substitute(map);
-      var newUpperBound = this.UpperBound.Substitute(map);
-      // bound variable is not substituted, so modify the map for the recursion body
-
-      Func<Variable, BoxedExpression, BoxedExpression> mapModified = (var, orig) => (orig == this.BoundVariable) ? orig : map(var, orig);
-
-      var newBody = this.Body.Substitute(mapModified);
-
-      if (newLowerBound == null || newUpperBound == null || newBody == null)
-        return null;
-
-      if (newLowerBound == this.LowerBound
-        && newUpperBound == this.UpperBound && newBody == this.Body)
-        return this;
-
-      return this.Factory(this.BoundVariable, newLowerBound, newUpperBound, newBody);
-    }
-
-    public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-    {
-      // if (this.BoundVariable == null) return null;
-      // don't rename bound variables
-      var newLowerBound = this.LowerBound.Rename(renaming, refiner);
-      var newUpperBound = this.UpperBound.Rename(renaming, refiner);
-
-      BoxedExpression newBody;
-
-      Variable underlyingBound;
-      if (this.BoundVariable.TryGetFrameworkVariable(out underlyingBound))
-      {
-        // have to remove it.
-        var modifiedMap = renaming.Remove(underlyingBound);
-        newBody = this.Body.Rename(modifiedMap, refiner);
-      }
-      else
-      {
-        newBody = this.Body.Rename(renaming, refiner);
-      }
-      if (newLowerBound == null || newUpperBound == null || newBody == null)
-        return null;
-
-      if (newLowerBound == this.LowerBound
-        && newUpperBound == this.UpperBound && newBody == this.Body)
-        return this;
-
-      return this.Factory(this.BoundVariable, newLowerBound, newUpperBound, newBody);
-    }
-    public override BoxedExpression Substitute(BoxedExpression what, BoxedExpression newExp)
-    {
-      var boundVarSub = this.BoundVariable.Substitute(what, newExp);
- //     if (boundVarSub != null)
-      {
-        var lowerBoundSub = this.LowerBound.Substitute(what, newExp);
- //       if (lowerBoundSub != null)
+        public static BoxedExpression MakeUnary(UnaryOperator op, BoxedExpression arg)
         {
-          var upperBoundSub = this.UpperBound.Substitute(what, newExp);
- //         if (upperBoundSub != null)
-          {
-            var bodySub = this.Body.Substitute(what, newExp);
-            return this.Factory(boundVarSub, lowerBoundSub, upperBoundSub, bodySub);
-          }
-        }
-      }
- //     return null;
-    }
+            Contract.Requires(arg != null);
 
-    public override void Dispatch(IBoxedExpressionVisitor visitor)
-    {
-      visitor.ForAll(this.BoundVariable, this.LowerBound, this.UpperBound, this.Body, this);
-    }
-
-    internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-    {
-      return visitor.Nop(pc, data);
-    }
-
-    public override bool Equals(object obj)
-    {
-      var that = obj as QuantifiedIndexedExpression;
-      if (that == null)
-        return false;
-
-      return this.Name.Equals(that.Name) && 
-        this.BoundVariable.Equals(that.BoundVariable) && this.LowerBound.Equals(that.LowerBound) 
-        && this.UpperBound.Equals(that.UpperBound) && this.Body.Equals(that.Body);
-    }
-
-    #endregion
-
-    #region Implementation of virtuals 
-
-    public override bool IsQuantified
-    {
-      get
-      {
-        return true;
-      }
-    }
-
-    public override bool IsQuantifiedExpression(out bool isForAll, out BoxedExpression boundVar, out BoxedExpression lower, out BoxedExpression upper, out BoxedExpression body)
-    {
-      isForAll = this is ForAllIndexedExpression;
-      boundVar = this.BoundVariable;
-      lower = this.LowerBound;
-      upper = this.UpperBound;
-      body = this.Body;
-
-      return true;
-    }
-
-    public override object UnderlyingVariable
-    {
-      get
-      {
-        return this.var;
-      }
-    }
-
-    #endregion
-  }
-
-  [ContractVerification(true)]
-  [Serializable]
-  public class ForAllIndexedExpression : QuantifiedIndexedExpression
-  {
-
-    public ForAllIndexedExpression(object value, BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
-      : base(value, boundVariable, lowerBound, upperBound, bodyDecoded)
-    {
-      Contract.Requires(boundVariable != null);
-      Contract.Requires(lowerBound != null);
-      Contract.Requires(upperBound != null);
-      Contract.Requires(bodyDecoded != null);
-    }
-   
-    protected override string Name
-    {
-      get { return "ForAll"; }
-    }
-
-    protected override BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object variable = null)
-    {
-      return new ForAllIndexedExpression(variable, boundVar, lowerBound, upperBound, newBody);
-    }
-
-    public override BoxedExpression Negate()
-    {
-      return new ExistsIndexedExpression(null, this.BoundVariable, this.LowerBound, this.UpperBound, this.Body.Negate());        
-    }
-  }
-
-  [ContractVerification(true)]
-  [Serializable]
-  public class ExistsIndexedExpression : QuantifiedIndexedExpression
-  {
-    public ExistsIndexedExpression(object value, BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
-      : base(value, boundVariable, lowerBound, upperBound, bodyDecoded)
-    {
-      Contract.Requires(boundVariable != null);
-      Contract.Requires(lowerBound != null);
-      Contract.Requires(upperBound != null);
-      Contract.Requires(bodyDecoded != null);
-    }
-
-    protected override string Name
-    {
-      get { return "Exists"; }
-    }
-
-    protected override BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object variable = null)
-    {
-      return new ExistsIndexedExpression(variable, boundVar, lowerBound, upperBound, newBody);
-    }
-
-    public override BoxedExpression Negate()
-    {
-      return new ForAllIndexedExpression(null, this.BoundVariable, this.LowerBound, this.UpperBound, this.Body.Negate());
-    }
-  }
-
-  #region Contracts for QuantifiedIndexedExpression
-  [ContractClassFor(typeof(QuantifiedIndexedExpression))]
-  abstract class QuantifiedIndexedExpressionContracts : QuantifiedIndexedExpression
-  {
-
-
-    protected override string Name
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<string>() != null);
-
-        return default(string);
-      }
-    }
-
-    protected override BoxedExpression Factory(BoxedExpression boundVar, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression newBody, object var = null)
-    {
-      Contract.Requires(boundVar != null);
-      Contract.Requires(lowerBound != null);
-      Contract.Requires(upperBound != null);
-      Contract.Requires(newBody != null);
-
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      return default(BoxedExpression);
-    }
-
-    // To make the complier happy
-    QuantifiedIndexedExpressionContracts(BoxedExpression boundVariable, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression bodyDecoded)
-      : base(null, boundVariable, lowerBound, upperBound, bodyDecoded)
-    {
-    }
-  }
-  #endregion
-
-  /// <summary>
-  /// A ClousotExpression contains OR an expression created outside the analyzer (i.e. an ExternalExpression) OR an expression created by the analyzer (i.e. an InternalExpression)
-  /// </summary>
-  [Serializable]
-  public abstract class ClousotExpression<Typ> : BoxedExpression
-  {
-
-    #region Factories
-
-    public static BoxedExpression MakeIsInst(Typ type, BoxedExpression arg)
-    {
-      Contract.Requires(arg != null);
-
-      return new IsInstExpression(arg, type, null);
-    }
-
-    public static BoxedExpression MakeSizeOf(Typ type, int sizeAsConst)
-    {
-      return new SizeOfExpression(type, sizeAsConst);
-    }
-
-    public static BoxedExpression MakeUnary(UnaryOperator op, BoxedExpression arg)
-    {
-      Contract.Requires(arg != null);
-
-      return new UnaryExpression(op, arg, null);
-    }
-
-    internal static bool TryConvert<Variable, ExternalExpression>(ExternalExpression exp, IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder, 
-      int maxdepth, bool trysimplify, bool replaceConstants, bool replaceNull, Func<Variable, FList<PathElement>> accessPaths, out BoxedExpression result)
-      where ExternalExpression : IEquatable<ExternalExpression>
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
-
-      if (maxdepth <= 0)
-      {
-        result = null;
-        return false;
-      }
-
-      try
-      {
-        object constant, variable;
-        Typ type;
-        UnaryOperator uop;
-        BinaryOperator bop;
-        BoxedExpression convertedLeft, convertedRight;
-        ExternalExpression uarg, left, right, associatedInfo;
-
-        var frameworkVar = decoder.UnderlyingVariable(exp);
-
-        if (decoder.IsConstant(exp, out constant, out type))
-        {
-          result = replaceConstants ? new ConstantExpression(constant, type, frameworkVar) :
-            BoxedExpression.Var(frameworkVar, accessPaths != null ? accessPaths(frameworkVar) : null);
-          return true;
+            return new UnaryExpression(op, arg, null);
         }
 
-        // We want to check if it is a variable before checking if it is null, to avoid the too smartness of the heap analysis
-        if (decoder.IsVariable(exp, out variable))
+        internal static bool TryConvert<Variable, ExternalExpression>(ExternalExpression exp, IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder,
+          int maxdepth, bool trysimplify, bool replaceConstants, bool replaceNull, Func<Variable, FList<PathElement>> accessPaths, out BoxedExpression result)
+          where ExternalExpression : IEquatable<ExternalExpression>
         {
-          var path = decoder.GetVariableAccessPath(exp);
-          if (decoder.TryGetAssociatedExpression(exp, AssociatedInfo.WritableBytes, out associatedInfo))
-          {
-            result = new VariableExpression(variable, path, BoxedExpression.For(associatedInfo, decoder));
-          }
-          else
-          {
-            object expType;
-            if (decoder.TryGetType(exp, out expType))
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out result) != null);
+
+            if (maxdepth <= 0)
             {
-              // we are happy
+                result = null;
+                return false;
             }
-            else
-            {
-              expType = null; // make sure we have no garbage
-            }
-            result = new VariableExpression(variable, path, expType);
-          }
-          return true;
-        }
-        if (replaceNull && decoder.IsNull(exp))
-        {
-          result = new ConstantExpression(null, default(Typ));
-          return true;
-        }
-        if (decoder.IsSizeOf(exp, out type))
-        {
-          int value;
-          if (decoder.TrySizeOfAsConstant(exp, out value))
-          {
-            result = new SizeOfExpression(type, value, frameworkVar);
-          }
-          else
-          {
-            result = new SizeOfExpression(type, frameworkVar);
-          }
-          return true;
-        }
-        else if (decoder.IsInst(exp, out uarg, out type))
-        {
-          if (TryConvert(uarg, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedLeft))
-          {
-            result = new IsInstExpression(convertedLeft, type, frameworkVar);
-            return true;
-          }
-          else
-          {
-            result = null;
-            return false;
-          }
-        }
-        else if (decoder.IsUnaryOperator(exp, out uop, out uarg))
-        {
-          if (TryConvert(uarg, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedLeft))
-          {
-            // Get rid of the annoying cast "(int32)uarg"  when we know that uarg is of type int32
-            object uargType;
-            if (uop == UnaryOperator.Conv_i4
-              && convertedLeft.IsVariable  // HACKHACK!!! if converted left is an expression of wider type, the framework believes it is of the type of the cast. Example (int) ((long)y + (long) t)
-              && decoder.TryGetType(uarg, out uargType) && decoder.System_Int32.Equals(uargType))
-            {
-              result = convertedLeft;
-            }
-            else if (uop == UnaryOperator.Not && decoder.TryGetType(uarg, out uargType) && decoder.IsReferenceType((Typ)uargType))
-            {
-              // turn into == null unless it is (x as ValueType)
-              BoxedExpression isinstArg;
-              object isinstType;
-              if (convertedLeft.IsIsInstExpression(out isinstArg, out isinstType))
-              {
-                if (isinstType is Typ && !decoder.IsReferenceType((Typ)isinstType))
-                {
-                  result = new UnaryExpression(uop, convertedLeft, frameworkVar);
-                  return true;
-                }
-              }
-              result = new BinaryExpression(BinaryOperator.Ceq, convertedLeft, new ConstantExpression(null, (Typ)uargType));
-            }
-            else
-            {
-              // HACK HACK: We cannot apply conversion to a null paramameter
-              if (uop.IsConversionOperator() && convertedLeft.IsConstant)
-              {
-                if (convertedLeft.Constant == null)
-                {
-                  result = null;
-                  return false;
-                }
-              }
 
-              result = new UnaryExpression(uop, convertedLeft, frameworkVar);
-            }
-            return true;
-          }
-          else
-          {
-            result = null;
-            return false;
-          }
-        }
-        else if (decoder.IsBinaryOperator(exp, out bop, out left, out right))
-        {
-          if (trysimplify && (bop == BinaryOperator.Ceq || bop == BinaryOperator.Cobjeq) && decoder.IsNull(left) && decoder.IsNull(right))
-          {
-            result = new ConstantExpression(1, decoder.System_Int32);
-            return true;
-          }
-
-          if (TryConvert(left, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedLeft)
-            && TryConvert(right, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedRight))
-          {
-            result = new BinaryExpression(bop, convertedLeft, convertedRight, frameworkVar);
-            return true;
-          }
-
-          result = null;
-          return false;
-        }
-        else
-        {
-          Contract.Assume(false, "Type of expression unknown!");
-
-          throw new NotImplementedException();
-        }
-      }
-      catch(Exception)
-      {
-        // something can go wrong while trying to convert. In this case we just give up
-        result = null;
-        return false;
-      }
-    }
-    #endregion
-
-    #region CastExpression (embedding the real expression)
-    [Serializable]
-    internal class CastExpression : ClousotExpression<Typ>
-    {
-      public readonly Typ mTypeCasting;
-      public readonly BoxedExpression mEmbeddedExpression;
-      public readonly bool mbUnchecked;
-      private readonly string expressionName;
-
-      public override bool IsCast
-      {
-        get
-        {
-          return true;
-        }
-      }
-
-      public CastExpression(BoxedExpression embedded_exp, string/*?*/ expname, Typ type_casting, bool mbUnchecked)
-      {
-        this.mEmbeddedExpression = embedded_exp;
-        this.expressionName = expname;
-        this.mTypeCasting = type_casting;
-        this.mbUnchecked = mbUnchecked;
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        mEmbeddedExpression.AddFreeVariables(set);
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        return mEmbeddedExpression.Substitute(map); // the cast is lost?? REVIEW: this looks bad
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var newEmbedded = mEmbeddedExpression.Rename(renaming, refiner);
-        if (newEmbedded == null) return null;
-        if (newEmbedded == this.mEmbeddedExpression) return this;
-        return new CastExpression(newEmbedded, this.expressionName, this.mTypeCasting, this.mbUnchecked);
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        return mEmbeddedExpression.ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(pc, visitor, data);
-      }
-
-      public override string ToString()
-      {
-        string format;
-
-        if (!mbUnchecked && this.expressionName != null)
-        {
-          return string.Format("{0}.{1}", mTypeCasting.ToString().Replace('+', '.'), expressionName);
-        }
-        
-        if (!mbUnchecked)
-          format = "(({0})({1}))";
-        else
-          format = "(unchecked({0})({1}))";
-
-          return string.Format(format, mTypeCasting.ToString().Replace('+', '.'), mEmbeddedExpression.ToString());
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        Contract.Assume(converter != null);
-
-        if (mTypeCasting is Typ2)
-        {
-          string format;
-          if (!mbUnchecked)
-            format = "(({0})({1}))";
-          else
-            format = "(unchecked({0})({1}))";
-          return string.Format(format, converter((Typ2)(object)mTypeCasting), mEmbeddedExpression.ToString(converter));
-        }
-        else
-          return ToString();
-      }
-
-      public override PathElement[] AccessPath
-      {
-        get
-        {
-          return mEmbeddedExpression.AccessPath;
-        }
-      }
-
-      public override BoxedExpression BinaryLeft
-      {
-        get
-        {
-          return mEmbeddedExpression.BinaryLeft;
-        }
-      }
-
-      public override BinaryOperator BinaryOp
-      {
-        get
-        {
-          return mEmbeddedExpression.BinaryOp;
-        }
-      }
-
-      public override BoxedExpression BinaryRight
-      {
-        get
-        {
-          return mEmbeddedExpression.BinaryRight;
-        }
-      }
-
-      public override object Constant
-      {
-        get
-        {
-          return mEmbeddedExpression.Constant;
-        }
-      }
-
-      public override object ConstantType
-      {
-        get
-        {
-          return mEmbeddedExpression.ConstantType;
-        }
-      }
-
-      public override bool IsBinary
-      {
-        get
-        {
-          return mEmbeddedExpression.IsBinary;
-        }
-      }
-
-      public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
-      {
-        return mEmbeddedExpression.IsBinaryExpression(out bop, out left, out right);
-      }
-
-      public override bool IsBooleanTyped
-      {
-        get
-        {
-          return mEmbeddedExpression.IsBooleanTyped;
-        }
-      }
-
-      public override bool IsConstant
-      {
-        get
-        {
-          return mEmbeddedExpression.IsConstant;
-        }
-      }
-
-      public override bool IsIsInst
-      {
-        get
-        {
-          return mEmbeddedExpression.IsIsInst;
-        }
-      }
-
-      public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
-      {
-        return mEmbeddedExpression.IsIsInstExpression(out exp, out type);
-      }
-
-      public override bool IsNull
-      {
-        get
-        {
-          return mEmbeddedExpression.IsNull;
-        }
-      }
-
-      public override bool IsResult
-      {
-        get
-        {
-          return mEmbeddedExpression.IsResult;
-        }
-      }
-
-      public override bool IsSizeOf
-      {
-        get
-        {
-          return mEmbeddedExpression.IsSizeOf;
-        }
-      }
-
-      public override bool IsUnary
-      {
-        get
-        {
-          return mEmbeddedExpression.IsUnary;
-        }
-      }
-
-      public override bool IsVariable
-      {
-        get
-        {
-          return mEmbeddedExpression.IsVariable;
-        }
-      }
-
-      protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
-      {
-        return ((ClousotExpression<Typ>)mEmbeddedExpression).RecursiveSubstitute(what, newExp);
-      }
-
-      public override bool SizeOf(out int size)
-      {
-        return mEmbeddedExpression.SizeOf(out size);
-      }
-
-      public override bool SizeOf(out object type, out int size)
-      {
-        return mEmbeddedExpression.SizeOf(out type, out size);
-      }
-
-      public override BoxedExpression Substitute(BoxedExpression what, BoxedExpression newExp)
-      {
-        return mEmbeddedExpression.Substitute(what, newExp);
-      }
-
-      public override bool TryGetAssociatedInfo(APC atPC, AssociatedInfo infoKind, out BoxedExpression info)
-      {
-        return mEmbeddedExpression.TryGetAssociatedInfo(atPC, infoKind, out info);
-      }
-
-      public override bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
-      {
-        return mEmbeddedExpression.TryGetAssociatedInfo(infoKind, out info);
-      }
-
-      public override bool TryGetType(out object type)
-      {
-        return mEmbeddedExpression.TryGetType(out type);
-      }
-
-      public override BoxedExpression UnaryArgument
-      {
-        get
-        {
-          return mEmbeddedExpression.UnaryArgument;
-        }
-      }
-
-      public override UnaryOperator UnaryOp
-      {
-        get
-        {
-          return mEmbeddedExpression.UnaryOp;
-        }
-      }
-
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          return mEmbeddedExpression.UnderlyingVariable;
-        }
-      }
-
-      protected override int ComputeHashCode()
-      {
-        if (this.mEmbeddedExpression == null) return 1;
-        return this.mEmbeddedExpression.GetHashCode();
-      }
-
-      public override bool Equals(object obj)
-      {
-        if (obj is CastExpression)
-        {
-          CastExpression ce = obj as CastExpression;
-          return this.mEmbeddedExpression == ce.mEmbeddedExpression
-            && this.mbUnchecked == ce.mbUnchecked
-            && this.mTypeCasting.Equals(ce.mTypeCasting);
-        }
-        return false;
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        if (this.mEmbeddedExpression == null) return;
-        this.mEmbeddedExpression.Dispatch(visitor);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.Unary(UnaryOperator.Not, this);
-      }
-    }
-    #endregion
-
-    #region Actual expression types
-
-    [Serializable]
-    internal class ConstantExpression : ClousotExpression<Typ>
-    {
-      public readonly object Value;
-      public readonly Typ Type;
-      private readonly bool isBoolean;     // True if we are sure that we have a int value that represents a Boolean 
-                                           // False means that we do not know
-
-      [NonSerialized] private readonly object frameworkVar;
-
-      public ConstantExpression(object value, Typ type, object frameworkVar = null)
-      {
-        this.Value = value;
-        this.Type = type;
-        this.isBoolean = false;
-        this.frameworkVar = frameworkVar;
-      }
-
-      public ConstantExpression(object value, Typ type, bool isBoolean, object frameworkVar = null)
-      {
-        this.Value = value;
-        this.Type = type;
-        this.isBoolean = isBoolean;
-        this.frameworkVar = frameworkVar;
-      }
-
-      public override bool IsConstant { get { return true; } }
-      public override object Constant { get { return this.Value; } }
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          return this.frameworkVar;
-        }
-      }
-
-      public override object ConstantType
-      {
-        get
-        {
-          return this.Type;
-        }
-      }
-
-      public override bool IsNull
-      {
-        get
-        {
-          if (Value == null) return true;
-          IConvertible ic = this.Value as IConvertible;
-          if (ic != null && !(this.Value is string))
-          {
             try
             {
-              if (ic.ToInt32(null) == 0) return true;
+                object constant, variable;
+                Typ type;
+                UnaryOperator uop;
+                BinaryOperator bop;
+                BoxedExpression convertedLeft, convertedRight;
+                ExternalExpression uarg, left, right, associatedInfo;
+
+                var frameworkVar = decoder.UnderlyingVariable(exp);
+
+                if (decoder.IsConstant(exp, out constant, out type))
+                {
+                    result = replaceConstants ? new ConstantExpression(constant, type, frameworkVar) :
+                      BoxedExpression.Var(frameworkVar, accessPaths != null ? accessPaths(frameworkVar) : null);
+                    return true;
+                }
+
+                // We want to check if it is a variable before checking if it is null, to avoid the too smartness of the heap analysis
+                if (decoder.IsVariable(exp, out variable))
+                {
+                    var path = decoder.GetVariableAccessPath(exp);
+                    if (decoder.TryGetAssociatedExpression(exp, AssociatedInfo.WritableBytes, out associatedInfo))
+                    {
+                        result = new VariableExpression(variable, path, BoxedExpression.For(associatedInfo, decoder));
+                    }
+                    else
+                    {
+                        object expType;
+                        if (decoder.TryGetType(exp, out expType))
+                        {
+                            // we are happy
+                        }
+                        else
+                        {
+                            expType = null; // make sure we have no garbage
+                        }
+                        result = new VariableExpression(variable, path, expType);
+                    }
+                    return true;
+                }
+                if (replaceNull && decoder.IsNull(exp))
+                {
+                    result = new ConstantExpression(null, default(Typ));
+                    return true;
+                }
+                if (decoder.IsSizeOf(exp, out type))
+                {
+                    int value;
+                    if (decoder.TrySizeOfAsConstant(exp, out value))
+                    {
+                        result = new SizeOfExpression(type, value, frameworkVar);
+                    }
+                    else
+                    {
+                        result = new SizeOfExpression(type, frameworkVar);
+                    }
+                    return true;
+                }
+                else if (decoder.IsInst(exp, out uarg, out type))
+                {
+                    if (TryConvert(uarg, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedLeft))
+                    {
+                        result = new IsInstExpression(convertedLeft, type, frameworkVar);
+                        return true;
+                    }
+                    else
+                    {
+                        result = null;
+                        return false;
+                    }
+                }
+                else if (decoder.IsUnaryOperator(exp, out uop, out uarg))
+                {
+                    if (TryConvert(uarg, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedLeft))
+                    {
+                        // Get rid of the annoying cast "(int32)uarg"  when we know that uarg is of type int32
+                        object uargType;
+                        if (uop == UnaryOperator.Conv_i4
+                          && convertedLeft.IsVariable  // HACKHACK!!! if converted left is an expression of wider type, the framework believes it is of the type of the cast. Example (int) ((long)y + (long) t)
+                          && decoder.TryGetType(uarg, out uargType) && decoder.System_Int32.Equals(uargType))
+                        {
+                            result = convertedLeft;
+                        }
+                        else if (uop == UnaryOperator.Not && decoder.TryGetType(uarg, out uargType) && decoder.IsReferenceType((Typ)uargType))
+                        {
+                            // turn into == null unless it is (x as ValueType)
+                            BoxedExpression isinstArg;
+                            object isinstType;
+                            if (convertedLeft.IsIsInstExpression(out isinstArg, out isinstType))
+                            {
+                                if (isinstType is Typ && !decoder.IsReferenceType((Typ)isinstType))
+                                {
+                                    result = new UnaryExpression(uop, convertedLeft, frameworkVar);
+                                    return true;
+                                }
+                            }
+                            result = new BinaryExpression(BinaryOperator.Ceq, convertedLeft, new ConstantExpression(null, (Typ)uargType));
+                        }
+                        else
+                        {
+                            // HACK HACK: We cannot apply conversion to a null paramameter
+                            if (uop.IsConversionOperator() && convertedLeft.IsConstant)
+                            {
+                                if (convertedLeft.Constant == null)
+                                {
+                                    result = null;
+                                    return false;
+                                }
+                            }
+
+                            result = new UnaryExpression(uop, convertedLeft, frameworkVar);
+                        }
+                        return true;
+                    }
+                    else
+                    {
+                        result = null;
+                        return false;
+                    }
+                }
+                else if (decoder.IsBinaryOperator(exp, out bop, out left, out right))
+                {
+                    if (trysimplify && (bop == BinaryOperator.Ceq || bop == BinaryOperator.Cobjeq) && decoder.IsNull(left) && decoder.IsNull(right))
+                    {
+                        result = new ConstantExpression(1, decoder.System_Int32);
+                        return true;
+                    }
+
+                    if (TryConvert(left, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedLeft)
+                      && TryConvert(right, decoder, maxdepth - 1, trysimplify, replaceConstants, replaceNull, accessPaths, out convertedRight))
+                    {
+                        result = new BinaryExpression(bop, convertedLeft, convertedRight, frameworkVar);
+                        return true;
+                    }
+
+                    result = null;
+                    return false;
+                }
+                else
+                {
+                    Contract.Assume(false, "Type of expression unknown!");
+
+                    throw new NotImplementedException();
+                }
             }
-            catch
-            { // this is the case if Value is a double, or a Int64, etc
-              return false;
+            catch (Exception)
+            {
+                // something can go wrong while trying to convert. In this case we just give up
+                result = null;
+                return false;
             }
-          }
-          return false;
         }
-      }
+        #endregion
 
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      {
-        if (this.Value == null)
+        #region CastExpression (embedding the real expression)
+        [Serializable]
+        internal class CastExpression : ClousotExpression<Typ>
         {
-          return visitor.Ldnull(pc, Unit.Value, data);
+            public readonly Typ mTypeCasting;
+            public readonly BoxedExpression mEmbeddedExpression;
+            public readonly bool mbUnchecked;
+            private readonly string expressionName;
+
+            public override bool IsCast
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public CastExpression(BoxedExpression embedded_exp, string/*?*/ expname, Typ type_casting, bool mbUnchecked)
+            {
+                this.mEmbeddedExpression = embedded_exp;
+                expressionName = expname;
+                this.mTypeCasting = type_casting;
+                this.mbUnchecked = mbUnchecked;
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                mEmbeddedExpression.AddFreeVariables(set);
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                return mEmbeddedExpression.Substitute(map); // the cast is lost?? REVIEW: this looks bad
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var newEmbedded = mEmbeddedExpression.Rename(renaming, refiner);
+                if (newEmbedded == null) return null;
+                if (newEmbedded == this.mEmbeddedExpression) return this;
+                return new CastExpression(newEmbedded, expressionName, this.mTypeCasting, this.mbUnchecked);
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                return mEmbeddedExpression.ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(pc, visitor, data);
+            }
+
+            public override string ToString()
+            {
+                string format;
+
+                if (!mbUnchecked && expressionName != null)
+                {
+                    return string.Format("{0}.{1}", mTypeCasting.ToString().Replace('+', '.'), expressionName);
+                }
+
+                if (!mbUnchecked)
+                    format = "(({0})({1}))";
+                else
+                    format = "(unchecked({0})({1}))";
+
+                return string.Format(format, mTypeCasting.ToString().Replace('+', '.'), mEmbeddedExpression.ToString());
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                Contract.Assume(converter != null);
+
+                if (mTypeCasting is Typ2)
+                {
+                    string format;
+                    if (!mbUnchecked)
+                        format = "(({0})({1}))";
+                    else
+                        format = "(unchecked({0})({1}))";
+                    return string.Format(format, converter((Typ2)(object)mTypeCasting), mEmbeddedExpression.ToString(converter));
+                }
+                else
+                    return ToString();
+            }
+
+            public override PathElement[] AccessPath
+            {
+                get
+                {
+                    return mEmbeddedExpression.AccessPath;
+                }
+            }
+
+            public override BoxedExpression BinaryLeft
+            {
+                get
+                {
+                    return mEmbeddedExpression.BinaryLeft;
+                }
+            }
+
+            public override BinaryOperator BinaryOp
+            {
+                get
+                {
+                    return mEmbeddedExpression.BinaryOp;
+                }
+            }
+
+            public override BoxedExpression BinaryRight
+            {
+                get
+                {
+                    return mEmbeddedExpression.BinaryRight;
+                }
+            }
+
+            public override object Constant
+            {
+                get
+                {
+                    return mEmbeddedExpression.Constant;
+                }
+            }
+
+            public override object ConstantType
+            {
+                get
+                {
+                    return mEmbeddedExpression.ConstantType;
+                }
+            }
+
+            public override bool IsBinary
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsBinary;
+                }
+            }
+
+            public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
+            {
+                return mEmbeddedExpression.IsBinaryExpression(out bop, out left, out right);
+            }
+
+            public override bool IsBooleanTyped
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsBooleanTyped;
+                }
+            }
+
+            public override bool IsConstant
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsConstant;
+                }
+            }
+
+            public override bool IsIsInst
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsIsInst;
+                }
+            }
+
+            public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
+            {
+                return mEmbeddedExpression.IsIsInstExpression(out exp, out type);
+            }
+
+            public override bool IsNull
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsNull;
+                }
+            }
+
+            public override bool IsResult
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsResult;
+                }
+            }
+
+            public override bool IsSizeOf
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsSizeOf;
+                }
+            }
+
+            public override bool IsUnary
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsUnary;
+                }
+            }
+
+            public override bool IsVariable
+            {
+                get
+                {
+                    return mEmbeddedExpression.IsVariable;
+                }
+            }
+
+            protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
+            {
+                return ((ClousotExpression<Typ>)mEmbeddedExpression).RecursiveSubstitute(what, newExp);
+            }
+
+            public override bool SizeOf(out int size)
+            {
+                return mEmbeddedExpression.SizeOf(out size);
+            }
+
+            public override bool SizeOf(out object type, out int size)
+            {
+                return mEmbeddedExpression.SizeOf(out type, out size);
+            }
+
+            public override BoxedExpression Substitute(BoxedExpression what, BoxedExpression newExp)
+            {
+                return mEmbeddedExpression.Substitute(what, newExp);
+            }
+
+            public override bool TryGetAssociatedInfo(APC atPC, AssociatedInfo infoKind, out BoxedExpression info)
+            {
+                return mEmbeddedExpression.TryGetAssociatedInfo(atPC, infoKind, out info);
+            }
+
+            public override bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
+            {
+                return mEmbeddedExpression.TryGetAssociatedInfo(infoKind, out info);
+            }
+
+            public override bool TryGetType(out object type)
+            {
+                return mEmbeddedExpression.TryGetType(out type);
+            }
+
+            public override BoxedExpression UnaryArgument
+            {
+                get
+                {
+                    return mEmbeddedExpression.UnaryArgument;
+                }
+            }
+
+            public override UnaryOperator UnaryOp
+            {
+                get
+                {
+                    return mEmbeddedExpression.UnaryOp;
+                }
+            }
+
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return mEmbeddedExpression.UnderlyingVariable;
+                }
+            }
+
+            protected override int ComputeHashCode()
+            {
+                if (this.mEmbeddedExpression == null) return 1;
+                return this.mEmbeddedExpression.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is CastExpression)
+                {
+                    CastExpression ce = obj as CastExpression;
+                    return this.mEmbeddedExpression == ce.mEmbeddedExpression
+                      && this.mbUnchecked == ce.mbUnchecked
+                      && this.mTypeCasting.Equals(ce.mTypeCasting);
+                }
+                return false;
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                if (this.mEmbeddedExpression == null) return;
+                this.mEmbeddedExpression.Dispatch(visitor);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.Unary(UnaryOperator.Not, this);
+            }
         }
-        var that = (ClousotExpression<Type2>.ConstantExpression)(object)this;
+        #endregion
 
-        return visitor.Ldconst(pc, Value, that.Type, Unit.Value, data);
-      }
+        #region Actual expression types
 
-      #region System.Object overrides
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
-        BoxedExpression that = obj as BoxedExpression;
-        if (that != null && that.IsConstant)
+        [Serializable]
+        internal class ConstantExpression : ClousotExpression<Typ>
         {
-          if (this.Value == that.Constant) return true;
-          if (this.Value == null) return false;
-          return this.Value.Equals(that.Constant);
+            public readonly object Value;
+            public readonly Typ Type;
+            private readonly bool isBoolean;     // True if we are sure that we have a int value that represents a Boolean 
+                                                 // False means that we do not know
+
+            [NonSerialized]
+            private readonly object frameworkVar;
+
+            public ConstantExpression(object value, Typ type, object frameworkVar = null)
+            {
+                this.Value = value;
+                this.Type = type;
+                isBoolean = false;
+                this.frameworkVar = frameworkVar;
+            }
+
+            public ConstantExpression(object value, Typ type, bool isBoolean, object frameworkVar = null)
+            {
+                this.Value = value;
+                this.Type = type;
+                this.isBoolean = isBoolean;
+                this.frameworkVar = frameworkVar;
+            }
+
+            public override bool IsConstant { get { return true; } }
+            public override object Constant { get { return this.Value; } }
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return frameworkVar;
+                }
+            }
+
+            public override object ConstantType
+            {
+                get
+                {
+                    return this.Type;
+                }
+            }
+
+            public override bool IsNull
+            {
+                get
+                {
+                    if (Value == null) return true;
+                    IConvertible ic = this.Value as IConvertible;
+                    if (ic != null && !(this.Value is string))
+                    {
+                        try
+                        {
+                            if (ic.ToInt32(null) == 0) return true;
+                        }
+                        catch
+                        { // this is the case if Value is a double, or a Int64, etc
+                            return false;
+                        }
+                    }
+                    return false;
+                }
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+            {
+                if (this.Value == null)
+                {
+                    return visitor.Ldnull(pc, Unit.Value, data);
+                }
+                var that = (ClousotExpression<Type2>.ConstantExpression)(object)this;
+
+                return visitor.Ldconst(pc, Value, that.Type, Unit.Value, data);
+            }
+
+            #region System.Object overrides
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+                BoxedExpression that = obj as BoxedExpression;
+                if (that != null && that.IsConstant)
+                {
+                    if (this.Value == that.Constant) return true;
+                    if (this.Value == null) return false;
+                    return this.Value.Equals(that.Constant);
+                }
+
+                return false;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                if (Value == null) return 1;
+                return this.Value.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return this.ToStringInternal();
+            }
+
+            private string ToStringInternal()
+            {
+                if (this.Value == null)
+                {
+                    return "null";
+                }
+                // Special case here to return legal C# constants
+                else if (this.Value is bool)
+                {
+                    return (bool)this.Value ? "true" : "false";
+                }
+                else if (isBoolean && this.Value is Int32)
+                {
+                    var v = (Int32)this.Value;
+                    return v != 0 ? "true" : "false";
+                }
+                // Pretty printing for MinInt and MaxInt
+                else if (this.Value is Int32)
+                {
+                    switch ((Int32)this.Value)
+                    {
+                        case Int32.MaxValue:
+                            return "Int32.MaxValue";
+                        case Int32.MinValue:
+                            return "Int32.MinValue";
+                        default:
+                            return this.Value.ToString();
+                    }
+                }
+                else if (this.Value is string)
+                {
+                    string str = this.Value as string;
+                    return "@\"" + str.Replace("\"", "\"\"") + "\""; // correctly escape the characters
+                }
+                else
+                {
+                    return this.Value.ToString();
+                }
+            }
+            #endregion
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                return this;
+            }
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                return this;
+            }
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Constant<Typ>(this.Type, this.Value, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                if (Value is Int32)
+                {
+                    int v = (Int32)Value;
+
+                    if (v == 0)
+                        return new ClousotExpression<Typ>.ConstantExpression(1, this.Type);
+                    else
+                        return new ClousotExpression<Typ>.ConstantExpression(0, this.Type);
+                }
+
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
         }
 
-        return false;
-      }
-
-      protected override int ComputeHashCode()
-      {
-        if (Value == null) return 1;
-        return this.Value.GetHashCode();
-      }
-
-      public override string ToString()
-      {
-        return this.ToStringInternal();
-      }
-
-      private string ToStringInternal()
-      {
-        if (this.Value == null) 
-        { 
-          return "null"; 
-        }
-          // Special case here to return legal C# constants
-        else if (this.Value is bool)
+        [Serializable]
+        internal class SizeOfExpression : ClousotExpression<Typ>
         {
-          return (bool)this.Value ? "true" : "false";
-        }
-        else if (this.isBoolean && this.Value is Int32)
-        {
-          var v = (Int32)this.Value;
-          return v != 0 ? "true" : "false";
-        }
-        // Pretty printing for MinInt and MaxInt
-        else if (this.Value is Int32)
-        {
-          switch ((Int32)this.Value)
-          {
-            case Int32.MaxValue:
-              return "Int32.MaxValue";
-            case Int32.MinValue:
-              return "Int32.MinValue";
-            default:
-              return this.Value.ToString();
-          }
-        }
-        else if (this.Value is string)
-        {
-          string str = this.Value as string;
-          return "@\"" + str.Replace("\"", "\"\"") + "\""; // correctly escape the characters
-        }
-        else
-        {
-          return this.Value.ToString();
-        }
-      }
-      #endregion
+            public readonly Typ Type;
+            public readonly int sizeAsConstant;
 
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        return this;
-      }
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        return this;
-      }
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Constant<Typ>(this.Type, this.Value, this);
-      }
+            [NonSerialized]
+            private readonly object frameworkVar;
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return frameworkVar;
+                }
+            }
 
-      public override BoxedExpression Negate()
-      {
-        if (Value is Int32)
-        {
-          int v = (Int32)Value;
+            public SizeOfExpression(Typ type, int sizeAsConstant, object frameworkVar)
+            {
+                this.Type = type;
+                this.sizeAsConstant = sizeAsConstant;
+                this.frameworkVar = frameworkVar;
+            }
 
-          if (v == 0)
-            return new ClousotExpression<Typ>.ConstantExpression(1, this.Type);
-          else
-            return new ClousotExpression<Typ>.ConstantExpression(0, this.Type);
+            public SizeOfExpression(Typ type, object frameworkVar) : this(type, -1, frameworkVar) { }
+
+            public override bool IsSizeOf { get { return true; } }
+
+            public override bool SizeOf(out int size)
+            {
+                size = this.sizeAsConstant;
+                return (size >= 0);
+            }
+
+            public override bool SizeOf(out object type, out int size)
+            {
+                type = this.Type;
+                size = this.sizeAsConstant;
+                return (size >= 0);
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+            }
+
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+            {
+                ClousotExpression<Type2>.SizeOfExpression that = (ClousotExpression<Type2>.SizeOfExpression)(object)this;
+                return visitor.Sizeof(pc, that.Type, Unit.Value, data);
+            }
+
+
+            #region System.Object overrides
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+
+                ClousotExpression<Typ>.SizeOfExpression that = obj as ClousotExpression<Typ>.SizeOfExpression;
+                if (that == null) return false;
+
+                return this.Type.Equals(that.Type);
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return this.Type.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                return String.Format("sizeof({0})", this.Type.ToString());
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                Contract.Assume(converter != null);
+
+                if (this.Type is Typ2)
+                    return String.Format("sizeof({0})", converter((Typ2)(object)this.Type));
+                return ToString();
+            }
+            #endregion
+
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                return this;
+            }
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                return this;
+            }
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.SizeOf<Typ>(this.Type, this.sizeAsConstant, this);
+            }
         }
 
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
+        [Serializable]
+        public class IsInstExpression : ClousotExpression<Typ>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(arg != null);
+            }
+
+
+            private readonly BoxedExpression arg;
+            private readonly Typ type;
+
+            [NonSerialized]
+            private readonly object frameworkVar;
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return frameworkVar;
+                }
+            }
+
+            public IsInstExpression(BoxedExpression arg, Typ type, object frameworkVar)
+            {
+                Contract.Requires(arg != null);
+
+                this.arg = arg;
+                this.type = type;
+                this.frameworkVar = frameworkVar;
+            }
+
+            public override bool IsIsInst
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
+            {
+                exp = arg;
+                type = this.type;
+
+                return true;
+            }
+
+            public override BoxedExpression UnaryArgument
+            {
+                get
+                {
+                    return arg;
+                }
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+            {
+                ClousotExpression<Type2>.IsInstExpression that = (ClousotExpression<Type2>.IsInstExpression)(object)this;
+
+                return visitor.Isinst(pc, that.type, Unit.Value, Unit.Value, data);
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return arg.GetHashCode();
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                arg.AddFreeVariables(set);
+            }
+
+            public override bool Equals(object obj)
+            {
+                ClousotExpression<Typ>.IsInstExpression that = obj as ClousotExpression<Typ>.IsInstExpression;
+                if (that == null) return false;
+                return arg.Equals(that.arg) && type.Equals(that.type);
+            }
+
+            public override string ToString()
+            {
+                return String.Format("({0} as {1})", arg.ToString(), type.ToString());
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                Contract.Assume(converter != null);
+
+                if (type is Typ2)
+                    return String.Format("({0} as {1})", arg.ToString(), converter((Typ2)(object)type));
+                else
+                    return ToString();
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var arg = this.arg.Substitute(map);
+                if (arg == this.arg) return this;
+                if (arg == null) return null;
+                return new IsInstExpression(arg, type, null);
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var arg = this.arg.Rename(renaming, refiner);
+                if (arg == this.arg) return this;
+                if (arg == null) return null;
+                return new IsInstExpression(arg, type, null);
+            }
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.IsInst<Typ>(type, arg, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
+        }
+
+        [Serializable]
+        internal class ResultExpression : ClousotExpression<Typ>
+        {
+            private const string ContractResultTemplate = "Contract.Result<{0}>()";
+
+            public readonly Typ type;
+
+            public ResultExpression(Typ type)
+            {
+                this.type = type;
+            }
+
+            public override bool IsResult
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override string ToString()
+            {
+                return string.Format(ContractResultTemplate, type.ToString());
+                //return string.Format(ContractResultTemplate, type.ToString());
+                //return string.Format(ContractResultTemplate, OutputPrettyCS.TypeHelper.TypeFullName());
+            }
+
+            public override string ToString<Typ2>(Converter<Typ2, string> converter)
+            {
+                Contract.Assume(converter != null);
+
+                if (type is Typ2)
+                    return string.Format(ContractResultTemplate, converter((Typ2)(object)type));
+                else
+                    return ToString();
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return type.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                ResultExpression other = obj as ResultExpression;
+                if (other == null) return false;
+                return this.type.Equals(other.type);
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                return this;
+            }
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                return this;
+            }
+            [ContractVerification(false)]
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                return visitor.Ldresult(pc, (Type)(object)this.type, Unit.Value, Unit.Value, data);
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Result<Typ>(this.type, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
+        }
+
+        [Serializable]
+        internal class OldExpression : ClousotExpression<Typ>
+        {
+            private const string FoxTrotOld = "Contract.OldValue({0})";
+
+            public readonly BoxedExpression Old;
+            public readonly Typ Type;
+
+            public OldExpression(BoxedExpression old, Typ typ)
+            {
+                this.Old = old;
+                this.Type = typ;
+            }
+
+            public OldExpression(BoxedExpression old, Typ typ, bool mbOut)
+            {
+                this.Old = old;
+                this.Type = typ;
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                this.Old.AddFreeVariables(set);
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return Old.GetHashCode() * 2 + 1;
+            }
+
+            public override bool Equals(object obj)
+            {
+                OldExpression that = obj as OldExpression;
+                if (that == null) return false;
+                return this.Old.Equals(that.Old);
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var old = this.Old.Substitute(map);
+                if (old == this.Old) return this;
+                if (old == null) return null;
+                return new OldExpression(old, this.Type);
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var old = this.Old.Rename(renaming, refiner);
+                if (old == this.Old) return this;
+                if (old == null) return null;
+                return new OldExpression(old, this.Type);
+            }
+
+            #region The Old expression is "transparent", so everything gets forwarded to the embedded expression
+            public override PathElement[] AccessPath
+            {
+                get
+                {
+                    return this.Old.AccessPath;
+                }
+            }
+
+            public override BoxedExpression BinaryLeft
+            {
+                get
+                {
+                    return this.Old.BinaryLeft;
+                }
+            }
+
+            public override BinaryOperator BinaryOp
+            {
+                get
+                {
+                    return this.Old.BinaryOp;
+                }
+            }
+            public override BoxedExpression BinaryRight
+            {
+                get
+                {
+                    return this.Old.BinaryRight;
+                }
+            }
+
+            public override object Constant
+            {
+                get
+                {
+                    return this.Old.Constant;
+                }
+            }
+
+            public override object ConstantType
+            {
+                get
+                {
+                    return this.Old.ConstantType;
+                }
+            }
+
+            public override bool IsBinary
+            {
+                get
+                {
+                    return this.Old.IsBinary;
+                }
+            }
+
+            public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
+            {
+                return this.Old.IsBinaryExpression(out bop, out left, out right);
+            }
+
+
+            public override bool IsConstant
+            {
+                get
+                {
+                    return this.Old.IsConstant;
+                }
+            }
+
+            public override bool IsIsInst
+            {
+                get
+                {
+                    return this.Old.IsIsInst;
+                }
+            }
+
+            public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
+            {
+                return this.Old.IsIsInstExpression(out exp, out type);
+            }
+
+            public override bool IsNull
+            {
+                get
+                {
+                    return this.Old.IsNull;
+                }
+            }
+
+            public override bool IsSizeOf
+            {
+                get
+                {
+                    return this.Old.IsSizeOf;
+                }
+            }
+
+            public override bool IsUnary
+            {
+                get
+                {
+                    return this.Old.IsUnary;
+                }
+            }
+
+            public override bool IsVariable
+            {
+                get
+                {
+                    return this.Old.IsVariable;
+                }
+            }
+
+            public override bool SizeOf(out int size)
+            {
+                return this.Old.SizeOf(out size);
+            }
+
+
+            public override BoxedExpression UnaryArgument
+            {
+                get
+                {
+                    return this.Old.UnaryArgument;
+                }
+            }
+            public override UnaryOperator UnaryOp
+            {
+                get
+                {
+                    return this.Old.UnaryOp;
+                }
+            }
+
+            //public override object Variable
+            //{
+            //  get
+            //  {
+            //    return this.Old.Variable;
+            //  }
+            //}
+
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return this.Old.UnderlyingVariable;
+                }
+            }
+
+            public override bool SizeOf(out object type, out int size)
+            {
+                return this.Old.SizeOf(out type, out size);
+            }
+
+            #endregion
+
+            public override string ToString()
+            {
+                return String.Format(FoxTrotOld, Old.ToString());
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                ClousotExpression<Type>.OldExpression that = (ClousotExpression<Type>.OldExpression)(object)this;
+                // this represents EndOld
+                return visitor.EndOld(pc, new PC(pc.Node, 0), that.Type, Unit.Value, Unit.Value, data);
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.Old<Typ>(this.Type, this.Old, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
+        }
+
+        [Serializable]
+        internal class ValueAtReturnExpression : ClousotExpression<Typ>
+        {
+            private const string FoxTrotValueAtReturn = "Contract.ValueAtReturn(out {0})";
+
+            public readonly BoxedExpression Value;
+            public readonly Typ Type;
+
+            public ValueAtReturnExpression(BoxedExpression value, Typ typ)
+            {
+                this.Value = value;
+                this.Type = typ;
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                this.Value.AddFreeVariables(set);
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return Value.GetHashCode() * 2 + 1;
+            }
+
+            public override bool Equals(object obj)
+            {
+                OldExpression that = obj as OldExpression;
+                if (that == null) return false;
+                return this.Value.Equals(that.Old);
+            }
+
+            public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
+            {
+                var val = this.Value.Substitute(map);
+                if (val == this.Value) return this;
+                if (val == null) return null;
+                return new ValueAtReturnExpression(val, this.Type);
+            }
+
+            public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
+            {
+                var val = this.Value.Rename(renaming, refiner);
+                if (val == this.Value) return this;
+                if (val == null) return null;
+                return new ValueAtReturnExpression(val, this.Type);
+            }
+            #region The Old expression is "transparent", so everything gets forwarded to the embedded expression
+            public override PathElement[] AccessPath
+            {
+                get
+                {
+                    return this.Value.AccessPath;
+                }
+            }
+
+            public override BoxedExpression BinaryLeft
+            {
+                get
+                {
+                    return this.Value.BinaryLeft;
+                }
+            }
+
+            public override BinaryOperator BinaryOp
+            {
+                get
+                {
+                    return this.Value.BinaryOp;
+                }
+            }
+            public override BoxedExpression BinaryRight
+            {
+                get
+                {
+                    return this.Value.BinaryRight;
+                }
+            }
+
+            public override object Constant
+            {
+                get
+                {
+                    return this.Value.Constant;
+                }
+            }
+
+            public override object ConstantType
+            {
+                get
+                {
+                    return this.Value.ConstantType;
+                }
+            }
+
+            public override bool IsBinary
+            {
+                get
+                {
+                    return this.Value.IsBinary;
+                }
+            }
+
+            public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
+            {
+                return this.Value.IsBinaryExpression(out bop, out left, out right);
+            }
+
+
+            public override bool IsConstant
+            {
+                get
+                {
+                    return this.Value.IsConstant;
+                }
+            }
+
+            public override bool IsIsInst
+            {
+                get
+                {
+                    return this.Value.IsIsInst;
+                }
+            }
+
+            public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
+            {
+                return this.Value.IsIsInstExpression(out exp, out type);
+            }
+
+            public override bool IsNull
+            {
+                get
+                {
+                    return this.Value.IsNull;
+                }
+            }
+
+            public override bool IsSizeOf
+            {
+                get
+                {
+                    return this.Value.IsSizeOf;
+                }
+            }
+
+            public override bool IsUnary
+            {
+                get
+                {
+                    return this.Value.IsUnary;
+                }
+            }
+
+            public override bool IsVariable
+            {
+                get
+                {
+                    return this.Value.IsVariable;
+                }
+            }
+
+            public override bool SizeOf(out int size)
+            {
+                return this.Value.SizeOf(out size);
+            }
+
+
+            public override BoxedExpression UnaryArgument
+            {
+                get
+                {
+                    return this.Value.UnaryArgument;
+                }
+            }
+            public override UnaryOperator UnaryOp
+            {
+                get
+                {
+                    return this.Value.UnaryOp;
+                }
+            }
+
+            //public override object Variable
+            //{
+            //  get
+            //  {
+            //    return this.Value.Variable;
+            //  }
+            //}
+
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    return this.Value.UnderlyingVariable;
+                }
+            }
+
+            public override bool SizeOf(out object type, out int size)
+            {
+                return this.Value.SizeOf(out type, out size);
+            }
+
+            #endregion
+
+            public override string ToString()
+            {
+                return String.Format(FoxTrotValueAtReturn, Value.ToString());
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
+            {
+                ClousotExpression<Type>.ValueAtReturnExpression that = (ClousotExpression<Type>.ValueAtReturnExpression)(object)this;
+                // this represents ldind
+                return visitor.Ldind(pc, that.Type, false, Unit.Value, Unit.Value, data);
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                visitor.ValueAtReturn<Typ>(this.Type, this.Value, this);
+            }
+
+            public override BoxedExpression Negate()
+            {
+                return BoxedExpression.UnaryLogicalNot(this);
+            }
+        }
+
+        [Serializable]
+        internal class ExternalBox<Variable, ExternalExpression> : ClousotExpression<Typ>, ISerializable
+          where ExternalExpression : IEquatable<ExternalExpression>
+        {
+            private ExternalExpression exp;
+            private IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder;
+
+            #region Caching
+
+            private Optional<object> var;
+            private Optional<Pair<bool, object>> type;
+            private Optional<Pair<bool, Object>> isVar;
+            private Optional<Microsoft.Research.DataStructures.STuple<bool, object, Typ>> constant;
+            private Optional<Microsoft.Research.DataStructures.STuple<bool, BoxedExpression, Typ>> isInst;
+            private Optional<Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>> unary;
+            private Optional<Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>> binary;
+
+            #endregion
+
+            #region ISerializable members
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                info.SetType(typeof(BoxedExpressionProxy));
+                info.AddValue("BE", BoxedExpression.Convert(exp, decoder, Int32.MaxValue));
+            }
+            #endregion
+
+            public ExternalBox(ExternalExpression exp, IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder)
+            {
+                this.exp = exp;
+                this.decoder = decoder;
+            }
+
+            public override bool IsBinary
+            {
+                get
+                {
+                    if (binary.IsValid)
+                    {
+                        return binary.Value.One;
+                    }
+
+                    BinaryOperator op;
+                    ExternalExpression left, right;
+                    var res = decoder.IsBinaryOperator(exp, out op, out left, out right);
+
+                    binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>
+                       (res, op, BoxedExpression.For(left, decoder), BoxedExpression.For(right, decoder));
+
+                    return res;
+                }
+            }
+
+            [ContractVerification(false)]
+            public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
+            {
+                if (binary.IsValid)
+                {
+                    bop = binary.Value.Two;
+                    left = binary.Value.Three;
+                    right = binary.Value.Four;
+
+                    return binary.Value.One;
+                }
+
+                ExternalExpression eleft, eright;
+                if (decoder.IsBinaryOperator(exp, out bop, out eleft, out eright))
+                {
+                    left = BoxedExpression.For(eleft, decoder);
+                    right = BoxedExpression.For(eright, decoder);
+
+                    binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>(true, bop, left, right);
+
+                    return true;
+                }
+
+
+                left = null;
+                right = null;
+
+                binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>(false, bop, left, right);
+                return false;
+            }
+
+            public override BinaryOperator BinaryOp
+            {
+                get
+                {
+                    if (binary.IsValid)
+                    {
+                        return binary.Value.Two;
+                    }
+
+                    BinaryOperator bop;
+                    ExternalExpression left, right;
+                    if (decoder.IsBinaryOperator(exp, out bop, out left, out right))
+                    {
+                        binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>
+                          (true, bop, BoxedExpression.For(left, decoder), BoxedExpression.For(right, decoder));
+
+                        return bop;
+                    }
+                    throw new InvalidOperationException();
+                }
+            }
+
+            public override BoxedExpression BinaryLeft
+            {
+                get
+                {
+                    if (binary.IsValid)
+                    {
+                        Contract.Assume(binary.Value.Three != null);
+                        return binary.Value.Three;
+                    }
+
+                    BinaryOperator bop;
+                    ExternalExpression left, right;
+                    if (decoder.IsBinaryOperator(exp, out bop, out left, out right))
+                    {
+                        return BoxedExpression.For(left, decoder);
+                    }
+                    throw new InvalidOperationException();
+                }
+            }
+
+            public override BoxedExpression BinaryRight
+            {
+                get
+                {
+                    if (binary.IsValid)
+                    {
+                        Contract.Assume(binary.Value.Four != null);
+
+                        return binary.Value.Four;
+                    }
+
+                    BinaryOperator bop;
+                    ExternalExpression left, right;
+                    if (decoder.IsBinaryOperator(exp, out bop, out left, out right))
+                    {
+                        return BoxedExpression.For(right, decoder);
+                    }
+                    throw new InvalidOperationException();
+                }
+            }
+
+            public override bool IsConstant
+            {
+                get
+                {
+                    if (constant.IsValid)
+                    {
+                        return constant.Value.One;
+                    }
+
+                    try // We are catching it because the underlying decoder may fail in some weird cases when this.exp is not a constant
+                    {
+                        object value;
+                        Typ type;
+                        var r = decoder.IsConstant(exp, out value, out type);
+
+                        constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(r, value, type);
+
+                        return r;
+                    }
+                    catch (NullReferenceException)
+                    {
+                        return false;
+                    }
+                }
+            }
+            public override object Constant
+            {
+                get
+                {
+                    if (constant.IsValid)
+                    {
+                        return constant.Value.Two;
+                    }
+
+                    object value;
+                    Typ type;
+                    if (decoder.IsConstant(exp, out value, out type))
+                    {
+                        constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
+                        return value;
+                    }
+
+                    constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
+
+                    return null;
+                }
+            }
+
+            public override object ConstantType
+            {
+                get
+                {
+                    if (constant.IsValid)
+                    {
+                        return constant.Value.Three;
+                    }
+
+                    object value;
+                    Typ type;
+                    if (decoder.IsConstant(exp, out value, out type))
+                    {
+                        constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
+
+                        return type;
+                    }
+
+                    constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
+                    return null;
+                }
+            }
+
+            public override bool IsSizeOf
+            {
+                get
+                {
+                    Typ type;
+                    return decoder.IsSizeOf(exp, out type);
+                }
+            }
+
+            public override bool SizeOf(out object type, out int size)
+            {
+                Typ ttype;
+                if (decoder.IsSizeOf(exp, out ttype))
+                {
+                    decoder.TrySizeOfAsConstant(exp, out size);
+                    type = ttype;
+                    return size >= 0;
+                }
+                type = null; size = -1;
+                return false;
+            }
+
+            public override bool SizeOf(out int size)
+            {
+                return decoder.TrySizeOfAsConstant(exp, out size);
+            }
+
+            public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
+            {
+                if (this.IsIsInst)
+                {
+                    Contract.Assume(isInst.Value.Two != null);
+
+                    exp = isInst.Value.Two;
+                    type = isInst.Value.Three;
+
+                    return true;
+                }
+
+                exp = default(BoxedExpression);
+                type = default(object);
+                return false;
+            }
+
+            public override bool IsIsInst
+            {
+                get
+                {
+                    if (!isInst.IsValid)
+                    {
+                        ExternalExpression arg;
+                        Typ type;
+                        var outcome = decoder.IsInst(exp, out arg, out type);
+
+                        isInst = new Microsoft.Research.DataStructures.STuple<bool, BoxedExpression, Typ>(outcome, BoxedExpression.For(arg, decoder), type);
+                    }
+
+                    return isInst.Value.One;
+                }
+            }
+
+            public override bool IsUnary
+            {
+                get
+                {
+                    if (unary.IsValid)
+                    {
+                        return unary.Value.One;
+                    }
+
+                    UnaryOperator op;
+                    ExternalExpression arg;
+                    var res = decoder.IsUnaryOperator(exp, out op, out arg);
+
+                    unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(res, op, BoxedExpression.For(arg, decoder));
+
+                    return res;
+                }
+            }
+
+            public override bool IsUnaryExpression(out UnaryOperator uop, out BoxedExpression left)
+            {
+                if (unary.IsValid)
+                {
+                    Contract.Assume(unary.Value.Three != null, "F: Lazy, should be an object invariant");
+
+                    uop = unary.Value.Two;
+                    left = unary.Value.Three;
+                    return unary.Value.One;
+                }
+
+                ExternalExpression arg;
+                var res = decoder.IsUnaryOperator(exp, out uop, out arg);
+                left = BoxedExpression.For(arg, decoder);
+                unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(res, uop, left);
+
+                return res;
+            }
+
+            public override BoxedExpression UnaryArgument
+            {
+                get
+                {
+                    if (unary.IsValid)
+                    {
+                        Contract.Assume(unary.Value.Three != null);
+                        return unary.Value.Three;
+                    }
+
+                    UnaryOperator op;
+                    ExternalExpression arg;
+                    if (decoder.IsUnaryOperator(exp, out op, out arg))
+                    {
+                        var exp = BoxedExpression.For(arg, decoder);
+
+                        unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(true, op, exp);
+
+                        return exp;
+                    }
+
+                    unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(false, op, null);
+
+                    throw new InvalidOperationException();
+                }
+            }
+            public override UnaryOperator UnaryOp
+            {
+                get
+                {
+                    if (unary.IsValid)
+                    {
+                        return unary.Value.Two;
+                    }
+
+                    UnaryOperator op;
+                    ExternalExpression arg;
+                    if (decoder.IsUnaryOperator(exp, out op, out arg))
+                    {
+                        unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(true, op, BoxedExpression.For(arg, decoder));
+
+                        return op;
+                    }
+                    throw new InvalidOperationException();
+                }
+            }
+
+            public override bool IsVariable
+            {
+                get
+                {
+                    if (isVar.IsValid)
+                    {
+                        return isVar.Value.One;
+                    }
+
+                    object variable;
+                    var res = decoder.IsVariable(exp, out variable);
+
+                    isVar = new Pair<bool, object>(res, variable);
+
+                    return res;
+                }
+            }
+
+            public override object UnderlyingVariable
+            {
+                get
+                {
+                    if (var.IsValid)
+                    {
+                        return var.Value;
+                    }
+
+                    var v = decoder.UnderlyingVariable(exp);
+
+                    var = v;
+
+                    return v;
+                }
+            }
+
+
+            public override bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
+            {
+                ExternalExpression tempInfo;
+                bool success = decoder.TryGetAssociatedExpression(exp, infoKind, out tempInfo);
+                if (success) { info = BoxedExpression.For(tempInfo, decoder); return true; }
+                info = null;
+                return false;
+            }
+            public override bool TryGetAssociatedInfo(APC pc, AssociatedInfo infoKind, out BoxedExpression info)
+            {
+                ExternalExpression tempInfo;
+                bool success = decoder.TryGetAssociatedExpression(pc, exp, infoKind, out tempInfo);
+                if (success) { info = BoxedExpression.For(tempInfo, decoder); return true; }
+                info = null;
+                return false;
+            }
+
+            public override bool TryGetType(out object type)
+            {
+                if (this.type.IsValid)
+                {
+                    type = this.type.Value.Two;
+                    return this.type.Value.One;
+                }
+                var outcome = decoder.TryGetType(exp, out type);
+
+                this.type = new Pair<bool, object>(outcome, type);
+
+                return outcome;
+            }
+
+            private struct ISetWrapper : Microsoft.Research.DataStructures.IMutableSet<ExternalExpression>
+            {
+                private Set<BoxedExpression> set;
+                private IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder;
+                public ISetWrapper(Set<BoxedExpression> set, IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder)
+                {
+                    this.set = set;
+                    this.decoder = decoder;
+                }
+
+
+                #region Set<ExternalExpression> Members
+
+                public void AddRange(IEnumerable<ExternalExpression> range)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Microsoft.Research.DataStructures.IMutableSet<U> ConvertAll<U>(Converter<ExternalExpression, U> converter)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> Difference(IEnumerable<ExternalExpression> b)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> FindAll(Predicate<ExternalExpression> predicate)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public void ForEach(Action<ExternalExpression> action)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public bool Exists(Predicate<ExternalExpression> predicate)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> Intersection(IReadonlySet<ExternalExpression> b)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public bool IsSubset(IReadonlySet<ExternalExpression> s)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public bool IsEmpty
+                {
+                    get { throw new NotImplementedException(); }
+                }
+
+                public bool IsSingleton
+                {
+                    get { throw new NotImplementedException(); }
+                }
+
+                public ExternalExpression PickAnElement()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public bool TrueForAll(Predicate<ExternalExpression> predicate)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> Union(IReadonlySet<ExternalExpression> b)
+                {
+                    throw new NotImplementedException();
+                }
+
+                #endregion
+
+                #region ISet<ExternalExpression> Members
+
+                public bool Add(ExternalExpression item)
+                {
+                    return set.Add(BoxedExpression.For(item, decoder));
+                }
+
+                public bool Contains(ExternalExpression item)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public int Count
+                {
+                    get { throw new NotImplementedException(); }
+                }
+
+                #endregion
+
+                #region IEnumerable<ExternalExpression> Members
+
+                public IEnumerator<ExternalExpression> GetEnumerator()
+                {
+                    throw new NotImplementedException();
+                }
+
+                #endregion
+
+                #region IEnumerable Members
+
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+                {
+                    throw new NotImplementedException();
+                }
+
+                #endregion
+            }
+
+            public override void AddFreeVariables(Set<BoxedExpression> set)
+            {
+                decoder.AddFreeVariables(exp, new ISetWrapper(set, decoder));
+            }
+
+            public override bool IsNull { get { return decoder.IsNull(exp); } }
+
+            [ContractVerification(false)]
+            protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
+            {
+                // first internalize
+                var internalized = BoxedExpression.Convert(exp, decoder, Int32.MaxValue);
+                // now substitute
+                return internalized != null ? internalized.Substitute(what, newExp) : null;
+            }
+
+            [ContractVerification(false)]
+            public override BoxedExpression Negate()
+            {
+                var internalConvert = BoxedExpression.Convert(exp, decoder, Int32.MaxValue);
+                return internalConvert != null ? internalConvert.Negate() : null;
+            }
+
+            internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
+            {
+                IFullExpressionDecoder<Type2, Variable, ExternalExpression> decoder = (IFullExpressionDecoder<Type2, Variable, ExternalExpression>)(object)this.decoder;
+                object value;
+                Type2 type;
+                if (decoder.IsConstant(exp, out value, out type))
+                {
+                    if (value == null)
+                    {
+                        return visitor.Ldnull(pc, Unit.Value, data);
+                    }
+                    return visitor.Ldconst(pc, value, type, Unit.Value, data);
+                }
+                UnaryOperator uop;
+                ExternalExpression uarg;
+                if (decoder.IsUnaryOperator(exp, out uop, out uarg))
+                {
+                    return visitor.Unary(pc, uop, false, false, Unit.Value, Unit.Value, data);
+                }
+                BinaryOperator bop;
+                ExternalExpression left, right;
+                if (decoder.IsBinaryOperator(exp, out bop, out left, out right))
+                {
+                    return visitor.Binary(pc, bop, Unit.Value, Unit.Value, Unit.Value, data);
+                }
+                if (decoder.IsInst(exp, out uarg, out type))
+                {
+                    return visitor.Isinst(pc, type, Unit.Value, Unit.Value, data);
+                }
+                if (decoder.IsNull(exp))
+                {
+                    return visitor.Ldnull(pc, Unit.Value, data);
+                }
+                if (decoder.IsSizeOf(exp, out type))
+                {
+                    return visitor.Sizeof(pc, type, Unit.Value, data);
+                }
+                Contract.Assume(this.decoder.IsVariable(exp, out value));
+                throw new NotImplementedException("TODO");
+            }
+
+
+            #region Object overrides
+            public override bool Equals(object obj)
+            {
+                if (this == obj) return true;
+                ExternalBox<Variable, ExternalExpression> that = obj as ExternalBox<Variable, ExternalExpression>;
+                if (that != null)
+                {
+                    return exp.Equals(that.exp);
+                }
+                BoxedExpression other = obj as BoxedExpression;
+                if (other != null)
+                {
+                    // mixed case dispatch in reverse
+                    return other.Equals(this);
+                }
+                return false;
+            }
+
+            protected override int ComputeHashCode()
+            {
+                return exp.GetHashCode();
+            }
+
+            public override string ToString()
+            {
+                // Special case for constants 
+                if (this.IsConstant)
+                {
+                    if (this.Constant is string)
+                    {
+                        string str = this.Constant as string;
+                        return "@\"" + str.Replace("\"", "\"\"") + "\""; // correctly escape the characters
+                    }
+                    else
+                        return this.Constant != null ? this.Constant.ToString() : "null";
+                }
+
+                return exp.ToString();
+            }
+            #endregion
+
+            public override BoxedExpression Substitute<V>(Func<V, BoxedExpression, BoxedExpression> map)
+            {
+                // first internalize
+                var internalized = BoxedExpression.Convert(exp, decoder, Int32.MaxValue);
+                // now substitute
+                return internalized != null ? internalized.Substitute(map) : internalized;
+            }
+
+            public override BoxedExpression Rename<V>(IFunctionalMap<V, V> renaming, Func<V, BoxedExpression> refiner = null)
+            {
+                // first internalize
+                var internalized = BoxedExpression.Convert(exp, decoder, Int32.MaxValue);
+                // now substitute
+                return internalized != null ? internalized.Rename(renaming, refiner) : null;
+            }
+
+            public override void Dispatch(IBoxedExpressionVisitor visitor)
+            {
+                decoder.Dispatch(exp, visitor);
+            }
+        }
+
+        #endregion
     }
 
-    [Serializable]
-    internal class SizeOfExpression : ClousotExpression<Typ>
+    public interface IFullExpressionDecoder<Type, Variable, Expression>
     {
-      public readonly Typ Type;
-      public readonly int sizeAsConstant;
+        /// <summary>
+        /// Returns true if exp is a variable
+        /// </summary>
+        /// <param name="variable"></param>
+        /// <returns></returns>
+        bool IsVariable(Expression exp, out object variable);
 
-      [NonSerialized] private readonly object frameworkVar;
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          return this.frameworkVar;
-        }
-      }
+        Variable UnderlyingVariable(Expression exp);
 
-      public SizeOfExpression(Typ type, int sizeAsConstant, object frameworkVar)
-      {
-        this.Type = type;
-        this.sizeAsConstant = sizeAsConstant;
-        this.frameworkVar = frameworkVar;
-      }
+        /// <summary>
+        /// Returns true if exp is the null constant
+        /// </summary>
+        bool IsNull(Expression exp);
 
-      public SizeOfExpression(Typ type, object frameworkVar) : this(type, -1, frameworkVar) { }
+        /// <summary>
+        /// If the expression is a constant, this provides the value and the type
+        /// </summary>
+        bool IsConstant(Expression exp, out object value, out Type type);
 
-      public override bool IsSizeOf { get { return true; } }
-
-      public override bool SizeOf(out int size)
-      {
-        size = this.sizeAsConstant;
-        return (size >= 0);
-      }
-
-      public override bool SizeOf(out object type, out int size)
-      {
-        type = this.Type;
-        size = this.sizeAsConstant;
-        return (size >= 0);
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-      }
+        /// <summary>
+        /// If the expression is sizeof(T), this provides the type T
+        /// </summary>
+        bool IsSizeOf(Expression exp, out Type type);
 
 
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      {
-        ClousotExpression<Type2>.SizeOfExpression that = (ClousotExpression<Type2>.SizeOfExpression)(object)this;
-        return visitor.Sizeof(pc, that.Type, Unit.Value, data);
-      }
+        /// <summary>
+        /// If the expression is isInst(e, T), this provides e and T
+        /// </summary>
+        bool IsInst(Expression exp, out Expression arg, out Type type);
 
+        /// <summary>
+        /// If exp is a Unary operation (according to MSIL!), this returns the operator
+        /// and operand
+        /// </summary>
+        /// <param name="exp"></param>
+        /// <returns></returns>
+        bool IsUnaryOperator(Expression exp, out UnaryOperator op, out Expression arg);
 
-      #region System.Object overrides
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
+        /// <summary>
+        /// If exp is a binary operation (according to MSIL!), this returns the operator
+        /// and operands
+        /// </summary>
+        bool IsBinaryOperator(Expression exp, out BinaryOperator op, out Expression left, out Expression right);
 
-        ClousotExpression<Typ>.SizeOfExpression that = obj as ClousotExpression<Typ>.SizeOfExpression;
-        if (that == null) return false;
+        /// <summary>
+        /// If the expression has the associated info, it is returned.
+        /// </summary>
+        /// <returns>true if success, false, if no information</returns>
+        bool TryGetAssociatedExpression(Expression exp, AssociatedInfo infoKind, out Expression info);
 
-        return this.Type.Equals(that.Type);
-      }
+        /// <summary>
+        /// If the expression has the associated info, it is returned.
+        /// </summary>
+        /// <param name="pc">Try to find information associated at given pc (e.g., for variables)</param>
+        /// <returns>true if success, false, if no information</returns>
+        bool TryGetAssociatedExpression(APC pc, Expression exp, AssociatedInfo infoKind, out Expression info);
 
-      protected override int ComputeHashCode()
-      {
-        return this.Type.GetHashCode();
-      }
+        /// <summary>
+        /// Used to gather the free variables in exp and add them to the set
+        /// </summary>
+        void AddFreeVariables(Expression exp, Microsoft.Research.DataStructures.IMutableSet<Expression> set);
 
-      public override string ToString()
-      {
-        return String.Format("sizeof({0})", this.Type.ToString());
-      }
+        /// <summary>
+        /// Returns an access path to the expression (which is classified as a variable)
+        /// </summary>
+        FList<PathElement> GetVariableAccessPath(Expression exp);
 
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        Contract.Assume(converter != null);
+        /// <summary>
+        /// If exp is sizeof this tries to get the size of the type as a constant
+        /// </summary>
+        bool TrySizeOfAsConstant(Expression exp, out int value);
 
-        if (this.Type is Typ2)
-          return String.Format("sizeof({0})", converter((Typ2)(object)this.Type));
-        return ToString();
-      }
-      #endregion
+        bool TryGetType(Expression exp, out object type);
 
+        Type System_Int32 { get; }
 
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        return this;
-      }
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        return this;
-      }
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
+        bool IsReferenceType(Type type);
 
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.SizeOf<Typ>(this.Type, this.sizeAsConstant, this);
-      }
+        void Dispatch(Expression exp, IBoxedExpressionVisitor visitor);
     }
 
-    [Serializable]
-    public class IsInstExpression : ClousotExpression<Typ>
+    #region CodeProviders and MSIL decoders
+
+    public class ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type> :
+      ICodeProvider<BoxedExpression.PC, Local, Parameter, Method, Field, Type>
     {
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.arg != null);
-      }
+        public static readonly ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type> Decoder = new ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>(); // Thread-safe
 
+        #region ICodeProvider<PC,Method,Type> Members
 
-      readonly BoxedExpression arg;
-      readonly Typ type;
-
-      [NonSerialized] private readonly object frameworkVar;
-      public override object UnderlyingVariable
-      {
-        get
+        /// <summary>
+        /// To avoid redundantly encoding the logic for decoding the next and nested ops,
+        /// we return the next flat aggregate label as well as the possible nested aggregate op at the
+        /// current point.
+        ///
+        /// There are a number of possible outcomes
+        /// 1) the current program point refers to a sub-expression
+        ///   1a) and there is a syntactic next program point
+        ///   1b) and there is no syntactic next program point
+        /// 2) the current program point refers to a final operation (e.g. add elements on stack)
+        ///    and there is no syntactic next program point
+        /// 3) the current program point is a no-op and there is no syntactic next program point
+        /// 4) the current node is a variable and we are stepping through the access path! In this case
+        ///    the final operation is a no-op and there are no nested expressions that representable as ClousotExpressions.
+        ///
+        /// We encode these outcomes as follows:
+        /// If the result is null, it means there is a next program point, otherwise, it is the final operation
+        /// of the current PC (possibly no-ops, e.g. Block, or ExpressionStatement).
+        /// The out parameter nestedStart is non-null if the current PC labels that particular sub-expression
+        /// and it is null, if the current program point does not have a sub-expression to be evaluated.
+        /// If both the result and the nexted start are null, then this is a special encoding, e.g., for Begin_Old
+        /// In the case of stepping through a variable access path, the nested expression is the same as the original,
+        /// and the context must use the index to access the path element.
+        /// </summary>
+        /// <param name="nestedStart">Returns the sub-tree at this PC or null.</param>
+        /// <returns>The final operation referred to by this PC or null if there is a syntactic next pc.
+        /// </returns>
+        private static BoxedExpression FinalOpAndNested(BoxedExpression.PC pc, out BoxedExpression nestedStart)
         {
-          return this.frameworkVar;
-        }
-      }
-
-      public IsInstExpression(BoxedExpression arg, Typ type, object frameworkVar)
-      {
-        Contract.Requires(arg != null);
-
-        this.arg = arg;
-        this.type = type;
-        this.frameworkVar = frameworkVar;
-      }
-
-      public override bool IsIsInst
-      {
-        get
-        {
-          return true;
-        }
-      }
-
-      public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
-      {
-        exp = this.arg;
-        type = this.type;
-
-        return true;
-      }
-
-      public override BoxedExpression UnaryArgument
-      {
-        get
-        {
-          return this.arg;
-        }
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      {
-        ClousotExpression<Type2>.IsInstExpression that = (ClousotExpression<Type2>.IsInstExpression)(object)this;
-
-        return visitor.Isinst(pc, that.type, Unit.Value, Unit.Value, data);
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return arg.GetHashCode();
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        this.arg.AddFreeVariables(set);
-      }
-
-      public override bool Equals(object obj)
-      {
-        ClousotExpression<Typ>.IsInstExpression that = obj as ClousotExpression<Typ>.IsInstExpression;
-        if (that == null) return false;
-        return this.arg.Equals(that.arg) && this.type.Equals(that.type);
-      }
-
-      public override string ToString()
-      {
-        return String.Format("({0} as {1})", this.arg.ToString(), this.type.ToString());
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        Contract.Assume(converter != null);
-
-        if (this.type is Typ2)
-          return String.Format("({0} as {1})", this.arg.ToString(), converter((Typ2)(object)this.type));
-        else
-          return ToString();
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var arg = this.arg.Substitute(map);
-        if (arg == this.arg) return this;
-        if (arg == null) return null;
-        return new IsInstExpression(arg, this.type, null);
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var arg = this.arg.Rename(renaming, refiner);
-        if (arg == this.arg) return this;
-        if (arg == null) return null;
-        return new IsInstExpression(arg, this.type, null);
-      }
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.IsInst<Typ>(this.type, this.arg, this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
-    }
-
-    [Serializable]
-    internal class ResultExpression : ClousotExpression<Typ>
-    {
-      private const string ContractResultTemplate = "Contract.Result<{0}>()";
-
-      public readonly Typ type;
-
-      public ResultExpression(Typ type)
-      {
-        this.type = type;
-      }
-
-      public override bool IsResult
-      {
-        get
-        {
-          return true;
-        }
-      }
-
-      public override string ToString()
-      {
-        return string.Format(ContractResultTemplate, type.ToString());
-        //return string.Format(ContractResultTemplate, type.ToString());
-        //return string.Format(ContractResultTemplate, OutputPrettyCS.TypeHelper.TypeFullName());
-      }
-
-      public override string ToString<Typ2>(Converter<Typ2, string> converter)
-      {
-        Contract.Assume(converter != null);
-
-        if (type is Typ2)
-          return string.Format(ContractResultTemplate, converter((Typ2)(object)type));
-        else
-          return ToString();
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return type.GetHashCode();
-      }
-
-      public override bool Equals(object obj)
-      {
-        ResultExpression other = obj as ResultExpression;
-        if (other == null) return false;
-        return this.type.Equals(other.type);
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        return this;
-      }
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        return this;
-      }
-      [ContractVerification(false)]
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        return visitor.Ldresult(pc, (Type)(object)this.type, Unit.Value, Unit.Value, data);
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Result<Typ>(this.type, this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
-    }
-
-    [Serializable]
-    internal class OldExpression : ClousotExpression<Typ>
-    {
-      private const string FoxTrotOld = "Contract.OldValue({0})";
-
-      public readonly BoxedExpression Old;
-      public readonly Typ Type;
-
-      public OldExpression(BoxedExpression old, Typ typ)
-      {
-        this.Old = old;
-        this.Type = typ;
-      }
-
-      public OldExpression(BoxedExpression old, Typ typ, bool mbOut)
-      {
-        this.Old = old;
-        this.Type = typ;
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        this.Old.AddFreeVariables(set);
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return Old.GetHashCode() * 2 + 1;
-      }
-
-      public override bool Equals(object obj)
-      {
-        OldExpression that = obj as OldExpression;
-        if (that == null) return false;
-        return this.Old.Equals(that.Old);
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var old = this.Old.Substitute(map);
-        if (old == this.Old) return this;
-        if (old == null) return null;
-        return new OldExpression(old, this.Type);
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var old = this.Old.Rename(renaming, refiner);
-        if (old == this.Old) return this;
-        if (old == null) return null;
-        return new OldExpression(old, this.Type);
-      }
-
-    #region The Old expression is "transparent", so everything gets forwarded to the embedded expression
-      public override PathElement[] AccessPath
-      {
-        get
-        {
-          return this.Old.AccessPath;
-        }
-      }
-
-      public override BoxedExpression BinaryLeft
-      {
-        get
-        {
-          return this.Old.BinaryLeft;
-        }
-      }
-
-      public override BinaryOperator BinaryOp
-      {
-        get
-        {
-          return this.Old.BinaryOp;
-        }
-      }
-      public override BoxedExpression BinaryRight
-      {
-        get
-        {
-          return this.Old.BinaryRight;
-        }
-      }
-
-      public override object Constant
-      {
-        get
-        {
-          return this.Old.Constant;
-        }
-      }
-
-      public override object ConstantType
-      {
-        get
-        {
-          return this.Old.ConstantType;
-        }
-      }
-
-      public override bool IsBinary
-      {
-        get
-        {
-          return this.Old.IsBinary;
-        }
-      }
-
-      public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
-      {
-        return this.Old.IsBinaryExpression(out bop, out left, out right);
-      }
-
-
-      public override bool IsConstant
-      {
-        get
-        {
-          return this.Old.IsConstant;
-        }
-      }
-
-      public override bool IsIsInst
-      {
-        get
-        {
-          return this.Old.IsIsInst;
-        }
-      }
-
-      public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
-      {
-        return this.Old.IsIsInstExpression(out exp, out type);
-      }
-
-      public override bool IsNull
-      {
-        get
-        {
-          return this.Old.IsNull;
-        }
-      }
-
-      public override bool IsSizeOf
-      {
-        get
-        {
-          return this.Old.IsSizeOf;
-        }
-      }
-
-      public override bool IsUnary
-      {
-        get
-        {
-          return this.Old.IsUnary;
-        }
-      }
-
-      public override bool IsVariable
-      {
-        get
-        {
-          return this.Old.IsVariable;
-        }
-      }
-
-      public override bool SizeOf(out int size)
-      {
-        return this.Old.SizeOf(out size);
-      }
-
-
-      public override BoxedExpression UnaryArgument
-      {
-        get
-        {
-          return this.Old.UnaryArgument;
-        }
-      }
-      public override UnaryOperator UnaryOp
-      {
-        get
-        {
-          return this.Old.UnaryOp;
-        }
-      }
-      
-      //public override object Variable
-      //{
-      //  get
-      //  {
-      //    return this.Old.Variable;
-      //  }
-      //}
-
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          return this.Old.UnderlyingVariable;
-        }
-      }
-
-      public override bool SizeOf(out object type, out int size)
-      {
-        return this.Old.SizeOf(out type, out size);
-      }
-
-    #endregion
-
-      public override string ToString()
-      {
-        return String.Format(FoxTrotOld, Old.ToString());
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        ClousotExpression<Type>.OldExpression that = (ClousotExpression<Type>.OldExpression)(object)this;
-        // this represents EndOld
-        return visitor.EndOld(pc, new PC(pc.Node, 0), that.Type, Unit.Value, Unit.Value, data);
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.Old<Typ>(this.Type, this.Old, this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
-    }
-
-    [Serializable]
-    internal class ValueAtReturnExpression : ClousotExpression<Typ>
-    {
-      private const string FoxTrotValueAtReturn = "Contract.ValueAtReturn(out {0})";
-
-      public readonly BoxedExpression Value;
-      public readonly Typ Type;
-
-      public ValueAtReturnExpression(BoxedExpression value, Typ typ)
-      {
-        this.Value = value;
-        this.Type = typ;
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        this.Value.AddFreeVariables(set);
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return Value.GetHashCode() * 2 + 1;
-      }
-
-      public override bool Equals(object obj)
-      {
-        OldExpression that = obj as OldExpression;
-        if (that == null) return false;
-        return this.Value.Equals(that.Old);
-      }
-
-      public override BoxedExpression Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> map)
-      {
-        var val = this.Value.Substitute(map);
-        if (val == this.Value) return this;
-        if (val == null) return null;
-        return new ValueAtReturnExpression(val, this.Type);
-      }
-
-      public override BoxedExpression Rename<Variable>(IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-      {
-        var val = this.Value.Rename(renaming, refiner);
-        if (val == this.Value) return this;
-        if (val == null) return null;
-        return new ValueAtReturnExpression(val, this.Type);
-      }
-      #region The Old expression is "transparent", so everything gets forwarded to the embedded expression
-      public override PathElement[] AccessPath
-      {
-        get
-        {
-          return this.Value.AccessPath;
-        }
-      }
-
-      public override BoxedExpression BinaryLeft
-      {
-        get
-        {
-          return this.Value.BinaryLeft;
-        }
-      }
-
-      public override BinaryOperator BinaryOp
-      {
-        get
-        {
-          return this.Value.BinaryOp;
-        }
-      }
-      public override BoxedExpression BinaryRight
-      {
-        get
-        {
-          return this.Value.BinaryRight;
-        }
-      }
-
-      public override object Constant
-      {
-        get
-        {
-          return this.Value.Constant;
-        }
-      }
-
-      public override object ConstantType
-      {
-        get
-        {
-          return this.Value.ConstantType;
-        }
-      }
-
-      public override bool IsBinary
-      {
-        get
-        {
-          return this.Value.IsBinary;
-        }
-      }
-
-      public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
-      {
-        return this.Value.IsBinaryExpression(out bop, out left, out right);
-      }
-
-
-      public override bool IsConstant
-      {
-        get
-        {
-          return this.Value.IsConstant;
-        }
-      }
-
-      public override bool IsIsInst
-      {
-        get
-        {
-          return this.Value.IsIsInst;
-        }
-      }
-
-      public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
-      {
-        return this.Value.IsIsInstExpression(out exp, out type);
-      }
-
-      public override bool IsNull
-      {
-        get
-        {
-          return this.Value.IsNull;
-        }
-      }
-
-      public override bool IsSizeOf
-      {
-        get
-        {
-          return this.Value.IsSizeOf;
-        }
-      }
-
-      public override bool IsUnary
-      {
-        get
-        {
-          return this.Value.IsUnary;
-        }
-      }
-
-      public override bool IsVariable
-      {
-        get
-        {
-          return this.Value.IsVariable;
-        }
-      }
-
-      public override bool SizeOf(out int size)
-      {
-        return this.Value.SizeOf(out size);
-      }
-
-
-      public override BoxedExpression UnaryArgument
-      {
-        get
-        {
-          return this.Value.UnaryArgument;
-        }
-      }
-      public override UnaryOperator UnaryOp
-      {
-        get
-        {
-          return this.Value.UnaryOp;
-        }
-      }
-
-      //public override object Variable
-      //{
-      //  get
-      //  {
-      //    return this.Value.Variable;
-      //  }
-      //}
-
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          return this.Value.UnderlyingVariable;
-        }
-      }
-
-      public override bool SizeOf(out object type, out int size)
-      {
-        return this.Value.SizeOf(out type, out size);
-      }
-
-      #endregion
-
-      public override string ToString()
-      {
-        return String.Format(FoxTrotValueAtReturn, Value.ToString());
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(PC pc, Visitor visitor, Data data)
-      {
-        ClousotExpression<Type>.ValueAtReturnExpression that = (ClousotExpression<Type>.ValueAtReturnExpression)(object)this;
-        // this represents ldind
-        return visitor.Ldind(pc, that.Type, false, Unit.Value, Unit.Value, data);
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        visitor.ValueAtReturn<Typ>(this.Type, this.Value, this);
-      }
-
-      public override BoxedExpression Negate()
-      {
-        return BoxedExpression.UnaryLogicalNot(this);
-      }
-    }
-
-    [Serializable]
-    internal class ExternalBox<Variable, ExternalExpression> : ClousotExpression<Typ>, ISerializable
-      where ExternalExpression : IEquatable<ExternalExpression>
-    {
-      ExternalExpression exp;
-      IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder;
-
-      #region Caching
-    
-      Optional<object> var;
-      Optional<Pair<bool, object>> type;
-      Optional<Pair<bool, Object>> isVar;
-      Optional<Microsoft.Research.DataStructures.STuple<bool, object, Typ>> constant;
-      Optional<Microsoft.Research.DataStructures.STuple<bool, BoxedExpression, Typ>> isInst;
-      Optional<Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>> unary;
-      Optional<Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>> binary;      
-
-      #endregion
-
-      #region ISerializable members
-      void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
-      {
-        info.SetType(typeof(BoxedExpressionProxy));
-        info.AddValue("BE", BoxedExpression.Convert(this.exp, this.decoder, Int32.MaxValue));
-      }
-      #endregion
-
-      public ExternalBox(ExternalExpression exp, IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder)
-      {
-        this.exp = exp;
-        this.decoder = decoder;
-      }
-
-      public override bool IsBinary
-      {
-        get
-        {
-          if (this.binary.IsValid)
-          {
-            return binary.Value.One;
-          }
-
-          BinaryOperator op;
-          ExternalExpression left, right;
-          var res = this.decoder.IsBinaryOperator(this.exp, out op, out left, out right);
-
-          this.binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>
-             (res, op, BoxedExpression.For(left, this.decoder), BoxedExpression.For(right, this.decoder));
-
-          return res;
-        }
-      }
-
-      [ContractVerification(false)]
-      public override bool IsBinaryExpression(out BinaryOperator bop, out BoxedExpression left, out BoxedExpression right)
-      {
-        if (this.binary.IsValid)
-        {
-          bop = binary.Value.Two;
-          left = binary.Value.Three;
-          right = binary.Value.Four;
-
-          return binary.Value.One;
+            ClousotExpression<Type>.OldExpression oldExp = pc.Node as ClousotExpression<Type>.OldExpression;
+            if (oldExp != null)
+            {
+                // 0 is begin old
+                // 1 is nested aggregate
+                // 2 is end old
+                if (pc.Index == 0)
+                {
+                    nestedStart = null;
+                    return null;
+                }
+                if (pc.Index == 1)
+                {
+                    nestedStart = oldExp.Old;
+                    return null;
+                }
+                nestedStart = null;
+                return oldExp;
+            }
+
+            if (pc.Node.IsConstant || pc.Node.IsSizeOf)
+            {
+                nestedStart = null;
+                return pc.Node;
+            }
+            if (pc.Node.IsUnary)
+            {
+                if (pc.Index == 0)
+                {
+                    nestedStart = pc.Node.UnaryArgument;
+                    return null;
+                }
+                nestedStart = null;
+                return pc.Node;
+            }
+            if (pc.Node.IsBinary)
+            {
+                var bop = pc.Node.BinaryOp;
+                if (bop == BinaryOperator.LogicalAnd || bop == BinaryOperator.LogicalOr)
+                {
+                    // lazy eval producing the following code:
+                    //  a
+                    //  dup
+                    //  br.true pc.Node,5 (br.false pc.Node,5 for logical &&)
+                    //  pop
+                    //  b
+                    // pc,5:
+                    //  nop
+                    switch (pc.Index)
+                    {
+                        case 0:
+                            nestedStart = pc.Node.BinaryLeft;
+                            return null;
+
+                        case 1:
+                        case 2:
+                        case 3:
+                            nestedStart = null;
+                            return null;
+
+                        case 4:
+                            nestedStart = pc.Node.BinaryRight;
+                            return null;
+
+                        case 5:
+                            nestedStart = null;
+                            return pc.Node;
+                    }
+                }
+                if (pc.Index == 0)
+                {
+                    nestedStart = pc.Node.BinaryLeft;
+                    return null;
+                }
+                if (pc.Index == 1)
+                {
+                    nestedStart = pc.Node.BinaryRight;
+                    return null;
+                }
+                nestedStart = null;
+                return pc.Node;
+            }
+            if (pc.Node.IsVariable)
+            {
+                if (pc.Node.AccessPath != null // the access path can be null when we habe a bounded variable for quantifiers
+                  && pc.Node.AccessPath.Length > pc.Index)
+                {
+                    nestedStart = pc.Node;
+                    return null;
+                }
+                // End of variable sub expressions.
+                nestedStart = null;
+                return pc.Node;
+            }
+            if (pc.Node.IsIsInst)
+            {
+                if (pc.Index == 0)
+                {
+                    nestedStart = pc.Node.UnaryArgument;
+                    return null;
+                }
+                nestedStart = null;
+                return pc.Node;
+            }
+            // F: Added this case for the array index expressions
+            BoxedExpression array, index;
+            object type;
+            if (pc.Node.IsArrayIndexExpression(out array, out index, out type))
+            {
+                if (pc.Index == 0)
+                {
+                    nestedStart = array;
+                    return null;
+                }
+                if (pc.Index == 1)
+                {
+                    nestedStart = index;
+                    return null;
+                }
+                nestedStart = null;
+                return pc.Node;
+            }
+            BoxedExpression.ContractExpression assertExp = pc.Node as BoxedExpression.ContractExpression;
+            if (assertExp != null)
+            {
+                if (pc.Index == 0)
+                {
+                    nestedStart = assertExp.Condition;
+                    return null;
+                }
+                nestedStart = null;
+                return assertExp;
+            }
+            ClousotExpression<Type>.ResultExpression resExp = pc.Node as ClousotExpression<Type>.ResultExpression;
+            if (resExp != null)
+            {
+                nestedStart = null;
+                return pc.Node;
+            }
+            BoxedExpression.StatementSequence seq = pc.Node as BoxedExpression.StatementSequence;
+            if (seq != null)
+            {
+                if (pc.Index >= seq.Count)
+                {
+                    nestedStart = null;
+                    return pc.Node;
+                }
+                Contract.Assume(pc.Index >= 0, "limitation of invariants on readonly fields");
+                Contract.Assert(pc.Index < seq.Count, "Complicated invariant on pc's");
+                nestedStart = seq[pc.Index];
+                return null;
+            }
+
+            // F: Added quantified expressions
+            bool isForAll;
+            BoxedExpression boundVar, lower, upper, body;
+            if (pc.Node.IsQuantifiedExpression(out isForAll, out boundVar, out lower, out upper, out body))
+            {
+                switch (pc.Index)
+                {
+                    case 0:
+                        {
+                            nestedStart = boundVar;
+                            return null;
+                        }
+                    case 1:
+                        {
+                            nestedStart = lower;
+                            return null;
+                        }
+                    case 2:
+                        {
+                            nestedStart = upper;
+                            return null;
+                        }
+                    case 3:
+                        {
+                            nestedStart = body;
+                            return null;
+                        }
+                }
+                nestedStart = null;
+                return pc.Node;
+            }
+
+            throw new NotImplementedException();
         }
 
-        ExternalExpression eleft, eright;
-        if (this.decoder.IsBinaryOperator(this.exp, out bop, out eleft, out eright))
+#if false
+        public R Decode<Visitor, T, R>(BoxedExpression.PC label, Visitor query, T data)
+          where Visitor : ICodeQuery<BoxedExpression.PC, Local, Parameter, Method, Field, Type, T, R>
         {
-          left = BoxedExpression.For(eleft, this.decoder);
-          right = BoxedExpression.For(eright, this.decoder);
-
-          this.binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>(true, bop, left, right);
-          
-          return true;
+            BoxedExpression nested;
+            BoxedExpression finalOp = FinalOpAndNested(label, out nested);
+            if (nested != null)
+            {
+                if (nested == label.Node)
+                {
+                    // variable access path case
+                    Debug.Assert(nested.IsVariable);
+                    PathElement[] path = nested.AccessPath;
+                    return path[label.Index].Decode<T, R, Visitor, BoxedExpression.PC, Local, Parameter, Method, Field, Type>(label, query, data);
+                }
+                return query.Aggregate(label, new BoxedExpression.PC(nested, 0), false, data);
+            }
+            if (finalOp == null)
+            {
+                // begin old
+                return query.BeginOld(label, new BoxedExpression.PC(label.Node, 2), data);
+            }
+            ClousotExpression<Type>.OldExpression oldExp = finalOp as ClousotExpression<Type>.OldExpression;
+            if (oldExp != null)
+            {
+                return query.EndOld(label, new BoxedExpression.PC(label.Node, 0), oldExp.Type, Unit.Value, Unit.Value, data);
+            }
+            return query.Atomic(data, label);
         }
+#endif
 
-
-        left = null;
-        right = null;
-
-        this.binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>(false, bop, left, right);
-        return false;
-      }
-
-      public override BinaryOperator BinaryOp
-      {
-        get
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification = "Probably Clousot is right that this current.Node != null but we want to leave the check anyway")]
+        public bool Next(BoxedExpression.PC current, out BoxedExpression.PC nextLabel)
         {
-          if (this.binary.IsValid)
-          {
-            return binary.Value.Two;
-          }
+            BoxedExpression nested;
+            BoxedExpression finalOp = FinalOpAndNested(current, out nested);
+            if (finalOp == null && current.Node != null)
+            {
+                // has next
+                nextLabel = new BoxedExpression.PC(current.Node, current.Index + 1);
+                return true;
+            }
 
-          BinaryOperator bop;
-          ExternalExpression left, right;
-          if (this.decoder.IsBinaryOperator(exp, out bop, out left, out right))
-          {
-            this.binary = new Microsoft.Research.DataStructures.STuple<bool, BinaryOperator, BoxedExpression, BoxedExpression>
-              (true, bop, BoxedExpression.For(left, this.decoder), BoxedExpression.For(right, this.decoder));
-
-            return bop;
-          }
-          throw new InvalidOperationException();
-        }
-      }
-
-      public override BoxedExpression BinaryLeft
-      {
-        get
-        {
-          if (this.binary.IsValid)
-          {
-            Contract.Assume(this.binary.Value.Three != null);
-            return this.binary.Value.Three;
-          }
-
-          BinaryOperator bop;
-          ExternalExpression left, right;
-          if (this.decoder.IsBinaryOperator(exp, out bop, out left, out right))
-          {
-            return BoxedExpression.For(left, this.decoder);
-          }
-          throw new InvalidOperationException();
-        }
-      }
-
-      public override BoxedExpression BinaryRight
-      {
-        get
-        {
-          if (binary.IsValid)
-          {
-            Contract.Assume(this.binary.Value.Four!= null);
-
-            return binary.Value.Four;
-          }
-
-          BinaryOperator bop;
-          ExternalExpression left, right;
-          if (this.decoder.IsBinaryOperator(exp, out bop, out left, out right))
-          {
-            return BoxedExpression.For(right, this.decoder);
-          }
-          throw new InvalidOperationException();
-        }
-      }
-
-      public override bool IsConstant
-      {
-        get
-        {
-          if (constant.IsValid)
-          {
-            return constant.Value.One;
-          }
-
-          try // We are catching it because the underlying decoder may fail in some weird cases when this.exp is not a constant
-          {
-            object value;
-            Typ type;
-            var r = this.decoder.IsConstant(this.exp, out value, out type);
-
-            constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(r, value, type);
-
-            return r;
-          }
-          catch (NullReferenceException)
-          {
+            nextLabel = default(BoxedExpression.PC);
             return false;
-          }
-        }
-      }
-      public override object Constant
-      {
-        get
-        {
-          if (constant.IsValid)
-          {
-            return constant.Value.Two;
-          }
-
-          object value;
-          Typ type;
-          if (this.decoder.IsConstant(this.exp, out value, out type))
-          {
-            constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
-            return value;
-          }
-
-          constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
-
-          return null;
-        }
-      }
-
-      public override object ConstantType
-      {
-        get
-        {
-          if (constant.IsValid)
-          {
-            return constant.Value.Three;
-          }
-
-          object value;
-          Typ type;
-          if (this.decoder.IsConstant(this.exp, out value, out type))
-          {
-            constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
-
-            return type;
-          }
-
-          constant = new Microsoft.Research.DataStructures.STuple<bool, object, Typ>(false, value, type);
-          return null;
-        }
-      }
-
-      public override bool IsSizeOf
-      {
-        get
-        {
-          Typ type;
-          return this.decoder.IsSizeOf(this.exp, out type);
-        }
-      }
-
-      public override bool SizeOf(out object type, out int size)
-      {
-        Typ ttype;
-        if (this.decoder.IsSizeOf(this.exp, out ttype))
-        {
-          this.decoder.TrySizeOfAsConstant(this.exp, out size);
-          type = ttype;
-          return size >= 0;
-        }
-        type = null; size = -1;
-        return false;
-      }
-
-      public override bool SizeOf(out int size)
-      {
-        return this.decoder.TrySizeOfAsConstant(this.exp, out size);
-      }
-
-      public override bool IsIsInstExpression(out BoxedExpression exp, out object type)
-      {
-        if (this.IsIsInst)
-        {
-          Contract.Assume(this.isInst.Value.Two != null);
-
-          exp = this.isInst.Value.Two;
-          type = this.isInst.Value.Three;
-
-          return true;
         }
 
-        exp = default(BoxedExpression);
-        type = default(object);
-        return false;
-      }
-
-      public override bool IsIsInst
-      {
-        get
+        public void PrintCodeAt(BoxedExpression.PC pc, string indent, TextWriter tw)
         {
-          if (!this.isInst.IsValid)
-          {
-            ExternalExpression arg;
-            Typ type;
-            var outcome = this.decoder.IsInst(this.exp, out arg, out type);
+            Contract.Requires(tw != null);
 
-            this.isInst = new Microsoft.Research.DataStructures.STuple<bool, BoxedExpression, Typ>(outcome, BoxedExpression.For(arg, this.decoder), type);
-          }
-
-          return this.isInst.Value.One;
-        }
-      }
-
-      public override bool IsUnary
-      {
-        get
-        {
-          if (this.unary.IsValid)
-          {
-            return this.unary.Value.One;
-          }
-
-          UnaryOperator op;
-          ExternalExpression arg;
-          var res = decoder.IsUnaryOperator(this.exp, out op, out arg);
-
-          this.unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(res, op, BoxedExpression.For(arg, this.decoder));
-
-          return res;
-        }
-      }
-
-      public override bool IsUnaryExpression(out UnaryOperator uop, out BoxedExpression left)
-      {
-        if (this.unary.IsValid)
-        {
-          Contract.Assume(this.unary.Value.Three != null, "F: Lazy, should be an object invariant");
-
-          uop = this.unary.Value.Two;
-          left = this.unary.Value.Three;
-          return this.unary.Value.One;
+            Contract.Assume(pc.Node != null);
+            tw.WriteLine("[{0},{1}]", pc.Index, pc.Node.ToString());
         }
 
-        ExternalExpression arg;
-        var res = decoder.IsUnaryOperator(this.exp, out uop, out arg);
-        left = BoxedExpression.For(arg, this.decoder);
-        this.unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(res, uop, left);
-
-        return res;
-      }
-
-      public override BoxedExpression UnaryArgument
-      {
-        get
+        public bool HasSourceContext(BoxedExpression.PC pc)
         {
-          if (this.unary.IsValid)
-          {
-            Contract.Assume(this.unary.Value.Three != null);
-            return this.unary.Value.Three;
-          }
-
-          UnaryOperator op;
-          ExternalExpression arg;
-          if (decoder.IsUnaryOperator(this.exp, out op, out arg))
-          {
-            var exp = BoxedExpression.For(arg, this.decoder);
-
-            this.unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(true, op, exp);
-
-            return exp;
-          }
-
-          this.unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(false, op, null);
-
-          throw new InvalidOperationException();
-        }
-      }
-      public override UnaryOperator UnaryOp
-      {
-        get
-        {
-          if (this.unary.IsValid)
-          {
-            return unary.Value.Two;
-          }
-
-          UnaryOperator op;
-          ExternalExpression arg;
-          if (this.decoder.IsUnaryOperator(this.exp, out op, out arg))
-          {
-
-            this.unary = new Microsoft.Research.DataStructures.STuple<bool, UnaryOperator, BoxedExpression>(true, op, BoxedExpression.For(arg, this.decoder));
-
-            return op;
-          }
-          throw new InvalidOperationException();
-        }
-      }
-
-      public override bool IsVariable
-      {
-        get
-        {
-          if (this.isVar.IsValid)
-          {
-            return this.isVar.Value.One;
-          }
-
-          object variable;
-          var res = this.decoder.IsVariable(this.exp, out variable);
-
-          this.isVar = new Pair<bool, object>(res, variable);
-
-          return res;
-        }
-      }
-
-      public override object UnderlyingVariable
-      {
-        get
-        {
-          if (this.var.IsValid)
-          {
-            return var.Value;
-          }
-
-          var v = this.decoder.UnderlyingVariable(this.exp);
-
-          this.var = v;
-
-          return v;
-        }
-      }
-
-
-      public override bool TryGetAssociatedInfo(AssociatedInfo infoKind, out BoxedExpression info)
-      {
-        ExternalExpression tempInfo;
-        bool success = this.decoder.TryGetAssociatedExpression(this.exp, infoKind, out tempInfo);
-        if (success) { info = BoxedExpression.For(tempInfo, decoder); return true; }
-        info = null;
-        return false;
-      }
-      public override bool TryGetAssociatedInfo(APC pc, AssociatedInfo infoKind, out BoxedExpression info)
-      {
-        ExternalExpression tempInfo;
-        bool success = this.decoder.TryGetAssociatedExpression(pc, this.exp, infoKind, out tempInfo);
-        if (success) { info = BoxedExpression.For(tempInfo, decoder); return true; }
-        info = null;
-        return false;
-      }
-
-      public override bool TryGetType(out object type)
-      {
-        if (this.type.IsValid)
-        {
-          type = this.type.Value.Two;
-          return this.type.Value.One;
-        }
-        var outcome = this.decoder.TryGetType(this.exp, out type);
-
-        this.type = new Pair<bool, object>(outcome, type);
-
-        return outcome;
-      }
-
-      struct ISetWrapper : Microsoft.Research.DataStructures.IMutableSet<ExternalExpression>
-      {
-        Set<BoxedExpression> set;
-        IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder;
-        public ISetWrapper(Set<BoxedExpression> set, IFullExpressionDecoder<Typ, Variable, ExternalExpression> decoder)
-        {
-          this.set = set;
-          this.decoder = decoder;
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.HasSourceContext;
+            }
+            return false;
         }
 
-
-        #region Set<ExternalExpression> Members
-
-        public void AddRange(IEnumerable<ExternalExpression> range)
+        public string SourceAssertionCondition(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceAssertionCondition;
+            }
+            return null;
         }
 
-        public Microsoft.Research.DataStructures.IMutableSet<U> ConvertAll<U>(Converter<ExternalExpression, U> converter)
+        public string SourceDocument(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceDocument;
+            }
+            throw new NotImplementedException();
         }
 
-        public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> Difference(IEnumerable<ExternalExpression> b)
+        public int SourceStartLine(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceStartLine;
+            }
+            throw new NotImplementedException();
         }
 
-        public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> FindAll(Predicate<ExternalExpression> predicate)
+        public int SourceEndLine(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceEndLine;
+            }
+            throw new NotImplementedException();
         }
 
-        public void ForEach(Action<ExternalExpression> action)
+        public int SourceStartColumn(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceStartColumn;
+            }
+            throw new NotImplementedException();
         }
 
-        public bool Exists(Predicate<ExternalExpression> predicate)
+        public int SourceEndColumn(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceEndColumn;
+            }
+            throw new NotImplementedException();
         }
 
-        public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> Intersection(IReadonlySet<ExternalExpression> b)
+        public int SourceStartIndex(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceStartIndex;
+            }
+            throw new NotImplementedException();
         }
 
-        public bool IsSubset(IReadonlySet<ExternalExpression> s)
+        public int SourceLength(BoxedExpression.PC pc)
         {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null)
+            {
+                return assert.SourceLength;
+            }
+            throw new NotImplementedException();
         }
 
-        public bool IsEmpty
+        public int ILOffset(BoxedExpression.PC pc)
         {
-          get { throw new NotImplementedException(); }
-        }
-
-        public bool IsSingleton
-        {
-          get { throw new NotImplementedException(); }
-        }
-
-        public ExternalExpression PickAnElement()
-        {
-          throw new NotImplementedException();
-        }
-
-        public bool TrueForAll(Predicate<ExternalExpression> predicate)
-        {
-          throw new NotImplementedException();
-        }
-
-        public Microsoft.Research.DataStructures.IMutableSet<ExternalExpression> Union(IReadonlySet<ExternalExpression> b)
-        {
-          throw new NotImplementedException();
+            BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
+            if (assert != null && assert.Apc.Block != null)
+            {
+                return assert.ILOffset;
+            }
+            return 0;
         }
 
         #endregion
 
-        #region ISet<ExternalExpression> Members
+        #region IDecodeMSIL<PC,Local,Parameter,Method,Field,Type,Unit,Unit,Unit> Members
 
-        public bool Add(ExternalExpression item)
+        /// <summary>
+        /// NOTE: Variable is not atomic, as it is decoded into an access path!!!
+        /// </summary>
+        private bool IsAtomic(BoxedExpression exp)
         {
-          return this.set.Add(BoxedExpression.For(item, this.decoder));
+            return exp.IsConstant || exp.IsSizeOf;
         }
 
-        public bool Contains(ExternalExpression item)
+        public Result Decode<Visitor, Data, Result>(BoxedExpression.PC pc, Visitor visitor, Data data)
+          where Visitor : ICodeQuery<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Data, Result>
         {
-          throw new NotImplementedException();
+            BoxedExpression nested;
+            BoxedExpression currentOp = FinalOpAndNested(pc, out nested);
+            if (nested != null)
+            {
+                if (nested == pc.Node)
+                {
+                    // variable access path case
+                    Contract.Assume(nested.IsVariable);
+                    var path = nested.AccessPath;
+
+                    Contract.Assume(pc.Index < path.Length);
+                    Contract.Assume(path[pc.Index] != null);
+
+                    return path[pc.Index].Decode<Data, Result, Visitor, BoxedExpression.PC, Local, Parameter, Method, Field, Type>(pc, visitor, data);
+                }
+                return visitor.Aggregate(pc, new BoxedExpression.PC(nested, 0), false, data);
+#if false
+                if (IsAtomic(nested))
+                {
+                    currentOp = nested;
+                }
+                else
+                {
+                    return visitor.Nop(pc, data);
+                }
+#endif
+            }
+            if (currentOp == null)
+            {
+                if (pc.Node is ClousotExpression<Type>.OldExpression)
+                {
+                    // begin old
+                    return visitor.BeginOld(pc, new BoxedExpression.PC(pc.Node, 2), data);
+                }
+                if (pc.Node.IsBinary)
+                {
+                    return DecodeBinary<Visitor, Data, Result>(pc, visitor, data);
+                }
+                return visitor.Nop(pc, data);
+            }
+            // final op is decoded by the expression itself
+            return currentOp.ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type, Visitor>(pc, visitor, data);
         }
 
-        public int Count
+        private Result DecodeBinary<Visitor, Data, Result>(BoxedExpression.PC pc, Visitor visitor, Data data)
+          where Visitor : ICodeQuery<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Data, Result>
         {
-          get { throw new NotImplementedException(); }
+            switch (pc.Index)
+            {
+                case 1:
+                    return visitor.Ldstack(pc, 0, Unit.Value, Unit.Value, false, data);
+                case 2:
+                    if (pc.Node.BinaryOp == BinaryOperator.LogicalAnd)
+                    {
+                        return visitor.BranchFalse(pc, new BoxedExpression.PC(pc.Node, 5), Unit.Value, data);
+                    }
+                    else
+                    {
+                        return visitor.BranchTrue(pc, new BoxedExpression.PC(pc.Node, 5), Unit.Value, data);
+                    }
+                case 3:
+                    return visitor.Pop(pc, Unit.Value, data); // pop the extra argument from the first evaluation
+                                                              //case 0:
+                                                              //case 4:
+                                                              //case 5:
+                default:
+                    return visitor.Nop(pc, data);
+            }
+        }
+
+#if false
+        public Transformer<BoxedExpression.PC, Data, Result> CacheForwardDecoder<Data, Result>(IVisitMSIL<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result> visitor)
+        {
+            return (label, data) => ForwardDecode<Data, Result, IVisitMSIL<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>>(label, visitor, data);
+        }
+#endif
+
+        public Unit GetContext
+        {
+            get { return Unit.Value; }
         }
 
         #endregion
-
-        #region IEnumerable<ExternalExpression> Members
-
-        public IEnumerator<ExternalExpression> GetEnumerator()
-        {
-          throw new NotImplementedException();
-        }
-
-        #endregion
-
-        #region IEnumerable Members
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-          throw new NotImplementedException();
-        }
-
-        #endregion
-      }
-
-      public override void AddFreeVariables(Set<BoxedExpression> set)
-      {
-        this.decoder.AddFreeVariables(this.exp, new ISetWrapper(set, this.decoder));
-      }
-
-      public override bool IsNull { get { return this.decoder.IsNull(this.exp); } }
-
-      [ContractVerification(false)]
-      protected override BoxedExpression RecursiveSubstitute(BoxedExpression what, BoxedExpression newExp)
-      {
-        // first internalize
-        var internalized = BoxedExpression.Convert(this.exp, this.decoder, Int32.MaxValue);
-        // now substitute
-        return internalized != null ? internalized.Substitute(what, newExp) : null;
-      }
-
-      [ContractVerification(false)]
-      public override BoxedExpression Negate()
-      {
-        var internalConvert = BoxedExpression.Convert(this.exp, this.decoder, Int32.MaxValue);
-        return internalConvert != null ? internalConvert.Negate() : null;
-      }
-
-      internal override Result ForwardDecode<Data, Result, Local, Parameter, Field, Method, Type2, Visitor>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      {
-        IFullExpressionDecoder<Type2, Variable, ExternalExpression> decoder = (IFullExpressionDecoder<Type2, Variable, ExternalExpression>)(object)this.decoder;
-        object value;
-        Type2 type;
-        if (decoder.IsConstant(this.exp, out value, out type))
-        {
-          if (value == null)
-          {
-            return visitor.Ldnull(pc, Unit.Value, data);
-          }
-          return visitor.Ldconst(pc, value, type, Unit.Value, data);
-        }
-        UnaryOperator uop;
-        ExternalExpression uarg;
-        if (decoder.IsUnaryOperator(this.exp, out uop, out uarg))
-        {
-          return visitor.Unary(pc, uop, false, false, Unit.Value, Unit.Value, data);
-        }
-        BinaryOperator bop;
-        ExternalExpression left, right;
-        if (decoder.IsBinaryOperator(this.exp, out bop, out left, out right))
-        {
-          return visitor.Binary(pc, bop, Unit.Value, Unit.Value, Unit.Value, data);
-        }
-        if (decoder.IsInst(this.exp, out uarg, out type))
-        {
-          return visitor.Isinst(pc, type, Unit.Value, Unit.Value, data);
-        }
-        if (decoder.IsNull(this.exp))
-        {
-          return visitor.Ldnull(pc, Unit.Value, data);
-        }
-        if (decoder.IsSizeOf(this.exp, out type))
-        {
-          return visitor.Sizeof(pc, type, Unit.Value, data);
-        }
-        Contract.Assume(this.decoder.IsVariable(this.exp, out value));
-        throw new NotImplementedException("TODO");
-      }
-
-
-      #region Object overrides
-      public override bool Equals(object obj)
-      {
-        if (this == obj) return true;
-        ExternalBox<Variable, ExternalExpression> that = obj as ExternalBox<Variable, ExternalExpression>;
-        if (that != null)
-        {
-          return this.exp.Equals(that.exp);
-        }
-        BoxedExpression other = obj as BoxedExpression;
-        if (other != null)
-        {
-          // mixed case dispatch in reverse
-          return other.Equals(this);
-        }
-        return false;
-      }
-
-      protected override int ComputeHashCode()
-      {
-        return this.exp.GetHashCode();
-      }
-
-      public override string ToString()
-      {
-        // Special case for constants 
-        if (this.IsConstant)
-        {
-          if (this.Constant is string)
-          {
-            string str = this.Constant as string;
-            return "@\"" + str.Replace("\"", "\"\"") + "\""; // correctly escape the characters
-          }
-          else
-            return this.Constant != null ? this.Constant.ToString() : "null";
-        }
-        
-        return this.exp.ToString();
-      }
-      #endregion
-
-      public override BoxedExpression Substitute<V>(Func<V, BoxedExpression, BoxedExpression> map)
-      {
-        // first internalize
-        var internalized = BoxedExpression.Convert(this.exp, this.decoder, Int32.MaxValue);
-        // now substitute
-        return internalized != null ? internalized.Substitute(map) : internalized;
-        
-      }
-
-      public override BoxedExpression Rename<V>(IFunctionalMap<V, V> renaming, Func<V, BoxedExpression> refiner = null)
-      {
-        // first internalize
-        var internalized = BoxedExpression.Convert(this.exp, this.decoder, Int32.MaxValue);
-        // now substitute
-        return internalized != null ? internalized.Rename(renaming, refiner) : null;
-      }
-
-      public override void Dispatch(IBoxedExpressionVisitor visitor)
-      {
-        this.decoder.Dispatch(this.exp, visitor);
-      }
     }
 
     #endregion
-
-  }
-
-  public interface IFullExpressionDecoder<Type, Variable, Expression>
-  {
-    /// <summary>
-    /// Returns true if exp is a variable
-    /// </summary>
-    /// <param name="variable"></param>
-    /// <returns></returns>
-    bool IsVariable(Expression exp, out object variable);
-
-    Variable UnderlyingVariable(Expression exp);
-
-    /// <summary>
-    /// Returns true if exp is the null constant
-    /// </summary>
-    bool IsNull(Expression exp);
-
-    /// <summary>
-    /// If the expression is a constant, this provides the value and the type
-    /// </summary>
-    bool IsConstant(Expression exp, out object value, out Type type);
-
-    /// <summary>
-    /// If the expression is sizeof(T), this provides the type T
-    /// </summary>
-    bool IsSizeOf(Expression exp, out Type type);
-
-
-    /// <summary>
-    /// If the expression is isInst(e, T), this provides e and T
-    /// </summary>
-    bool IsInst(Expression exp, out Expression arg, out Type type);
-
-    /// <summary>
-    /// If exp is a Unary operation (according to MSIL!), this returns the operator
-    /// and operand
-    /// </summary>
-    /// <param name="exp"></param>
-    /// <returns></returns>
-    bool IsUnaryOperator(Expression exp, out UnaryOperator op, out Expression arg);
-
-    /// <summary>
-    /// If exp is a binary operation (according to MSIL!), this returns the operator
-    /// and operands
-    /// </summary>
-    bool IsBinaryOperator(Expression exp, out BinaryOperator op, out Expression left, out Expression right);
-
-    /// <summary>
-    /// If the expression has the associated info, it is returned.
-    /// </summary>
-    /// <returns>true if success, false, if no information</returns>
-    bool TryGetAssociatedExpression(Expression exp, AssociatedInfo infoKind, out Expression info);
-
-    /// <summary>
-    /// If the expression has the associated info, it is returned.
-    /// </summary>
-    /// <param name="pc">Try to find information associated at given pc (e.g., for variables)</param>
-    /// <returns>true if success, false, if no information</returns>
-    bool TryGetAssociatedExpression(APC pc, Expression exp, AssociatedInfo infoKind, out Expression info);
-
-    /// <summary>
-    /// Used to gather the free variables in exp and add them to the set
-    /// </summary>
-    void AddFreeVariables(Expression exp, Microsoft.Research.DataStructures.IMutableSet<Expression> set);
-
-    /// <summary>
-    /// Returns an access path to the expression (which is classified as a variable)
-    /// </summary>
-    FList<PathElement> GetVariableAccessPath(Expression exp);
-
-    /// <summary>
-    /// If exp is sizeof this tries to get the size of the type as a constant
-    /// </summary>
-    bool TrySizeOfAsConstant(Expression exp, out int value);
-
-    bool TryGetType(Expression exp, out object type);
-
-    Type System_Int32 { get; }
-
-    bool IsReferenceType(Type type);
-
-    void Dispatch(Expression exp, IBoxedExpressionVisitor visitor);
-  }
-
-  #region CodeProviders and MSIL decoders
-
-  public class ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type> :
-    ICodeProvider<BoxedExpression.PC, Local, Parameter, Method, Field, Type> 
-  {
-    public static readonly ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type> Decoder = new ClousotExpressionCodeProvider<Local, Parameter, Method, Field, Type>(); // Thread-safe
-
-    #region ICodeProvider<PC,Method,Type> Members
-
-    /// <summary>
-    /// To avoid redundantly encoding the logic for decoding the next and nested ops,
-    /// we return the next flat aggregate label as well as the possible nested aggregate op at the
-    /// current point.
-    ///
-    /// There are a number of possible outcomes
-    /// 1) the current program point refers to a sub-expression
-    ///   1a) and there is a syntactic next program point
-    ///   1b) and there is no syntactic next program point
-    /// 2) the current program point refers to a final operation (e.g. add elements on stack)
-    ///    and there is no syntactic next program point
-    /// 3) the current program point is a no-op and there is no syntactic next program point
-    /// 4) the current node is a variable and we are stepping through the access path! In this case
-    ///    the final operation is a no-op and there are no nested expressions that representable as ClousotExpressions.
-    ///
-    /// We encode these outcomes as follows:
-    /// If the result is null, it means there is a next program point, otherwise, it is the final operation
-    /// of the current PC (possibly no-ops, e.g. Block, or ExpressionStatement).
-    /// The out parameter nestedStart is non-null if the current PC labels that particular sub-expression
-    /// and it is null, if the current program point does not have a sub-expression to be evaluated.
-    /// If both the result and the nexted start are null, then this is a special encoding, e.g., for Begin_Old
-    /// In the case of stepping through a variable access path, the nested expression is the same as the original,
-    /// and the context must use the index to access the path element.
-    /// </summary>
-    /// <param name="nestedStart">Returns the sub-tree at this PC or null.</param>
-    /// <returns>The final operation referred to by this PC or null if there is a syntactic next pc.
-    /// </returns>
-    static BoxedExpression FinalOpAndNested(BoxedExpression.PC pc, out BoxedExpression nestedStart)
-    {
-      ClousotExpression<Type>.OldExpression oldExp = pc.Node as ClousotExpression<Type>.OldExpression;
-      if (oldExp != null)
-      {
-        // 0 is begin old
-        // 1 is nested aggregate
-        // 2 is end old
-        if (pc.Index == 0)
-        {
-          nestedStart = null;
-          return null;
-        }
-        if (pc.Index == 1)
-        {
-          nestedStart = oldExp.Old;
-          return null;
-        }
-        nestedStart = null;
-        return oldExp;
-      }
-
-      if (pc.Node.IsConstant || pc.Node.IsSizeOf)
-      {
-        nestedStart = null;
-        return pc.Node;
-      }
-      if (pc.Node.IsUnary)
-      {
-        if (pc.Index == 0)
-        {
-          nestedStart = pc.Node.UnaryArgument;
-          return null;
-        }
-        nestedStart = null;
-        return pc.Node;
-      }
-      if (pc.Node.IsBinary)
-      {
-        var bop = pc.Node.BinaryOp;
-        if (bop == BinaryOperator.LogicalAnd || bop == BinaryOperator.LogicalOr)
-        {
-          // lazy eval producing the following code:
-          //  a
-          //  dup
-          //  br.true pc.Node,5 (br.false pc.Node,5 for logical &&)
-          //  pop
-          //  b
-          // pc,5:
-          //  nop
-          switch (pc.Index)
-          {
-            case 0:
-              nestedStart = pc.Node.BinaryLeft;
-              return null;
-
-            case 1:
-            case 2:
-            case 3:
-              nestedStart = null;
-              return null;
-
-            case 4:
-              nestedStart = pc.Node.BinaryRight;
-              return null;
-
-            case 5:
-              nestedStart = null;
-              return pc.Node;
-          }
-        }
-        if (pc.Index == 0)
-        {
-          nestedStart = pc.Node.BinaryLeft;
-          return null;
-        }
-        if (pc.Index == 1)
-        {
-          nestedStart = pc.Node.BinaryRight;
-          return null;
-        }
-        nestedStart = null;
-        return pc.Node;
-      }
-      if (pc.Node.IsVariable)
-      {
-        if (pc.Node.AccessPath != null // the access path can be null when we habe a bounded variable for quantifiers
-          && pc.Node.AccessPath.Length > pc.Index)
-        {
-          nestedStart = pc.Node;
-          return null;
-        }
-        // End of variable sub expressions.
-        nestedStart = null;
-        return pc.Node;
-      }
-      if (pc.Node.IsIsInst)
-      {
-        if (pc.Index == 0)
-        {
-          nestedStart = pc.Node.UnaryArgument;
-          return null;
-        }
-        nestedStart = null;
-        return pc.Node;
-      }
-      // F: Added this case for the array index expressions
-      BoxedExpression array, index;
-      object type;
-      if (pc.Node.IsArrayIndexExpression(out array, out index, out type))
-      {
-        if (pc.Index == 0)
-        {
-          nestedStart = array;
-          return null;
-        }
-        if (pc.Index == 1)
-        {
-          nestedStart = index;
-          return null;
-        }
-        nestedStart = null;
-        return pc.Node;
-      }
-      BoxedExpression.ContractExpression assertExp = pc.Node as BoxedExpression.ContractExpression;
-      if (assertExp != null)
-      {
-        if (pc.Index == 0)
-        {
-          nestedStart = assertExp.Condition;
-          return null;
-        }
-        nestedStart = null;
-        return assertExp;
-      }
-      ClousotExpression<Type>.ResultExpression resExp = pc.Node as ClousotExpression<Type>.ResultExpression;
-      if (resExp != null)
-      {
-        nestedStart = null;
-        return pc.Node;
-      }
-      BoxedExpression.StatementSequence seq = pc.Node as BoxedExpression.StatementSequence;
-      if (seq != null)
-      {
-        if (pc.Index >= seq.Count)
-        {
-          nestedStart = null;
-          return pc.Node;
-        }
-        Contract.Assume(pc.Index >= 0, "limitation of invariants on readonly fields");
-        Contract.Assert(pc.Index < seq.Count, "Complicated invariant on pc's");
-        nestedStart = seq[pc.Index];
-        return null;
-      }
-
-      // F: Added quantified expressions
-      bool isForAll;
-      BoxedExpression boundVar, lower, upper, body;
-      if (pc.Node.IsQuantifiedExpression(out isForAll, out boundVar, out lower, out upper, out body))
-      {
-        switch (pc.Index)
-        {
-          case 0:
-            {
-              nestedStart = boundVar;
-              return null;
-            }
-          case 1:
-            {
-              nestedStart = lower;
-              return null;
-            }
-          case 2:
-            {
-              nestedStart = upper;
-              return null;
-            }
-          case 3:
-            {
-              nestedStart = body;
-              return null;
-            }
-        }
-        nestedStart = null;
-        return pc.Node;
-      }
-
-      throw new NotImplementedException();
-    }
-
-#if false
-    public R Decode<Visitor, T, R>(BoxedExpression.PC label, Visitor query, T data)
-      where Visitor : ICodeQuery<BoxedExpression.PC, Local, Parameter, Method, Field, Type, T, R>
-    {
-      BoxedExpression nested;
-      BoxedExpression finalOp = FinalOpAndNested(label, out nested);
-      if (nested != null)
-      {
-        if (nested == label.Node)
-        {
-          // variable access path case
-          Debug.Assert(nested.IsVariable);
-          PathElement[] path = nested.AccessPath;
-          return path[label.Index].Decode<T, R, Visitor, BoxedExpression.PC, Local, Parameter, Method, Field, Type>(label, query, data);
-        }
-        return query.Aggregate(label, new BoxedExpression.PC(nested, 0), false, data);
-      }
-      if (finalOp == null)
-      {
-        // begin old
-        return query.BeginOld(label, new BoxedExpression.PC(label.Node, 2), data);
-      }
-      ClousotExpression<Type>.OldExpression oldExp = finalOp as ClousotExpression<Type>.OldExpression;
-      if (oldExp != null)
-      {
-        return query.EndOld(label, new BoxedExpression.PC(label.Node, 0), oldExp.Type, Unit.Value, Unit.Value, data);
-      }
-      return query.Atomic(data, label);
-    }
-#endif
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification = "Probably Clousot is right that this current.Node != null but we want to leave the check anyway")]
-    public bool Next(BoxedExpression.PC current, out BoxedExpression.PC nextLabel)
-    {
-      BoxedExpression nested;
-      BoxedExpression finalOp = FinalOpAndNested(current, out nested);
-      if (finalOp == null && current.Node != null) {
-        // has next
-        nextLabel = new BoxedExpression.PC(current.Node, current.Index + 1);
-        return true;
-      }
-
-      nextLabel = default(BoxedExpression.PC);
-      return false;
-    }
-
-    public void PrintCodeAt(BoxedExpression.PC pc, string indent, TextWriter tw)
-    {
-      Contract.Requires(tw != null);
-
-      Contract.Assume(pc.Node != null);
-      tw.WriteLine("[{0},{1}]", pc.Index, pc.Node.ToString());
-    }
-
-    public bool HasSourceContext(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.HasSourceContext;
-      }
-      return false;
-    }
-
-    public string SourceAssertionCondition(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceAssertionCondition;
-      }
-      return null;
-    }
-
-    public string SourceDocument(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceDocument;
-      }
-      throw new NotImplementedException();
-    }
-
-    public int SourceStartLine(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceStartLine;
-      }
-      throw new NotImplementedException();
-    }
-
-    public int SourceEndLine(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceEndLine;
-      }
-      throw new NotImplementedException();
-    }
-
-    public int SourceStartColumn(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceStartColumn;
-      }
-      throw new NotImplementedException();
-    }
-
-    public int SourceEndColumn(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceEndColumn;
-      }
-      throw new NotImplementedException();
-    }
-
-    public int SourceStartIndex(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceStartIndex;
-      }
-      throw new NotImplementedException();
-    }
-
-    public int SourceLength(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null)
-      {
-        return assert.SourceLength;
-      }
-      throw new NotImplementedException();
-    }
-
-    public int ILOffset(BoxedExpression.PC pc)
-    {
-      BoxedExpression.ContractExpression assert = pc.Node as BoxedExpression.ContractExpression;
-      if (assert != null && assert.Apc.Block != null)
-      {
-        return assert.ILOffset;
-      }
-      return 0;
-    }
-
-      #endregion
-
-    #region IDecodeMSIL<PC,Local,Parameter,Method,Field,Type,Unit,Unit,Unit> Members
-
-    /// <summary>
-    /// NOTE: Variable is not atomic, as it is decoded into an access path!!!
-    /// </summary>
-    bool IsAtomic(BoxedExpression exp)
-    {
-      return exp.IsConstant || exp.IsSizeOf;
-    }
-
-    public Result Decode<Visitor, Data, Result>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      where Visitor : ICodeQuery<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Data, Result>
-    {
-      BoxedExpression nested;
-      BoxedExpression currentOp = FinalOpAndNested(pc, out nested);
-      if (nested != null)
-      {
-        if (nested == pc.Node)
-        {
-          // variable access path case
-          Contract.Assume(nested.IsVariable);
-          var path = nested.AccessPath;
-
-          Contract.Assume(pc.Index < path.Length);
-          Contract.Assume(path[pc.Index] != null);
-
-          return path[pc.Index].Decode<Data, Result, Visitor, BoxedExpression.PC, Local, Parameter, Method, Field, Type>(pc, visitor, data);
-        }
-        return visitor.Aggregate(pc, new BoxedExpression.PC(nested, 0), false, data);
-#if false
-        if (IsAtomic(nested))
-        {
-          currentOp = nested;
-        }
-        else
-        {
-          return visitor.Nop(pc, data);
-        }
-#endif
-      }
-      if (currentOp == null)
-      {
-        if (pc.Node is ClousotExpression<Type>.OldExpression)
-        {
-          // begin old
-          return visitor.BeginOld(pc, new BoxedExpression.PC(pc.Node, 2), data);
-        }
-        if (pc.Node.IsBinary)
-        {
-          return DecodeBinary<Visitor, Data, Result>(pc, visitor, data);
-        }
-        return visitor.Nop(pc, data);
-      }
-      // final op is decoded by the expression itself
-      return currentOp.ForwardDecode<Data,Result,Local,Parameter,Field,Method,Type,Visitor>(pc, visitor, data);
-    }
-
-    private Result DecodeBinary<Visitor, Data, Result>(BoxedExpression.PC pc, Visitor visitor, Data data)
-      where Visitor : ICodeQuery<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Data, Result>
-    {
-      switch (pc.Index)
-      {
-        case 1:
-          return visitor.Ldstack(pc, 0, Unit.Value, Unit.Value, false, data);
-        case 2:
-          if (pc.Node.BinaryOp == BinaryOperator.LogicalAnd)
-          {
-            return visitor.BranchFalse(pc, new BoxedExpression.PC(pc.Node, 5), Unit.Value, data);
-          }
-          else
-          {
-            return visitor.BranchTrue(pc, new BoxedExpression.PC(pc.Node, 5), Unit.Value, data);
-          }
-        case 3:
-          return visitor.Pop(pc, Unit.Value, data); // pop the extra argument from the first evaluation
-        //case 0:
-        //case 4:
-        //case 5:
-        default:
-          return visitor.Nop(pc, data);
-      }
-    }
-
-#if false
-    public Transformer<BoxedExpression.PC, Data, Result> CacheForwardDecoder<Data, Result>(IVisitMSIL<BoxedExpression.PC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result> visitor)
-    {
-      return (label, data) => ForwardDecode<Data,Result,IVisitMSIL<BoxedExpression.PC, Local,Parameter, Method,Field,Type,Unit,Unit,Data,Result>>(label, visitor, data);
-    }
-#endif
-
-    public Unit GetContext
-    {
-      get { return Unit.Value; }
-    }
-
-    #endregion
-  }
-
-  #endregion
-
-
 }

--- a/Microsoft.Research/CodeAnalysis/ExpressionAnalysis.cs
+++ b/Microsoft.Research/CodeAnalysis/ExpressionAnalysis.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,1850 +11,1843 @@ using System.Linq;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
-  using System.Diagnostics.Contracts;
-
-  public class ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData>
-    where Context : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
-    where SymbolicValue : IEquatable<SymbolicValue>
-    where Type:IEquatable<Type>
-    where EdgeData:IFunctionalMap<SymbolicValue,FList<SymbolicValue>>
-  {
-
-    #region Privates
-    IFixpointInfo<APC, Domain> fixpointInfo;
-    private ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, Context, EdgeData> valueLayer;
-
-    bool PreStateLookup(APC label, out Domain ifFound) { return this.fixpointInfo.PreState(label, out ifFound); }
-    bool PostStateLookup(APC label, out Domain ifFound) { return this.fixpointInfo.PostState(label, out ifFound); }
-
-    IFrameworkLogOptions options;
-    Predicate<APC> isUnreachable;
-    #endregion
-
-    public ExpressionAnalysis(
-      ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, Context, EdgeData> valueLayer,
-      IFrameworkLogOptions options, Predicate<APC> isUnreachable)
-    {
-      this.valueLayer = valueLayer;
-      this.options = options;
-      this.isUnreachable = isUnreachable;
-    }
-
-    public bool Debug;
-
-    #region internal Expressions
-    public abstract class Expression : IEquatable<Expression>
-    {
-      #region Internals
-
-      internal abstract Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
-        where Visitor : IVisitExprIL<APC, Type, SymbolicValue, SymbolicValue, Data, Result>;
-
-      /// <summary>
-      /// Return an expression with the given substitution applied
-      /// </summary>
-      internal abstract Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst);
-
-      /// <summary>
-      /// Returns true if the expression contains one of the variables in the candidate set
-      /// </summary>
-      internal abstract bool Contains(IFunctionalSet<SymbolicValue> candidates);
-
-      /// <summary>
-      /// Returns true if the expression contains the symbolic value (one level deep)
-      /// </summary>
-      internal abstract bool Contains(SymbolicValue symbol);
-
-      internal abstract IEnumerable<SymbolicValue> Variables
-      {
-        get;
-      }
-
-      public abstract override string ToString();
-
-      internal class Unary : Expression
-      {
-        // symbol being operand of unary op
-        internal SymbolicValue source;
-        internal UnaryOperator op;
-        internal bool overflow;
-        internal bool unsigned;
-
-        internal Unary(SymbolicValue source, UnaryOperator op, bool overflow, bool unsigned)
-        {
-          this.source = source;
-          this.op = op;
-          this.overflow = overflow;
-          this.unsigned = unsigned;
-        }
-
-        public override bool Equals(Expression e)
-        {
-          Unary other = e as Unary;
-          if (other == null) { return false; }
-          return other.op == this.op && other.overflow == this.overflow && other.unsigned == this.unsigned && other.source.Equals(this.source);
-        }
-
-
-        internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
-        {
-          return visitor.Unary(at, op, overflow, unsigned, dest, source, data);
-        }
-
-        internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
-        {
-          if (subst.Contains(source))
-          {
-            return new Unary(subst[source].Head, op, overflow, unsigned);
-          }
-          return null;
-        }
-
-        internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
-        {
-          if (candidates.Contains(source)) return true;
-          return false;
-        }
-
-        internal override bool Contains(SymbolicValue symbol)
-        {
-          return symbol.Equals(this.source);
-        }
-
-
-        public override string ToString()
-        {
-          return String.Format("Unary({0} {1})", op, source);
-        }
-
-        internal override IEnumerable<SymbolicValue> Variables
-        {
-          get { yield return this.source; }
-        }
-      }
-
-      internal class Binary : Expression
-      {
-        internal SymbolicValue left;
-        internal SymbolicValue right;
-        internal BinaryOperator op;
-
-        internal Binary(SymbolicValue left, SymbolicValue right, BinaryOperator op)
-        {
-          this.left = left;
-          this.right = right;
-          this.op = op;
-        }
-
-        public override bool Equals(Expression e)
-        {
-          Binary other = e as Binary;
-          if (other == null) { return false; }
-          return other.op == this.op && other.left.Equals(this.left) && other.right.Equals(this.right);
-        }
-
-
-        internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
-        {
-          return visitor.Binary(at, op, dest, left, right, data);
-        }
-
-        internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
-        {
-          bool hasLeft = subst.Contains(left);
-          bool hasRight = subst.Contains(right);
-
-          if (hasLeft && hasRight)
-          {
-            return new Binary(subst[left].Head, subst[right].Head, op);
-          }
-          else
-          {
-            return null;
-          }
-        }
-
-        internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
-        {
-          if (candidates.Contains(left)) return true;
-          if (candidates.Contains(right)) return true;
-          return false;
-        }
-
-        internal override bool Contains(SymbolicValue symbol)
-        {
-          return this.left.Equals(symbol) || this.right.Equals(symbol);
-        }
-
-
-        public override string ToString()
-        {
-          return String.Format("Binary({0} {1} {2})", left, op, right);
-        }
-
-        internal override IEnumerable<SymbolicValue> Variables
-        {
-          get
-          {
-            yield return this.left;
-            yield return this.right;
-          }
-        }
-      }
-
-      internal class IsInst : Expression
-      {
-        internal readonly Type type;
-        internal readonly SymbolicValue argument;
-
-        public IsInst(Type type, SymbolicValue argument)
-        {
-          this.type = type;
-          this.argument = argument;
-        }
-
-        public override bool Equals(Expression e)
-        {
-          IsInst other = e as IsInst;
-          if (other == null) { return false; }
-          return other.argument.Equals(this.argument) && other.type.Equals(this.type);
-        }
-
-
-        internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
-        {
-          return visitor.Isinst(at, type, dest, argument, data);
-        }
-
-        internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
-        {
-          if (subst.Contains(argument))
-          {
-            return new IsInst(type, subst[argument].Head);
-          }
-          else
-          {
-            return null;
-          }
-        }
-
-        internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
-        {
-          return candidates.Contains(argument);
-        }
-
-        internal override bool Contains(SymbolicValue symbol)
-        {
-          return this.argument.Equals(symbol);
-        }
-
-        public override string ToString()
-        {
-          return String.Format("IsInst({0} {1})", type.ToString(), argument.ToString());
-        }
-
-
-
-        internal override IEnumerable<SymbolicValue> Variables
-        {
-          get { yield return this.argument; }
-        }
-      }
-
-      internal class Sizeof : Expression
-      {
-        internal readonly Type type;
-
-        public Sizeof(Type type)
-        {
-          this.type = type;
-        }
-
-        public override bool Equals(Expression e)
-        {
-          Sizeof other = e as Sizeof;
-          if (other == null) { return false; }
-          return other.type.Equals(this.type);
-        }
-
-        internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
-        {
-          return visitor.Sizeof(at, type, dest, data);
-        }
-
-        internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
-        {
-          return this;
-        }
-
-        internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
-        {
-          return false;
-        }
-
-        internal override bool Contains(SymbolicValue symbol)
-        {
-          return false;
-        }
-
-        public override string ToString()
-        {
-          return String.Format("Sizeof({0})", type.ToString());
-        }
-
-        internal override IEnumerable<SymbolicValue> Variables
-        {
-          get { yield break; }
-        }
-      }
-
-      internal class Const : Expression
-      {
-        internal readonly Type type;
-        internal readonly object value;
-
-        public Const(Type type, object value)
-        {
-          this.type = type;
-          this.value = value;
-        }
-
-        public override bool Equals(Expression e)
-        {
-          Const other = e as Const;
-          if (other == null) { return false; }
-          return (other.value.Equals(this.value) && other.type.Equals(this.type));
-        }
-
-        internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
-        {
-          return visitor.Ldconst(at, value, type, dest, data);
-        }
-
-        internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
-        {
-          return this;
-        }
-
-        internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
-        {
-          return false;
-        }
-
-        internal override bool Contains(SymbolicValue symbol)
-        {
-          return false;
-        }
-
-        public override string ToString()
-        {
-          return String.Format("Const({0} {1})", type.ToString(), value.ToString());
-        }
-
-        internal override IEnumerable<SymbolicValue> Variables
-        {
-          get { yield break; }
-        }
-      }
-
-      internal class Null : Expression
-      {
-        public override bool Equals(Expression e)
-        {
-          return e == this;
-        }
-
-        internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
-        {
-          return visitor.Ldnull(at, dest, data);
-        }
-
-        internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
-        {
-          return this;
-        }
-
-        internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
-        {
-          return false;
-        }
-        internal override bool Contains(SymbolicValue symbol)
-        {
-          return false;
-        }
-        public override string ToString()
-        {
-          return "Null()";
-        }
-
-        internal override IEnumerable<SymbolicValue> Variables
-        {
-          get { yield break; }
-        }
-      }
-      #endregion
-
-      public static readonly Expression NullValue = new Null(); // Thread-safe
-
-      public abstract bool Equals(Expression e);
-    }
-    #endregion
-
-    public Domain InitialValue(Converter<SymbolicValue/*!*/, int> keyNumber)
-    {
-      return Domain.TopValue(keyNumber);
-    }
-
-    public IAnalysis<APC, Domain, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>, EdgeData>
-      CreateExpressionAnalyzer()
-    {
-      return new ValueAnalysis(this);
-    }
-
-    public IEnumerable<SubroutineContext> GetContexts(CFGBlock block)
-    {
-      return this.fixpointInfo.CachedContexts(block);
-    }
-
-    #region Value analysis interface
-    class ValueAnalysis 
-      : IAnalysis<APC, Domain, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>, EdgeData>
-    {
-      internal ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
-      public ValueAnalysis(ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent)
-      {
-        this.parent = parent;
-      }
-      #region IAnalysis<Label,EnvironmentDomain<SymbolicValue,Label>,IVisitMSIL<Label,Local,Parameter,Method,Field,Type,SymbolicValue,SymbolicValue,EnvironmentDomain<SymbolicValue,Label>,EnvironmentDomain<SymbolicValue,Label>>,SymbolicValue> Members
-
-      /// <summary>
-      /// Note: we keep some mappings, even though the source key is not appearing anywhere in the renaming. We do this to 
-      /// keep track of expressions such as sizeof(...) and others that are not represented in the Egraph and thus become
-      /// unreachable. In principle, if the egraph kept all expressions so we could hash cons them, then this problem would
-      /// go away and we could build a map from scratch, rather than removing things that are killed.
-      /// </summary>
-      public Domain EdgeConversion(APC from, APC to, bool joinPoint, EdgeData sourceTargetMap, Domain originalState)
-      {
-        if (sourceTargetMap == null) return originalState;
-
-        if (this.parent.Debug)
-        {
-          Console.WriteLine("====Expression analysis Parallel Assign===");
-          DumpMap(sourceTargetMap);
-          DumpExpressions("original exprs", originalState);
-        }
-
-        Domain newState = originalState.Empty();
-
-        Domain renamedState = originalState.Empty();
-        // apply the substitution (to the first target) to all our expressions in our domain, provided, they are not killed
-        foreach (SymbolicValue key in originalState.Keys)
-        {
-          Expression expr = originalState[key].Value;
-          Contract.Assume(expr != null);
-          var subst = expr.Substitute(sourceTargetMap);
-          if (subst != null)
-          {
-            renamedState = renamedState.Add(key, subst);
-          }
-        }
-
-        // constrain all targets
-        foreach (SymbolicValue source in sourceTargetMap.Keys)
-        {
-          //^ assume targets != null
-          FlatDomain<Expression> renamedExpression = renamedState[source];
-          if (renamedExpression.IsNormal)
-          {
-            for (FList<SymbolicValue> targets = sourceTargetMap[source]; targets != null; targets = targets.Tail)
-            {
-              SymbolicValue target = targets.Head;
-              newState = newState.Add(target, renamedExpression.Value);
-            }
-          }
-        }
-
-        if (this.parent.Debug)
-        {
-          DumpExpressions("new exprs", newState);
-        }
-        return newState;
-      }
-
-      private void DumpExpressions(string header, Domain originalState)
-      {
-        Console.WriteLine("---  {0}  ---", header);
-        foreach (var key in originalState.Keys)
-        {
-          var target = originalState[key];
-          if (target.IsNormal)
-          {
-            Console.WriteLine("{0} -> {1}", key, target.Value.ToString());
-          }
-          else if (target.IsTop)
-          {
-            Console.WriteLine("{0} -> (Top)", key);
-          }
-          else if (target.IsBottom)
-          {
-            Console.WriteLine("{0} -> (Bot)", key);
-          }
-        }
-      }
-
-      private void DumpMap(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> sourceTargetMap)
-      {
-        Console.WriteLine("Source-target assignment");
-        foreach (var key in sourceTargetMap.Keys)
-        {
-          var targets = sourceTargetMap[key];
-          for (var t = targets; t != null; t = t.Tail)
-          {
-            Console.Write("{0} ", t.Head);
-          }
-          Console.WriteLine(" := {0}", key);
-        }
-      }
-
-      public Domain Join(Pair<APC, APC> edge, Domain newState, Domain prevState, out bool weaker, bool widen)
-      {
-        return prevState.Join(newState, out weaker, widen);
-      }
-
-      public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>
-        Visitor()
-      {
-        return new AnalysisDecoder(this);
-      }
-
-      public Predicate<APC> CacheStates(IFixpointInfo<APC, Domain> fixpointInfo)
-      {
-        this.parent.fixpointInfo = fixpointInfo;
-        return delegate(APC pc) { return true; };
-      }
-
-      public bool IsBottom(APC pc, Domain state)
-      {
-        return state.IsBottom;
-      }
-
-      public bool IsTop(APC pc, Domain state)
-      {
-        return false;
-      }
-
-      public Domain ImmutableVersion(Domain state)
-      {
-        return state;
-      }
-
-      public Domain MutableVersion(Domain state)
-      {
-        // our domain is functional, so no clone needed.
-        return state;
-      }
-
-      public void Dump(Pair<Domain, TextWriter> statetw)
-      {
-        statetw.One.Dump(statetw.Two);
-      }
-
-      #endregion
-    }
-    #endregion
-
-    #region Expression analysis instruction visitor
-    /// <summary>
-    /// Used to compute the expression mapping when running the expression analysis.
-    /// </summary>
-    public struct Domain : IGraph<SymbolicValue, Unit>
-    {
-      EnvironmentDomain<SymbolicValue, FlatDomain<Expression>> expressions;
-
-      private Domain(
-        EnvironmentDomain<SymbolicValue, FlatDomain<Expression>> expressions
-      )
-      {
-        this.expressions = expressions;
-      }
-
-      internal static Domain TopValue(Converter<SymbolicValue, int> keyNumber)
-      {
-        return new Domain(EnvironmentDomain<SymbolicValue, FlatDomain<Expression>>.TopValue(keyNumber));
-      }
-
-      internal IEnumerable<SymbolicValue> Keys { get { return this.expressions.Keys; } }
-      internal Domain Add(SymbolicValue sv, Expression exp)
-      {
-        return new Domain(this.expressions.Add(sv, exp));
-      }
-
-      internal bool HasRefinement(SymbolicValue key)
-      {
-        return this.expressions.Contains(key);
-      }
-
-      internal Domain Remove(SymbolicValue key)
-      {
-        return new Domain(this.expressions.Remove(key));
-      }
-
-      internal FlatDomain<Expression> this[SymbolicValue key] { get { return this.expressions[key]; } }
-
-      internal bool IsBottom { get { return this.expressions.IsBottom; } }
-
-      internal Domain Join(Domain that, out bool weaker, bool widen)
-      {
-        return new Domain(this.expressions.Join(that.expressions, out weaker, widen));
-      }
-
-      internal SymbolicValue Find(SymbolicValue sv)
-      {
-        return sv;
-      }
-
-      internal void Dump(TextWriter tw)
-      {
-        this.expressions.Dump(tw);
-      }
-
-
-
-      internal Domain Empty()
-      {
-        return new Domain(this.expressions.Empty());
-      }
-
-      #region IGraph<SymbolicValue,Unit> Members
-
-      IEnumerable<SymbolicValue> IGraph<SymbolicValue, Unit>.Nodes
-      {
-        get { return this.expressions.Keys;  }
-      }
-
-      bool IGraph<SymbolicValue, Unit>.Contains(SymbolicValue node)
-      {
-        return this.expressions.Contains(node);
-      }
-
-      IEnumerable<Pair<Unit, SymbolicValue>> IGraph<SymbolicValue, Unit>.Successors(SymbolicValue node)
-      {
-        var expr = this.expressions[node];
-        if (!expr.IsNormal) { yield break; }
-        foreach (var sub in expr.Value.Variables)
-        {
-          yield return new Pair<Unit,SymbolicValue>(Unit.Value, sub);
-        }
-      }
-
-      #endregion
-
-      /// <summary>
-      /// Checks if target is reachable from root in graph represented by the sub-expression relation
-      /// </summary>
-      internal bool IsReachableFrom(SymbolicValue root, SymbolicValue target)
-      {
-        bool reachable = false;
-        DepthFirst.Visit(this, root, delegate(SymbolicValue found) { if (found.Equals(target)) reachable = true; return true; }, null);
-        return reachable;
-      }
-
-      internal bool Occurs(SymbolicValue var, SymbolicValue tree)
-      {
-        var checkedVars = new Set<SymbolicValue>();
-        return Occurs(var, tree, checkedVars);
-      }
-
-      private bool Occurs(SymbolicValue var, SymbolicValue tree, Set<SymbolicValue> checkedVars)
-      {
-        if (!checkedVars.Add(tree)) return false;
-
-        var exp = this.expressions[tree];
-        if (!exp.IsNormal) return false;
-        foreach (var contained in exp.Value.Variables.AssumeNotNull())
-        {
-          if (var.Equals(contained) || Occurs(var, contained, checkedVars)) return true;
-        }
-        return false;
-      }
-
-    }
-
-    class AnalysisDecoder :
-      MSILVisitor<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>
-    {
-      private ValueAnalysis valueAnalysis;
-
-      public AnalysisDecoder(ValueAnalysis valueAnalysis)
-      {
-        this.valueAnalysis = valueAnalysis;
-      }
-
-      protected override Domain Default(APC pc, Domain data)
-      {
-        return data;
-      }
-
-      struct AssumeDecoder : IVisitExprIL<APC,Type,SymbolicValue,SymbolicValue,Domain,Domain>
-      {
-        bool truth;
-        public AssumeDecoder(bool truth)
-        {
-          this.truth = truth;
-        }
-
-        #region IVisitExprIL<Label,Type,SymbolicValue,SymbolicValue,Domain,Domain> Members
-
-        bool IsEqOperator(BinaryOperator op)
-        {
-          return op == BinaryOperator.Ceq || op == BinaryOperator.Cobjeq;
-        }
-        /// <summary>
-        /// Important. This needs an occurs check before making something equal to something else, for otherwise
-        /// we build recursive terms, such as (x == (x & mask)), will generate a recursive term.
-        /// </summary>
-        public Domain Binary(APC pc, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Domain data)
-        {
-          if (truth && IsEqOperator(op))
-          {
-            if (!data.HasRefinement(s1))
-            {
-              var refinement = data[s2];
-              if (refinement.IsNormal && !data.IsReachableFrom(s2, s1))
-              {
-                return data.Add(s1, refinement.Value);
-              }
-            }
-            else if (!data.HasRefinement(s2))
-            {
-              var refinement = data[s1];
-              if (refinement.IsNormal && !data.IsReachableFrom(s1, s2))
-              {
-                return data.Add(s2, refinement.Value);
-              }
-            }
-          }
-          if (!truth && op == BinaryOperator.Cne_Un)
-          {
-            if (!data.HasRefinement(s1))
-            {
-              var refinement = data[s2];
-              if (refinement.IsNormal && !data.IsReachableFrom(s2, s1))
-              {
-                return data.Add(s1, refinement.Value);
-              }
-            }
-            else if (!data.HasRefinement(s2))
-            {
-              var refinement = data[s1];
-              if (refinement.IsNormal && !data.IsReachableFrom(s1, s2))
-              {
-                return data.Add(s2, refinement.Value);
-              }
-            }
-          }
-          return data;
-        }
-
-        public Domain Isinst(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Domain data)
-        {
-          return data;
-        }
-
-        public Domain Ldconst(APC pc, object constant, Type type, SymbolicValue dest, Domain data)
-        {
-          return data;
-        }
-
-        public Domain Ldnull(APC pc, SymbolicValue dest, Domain data)
-        {
-          return data;
-        }
-
-        public Domain Sizeof(APC pc, Type type, SymbolicValue dest, Domain data)
-        {
-          return data;
-        }
-
-        public Domain Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Domain data)
-        {
-          return data;
-        }
-
-        public Domain Box(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Domain data)
-        {
-          return data;
-        }
-
-        #endregion
-      }
-
-      public override Domain Assume(APC pc, string tag, SymbolicValue condition, object provenance, Domain data)
-      {
-        var conditionRefinement = data[condition];
-        if (conditionRefinement.IsNormal) {
-          bool truth = (tag != "false");
-          data = conditionRefinement.Value.Decode<Domain,Domain,AssumeDecoder>(pc, condition, new AssumeDecoder(truth), data);
-        }
-        return data;
-      }
-
-      public override Domain Assert(APC pc, string tag, SymbolicValue condition, object provenance, Domain data)
-      {
-        var conditionRefinement = data[condition];
-        if (conditionRefinement.IsNormal)
-        {
-          data = conditionRefinement.Value.Decode<Domain, Domain, AssumeDecoder>(pc, condition, new AssumeDecoder(true), data);
-        }
-        return data;
-      }
-
-      public override Domain Binary(APC pc, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Domain data)
-      {
-        if (this.valueAnalysis.parent.valueLayer.NewerThan(dest, s1) && this.valueAnalysis.parent.valueLayer.NewerThan(dest, s2))
-        { // avoid recursive terms
-          return data.Add(dest, new Expression.Binary(s1, s2, op));
-        }
-        else
-        {
-          // do a full occurs check
-          if (!data.Occurs(dest, s1) && !data.Occurs(dest, s2))
-          {
-            return data.Add(dest, new Expression.Binary(s1, s2, op));
-          }
-        }
-        return data;
-      }
-
-      public override Domain Isinst(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Domain data)
-      {
-        if (dest.Equals(obj)) return data;
-        return data.Add(dest, new Expression.IsInst(type, obj));
-      }
-
-      public override Domain Ldconst(APC pc, object constant, Type type, SymbolicValue dest, Domain data)
-      {
-        return data.Add(dest, new Expression.Const(type, constant));
-      }
-
-      public override Domain Ldnull(APC pc, SymbolicValue dest, Domain data)
-      {
-        return data.Add(dest, Expression.NullValue);
-      }
-
-      public override Domain Sizeof(APC pc, Type type, SymbolicValue dest, Domain data)
-      {
-        return data.Add(dest, new Expression.Sizeof(type));
-      }
-
-      public override Domain Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Domain data)
-      {
-
-        if (!dest.Equals(source))
-        { // avoid recursive terms
-          return data.Add(dest, new Expression.Unary(source, op, overflow, unsigned));
-        }
-        else
-        {
-          var sourceExp = data[source];
-          if (sourceExp.IsNormal)
-          {
-            return data.Add(dest, sourceExp.Value);
-          }
-          else
-          {
-            return data.Remove(dest);
-          }
-        }
-      }
-
-    }
-    #endregion
-
-#if false
-    public IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, EdgeData>
-      GetExpressionDriver<AState>(
-        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> decoder,
-        IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>> exprdriver
-      )
-    {
-      return new ExpressionDriver<AState>(decoder, exprdriver, this);
-    }
-#endif
-
-    public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>, EdgeData>
-      GetDecoder(
-        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> ilDecoder
-      )
-    {
-      return new ExprDecoder(ilDecoder, this);
-    }
-
-    #region MSIL Decoder providing Expressions
-    class ExprDecoder :
-      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>, EdgeData>,
-      IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>,
-      IExpressionContextData<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>
-    {
-      #region Privates
-      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> ilDecoder;
-      ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
-      IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue> underlying;
-      #endregion
-
-      public ExprDecoder(
-        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> ilDecoder,
-        ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent
-      )
-      {
-        this.ilDecoder = ilDecoder;
-        this.parent = parent;
-        this.underlying = ilDecoder.Context;
-      }
-
-      #region IMethodContext<Method> IStackContext<...> IValueContext<Label,Method,Type,SymbolicValue> Members
-
-      public IExpressionContextData<Local, Parameter, Method, Field, Type, ExternalExpression<APC,SymbolicValue>, SymbolicValue> ExpressionContext { get { return this; } }
-      public IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext { get { return this.underlying.ValueContext; } }
-      public IStackContextData<Field, Method> StackContext { get { return this.underlying.StackContext; } }
-      public IMethodContextData<Field, Method> MethodContext { get { return this.underlying.MethodContext; } }
-
-
-      #endregion
-
-
-      #region IExpressionContextData<Label,Method,Type,Expression,SymbolicValue> Members
-
-      struct ExpressionDecoderAdapter<Data, Result, Visitor> :
-        IVisitExprIL<APC, Type, SymbolicValue, SymbolicValue, Data, Result>
-        where Visitor : IVisitValueExprIL<ExternalExpression<APC, SymbolicValue>, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
-      {
-        Visitor visitor;
-        ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
-
-        public ExpressionDecoderAdapter(
-          Visitor visitor,
-          ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent
-        )
-        {
-          this.visitor = visitor;
-          this.parent = parent;
-        }
-
-        #region IVisitExprIL<Label,Type,SymbolicValue,SymbolicValue,Data,Result> Members
-
-        ExternalExpression<APC, SymbolicValue> Convert(APC at, SymbolicValue symbol)
-        {
-          return new ExternalExpression<APC, SymbolicValue>(at, symbol);
-        }
-
-        public Result Binary(APC at, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Data data)
-        {
-          return visitor.Binary(Convert(at, dest), op, dest, Convert(at, s1), Convert(at, s2), data);
-        }
-
-        public Result Isinst(APC at, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Isinst(Convert(at, dest), type, dest, Convert(at, obj), data);
-        }
-
-        public Result Ldconst(APC at, object constant, Type type, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldconst(Convert(at, dest), constant, type, dest, data);
-        }
-
-        public Result Ldnull(APC at, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldnull(Convert(at, dest), dest, data);
-        }
-
-        public Result Sizeof(APC at, Type type, SymbolicValue dest, Data data)
-        {
-          return visitor.Sizeof(Convert(at, dest), type, dest, data);
-        }
-
-        public Result Unary(APC at, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.Unary(Convert(at, dest), op, overflow, unsigned, dest, Convert(at, source), data);
-        }
-
-        public Result Box(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-            return visitor.Box(Convert(pc, dest), type, dest, Convert(pc, source), data);
-        }
-
-        #endregion
-      }
-
-      public Result Decode<Data, Result, Visitor>(ExternalExpression<APC, SymbolicValue> expr, Visitor visitor, Data data)
-        where Visitor : IVisitValueExprIL<ExternalExpression<APC, SymbolicValue>, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
-      {
-        Domain d;
-        if (!this.parent.PreStateLookup(expr.readAt, out d) || d.IsBottom)
-        {
-          return visitor.SymbolicConstant(expr, expr.symbol, data);
-        }
-        FlatDomain<Expression> fexpr = d[expr.symbol];
-        if (fexpr.IsNormal)
-        {
-          return fexpr.Value.Decode<Data, Result, ExpressionDecoderAdapter<Data, Result, Visitor>>(expr.readAt, expr.symbol,
-                                                                                           new ExpressionDecoderAdapter<Data, Result, Visitor>(visitor, this.parent),
-                                                                                           data);
-        }
-        else
-        {
-          Type type;
-          object value;
-          if (this.parent.valueLayer.Decoder.Context.ValueContext.IsConstant(expr.readAt, expr.symbol, out type, out value))
-          {
-            return visitor.Ldconst(expr, value, type, expr.symbol, data);
-          }
-          return visitor.SymbolicConstant(expr, expr.symbol, data);
-        }
-      }
-
-      public FlatDomain<Type> GetType(ExternalExpression<APC, SymbolicValue> expr)
-      {
-        return underlying.ValueContext.GetType(expr.readAt, expr.symbol);
-      }
-
-      public ExternalExpression<APC, SymbolicValue> Refine(APC pc, SymbolicValue symbol)
-      {
-        return new ExternalExpression<APC, SymbolicValue>(pc, symbol);
-      }
-
-      public SymbolicValue Unrefine(ExternalExpression<APC, SymbolicValue> expr)
-      {
-        return expr.symbol;
-      }
-
-      public APC GetPC(ExternalExpression<APC, SymbolicValue> expr)
-      {
-        return expr.readAt;
-      }
-
-      public ExternalExpression<APC, SymbolicValue> For(SymbolicValue value)
-      {
-        // We use the entry point as a label.
-        return new ExternalExpression<APC, SymbolicValue>(this.MethodContext.CFG.Entry, value);
-      }
-
-      public bool IsZero(ExternalExpression<APC, SymbolicValue> expr)
-      {
-        return this.ValueContext.IsZero(expr.readAt, expr.symbol);
-      }
-
-      public bool TryGetArrayLength(ExternalExpression<APC, SymbolicValue> array, out ExternalExpression<APC, SymbolicValue> length)
-      {
-        SymbolicValue lengthval;
-        if (underlying.ValueContext.TryGetArrayLength(array.readAt, array.symbol, out lengthval))
-        {
-          length = new ExternalExpression<APC, SymbolicValue>(array.readAt, lengthval);
-          return true;
-        }
-        length = new ExternalExpression<APC, SymbolicValue>();
-        return false;
-      }
-
-      public bool TryGetWritableBytes(ExternalExpression<APC, SymbolicValue> pointer, out ExternalExpression<APC, SymbolicValue> writableBytes)
-      {
-        SymbolicValue writableBytesVal;
-        if (underlying.ValueContext.TryGetWritableBytes(pointer.readAt, pointer.symbol, out writableBytesVal))
-        {
-          writableBytes = new ExternalExpression<APC, SymbolicValue>(pointer.readAt, writableBytesVal);
-          return true;
-        }
-        writableBytes = new ExternalExpression<APC, SymbolicValue>();
-        return false;
-      }
-
-      #endregion
-
-      #region IDecodeMSIL<Label,Local,Parmeter,Method,Field,Type,Expression,SymbolicValue,IExpressionContext<Label,Method,Type,Expression,SymbolicValue>> Members
-
-      public struct MSILDecoderAdapter<Data, Result, Visitor> :
-          IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Data, Result>
-          where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
-      {
-        ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
-        Visitor visitor;
-
-        public MSILDecoderAdapter(
-          ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent,
-          Visitor visitor
-        )
-        {
-          this.parent = parent;
-          this.visitor = visitor;
-        }
-
-        #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,SymbolicValue,SymbolicValue,Data,Result> Members
-
-        struct ArgumentWrapper<ArgList> : IIndexable<ExternalExpression<APC, SymbolicValue>>
-          where ArgList : IIndexable<SymbolicValue>
-        {
-          ArgList underlying;
-          APC readAt;
-
-          public ArgumentWrapper(ArgList underlying, APC readAt)
-          {
-            this.underlying = underlying;
-            this.readAt = readAt;
-          }
-
-          #region IIndexable<Expression> Members
-
-          public int Count
-          {
-            get {
-              Contract.Ensures(Contract.Result<int>() == this.underlying.Count);
-              return underlying.Count; 
-            }
-          }
-
-          public ExternalExpression<APC, SymbolicValue> this[int index]
-          {
-            get {
-              Contract.Assert(index < this.Count);
-              Contract.Assert(this.Count == this.underlying.Count);
-              Contract.Assert(index < this.underlying.Count);
-
-              return Convert(underlying[index], readAt); 
-            }
-          }
-
-          #endregion
-
-        }
-
-        static ExternalExpression<APC, SymbolicValue> Convert(SymbolicValue source, APC pc)
-        {
-          return new ExternalExpression<APC, SymbolicValue>(pc, source);
-        }
-
-        ArgumentWrapper<ArgList> Convert<ArgList>(APC pc, ArgList sources)
-          where ArgList : IIndexable<SymbolicValue>
-        {
-          return new ArgumentWrapper<ArgList>(sources, pc);
-        }
-
-        public Result Arglist(APC pc, SymbolicValue dest, Data data)
-        {
-          return visitor.Arglist(pc, dest, data);
-        }
-
-        public Result BranchCond(APC pc, APC target, BranchOperator bop, SymbolicValue value1, SymbolicValue value2, Data data)
-        {
-          throw new Exception("Should not get branches at this level of abstraction.");
-        }
-
-        public Result BranchTrue(APC pc, APC target, SymbolicValue cond, Data data)
-        {
-          throw new Exception("Should not get branches at this level of abstraction.");
-        }
-
-        public Result BranchFalse(APC pc, APC target, SymbolicValue cond, Data data)
-        {
-          throw new Exception("Should not get branches at this level of abstraction.");
-        }
-
-        public Result Branch(APC pc, APC target, bool leave, Data data)
-        {
-          throw new Exception("Should not get branches at this leverl of abstraction.");
-        }
-
-        public Result Break(APC pc, Data data)
-        {
-          return visitor.Break(pc, data);
-        }
-
-        public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, SymbolicValue dest, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<SymbolicValue>
-        {
-          return visitor.Call(pc, method, tail, virt, extraVarargs, dest, Convert(pc, args), data);
-        }
-
-        public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, SymbolicValue dest, SymbolicValue fp, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<SymbolicValue>
-        {
-          return visitor.Calli(pc, returnType, argTypes, tail, isInstance, dest, Convert(fp, pc), Convert(pc, args), data);
-        }
-
-        public Result Ckfinite(APC pc, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.Ckfinite(pc, dest, Convert(source, pc), data);
-        }
-
-        public Result Cpblk(APC pc, bool @volatile, SymbolicValue destaddr, SymbolicValue srcaddr, SymbolicValue len, Data data)
-        {
-          return visitor.Cpblk(pc, @volatile, Convert(destaddr, pc), Convert(srcaddr, pc), Convert(len, pc), data);
-        }
-
-        public Result Endfilter(APC pc, SymbolicValue decision, Data data)
-        {
-          return visitor.Endfilter(pc, Convert(decision, pc), data);
-        }
-
-        public Result Endfinally(APC pc, Data data)
-        {
-          return visitor.Endfinally(pc, data);
-        }
-
-        public Result Initblk(APC pc, bool @volatile, SymbolicValue destaddr, SymbolicValue value, SymbolicValue len, Data data)
-        {
-          return visitor.Initblk(pc, @volatile, Convert(destaddr, pc), Convert(value, pc), Convert(len, pc), data);
-        }
-
-        public Result Jmp(APC pc, Method method, Data data)
-        {
-          return visitor.Jmp(pc, method, data);
-        }
-
-        public Result Ldarg(APC pc, Parameter argument, bool isOld, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldarg(pc, argument, isOld, dest, data);
-        }
-
-        public Result Ldarga(APC pc, Parameter argument, bool isOld, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldarga(pc, argument, isOld, dest, data);
-        }
-
-        public Result Ldftn(APC pc, Method method, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldftn(pc, method, dest, data);
-        }
-
-        public Result Ldind(APC pc, Type type, bool @volatile, SymbolicValue dest, SymbolicValue ptr, Data data)
-        {
-          return visitor.Ldind(pc, type, @volatile, dest, Convert(ptr, pc), data);
-        }
-
-        public Result Ldloc(APC pc, Local local, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldloc(pc, local, dest, data);
-        }
-
-        public Result Ldloca(APC pc, Local local, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldloca(pc, local, dest, data);
-        }
-
-        public Result Localloc(APC pc, SymbolicValue dest, SymbolicValue size, Data data)
-        {
-          return visitor.Localloc(pc, dest, Convert(size, pc), data);
-        }
-
-        public Result Nop(APC pc, Data data)
-        {
-          return visitor.Nop(pc, data);
-        }
-
-        public Result Pop(APC pc, SymbolicValue source, Data data)
-        {
-          return visitor.Pop(pc, Convert(source, pc), data);
-        }
-
-        public Result Return(APC pc, SymbolicValue source, Data data)
-        {
-          return visitor.Return(pc, Convert(source, pc), data);
-        }
-
-        public Result Starg(APC pc, Parameter argument, SymbolicValue source, Data data)
-        {
-          return visitor.Starg(pc, argument, Convert(source, pc), data);
-        }
-
-        public Result Stind(APC pc, Type type, bool @volatile, SymbolicValue ptr, SymbolicValue value, Data data)
-        {
-          return visitor.Stind(pc, type, @volatile, Convert(ptr, pc), Convert(value, pc), data);
-        }
-
-        public Result Stloc(APC pc, Local local, SymbolicValue source, Data data)
-        {
-          return visitor.Stloc(pc, local, Convert(source, pc), data);
-        }
-
-        public Result Switch(APC pc, Type type, IEnumerable<Pair<object,APC>> cases, SymbolicValue value, Data data)
-        {
-          throw new Exception("Should not see Switch at this level of abstraction (assumes).");
-        }
-
-        public Result Box(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.Box(pc, type, dest, Convert(source, pc), data);
-        }
-
-        public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, SymbolicValue dest, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<SymbolicValue>
-        {
-          return visitor.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, dest, Convert(pc, args), data);
-        }
-
-        public Result Castclass(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Castclass(pc, type, dest, Convert(obj, pc), data);
-        }
-
-        public Result Cpobj(APC pc, Type type, SymbolicValue destptr, SymbolicValue srcptr, Data data)
-        {
-          return visitor.Cpobj(pc, type, Convert(destptr, pc), Convert(srcptr, pc), data);
-        }
-
-        public Result Initobj(APC pc, Type type, SymbolicValue ptr, Data data)
-        {
-          return visitor.Initobj(pc, type, Convert(ptr, pc), data);
-        }
-
-        public Result Ldelem(APC pc, Type type, SymbolicValue dest, SymbolicValue array, SymbolicValue index, Data data)
-        {
-          return visitor.Ldelem(pc, type, dest, Convert(array, pc), Convert(index, pc), data);
-        }
-
-        public Result Ldelema(APC pc, Type type, bool @readonly, SymbolicValue dest, SymbolicValue array, SymbolicValue index, Data data)
-        {
-          return visitor.Ldelema(pc, type, @readonly, dest, Convert(array, pc), Convert(index, pc), data);
-        }
-
-        public Result Ldfld(APC pc, Field field, bool @volatile, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Ldfld(pc, field, @volatile, dest, Convert(obj, pc), data);
-        }
-
-        public Result Ldflda(APC pc, Field field, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Ldflda(pc, field, dest, Convert(obj, pc), data);
-        }
-
-        public Result Ldlen(APC pc, SymbolicValue dest, SymbolicValue array, Data data)
-        {
-          return visitor.Ldlen(pc, dest, Convert(array, pc), data);
-        }
-
-        public Result Ldsfld(APC pc, Field field, bool @volatile, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldsfld(pc, field, @volatile, dest, data);
-        }
-
-        public Result Ldsflda(APC pc, Field field, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldsflda(pc, field, dest, data);
-        }
-
-        public Result Ldtypetoken(APC pc, Type type, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldtypetoken(pc, type, dest, data);
-        }
-
-        public Result Ldfieldtoken(APC pc, Field field, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldfieldtoken(pc, field, dest, data);
-        }
-
-        public Result Ldmethodtoken(APC pc, Method method, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldmethodtoken(pc, method, dest, data);
-        }
-
-        public Result Ldvirtftn(APC pc, Method method, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Ldvirtftn(pc, method, dest, Convert(obj, pc), data);
-        }
-
-        public Result Mkrefany(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Mkrefany(pc, type, dest, Convert(obj, pc), data);
-        }
-
-        public Result Newarray<ArgList>(APC pc, Type type, SymbolicValue dest, ArgList lengths, Data data)
-          where ArgList : IIndexable<SymbolicValue>
-        {
-          return visitor.Newarray(pc, type, dest, Convert(pc, lengths), data);
-        }
-
-        public Result Newobj<ArgList>(APC pc, Method ctor, SymbolicValue dest, ArgList args, Data data)
-          where ArgList : IIndexable<SymbolicValue>
-        {
-          return visitor.Newobj(pc, ctor, dest, Convert(pc, args), data);
-        }
-
-        public Result Refanytype(APC pc, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.Refanytype(pc, dest, Convert(source, pc), data);
-        }
-
-        public Result Refanyval(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.Refanyval(pc, type, dest, Convert(source, pc), data);
-        }
-
-        public Result Rethrow(APC pc, Data data)
-        {
-          return visitor.Rethrow(pc, data);
-        }
-
-        public Result Stelem(APC pc, Type type, SymbolicValue array, SymbolicValue index, SymbolicValue value, Data data)
-        {
-          return visitor.Stelem(pc, type, Convert(array, pc), Convert(index, pc), Convert(value, pc), data);
-        }
-
-        public Result Stfld(APC pc, Field field, bool @volatile, SymbolicValue obj, SymbolicValue value, Data data)
-        {
-          return visitor.Stfld(pc, field, @volatile, Convert(obj, pc), Convert(value, pc), data);
-        }
-
-        public Result Stsfld(APC pc, Field field, bool @volatile, SymbolicValue value, Data data)
-        {
-          return visitor.Stsfld(pc, field, @volatile, Convert(value, pc), data);
-        }
-
-        public Result Throw(APC pc, SymbolicValue exn, Data data)
-        {
-          return visitor.Throw(pc, Convert(exn, pc), data);
-        }
-
-        public Result Unbox(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Unbox(pc, type, dest, Convert(obj, pc), data);
-        }
-
-        public Result Unboxany(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Unboxany(pc, type, dest, Convert(obj, pc), data);
-        }
-
-        #endregion
-
-        #region IVisitSynthIL<Label,SymbolicValue,Data,Result> Members
-
-        public Result Assume(APC pc, string tag, SymbolicValue source, object provenance, Data data)
-        {
-          return visitor.Assume(pc, tag, Convert(source, pc), provenance, data);
-        }
-
-        public Result Assert(APC pc, string tag, SymbolicValue condition, object provenance, Data data)
-        {
-          return visitor.Assert(pc, tag, Convert(condition, pc), provenance, data);
-        }
-
-        public Result Entry(APC pc, Method method, Data data)
-        {
-          return visitor.Entry(pc, method, data);
-        }
-
-        public Result Ldstack(APC pc, int offset, SymbolicValue dest, SymbolicValue source, bool isOld, Data data)
-        {
-          return visitor.Ldstack(pc, offset, dest, Convert(source, pc), isOld, data);
-        }
-
-        public Result Ldstacka(APC pc, int offset, SymbolicValue dest, SymbolicValue source, Type type, bool isOld, Data data)
-        {
-          return visitor.Ldstacka(pc, offset, dest, Convert(source, pc), type, isOld, data);
-        }
-
-        public Result BeginOld(APC pc, APC matchingEnd, Data data)
-        {
-          return visitor.BeginOld(pc, matchingEnd, data);
-        }
-
-        public Result EndOld(APC pc, APC matchingBegin, Type type, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.EndOld(pc, matchingBegin, type, dest, Convert(source, pc), data);
-        }
-
-        public Result Ldresult(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.Ldresult(pc, type, dest, Convert(source, pc), data);
-        }
-
-        #endregion        #endregion
-
-        #region IVisitExprIL<Label,Type,SymbolicValue,SymbolicValue,Data,Result> Members
-
-        public Result Binary(APC pc, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Data data)
-        {
-          return visitor.Binary(pc, op, dest, Convert(s1, pc), Convert(s2, pc), data);
-        }
-
-        public Result Isinst(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
-        {
-          return visitor.Isinst(pc, type, dest, Convert(obj,pc), data);
-        }
-
-        public Result Ldconst(APC pc, object constant, Type type, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldconst(pc, constant, type, dest, data);
-        }
-
-        public Result Ldnull(APC pc, SymbolicValue dest, Data data)
-        {
-          return visitor.Ldnull(pc, dest, data);
-        }
-
-        public Result Sizeof(APC pc, Type type, SymbolicValue dest, Data data)
-        {
-          return visitor.Sizeof(pc, type, dest, data);
-        }
-
-        public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Data data)
-        {
-          return visitor.Unary(pc, op, overflow, unsigned, dest, Convert(source, pc), data);
-        }
-
-        #endregion
-
-
-      }
-
-      public Result ForwardDecode<Data, Result, Visitor>(APC lab, Visitor visitor, Data data)
-        where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
-      {
-        return this.ilDecoder.ForwardDecode<Data, Result, MSILDecoderAdapter<Data, Result, Visitor>>(lab, new MSILDecoderAdapter<Data, Result, Visitor>(this.parent, visitor), data);
-      }
-
-      public IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> Context
-      {
-        get { return this; }
-      }
-
-      public bool IsUnreachable(APC pc)
-      {
-        return this.parent.isUnreachable(pc);
-      }
-
-      public EdgeData EdgeData(APC from, APC to)
-      {
-        return parent.valueLayer.Decoder.EdgeData(from, to);
-      }
-
-      public void Display(TextWriter tw, string prefix, EdgeData edgeData)
-      {
-        edgeData.Visit(delegate(SymbolicValue key, FList<SymbolicValue> targets)
-        {
-          tw.Write("  {0} -> ", key);
-          foreach (var target in targets.GetEnumerable())
-      {
-            tw.Write("{0} ", target);
-          }
-          tw.WriteLine();
-          return VisitStatus.ContinueVisit;
-        });
-      }
-
-      #endregion
-
-
-    }
-    #endregion
-
-    public void BlockInfoPrinter(APC blockend, string prefix, TextWriter tw, Converter<ExternalExpression<APC, SymbolicValue>, string> source2string)
-    {
-      Contract.Requires(tw != null);
-      Contract.Requires(source2string != null);
-
-      foreach (var succ in this.valueLayer.Decoder.Context.MethodContext.CFG.Successors(blockend))
-      {
-        var rebindings = this.valueLayer.Decoder.EdgeData(blockend, succ);
-        if (rebindings != null)
-          {
-        bool firstTime = true;
-        foreach (SymbolicValue source in rebindings.Keys.OrderBy(s => s))
-        {
-          if (firstTime)
-          {
-              tw.WriteLine("{0}Rebinding on ({1} -> {2})", prefix, blockend, succ);
-            firstTime = false;
-          }
-          FList<SymbolicValue> targets = rebindings[source];
-          while (targets != null)
-          {
-            SymbolicValue target = targets.Head;
-            if (source == null)
-            {
-              tw.WriteLine("{0}  havoc {1}", prefix, target);
-            }
-            else
-            {
-                ExternalExpression<APC, SymbolicValue> expr = new ExternalExpression<APC, SymbolicValue>(blockend, source);
-                tw.WriteLine("{0}  {1} := {2} {3}", prefix, target, source2string(expr), this.valueLayer.Decoder.Context.ValueContext.GetType(blockend, source));
-            }
-            targets = targets.Tail;
-          }
-        }
-      }
-    }
-    }
-
-    public BlockInfoPrinter<APC> GetBlockPrinter(Converter<ExternalExpression<APC, SymbolicValue>, string> source2string)
-    {
-      return delegate(APC blockend, string prefix, TextWriter tw)
-      {
-        BlockInfoPrinter(blockend, prefix, tw, source2string);
-      };
-    }
-#if false
-
-    /// <returns>
-    /// A map of assignments "target := source"
-    /// </returns>
-    public IFunctionalMap<string, string> RenamingsFor(Converter<ExternalExpression<APC, SymbolicValue>, string> converter, APC blockend, APC blockTarget)
-    {
-      foreach (APC l in this.rebindings.Keys2(blockend))
-      {
-        if (l.Equals(blockTarget))
-        {
-          IFunctionalMap<string, string> result = FunctionalMap<string, string>.Empty;
-          
-          IFunctionalMap<SymbolicValue, FList<SymbolicValue>> rebindings = this.rebindings[blockend, blockTarget];
-
-          Pair<APC, APC> edge = new Pair<APC, APC>(blockend, blockTarget);
-          foreach (SymbolicValue source in rebindings.Keys)
-          {
-            FList<SymbolicValue> targets = rebindings[source];
-            while (targets != null)
-            {
-              SymbolicValue target = targets.Head;
-              if (source == null)
-              {
-                result = result.Add(target.ToString(), "...havoc..."); // Empty list means that the value is havoc-ed
-              }
-              else
-              {
-                ExternalExpression<APC, SymbolicValue> expr = new ExternalExpression<APC, SymbolicValue>(edge.One, source);
-                
-               // Console.WriteLine("{0} := {1}", target, converter(expr));
-                result = result.Add(target.ToString(), converter(expr));
-              }
-              targets = targets.Tail;
-            }
-          }
-          return result;
-        }
-      }
-      return FunctionalMap<string, string>.Empty;
-    }
-
-    public CrossBlockRenamings<APC> GetBlockRenamings(Converter<ExternalExpression<APC, SymbolicValue>, string> converter)
-    {
-      return delegate(APC blockend, APC blockstart)
-      {
-        return this.RenamingsFor(converter, blockend, blockstart);
-      };
-    }
-
-    public Set<string> RenamingsFor(APC blockend, APC blockTarget, Converter<ExternalExpression<APC, SymbolicValue>, Set<string>> converter)
-    {
-      foreach (APC l in this.rebindings.Keys2(blockend))
-      {
-        if (l.Equals(blockTarget))
-        {
-          Set<string> result = new Set<String>();
-
-          IFunctionalMap<SymbolicValue, FList<SymbolicValue>> rebindings = this.rebindings[blockend, blockTarget];
-
-          Pair<APC, APC> edge = new Pair<APC, APC>(blockend, blockTarget);
-          foreach (SymbolicValue source in rebindings.Keys)
-          {
-            FList<SymbolicValue> targets = rebindings[source];
-
-            while (targets != null)
-            {
-              SymbolicValue target = targets.Head;
-              if (source != null)
-              {
-                ExternalExpression<APC, SymbolicValue> expr = new ExternalExpression<APC, SymbolicValue>(edge.One, source);
-
-                // Console.WriteLine("{1}", target, converter(expr));
-                result.AddRange(converter(expr));
-              }
-              targets = targets.Tail;
-            }
-          }
-          return result;
-        }
-      }
-      return new Set<string>();
-    }
-
-    public RenamedVariables<APC> GetRenamedVariables(Converter<ExternalExpression<APC, SymbolicValue>, Set<string>> converter)
-    {
-      return delegate(APC blockend, APC blockstart)
-      {
-        return this.RenamingsFor(blockend, blockstart, converter);
-      };
-    }
-#endif
-  }
-
-  public struct ExternalExpression<Label,SymbolicValue> : IEquatable<ExternalExpression<Label,SymbolicValue>>
-    where SymbolicValue : IEquatable<SymbolicValue>
-  {
-    internal readonly Label readAt;
-    internal readonly SymbolicValue symbol;
-
-    internal ExternalExpression(Label readAt, SymbolicValue symbol)
-    {
-      this.readAt = readAt;
-      this.symbol = symbol;
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj is ExternalExpression<Label, SymbolicValue>)
-      {
-        ExternalExpression<Label, SymbolicValue> other = (ExternalExpression<Label, SymbolicValue>)obj;  // unbox
-        // HACK! for reasons in the AI handling of expressions as variables, we consider expressions equal if they refer to the same symbolic name
-        return this.symbol.Equals(other.symbol); // && this.readAt.Equals(other.readAt);
-      }
-      return false;
-    }
-
-    public override int GetHashCode()
-    {
-      return this.symbol.GetHashCode();
-    }
-
-    public override string ToString()
-    {
-      return symbol.ToString() + "@" + readAt;
-    }
-
-    #region IEquatable<ExternalExpression<Label,SymbolicValue>> Members
-
-    public bool Equals(ExternalExpression<Label, SymbolicValue> other)
-    {
-      // HACK! for reasons in the AI handling of expressions as variables, we consider expressions equal if they refer to the same symbolic name
-      return this.symbol.Equals(other.symbol); // && this.readAt.Equals(other.readAt);
-    }
-
-    #endregion
-  }
-
-  public class ExprPrinter
-  {
-
-    class Decoder<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly, LogOptions>
-      : IVisitValueExprIL<ExternalExpression<APC,SymbolicValue>, Type, ExternalExpression<APC,SymbolicValue>, SymbolicValue, StringBuilder, Unit>
-      where SymbolicValue : IEquatable<SymbolicValue>
-      where Type:IEquatable<Type>
-      where LogOptions : IFrameworkLogOptions
-    {
-      IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC,SymbolicValue>, SymbolicValue> decoder;
-      IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions> mDriver;
-
-      public Decoder(
-        IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC,SymbolicValue>, SymbolicValue> decoder,
-        IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC,SymbolicValue>, SymbolicValue, LogOptions> mDriver
-      )
-      {
-        this.decoder = decoder;
-        this.mDriver = mDriver;
-      }
-
-      public string ToString(ExternalExpression<APC,SymbolicValue> expr)
-      {
-        StringBuilder sb = new StringBuilder();
-        Recurse(sb, expr);
-        return sb.ToString();
-      }
-
-      #region IVisitExprIL<Type,ExternalExpression,SymbolicValue,StringBuilder,Unit> Members
-
-      void Recurse(StringBuilder tw, ExternalExpression<APC, SymbolicValue> expr)
-      {
-        if (expr.symbol.Equals(default(SymbolicValue))) { tw.Append("<null>"); return; }
-        decoder.ExpressionContext.Decode<StringBuilder, Unit, Decoder<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly, LogOptions>>(expr, this, tw);
-      }
-
-
-      public Unit Binary(ExternalExpression<APC,SymbolicValue> pc, BinaryOperator op, SymbolicValue dest, ExternalExpression<APC,SymbolicValue> s1, ExternalExpression<APC,SymbolicValue> s2, StringBuilder data)
-      {
-        data.Append('(');
-        Recurse(data, s1);
-        data.AppendFormat(" {0} ", op.ToString());
-        Recurse(data, s2);
-        data.Append(')');
-        return Unit.Value;
-      }
-
-      public Unit Isinst(ExternalExpression<APC,SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<APC,SymbolicValue> obj, StringBuilder data)
-      {
-        data.AppendFormat("IsInst({0}) ", mDriver.MetaDataDecoder.FullName(type));
-        Recurse(data, obj);
-        return Unit.Value;
-      }
-
-      public Unit Ldconst(ExternalExpression<APC,SymbolicValue> pc, object constant, Type type, SymbolicValue dest, StringBuilder data)
-      {
-        data.Append(constant.ToString());
-        return Unit.Value;
-      }
-
-      public Unit Ldnull(ExternalExpression<APC,SymbolicValue> pc, SymbolicValue dest, StringBuilder data)
-      {
-        data.Append("null");
-        return Unit.Value;
-      }
-
-      public Unit Sizeof(ExternalExpression<APC,SymbolicValue> pc, Type type, SymbolicValue dest, StringBuilder data)
-      {
-        data.AppendFormat("sizeof({0})", mDriver.MetaDataDecoder.FullName(type));
-        return Unit.Value;
-      }
-
-      public Unit Unary(ExternalExpression<APC,SymbolicValue> pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, ExternalExpression<APC,SymbolicValue> source, StringBuilder data)
-      {
-        data.AppendFormat("{0} ", op.ToString());
-        Recurse(data, source);
-        return Unit.Value;
-      }
-
-      public Unit SymbolicConstant(ExternalExpression<APC, SymbolicValue> pc, SymbolicValue symbol, StringBuilder data)
-      {
-        // try forall decoding
-        var forall = this.mDriver.AsForAllIndexed(pc.readAt, symbol);
-        if (forall != null)
-        {
-          data.Append(forall.ToString());
-
-          return Unit.Value;
-        }
-        // try exists decoding
-        var exists = this.mDriver.AsExistsIndexed(pc.readAt, symbol);
-        if (exists != null)
-        {
-          data.Append(exists.ToString());
-        }
-        else
-        {
-          data.Append(symbol.ToString());
-        }
-        return Unit.Value;
-      }
-
-      public Unit Box(ExternalExpression<APC, SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<APC, SymbolicValue> source, StringBuilder data)
-      {
-        data.AppendFormat("Box({0}) ", mDriver.MetaDataDecoder.FullName(type));
-        Recurse(data, source);
-        return Unit.Value;
-      }
-
-      #endregion
-    }
-
-    public static Converter<ExternalExpression<APC,SymbolicValue>, string> Printer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, LogOptions>(
-      IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC,SymbolicValue>, SymbolicValue> decoder,
-      IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC,SymbolicValue>, SymbolicValue, LogOptions> mDriver)
+    using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
+    using System.Diagnostics.Contracts;
+
+    public class ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData>
+      where Context : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
       where SymbolicValue : IEquatable<SymbolicValue>
       where Type : IEquatable<Type>
-      where LogOptions : IFrameworkLogOptions
+      where EdgeData : IFunctionalMap<SymbolicValue, FList<SymbolicValue>>
     {
-      var exprPrinter = new Decoder<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly, LogOptions>(decoder, mDriver);
-      return exprPrinter.ToString;
+        #region Privates
+        private IFixpointInfo<APC, Domain> fixpointInfo;
+        private ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, Context, EdgeData> valueLayer;
+
+        private bool PreStateLookup(APC label, out Domain ifFound) { return fixpointInfo.PreState(label, out ifFound); }
+        private bool PostStateLookup(APC label, out Domain ifFound) { return fixpointInfo.PostState(label, out ifFound); }
+
+        private IFrameworkLogOptions options;
+        private Predicate<APC> isUnreachable;
+        #endregion
+
+        public ExpressionAnalysis(
+          ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, SymbolicValue, Context, EdgeData> valueLayer,
+          IFrameworkLogOptions options, Predicate<APC> isUnreachable)
+        {
+            this.valueLayer = valueLayer;
+            this.options = options;
+            this.isUnreachable = isUnreachable;
+        }
+
+        public bool Debug;
+
+        #region internal Expressions
+        public abstract class Expression : IEquatable<Expression>
+        {
+            #region Internals
+
+            internal abstract Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
+              where Visitor : IVisitExprIL<APC, Type, SymbolicValue, SymbolicValue, Data, Result>;
+
+            /// <summary>
+            /// Return an expression with the given substitution applied
+            /// </summary>
+            internal abstract Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst);
+
+            /// <summary>
+            /// Returns true if the expression contains one of the variables in the candidate set
+            /// </summary>
+            internal abstract bool Contains(IFunctionalSet<SymbolicValue> candidates);
+
+            /// <summary>
+            /// Returns true if the expression contains the symbolic value (one level deep)
+            /// </summary>
+            internal abstract bool Contains(SymbolicValue symbol);
+
+            internal abstract IEnumerable<SymbolicValue> Variables
+            {
+                get;
+            }
+
+            public abstract override string ToString();
+
+            internal class Unary : Expression
+            {
+                // symbol being operand of unary op
+                internal SymbolicValue source;
+                internal UnaryOperator op;
+                internal bool overflow;
+                internal bool unsigned;
+
+                internal Unary(SymbolicValue source, UnaryOperator op, bool overflow, bool unsigned)
+                {
+                    this.source = source;
+                    this.op = op;
+                    this.overflow = overflow;
+                    this.unsigned = unsigned;
+                }
+
+                public override bool Equals(Expression e)
+                {
+                    Unary other = e as Unary;
+                    if (other == null) { return false; }
+                    return other.op == this.op && other.overflow == this.overflow && other.unsigned == this.unsigned && other.source.Equals(this.source);
+                }
+
+
+                internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
+                {
+                    return visitor.Unary(at, op, overflow, unsigned, dest, source, data);
+                }
+
+                internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
+                {
+                    if (subst.Contains(source))
+                    {
+                        return new Unary(subst[source].Head, op, overflow, unsigned);
+                    }
+                    return null;
+                }
+
+                internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
+                {
+                    if (candidates.Contains(source)) return true;
+                    return false;
+                }
+
+                internal override bool Contains(SymbolicValue symbol)
+                {
+                    return symbol.Equals(this.source);
+                }
+
+
+                public override string ToString()
+                {
+                    return String.Format("Unary({0} {1})", op, source);
+                }
+
+                internal override IEnumerable<SymbolicValue> Variables
+                {
+                    get { yield return this.source; }
+                }
+            }
+
+            internal class Binary : Expression
+            {
+                internal SymbolicValue left;
+                internal SymbolicValue right;
+                internal BinaryOperator op;
+
+                internal Binary(SymbolicValue left, SymbolicValue right, BinaryOperator op)
+                {
+                    this.left = left;
+                    this.right = right;
+                    this.op = op;
+                }
+
+                public override bool Equals(Expression e)
+                {
+                    Binary other = e as Binary;
+                    if (other == null) { return false; }
+                    return other.op == this.op && other.left.Equals(this.left) && other.right.Equals(this.right);
+                }
+
+
+                internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
+                {
+                    return visitor.Binary(at, op, dest, left, right, data);
+                }
+
+                internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
+                {
+                    bool hasLeft = subst.Contains(left);
+                    bool hasRight = subst.Contains(right);
+
+                    if (hasLeft && hasRight)
+                    {
+                        return new Binary(subst[left].Head, subst[right].Head, op);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+
+                internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
+                {
+                    if (candidates.Contains(left)) return true;
+                    if (candidates.Contains(right)) return true;
+                    return false;
+                }
+
+                internal override bool Contains(SymbolicValue symbol)
+                {
+                    return this.left.Equals(symbol) || this.right.Equals(symbol);
+                }
+
+
+                public override string ToString()
+                {
+                    return String.Format("Binary({0} {1} {2})", left, op, right);
+                }
+
+                internal override IEnumerable<SymbolicValue> Variables
+                {
+                    get
+                    {
+                        yield return this.left;
+                        yield return this.right;
+                    }
+                }
+            }
+
+            internal class IsInst : Expression
+            {
+                internal readonly Type type;
+                internal readonly SymbolicValue argument;
+
+                public IsInst(Type type, SymbolicValue argument)
+                {
+                    this.type = type;
+                    this.argument = argument;
+                }
+
+                public override bool Equals(Expression e)
+                {
+                    IsInst other = e as IsInst;
+                    if (other == null) { return false; }
+                    return other.argument.Equals(this.argument) && other.type.Equals(this.type);
+                }
+
+
+                internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
+                {
+                    return visitor.Isinst(at, type, dest, argument, data);
+                }
+
+                internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
+                {
+                    if (subst.Contains(argument))
+                    {
+                        return new IsInst(type, subst[argument].Head);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+
+                internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
+                {
+                    return candidates.Contains(argument);
+                }
+
+                internal override bool Contains(SymbolicValue symbol)
+                {
+                    return this.argument.Equals(symbol);
+                }
+
+                public override string ToString()
+                {
+                    return String.Format("IsInst({0} {1})", type.ToString(), argument.ToString());
+                }
+
+
+
+                internal override IEnumerable<SymbolicValue> Variables
+                {
+                    get { yield return this.argument; }
+                }
+            }
+
+            internal class Sizeof : Expression
+            {
+                internal readonly Type type;
+
+                public Sizeof(Type type)
+                {
+                    this.type = type;
+                }
+
+                public override bool Equals(Expression e)
+                {
+                    Sizeof other = e as Sizeof;
+                    if (other == null) { return false; }
+                    return other.type.Equals(this.type);
+                }
+
+                internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
+                {
+                    return visitor.Sizeof(at, type, dest, data);
+                }
+
+                internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
+                {
+                    return this;
+                }
+
+                internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
+                {
+                    return false;
+                }
+
+                internal override bool Contains(SymbolicValue symbol)
+                {
+                    return false;
+                }
+
+                public override string ToString()
+                {
+                    return String.Format("Sizeof({0})", type.ToString());
+                }
+
+                internal override IEnumerable<SymbolicValue> Variables
+                {
+                    get { yield break; }
+                }
+            }
+
+            internal class Const : Expression
+            {
+                internal readonly Type type;
+                internal readonly object value;
+
+                public Const(Type type, object value)
+                {
+                    this.type = type;
+                    this.value = value;
+                }
+
+                public override bool Equals(Expression e)
+                {
+                    Const other = e as Const;
+                    if (other == null) { return false; }
+                    return (other.value.Equals(this.value) && other.type.Equals(this.type));
+                }
+
+                internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
+                {
+                    return visitor.Ldconst(at, value, type, dest, data);
+                }
+
+                internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
+                {
+                    return this;
+                }
+
+                internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
+                {
+                    return false;
+                }
+
+                internal override bool Contains(SymbolicValue symbol)
+                {
+                    return false;
+                }
+
+                public override string ToString()
+                {
+                    return String.Format("Const({0} {1})", type.ToString(), value.ToString());
+                }
+
+                internal override IEnumerable<SymbolicValue> Variables
+                {
+                    get { yield break; }
+                }
+            }
+
+            internal class Null : Expression
+            {
+                public override bool Equals(Expression e)
+                {
+                    return e == this;
+                }
+
+                internal override Result Decode<Data, Result, Visitor>(APC at, SymbolicValue dest, Visitor visitor, Data data)
+                {
+                    return visitor.Ldnull(at, dest, data);
+                }
+
+                internal override Expression Substitute(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> subst)
+                {
+                    return this;
+                }
+
+                internal override bool Contains(IFunctionalSet<SymbolicValue> candidates)
+                {
+                    return false;
+                }
+                internal override bool Contains(SymbolicValue symbol)
+                {
+                    return false;
+                }
+                public override string ToString()
+                {
+                    return "Null()";
+                }
+
+                internal override IEnumerable<SymbolicValue> Variables
+                {
+                    get { yield break; }
+                }
+            }
+            #endregion
+
+            public static readonly Expression NullValue = new Null(); // Thread-safe
+
+            public abstract bool Equals(Expression e);
+        }
+        #endregion
+
+        public Domain InitialValue(Converter<SymbolicValue/*!*/, int> keyNumber)
+        {
+            return Domain.TopValue(keyNumber);
+        }
+
+        public IAnalysis<APC, Domain, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>, EdgeData>
+          CreateExpressionAnalyzer()
+        {
+            return new ValueAnalysis(this);
+        }
+
+        public IEnumerable<SubroutineContext> GetContexts(CFGBlock block)
+        {
+            return fixpointInfo.CachedContexts(block);
+        }
+
+        #region Value analysis interface
+        private class ValueAnalysis
+          : IAnalysis<APC, Domain, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>, EdgeData>
+        {
+            internal ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
+            public ValueAnalysis(ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent)
+            {
+                this.parent = parent;
+            }
+            #region IAnalysis<Label,EnvironmentDomain<SymbolicValue,Label>,IVisitMSIL<Label,Local,Parameter,Method,Field,Type,SymbolicValue,SymbolicValue,EnvironmentDomain<SymbolicValue,Label>,EnvironmentDomain<SymbolicValue,Label>>,SymbolicValue> Members
+
+            /// <summary>
+            /// Note: we keep some mappings, even though the source key is not appearing anywhere in the renaming. We do this to 
+            /// keep track of expressions such as sizeof(...) and others that are not represented in the Egraph and thus become
+            /// unreachable. In principle, if the egraph kept all expressions so we could hash cons them, then this problem would
+            /// go away and we could build a map from scratch, rather than removing things that are killed.
+            /// </summary>
+            public Domain EdgeConversion(APC from, APC to, bool joinPoint, EdgeData sourceTargetMap, Domain originalState)
+            {
+                if (sourceTargetMap == null) return originalState;
+
+                if (this.parent.Debug)
+                {
+                    Console.WriteLine("====Expression analysis Parallel Assign===");
+                    DumpMap(sourceTargetMap);
+                    DumpExpressions("original exprs", originalState);
+                }
+
+                Domain newState = originalState.Empty();
+
+                Domain renamedState = originalState.Empty();
+                // apply the substitution (to the first target) to all our expressions in our domain, provided, they are not killed
+                foreach (SymbolicValue key in originalState.Keys)
+                {
+                    Expression expr = originalState[key].Value;
+                    Contract.Assume(expr != null);
+                    var subst = expr.Substitute(sourceTargetMap);
+                    if (subst != null)
+                    {
+                        renamedState = renamedState.Add(key, subst);
+                    }
+                }
+
+                // constrain all targets
+                foreach (SymbolicValue source in sourceTargetMap.Keys)
+                {
+                    //^ assume targets != null
+                    FlatDomain<Expression> renamedExpression = renamedState[source];
+                    if (renamedExpression.IsNormal)
+                    {
+                        for (FList<SymbolicValue> targets = sourceTargetMap[source]; targets != null; targets = targets.Tail)
+                        {
+                            SymbolicValue target = targets.Head;
+                            newState = newState.Add(target, renamedExpression.Value);
+                        }
+                    }
+                }
+
+                if (this.parent.Debug)
+                {
+                    DumpExpressions("new exprs", newState);
+                }
+                return newState;
+            }
+
+            private void DumpExpressions(string header, Domain originalState)
+            {
+                Console.WriteLine("---  {0}  ---", header);
+                foreach (var key in originalState.Keys)
+                {
+                    var target = originalState[key];
+                    if (target.IsNormal)
+                    {
+                        Console.WriteLine("{0} -> {1}", key, target.Value.ToString());
+                    }
+                    else if (target.IsTop)
+                    {
+                        Console.WriteLine("{0} -> (Top)", key);
+                    }
+                    else if (target.IsBottom)
+                    {
+                        Console.WriteLine("{0} -> (Bot)", key);
+                    }
+                }
+            }
+
+            private void DumpMap(IFunctionalMap<SymbolicValue, FList<SymbolicValue>> sourceTargetMap)
+            {
+                Console.WriteLine("Source-target assignment");
+                foreach (var key in sourceTargetMap.Keys)
+                {
+                    var targets = sourceTargetMap[key];
+                    for (var t = targets; t != null; t = t.Tail)
+                    {
+                        Console.Write("{0} ", t.Head);
+                    }
+                    Console.WriteLine(" := {0}", key);
+                }
+            }
+
+            public Domain Join(Pair<APC, APC> edge, Domain newState, Domain prevState, out bool weaker, bool widen)
+            {
+                return prevState.Join(newState, out weaker, widen);
+            }
+
+            public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>
+              Visitor()
+            {
+                return new AnalysisDecoder(this);
+            }
+
+            public Predicate<APC> CacheStates(IFixpointInfo<APC, Domain> fixpointInfo)
+            {
+                this.parent.fixpointInfo = fixpointInfo;
+                return delegate (APC pc) { return true; };
+            }
+
+            public bool IsBottom(APC pc, Domain state)
+            {
+                return state.IsBottom;
+            }
+
+            public bool IsTop(APC pc, Domain state)
+            {
+                return false;
+            }
+
+            public Domain ImmutableVersion(Domain state)
+            {
+                return state;
+            }
+
+            public Domain MutableVersion(Domain state)
+            {
+                // our domain is functional, so no clone needed.
+                return state;
+            }
+
+            public void Dump(Pair<Domain, TextWriter> statetw)
+            {
+                statetw.One.Dump(statetw.Two);
+            }
+
+            #endregion
+        }
+        #endregion
+
+        #region Expression analysis instruction visitor
+        /// <summary>
+        /// Used to compute the expression mapping when running the expression analysis.
+        /// </summary>
+        public struct Domain : IGraph<SymbolicValue, Unit>
+        {
+            private EnvironmentDomain<SymbolicValue, FlatDomain<Expression>> expressions;
+
+            private Domain(
+              EnvironmentDomain<SymbolicValue, FlatDomain<Expression>> expressions
+            )
+            {
+                this.expressions = expressions;
+            }
+
+            internal static Domain TopValue(Converter<SymbolicValue, int> keyNumber)
+            {
+                return new Domain(EnvironmentDomain<SymbolicValue, FlatDomain<Expression>>.TopValue(keyNumber));
+            }
+
+            internal IEnumerable<SymbolicValue> Keys { get { return expressions.Keys; } }
+            internal Domain Add(SymbolicValue sv, Expression exp)
+            {
+                return new Domain(expressions.Add(sv, exp));
+            }
+
+            internal bool HasRefinement(SymbolicValue key)
+            {
+                return expressions.Contains(key);
+            }
+
+            internal Domain Remove(SymbolicValue key)
+            {
+                return new Domain(expressions.Remove(key));
+            }
+
+            internal FlatDomain<Expression> this[SymbolicValue key] { get { return expressions[key]; } }
+
+            internal bool IsBottom { get { return expressions.IsBottom; } }
+
+            internal Domain Join(Domain that, out bool weaker, bool widen)
+            {
+                return new Domain(expressions.Join(that.expressions, out weaker, widen));
+            }
+
+            internal SymbolicValue Find(SymbolicValue sv)
+            {
+                return sv;
+            }
+
+            internal void Dump(TextWriter tw)
+            {
+                expressions.Dump(tw);
+            }
+
+
+
+            internal Domain Empty()
+            {
+                return new Domain(expressions.Empty());
+            }
+
+            #region IGraph<SymbolicValue,Unit> Members
+
+            IEnumerable<SymbolicValue> IGraph<SymbolicValue, Unit>.Nodes
+            {
+                get { return expressions.Keys; }
+            }
+
+            bool IGraph<SymbolicValue, Unit>.Contains(SymbolicValue node)
+            {
+                return expressions.Contains(node);
+            }
+
+            IEnumerable<Pair<Unit, SymbolicValue>> IGraph<SymbolicValue, Unit>.Successors(SymbolicValue node)
+            {
+                var expr = expressions[node];
+                if (!expr.IsNormal) { yield break; }
+                foreach (var sub in expr.Value.Variables)
+                {
+                    yield return new Pair<Unit, SymbolicValue>(Unit.Value, sub);
+                }
+            }
+
+            #endregion
+
+            /// <summary>
+            /// Checks if target is reachable from root in graph represented by the sub-expression relation
+            /// </summary>
+            internal bool IsReachableFrom(SymbolicValue root, SymbolicValue target)
+            {
+                bool reachable = false;
+                DepthFirst.Visit(this, root, delegate (SymbolicValue found) { if (found.Equals(target)) reachable = true; return true; }, null);
+                return reachable;
+            }
+
+            internal bool Occurs(SymbolicValue var, SymbolicValue tree)
+            {
+                var checkedVars = new Set<SymbolicValue>();
+                return Occurs(var, tree, checkedVars);
+            }
+
+            private bool Occurs(SymbolicValue var, SymbolicValue tree, Set<SymbolicValue> checkedVars)
+            {
+                if (!checkedVars.Add(tree)) return false;
+
+                var exp = expressions[tree];
+                if (!exp.IsNormal) return false;
+                foreach (var contained in exp.Value.Variables.AssumeNotNull())
+                {
+                    if (var.Equals(contained) || Occurs(var, contained, checkedVars)) return true;
+                }
+                return false;
+            }
+        }
+
+        private class AnalysisDecoder :
+          MSILVisitor<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Domain, Domain>
+        {
+            private ValueAnalysis valueAnalysis;
+
+            public AnalysisDecoder(ValueAnalysis valueAnalysis)
+            {
+                this.valueAnalysis = valueAnalysis;
+            }
+
+            protected override Domain Default(APC pc, Domain data)
+            {
+                return data;
+            }
+
+            private struct AssumeDecoder : IVisitExprIL<APC, Type, SymbolicValue, SymbolicValue, Domain, Domain>
+            {
+                private bool truth;
+                public AssumeDecoder(bool truth)
+                {
+                    this.truth = truth;
+                }
+
+                #region IVisitExprIL<Label,Type,SymbolicValue,SymbolicValue,Domain,Domain> Members
+
+                private bool IsEqOperator(BinaryOperator op)
+                {
+                    return op == BinaryOperator.Ceq || op == BinaryOperator.Cobjeq;
+                }
+                /// <summary>
+                /// Important. This needs an occurs check before making something equal to something else, for otherwise
+                /// we build recursive terms, such as (x == (x & mask)), will generate a recursive term.
+                /// </summary>
+                public Domain Binary(APC pc, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Domain data)
+                {
+                    if (truth && IsEqOperator(op))
+                    {
+                        if (!data.HasRefinement(s1))
+                        {
+                            var refinement = data[s2];
+                            if (refinement.IsNormal && !data.IsReachableFrom(s2, s1))
+                            {
+                                return data.Add(s1, refinement.Value);
+                            }
+                        }
+                        else if (!data.HasRefinement(s2))
+                        {
+                            var refinement = data[s1];
+                            if (refinement.IsNormal && !data.IsReachableFrom(s1, s2))
+                            {
+                                return data.Add(s2, refinement.Value);
+                            }
+                        }
+                    }
+                    if (!truth && op == BinaryOperator.Cne_Un)
+                    {
+                        if (!data.HasRefinement(s1))
+                        {
+                            var refinement = data[s2];
+                            if (refinement.IsNormal && !data.IsReachableFrom(s2, s1))
+                            {
+                                return data.Add(s1, refinement.Value);
+                            }
+                        }
+                        else if (!data.HasRefinement(s2))
+                        {
+                            var refinement = data[s1];
+                            if (refinement.IsNormal && !data.IsReachableFrom(s1, s2))
+                            {
+                                return data.Add(s2, refinement.Value);
+                            }
+                        }
+                    }
+                    return data;
+                }
+
+                public Domain Isinst(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Domain data)
+                {
+                    return data;
+                }
+
+                public Domain Ldconst(APC pc, object constant, Type type, SymbolicValue dest, Domain data)
+                {
+                    return data;
+                }
+
+                public Domain Ldnull(APC pc, SymbolicValue dest, Domain data)
+                {
+                    return data;
+                }
+
+                public Domain Sizeof(APC pc, Type type, SymbolicValue dest, Domain data)
+                {
+                    return data;
+                }
+
+                public Domain Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Domain data)
+                {
+                    return data;
+                }
+
+                public Domain Box(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Domain data)
+                {
+                    return data;
+                }
+
+                #endregion
+            }
+
+            public override Domain Assume(APC pc, string tag, SymbolicValue condition, object provenance, Domain data)
+            {
+                var conditionRefinement = data[condition];
+                if (conditionRefinement.IsNormal)
+                {
+                    bool truth = (tag != "false");
+                    data = conditionRefinement.Value.Decode<Domain, Domain, AssumeDecoder>(pc, condition, new AssumeDecoder(truth), data);
+                }
+                return data;
+            }
+
+            public override Domain Assert(APC pc, string tag, SymbolicValue condition, object provenance, Domain data)
+            {
+                var conditionRefinement = data[condition];
+                if (conditionRefinement.IsNormal)
+                {
+                    data = conditionRefinement.Value.Decode<Domain, Domain, AssumeDecoder>(pc, condition, new AssumeDecoder(true), data);
+                }
+                return data;
+            }
+
+            public override Domain Binary(APC pc, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Domain data)
+            {
+                if (valueAnalysis.parent.valueLayer.NewerThan(dest, s1) && valueAnalysis.parent.valueLayer.NewerThan(dest, s2))
+                { // avoid recursive terms
+                    return data.Add(dest, new Expression.Binary(s1, s2, op));
+                }
+                else
+                {
+                    // do a full occurs check
+                    if (!data.Occurs(dest, s1) && !data.Occurs(dest, s2))
+                    {
+                        return data.Add(dest, new Expression.Binary(s1, s2, op));
+                    }
+                }
+                return data;
+            }
+
+            public override Domain Isinst(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Domain data)
+            {
+                if (dest.Equals(obj)) return data;
+                return data.Add(dest, new Expression.IsInst(type, obj));
+            }
+
+            public override Domain Ldconst(APC pc, object constant, Type type, SymbolicValue dest, Domain data)
+            {
+                return data.Add(dest, new Expression.Const(type, constant));
+            }
+
+            public override Domain Ldnull(APC pc, SymbolicValue dest, Domain data)
+            {
+                return data.Add(dest, Expression.NullValue);
+            }
+
+            public override Domain Sizeof(APC pc, Type type, SymbolicValue dest, Domain data)
+            {
+                return data.Add(dest, new Expression.Sizeof(type));
+            }
+
+            public override Domain Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Domain data)
+            {
+                if (!dest.Equals(source))
+                { // avoid recursive terms
+                    return data.Add(dest, new Expression.Unary(source, op, overflow, unsigned));
+                }
+                else
+                {
+                    var sourceExp = data[source];
+                    if (sourceExp.IsNormal)
+                    {
+                        return data.Add(dest, sourceExp.Value);
+                    }
+                    else
+                    {
+                        return data.Remove(dest);
+                    }
+                }
+            }
+        }
+        #endregion
+
+#if false
+        public IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, EdgeData>
+          GetExpressionDriver<AState>(
+            IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> decoder,
+            IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>> exprdriver
+          )
+        {
+            return new ExpressionDriver<AState>(decoder, exprdriver, this);
+        }
+#endif
+
+        public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>, EdgeData>
+          GetDecoder(
+            IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> ilDecoder
+          )
+        {
+            return new ExprDecoder(ilDecoder, this);
+        }
+
+        #region MSIL Decoder providing Expressions
+        private class ExprDecoder :
+          IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>, EdgeData>,
+          IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>,
+          IExpressionContextData<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue>
+        {
+            #region Privates
+            private IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> ilDecoder;
+            private ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
+            private IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue> underlying;
+            #endregion
+
+            public ExprDecoder(
+              IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData> ilDecoder,
+              ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent
+            )
+            {
+                this.ilDecoder = ilDecoder;
+                this.parent = parent;
+                underlying = ilDecoder.Context;
+            }
+
+            #region IMethodContext<Method> IStackContext<...> IValueContext<Label,Method,Type,SymbolicValue> Members
+
+            public IExpressionContextData<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> ExpressionContext { get { return this; } }
+            public IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> ValueContext { get { return underlying.ValueContext; } }
+            public IStackContextData<Field, Method> StackContext { get { return underlying.StackContext; } }
+            public IMethodContextData<Field, Method> MethodContext { get { return underlying.MethodContext; } }
+
+
+            #endregion
+
+
+            #region IExpressionContextData<Label,Method,Type,Expression,SymbolicValue> Members
+
+            private struct ExpressionDecoderAdapter<Data, Result, Visitor> :
+              IVisitExprIL<APC, Type, SymbolicValue, SymbolicValue, Data, Result>
+              where Visitor : IVisitValueExprIL<ExternalExpression<APC, SymbolicValue>, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
+            {
+                private Visitor visitor;
+                private ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
+
+                public ExpressionDecoderAdapter(
+                  Visitor visitor,
+                  ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent
+                )
+                {
+                    this.visitor = visitor;
+                    this.parent = parent;
+                }
+
+                #region IVisitExprIL<Label,Type,SymbolicValue,SymbolicValue,Data,Result> Members
+
+                private ExternalExpression<APC, SymbolicValue> Convert(APC at, SymbolicValue symbol)
+                {
+                    return new ExternalExpression<APC, SymbolicValue>(at, symbol);
+                }
+
+                public Result Binary(APC at, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Data data)
+                {
+                    return visitor.Binary(Convert(at, dest), op, dest, Convert(at, s1), Convert(at, s2), data);
+                }
+
+                public Result Isinst(APC at, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Isinst(Convert(at, dest), type, dest, Convert(at, obj), data);
+                }
+
+                public Result Ldconst(APC at, object constant, Type type, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldconst(Convert(at, dest), constant, type, dest, data);
+                }
+
+                public Result Ldnull(APC at, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldnull(Convert(at, dest), dest, data);
+                }
+
+                public Result Sizeof(APC at, Type type, SymbolicValue dest, Data data)
+                {
+                    return visitor.Sizeof(Convert(at, dest), type, dest, data);
+                }
+
+                public Result Unary(APC at, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Unary(Convert(at, dest), op, overflow, unsigned, dest, Convert(at, source), data);
+                }
+
+                public Result Box(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Box(Convert(pc, dest), type, dest, Convert(pc, source), data);
+                }
+
+                #endregion
+            }
+
+            public Result Decode<Data, Result, Visitor>(ExternalExpression<APC, SymbolicValue> expr, Visitor visitor, Data data)
+              where Visitor : IVisitValueExprIL<ExternalExpression<APC, SymbolicValue>, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
+            {
+                Domain d;
+                if (!parent.PreStateLookup(expr.readAt, out d) || d.IsBottom)
+                {
+                    return visitor.SymbolicConstant(expr, expr.symbol, data);
+                }
+                FlatDomain<Expression> fexpr = d[expr.symbol];
+                if (fexpr.IsNormal)
+                {
+                    return fexpr.Value.Decode<Data, Result, ExpressionDecoderAdapter<Data, Result, Visitor>>(expr.readAt, expr.symbol,
+                                                                                                     new ExpressionDecoderAdapter<Data, Result, Visitor>(visitor, parent),
+                                                                                                     data);
+                }
+                else
+                {
+                    Type type;
+                    object value;
+                    if (parent.valueLayer.Decoder.Context.ValueContext.IsConstant(expr.readAt, expr.symbol, out type, out value))
+                    {
+                        return visitor.Ldconst(expr, value, type, expr.symbol, data);
+                    }
+                    return visitor.SymbolicConstant(expr, expr.symbol, data);
+                }
+            }
+
+            public FlatDomain<Type> GetType(ExternalExpression<APC, SymbolicValue> expr)
+            {
+                return underlying.ValueContext.GetType(expr.readAt, expr.symbol);
+            }
+
+            public ExternalExpression<APC, SymbolicValue> Refine(APC pc, SymbolicValue symbol)
+            {
+                return new ExternalExpression<APC, SymbolicValue>(pc, symbol);
+            }
+
+            public SymbolicValue Unrefine(ExternalExpression<APC, SymbolicValue> expr)
+            {
+                return expr.symbol;
+            }
+
+            public APC GetPC(ExternalExpression<APC, SymbolicValue> expr)
+            {
+                return expr.readAt;
+            }
+
+            public ExternalExpression<APC, SymbolicValue> For(SymbolicValue value)
+            {
+                // We use the entry point as a label.
+                return new ExternalExpression<APC, SymbolicValue>(this.MethodContext.CFG.Entry, value);
+            }
+
+            public bool IsZero(ExternalExpression<APC, SymbolicValue> expr)
+            {
+                return this.ValueContext.IsZero(expr.readAt, expr.symbol);
+            }
+
+            public bool TryGetArrayLength(ExternalExpression<APC, SymbolicValue> array, out ExternalExpression<APC, SymbolicValue> length)
+            {
+                SymbolicValue lengthval;
+                if (underlying.ValueContext.TryGetArrayLength(array.readAt, array.symbol, out lengthval))
+                {
+                    length = new ExternalExpression<APC, SymbolicValue>(array.readAt, lengthval);
+                    return true;
+                }
+                length = new ExternalExpression<APC, SymbolicValue>();
+                return false;
+            }
+
+            public bool TryGetWritableBytes(ExternalExpression<APC, SymbolicValue> pointer, out ExternalExpression<APC, SymbolicValue> writableBytes)
+            {
+                SymbolicValue writableBytesVal;
+                if (underlying.ValueContext.TryGetWritableBytes(pointer.readAt, pointer.symbol, out writableBytesVal))
+                {
+                    writableBytes = new ExternalExpression<APC, SymbolicValue>(pointer.readAt, writableBytesVal);
+                    return true;
+                }
+                writableBytes = new ExternalExpression<APC, SymbolicValue>();
+                return false;
+            }
+
+            #endregion
+
+            #region IDecodeMSIL<Label,Local,Parmeter,Method,Field,Type,Expression,SymbolicValue,IExpressionContext<Label,Method,Type,Expression,SymbolicValue>> Members
+
+            public struct MSILDecoderAdapter<Data, Result, Visitor> :
+                IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Data, Result>
+                where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
+            {
+                private ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent;
+                private Visitor visitor;
+
+                public MSILDecoderAdapter(
+                  ExpressionAnalysis<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, Context, EdgeData> parent,
+                  Visitor visitor
+                )
+                {
+                    this.parent = parent;
+                    this.visitor = visitor;
+                }
+
+                #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,SymbolicValue,SymbolicValue,Data,Result> Members
+
+                private struct ArgumentWrapper<ArgList> : IIndexable<ExternalExpression<APC, SymbolicValue>>
+                  where ArgList : IIndexable<SymbolicValue>
+                {
+                    private ArgList underlying;
+                    private APC readAt;
+
+                    public ArgumentWrapper(ArgList underlying, APC readAt)
+                    {
+                        this.underlying = underlying;
+                        this.readAt = readAt;
+                    }
+
+                    #region IIndexable<Expression> Members
+
+                    public int Count
+                    {
+                        get
+                        {
+                            Contract.Ensures(Contract.Result<int>() == underlying.Count);
+                            return underlying.Count;
+                        }
+                    }
+
+                    public ExternalExpression<APC, SymbolicValue> this[int index]
+                    {
+                        get
+                        {
+                            Contract.Assert(index < this.Count);
+                            Contract.Assert(this.Count == underlying.Count);
+                            Contract.Assert(index < underlying.Count);
+
+                            return Convert(underlying[index], readAt);
+                        }
+                    }
+
+                    #endregion
+                }
+
+                private static ExternalExpression<APC, SymbolicValue> Convert(SymbolicValue source, APC pc)
+                {
+                    return new ExternalExpression<APC, SymbolicValue>(pc, source);
+                }
+
+                private ArgumentWrapper<ArgList> Convert<ArgList>(APC pc, ArgList sources)
+                  where ArgList : IIndexable<SymbolicValue>
+                {
+                    return new ArgumentWrapper<ArgList>(sources, pc);
+                }
+
+                public Result Arglist(APC pc, SymbolicValue dest, Data data)
+                {
+                    return visitor.Arglist(pc, dest, data);
+                }
+
+                public Result BranchCond(APC pc, APC target, BranchOperator bop, SymbolicValue value1, SymbolicValue value2, Data data)
+                {
+                    throw new Exception("Should not get branches at this level of abstraction.");
+                }
+
+                public Result BranchTrue(APC pc, APC target, SymbolicValue cond, Data data)
+                {
+                    throw new Exception("Should not get branches at this level of abstraction.");
+                }
+
+                public Result BranchFalse(APC pc, APC target, SymbolicValue cond, Data data)
+                {
+                    throw new Exception("Should not get branches at this level of abstraction.");
+                }
+
+                public Result Branch(APC pc, APC target, bool leave, Data data)
+                {
+                    throw new Exception("Should not get branches at this leverl of abstraction.");
+                }
+
+                public Result Break(APC pc, Data data)
+                {
+                    return visitor.Break(pc, data);
+                }
+
+                public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, SymbolicValue dest, ArgList args, Data data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<SymbolicValue>
+                {
+                    return visitor.Call(pc, method, tail, virt, extraVarargs, dest, Convert(pc, args), data);
+                }
+
+                public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, SymbolicValue dest, SymbolicValue fp, ArgList args, Data data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<SymbolicValue>
+                {
+                    return visitor.Calli(pc, returnType, argTypes, tail, isInstance, dest, Convert(fp, pc), Convert(pc, args), data);
+                }
+
+                public Result Ckfinite(APC pc, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Ckfinite(pc, dest, Convert(source, pc), data);
+                }
+
+                public Result Cpblk(APC pc, bool @volatile, SymbolicValue destaddr, SymbolicValue srcaddr, SymbolicValue len, Data data)
+                {
+                    return visitor.Cpblk(pc, @volatile, Convert(destaddr, pc), Convert(srcaddr, pc), Convert(len, pc), data);
+                }
+
+                public Result Endfilter(APC pc, SymbolicValue decision, Data data)
+                {
+                    return visitor.Endfilter(pc, Convert(decision, pc), data);
+                }
+
+                public Result Endfinally(APC pc, Data data)
+                {
+                    return visitor.Endfinally(pc, data);
+                }
+
+                public Result Initblk(APC pc, bool @volatile, SymbolicValue destaddr, SymbolicValue value, SymbolicValue len, Data data)
+                {
+                    return visitor.Initblk(pc, @volatile, Convert(destaddr, pc), Convert(value, pc), Convert(len, pc), data);
+                }
+
+                public Result Jmp(APC pc, Method method, Data data)
+                {
+                    return visitor.Jmp(pc, method, data);
+                }
+
+                public Result Ldarg(APC pc, Parameter argument, bool isOld, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldarg(pc, argument, isOld, dest, data);
+                }
+
+                public Result Ldarga(APC pc, Parameter argument, bool isOld, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldarga(pc, argument, isOld, dest, data);
+                }
+
+                public Result Ldftn(APC pc, Method method, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldftn(pc, method, dest, data);
+                }
+
+                public Result Ldind(APC pc, Type type, bool @volatile, SymbolicValue dest, SymbolicValue ptr, Data data)
+                {
+                    return visitor.Ldind(pc, type, @volatile, dest, Convert(ptr, pc), data);
+                }
+
+                public Result Ldloc(APC pc, Local local, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldloc(pc, local, dest, data);
+                }
+
+                public Result Ldloca(APC pc, Local local, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldloca(pc, local, dest, data);
+                }
+
+                public Result Localloc(APC pc, SymbolicValue dest, SymbolicValue size, Data data)
+                {
+                    return visitor.Localloc(pc, dest, Convert(size, pc), data);
+                }
+
+                public Result Nop(APC pc, Data data)
+                {
+                    return visitor.Nop(pc, data);
+                }
+
+                public Result Pop(APC pc, SymbolicValue source, Data data)
+                {
+                    return visitor.Pop(pc, Convert(source, pc), data);
+                }
+
+                public Result Return(APC pc, SymbolicValue source, Data data)
+                {
+                    return visitor.Return(pc, Convert(source, pc), data);
+                }
+
+                public Result Starg(APC pc, Parameter argument, SymbolicValue source, Data data)
+                {
+                    return visitor.Starg(pc, argument, Convert(source, pc), data);
+                }
+
+                public Result Stind(APC pc, Type type, bool @volatile, SymbolicValue ptr, SymbolicValue value, Data data)
+                {
+                    return visitor.Stind(pc, type, @volatile, Convert(ptr, pc), Convert(value, pc), data);
+                }
+
+                public Result Stloc(APC pc, Local local, SymbolicValue source, Data data)
+                {
+                    return visitor.Stloc(pc, local, Convert(source, pc), data);
+                }
+
+                public Result Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, SymbolicValue value, Data data)
+                {
+                    throw new Exception("Should not see Switch at this level of abstraction (assumes).");
+                }
+
+                public Result Box(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Box(pc, type, dest, Convert(source, pc), data);
+                }
+
+                public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, SymbolicValue dest, ArgList args, Data data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<SymbolicValue>
+                {
+                    return visitor.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, dest, Convert(pc, args), data);
+                }
+
+                public Result Castclass(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Castclass(pc, type, dest, Convert(obj, pc), data);
+                }
+
+                public Result Cpobj(APC pc, Type type, SymbolicValue destptr, SymbolicValue srcptr, Data data)
+                {
+                    return visitor.Cpobj(pc, type, Convert(destptr, pc), Convert(srcptr, pc), data);
+                }
+
+                public Result Initobj(APC pc, Type type, SymbolicValue ptr, Data data)
+                {
+                    return visitor.Initobj(pc, type, Convert(ptr, pc), data);
+                }
+
+                public Result Ldelem(APC pc, Type type, SymbolicValue dest, SymbolicValue array, SymbolicValue index, Data data)
+                {
+                    return visitor.Ldelem(pc, type, dest, Convert(array, pc), Convert(index, pc), data);
+                }
+
+                public Result Ldelema(APC pc, Type type, bool @readonly, SymbolicValue dest, SymbolicValue array, SymbolicValue index, Data data)
+                {
+                    return visitor.Ldelema(pc, type, @readonly, dest, Convert(array, pc), Convert(index, pc), data);
+                }
+
+                public Result Ldfld(APC pc, Field field, bool @volatile, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Ldfld(pc, field, @volatile, dest, Convert(obj, pc), data);
+                }
+
+                public Result Ldflda(APC pc, Field field, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Ldflda(pc, field, dest, Convert(obj, pc), data);
+                }
+
+                public Result Ldlen(APC pc, SymbolicValue dest, SymbolicValue array, Data data)
+                {
+                    return visitor.Ldlen(pc, dest, Convert(array, pc), data);
+                }
+
+                public Result Ldsfld(APC pc, Field field, bool @volatile, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldsfld(pc, field, @volatile, dest, data);
+                }
+
+                public Result Ldsflda(APC pc, Field field, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldsflda(pc, field, dest, data);
+                }
+
+                public Result Ldtypetoken(APC pc, Type type, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldtypetoken(pc, type, dest, data);
+                }
+
+                public Result Ldfieldtoken(APC pc, Field field, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldfieldtoken(pc, field, dest, data);
+                }
+
+                public Result Ldmethodtoken(APC pc, Method method, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldmethodtoken(pc, method, dest, data);
+                }
+
+                public Result Ldvirtftn(APC pc, Method method, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Ldvirtftn(pc, method, dest, Convert(obj, pc), data);
+                }
+
+                public Result Mkrefany(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Mkrefany(pc, type, dest, Convert(obj, pc), data);
+                }
+
+                public Result Newarray<ArgList>(APC pc, Type type, SymbolicValue dest, ArgList lengths, Data data)
+                  where ArgList : IIndexable<SymbolicValue>
+                {
+                    return visitor.Newarray(pc, type, dest, Convert(pc, lengths), data);
+                }
+
+                public Result Newobj<ArgList>(APC pc, Method ctor, SymbolicValue dest, ArgList args, Data data)
+                  where ArgList : IIndexable<SymbolicValue>
+                {
+                    return visitor.Newobj(pc, ctor, dest, Convert(pc, args), data);
+                }
+
+                public Result Refanytype(APC pc, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Refanytype(pc, dest, Convert(source, pc), data);
+                }
+
+                public Result Refanyval(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Refanyval(pc, type, dest, Convert(source, pc), data);
+                }
+
+                public Result Rethrow(APC pc, Data data)
+                {
+                    return visitor.Rethrow(pc, data);
+                }
+
+                public Result Stelem(APC pc, Type type, SymbolicValue array, SymbolicValue index, SymbolicValue value, Data data)
+                {
+                    return visitor.Stelem(pc, type, Convert(array, pc), Convert(index, pc), Convert(value, pc), data);
+                }
+
+                public Result Stfld(APC pc, Field field, bool @volatile, SymbolicValue obj, SymbolicValue value, Data data)
+                {
+                    return visitor.Stfld(pc, field, @volatile, Convert(obj, pc), Convert(value, pc), data);
+                }
+
+                public Result Stsfld(APC pc, Field field, bool @volatile, SymbolicValue value, Data data)
+                {
+                    return visitor.Stsfld(pc, field, @volatile, Convert(value, pc), data);
+                }
+
+                public Result Throw(APC pc, SymbolicValue exn, Data data)
+                {
+                    return visitor.Throw(pc, Convert(exn, pc), data);
+                }
+
+                public Result Unbox(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Unbox(pc, type, dest, Convert(obj, pc), data);
+                }
+
+                public Result Unboxany(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Unboxany(pc, type, dest, Convert(obj, pc), data);
+                }
+
+                #endregion
+
+                #region IVisitSynthIL<Label,SymbolicValue,Data,Result> Members
+
+                public Result Assume(APC pc, string tag, SymbolicValue source, object provenance, Data data)
+                {
+                    return visitor.Assume(pc, tag, Convert(source, pc), provenance, data);
+                }
+
+                public Result Assert(APC pc, string tag, SymbolicValue condition, object provenance, Data data)
+                {
+                    return visitor.Assert(pc, tag, Convert(condition, pc), provenance, data);
+                }
+
+                public Result Entry(APC pc, Method method, Data data)
+                {
+                    return visitor.Entry(pc, method, data);
+                }
+
+                public Result Ldstack(APC pc, int offset, SymbolicValue dest, SymbolicValue source, bool isOld, Data data)
+                {
+                    return visitor.Ldstack(pc, offset, dest, Convert(source, pc), isOld, data);
+                }
+
+                public Result Ldstacka(APC pc, int offset, SymbolicValue dest, SymbolicValue source, Type type, bool isOld, Data data)
+                {
+                    return visitor.Ldstacka(pc, offset, dest, Convert(source, pc), type, isOld, data);
+                }
+
+                public Result BeginOld(APC pc, APC matchingEnd, Data data)
+                {
+                    return visitor.BeginOld(pc, matchingEnd, data);
+                }
+
+                public Result EndOld(APC pc, APC matchingBegin, Type type, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.EndOld(pc, matchingBegin, type, dest, Convert(source, pc), data);
+                }
+
+                public Result Ldresult(APC pc, Type type, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Ldresult(pc, type, dest, Convert(source, pc), data);
+                }
+
+                #endregion        #endregion
+
+                #region IVisitExprIL<Label,Type,SymbolicValue,SymbolicValue,Data,Result> Members
+
+                public Result Binary(APC pc, BinaryOperator op, SymbolicValue dest, SymbolicValue s1, SymbolicValue s2, Data data)
+                {
+                    return visitor.Binary(pc, op, dest, Convert(s1, pc), Convert(s2, pc), data);
+                }
+
+                public Result Isinst(APC pc, Type type, SymbolicValue dest, SymbolicValue obj, Data data)
+                {
+                    return visitor.Isinst(pc, type, dest, Convert(obj, pc), data);
+                }
+
+                public Result Ldconst(APC pc, object constant, Type type, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldconst(pc, constant, type, dest, data);
+                }
+
+                public Result Ldnull(APC pc, SymbolicValue dest, Data data)
+                {
+                    return visitor.Ldnull(pc, dest, data);
+                }
+
+                public Result Sizeof(APC pc, Type type, SymbolicValue dest, Data data)
+                {
+                    return visitor.Sizeof(pc, type, dest, data);
+                }
+
+                public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, SymbolicValue source, Data data)
+                {
+                    return visitor.Unary(pc, op, overflow, unsigned, dest, Convert(source, pc), data);
+                }
+
+                #endregion
+            }
+
+            public Result ForwardDecode<Data, Result, Visitor>(APC lab, Visitor visitor, Data data)
+              where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, Data, Result>
+            {
+                return ilDecoder.ForwardDecode<Data, Result, MSILDecoderAdapter<Data, Result, Visitor>>(lab, new MSILDecoderAdapter<Data, Result, Visitor>(parent, visitor), data);
+            }
+
+            public IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> Context
+            {
+                get { return this; }
+            }
+
+            public bool IsUnreachable(APC pc)
+            {
+                return parent.isUnreachable(pc);
+            }
+
+            public EdgeData EdgeData(APC from, APC to)
+            {
+                return parent.valueLayer.Decoder.EdgeData(from, to);
+            }
+
+            public void Display(TextWriter tw, string prefix, EdgeData edgeData)
+            {
+                edgeData.Visit(delegate (SymbolicValue key, FList<SymbolicValue> targets)
+                {
+                    tw.Write("  {0} -> ", key);
+                    foreach (var target in targets.GetEnumerable())
+                    {
+                        tw.Write("{0} ", target);
+                    }
+                    tw.WriteLine();
+                    return VisitStatus.ContinueVisit;
+                });
+            }
+
+            #endregion
+        }
+        #endregion
+
+        public void BlockInfoPrinter(APC blockend, string prefix, TextWriter tw, Converter<ExternalExpression<APC, SymbolicValue>, string> source2string)
+        {
+            Contract.Requires(tw != null);
+            Contract.Requires(source2string != null);
+
+            foreach (var succ in valueLayer.Decoder.Context.MethodContext.CFG.Successors(blockend))
+            {
+                var rebindings = valueLayer.Decoder.EdgeData(blockend, succ);
+                if (rebindings != null)
+                {
+                    bool firstTime = true;
+                    foreach (SymbolicValue source in rebindings.Keys.OrderBy(s => s))
+                    {
+                        if (firstTime)
+                        {
+                            tw.WriteLine("{0}Rebinding on ({1} -> {2})", prefix, blockend, succ);
+                            firstTime = false;
+                        }
+                        FList<SymbolicValue> targets = rebindings[source];
+                        while (targets != null)
+                        {
+                            SymbolicValue target = targets.Head;
+                            if (source == null)
+                            {
+                                tw.WriteLine("{0}  havoc {1}", prefix, target);
+                            }
+                            else
+                            {
+                                ExternalExpression<APC, SymbolicValue> expr = new ExternalExpression<APC, SymbolicValue>(blockend, source);
+                                tw.WriteLine("{0}  {1} := {2} {3}", prefix, target, source2string(expr), valueLayer.Decoder.Context.ValueContext.GetType(blockend, source));
+                            }
+                            targets = targets.Tail;
+                        }
+                    }
+                }
+            }
+        }
+
+        public BlockInfoPrinter<APC> GetBlockPrinter(Converter<ExternalExpression<APC, SymbolicValue>, string> source2string)
+        {
+            return delegate (APC blockend, string prefix, TextWriter tw)
+            {
+                BlockInfoPrinter(blockend, prefix, tw, source2string);
+            };
+        }
+#if false
+
+        /// <returns>
+        /// A map of assignments "target := source"
+        /// </returns>
+        public IFunctionalMap<string, string> RenamingsFor(Converter<ExternalExpression<APC, SymbolicValue>, string> converter, APC blockend, APC blockTarget)
+        {
+            foreach (APC l in this.rebindings.Keys2(blockend))
+            {
+                if (l.Equals(blockTarget))
+                {
+                    IFunctionalMap<string, string> result = FunctionalMap<string, string>.Empty;
+
+                    IFunctionalMap<SymbolicValue, FList<SymbolicValue>> rebindings = this.rebindings[blockend, blockTarget];
+
+                    Pair<APC, APC> edge = new Pair<APC, APC>(blockend, blockTarget);
+                    foreach (SymbolicValue source in rebindings.Keys)
+                    {
+                        FList<SymbolicValue> targets = rebindings[source];
+                        while (targets != null)
+                        {
+                            SymbolicValue target = targets.Head;
+                            if (source == null)
+                            {
+                                result = result.Add(target.ToString(), "...havoc..."); // Empty list means that the value is havoc-ed
+                            }
+                            else
+                            {
+                                ExternalExpression<APC, SymbolicValue> expr = new ExternalExpression<APC, SymbolicValue>(edge.One, source);
+
+                                // Console.WriteLine("{0} := {1}", target, converter(expr));
+                                result = result.Add(target.ToString(), converter(expr));
+                            }
+                            targets = targets.Tail;
+                        }
+                    }
+                    return result;
+                }
+            }
+            return FunctionalMap<string, string>.Empty;
+        }
+
+        public CrossBlockRenamings<APC> GetBlockRenamings(Converter<ExternalExpression<APC, SymbolicValue>, string> converter)
+        {
+            return delegate (APC blockend, APC blockstart)
+            {
+                return this.RenamingsFor(converter, blockend, blockstart);
+            };
+        }
+
+        public Set<string> RenamingsFor(APC blockend, APC blockTarget, Converter<ExternalExpression<APC, SymbolicValue>, Set<string>> converter)
+        {
+            foreach (APC l in this.rebindings.Keys2(blockend))
+            {
+                if (l.Equals(blockTarget))
+                {
+                    Set<string> result = new Set<String>();
+
+                    IFunctionalMap<SymbolicValue, FList<SymbolicValue>> rebindings = this.rebindings[blockend, blockTarget];
+
+                    Pair<APC, APC> edge = new Pair<APC, APC>(blockend, blockTarget);
+                    foreach (SymbolicValue source in rebindings.Keys)
+                    {
+                        FList<SymbolicValue> targets = rebindings[source];
+
+                        while (targets != null)
+                        {
+                            SymbolicValue target = targets.Head;
+                            if (source != null)
+                            {
+                                ExternalExpression<APC, SymbolicValue> expr = new ExternalExpression<APC, SymbolicValue>(edge.One, source);
+
+                                // Console.WriteLine("{1}", target, converter(expr));
+                                result.AddRange(converter(expr));
+                            }
+                            targets = targets.Tail;
+                        }
+                    }
+                    return result;
+                }
+            }
+            return new Set<string>();
+        }
+
+        public RenamedVariables<APC> GetRenamedVariables(Converter<ExternalExpression<APC, SymbolicValue>, Set<string>> converter)
+        {
+            return delegate (APC blockend, APC blockstart)
+            {
+                return this.RenamingsFor(blockend, blockstart, converter);
+            };
+        }
+#endif
     }
-  }
+
+    public struct ExternalExpression<Label, SymbolicValue> : IEquatable<ExternalExpression<Label, SymbolicValue>>
+      where SymbolicValue : IEquatable<SymbolicValue>
+    {
+        internal readonly Label readAt;
+        internal readonly SymbolicValue symbol;
+
+        internal ExternalExpression(Label readAt, SymbolicValue symbol)
+        {
+            this.readAt = readAt;
+            this.symbol = symbol;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ExternalExpression<Label, SymbolicValue>)
+            {
+                ExternalExpression<Label, SymbolicValue> other = (ExternalExpression<Label, SymbolicValue>)obj;  // unbox
+                                                                                                                 // HACK! for reasons in the AI handling of expressions as variables, we consider expressions equal if they refer to the same symbolic name
+                return this.symbol.Equals(other.symbol); // && this.readAt.Equals(other.readAt);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.symbol.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return symbol.ToString() + "@" + readAt;
+        }
+
+        #region IEquatable<ExternalExpression<Label,SymbolicValue>> Members
+
+        public bool Equals(ExternalExpression<Label, SymbolicValue> other)
+        {
+            // HACK! for reasons in the AI handling of expressions as variables, we consider expressions equal if they refer to the same symbolic name
+            return this.symbol.Equals(other.symbol); // && this.readAt.Equals(other.readAt);
+        }
+
+        #endregion
+    }
+
+    public class ExprPrinter
+    {
+        private class Decoder<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly, LogOptions>
+          : IVisitValueExprIL<ExternalExpression<APC, SymbolicValue>, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue, StringBuilder, Unit>
+          where SymbolicValue : IEquatable<SymbolicValue>
+          where Type : IEquatable<Type>
+          where LogOptions : IFrameworkLogOptions
+        {
+            private IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> decoder;
+            private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions> mDriver;
+
+            public Decoder(
+              IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> decoder,
+              IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions> mDriver
+            )
+            {
+                this.decoder = decoder;
+                this.mDriver = mDriver;
+            }
+
+            public string ToString(ExternalExpression<APC, SymbolicValue> expr)
+            {
+                StringBuilder sb = new StringBuilder();
+                Recurse(sb, expr);
+                return sb.ToString();
+            }
+
+            #region IVisitExprIL<Type,ExternalExpression,SymbolicValue,StringBuilder,Unit> Members
+
+            private void Recurse(StringBuilder tw, ExternalExpression<APC, SymbolicValue> expr)
+            {
+                if (expr.symbol.Equals(default(SymbolicValue))) { tw.Append("<null>"); return; }
+                decoder.ExpressionContext.Decode<StringBuilder, Unit, Decoder<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly, LogOptions>>(expr, this, tw);
+            }
+
+
+            public Unit Binary(ExternalExpression<APC, SymbolicValue> pc, BinaryOperator op, SymbolicValue dest, ExternalExpression<APC, SymbolicValue> s1, ExternalExpression<APC, SymbolicValue> s2, StringBuilder data)
+            {
+                data.Append('(');
+                Recurse(data, s1);
+                data.AppendFormat(" {0} ", op.ToString());
+                Recurse(data, s2);
+                data.Append(')');
+                return Unit.Value;
+            }
+
+            public Unit Isinst(ExternalExpression<APC, SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<APC, SymbolicValue> obj, StringBuilder data)
+            {
+                data.AppendFormat("IsInst({0}) ", mDriver.MetaDataDecoder.FullName(type));
+                Recurse(data, obj);
+                return Unit.Value;
+            }
+
+            public Unit Ldconst(ExternalExpression<APC, SymbolicValue> pc, object constant, Type type, SymbolicValue dest, StringBuilder data)
+            {
+                data.Append(constant.ToString());
+                return Unit.Value;
+            }
+
+            public Unit Ldnull(ExternalExpression<APC, SymbolicValue> pc, SymbolicValue dest, StringBuilder data)
+            {
+                data.Append("null");
+                return Unit.Value;
+            }
+
+            public Unit Sizeof(ExternalExpression<APC, SymbolicValue> pc, Type type, SymbolicValue dest, StringBuilder data)
+            {
+                data.AppendFormat("sizeof({0})", mDriver.MetaDataDecoder.FullName(type));
+                return Unit.Value;
+            }
+
+            public Unit Unary(ExternalExpression<APC, SymbolicValue> pc, UnaryOperator op, bool overflow, bool unsigned, SymbolicValue dest, ExternalExpression<APC, SymbolicValue> source, StringBuilder data)
+            {
+                data.AppendFormat("{0} ", op.ToString());
+                Recurse(data, source);
+                return Unit.Value;
+            }
+
+            public Unit SymbolicConstant(ExternalExpression<APC, SymbolicValue> pc, SymbolicValue symbol, StringBuilder data)
+            {
+                // try forall decoding
+                var forall = mDriver.AsForAllIndexed(pc.readAt, symbol);
+                if (forall != null)
+                {
+                    data.Append(forall.ToString());
+
+                    return Unit.Value;
+                }
+                // try exists decoding
+                var exists = mDriver.AsExistsIndexed(pc.readAt, symbol);
+                if (exists != null)
+                {
+                    data.Append(exists.ToString());
+                }
+                else
+                {
+                    data.Append(symbol.ToString());
+                }
+                return Unit.Value;
+            }
+
+            public Unit Box(ExternalExpression<APC, SymbolicValue> pc, Type type, SymbolicValue dest, ExternalExpression<APC, SymbolicValue> source, StringBuilder data)
+            {
+                data.AppendFormat("Box({0}) ", mDriver.MetaDataDecoder.FullName(type));
+                Recurse(data, source);
+                return Unit.Value;
+            }
+
+            #endregion
+        }
+
+        public static Converter<ExternalExpression<APC, SymbolicValue>, string> Printer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, SymbolicValue, LogOptions>(
+          IExpressionContext<Local, Parameter, Method, Field, Type, ExternalExpression<APC, SymbolicValue>, SymbolicValue> decoder,
+          IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, SymbolicValue>, SymbolicValue, LogOptions> mDriver)
+          where SymbolicValue : IEquatable<SymbolicValue>
+          where Type : IEquatable<Type>
+          where LogOptions : IFrameworkLogOptions
+        {
+            var exprPrinter = new Decoder<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Attribute, Assembly, LogOptions>(decoder, mDriver);
+            return exprPrinter.ToString;
+        }
+    }
 }

--- a/Microsoft.Research/CodeAnalysis/ExpressionCodeVisitor.cs
+++ b/Microsoft.Research/CodeAnalysis/ExpressionCodeVisitor.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -18,116 +7,115 @@ using System.Text;
 using Microsoft.Research.DataStructures;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Research.CodeAnalysis {
-
-  public class ExpressionCodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly>
-  : CodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly,
-                IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>,
-                IFunctionalMap<Variable,FList<Variable>>>
-  where Type : IEquatable<Type>
-  {
-  }
-
-  public class ValueCodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Attribute, Assembly>
-    : CodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Variable, Attribute, Assembly,
-                  IValueContext<Local, Parameter, Method, Field, Type, Variable>,
-                  IFunctionalMap<Variable,FList<Variable>>>
+namespace Microsoft.Research.CodeAnalysis
+{
+    public class ExpressionCodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly>
+    : CodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly,
+                  IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable>,
+                  IFunctionalMap<Variable, FList<Variable>>>
     where Type : IEquatable<Type>
-  {
-  }
-
-  /// <summary>
-  /// This crawler visits each instruction once (currently ignores exception paths)
-  ///
-  /// Subclasses should override the MSIL instructions at which they want to perform certain actions, such
-  /// as gathering facts.
-  /// </summary>
-  public class CodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly, ContextData, EdgeData>
-    : MSILVisitor<APC, Local, Parameter, Method, Field, Type, Expression, Variable, bool, bool>
-    , IAnalysis<APC, bool, 
-                IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, bool, bool>,
-                EdgeData>
-    where Type : IEquatable<Type>
-    where ContextData : IMethodContext<Field, Method>
-  {
-
-    #region State
-    ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData> codeLayer;
-    #endregion
-
-    #region Main Entry point
-    public void Run(
-      ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData> codeLayer
-      )
     {
-      Contract.Requires(codeLayer != null);
-
-      this.codeLayer = codeLayer;
-      var closure = codeLayer.CreateForward<bool>(this, this.Options);
-      closure(true);   // Do the analysis 
-    }
-    #endregion
-
-    #region Available to sub classes
-    public DFAOptions Options = new DFAOptions();
-    public ContextData Context { get { return this.codeLayer.Decoder.Context; } }
-    protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get { return this.codeLayer.MetaDataDecoder; } }
-    #endregion
-
-    #region IValueAnalysis<APC,bool,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Variable,Variable,bool,bool>,Variable,IExpressionContext<APC,Local,Parameter,Method,Field,Type,Expression,Variable>> Members
-
-    public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, bool, bool> Visitor()
-    {
-      return this;
     }
 
-    // Made virtual to count the # of join points in the SyntacticComplexityAnalysis
-    virtual public bool Join(Microsoft.Research.DataStructures.Pair<APC, APC> edge, bool newState, bool prevState, out bool weaker, bool widen)
+    public class ValueCodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Attribute, Assembly>
+      : CodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Variable, Attribute, Assembly,
+                    IValueContext<Local, Parameter, Method, Field, Type, Variable>,
+                    IFunctionalMap<Variable, FList<Variable>>>
+      where Type : IEquatable<Type>
     {
-      weaker = false;
-      return true;
     }
 
-    public bool IsBottom(APC pc, bool state)
+    /// <summary>
+    /// This crawler visits each instruction once (currently ignores exception paths)
+    ///
+    /// Subclasses should override the MSIL instructions at which they want to perform certain actions, such
+    /// as gathering facts.
+    /// </summary>
+    public class CodeVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly, ContextData, EdgeData>
+      : MSILVisitor<APC, Local, Parameter, Method, Field, Type, Expression, Variable, bool, bool>
+      , IAnalysis<APC, bool,
+                  IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, bool, bool>,
+                  EdgeData>
+      where Type : IEquatable<Type>
+      where ContextData : IMethodContext<Field, Method>
     {
-      return state == false;
-    }
+        #region State
+        private ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData> codeLayer;
+        #endregion
 
-    public bool IsTop(APC pc, bool state)
-    {
-      return false;
-    }
+        #region Main Entry point
+        public void Run(
+          ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, ContextData, EdgeData> codeLayer
+          )
+        {
+            Contract.Requires(codeLayer != null);
 
-    public bool ImmutableVersion(bool state)
-    {
-      return state;
-    }
+            this.codeLayer = codeLayer;
+            var closure = codeLayer.CreateForward<bool>(this, this.Options);
+            closure(true);   // Do the analysis 
+        }
+        #endregion
 
-    public bool MutableVersion(bool state)
-    {
-      return state;
-    }
+        #region Available to sub classes
+        public DFAOptions Options = new DFAOptions();
+        public ContextData Context { get { return codeLayer.Decoder.Context; } }
+        protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder { get { return codeLayer.MetaDataDecoder; } }
+        #endregion
 
-    public void Dump(Microsoft.Research.DataStructures.Pair<bool, System.IO.TextWriter> stateAndWriter)
-    {
-      // do nothing
-    }
+        #region IValueAnalysis<APC,bool,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Variable,Variable,bool,bool>,Variable,IExpressionContext<APC,Local,Parameter,Method,Field,Type,Expression,Variable>> Members
 
-    public bool EdgeConversion(APC from, APC next, bool joinPoint, EdgeData edgeData, bool state)
-    {
-      return state;
-    }
+        public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, bool, bool> Visitor()
+        {
+            return this;
+        }
 
-    public Predicate<APC> CacheStates(IFixpointInfo<APC, bool> fixpointInfo)
-    {
-      return null;
-    }
+        // Made virtual to count the # of join points in the SyntacticComplexityAnalysis
+        virtual public bool Join(Microsoft.Research.DataStructures.Pair<APC, APC> edge, bool newState, bool prevState, out bool weaker, bool widen)
+        {
+            weaker = false;
+            return true;
+        }
 
-    #endregion
+        public bool IsBottom(APC pc, bool state)
+        {
+            return state == false;
+        }
 
-    protected override bool Default(APC pc, bool data)
-    {
-      return data;
+        public bool IsTop(APC pc, bool state)
+        {
+            return false;
+        }
+
+        public bool ImmutableVersion(bool state)
+        {
+            return state;
+        }
+
+        public bool MutableVersion(bool state)
+        {
+            return state;
+        }
+
+        public void Dump(Microsoft.Research.DataStructures.Pair<bool, System.IO.TextWriter> stateAndWriter)
+        {
+            // do nothing
+        }
+
+        public bool EdgeConversion(APC from, APC next, bool joinPoint, EdgeData edgeData, bool state)
+        {
+            return state;
+        }
+
+        public Predicate<APC> CacheStates(IFixpointInfo<APC, bool> fixpointInfo)
+        {
+            return null;
+        }
+
+        #endregion
+
+        protected override bool Default(APC pc, bool data)
+        {
+            return data;
+        }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/AddExplicitCast.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/AddExplicitCast.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,41 +10,41 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis.Expressions
 {
-  public class AddExplicitCastToTheExpression<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variabl, LogOptions> 
-    : BoxedExpressionTransformer<Void>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
- 
-  {
-    readonly private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variabl, LogOptions> MethodDriver;
-    readonly private Type castTo;
+    public class AddExplicitCastToTheExpression<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variabl, LogOptions>
+      : BoxedExpressionTransformer<Void>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
 
-    public AddExplicitCastToTheExpression(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variabl, LogOptions> mDriver)
     {
-      Contract.Requires(mDriver!= null);
+        readonly private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variabl, LogOptions> MethodDriver;
+        readonly private Type castTo;
 
-      this.MethodDriver = mDriver;
-      this.castTo = this.MethodDriver.MetaDataDecoder.DeclaringType(this.MethodDriver.CurrentMethod);
-    }
-
-    protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
-    {
-      if (var is Variabl && path != null && path.Length > 0)
-      {
-        var varAsV = (Variabl)var;
-        var pathAsFList = path.ToFList();
-
-        if (this.MethodDriver.Context.ValueContext.IsRootedInParameter(pathAsFList) && path[0].AssumeNotNull().ToString() == "this")
+        public AddExplicitCastToTheExpression(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variabl, LogOptions> mDriver)
         {
-          return BoxedExpression.VarCast(var, path, default(Type), this.castTo);
-        }
-        else
-        {
-          return original;
-        }
-      }
+            Contract.Requires(mDriver != null);
 
-      return null;
+            MethodDriver = mDriver;
+            castTo = MethodDriver.MetaDataDecoder.DeclaringType(MethodDriver.CurrentMethod);
+        }
+
+        protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
+        {
+            if (var is Variabl && path != null && path.Length > 0)
+            {
+                var varAsV = (Variabl)var;
+                var pathAsFList = path.ToFList();
+
+                if (MethodDriver.Context.ValueContext.IsRootedInParameter(pathAsFList) && path[0].AssumeNotNull().ToString() == "this")
+                {
+                    return BoxedExpression.VarCast(var, path, default(Type), castTo);
+                }
+                else
+                {
+                    return original;
+                }
+            }
+
+            return null;
+        }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/BoxedExpressionTransformer.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/BoxedExpressionTransformer.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,240 +10,240 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public struct Void { }
+    public struct Void { }
 
-  abstract public class BoxedExpressionTransformer<ExtraInfo>
-  {
-    protected ExtraInfo Info { get; private set; }
-    protected Func<object, FList<PathElement>> PathFetcher;
-
-    virtual public BoxedExpression Visit(BoxedExpression exp, ExtraInfo info, Func<object, FList<PathElement>> PathFetcher = null)
+    abstract public class BoxedExpressionTransformer<ExtraInfo>
     {
-      Contract.Requires(exp != null);
+        protected ExtraInfo Info { get; private set; }
+        protected Func<object, FList<PathElement>> PathFetcher;
 
-      this.Info = info;
-      this.PathFetcher = GetPathFetcher(PathFetcher);
-      return this.Visit(exp);
-    }
-
-    protected virtual Func<object, FList<PathElement>> GetPathFetcher(Func<object, FList<PathElement>> PathFetcher)
-    {
-      return PathFetcher;
-    }
-
-    protected BoxedExpression Visit(BoxedExpression exp)
-    {
-      Contract.Requires(exp != null);
-
-      if (exp.IsVariable)
-      {
-          return this.Variable(exp, exp.UnderlyingVariable, exp.AccessPath);
-      }
-      if (exp.IsNull)
-      {
-        return this.Null(exp);
-      }
-      if (exp.IsConstant)
-      {
-        return this.Constant(exp, exp.ConstantType, exp.Constant);
-      }
-      BinaryOperator bop;
-      BoxedExpression left, right;
-      if (exp.IsBinaryExpression(out bop, out left, out right))
-      {
-        return this.Binary(exp, bop, left, right);
-      }
-      UnaryOperator uop;
-      if (exp.IsUnaryExpression(out uop, out left))
-      {
-        return this.Unary(exp, uop, left);
-      }
-      if (exp.IsSizeOf)
-      {
-        return this.SizeOf(exp);
-      }
-      object type;
-      if (exp.IsIsInstExpression(out left, out type))
-      {
-        return this.IsInst(exp, type, left);
-      }
-      BoxedExpression array, index;
-      if(exp.IsArrayIndexExpression(out array, out index, out type))
-      {
-        return this.ArrayIndex(exp, type, array, index);
-      }
-      if (exp.IsResult)
-      {
-        return this.Result(exp);
-      }
-      // exp.IsOld ??
-      // exp.IsValueAtReturn??
-      // exp.IsAssert ??
-      // exp.IsAssume ??
-      // exp.IsStatementSequence ??
-      bool isForAll;
-      BoxedExpression boundedVar, low, upp, body;
-      if (exp.IsQuantifiedExpression(out isForAll, out boundedVar, out low, out upp, out body))
-      {
-        if (isForAll)
+        virtual public BoxedExpression Visit(BoxedExpression exp, ExtraInfo info, Func<object, FList<PathElement>> PathFetcher = null)
         {
-          return this.ForAll(exp, boundedVar, low, upp, body);
+            Contract.Requires(exp != null);
+
+            this.Info = info;
+            this.PathFetcher = GetPathFetcher(PathFetcher);
+            return this.Visit(exp);
         }
-        else
+
+        protected virtual Func<object, FList<PathElement>> GetPathFetcher(Func<object, FList<PathElement>> PathFetcher)
         {
-          return this.Exists(exp, boundedVar, low, upp, body);
+            return PathFetcher;
         }
-      }
 
-      throw new NotImplementedException("Missing case !!!!");
+        protected BoxedExpression Visit(BoxedExpression exp)
+        {
+            Contract.Requires(exp != null);
+
+            if (exp.IsVariable)
+            {
+                return this.Variable(exp, exp.UnderlyingVariable, exp.AccessPath);
+            }
+            if (exp.IsNull)
+            {
+                return this.Null(exp);
+            }
+            if (exp.IsConstant)
+            {
+                return this.Constant(exp, exp.ConstantType, exp.Constant);
+            }
+            BinaryOperator bop;
+            BoxedExpression left, right;
+            if (exp.IsBinaryExpression(out bop, out left, out right))
+            {
+                return this.Binary(exp, bop, left, right);
+            }
+            UnaryOperator uop;
+            if (exp.IsUnaryExpression(out uop, out left))
+            {
+                return this.Unary(exp, uop, left);
+            }
+            if (exp.IsSizeOf)
+            {
+                return this.SizeOf(exp);
+            }
+            object type;
+            if (exp.IsIsInstExpression(out left, out type))
+            {
+                return this.IsInst(exp, type, left);
+            }
+            BoxedExpression array, index;
+            if (exp.IsArrayIndexExpression(out array, out index, out type))
+            {
+                return this.ArrayIndex(exp, type, array, index);
+            }
+            if (exp.IsResult)
+            {
+                return this.Result(exp);
+            }
+            // exp.IsOld ??
+            // exp.IsValueAtReturn??
+            // exp.IsAssert ??
+            // exp.IsAssume ??
+            // exp.IsStatementSequence ??
+            bool isForAll;
+            BoxedExpression boundedVar, low, upp, body;
+            if (exp.IsQuantifiedExpression(out isForAll, out boundedVar, out low, out upp, out body))
+            {
+                if (isForAll)
+                {
+                    return this.ForAll(exp, boundedVar, low, upp, body);
+                }
+                else
+                {
+                    return this.Exists(exp, boundedVar, low, upp, body);
+                }
+            }
+
+            throw new NotImplementedException("Missing case !!!!");
+        }
+
+        #region Virtual methods
+        protected virtual BoxedExpression Null(BoxedExpression original)
+        {
+            return original;
+        }
+
+        protected virtual BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
+        {
+            Contract.Requires(original != null);
+            Contract.Requires(original.UnderlyingVariable == var);
+
+            if (path != null || this.PathFetcher == null)
+            {
+                return original;
+            }
+            else
+            {
+                Contract.Assert(this.PathFetcher != null);
+                var newPath = this.PathFetcher(original.UnderlyingVariable);
+                return newPath != null ? BoxedExpression.Var(original.UnderlyingVariable, newPath) : null;
+            }
+        }
+
+        protected virtual BoxedExpression Constant(BoxedExpression original, object type, object value)
+        {
+            return original;
+        }
+
+        protected virtual BoxedExpression Binary(BoxedExpression original, BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right)
+        {
+            Contract.Requires(original != null);
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            var recLeft = this.Visit(left);
+            if (recLeft == null)
+                return recLeft;
+
+            var recRight = this.Visit(right);
+            if (recRight == null)
+                return recRight;
+
+            return BoxedExpression.Binary(binaryOperator, recLeft, recRight, original.UnderlyingVariable);
+        }
+
+        protected virtual BoxedExpression Unary(BoxedExpression original, UnaryOperator unaryOperator, BoxedExpression argument)
+        {
+            Contract.Requires(original != null);
+            Contract.Requires(argument != null);
+
+            var recArgument = this.Visit(argument);
+            if (recArgument == null)
+                return null;
+
+            return BoxedExpression.Unary(unaryOperator, recArgument);
+        }
+
+        protected virtual BoxedExpression SizeOf(BoxedExpression original)
+        {
+            return original;
+        }
+
+        protected virtual BoxedExpression IsInst(BoxedExpression original, object type, BoxedExpression argument)
+        {
+            return original;
+        }
+
+        protected virtual BoxedExpression ArrayIndex<Typ>(BoxedExpression original, Typ type, BoxedExpression array, BoxedExpression index)
+        {
+            Contract.Requires(original != null);
+            Contract.Requires(array != null);
+            Contract.Requires(index != null);
+
+            var arrayRec = this.Visit(array);
+            if (arrayRec == null)
+                return null;
+
+            var indexRec = this.Visit(index);
+            if (indexRec == null)
+                return null;
+
+            return BoxedExpression.ArrayIndex(arrayRec, indexRec, (Typ)type);
+        }
+
+        protected virtual BoxedExpression Result(BoxedExpression original)
+        {
+            return original;
+        }
+
+        protected virtual BoxedExpression ForAll(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
+        {
+            if (boundVariable == null || lower == null || upper == null || body == null)
+            {
+                return null;
+            }
+
+            var recboundVariable = this.Visit(boundVariable);
+            if (recboundVariable == null)
+                return null;
+
+            var recLower = this.Visit(lower);
+            if (recLower == null)
+                return null;
+
+            var recUpper = this.Visit(upper);
+            if (recUpper == null)
+                return null;
+
+            var recBody = this.Visit(body);
+            if (recBody == null)
+                return null;
+
+            return new ForAllIndexedExpression(null, recboundVariable, recLower, recUpper, recBody);
+        }
+
+        protected virtual BoxedExpression Exists(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
+        {
+            if (boundVariable == null || lower == null || upper == null || body == null)
+            {
+                return null;
+            }
+
+            var recboundVariable = this.Visit(boundVariable);
+            if (recboundVariable == null)
+                return null;
+
+            var recLower = this.Visit(lower);
+            if (recLower == null)
+                return null;
+
+            var recUpper = this.Visit(upper);
+            if (recUpper == null)
+                return null;
+
+            var recBody = this.Visit(body);
+            if (recBody == null)
+                return null;
+
+            return new ExistsIndexedExpression(null, recboundVariable, recLower, recUpper, recBody);
+        }
+        //abstract BoxedExpression Old(BoxedExpression original, object type, BoxedExpression expression);
+        //abstract BoxedExpression ValueAtReturn(BoxedExpression original, object type, BoxedExpression expression);
+        //abstract BoxedExpression Assert(BoxedExpression original, BoxedExpression condition);
+        //abstract BoxedExpression Assume(BoxedExpression original, BoxedExpression condition);
+        //abstract BoxedExpression StatementSequence(BoxedExpression original, IIndexable<BoxedExpression> statements);
+
+        #endregion
     }
-
-    #region Virtual methods
-    protected virtual BoxedExpression Null(BoxedExpression original) 
-    { 
-      return original; 
-    }
-
-    protected virtual BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
-    {
-      Contract.Requires(original != null);
-      Contract.Requires(original.UnderlyingVariable == var);
-
-      if (path != null || this.PathFetcher == null)
-      {
-        return original;
-      }
-      else
-      {
-        Contract.Assert(this.PathFetcher != null);
-        var newPath = this.PathFetcher(original.UnderlyingVariable);
-        return newPath != null ? BoxedExpression.Var(original.UnderlyingVariable, newPath) : null;
-      }
-    }
-
-    protected virtual BoxedExpression Constant(BoxedExpression original, object type, object value)
-    {
-      return original;
-    }
-
-    protected virtual BoxedExpression Binary(BoxedExpression original, BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right)
-    {
-      Contract.Requires(original != null);
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      var recLeft = this.Visit(left);
-      if (recLeft == null)
-        return recLeft;
-
-      var recRight = this.Visit(right);
-      if (recRight == null)
-        return recRight;
-
-      return BoxedExpression.Binary(binaryOperator, recLeft, recRight, original.UnderlyingVariable);
-    }
-
-    protected virtual BoxedExpression Unary(BoxedExpression original, UnaryOperator unaryOperator, BoxedExpression argument)
-    {
-      Contract.Requires(original != null);
-      Contract.Requires(argument != null);
-
-      var recArgument = this.Visit(argument);
-      if (recArgument == null)
-        return null;
-
-      return BoxedExpression.Unary(unaryOperator, recArgument);
-    }
-
-    protected virtual BoxedExpression SizeOf(BoxedExpression original)
-    {
-      return original;
-    }
-
-    protected virtual BoxedExpression IsInst(BoxedExpression original, object type, BoxedExpression argument)
-    {
-      return original;
-    }
-
-    protected virtual BoxedExpression ArrayIndex<Typ>(BoxedExpression original, Typ type, BoxedExpression array, BoxedExpression index)
-    {
-      Contract.Requires(original != null);
-      Contract.Requires(array != null);
-      Contract.Requires(index != null);
-
-      var arrayRec = this.Visit(array);
-      if (arrayRec == null)
-        return null;
-
-      var indexRec = this.Visit(index);
-      if (indexRec == null)
-        return null;
-
-      return BoxedExpression.ArrayIndex(arrayRec, indexRec, (Typ)type);
-    }
-
-    protected virtual BoxedExpression Result(BoxedExpression original)
-    {
-      return original;
-    }
-
-    protected virtual BoxedExpression ForAll(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
-    {
-      if (boundVariable == null || lower == null || upper == null || body == null)
-      {
-        return null;
-      }
-
-      var recboundVariable = this.Visit(boundVariable);
-      if (recboundVariable == null)
-        return null;
-
-      var recLower = this.Visit(lower);
-      if (recLower == null)
-        return null;
-
-      var recUpper = this.Visit(upper);
-      if (recUpper == null)
-        return null;
-
-      var recBody = this.Visit(body);
-      if (recBody == null)
-        return null;
-
-      return new ForAllIndexedExpression(null, recboundVariable, recLower, recUpper, recBody);
-    }
-
-    protected virtual BoxedExpression Exists(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
-    {
-      if (boundVariable == null || lower == null || upper == null || body == null)
-      {
-        return null;      
-      }
-
-      var recboundVariable = this.Visit(boundVariable);
-      if (recboundVariable == null)
-        return null;
-
-      var recLower = this.Visit(lower);
-      if (recLower == null)
-        return null;
-
-      var recUpper = this.Visit(upper);
-      if (recUpper == null)
-        return null;
-
-      var recBody = this.Visit(body);
-      if (recBody == null)
-        return null;
-
-      return new ExistsIndexedExpression(null, recboundVariable, recLower, recUpper, recBody);
-    }
-    //abstract BoxedExpression Old(BoxedExpression original, object type, BoxedExpression expression);
-    //abstract BoxedExpression ValueAtReturn(BoxedExpression original, object type, BoxedExpression expression);
-    //abstract BoxedExpression Assert(BoxedExpression original, BoxedExpression condition);
-    //abstract BoxedExpression Assume(BoxedExpression original, BoxedExpression condition);
-    //abstract BoxedExpression StatementSequence(BoxedExpression original, IIndexable<BoxedExpression> statements);
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/ConstantEvaluator.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/ConstantEvaluator.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,95 +9,92 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public class ConstantEvaluator<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> : 
-    BoxedExpressionTransformer<Void>
-  {
-
-    private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder;
-
-    public ConstantEvaluator(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+    public class ConstantEvaluator<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> :
+      BoxedExpressionTransformer<Void>
     {
-      Contract.Requires(mdDecoder != null);
+        private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder;
 
-      this.MetaDataDecoder = mdDecoder;
-    }
-
-    protected override BoxedExpression Unary(BoxedExpression original, UnaryOperator unaryOperator, BoxedExpression argument)
-    {
-      int value;
-      if (unaryOperator == UnaryOperator.Neg && argument.IsConstantInt(out value))
-      {
-        return BoxedExpression.Const(-value, MetaDataDecoder.System_Int32, this.MetaDataDecoder);
-      }
-      else
-      {
-        return base.Unary(original, unaryOperator, argument);
-      }
-    }
-
-    protected override BoxedExpression Binary(BoxedExpression original, BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right)
-    {
-      int a, b;
-      if (left.IsConstantInt(out a) && right.IsConstantInt(out b))
-      {
-        switch (binaryOperator)
+        public ConstantEvaluator(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
         {
-          case BinaryOperator.Add:
-          case BinaryOperator.Add_Ovf:
-            return this.Const(a + b);
+            Contract.Requires(mdDecoder != null);
 
-          case BinaryOperator.Add_Ovf_Un:
-            return this.Const((uint)a + (uint)b);
-
-          case BinaryOperator.Div:
-            return b != 0 ? this.Const(a / b) : original;
-
-          case BinaryOperator.Div_Un:
-            return b != 0 ? this.Const((uint)a / (uint)b) : original;
-
-          case BinaryOperator.Mul:
-          case BinaryOperator.Mul_Ovf:
-            return this.Const(a * b);
-
-          case BinaryOperator.Mul_Ovf_Un:
-            return this.Const((uint)a * (uint)b);
-
-          case BinaryOperator.Rem:
-            return b != 0 ? this.Const(a % b) : original;
-
-          case BinaryOperator.Rem_Un:
-            return b != 0 ? this.Const((uint)a % (uint)b) : original;
-
-          case BinaryOperator.Sub:
-          case BinaryOperator.Sub_Ovf:
-            return this.Const(a - b);
-
-          case BinaryOperator.Sub_Ovf_Un:
-            return this.Const((uint)a - (uint)b);
-
-          case BinaryOperator.Shl:
-          case BinaryOperator.Shr:
-          case BinaryOperator.Shr_Un:
-          default:
-
-            return original;
+            MetaDataDecoder = mdDecoder;
         }
-      }
 
-      var leftResult = this.Visit(left);
-      Contract.Assume(leftResult != null);
+        protected override BoxedExpression Unary(BoxedExpression original, UnaryOperator unaryOperator, BoxedExpression argument)
+        {
+            int value;
+            if (unaryOperator == UnaryOperator.Neg && argument.IsConstantInt(out value))
+            {
+                return BoxedExpression.Const(-value, MetaDataDecoder.System_Int32, MetaDataDecoder);
+            }
+            else
+            {
+                return base.Unary(original, unaryOperator, argument);
+            }
+        }
 
-      var rightResult = this.Visit(right);
-      Contract.Assume(rightResult != null);
+        protected override BoxedExpression Binary(BoxedExpression original, BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right)
+        {
+            int a, b;
+            if (left.IsConstantInt(out a) && right.IsConstantInt(out b))
+            {
+                switch (binaryOperator)
+                {
+                    case BinaryOperator.Add:
+                    case BinaryOperator.Add_Ovf:
+                        return this.Const(a + b);
 
-      return BoxedExpression.Binary(binaryOperator, leftResult, rightResult, original.UnderlyingVariable);
+                    case BinaryOperator.Add_Ovf_Un:
+                        return this.Const((uint)a + (uint)b);
+
+                    case BinaryOperator.Div:
+                        return b != 0 ? this.Const(a / b) : original;
+
+                    case BinaryOperator.Div_Un:
+                        return b != 0 ? this.Const((uint)a / (uint)b) : original;
+
+                    case BinaryOperator.Mul:
+                    case BinaryOperator.Mul_Ovf:
+                        return this.Const(a * b);
+
+                    case BinaryOperator.Mul_Ovf_Un:
+                        return this.Const((uint)a * (uint)b);
+
+                    case BinaryOperator.Rem:
+                        return b != 0 ? this.Const(a % b) : original;
+
+                    case BinaryOperator.Rem_Un:
+                        return b != 0 ? this.Const((uint)a % (uint)b) : original;
+
+                    case BinaryOperator.Sub:
+                    case BinaryOperator.Sub_Ovf:
+                        return this.Const(a - b);
+
+                    case BinaryOperator.Sub_Ovf_Un:
+                        return this.Const((uint)a - (uint)b);
+
+                    case BinaryOperator.Shl:
+                    case BinaryOperator.Shr:
+                    case BinaryOperator.Shr_Un:
+                    default:
+
+                        return original;
+                }
+            }
+
+            var leftResult = this.Visit(left);
+            Contract.Assume(leftResult != null);
+
+            var rightResult = this.Visit(right);
+            Contract.Assume(rightResult != null);
+
+            return BoxedExpression.Binary(binaryOperator, leftResult, rightResult, original.UnderlyingVariable);
+        }
+
+        private BoxedExpression Const(object k)
+        {
+            return BoxedExpression.Const(k, MetaDataDecoder.System_Int32, MetaDataDecoder);
+        }
     }
-
-    private BoxedExpression Const(object k)
-    {
-      return BoxedExpression.Const(k, this.MetaDataDecoder.System_Int32, this.MetaDataDecoder);
-    }
-
-  }  
-
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/ExpressionReader.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/ExpressionReader.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,43 +10,41 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public struct ReaderInfo<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable> 
-    where Type : IEquatable<Type>
-  {
-    readonly public APC PC;
-    readonly public IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context;
-    readonly public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder;
-
-    public ReaderInfo(APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
+    public struct ReaderInfo<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>
+      where Type : IEquatable<Type>
     {
-      Contract.Requires(Context != null);
-      Contract.Requires(MetaDataDecoder != null);
+        readonly public APC PC;
+        readonly public IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context;
+        readonly public IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder;
 
-      this.PC = pc;
-      this.Context = Context;
-      this.MetaDataDecoder = MetaDataDecoder;
-    }
-  }
-
-  public class ExpressionReader<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable> 
-    : BoxedExpressionTransformer<ReaderInfo<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>>
-    where Type : IEquatable<Type>
-  {
-
-    protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, FList<PathElement>> PathFetcher)
-    {
-      return (object o) =>
-      {
-        if (o is Variable)
+        public ReaderInfo(APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
         {
-          return this.Info.Context.ValueContext.AccessPathList(this.Info.PC, (Variable)o, true, true);
+            Contract.Requires(Context != null);
+            Contract.Requires(MetaDataDecoder != null);
+
+            this.PC = pc;
+            this.Context = Context;
+            this.MetaDataDecoder = MetaDataDecoder;
         }
-        else
-        {
-          return null;
-        }
-      };
     }
 
-  }
+    public class ExpressionReader<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>
+      : BoxedExpressionTransformer<ReaderInfo<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>>
+      where Type : IEquatable<Type>
+    {
+        protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, FList<PathElement>> PathFetcher)
+        {
+            return (object o) =>
+            {
+                if (o is Variable)
+                {
+                    return this.Info.Context.ValueContext.AccessPathList(this.Info.PC, (Variable)o, true, true);
+                }
+                else
+                {
+                    return null;
+                }
+            };
+        }
+    }
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/FilterVars.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/FilterVars.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,36 +10,36 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis.Expressions
 {
-  public class FilterVars<Var> : BoxedExpressionTransformer<Void>
-  {
-    private readonly Func<Var, FList<PathElement>> AccessPath;
-    private readonly Func<object, PathElement[], bool> Filter;
-
-    public FilterVars(Func<Var, FList<PathElement>> AccessPath, Func<object, PathElement[], bool> Filter)
+    public class FilterVars<Var> : BoxedExpressionTransformer<Void>
     {
-      Contract.Requires(Filter != null);
+        private readonly Func<Var, FList<PathElement>> AccessPath;
+        private readonly Func<object, PathElement[], bool> Filter;
 
-      this.AccessPath = AccessPath;
-      this.Filter = Filter;
+        public FilterVars(Func<Var, FList<PathElement>> AccessPath, Func<object, PathElement[], bool> Filter)
+        {
+            Contract.Requires(Filter != null);
+
+            this.AccessPath = AccessPath;
+            this.Filter = Filter;
+        }
+
+        protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
+        {
+            if (Filter(var, path))
+            {
+                return null;
+            }
+
+            return base.Variable(original, var, path);
+        }
+
+        protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, DataStructures.FList<PathElement>> PathFetcher)
+        {
+            return (object obj) =>
+            {
+                if (obj is Var) return AccessPath((Var)obj);
+                else return null;
+            };
+        }
     }
-
-    protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
-    {
-      if (this.Filter(var, path))
-      {
-        return null;
-      }
-
-      return base.Variable(original, var, path);
-    }
-
-    protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, DataStructures.FList<PathElement>> PathFetcher)
-    {
-      return (object obj) =>
-      {
-        if (obj is Var) return this.AccessPath((Var)obj);
-        else return null;
-      };
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/IntervalStruct.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/IntervalStruct.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,26 +10,26 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.DataStructures
 {
-  public struct IntervalStruct
-  {
-    public readonly bool IsValid;
-    public readonly BoxedExpression MinValue;
-    public readonly BoxedExpression MaxValue;
-
-    public static IntervalStruct None { get { return new IntervalStruct(); } }
-
-    public IntervalStruct(Decimal MinValue, Decimal MaxValue, Func<Decimal, BoxedExpression> ToBoxedExpression)
+    public struct IntervalStruct
     {
-      Contract.Requires(ToBoxedExpression != null);
+        public readonly bool IsValid;
+        public readonly BoxedExpression MinValue;
+        public readonly BoxedExpression MaxValue;
 
-      this.IsValid = true;
-      this.MinValue = ToBoxedExpression(MinValue);
-      this.MaxValue = ToBoxedExpression(MaxValue);
-    }
+        public static IntervalStruct None { get { return new IntervalStruct(); } }
 
-    public override string ToString()
-    {
-      return this.IsValid ?  string.Format("({0}, {1})", this.MinValue, this.MaxValue) :  "None";
+        public IntervalStruct(Decimal MinValue, Decimal MaxValue, Func<Decimal, BoxedExpression> ToBoxedExpression)
+        {
+            Contract.Requires(ToBoxedExpression != null);
+
+            this.IsValid = true;
+            this.MinValue = ToBoxedExpression(MinValue);
+            this.MaxValue = ToBoxedExpression(MaxValue);
+        }
+
+        public override string ToString()
+        {
+            return this.IsValid ? string.Format("({0}, {1})", this.MinValue, this.MaxValue) : "None";
+        }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/RemoveFrameworkVariables.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/RemoveFrameworkVariables.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,28 +9,28 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis.Expressions
 {
-  public class RemoveFrameworkVariables<Var> : BoxedExpressionTransformer<Void>
-  {
-    private readonly Func<Var, FList<PathElement>> AccessPath;
-    public RemoveFrameworkVariables(Func<Var, FList<PathElement>> AccessPath)
+    public class RemoveFrameworkVariables<Var> : BoxedExpressionTransformer<Void>
     {
-      this.AccessPath = AccessPath;
-    }
+        private readonly Func<Var, FList<PathElement>> AccessPath;
+        public RemoveFrameworkVariables(Func<Var, FList<PathElement>> AccessPath)
+        {
+            this.AccessPath = AccessPath;
+        }
 
 
-    protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
-    {
-      // Let's remove the variable
-      return new BoxedExpression.VariableExpression(null, path);
-    }
+        protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
+        {
+            // Let's remove the variable
+            return new BoxedExpression.VariableExpression(null, path);
+        }
 
-     protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, DataStructures.FList<PathElement>> PathFetcher)
-    {
-      return (object obj) =>
-      {
-        if (obj is Var) return this.AccessPath((Var)obj);
-        else return null;
-      };
+        protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, DataStructures.FList<PathElement>> PathFetcher)
+        {
+            return (object obj) =>
+            {
+                if (obj is Var) return AccessPath((Var)obj);
+                else return null;
+            };
+        }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Expressions/SourceReadableExpression.cs
+++ b/Microsoft.Research/CodeAnalysis/Expressions/SourceReadableExpression.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,29 +10,29 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis.Expressions
 {
-  public class SourceLevelReadableExpression<Variable> : BoxedExpressionTransformer<Void>
-  {
-    private readonly Func<Variable, FList<PathElement>> AccessPath;
-
-    public SourceLevelReadableExpression(Func<Variable, FList<PathElement>> AccessPath)
+    public class SourceLevelReadableExpression<Variable> : BoxedExpressionTransformer<Void>
     {
-      this.AccessPath = AccessPath;
-    }
+        private readonly Func<Variable, FList<PathElement>> AccessPath;
 
-    protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, DataStructures.FList<PathElement>> PathFetcher)
-    {
-      if (this.AccessPath != null)
-      {
-        return (object obj) =>
+        public SourceLevelReadableExpression(Func<Variable, FList<PathElement>> AccessPath)
         {
-          if (obj is Variable) return this.AccessPath((Variable)obj);
-          else return null;
-        };
-      }
-      else // return the function always returning null
-      {
-        return (object obj) => { return null; };
-      }
+            this.AccessPath = AccessPath;
+        }
+
+        protected override Func<object, FList<PathElement>> GetPathFetcher(Func<object, DataStructures.FList<PathElement>> PathFetcher)
+        {
+            if (AccessPath != null)
+            {
+                return (object obj) =>
+                {
+                    if (obj is Variable) return AccessPath((Variable)obj);
+                    else return null;
+                };
+            }
+            else // return the function always returning null
+            {
+                return (object obj) => { return null; };
+            }
+        }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Extensions.cs
+++ b/Microsoft.Research/CodeAnalysis/Extensions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,2904 +11,2892 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-
-  public static class BoxedExpressionExtensions
-  {
-    [Pure]
-    static public bool IsConstantFalse(this BoxedExpression be)
+    public static class BoxedExpressionExtensions
     {
-      Contract.Requires(be != null);
-
-      if (!be.IsConstant)
-      {
-        return false;
-      }
-
-      int k;
-      if (be.IsConstantInt(out k) && k == 0)
-      {
-        return true;
-      }
-
-      if (be.Constant is bool)
-      {
-        return ((bool)be.Constant) == false;
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static bool IsConstantInt(this BoxedExpression b, out int value)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant)
-      {
-        var k = b.Constant;
-
-        if (k is Int32)
+        [Pure]
+        static public bool IsConstantFalse(this BoxedExpression be)
         {
-          value = (Int32)k;
-          return true;
-        }
-        else if (k is System.Double || k is System.Single)
-        {
-          double kAsDouble = k is System.Single ? (Single)k : (Double)k;
-          
-          if (!Double.IsInfinity(kAsDouble) && !Double.IsNaN(kAsDouble))
-          {
-            var floor = Math.Floor(kAsDouble);
-            var ceiling = Math.Ceiling(kAsDouble);
-            if (floor == ceiling) // here it is ok to use == on doubles
+            Contract.Requires(be != null);
+
+            if (!be.IsConstant)
             {
-              var kAsInt64 = (Int64)Math.Floor(kAsDouble);
-
-              if (Int32.MinValue <= kAsInt64 && kAsInt64 <= Int32.MaxValue)
-              {
-                value = (Int32)kAsInt64;
-                return true;
-              }
-            }
-          }
-        }
-        else
-        {
-          try
-          {
-            var ic = k as IConvertible;
-            if (ic == null || k is string)
-            {
-              value = 0;
-              return false;
-            }
-
-            value = ic.ToInt32(null);
-            return true;
-          }
-          catch (Exception)
-          {
-            // to nothing
-          }
-        }
-      }
-
-      value = 0;
-      return false;
-    }
-
-    [Pure]
-    public static bool IsConstantInt64(this BoxedExpression b, out long value)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant)
-      {
-        var k = b.Constant;
-
-        if (k is Int64)
-        {
-          value = (Int64)k;
-          return true;
-        }
-        else
-        {
-          try
-          {
-            var ic = k as IConvertible;
-            if (ic == null)
-            {
-              value = 0;
-              return false;
-            }
-            value = ic.ToInt64(null);
-            return true;
-          }
-          catch (Exception)
-          {
-            // to nothing
-          }
-        }
-      }
-
-      value = 0;
-      return false;
-    }
-
-    /// <summary>
-    /// Matches the boxed expression *exactly* with a Float64
-    /// </summary>
-    [Pure]
-    public static bool IsConstantFloat64(this BoxedExpression b, out double value)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant)
-      {
-        var k = b.Constant;
-
-        if (k is Double)
-        {
-          value = (Double)k;
-          return true;
-        }
-      }
-
-      value = 0.0d;
-      return false;
-    }
-
-    [Pure]
-    public static bool IsConstantFloat32(this BoxedExpression b, out float value)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant)
-      {
-        var k = b.Constant;
-
-        if (k is float)
-        {
-          value = (float)k;
-          return true;
-        }
-      }
-
-      value = 0.0f;
-      return false;
-    }
-
-    [Pure]
-    public static bool IsConstantIntOrNull(this BoxedExpression b, out int value)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant)
-      {
-        var k = b.Constant;
-
-        if (k is Int32)
-        {
-          value = (Int32)k;
-          return true;
-        }
-        if (k == null)
-        {
-          value = 0; // treat null as 0
-          return true;
-        }
-      }
-      value = 0;
-      return false;
-    }
-
-    [Pure]
-    public static bool IsConstantBool(this BoxedExpression b, out bool value)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant)
-      {
-        if (b.Constant is Boolean)
-        {
-          value = (Boolean)b.Constant;
-
-          return true;
-        }
-        if (b.Constant is Int32)
-        {
-          value = ((Int32)b.Constant) != 0;
-
-          return true;
-        }
-
-      }
-      value = false;
-      return false;
-    }
-
-    [Pure]
-    public static bool IsNaN(this BoxedExpression b)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant)
-      {
-        var k = b.Constant;
-
-        if (k is Single)
-        {
-          return Single.IsNaN((Single)k);
-        }
-
-        if (k is Double)
-        {
-          return Double.IsNaN((Double)k);
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static bool IsConstantString(this BoxedExpression b, out string value)
-    {
-      Contract.Requires(b != null);
-
-      if (b.IsConstant && b.Constant is string)
-      {
-        value = b.Constant as string; // value can be null, as null is an admissible string constant
-        return true;
-      }
-
-      // HACKHACKHACK for string.Empty
-      if (b.AccessPath != null && b.AccessPath.Length == 2 && b.AccessPath[0].ToString() == "string.Empty")
-      {
-        value = "";
-        return true;
-      }
-
-      value = null;
-      return false;
-    }
-
-    [Pure]
-    static public bool IsAssumeIsAType<Variable, Type>(this BoxedExpression cond, out Variable var, out Type type)
-    {
-      Contract.Requires(cond != null);
-
-      // We do pattern matching for the C# compiler generated condition
-      BinaryOperator bop;
-      BoxedExpression left, right;
-      if (cond.IsBinaryExpression(out bop, out left, out right) && bop == BinaryOperator.Cle_Un && right.IsNull)
-      {
-        object type_obj;
-        BoxedExpression exp;
-        if (left.IsIsInstExpression(out exp, out type_obj) && type_obj is Type && exp.TryGetFrameworkVariable(out var))
-        {
-          type = (Type)type_obj;
-
-          return true;
-        }
-      }
-
-      var = default(Variable);
-      type = default(Type);
-      return false;
-    }
-
-
-    public static bool IsArrayLengthOrThisDotCount<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-      this BoxedExpression exp, APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(Context != null);
-
-      return exp.IsArrayLength(pc, Context, MetaDataDecoder) || exp.IsThisDotCount(pc, Context, MetaDataDecoder);
-    }
-
-    /// <summary>
-    /// Syntactic pattern matching to detect if exp is "this.Count".
-    /// To be used only in heuristics to filter stupid preconditions
-    /// </summary>
-    [Pure]
-    public static bool IsThisDotCount<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-      this BoxedExpression exp, APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(exp != null);
-
-      Variable var;
-      if (exp.IsVariable && exp.TryGetFrameworkVariable(out var))
-      {
-        var accessPath = Context.ValueContext.AccessPathList(pc, var, false, false);
-
-        // simple syntactic pattern matching
-        if (accessPath != null && accessPath.Length() == 2)
-        {
-          if (Context.ValueContext.IsRootedInParameter(accessPath) &&
-            accessPath.Head.ToString() == "this" && accessPath.Tail.Head.IsGetter &&
-            accessPath.Tail.Head.ToString() == "Count")
-          {
-            return true;
-          }
-        }
-      }
-      return false;
-    }
-
-    [Pure]
-    public static bool IsExpressionNotEqualToNull(this BoxedExpression exp, out BoxedExpression innerExp)
-    {
-
-      innerExp = null;
-
-      if (exp == null)
-      {
-        return false;
-      }
-
-      BinaryOperator bop;
-      BoxedExpression left, right;
-      if (exp.IsBinaryExpression(out bop, out left, out right) && bop == BinaryOperator.Cne_Un)
-      {
-        if (left.IsNull)
-        {
-          innerExp = right;
-          return true;
-        }
-        if (right.IsNull)
-        {
-          innerExp = left;
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static bool IsConstantLimitValue(this BoxedExpression be)
-    {
-      Contract.Requires(be != null);
-      if(be.IsConstant)
-      {
-        int i;
-        if(be.IsConstantInt(out i) && (Int32.MinValue == i || Int32.MaxValue == i))
-        {
-          return true;
-        }
-        long l;
-        if(be.IsConstantInt64(out l) && (Int64.MinValue == l || Int64.MaxValue == l))
-        {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static bool IsBinaryExpressionExpOpConst(this BoxedExpression exp, out BinaryOperator bop, out BoxedExpression left, out int value, bool preserveOrder = true)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
-
-      BoxedExpression l, r;
-      if (exp.IsBinaryExpression(out bop, out l, out r))
-      {
-        if (r.IsConstantInt(out value))
-        {
-          left = l;
-          return true;
-        }
-
-        if (!preserveOrder)
-        {
-          if (l.IsConstantInt(out value))
-          {
-            left = r;
-            return true;
-          }
-        }
-      }
-
-      left = default(BoxedExpression);
-      value = default(int);
-      return false;
-    }
-
-    [Pure]
-    public static bool IsArrayLength<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-      this BoxedExpression exp, APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(exp != null);
-      Contract.Requires(Context != null);
-
-      Variable var;
-      if (exp.IsVariable && exp.TryGetFrameworkVariable(out var))
-      {
-        var accessPath = Context.ValueContext.AccessPathList(pc, var, false, false);
-        // pattern match for the access path *.a.Length for some a
-        if (accessPath != null)
-        {
-          var accessPathArray = accessPath.ToArray();
-
-          Contract.Assume(Contract.ForAll(accessPathArray, p => p != null));
-
-          // a.Length?
-          if (accessPathArray.Length == 2)
-          {
-            if (IsArrayDotLength(accessPathArray[accessPathArray.Length - 2], accessPathArray[accessPathArray.Length - 1], MetaDataDecoder))
-              return true;
-          }
-
-          // *.a.Length? there is a deref
-          if (accessPathArray.Length >= 3 && accessPathArray[accessPathArray.Length - 2].IsDeref)
-          {
-            if (IsArrayDotLength(accessPathArray[accessPathArray.Length - 3], accessPathArray[accessPathArray.Length - 1], MetaDataDecoder))
-              return true;
-          }
-
-          return false;
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    public static BoxedExpression Stripped(this BoxedExpression exp)
-    {
-      Contract.Ensures(exp == null || Contract.Result<BoxedExpression>() != null);
-
-      UnaryOperator uop;
-      BoxedExpression inner;
-      if (exp != null && exp.IsUnaryExpression(out uop, out inner) && uop.IsConversionOperator())
-      {
-        return inner;
-      }
-
-      return exp;
-    }
-
-    /// <summary>
-    /// If exp == (int)a.Length, for some a, return a.Length
-    /// </summary>
-    [Pure]
-    public static BoxedExpression StripIfCastOfArrayLength(this BoxedExpression exp)
-    {
-      Contract.Requires(exp != null);
-
-      UnaryOperator uop;
-      BoxedExpression inner;
-      if (exp.IsCastExpression(out uop, out inner) && uop == UnaryOperator.Conv_i4 && inner.AccessPath != null)
-      {
-        var accessPathArray = inner.AccessPath.ToArray();
-
-        if (accessPathArray.Length >= 2 && accessPathArray[accessPathArray.Length - 1].AssumeNotNull().ToString() == "Length")
-        {
-          return inner;
-        }
-      }
-
-      return exp;
-    }
-
-    [Pure]
-    static private bool IsArrayDotLength<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      PathElement candidateArray, PathElement candidateLength,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
-    {
-      try
-      {
-        Type t;
-        return candidateLength.ToString() == "Length" && candidateArray.TryGetResultType(out t) &&
-          !MetaDataDecoder.IsPrimitive(t) && (MetaDataDecoder.IsArray(t) || MetaDataDecoder.IsArray(MetaDataDecoder.ElementType(t)));
-      }
-      catch (NotImplementedException) // Our heuristic is partially pattern-based, so we may sometime fail
-      {
-        return false;
-      }
-    }
-
-    [Pure]
-    static public bool IsCastExpression(this BoxedExpression exp, out UnaryOperator cast, out BoxedExpression casted)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out casted) != null);
-
-      if (exp.IsUnaryExpression(out cast, out casted) && cast.IsConversionOperator())
-      {
-        return true;
-      }
-
-      return false;
-    }
-
-    [Pure]
-    static public bool IsCheckOfEnumValue<Variable>(this BoxedExpression exp, Predicate<Variable> IsEnumTyped)
-    {
-      Contract.Requires(IsEnumTyped != null);
-
-      if(exp == null)
-      {
-        return false;
-      }
-
-      BinaryOperator bop;
-      BoxedExpression left, right;
-      if(exp.IsBinaryExpression(out bop, out left, out right) && (left.IsConstant|| right.IsConstant))
-      {
-        if(right.IsConstant)
-        {
-          return left.IsVariable && left.UnderlyingVariable is Variable && IsEnumTyped((Variable)left.UnderlyingVariable); 
-        }
-        else
-        {
-          Contract.Assert(left.IsConstant);
-          return right.IsVariable && right.UnderlyingVariable is Variable && IsEnumTyped((Variable)right.UnderlyingVariable); 
-        }
-      }
-
-      return false;
-    }
-
-    [Pure]
-    static public bool IsTrivialCondition(this BoxedExpression exp, out bool result)
-    {
-      Contract.Requires(exp != null);
-
-      // "constant"
-      int value;
-      if (exp.IsConstantIntOrNull(out value))
-      {
-        result = value != 0;
-
-        return true;
-      }
-
-      if (exp.IsConstantBool(out result))
-      {
-        return true;
-      }
-
-      UnaryOperator uop;
-      BoxedExpression unaryExp;
-      if (exp.IsUnaryExpression(out uop, out unaryExp) && uop == UnaryOperator.Not)
-      {
-        bool innerResult;
-        if (unaryExp.IsTrivialCondition(out innerResult))
-        {
-          result = !innerResult;
-          return true;
-        }
-      }
-
-      BinaryOperator bop;
-      BoxedExpression left, right;
-      if (exp.IsBinaryExpression(out bop, out left, out right))
-      {
-        int x, y;
-
-        var leftConst = left.IsConstantIntOrNull(out x);
-        var rightConst = right.IsConstantIntOrNull(out y);
-
-        if (bop == BinaryOperator.Ceq)
-        {
-          #region Equalities
-          // "assume NaN == NaN"
-          if (left.IsNaN() || right.IsNaN())
-          {
-            result = false;
-            return true;
-          }
-
-          if (leftConst && rightConst)
-          {
-            result = x == y;
-            return true;
-          }
-
-          if (rightConst && y == 0)
-          {
-            bool recursiveResult;
-            if (IsTrivialCondition(left, out recursiveResult))
-            {
-              result = !recursiveResult;
-              return true;
-            }
-          }
-
-          if (leftConst && x == 0)
-          {
-            bool recursiveResult;
-            if (IsTrivialCondition(right, out recursiveResult))
-            {
-              result = !recursiveResult;
-              return true;
-            }
-          }
-          #endregion
-        }
-        // simplify things like x < x
-        if(bop == BinaryOperator.Clt || bop == BinaryOperator.Cgt || bop == BinaryOperator.Cne_Un)
-        {
-          if (left.UnderlyingVariable != null && left.UnderlyingVariable.Equals(right.UnderlyingVariable))
-          {
-            return IsTrue(false, out result);
-          }
-        }
-
-        if (leftConst && rightConst)
-        {
-          #region All the cases
-          switch (bop)
-          {
-            case BinaryOperator.Add:
-            case BinaryOperator.Add_Ovf:
-              return IsTrue(x + y != 0, out result);
-
-            case BinaryOperator.Add_Ovf_Un:
-              return IsTrue((uint)x + (uint)y != 0, out result);
-
-            case BinaryOperator.And:
-              return IsTrue((x & y) != 0, out result);
-
-            case BinaryOperator.Cge:
-              return IsTrue(x >= y, out result);
-
-            case BinaryOperator.Cge_Un:
-              return IsTrue((uint)x >= (uint)y, out result);
-
-            case BinaryOperator.Cgt:
-              return IsTrue(x > y, out result);
-
-            case BinaryOperator.Cgt_Un:
-              return IsTrue((uint)x > (uint)y, out result);
-
-            case BinaryOperator.Cle:
-              return IsTrue(x <= y, out result);
-
-            case BinaryOperator.Cle_Un:
-              return IsTrue((uint)x <= (uint)y, out result);
-
-            case BinaryOperator.Clt:
-              return IsTrue(x < y, out result);
-
-            case BinaryOperator.Clt_Un:
-              return IsTrue((uint)x < (uint)y, out result);
-
-            case BinaryOperator.Cne_Un:
-              return IsTrue((uint)x != (uint)y, out result);
-
-            case BinaryOperator.Div:
-              {
-                result = false;
-                return y != 0 ? IsTrue(x / y != 0, out result) : false;
-              }
-            case BinaryOperator.Div_Un:
-              {
-                result = false;
-                return y != 0 ? IsTrue((uint)x / (uint)y != 0, out result) : false;
-              }
-
-            case BinaryOperator.LogicalAnd:
-              return IsTrue(x != 0 && y != 0, out result);
-
-            case BinaryOperator.LogicalOr:
-              return IsTrue(x != 0 || y != 0, out result);
-
-            case BinaryOperator.Mul:
-              return IsTrue(x * y != 0, out result);
-
-            case BinaryOperator.Mul_Ovf_Un:
-              return IsTrue((uint)x * (uint)y != 0, out result);
-
-            case BinaryOperator.Or:
-              return IsTrue((x | y) != 0, out result);
-
-            case BinaryOperator.Rem:
-                return y != 0 ? IsTrue(x % y != 0, out result) : false;
-            case BinaryOperator.Rem_Un:
-              return IsTrue((uint)x % (uint)y != 0, out result);
-
-            case BinaryOperator.Shl:
-              return IsTrue((x << y) != 0, out result);
-
-            case BinaryOperator.Shr:
-              return IsTrue((x >> y) != 0, out result);
-
-            case BinaryOperator.Shr_Un:
-              return IsTrue(((uint)x >> y) != 0, out result);
-
-            case BinaryOperator.Sub:
-              return IsTrue(x - y != 0, out result);
-
-            case BinaryOperator.Sub_Ovf_Un:
-              return IsTrue(((uint)x - (uint)y) != 0, out result);
-
-            case BinaryOperator.Xor:
-              return IsTrue((x ^ y) != 0, out result);
-
-            default:
-              result = false;
-              return false;
-          }
-          #endregion
-        }
-      }
-
-      result = default(bool);
-      return false;
-    }
-
-    /// <summary>
-    /// Try match the boxed expresion to (checkedExp == null) == 0
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExpNotNotNull(this BoxedExpression exp, out BoxedExpression checkedExp)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out checkedExp) != null);
-
-      int val;
-      BinaryOperator bop;
-      BoxedExpression left, right;
-
-      if(exp.IsBinaryExpression(out bop, out checkedExp, out right) && bop == BinaryOperator.Cne_Un && right.IsNull)
-      {
-        return true;
-      }
-      
-      if (exp.IsBinaryExpression(out bop, out left, out right) && bop == BinaryOperator.Ceq
-        && right.IsConstantIntOrNull(out val) && val == 0)
-      {
-        if (left.IsBinaryExpression(out bop, out checkedExp, out right) && bop == BinaryOperator.Ceq && right.IsNull)
-        {
-          return true;
-        }
-      }
-
-
-      checkedExp = default(BoxedExpression);
-      return false;
-    }
-
-    /// <summary>
-    /// Try match the boxed expression to (exp1 == k)
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1EqConst(this BoxedExpression exp, out BoxedExpression exp1, out int k)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
-
-      BinaryOperator bop;
-      return exp.IsCheckExpOpConst(out bop, out exp1, out k) && bop == BinaryOperator.Ceq;
-    }
-
-    /// <summary>
-    /// Try match the boxed expression to (var == k)
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1EqConst<Variable>(this BoxedExpression exp, out Variable var, out int k)
-    {
-      Contract.Requires(exp != null);
-
-      BoxedExpression tmp;
-      var = default(Variable);
-
-      return exp.IsCheckExp1EqConst(out tmp, out k) && tmp.TryGetFrameworkVariable(out var);
-    }
-
-    /// <summary>
-    /// Mathches (exp == k) or (!exp), in which case it returns (exp != 0)
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExpOpConst(this BoxedExpression exp, out BinaryOperator bop, out BoxedExpression exp1, out int k)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out exp1) != null);
-
-      BoxedExpression exp2;
-      k = default(int);
-      if (exp.IsBinaryExpression(out bop, out exp1, out exp2) && exp2.IsConstantInt(out k))
-      {
-        return true;
-      }
-
-      UnaryOperator uop;
-      if (exp.IsUnaryExpression(out uop, out exp1) && uop == UnaryOperator.Not)
-      {
-        bop = BinaryOperator.Ceq;
-        k = 0;
-        return true;
-      }
-
-      return false;
-    }
-
-    [Pure]
-    static public bool IsCheckExpOpConst<Variable>(this BoxedExpression exp, out BinaryOperator bop, out Variable var, out int k)
-    {
-      BoxedExpression tmp;
-
-      bop = default(BinaryOperator);
-      var = default(Variable);
-      k = default(int);
-
-      return exp != null && exp.IsCheckExpOpConst(out bop, out tmp, out k) && tmp.TryGetFrameworkVariable(out var);
-    }
-
-    /// <summary>
-    /// Try to match the boxed expression to (exp1 == exp2)
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1EqExp2(this BoxedExpression exp, out BoxedExpression exp1, out BoxedExpression exp2)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
-
-      BinaryOperator bop;
-
-      if (exp.IsBinaryExpression(out bop, out exp1, out exp2))
-      {
-        switch (bop)
-        {
-          // exp1 == exp2
-          case BinaryOperator.Ceq:
-            return true;
-
-          default:
-            return false;
-        }
-      }
-
-      return false;
-    }
-
-    /// <summary>
-    /// Try to match the boxed expression to (v1 == v2)
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1EqExp2<Variable>(this BoxedExpression exp, out Variable v1, out Variable v2)
-    {
-      BoxedExpression e1, e2;
-      v1 = v2 = default(Variable);
-      return exp != null && exp.IsCheckExp1EqExp2(out e1, out e2) && e1.TryGetFrameworkVariable(out v1) && e2.TryGetFrameworkVariable(out v2);
-    }
-
-    /// <summary>
-    /// Try to match the boxed expression to (exp1 != exp2)
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1NotEqExp2(this BoxedExpression exp, out BoxedExpression exp1, out BoxedExpression exp2)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
-
-      BinaryOperator bop;
-
-      if (exp.IsBinaryExpression(out bop, out exp1, out exp2))
-      {
-        switch (bop)
-        {
-          case BinaryOperator.Cne_Un:
-            {
-              return true;
-            }
-
-          case BinaryOperator.Ceq:
-            {
-              int value;
-              if (exp2.IsConstantIntOrNull(out value) && value == 0)
-              {
-                return exp1.IsCheckExp1EqExp2(out exp1, out exp2);
-              }
-              else
-              {
                 return false;
-              }
             }
-        }
-      }
 
-      return false;
-    }
-
-    /// <summary>
-    /// Try to match the boxed expression to (v1 != v2)
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1NotEqExp2<Variable>(this BoxedExpression exp, out Variable v1, out Variable v2)
-    {
-      Contract.Requires(exp != null);
-
-      BoxedExpression exp1, exp2;
-
-      v1 = v2 = default(Variable);
-      return exp.IsCheckExp1NotEqExp2(out exp1, out exp2) && exp1.TryGetFrameworkVariable(out v1) && exp2.TryGetFrameworkVariable(out v2);
-    }
-
-    /// <summary>
-    /// Try to match the boxed expression to (left \leq right).
-    /// It is ok to pass null. The postcondition ensures that if we return true, then be != null
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1LEQExp2(this BoxedExpression be, out BoxedExpression exp1, out BoxedExpression exp2)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || be != null);
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
-
-      BinaryOperator bop;
-      if (be != null && be.IsBinaryExpression(out bop, out exp1, out exp2))
-      {
-        switch (bop)
-        {
-          case BinaryOperator.Ceq:
+            int k;
+            if (be.IsConstantInt(out k) && k == 0)
             {
-              int value;
-              if (exp2.IsConstantIntOrNull(out value) && value == 0)
-              {
-                return exp1.IsCheckExp1LTExp2(out exp2, out exp1);
-              }
-              break;
+                return true;
             }
 
-          case BinaryOperator.Cle:
+            if (be.Constant is bool)
             {
-              return true;
+                return ((bool)be.Constant) == false;
             }
 
-          default:
             return false;
         }
-      }
 
-      exp1 = exp2 = default(BoxedExpression);
-
-      return false;
-    }
-
-    /// <summary>
-    /// Try to match the boxed expression to (left \lt right).
-    /// It is ok to pass null as be. The contract ensures that if true is returned then be != null
-    /// </summary>
-    [Pure]
-    static public bool IsCheckExp1LTExp2(this BoxedExpression be, out BoxedExpression exp1, out BoxedExpression exp2)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || be != null);
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
-
-      BinaryOperator bop;
-      if (be != null && be.IsBinaryExpression(out bop, out exp1, out exp2))
-      {
-        switch (bop)
+        [Pure]
+        public static bool IsConstantInt(this BoxedExpression b, out int value)
         {
-          case BinaryOperator.Ceq:
+            Contract.Requires(b != null);
+
+            if (b.IsConstant)
             {
-              int value;
-              if (exp2.IsConstantIntOrNull(out value) && value == 0)
-              {
-                return exp1.IsCheckExp1LEQExp2(out exp2, out exp1);
-              }
-              break;
+                var k = b.Constant;
+
+                if (k is Int32)
+                {
+                    value = (Int32)k;
+                    return true;
+                }
+                else if (k is System.Double || k is System.Single)
+                {
+                    double kAsDouble = k is System.Single ? (Single)k : (Double)k;
+
+                    if (!Double.IsInfinity(kAsDouble) && !Double.IsNaN(kAsDouble))
+                    {
+                        var floor = Math.Floor(kAsDouble);
+                        var ceiling = Math.Ceiling(kAsDouble);
+                        if (floor == ceiling) // here it is ok to use == on doubles
+                        {
+                            var kAsInt64 = (Int64)Math.Floor(kAsDouble);
+
+                            if (Int32.MinValue <= kAsInt64 && kAsInt64 <= Int32.MaxValue)
+                            {
+                                value = (Int32)kAsInt64;
+                                return true;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        var ic = k as IConvertible;
+                        if (ic == null || k is string)
+                        {
+                            value = 0;
+                            return false;
+                        }
+
+                        value = ic.ToInt32(null);
+                        return true;
+                    }
+                    catch (Exception)
+                    {
+                        // to nothing
+                    }
+                }
             }
 
-          case BinaryOperator.Clt:
-            {
-              return true;
-            }
-
-          default:
+            value = 0;
             return false;
         }
-      }
 
-      exp1 = exp2 = default(BoxedExpression);
-
-      return false;
-    }
-
-    private static bool IsTrue(bool condition, out bool result)
-    {
-      result = condition;
-      return true;
-    }
-
-    [Pure]
-    public static bool TryGetFrameworkVariable<Variable>(this BoxedExpression be, out Variable var)
-    {
-      Contract.Requires(be != null);
-
-      var loc = be.UnderlyingVariable;
-      var asBoxedVar = loc as BoxedVariable<Variable>;
-
-      if (asBoxedVar != null && asBoxedVar.TryUnpackVariable(out var))
-      {
-        return true;
-      }
-
-      if (loc is Variable)
-      {
-        var = (Variable)loc;
-        return true;
-      }
-
-      var = default(Variable);
-      return false;
-    }
-
-    /// <summary>
-    /// Searches an ArrayIndexExpression in exp with index == index.
-    /// If there are more than one, it returns the first one.
-    /// </summary>    
-    public static bool TryFindArrayExp<Typ>(this BoxedExpression exp, BoxedExpression index,
-      out BoxedExpression.ArrayIndexExpression<Typ> res)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out res) != null);
-
-      if (exp == null)
-      {
-        res = default(BoxedExpression.ArrayIndexExpression<Typ>);
-        return false;
-      }
-
-      res = exp as BoxedExpression.ArrayIndexExpression<Typ>;
-      if (res != null)
-      {
-        // Looking for a[index]
-        // TODO: Extend to more complex indexing
-        return index == res.Index;
-      }
-
-      UnaryOperator unaryDummy;
-      BoxedExpression unaryExp;
-      if (exp.IsUnaryExpression(out unaryDummy, out unaryExp))
-      {
-        return unaryExp.TryFindArrayExp(index, out res);
-      }
-
-      BinaryOperator dummy;
-      BoxedExpression left, right;
-      if (exp.IsBinaryExpression(out dummy, out left, out right))
-      {
-        return left.TryFindArrayExp(index, out res) || right.TryFindArrayExp(index, out res);
-      }
-
-      res = null;
-      return false;
-    }
-
-    public static bool TryFindArrayExpBinOpArrayExp<Typ>(this BoxedExpression exp,
-      BoxedExpression index,
-      out BinaryOperator bop,
-      out BoxedExpression.ArrayIndexExpression<Typ> left,
-      out BoxedExpression.ArrayIndexExpression<Typ> right)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out right) != null);
-
-      BoxedExpression leftExp, rightExp;
-      if (exp.IsBinaryExpression(out bop, out leftExp, out rightExp) && leftExp.TryFindArrayExp(index, out left))
-      {
-        return rightExp.TryFindArrayExp(index, out right);
-      }
-
-      left = right = default(BoxedExpression.ArrayIndexExpression<Typ>);
-      return false;
-    }
-
-    public static IEnumerable<BoxedExpression> SyntacticReductionRemoval(this IEnumerable<BoxedExpression> input,
-      bool removeChecksWithMinValue = false, bool keepStronger = true)
-    {
-      if (input == null)
-      {
-        return input;
-      }
-
-      var tmp = new List<BoxedExpression>();
-
-      // 1. Remove doubles
-      // 2. Put all the binary expressions in the form a {<, <= } b
-      foreach (var b in input.Distinct())
-      {
-        var toAdd = b;
-        BinaryOperator bop;
-        BoxedExpression left, right;
-        if (b.IsBinaryExpression(out bop, out left, out right) &&
-          (bop == BinaryOperator.Cge || bop == BinaryOperator.Cge_Un || bop == BinaryOperator.Cgt || bop == BinaryOperator.Cgt_Un))
+        [Pure]
+        public static bool IsConstantInt64(this BoxedExpression b, out long value)
         {
-          if (bop.TryInvert(out bop))
-          {
-            toAdd = BoxedExpression.Binary(bop, right, left);
-          }
-          else
-          {
-            Contract.Assume(false, "impossible?");
-          }
+            Contract.Requires(b != null);
+
+            if (b.IsConstant)
+            {
+                var k = b.Constant;
+
+                if (k is Int64)
+                {
+                    value = (Int64)k;
+                    return true;
+                }
+                else
+                {
+                    try
+                    {
+                        var ic = k as IConvertible;
+                        if (ic == null)
+                        {
+                            value = 0;
+                            return false;
+                        }
+                        value = ic.ToInt64(null);
+                        return true;
+                    }
+                    catch (Exception)
+                    {
+                        // to nothing
+                    }
+                }
+            }
+
+            value = 0;
+            return false;
         }
 
-        tmp.Add(toAdd);
-      }
-
-      var result = new List<BoxedExpression>(tmp.Count);
-
-      // 3. if a < b and a <= b are in input keep a < b if keepStronger==true, otherwise a <= b
-      // 4. if a <= b and b is MaxValue or a is MinValue then drop them -- TODO use types
-      foreach (var b in tmp)
-      {
-        BinaryOperator bop;
-        BoxedExpression left, right;
-        if (b.IsBinaryExpression(out bop, out left, out right))
+        /// <summary>
+        /// Matches the boxed expression *exactly* with a Float64
+        /// </summary>
+        [Pure]
+        public static bool IsConstantFloat64(this BoxedExpression b, out double value)
         {
-          if (keepStronger)
-          {            // if b is a <= b, then do not put it if there is a a < b in the list
-            if (bop == BinaryOperator.Cle)
+            Contract.Requires(b != null);
+
+            if (b.IsConstant)
             {
-              if (tmp.Contains(BoxedExpression.Binary(BinaryOperator.Clt, left, right)))
-              {
-                continue;
-              }
-              if (removeChecksWithMinValue)
-              {
-                int k;
-                if (left.IsConstantInt(out k) && k == Int32.MinValue)
+                var k = b.Constant;
+
+                if (k is Double)
                 {
-                  continue;
+                    value = (Double)k;
+                    return true;
                 }
-                if (right.IsConstantInt(out k) && k == Int32.MaxValue)
-                {
-                  continue;
-                }
-              }
             }
-            if (bop == BinaryOperator.Cle_Un)
-            {
-              if (tmp.Contains(BoxedExpression.Binary(BinaryOperator.Clt_Un, left, right)))
-              {
-                continue;
-              }
-              if (removeChecksWithMinValue)
-              {
-                int k;
-                if (left.IsConstantInt(out k) && k == Int32.MinValue)
-                {
-                  continue;
-                }
-                if (right.IsConstantInt(out k) && k == Int32.MaxValue)
-                {
-                  continue;
-                }
-              }
-            }
-          }
-          else
-          {
-            if (bop == BinaryOperator.Clt && tmp.Contains(BoxedExpression.Binary(BinaryOperator.Cle, left, right)))
-            {
-              continue;
-            }
-            if (bop == BinaryOperator.Clt_Un && tmp.Contains(BoxedExpression.Binary(BinaryOperator.Cle_Un, left, right)))
-            {
-              continue;
-            }
-          }
-        }
-        result.Add(b);
-      }
 
-      return result;
-    }
-
-    static public ExpressionInPreStateKind GuessExpressionInPreStateKind<Local, Parameter, Method, Field, Type, Variable>
-      (this BoxedExpression condition, APC pc, IValueContextData<Local, Parameter, Method, Field, Type, Variable> context, Func<FList<PathElement>, bool> IsReadonlyField)
-    where Type : IEquatable<Type>
-    {
-      Contract.Requires(condition != null);
-      Contract.Requires(IsReadonlyField != null);
-
-      var inferKinds = condition.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-      switch (inferKinds)
-      {
-        case EnumType.Assume:
-          return ExpressionInPreStateKind.Assume;
-
-        case EnumType.Neutral:
-        case EnumType.Parameter:
-        case EnumType.PublicField:
-          return ExpressionInPreStateKind.MethodPrecondition;
-
-        case EnumType.PrivateField:
-          return ExpressionInPreStateKind.ObjectInvariant;
-
-        default:
-          Contract.Assert(false);
-          break;
-      }
-
-      // Should be unreachable
-      return ExpressionInPreStateKind.Any;
-    }
-
-    private enum EnumType { Neutral, Parameter, PublicField, PrivateField, Assume }
-
-    static private EnumType GuessExpressionInPreStateKind_Internal<Local, Parameter, Method, Field, Type, Variable>
-    (this BoxedExpression condition, APC pc, IValueContextData<Local, Parameter, Method, Field, Type, Variable> context, Func<FList<PathElement>, bool> IsReadonlyField)
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(IsReadonlyField != null);
-
-      #region All the cases
-
-      if (condition.IsVariable)
-      {
-        // Special case as we may have some slack variable
-        Variable var;
-        if (!condition.TryGetFrameworkVariable(out var))
-        {
-          return EnumType.Neutral;
+            value = 0.0d;
+            return false;
         }
 
-        // First check if we've got a constant
-        Type type;
-        object value;
-        if (context.IsConstant(pc, var, out type, out value))
+        [Pure]
+        public static bool IsConstantFloat32(this BoxedExpression b, out float value)
         {
-          return EnumType.Neutral;
+            Contract.Requires(b != null);
+
+            if (b.IsConstant)
+            {
+                var k = b.Constant;
+
+                if (k is float)
+                {
+                    value = (float)k;
+                    return true;
+                }
+            }
+
+            value = 0.0f;
+            return false;
         }
 
-        FList<PathElement> accessPath;
-        accessPath = context.VisibleAccessPathListFromPre(pc, var);
-
-        if (accessPath != null)
+        [Pure]
+        public static bool IsConstantIntOrNull(this BoxedExpression b, out int value)
         {
-          if (accessPath.Head.ToString() == "this")
-          {
-            return EnumType.PublicField;
-          }
-          else
-          {
+            Contract.Requires(b != null);
+
+            if (b.IsConstant)
+            {
+                var k = b.Constant;
+
+                if (k is Int32)
+                {
+                    value = (Int32)k;
+                    return true;
+                }
+                if (k == null)
+                {
+                    value = 0; // treat null as 0
+                    return true;
+                }
+            }
+            value = 0;
+            return false;
+        }
+
+        [Pure]
+        public static bool IsConstantBool(this BoxedExpression b, out bool value)
+        {
+            Contract.Requires(b != null);
+
+            if (b.IsConstant)
+            {
+                if (b.Constant is Boolean)
+                {
+                    value = (Boolean)b.Constant;
+
+                    return true;
+                }
+                if (b.Constant is Int32)
+                {
+                    value = ((Int32)b.Constant) != 0;
+
+                    return true;
+                }
+            }
+            value = false;
+            return false;
+        }
+
+        [Pure]
+        public static bool IsNaN(this BoxedExpression b)
+        {
+            Contract.Requires(b != null);
+
+            if (b.IsConstant)
+            {
+                var k = b.Constant;
+
+                if (k is Single)
+                {
+                    return Single.IsNaN((Single)k);
+                }
+
+                if (k is Double)
+                {
+                    return Double.IsNaN((Double)k);
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        public static bool IsConstantString(this BoxedExpression b, out string value)
+        {
+            Contract.Requires(b != null);
+
+            if (b.IsConstant && b.Constant is string)
+            {
+                value = b.Constant as string; // value can be null, as null is an admissible string constant
+                return true;
+            }
+
+            // HACKHACKHACK for string.Empty
+            if (b.AccessPath != null && b.AccessPath.Length == 2 && b.AccessPath[0].ToString() == "string.Empty")
+            {
+                value = "";
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        [Pure]
+        static public bool IsAssumeIsAType<Variable, Type>(this BoxedExpression cond, out Variable var, out Type type)
+        {
+            Contract.Requires(cond != null);
+
+            // We do pattern matching for the C# compiler generated condition
+            BinaryOperator bop;
+            BoxedExpression left, right;
+            if (cond.IsBinaryExpression(out bop, out left, out right) && bop == BinaryOperator.Cle_Un && right.IsNull)
+            {
+                object type_obj;
+                BoxedExpression exp;
+                if (left.IsIsInstExpression(out exp, out type_obj) && type_obj is Type && exp.TryGetFrameworkVariable(out var))
+                {
+                    type = (Type)type_obj;
+
+                    return true;
+                }
+            }
+
+            var = default(Variable);
+            type = default(Type);
+            return false;
+        }
+
+
+        public static bool IsArrayLengthOrThisDotCount<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+          this BoxedExpression exp, APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(Context != null);
+
+            return exp.IsArrayLength(pc, Context, MetaDataDecoder) || exp.IsThisDotCount(pc, Context, MetaDataDecoder);
+        }
+
+        /// <summary>
+        /// Syntactic pattern matching to detect if exp is "this.Count".
+        /// To be used only in heuristics to filter stupid preconditions
+        /// </summary>
+        [Pure]
+        public static bool IsThisDotCount<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+          this BoxedExpression exp, APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(exp != null);
+
+            Variable var;
+            if (exp.IsVariable && exp.TryGetFrameworkVariable(out var))
+            {
+                var accessPath = Context.ValueContext.AccessPathList(pc, var, false, false);
+
+                // simple syntactic pattern matching
+                if (accessPath != null && accessPath.Length() == 2)
+                {
+                    if (Context.ValueContext.IsRootedInParameter(accessPath) &&
+                      accessPath.Head.ToString() == "this" && accessPath.Tail.Head.IsGetter &&
+                      accessPath.Tail.Head.ToString() == "Count")
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        [Pure]
+        public static bool IsExpressionNotEqualToNull(this BoxedExpression exp, out BoxedExpression innerExp)
+        {
+            innerExp = null;
+
+            if (exp == null)
+            {
+                return false;
+            }
+
+            BinaryOperator bop;
+            BoxedExpression left, right;
+            if (exp.IsBinaryExpression(out bop, out left, out right) && bop == BinaryOperator.Cne_Un)
+            {
+                if (left.IsNull)
+                {
+                    innerExp = right;
+                    return true;
+                }
+                if (right.IsNull)
+                {
+                    innerExp = left;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        public static bool IsConstantLimitValue(this BoxedExpression be)
+        {
+            Contract.Requires(be != null);
+            if (be.IsConstant)
+            {
+                int i;
+                if (be.IsConstantInt(out i) && (Int32.MinValue == i || Int32.MaxValue == i))
+                {
+                    return true;
+                }
+                long l;
+                if (be.IsConstantInt64(out l) && (Int64.MinValue == l || Int64.MaxValue == l))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        public static bool IsBinaryExpressionExpOpConst(this BoxedExpression exp, out BinaryOperator bop, out BoxedExpression left, out int value, bool preserveOrder = true)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
+
+            BoxedExpression l, r;
+            if (exp.IsBinaryExpression(out bop, out l, out r))
+            {
+                if (r.IsConstantInt(out value))
+                {
+                    left = l;
+                    return true;
+                }
+
+                if (!preserveOrder)
+                {
+                    if (l.IsConstantInt(out value))
+                    {
+                        left = r;
+                        return true;
+                    }
+                }
+            }
+
+            left = default(BoxedExpression);
+            value = default(int);
+            return false;
+        }
+
+        [Pure]
+        public static bool IsArrayLength<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+          this BoxedExpression exp, APC pc, IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> Context, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(exp != null);
+            Contract.Requires(Context != null);
+
+            Variable var;
+            if (exp.IsVariable && exp.TryGetFrameworkVariable(out var))
+            {
+                var accessPath = Context.ValueContext.AccessPathList(pc, var, false, false);
+                // pattern match for the access path *.a.Length for some a
+                if (accessPath != null)
+                {
+                    var accessPathArray = accessPath.ToArray();
+
+                    Contract.Assume(Contract.ForAll(accessPathArray, p => p != null));
+
+                    // a.Length?
+                    if (accessPathArray.Length == 2)
+                    {
+                        if (IsArrayDotLength(accessPathArray[accessPathArray.Length - 2], accessPathArray[accessPathArray.Length - 1], MetaDataDecoder))
+                            return true;
+                    }
+
+                    // *.a.Length? there is a deref
+                    if (accessPathArray.Length >= 3 && accessPathArray[accessPathArray.Length - 2].IsDeref)
+                    {
+                        if (IsArrayDotLength(accessPathArray[accessPathArray.Length - 3], accessPathArray[accessPathArray.Length - 1], MetaDataDecoder))
+                            return true;
+                    }
+
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        public static BoxedExpression Stripped(this BoxedExpression exp)
+        {
+            Contract.Ensures(exp == null || Contract.Result<BoxedExpression>() != null);
+
+            UnaryOperator uop;
+            BoxedExpression inner;
+            if (exp != null && exp.IsUnaryExpression(out uop, out inner) && uop.IsConversionOperator())
+            {
+                return inner;
+            }
+
+            return exp;
+        }
+
+        /// <summary>
+        /// If exp == (int)a.Length, for some a, return a.Length
+        /// </summary>
+        [Pure]
+        public static BoxedExpression StripIfCastOfArrayLength(this BoxedExpression exp)
+        {
+            Contract.Requires(exp != null);
+
+            UnaryOperator uop;
+            BoxedExpression inner;
+            if (exp.IsCastExpression(out uop, out inner) && uop == UnaryOperator.Conv_i4 && inner.AccessPath != null)
+            {
+                var accessPathArray = inner.AccessPath.ToArray();
+
+                if (accessPathArray.Length >= 2 && accessPathArray[accessPathArray.Length - 1].AssumeNotNull().ToString() == "Length")
+                {
+                    return inner;
+                }
+            }
+
+            return exp;
+        }
+
+        [Pure]
+        static private bool IsArrayDotLength<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          PathElement candidateArray, PathElement candidateLength,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetaDataDecoder)
+        {
+            try
+            {
+                Type t;
+                return candidateLength.ToString() == "Length" && candidateArray.TryGetResultType(out t) &&
+                  !MetaDataDecoder.IsPrimitive(t) && (MetaDataDecoder.IsArray(t) || MetaDataDecoder.IsArray(MetaDataDecoder.ElementType(t)));
+            }
+            catch (NotImplementedException) // Our heuristic is partially pattern-based, so we may sometime fail
+            {
+                return false;
+            }
+        }
+
+        [Pure]
+        static public bool IsCastExpression(this BoxedExpression exp, out UnaryOperator cast, out BoxedExpression casted)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out casted) != null);
+
+            if (exp.IsUnaryExpression(out cast, out casted) && cast.IsConversionOperator())
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        [Pure]
+        static public bool IsCheckOfEnumValue<Variable>(this BoxedExpression exp, Predicate<Variable> IsEnumTyped)
+        {
+            Contract.Requires(IsEnumTyped != null);
+
+            if (exp == null)
+            {
+                return false;
+            }
+
+            BinaryOperator bop;
+            BoxedExpression left, right;
+            if (exp.IsBinaryExpression(out bop, out left, out right) && (left.IsConstant || right.IsConstant))
+            {
+                if (right.IsConstant)
+                {
+                    return left.IsVariable && left.UnderlyingVariable is Variable && IsEnumTyped((Variable)left.UnderlyingVariable);
+                }
+                else
+                {
+                    Contract.Assert(left.IsConstant);
+                    return right.IsVariable && right.UnderlyingVariable is Variable && IsEnumTyped((Variable)right.UnderlyingVariable);
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        static public bool IsTrivialCondition(this BoxedExpression exp, out bool result)
+        {
+            Contract.Requires(exp != null);
+
+            // "constant"
+            int value;
+            if (exp.IsConstantIntOrNull(out value))
+            {
+                result = value != 0;
+
+                return true;
+            }
+
+            if (exp.IsConstantBool(out result))
+            {
+                return true;
+            }
+
+            UnaryOperator uop;
+            BoxedExpression unaryExp;
+            if (exp.IsUnaryExpression(out uop, out unaryExp) && uop == UnaryOperator.Not)
+            {
+                bool innerResult;
+                if (unaryExp.IsTrivialCondition(out innerResult))
+                {
+                    result = !innerResult;
+                    return true;
+                }
+            }
+
+            BinaryOperator bop;
+            BoxedExpression left, right;
+            if (exp.IsBinaryExpression(out bop, out left, out right))
+            {
+                int x, y;
+
+                var leftConst = left.IsConstantIntOrNull(out x);
+                var rightConst = right.IsConstantIntOrNull(out y);
+
+                if (bop == BinaryOperator.Ceq)
+                {
+                    #region Equalities
+                    // "assume NaN == NaN"
+                    if (left.IsNaN() || right.IsNaN())
+                    {
+                        result = false;
+                        return true;
+                    }
+
+                    if (leftConst && rightConst)
+                    {
+                        result = x == y;
+                        return true;
+                    }
+
+                    if (rightConst && y == 0)
+                    {
+                        bool recursiveResult;
+                        if (IsTrivialCondition(left, out recursiveResult))
+                        {
+                            result = !recursiveResult;
+                            return true;
+                        }
+                    }
+
+                    if (leftConst && x == 0)
+                    {
+                        bool recursiveResult;
+                        if (IsTrivialCondition(right, out recursiveResult))
+                        {
+                            result = !recursiveResult;
+                            return true;
+                        }
+                    }
+                    #endregion
+                }
+                // simplify things like x < x
+                if (bop == BinaryOperator.Clt || bop == BinaryOperator.Cgt || bop == BinaryOperator.Cne_Un)
+                {
+                    if (left.UnderlyingVariable != null && left.UnderlyingVariable.Equals(right.UnderlyingVariable))
+                    {
+                        return IsTrue(false, out result);
+                    }
+                }
+
+                if (leftConst && rightConst)
+                {
+                    #region All the cases
+                    switch (bop)
+                    {
+                        case BinaryOperator.Add:
+                        case BinaryOperator.Add_Ovf:
+                            return IsTrue(x + y != 0, out result);
+
+                        case BinaryOperator.Add_Ovf_Un:
+                            return IsTrue((uint)x + (uint)y != 0, out result);
+
+                        case BinaryOperator.And:
+                            return IsTrue((x & y) != 0, out result);
+
+                        case BinaryOperator.Cge:
+                            return IsTrue(x >= y, out result);
+
+                        case BinaryOperator.Cge_Un:
+                            return IsTrue((uint)x >= (uint)y, out result);
+
+                        case BinaryOperator.Cgt:
+                            return IsTrue(x > y, out result);
+
+                        case BinaryOperator.Cgt_Un:
+                            return IsTrue((uint)x > (uint)y, out result);
+
+                        case BinaryOperator.Cle:
+                            return IsTrue(x <= y, out result);
+
+                        case BinaryOperator.Cle_Un:
+                            return IsTrue((uint)x <= (uint)y, out result);
+
+                        case BinaryOperator.Clt:
+                            return IsTrue(x < y, out result);
+
+                        case BinaryOperator.Clt_Un:
+                            return IsTrue((uint)x < (uint)y, out result);
+
+                        case BinaryOperator.Cne_Un:
+                            return IsTrue((uint)x != (uint)y, out result);
+
+                        case BinaryOperator.Div:
+                            {
+                                result = false;
+                                return y != 0 ? IsTrue(x / y != 0, out result) : false;
+                            }
+                        case BinaryOperator.Div_Un:
+                            {
+                                result = false;
+                                return y != 0 ? IsTrue((uint)x / (uint)y != 0, out result) : false;
+                            }
+
+                        case BinaryOperator.LogicalAnd:
+                            return IsTrue(x != 0 && y != 0, out result);
+
+                        case BinaryOperator.LogicalOr:
+                            return IsTrue(x != 0 || y != 0, out result);
+
+                        case BinaryOperator.Mul:
+                            return IsTrue(x * y != 0, out result);
+
+                        case BinaryOperator.Mul_Ovf_Un:
+                            return IsTrue((uint)x * (uint)y != 0, out result);
+
+                        case BinaryOperator.Or:
+                            return IsTrue((x | y) != 0, out result);
+
+                        case BinaryOperator.Rem:
+                            return y != 0 ? IsTrue(x % y != 0, out result) : false;
+                        case BinaryOperator.Rem_Un:
+                            return IsTrue((uint)x % (uint)y != 0, out result);
+
+                        case BinaryOperator.Shl:
+                            return IsTrue((x << y) != 0, out result);
+
+                        case BinaryOperator.Shr:
+                            return IsTrue((x >> y) != 0, out result);
+
+                        case BinaryOperator.Shr_Un:
+                            return IsTrue(((uint)x >> y) != 0, out result);
+
+                        case BinaryOperator.Sub:
+                            return IsTrue(x - y != 0, out result);
+
+                        case BinaryOperator.Sub_Ovf_Un:
+                            return IsTrue(((uint)x - (uint)y) != 0, out result);
+
+                        case BinaryOperator.Xor:
+                            return IsTrue((x ^ y) != 0, out result);
+
+                        default:
+                            result = false;
+                            return false;
+                    }
+                    #endregion
+                }
+            }
+
+            result = default(bool);
+            return false;
+        }
+
+        /// <summary>
+        /// Try match the boxed expresion to (checkedExp == null) == 0
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExpNotNotNull(this BoxedExpression exp, out BoxedExpression checkedExp)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out checkedExp) != null);
+
+            int val;
+            BinaryOperator bop;
+            BoxedExpression left, right;
+
+            if (exp.IsBinaryExpression(out bop, out checkedExp, out right) && bop == BinaryOperator.Cne_Un && right.IsNull)
+            {
+                return true;
+            }
+
+            if (exp.IsBinaryExpression(out bop, out left, out right) && bop == BinaryOperator.Ceq
+              && right.IsConstantIntOrNull(out val) && val == 0)
+            {
+                if (left.IsBinaryExpression(out bop, out checkedExp, out right) && bop == BinaryOperator.Ceq && right.IsNull)
+                {
+                    return true;
+                }
+            }
+
+
+            checkedExp = default(BoxedExpression);
+            return false;
+        }
+
+        /// <summary>
+        /// Try match the boxed expression to (exp1 == k)
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1EqConst(this BoxedExpression exp, out BoxedExpression exp1, out int k)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
+
+            BinaryOperator bop;
+            return exp.IsCheckExpOpConst(out bop, out exp1, out k) && bop == BinaryOperator.Ceq;
+        }
+
+        /// <summary>
+        /// Try match the boxed expression to (var == k)
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1EqConst<Variable>(this BoxedExpression exp, out Variable var, out int k)
+        {
+            Contract.Requires(exp != null);
+
+            BoxedExpression tmp;
+            var = default(Variable);
+
+            return exp.IsCheckExp1EqConst(out tmp, out k) && tmp.TryGetFrameworkVariable(out var);
+        }
+
+        /// <summary>
+        /// Mathches (exp == k) or (!exp), in which case it returns (exp != 0)
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExpOpConst(this BoxedExpression exp, out BinaryOperator bop, out BoxedExpression exp1, out int k)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out exp1) != null);
+
+            BoxedExpression exp2;
+            k = default(int);
+            if (exp.IsBinaryExpression(out bop, out exp1, out exp2) && exp2.IsConstantInt(out k))
+            {
+                return true;
+            }
+
+            UnaryOperator uop;
+            if (exp.IsUnaryExpression(out uop, out exp1) && uop == UnaryOperator.Not)
+            {
+                bop = BinaryOperator.Ceq;
+                k = 0;
+                return true;
+            }
+
+            return false;
+        }
+
+        [Pure]
+        static public bool IsCheckExpOpConst<Variable>(this BoxedExpression exp, out BinaryOperator bop, out Variable var, out int k)
+        {
+            BoxedExpression tmp;
+
+            bop = default(BinaryOperator);
+            var = default(Variable);
+            k = default(int);
+
+            return exp != null && exp.IsCheckExpOpConst(out bop, out tmp, out k) && tmp.TryGetFrameworkVariable(out var);
+        }
+
+        /// <summary>
+        /// Try to match the boxed expression to (exp1 == exp2)
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1EqExp2(this BoxedExpression exp, out BoxedExpression exp1, out BoxedExpression exp2)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
+
+            BinaryOperator bop;
+
+            if (exp.IsBinaryExpression(out bop, out exp1, out exp2))
+            {
+                switch (bop)
+                {
+                    // exp1 == exp2
+                    case BinaryOperator.Ceq:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Try to match the boxed expression to (v1 == v2)
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1EqExp2<Variable>(this BoxedExpression exp, out Variable v1, out Variable v2)
+        {
+            BoxedExpression e1, e2;
+            v1 = v2 = default(Variable);
+            return exp != null && exp.IsCheckExp1EqExp2(out e1, out e2) && e1.TryGetFrameworkVariable(out v1) && e2.TryGetFrameworkVariable(out v2);
+        }
+
+        /// <summary>
+        /// Try to match the boxed expression to (exp1 != exp2)
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1NotEqExp2(this BoxedExpression exp, out BoxedExpression exp1, out BoxedExpression exp2)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
+
+            BinaryOperator bop;
+
+            if (exp.IsBinaryExpression(out bop, out exp1, out exp2))
+            {
+                switch (bop)
+                {
+                    case BinaryOperator.Cne_Un:
+                        {
+                            return true;
+                        }
+
+                    case BinaryOperator.Ceq:
+                        {
+                            int value;
+                            if (exp2.IsConstantIntOrNull(out value) && value == 0)
+                            {
+                                return exp1.IsCheckExp1EqExp2(out exp1, out exp2);
+                            }
+                            else
+                            {
+                                return false;
+                            }
+                        }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Try to match the boxed expression to (v1 != v2)
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1NotEqExp2<Variable>(this BoxedExpression exp, out Variable v1, out Variable v2)
+        {
+            Contract.Requires(exp != null);
+
+            BoxedExpression exp1, exp2;
+
+            v1 = v2 = default(Variable);
+            return exp.IsCheckExp1NotEqExp2(out exp1, out exp2) && exp1.TryGetFrameworkVariable(out v1) && exp2.TryGetFrameworkVariable(out v2);
+        }
+
+        /// <summary>
+        /// Try to match the boxed expression to (left \leq right).
+        /// It is ok to pass null. The postcondition ensures that if we return true, then be != null
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1LEQExp2(this BoxedExpression be, out BoxedExpression exp1, out BoxedExpression exp2)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || be != null);
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
+
+            BinaryOperator bop;
+            if (be != null && be.IsBinaryExpression(out bop, out exp1, out exp2))
+            {
+                switch (bop)
+                {
+                    case BinaryOperator.Ceq:
+                        {
+                            int value;
+                            if (exp2.IsConstantIntOrNull(out value) && value == 0)
+                            {
+                                return exp1.IsCheckExp1LTExp2(out exp2, out exp1);
+                            }
+                            break;
+                        }
+
+                    case BinaryOperator.Cle:
+                        {
+                            return true;
+                        }
+
+                    default:
+                        return false;
+                }
+            }
+
+            exp1 = exp2 = default(BoxedExpression);
+
+            return false;
+        }
+
+        /// <summary>
+        /// Try to match the boxed expression to (left \lt right).
+        /// It is ok to pass null as be. The contract ensures that if true is returned then be != null
+        /// </summary>
+        [Pure]
+        static public bool IsCheckExp1LTExp2(this BoxedExpression be, out BoxedExpression exp1, out BoxedExpression exp2)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || be != null);
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp1) != null));
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out exp2) != null));
+
+            BinaryOperator bop;
+            if (be != null && be.IsBinaryExpression(out bop, out exp1, out exp2))
+            {
+                switch (bop)
+                {
+                    case BinaryOperator.Ceq:
+                        {
+                            int value;
+                            if (exp2.IsConstantIntOrNull(out value) && value == 0)
+                            {
+                                return exp1.IsCheckExp1LEQExp2(out exp2, out exp1);
+                            }
+                            break;
+                        }
+
+                    case BinaryOperator.Clt:
+                        {
+                            return true;
+                        }
+
+                    default:
+                        return false;
+                }
+            }
+
+            exp1 = exp2 = default(BoxedExpression);
+
+            return false;
+        }
+
+        private static bool IsTrue(bool condition, out bool result)
+        {
+            result = condition;
+            return true;
+        }
+
+        [Pure]
+        public static bool TryGetFrameworkVariable<Variable>(this BoxedExpression be, out Variable var)
+        {
+            Contract.Requires(be != null);
+
+            var loc = be.UnderlyingVariable;
+            var asBoxedVar = loc as BoxedVariable<Variable>;
+
+            if (asBoxedVar != null && asBoxedVar.TryUnpackVariable(out var))
+            {
+                return true;
+            }
+
+            if (loc is Variable)
+            {
+                var = (Variable)loc;
+                return true;
+            }
+
+            var = default(Variable);
+            return false;
+        }
+
+        /// <summary>
+        /// Searches an ArrayIndexExpression in exp with index == index.
+        /// If there are more than one, it returns the first one.
+        /// </summary>    
+        public static bool TryFindArrayExp<Typ>(this BoxedExpression exp, BoxedExpression index,
+          out BoxedExpression.ArrayIndexExpression<Typ> res)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out res) != null);
+
+            if (exp == null)
+            {
+                res = default(BoxedExpression.ArrayIndexExpression<Typ>);
+                return false;
+            }
+
+            res = exp as BoxedExpression.ArrayIndexExpression<Typ>;
+            if (res != null)
+            {
+                // Looking for a[index]
+                // TODO: Extend to more complex indexing
+                return index == res.Index;
+            }
+
+            UnaryOperator unaryDummy;
+            BoxedExpression unaryExp;
+            if (exp.IsUnaryExpression(out unaryDummy, out unaryExp))
+            {
+                return unaryExp.TryFindArrayExp(index, out res);
+            }
+
+            BinaryOperator dummy;
+            BoxedExpression left, right;
+            if (exp.IsBinaryExpression(out dummy, out left, out right))
+            {
+                return left.TryFindArrayExp(index, out res) || right.TryFindArrayExp(index, out res);
+            }
+
+            res = null;
+            return false;
+        }
+
+        public static bool TryFindArrayExpBinOpArrayExp<Typ>(this BoxedExpression exp,
+          BoxedExpression index,
+          out BinaryOperator bop,
+          out BoxedExpression.ArrayIndexExpression<Typ> left,
+          out BoxedExpression.ArrayIndexExpression<Typ> right)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out left) != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out right) != null);
+
+            BoxedExpression leftExp, rightExp;
+            if (exp.IsBinaryExpression(out bop, out leftExp, out rightExp) && leftExp.TryFindArrayExp(index, out left))
+            {
+                return rightExp.TryFindArrayExp(index, out right);
+            }
+
+            left = right = default(BoxedExpression.ArrayIndexExpression<Typ>);
+            return false;
+        }
+
+        public static IEnumerable<BoxedExpression> SyntacticReductionRemoval(this IEnumerable<BoxedExpression> input,
+          bool removeChecksWithMinValue = false, bool keepStronger = true)
+        {
+            if (input == null)
+            {
+                return input;
+            }
+
+            var tmp = new List<BoxedExpression>();
+
+            // 1. Remove doubles
+            // 2. Put all the binary expressions in the form a {<, <= } b
+            foreach (var b in input.Distinct())
+            {
+                var toAdd = b;
+                BinaryOperator bop;
+                BoxedExpression left, right;
+                if (b.IsBinaryExpression(out bop, out left, out right) &&
+                  (bop == BinaryOperator.Cge || bop == BinaryOperator.Cge_Un || bop == BinaryOperator.Cgt || bop == BinaryOperator.Cgt_Un))
+                {
+                    if (bop.TryInvert(out bop))
+                    {
+                        toAdd = BoxedExpression.Binary(bop, right, left);
+                    }
+                    else
+                    {
+                        Contract.Assume(false, "impossible?");
+                    }
+                }
+
+                tmp.Add(toAdd);
+            }
+
+            var result = new List<BoxedExpression>(tmp.Count);
+
+            // 3. if a < b and a <= b are in input keep a < b if keepStronger==true, otherwise a <= b
+            // 4. if a <= b and b is MaxValue or a is MinValue then drop them -- TODO use types
+            foreach (var b in tmp)
+            {
+                BinaryOperator bop;
+                BoxedExpression left, right;
+                if (b.IsBinaryExpression(out bop, out left, out right))
+                {
+                    if (keepStronger)
+                    {            // if b is a <= b, then do not put it if there is a a < b in the list
+                        if (bop == BinaryOperator.Cle)
+                        {
+                            if (tmp.Contains(BoxedExpression.Binary(BinaryOperator.Clt, left, right)))
+                            {
+                                continue;
+                            }
+                            if (removeChecksWithMinValue)
+                            {
+                                int k;
+                                if (left.IsConstantInt(out k) && k == Int32.MinValue)
+                                {
+                                    continue;
+                                }
+                                if (right.IsConstantInt(out k) && k == Int32.MaxValue)
+                                {
+                                    continue;
+                                }
+                            }
+                        }
+                        if (bop == BinaryOperator.Cle_Un)
+                        {
+                            if (tmp.Contains(BoxedExpression.Binary(BinaryOperator.Clt_Un, left, right)))
+                            {
+                                continue;
+                            }
+                            if (removeChecksWithMinValue)
+                            {
+                                int k;
+                                if (left.IsConstantInt(out k) && k == Int32.MinValue)
+                                {
+                                    continue;
+                                }
+                                if (right.IsConstantInt(out k) && k == Int32.MaxValue)
+                                {
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (bop == BinaryOperator.Clt && tmp.Contains(BoxedExpression.Binary(BinaryOperator.Cle, left, right)))
+                        {
+                            continue;
+                        }
+                        if (bop == BinaryOperator.Clt_Un && tmp.Contains(BoxedExpression.Binary(BinaryOperator.Cle_Un, left, right)))
+                        {
+                            continue;
+                        }
+                    }
+                }
+                result.Add(b);
+            }
+
+            return result;
+        }
+
+        static public ExpressionInPreStateKind GuessExpressionInPreStateKind<Local, Parameter, Method, Field, Type, Variable>
+          (this BoxedExpression condition, APC pc, IValueContextData<Local, Parameter, Method, Field, Type, Variable> context, Func<FList<PathElement>, bool> IsReadonlyField)
+        where Type : IEquatable<Type>
+        {
+            Contract.Requires(condition != null);
+            Contract.Requires(IsReadonlyField != null);
+
+            var inferKinds = condition.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+            switch (inferKinds)
+            {
+                case EnumType.Assume:
+                    return ExpressionInPreStateKind.Assume;
+
+                case EnumType.Neutral:
+                case EnumType.Parameter:
+                case EnumType.PublicField:
+                    return ExpressionInPreStateKind.MethodPrecondition;
+
+                case EnumType.PrivateField:
+                    return ExpressionInPreStateKind.ObjectInvariant;
+
+                default:
+                    Contract.Assert(false);
+                    break;
+            }
+
+            // Should be unreachable
+            return ExpressionInPreStateKind.Any;
+        }
+
+        private enum EnumType { Neutral, Parameter, PublicField, PrivateField, Assume }
+
+        static private EnumType GuessExpressionInPreStateKind_Internal<Local, Parameter, Method, Field, Type, Variable>
+        (this BoxedExpression condition, APC pc, IValueContextData<Local, Parameter, Method, Field, Type, Variable> context, Func<FList<PathElement>, bool> IsReadonlyField)
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(IsReadonlyField != null);
+
+            #region All the cases
+
+            if (condition.IsVariable)
+            {
+                // Special case as we may have some slack variable
+                Variable var;
+                if (!condition.TryGetFrameworkVariable(out var))
+                {
+                    return EnumType.Neutral;
+                }
+
+                // First check if we've got a constant
+                Type type;
+                object value;
+                if (context.IsConstant(pc, var, out type, out value))
+                {
+                    return EnumType.Neutral;
+                }
+
+                FList<PathElement> accessPath;
+                accessPath = context.VisibleAccessPathListFromPre(pc, var);
+
+                if (accessPath != null)
+                {
+                    if (accessPath.Head.ToString() == "this")
+                    {
+                        return EnumType.PublicField;
+                    }
+                    else
+                    {
+                        return EnumType.Parameter;
+                    }
+                }
+
+                accessPath = context.AccessPathList(pc, var, false, false);
+                if (accessPath != null && context.PathSuitableInRequires(pc, accessPath) && accessPath.Head.AssumeNotNull().IsParameter)
+                {
+                    if (accessPath.Head.ToString() == "this")
+                    {
+                        return IsReadonlyField(accessPath) ? EnumType.PrivateField : EnumType.Assume;
+                    }
+                    else
+                    {
+                        return EnumType.Parameter;
+                    }
+                }
+
+                // F: HackHack: sometimes the two tests above return null, but condition has an access path. I do not know why
+                if (condition.AccessPath != null && condition.AccessPath.Length > 0 && condition.AccessPath[0].AssumeNotNull().ToString() == "this")
+                {
+                    return IsReadonlyField(accessPath) ? EnumType.PrivateField : EnumType.Assume;
+                }
+
+                return EnumType.Neutral;
+            }
+
+            if (condition.IsConstant || condition.IsNull || condition.IsSizeOf)
+            {
+                return EnumType.Neutral;
+            }
+            if (condition.IsUnary)
+            {
+                return condition.UnaryArgument.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+            }
+            if (condition.IsBinary)
+            {
+                var left = condition.BinaryLeft.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+                var right = condition.BinaryRight.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+
+                return Join(left, right);
+            }
+
+            BoxedExpression arrayExp, indexExp;
+            object t;
+            if (condition.IsArrayIndexExpression(out arrayExp, out indexExp, out t) && t is Type)
+            {
+                var left = arrayExp.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+                var right = indexExp.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+
+                return Join(left, right);
+            }
+
+            bool isForAll;
+            BoxedExpression boundExp, lowerBound, upperBound, body;
+            if (condition.IsQuantifiedExpression(out isForAll, out boundExp, out lowerBound, out upperBound, out body))
+            {
+                var newLowerBound = lowerBound.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+                var newUpperBound = upperBound.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+                var newBody = body.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
+
+                return Join(newLowerBound, Join(newUpperBound, newBody));
+            }
+
             return EnumType.Parameter;
-          }
+
+            #endregion
         }
 
-        accessPath = context.AccessPathList(pc, var, false, false);
-        if (accessPath != null && context.PathSuitableInRequires(pc, accessPath) && accessPath.Head.AssumeNotNull().IsParameter)
+        private static EnumType Join(EnumType left, EnumType right)
         {
-          if (accessPath.Head.ToString() == "this")
-          {
-            return IsReadonlyField(accessPath) ? EnumType.PrivateField : EnumType.Assume;
-          }
-          else
-          {
-            return EnumType.Parameter;
-          }
+            switch (left)
+            {
+                case EnumType.Neutral:
+                    {
+                        return right;
+                    }
+
+                case EnumType.Parameter:
+                    switch (right)
+                    {
+                        case EnumType.Neutral:
+                            return EnumType.Parameter;
+
+                        case EnumType.Parameter:
+                            return EnumType.Parameter;
+
+                        case EnumType.PrivateField:
+                            return EnumType.Assume;
+
+                        case EnumType.PublicField:
+                            return EnumType.Parameter;
+
+                        case EnumType.Assume:
+                            return EnumType.Assume;
+
+                        default:
+                            throw new InvalidOperationException();
+                    }
+
+                case EnumType.PublicField:
+                    switch (right)
+                    {
+                        case EnumType.Neutral:
+                            return EnumType.PublicField;
+
+                        case EnumType.Parameter:
+                            return EnumType.Parameter;
+
+                        case EnumType.PublicField:
+                            return EnumType.PublicField;
+
+                        case EnumType.PrivateField:
+                            return EnumType.PrivateField;
+
+                        case EnumType.Assume:
+                            return EnumType.Assume;
+
+                        default:
+                            throw new InvalidOperationException();
+                    }
+
+
+                case EnumType.PrivateField:
+                    switch (right)
+                    {
+                        case EnumType.Neutral:
+                            return EnumType.PrivateField;
+
+                        case EnumType.Parameter:
+                            return EnumType.Assume;
+
+                        case EnumType.PrivateField:
+                            return EnumType.PrivateField;
+
+                        case EnumType.PublicField:
+                            return EnumType.PrivateField;
+
+                        case EnumType.Assume:
+                            return EnumType.Assume;
+
+                        default:
+                            throw new InvalidOperationException();
+                    }
+
+                case EnumType.Assume:
+                    return EnumType.Assume;
+
+                default:
+                    throw new InvalidOperationException();
+            }
         }
 
-        // F: HackHack: sometimes the two tests above return null, but condition has an access path. I do not know why
-        if (condition.AccessPath != null && condition.AccessPath.Length > 0 && condition.AccessPath[0].AssumeNotNull().ToString() == "this")
+        /// <summary>
+        /// Constructs  the expression "condition != k"
+        /// </summary>
+        public static BoxedExpression NotK<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          this BoxedExpression condition, object K, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder)
         {
-          return IsReadonlyField(accessPath) ? EnumType.PrivateField : EnumType.Assume;
+            Contract.Requires(condition != null);
+            Contract.Requires(metaDataDecoder != null);
+
+            return BoxedExpression.Binary(BinaryOperator.Cne_Un, condition, BoxedExpression.Const(K, metaDataDecoder.System_Object, metaDataDecoder));
         }
 
-        return EnumType.Neutral;
-      }
-
-      if (condition.IsConstant || condition.IsNull || condition.IsSizeOf)
-      {
-        return EnumType.Neutral;
-      }
-      if (condition.IsUnary)
-      {
-        return condition.UnaryArgument.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-      }
-      if (condition.IsBinary)
-      {
-        var left = condition.BinaryLeft.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-        var right = condition.BinaryRight.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-
-        return Join(left, right);
-      }
-
-      BoxedExpression arrayExp, indexExp;
-      object t;
-      if (condition.IsArrayIndexExpression(out arrayExp, out indexExp, out t) && t is Type)
-      {
-        var left = arrayExp.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-        var right = indexExp.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-
-        return Join(left, right);
-      }
-
-      bool isForAll;
-      BoxedExpression boundExp, lowerBound, upperBound, body;
-      if (condition.IsQuantifiedExpression(out isForAll, out boundExp, out lowerBound, out upperBound, out body))
-      {
-
-        var newLowerBound = lowerBound.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-        var newUpperBound = upperBound.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-        var newBody = body.GuessExpressionInPreStateKind_Internal(pc, context, IsReadonlyField);
-
-        return Join(newLowerBound, Join(newUpperBound, newBody));
-
-      }
-
-      return EnumType.Parameter;
-
-      #endregion
-    }
-
-    private static EnumType Join(EnumType left, EnumType right)
-    {
-      switch (left)
-      {
-        case EnumType.Neutral:
-          {
-
-            return right;
-          }
-
-        case EnumType.Parameter:
-          switch (right)
-          {
-            case EnumType.Neutral:
-              return EnumType.Parameter;
-
-            case EnumType.Parameter:
-              return EnumType.Parameter;
-
-            case EnumType.PrivateField:
-              return EnumType.Assume;
-
-            case EnumType.PublicField:
-              return EnumType.Parameter;
-
-            case EnumType.Assume:
-              return EnumType.Assume;
-
-            default:
-              throw new InvalidOperationException();
-          }
-
-        case EnumType.PublicField:
-          switch (right)
-          {
-            case EnumType.Neutral:
-              return EnumType.PublicField;
-
-            case EnumType.Parameter:
-              return EnumType.Parameter;
-
-            case EnumType.PublicField:
-              return EnumType.PublicField;
-
-            case EnumType.PrivateField:
-              return EnumType.PrivateField;
-
-            case EnumType.Assume:
-              return EnumType.Assume;
-
-            default:
-              throw new InvalidOperationException();
-          }
-
-
-        case EnumType.PrivateField:
-          switch (right)
-          {
-            case EnumType.Neutral:
-              return EnumType.PrivateField;
-
-            case EnumType.Parameter:
-              return EnumType.Assume;
-
-            case EnumType.PrivateField:
-              return EnumType.PrivateField;
-
-            case EnumType.PublicField:
-              return EnumType.PrivateField;
-
-            case EnumType.Assume:
-              return EnumType.Assume;
-
-            default:
-              throw new InvalidOperationException();
-
-          }
-
-        case EnumType.Assume:
-          return EnumType.Assume;
-
-        default:
-          throw new InvalidOperationException();
-      }
-    }
-
-    /// <summary>
-    /// Constructs  the expression "condition != k"
-    /// </summary>
-    public static BoxedExpression NotK<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      this BoxedExpression condition, object K, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder)
-    {
-      Contract.Requires(condition != null);
-      Contract.Requires(metaDataDecoder != null);
-
-      return BoxedExpression.Binary(BinaryOperator.Cne_Un, condition, BoxedExpression.Const(K, metaDataDecoder.System_Object, metaDataDecoder));
-    }
-
-    /// <summary>
-    /// Constructs  the expression "condition == k"
-    /// </summary>
-    public static BoxedExpression EqualK<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-       this BoxedExpression condition, object K, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder)
-    {
-      Contract.Requires(condition != null);
-      Contract.Requires(metaDataDecoder != null);
-
-      return BoxedExpression.Binary(BinaryOperator.Ceq, condition, BoxedExpression.Const(K, metaDataDecoder.System_Object, metaDataDecoder));
-    }
-
-    /// <summary>
-    /// Constructs "original + exps[0] + ... + exps[n]
-    /// </summary>
-    public static BoxedExpression Add(this BoxedExpression original, IEnumerable<BoxedExpression> exps)
-    {
-      Contract.Requires(original != null);
-
-      var result = original;
-      if (exps != null)
-      {
-        foreach (var exp in exps)
+        /// <summary>
+        /// Constructs  the expression "condition == k"
+        /// </summary>
+        public static BoxedExpression EqualK<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+           this BoxedExpression condition, object K, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder)
         {
-          result = BoxedExpression.Binary(BinaryOperator.Add, result, exp);
+            Contract.Requires(condition != null);
+            Contract.Requires(metaDataDecoder != null);
+
+            return BoxedExpression.Binary(BinaryOperator.Ceq, condition, BoxedExpression.Const(K, metaDataDecoder.System_Object, metaDataDecoder));
         }
-      }
-      return result;
-    }
 
-    /// <summary>
-    /// Constructs "original - exps[0] - ... - exps[n]
-    /// </summary>
-    public static BoxedExpression Sub(this BoxedExpression original, IEnumerable<BoxedExpression> exps)
-    {
-      Contract.Requires(original != null);
-
-      var result = original;
-      if (exps != null)
-      {
-        foreach (var exp in exps)
+        /// <summary>
+        /// Constructs "original + exps[0] + ... + exps[n]
+        /// </summary>
+        public static BoxedExpression Add(this BoxedExpression original, IEnumerable<BoxedExpression> exps)
         {
-          result = BoxedExpression.Binary(BinaryOperator.Sub, result, exp);
+            Contract.Requires(original != null);
+
+            var result = original;
+            if (exps != null)
+            {
+                foreach (var exp in exps)
+                {
+                    result = BoxedExpression.Binary(BinaryOperator.Add, result, exp);
+                }
+            }
+            return result;
         }
-      }
-      return result;
-    }
 
-    static public Set<BoxedExpression> Constants(this BoxedExpression be)
-    {
-      Contract.Requires(be != null);
-      Contract.Ensures(Contract.Result<Set<BoxedExpression>>() != null);
+        /// <summary>
+        /// Constructs "original - exps[0] - ... - exps[n]
+        /// </summary>
+        public static BoxedExpression Sub(this BoxedExpression original, IEnumerable<BoxedExpression> exps)
+        {
+            Contract.Requires(original != null);
 
-      var visitor = new ConstantsInBoxedExpression();
+            var result = original;
+            if (exps != null)
+            {
+                foreach (var exp in exps)
+                {
+                    result = BoxedExpression.Binary(BinaryOperator.Sub, result, exp);
+                }
+            }
+            return result;
+        }
 
-      be.Dispatch(visitor);
+        static public Set<BoxedExpression> Constants(this BoxedExpression be)
+        {
+            Contract.Requires(be != null);
+            Contract.Ensures(Contract.Result<Set<BoxedExpression>>() != null);
 
-      return visitor.Constants;
-    }
+            var visitor = new ConstantsInBoxedExpression();
 
-    static public bool ContainsReturnValue(this BoxedExpression be)
-    {
-      Contract.Requires(be != null);
+            be.Dispatch(visitor);
 
-      var visitor = new HasReturnValue();
-      be.Dispatch(visitor);
+            return visitor.Constants;
+        }
 
-      return visitor.Found;
-    }
+        static public bool ContainsReturnValue(this BoxedExpression be)
+        {
+            Contract.Requires(be != null);
 
-    static public Set<Variable> Variables<Variable>(this BoxedExpression be)
-    {
-      Contract.Requires(be != null);
-      Contract.Ensures(Contract.Result<Set<Variable>>() != null);
+            var visitor = new HasReturnValue();
+            be.Dispatch(visitor);
 
-      var visitor = new VariablesInBoxedExpression();
+            return visitor.Found;
+        }
 
-      be.Dispatch(visitor);
+        static public Set<Variable> Variables<Variable>(this BoxedExpression be)
+        {
+            Contract.Requires(be != null);
+            Contract.Ensures(Contract.Result<Set<Variable>>() != null);
 
-      return visitor.Variables.ConvertIf(obj => obj is Variable, obj => (Variable)obj) ?? new Set<Variable>();
-    }
+            var visitor = new VariablesInBoxedExpression();
 
-    static public Set<BoxedExpression> Variables(this BoxedExpression be)
-    {
-      Contract.Requires(be != null);
-      Contract.Ensures(Contract.Result<Set<BoxedExpression>>() != null);
+            be.Dispatch(visitor);
 
-      var visitor = new VariablesInBoxedExpression();
+            return visitor.Variables.ConvertIf(obj => obj is Variable, obj => (Variable)obj) ?? new Set<Variable>();
+        }
 
-      be.Dispatch(visitor);
+        static public Set<BoxedExpression> Variables(this BoxedExpression be)
+        {
+            Contract.Requires(be != null);
+            Contract.Ensures(Contract.Result<Set<BoxedExpression>>() != null);
 
-      return visitor.VariablesAsBoxedExpressions ?? new Set<BoxedExpression>();
-    }
+            var visitor = new VariablesInBoxedExpression();
 
-    static public void Variables(this BoxedExpression be, out Set<object> frameworkVariables, out Set<BoxedExpression> beVariables, out bool onlyConstants)
-    {
-      Contract.Requires(be != null);
-      Contract.Ensures(Contract.ValueAtReturn(out frameworkVariables) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out beVariables) != null);
+            be.Dispatch(visitor);
 
-      var visitor = new VariablesInBoxedExpression();
+            return visitor.VariablesAsBoxedExpressions ?? new Set<BoxedExpression>();
+        }
 
-      be.Dispatch(visitor);
+        static public void Variables(this BoxedExpression be, out Set<object> frameworkVariables, out Set<BoxedExpression> beVariables, out bool onlyConstants)
+        {
+            Contract.Requires(be != null);
+            Contract.Ensures(Contract.ValueAtReturn(out frameworkVariables) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out beVariables) != null);
 
-      frameworkVariables = visitor.Variables ??  new Set<object>();
-      beVariables = visitor.VariablesAsBoxedExpressions ?? new Set<BoxedExpression>();
-      onlyConstants = visitor.OnlyConstants;
-    }
+            var visitor = new VariablesInBoxedExpression();
+
+            be.Dispatch(visitor);
+
+            frameworkVariables = visitor.Variables ?? new Set<object>();
+            beVariables = visitor.VariablesAsBoxedExpressions ?? new Set<BoxedExpression>();
+            onlyConstants = visitor.OnlyConstants;
+        }
 
 
-    static public Set<Variable> VariablesInnerNodes<Variable>(this BoxedExpression be)
-    {
-      Contract.Requires(be != null);
-      Contract.Ensures(Contract.Result<Set<Variable>>() != null);
+        static public Set<Variable> VariablesInnerNodes<Variable>(this BoxedExpression be)
+        {
+            Contract.Requires(be != null);
+            Contract.Ensures(Contract.Result<Set<Variable>>() != null);
 
-      var visitor = new FrameworkVariablesInBoxedExpression();
-      be.Dispatch(visitor);
+            var visitor = new FrameworkVariablesInBoxedExpression();
+            be.Dispatch(visitor);
 
-      return visitor.Variables.ConvertIf(obj => obj is Variable, obj => (Variable)obj) ?? new Set<Variable>();
-    }
+            return visitor.Variables.ConvertIf(obj => obj is Variable, obj => (Variable)obj) ?? new Set<Variable>();
+        }
 
-    static public bool CanPrintAsSourceCode(this BoxedExpression be)
-    {
-      if (be == null)
-      {
-        return false;
-      }
+        static public bool CanPrintAsSourceCode(this BoxedExpression be)
+        {
+            if (be == null)
+            {
+                return false;
+            }
 
-      if(be.IsConstant)
-      {
-        return true;
-      }
+            if (be.IsConstant)
+            {
+                return true;
+            }
 
-      Set<BoxedExpression> beVariables;
-      Set<object> frameworkVariables;
-      bool onlyConstants;
+            Set<BoxedExpression> beVariables;
+            Set<object> frameworkVariables;
+            bool onlyConstants;
 
-      be.Variables(out frameworkVariables, out beVariables, out onlyConstants);
+            be.Variables(out frameworkVariables, out beVariables, out onlyConstants);
 
-      return onlyConstants || (frameworkVariables.Count == beVariables.Count && frameworkVariables.Count > 0 && beVariables.All(exp => exp.AccessPath != null));
-    }
+            return onlyConstants || (frameworkVariables.Count == beVariables.Count && frameworkVariables.Count > 0 && beVariables.All(exp => exp.AccessPath != null));
+        }
 
-    public static BoxedExpression EvaluateConstants<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
-    (this BoxedExpression be, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Requires(be != null);
-      Contract.Requires(mdDecoder != null);
+        public static BoxedExpression EvaluateConstants<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
+        (this BoxedExpression be, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(be != null);
+            Contract.Requires(mdDecoder != null);
 
-      var eval = new ConstantEvaluator<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(mdDecoder);
+            var eval = new ConstantEvaluator<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(mdDecoder);
 
-      return eval.Visit(be, new Void());
-    }
+            return eval.Visit(be, new Void());
+        }
 
 #if bad
-    public static BoxedExpression Rename<Variable>(
-      this BoxedExpression original,
-      IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
-    {
-      Contract.Requires(renaming != null);
-
-      if (original == null)
-      {
-        return null;
-      }
-
-      UnaryOperator uop;
-      BinaryOperator bop;
-      BoxedExpression left, right;
-
-      if (original.IsBinaryExpression(out bop, out left, out right))
-      {
-        var exp1 = left.Rename(renaming, refiner);
-
-        if (exp1 == null)
-          return null;
-
-        var exp2 = right.Rename(renaming, refiner);
-
-        if (exp2 == null)
-          return null;
-
-        return BoxedExpression.Binary(bop, exp1, exp2);
-      }
-
-      if (original.IsUnaryExpression(out uop, out left))
-      {
-        var exp1 = Rename(left, renaming, refiner);
-
-        if (exp1 == null)
-          return null;
-
-        return BoxedExpression.Unary(uop, exp1);
-      }
-
-      if (original.IsVariable)
-      {
-        Variable v;
-        if (original.TryGetFrameworkVariable(out v))
+        public static BoxedExpression Rename<Variable>(
+          this BoxedExpression original,
+          IFunctionalMap<Variable, Variable> renaming, Func<Variable, BoxedExpression> refiner = null)
         {
-          if (renaming.Contains(v))
-          {
-            if (refiner != null)
+            Contract.Requires(renaming != null);
+
+            if (original == null)
             {
-              return refiner(renaming[v]);
+                return null;
             }
 
-            return BoxedExpression.Var(renaming[v]);
+            UnaryOperator uop;
+            BinaryOperator bop;
+            BoxedExpression left, right;
+
+            if (original.IsBinaryExpression(out bop, out left, out right))
+            {
+                var exp1 = left.Rename(renaming, refiner);
+
+                if (exp1 == null)
+                    return null;
+
+                var exp2 = right.Rename(renaming, refiner);
+
+                if (exp2 == null)
+                    return null;
+
+                return BoxedExpression.Binary(bop, exp1, exp2);
+            }
+
+            if (original.IsUnaryExpression(out uop, out left))
+            {
+                var exp1 = Rename(left, renaming, refiner);
+
+                if (exp1 == null)
+                    return null;
+
+                return BoxedExpression.Unary(uop, exp1);
+            }
+
+            if (original.IsVariable)
+            {
+                Variable v;
+                if (original.TryGetFrameworkVariable(out v))
+                {
+                    if (renaming.Contains(v))
+                    {
+                        if (refiner != null)
+                        {
+                            return refiner(renaming[v]);
+                        }
+
+                        return BoxedExpression.Var(renaming[v]);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+                else
+                {
+                    return original;
+                }
+            }
+
+            bool isForAll;
+            BoxedExpression boundVar, inf, upp, body;
+            if (original.IsQuantifiedExpression(out isForAll, out boundVar, out inf, out upp, out body))
+            {
+                if (boundVar == null)
+                    return null;
+
+                var infRenamed = inf.Rename(renaming);
+                if (infRenamed != null)
+                {
+                    var uppRenamed = upp.Rename(renaming);
+                    if (uppRenamed != null)
+                    {
+                        var bodyRenamed = body.Rename(renaming);
+                        if (bodyRenamed != null)
+                        {
+                            if (isForAll)
+                            {
+                                return new ForAllIndexedExpression(null, boundVar, infRenamed, uppRenamed, bodyRenamed);
+                            }
+                            else
+                            {
+                                return new ExistsIndexedExpression(null, boundVar, infRenamed, uppRenamed, bodyRenamed);
+                            }
+                        }
+                    }
+                }
+
+                return null;
+            }
+            if (original.IsArrayIndex)
+            {
+                var arrayIndexExp = (original as BoxedExpression.ArrayIndexExpression);
+                Contract.Assume(arrayIndexExp != null);
+                return arrayIndexExp.Rename<Variable>(renaming, refiner);
+            }
+
+            return original;
+        }
+#endif
+
+
+        public static BoxedExpression Simplify<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
+        (this BoxedExpression be, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          Func<BoxedExpression, bool> IsArrayLength = null,
+          Func<BoxedExpression, BoxedExpression> ExtraSimplification = null,
+          bool replaceIntConstantsByBooleans = true)
+        {
+            Contract.Requires(mdDecoder != null);
+
+            // propagate null
+            if (be == null)
+            {
+                return null;
+            }
+
+            bool result;
+            if (replaceIntConstantsByBooleans && be.IsTrivialCondition(out result))
+            {
+                return result
+                  ? BoxedExpression.ConstBool(true, mdDecoder)
+                  : BoxedExpression.ConstBool(false, mdDecoder);
+            }
+
+            var simplified = be.SimplifyInternal(mdDecoder, IsArrayLength);
+
+            return ExtraSimplification != null ? ExtraSimplification(simplified) : simplified;
+        }
+
+        private static BoxedExpression SimplifyInternal<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          this BoxedExpression be,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          Func<BoxedExpression, bool> IsArrayLength)
+        {
+            Contract.Requires(be != null);
+            Contract.Requires(mdDecoder != null);
+
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            BinaryOperator bop, negatedBop;
+            BoxedExpression left, right;
+
+            if (be.IsUnary)
+            {
+                var uop = be.UnaryOp;
+                var uarg = be.UnaryArgument;
+
+                var rec = uarg.SimplifyInternal(mdDecoder, IsArrayLength);
+
+                if (IsArrayLength != null && IsArrayLength(rec))
+                {
+                    return rec;
+                }
+
+                // !(a == b) --> (a != n) and similar cases...
+                // !(a %b) --> (a %b) == 0
+                if (uop == UnaryOperator.Not && rec.IsBinaryExpression(out bop, out left, out right))
+                {
+                    if (bop.TryNegate(out negatedBop))
+                    {
+                        return BoxedExpression.Binary(negatedBop, left, right);
+                    }
+                    else if (bop.IsArithmeticBinaryOperator() || bop.IsBitwiseBinaryOperator())
+                    /*          {
+                                return BoxedExpression.Binary(BinaryOperator.Cne_Un, rec, BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder));
+                              }
+                              else if (bop.IsBitwiseBinaryOperator())
+
+                     */
+                    {
+                        return BoxedExpression.Binary(BinaryOperator.Ceq, rec, BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder));
+                    }
+                }
+
+                return uarg.Equals(rec) ? be : BoxedExpression.Unary(uop, rec);
+            }
+
+            if (be.IsBinaryExpression(out bop, out left, out right))
+            {
+                var recLeft = left.SimplifyInternal(mdDecoder, IsArrayLength);
+                /*
+                if (recLeft == null)
+                {
+                  return be;
+                }
+                */
+                var recRight = right.SimplifyInternal(mdDecoder, IsArrayLength);
+                /*
+                if (recRight == null)
+                {
+                  return be;
+                }
+                */
+                // Handle cases as (x + 1) + 1 or (x -1) -1
+                ApplySimpleConstantPropagation(bop, ref recLeft, ref recRight, mdDecoder);
+
+                if (ApplyIdentities(mdDecoder, bop, ref recLeft, ref recRight))
+                {
+                    #region Cases
+                    if (recRight == null)
+                    {
+                        if (recLeft != null)
+                        {
+                            return recLeft;
+                        }
+                        // else we simplified both branches, and we give up by returning the original expression
+                        else
+                        {
+                            return be;
+                        }
+                    }
+                    else if (recLeft == null)
+                    {
+                        return recRight;
+                    }
+
+                    Contract.Assert(recLeft != null);
+                    Contract.Assert(recRight != null);
+                    #endregion
+                }
+                else
+                {
+                    // Apply identities may modify one of the two to null
+                    // We make sure this will not be the case
+                    // This bug was found by Clousot
+                    if (recLeft == null || recRight == null)
+                    {
+                        return be;
+                    }
+
+                    int k1, k2;
+                    if (recLeft.IsConstantInt(out k1) && recRight.IsConstantInt(out k2))
+                    {
+                        #region All the cases
+                        bool? truthValue = null;
+
+                        // we do not do the *_un version because we should make the difference between unsigned and floats
+                        switch (bop)
+                        {
+                            case BinaryOperator.Ceq:
+                                truthValue = k1 == k2;
+                                break;
+
+                            case BinaryOperator.Cge:
+                                truthValue = k1 >= k2;
+                                break;
+
+                            case BinaryOperator.Cgt:
+                                truthValue = k1 > k2;
+                                break;
+
+                            case BinaryOperator.Cle:
+                                truthValue = k1 <= k2;
+                                break;
+
+                            case BinaryOperator.Clt:
+                                truthValue = k1 < k2;
+                                break;
+
+                            case BinaryOperator.Cne_Un:
+                                truthValue = k1 != k2;
+                                break;
+                        }
+
+                        if (truthValue.HasValue)
+                        {
+                            return BoxedExpression.ConstBool(truthValue.Value, mdDecoder);
+                        }
+                        #endregion
+                    }
+
+                    if (bop == BinaryOperator.Ceq || bop == BinaryOperator.Cne_Un)
+                    {
+                        #region The cases
+                        // recLeft {==, !=} recRight ==> {"true", "false"} 
+                        if (recLeft.Equals(recRight))
+                        {
+                            return BoxedExpression.ConstBool(bop == BinaryOperator.Ceq ? true : false, mdDecoder);
+                        }
+
+                        // Pattern matches (recLeftLeft { relOp } recRightRight) == {false, true}
+                        BinaryOperator internalBop;
+                        BoxedExpression recLeftLeft, recRightRight;
+                        int k;
+                        if (recLeft.IsBinaryExpression(out internalBop, out recLeftLeft, out recRightRight)
+                          && internalBop.IsComparisonBinaryOperator()
+                          // && recRight != null 
+                          && recRight.IsConstantIntOrNull(out k))
+                        {
+                            if ((bop == BinaryOperator.Ceq && k != 0) || (bop == BinaryOperator.Cne_Un && k == 0))// true
+                            {
+                                return recLeft;
+                            }
+                            else  // false
+                            {
+                                BinaryOperator negatedOp;
+                                if (internalBop.TryNegate(out negatedOp))
+                                {
+                                    return BoxedExpression.Binary(negatedOp, recLeftLeft, recRightRight);
+                                }
+                            }
+                        }
+                        #endregion
+                    }
+
+                    // a / k < a ==> a != 0
+                    if (bop == BinaryOperator.Clt || bop == BinaryOperator.Cne_Un)
+                    {
+                        if (recLeft.IsBinary && recLeft.BinaryOp == BinaryOperator.Div && recLeft.BinaryRight.IsConstant && recLeft.BinaryLeft.Equals(recRight))
+                        {
+                            return BoxedExpression.Binary(BinaryOperator.Cne_Un, recLeft.BinaryLeft, BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder));
+                        }
+                    }
+
+#if false
+                    if (bop.IsComparisonBinaryOperator())
+                    {
+                        var tmpLeft = recLeft;
+                        var tmpRight = recRight;
+                        if (ApplySimplifications(mdDecoder, ref recLeft, ref recRight))
+                        {
+                            //             recLeft = tmpLeft;
+                            //              recRight = tmpRight;
+                        }
+                    }
+#endif
+                }
+
+                Contract.Assert(recLeft != null); // Let us make sure when we reach this point the two are not null
+                Contract.Assert(recRight != null);
+
+                return left.Equals(recLeft) && right.Equals(recRight) ? be : BoxedExpression.Binary(bop, recLeft, recRight);
+            }
+
+            return be;
+        }
+
+        private static bool ApplySimpleConstantPropagation<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(BinaryOperator bop, ref BoxedExpression recLeft, ref BoxedExpression recRight, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(recLeft != null);
+            Contract.Ensures(recLeft != null);
+            Contract.Ensures(recRight != null);
+
+            int kRight;
+            if ((bop == BinaryOperator.Add || bop == BinaryOperator.Add_Ovf || bop == BinaryOperator.Sub || bop == BinaryOperator.Sub_Ovf)
+              && recRight.IsConstantInt(out kRight))
+            {
+                BinaryOperator leftOp;
+                BoxedExpression leftleft;
+                int kLeft;
+
+                // examples: (x + 1) + 1 or (x - 1) - 1 or (x + 1) - 1 or (x - 1) + 1
+                if (recLeft.IsBinaryExpressionExpOpConst(out leftOp, out leftleft, out kLeft)
+                  && (leftOp == BinaryOperator.Add || leftOp == BinaryOperator.Sub))
+                {
+                    if (kLeft == Int32.MinValue)
+                    {
+                        return false;
+                    }
+
+                    switch (bop)
+                    {
+                        case BinaryOperator.Add:
+                        case BinaryOperator.Add_Ovf:
+                        case BinaryOperator.Sub:
+                        case BinaryOperator.Sub_Ovf:
+                            {
+                                if (leftOp == BinaryOperator.Sub)
+                                {
+                                    kLeft = -kLeft;
+                                }
+
+                                Contract.Assert(leftleft != null);
+                                recLeft = leftleft;
+                                recRight = BoxedExpression.Const(
+                                  bop == BinaryOperator.Add ? kRight + kLeft : kRight - kLeft,
+                                  mdDecoder.System_Int32, mdDecoder);
+                            }
+                            return true;
+
+
+                        default:
+                            {
+                            }
+                            break;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// If a parameter is null, then it means we applied some cancellation rule
+        /// </summary>
+        private static bool ApplyIdentities<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          BinaryOperator bop, ref BoxedExpression recLeft, ref BoxedExpression recRight)
+        {
+            Contract.Requires(recLeft != null);
+            Contract.Requires(recRight != null);
+
+            int value;
+
+            // We simplify identities
+            switch (bop)
+            {
+                // a +0 == 0 + a == a
+                case BinaryOperator.Add:
+                case BinaryOperator.Add_Ovf:
+                case BinaryOperator.Add_Ovf_Un:
+                    {
+                        recLeft = recLeft.IsConstantIntOrNull(out value) && value == 0 ? null : recLeft;
+                        recRight = recRight.IsConstantIntOrNull(out value) && value == 0 ? null : recRight;
+
+                        return true;
+                    }
+
+                // a - 0 == a
+                case BinaryOperator.Sub:
+                case BinaryOperator.Sub_Ovf:
+                case BinaryOperator.Sub_Ovf_Un:
+                    {
+                        recRight = recRight.IsConstantIntOrNull(out value) && value == 0 ? null : recRight;
+
+                        return true;
+                    }
+
+                // a / 1 == a
+                case BinaryOperator.Div:
+                case BinaryOperator.Div_Un:
+                    {
+                        recRight = recRight.IsConstantIntOrNull(out value) && value == 1 ? null : recRight;
+
+                        return true;
+                    }
+
+                // a * 1 = a
+                case BinaryOperator.Mul:
+                case BinaryOperator.Mul_Ovf:
+                case BinaryOperator.Mul_Ovf_Un:
+                    {
+                        recRight = recRight.IsConstantIntOrNull(out value) && value == 1 ? null : recRight;
+
+                        return true;
+                    }
+
+                case BinaryOperator.Ceq:
+                case BinaryOperator.Cne_Un:
+                    {
+                        object type;
+                        long k;
+                        bool b1 = false, b2 = false;
+                        if ((recLeft.TryGetType(out type) && recRight.IsConstantInt64(out k) && (b1 = true)) ||
+                          (recRight.TryGetType(out type) && recLeft.IsConstantInt64(out k) && (b2 = true)))
+                        {
+                            if (mdDecoder.System_UInt16.Equals(type))
+                            {
+                                if (b1)
+                                {
+                                    recRight = BoxedExpression.Const((UInt16)k, mdDecoder.System_UInt16, mdDecoder);
+                                }
+                                else
+                                {
+                                    Contract.Assert(b2);
+                                    recLeft = BoxedExpression.Const((UInt16)k, mdDecoder.System_UInt16, mdDecoder);
+                                }
+
+                                return true;
+                            }
+
+                            if (mdDecoder.System_UInt32.Equals(type))
+                            {
+                                if (b1)
+                                {
+                                    recRight = BoxedExpression.Const((UInt32)k, mdDecoder.System_UInt32, mdDecoder);
+                                }
+                                else
+                                {
+                                    Contract.Assert(b2);
+                                    recLeft = BoxedExpression.Const((UInt32)k, mdDecoder.System_UInt32, mdDecoder);
+                                }
+
+                                return true;
+                            }
+                        }
+                    }
+                    break;
+
+                case BinaryOperator.LogicalOr:
+                    {
+                        // false || e == e
+                        bool b;
+                        recLeft = recLeft.IsConstantBool(out b) && !b ? null : recLeft;
+                        recRight = recRight.IsConstantBool(out b) && !b ? null : recRight;
+
+                        return recLeft == null || recRight == null;
+                    }
+
+                case BinaryOperator.LogicalAnd:
+                    {
+                        // true && e == e
+                        bool b;
+                        recLeft = recLeft.IsConstantBool(out b) && b ? null : recLeft;
+                        recRight = recRight.IsConstantBool(out b) && b ? null : recRight;
+
+                        return recLeft == null || recRight == null;
+                    }
+            }
+
+            return false;
+        }
+
+        private static bool ApplySimplifications<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          ref BoxedExpression left, ref BoxedExpression right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            if (ApplySimplificationsInternal(mdDecoder, ref left, ref right))
+            {
+                return true;
+            }
+            if (ApplySimplificationsInternal(mdDecoder, ref right, ref left))
+            {
+                // We swapped the operands to simplify them. We should correct it
+                var tmp = left;
+                left = right;
+                right = tmp;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool ApplySimplificationsInternal<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          ref BoxedExpression left, ref BoxedExpression right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            Contract.Ensures(left != null);
+            Contract.Ensures(right != null);
+
+            BinaryOperator bop;
+            BoxedExpression l;
+            int k;
+            if (left.IsBinaryExpressionExpOpConst(out bop, out l, out k, false))
+            {
+                switch (bop)
+                {
+                    case BinaryOperator.Mul:
+                        {
+                            if (/*l != null && */l.Equals(right))
+                            {
+                                right = BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder);
+                                if (k == 1)
+                                {
+                                    left = right; // i.e., zero
+                                }
+                                else if (k == 2)
+                                {
+                                    left = l;
+                                }
+                                else
+                                {
+                                    left = BoxedExpression.Binary(BinaryOperator.Mul, BoxedExpression.Const(k - 1, mdDecoder.System_Int32, mdDecoder), l);
+                                }
+
+                                return true;
+                            }
+                            break;
+                        }
+
+                    default:
+                        {
+                            break;
+                        }
+                }
+            }
+
+            return false;
+        }
+
+        private class FrameworkVariablesInBoxedExpression : IBoxedExpressionVisitor
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(variablesMaybeWithRepetitions != null);
+            }
+
+            readonly private List<object> variablesMaybeWithRepetitions;
+
+            private Set<object> variables;
+
+            public Set<object> Variables
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<object>() != null);
+
+                    if (variables == null)
+                    {
+                        variables = new Set<object>();
+                        variables.AddRange(variablesMaybeWithRepetitions);
+                    }
+
+                    return variables;
+                }
+            }
+
+            public FrameworkVariablesInBoxedExpression()
+            {
+                variablesMaybeWithRepetitions = new List<object>();
+                variables = null;
+            }
+
+            #region IBoxedExpressionVisitor Members
+
+            public void Variable(object var, PathElement[] path, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(var);
+            }
+
+            public void Constant<Type>(Type type, object value, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+            }
+
+            public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                left.Dispatch(this);
+                right.Dispatch(this);
+            }
+
+            public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                argument.Dispatch(this);
+            }
+
+            public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+            }
+
+            public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                argument.Dispatch(this);
+            }
+
+            public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                array.Dispatch(this);
+                index.Dispatch(this);
+            }
+
+            public void Result<Type>(Type type, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+            }
+
+            public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                expression.Dispatch(this);
+            }
+
+            public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                expression.Dispatch(this);
+            }
+
+            public void Assert(BoxedExpression condition, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                condition.Dispatch(this);
+            }
+
+            public void Assume(BoxedExpression condition, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                condition.Dispatch(this);
+            }
+
+            public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                foreach (var statement in statements.Enumerate())
+                {
+                    statement.Dispatch(this);
+                }
+            }
+
+            public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
+            {
+                variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
+
+                boundVariable.Dispatch(this);
+                lower.Dispatch(this);
+                upper.Dispatch(this);
+                body.Dispatch(this);
+            }
+
+            #endregion
+        }
+
+        private class VariablesInBoxedExpression : IBoxedExpressionVisitor
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.Variables != null);
+            }
+
+            readonly public Set<object> Variables;
+            readonly public Set<BoxedExpression> VariablesAsBoxedExpressions;
+            public bool OnlyConstants { get; private set; }
+
+            public VariablesInBoxedExpression()
+            {
+                this.Variables = new Set<object>();
+                this.VariablesAsBoxedExpressions = new Set<BoxedExpression>();
+                this.OnlyConstants = true;
+            }
+
+            #region IBoxedExpressionVisitor Members
+
+            public void Variable(object var, PathElement[] path, BoxedExpression parent)
+            {
+                this.OnlyConstants = false;
+                Variables.Add(var);
+                if (path != null)
+                {
+                    VariablesAsBoxedExpressions.Add(BoxedExpression.Var(var, path));
+                }
+            }
+
+            public void Constant<Type>(Type type, object value, BoxedExpression parent)
+            {
+            }
+
+            public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
+            {
+                left.Dispatch(this);
+                right.Dispatch(this);
+            }
+
+            public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
+            {
+                argument.Dispatch(this);
+            }
+
+            public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression parent)
+            {
+            }
+
+            public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression parent)
+            {
+                argument.Dispatch(this);
+            }
+
+            public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
+            {
+                this.OnlyConstants = false;
+
+                array.Dispatch(this);
+                index.Dispatch(this);
+            }
+
+            public void Result<Type>(Type type, BoxedExpression parent)
+            {
+                this.OnlyConstants = false;
+            }
+
+            public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
+            {
+                this.OnlyConstants = false;
+                expression.Dispatch(this);
+            }
+
+            public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
+            {
+                this.OnlyConstants = false;
+                expression.Dispatch(this);
+            }
+
+            public void Assert(BoxedExpression condition, BoxedExpression parent)
+            {
+                this.OnlyConstants = false;
+                condition.Dispatch(this);
+            }
+
+            public void Assume(BoxedExpression condition, BoxedExpression parent)
+            {
+                condition.Dispatch(this);
+            }
+
+            public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
+            {
+                foreach (var statement in statements.Enumerate())
+                {
+                    statement.Dispatch(this);
+                }
+            }
+
+            public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
+            {
+                this.OnlyConstants = false;
+
+                boundVariable.Dispatch(this);
+                lower.Dispatch(this);
+                upper.Dispatch(this);
+                body.Dispatch(this);
+            }
+
+            #endregion
+        }
+
+        // 
+
+        private class ConstantsInBoxedExpression : IBoxedExpressionVisitor
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.Constants != null);
+            }
+
+            readonly public Set<BoxedExpression> Constants;
+
+            public ConstantsInBoxedExpression()
+            {
+                this.Constants = new Set<BoxedExpression>();
+            }
+
+            #region IBoxedExpressionVisitor Members
+
+            public void Variable(object var, PathElement[] path, BoxedExpression parent)
+            {
+            }
+
+            public void Constant<Type>(Type type, object value, BoxedExpression parent)
+            {
+                this.Constants.Add(parent);
+            }
+
+            public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
+            {
+                left.Dispatch(this);
+                right.Dispatch(this);
+            }
+
+            public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
+            {
+                argument.Dispatch(this);
+            }
+
+            public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression parent)
+            {
+            }
+
+            public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression parent)
+            {
+                argument.Dispatch(this);
+            }
+
+            public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
+            {
+                array.Dispatch(this);
+                index.Dispatch(this);
+            }
+
+            public void Result<Type>(Type type, BoxedExpression parent)
+            {
+            }
+
+            public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
+            {
+                expression.Dispatch(this);
+            }
+
+            public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
+            {
+                expression.Dispatch(this);
+            }
+
+            public void Assert(BoxedExpression condition, BoxedExpression parent)
+            {
+                condition.Dispatch(this);
+            }
+
+            public void Assume(BoxedExpression condition, BoxedExpression parent)
+            {
+                condition.Dispatch(this);
+            }
+
+            public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
+            {
+                foreach (var statement in statements.Enumerate())
+                {
+                    statement.Dispatch(this);
+                }
+            }
+
+            public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
+            {
+                boundVariable.Dispatch(this);
+                lower.Dispatch(this);
+                upper.Dispatch(this);
+                body.Dispatch(this);
+            }
+
+            #endregion
+        }
+
+
+        private class HasReturnValue : IBoxedExpressionVisitor
+        {
+            public bool Found { get; private set; }
+            public HasReturnValue()
+            {
+                this.Found = false;
+            }
+
+            public void Variable(object var, PathElement[] path, BoxedExpression original)
+            {
+            }
+
+            public void Constant<Type>(Type type, object value, BoxedExpression original)
+            {
+            }
+
+            public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression original)
+            {
+                left.Dispatch(this);
+                right.Dispatch(this);
+            }
+
+            public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression original)
+            {
+                argument.Dispatch(this);
+            }
+
+            public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression original)
+            {
+            }
+
+            public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression original)
+            {
+                argument.Dispatch(this);
+            }
+
+            public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression original)
+            {
+                array.Dispatch(this);
+                index.Dispatch(this);
+            }
+
+            public void Result<Type>(Type type, BoxedExpression original)
+            {
+                this.Found = true;
+            }
+
+            public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression original)
+            {
+                expression.Dispatch(this);
+            }
+
+            public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression original)
+            {
+                expression.Dispatch(this);
+            }
+
+            public void Assert(BoxedExpression condition, BoxedExpression original)
+            {
+            }
+
+            public void Assume(BoxedExpression condition, BoxedExpression original)
+            {
+            }
+
+            public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression original)
+            {
+                for (var i = 0; i < statements.Count; i++)
+                {
+                    statements[i].AssumeNotNull().Dispatch(this);
+                }
+            }
+
+            public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression original)
+            {
+                boundVariable.Dispatch(this);
+                lower.Dispatch(this);
+                upper.Dispatch(this);
+                body.Dispatch(this);
+            }
+        }
+    }
+
+    [ContractVerification(true)]
+    public static class ListOfBoxedExpressionsExtensions
+    {
+        public static BoxedExpression ToDisjunction(this List<BoxedExpression> disjuncts)
+        {
+            if (disjuncts == null || disjuncts.Count == 0)
+            {
+                return null;
+            }
+
+            var result = disjuncts[0];
+            Contract.Assume(result != null);
+
+            for (var i = 1; i < disjuncts.Count; i++)
+            {
+                var disjunct = disjuncts[i];
+                if (disjunct != null)
+                {
+                    result = BoxedExpression.Binary(BinaryOperator.LogicalOr, result, disjunct);
+                }
+            }
+
+            return result;
+        }
+    }
+
+    public static class IDecodeMetaDataExtensions
+    {
+        public static bool IsReadOnly<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          FList<PathElement> accessPath)
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(mdDecoder != null);
+
+            var accessPathArray = accessPath.ToArray();
+
+            Contract.Assume(Contract.ForAll(accessPathArray, p => p != null));
+
+            if (accessPathArray.Length < 2)
+            {
+                return false;
+            }
+
+            Field f;
+
+            if (accessPathArray.Length == 2)
+            {
+                return accessPathArray[1].TryField(out f) && mdDecoder.IsReadonly(f);
+            }
+
+            Contract.Assert(accessPathArray.Length > 2, "trivial, but make it sure");
+
+            // F: HACK - We need to pass the value context to check if the field is an array!
+            return
+              accessPathArray[accessPathArray.Length - 1].IsDeref && accessPathArray[accessPathArray.Length - 2].TryField(out f) && mdDecoder.IsReadonly(f) ||
+              accessPathArray[accessPathArray.Length - 3].TryField(out f) && mdDecoder.IsReadonly(f) && accessPathArray[accessPathArray.Length - 1].ToString() == "Length";
+        }
+    }
+
+    [ContractVerification(true)]
+    public static class PathElementExtensions
+    {
+        public static bool ContainsStaticFieldAccess<Field>(this PathElement[] pathElement)
+        {
+            Contract.Requires(pathElement != null);
+
+            for (var i = 0; i < pathElement.Length; i++)
+            {
+                var element = pathElement[i];
+                Contract.Assume(element != null);
+
+                Field f;
+                if (element.IsStatic && element.TryField(out f))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        public static bool IsNaNCall(this PathElement[] path, out bool isFloat64)
+        {
+            isFloat64 = false;
+
+            if (path == null || path.Length != 2)
+            {
+                return false;
+            }
+
+            var candidate = path[1];
+
+            if (candidate == null)
+            {
+                return false;
+            }
+
+            if (candidate.IsMethodCall && candidate.IsStatic)
+            {
+                var str = candidate.ToString();
+                if (str.EndsWith("IsNaN"))
+                {
+                    var strLowerCase = str.Split('.')[0].ToLower();
+                    switch (strLowerCase)
+                    {
+                        case "float":
+                        case "float32":
+                        case "system.float32":
+                        case "system.float":
+                            {
+                                isFloat64 = false;
+                                return true;
+                            }
+
+                        case "double":
+                        case "float64":
+                        case "system.float64":
+                        case "system.double":
+                            {
+                                isFloat64 = true;
+                                return true;
+                            }
+                        default:
+                            {
+                                break;
+                            }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool IsInfinityCall(this PathElement[] path, out bool isFloat64, out bool isPlusInfinty, out bool isMinusInfinity)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out isPlusInfinty) || Contract.ValueAtReturn(out isMinusInfinity));
+
+            isFloat64 = isPlusInfinty = isMinusInfinity = false;
+            if (path != null && path.Length == 2)
+            {
+                var candidate = path[1];
+
+                if (candidate == null)
+                {
+                    return false;
+                }
+
+                if (candidate.IsStatic && candidate.IsMethodCall)
+                {
+                    var str = candidate.ToString();
+                    if (str.EndsWith("Infinity"))
+                    {
+                        var split = str.ToLower().Split('.');
+                        if (split.Length == 2)
+                        {
+                            switch (split[0])
+                            {
+                                case "float":
+                                case "float32":
+                                case "system.float32":
+                                case "system.float":
+                                    {
+                                        isFloat64 = false;
+                                        break;
+                                    }
+
+                                case "double":
+                                case "float64":
+                                case "system.float64":
+                                case "system.double":
+                                    {
+                                        isFloat64 = true;
+                                        break;
+                                    }
+
+                                default:
+                                    {
+                                        return false;
+                                    }
+                            }
+
+                            switch (split[1])
+                            {
+                                case "isinfinity":
+                                    {
+                                        isPlusInfinty = true;
+                                        isMinusInfinity = true;
+                                        break;
+                                    }
+
+                                case "isminusinfinity":
+                                    {
+                                        isPlusInfinty = false;
+                                        isMinusInfinity = true;
+                                        break;
+                                    }
+
+                                case "isplusinfinity":
+                                    {
+                                        isPlusInfinty = true;
+                                        isMinusInfinity = false;
+                                        break;
+                                    }
+
+                                default:
+                                    {
+                                        return false;
+                                    }
+                            }
+
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public static class APCExtensions
+    {
+        public static APC GetFirstSuccessorWithSourceContext(this APC pc, ICFG cfg)
+        {
+            Contract.Requires(cfg != null);
+
+            if (pc.HasRealSourceContext)
+            {
+                return pc;
+            }
+
+            var oldPC = pc;
+
+            for (var i = 0; i < 10; i++)
+            {
+                pc = cfg.Post(pc);
+                if (pc.HasRealSourceContext)
+                {
+                    return pc;
+                }
+            }
+
+            return pc; // We failed. This shoulnd never happen
+        }
+
+        /*
+        // this recursive implementation caused stack overflow in mscorlib analysis
+        public static APC GetFirstPredecessorWithSourceContext(this APC pc, ICFG cfg)
+        {
+          Contract.Requires(cfg != null);
+
+          if (pc.HasRealSourceContext || cfg.Predecessors(pc).Count() == 0)
+          {
+            return pc;
+          }
+
+          var pre = cfg.Predecessors(pc).First();
+
+          if (pre.HasRealSourceContext)
+          {
+            return pre;
           }
           else
           {
-            return null;
+            return pre.GetFirstPredecessorWithSourceContext(cfg);
           }
         }
-        else
-        {
-          return original;
-        }
-      }
+         */
 
-      bool isForAll;
-      BoxedExpression boundVar, inf, upp, body;
-      if (original.IsQuantifiedExpression(out isForAll, out boundVar, out inf, out upp, out body))
-      {
-        if (boundVar == null)
-          return null;
-
-        var infRenamed = inf.Rename(renaming);
-        if (infRenamed != null)
+        public static APC GetFirstPredecessorWithSourceContext(this APC pc, ICFG cfg)
         {
-          var uppRenamed = upp.Rename(renaming);
-          if (uppRenamed != null)
-          {
-            var bodyRenamed = body.Rename(renaming);
-            if (bodyRenamed != null)
+            Contract.Requires(cfg != null);
+
+            var currPC = pc;
+
+            while (!currPC.HasRealSourceContext && cfg.Predecessors(currPC).Any())
             {
-              if (isForAll)
-              {
-                return new ForAllIndexedExpression(null, boundVar, infRenamed, uppRenamed, bodyRenamed);
-              }
-              else
-              {
-                return new ExistsIndexedExpression(null, boundVar, infRenamed, uppRenamed, bodyRenamed);
-              }
-            }
-          }
-        }
-
-        return null;
-      }
-      if (original.IsArrayIndex)
-      {
-        var arrayIndexExp = (original as BoxedExpression.ArrayIndexExpression);
-        Contract.Assume(arrayIndexExp != null);
-        return arrayIndexExp.Rename<Variable>(renaming, refiner);
-      }
-
-      return original;
-    }
-#endif
-
-
-    public static BoxedExpression Simplify<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
-    (this BoxedExpression be, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      Func<BoxedExpression, bool> IsArrayLength = null,
-      Func<BoxedExpression, BoxedExpression> ExtraSimplification = null,
-      bool replaceIntConstantsByBooleans = true)
-    {
-      Contract.Requires(mdDecoder != null);
-
-      // propagate null
-      if (be == null)
-      {
-        return null;
-      }
-
-      bool result;
-      if (replaceIntConstantsByBooleans && be.IsTrivialCondition(out result))
-      {
-        return result
-          ? BoxedExpression.ConstBool(true, mdDecoder)
-          : BoxedExpression.ConstBool(false, mdDecoder);
-      }
-
-      var simplified = be.SimplifyInternal(mdDecoder, IsArrayLength);
-
-      return ExtraSimplification != null ? ExtraSimplification(simplified) : simplified;
-    }
-
-    private static BoxedExpression SimplifyInternal<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      this BoxedExpression be,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      Func<BoxedExpression, bool> IsArrayLength)
-    {
-      Contract.Requires(be != null);
-      Contract.Requires(mdDecoder != null);
-
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      BinaryOperator bop, negatedBop;
-      BoxedExpression left, right;
-
-      if (be.IsUnary)
-      {
-        var uop = be.UnaryOp;
-        var uarg = be.UnaryArgument;
-
-        var rec = uarg.SimplifyInternal(mdDecoder, IsArrayLength);
-
-        if (IsArrayLength != null && IsArrayLength(rec))
-        {
-          return rec;
-        }
-
-        // !(a == b) --> (a != n) and similar cases...
-        // !(a %b) --> (a %b) == 0
-        if (uop == UnaryOperator.Not && rec.IsBinaryExpression(out bop, out left, out right))
-        {
-          if (bop.TryNegate(out negatedBop))
-          {
-            return BoxedExpression.Binary(negatedBop, left, right);
-          }
-          else if (bop.IsArithmeticBinaryOperator() || bop.IsBitwiseBinaryOperator())
-          /*          {
-                      return BoxedExpression.Binary(BinaryOperator.Cne_Un, rec, BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder));
-                    }
-                    else if (bop.IsBitwiseBinaryOperator())
-
-           */
-          {
-            return BoxedExpression.Binary(BinaryOperator.Ceq, rec, BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder));
-          }
-        }
-
-        return uarg.Equals(rec) ? be : BoxedExpression.Unary(uop, rec);
-      }
-
-      if (be.IsBinaryExpression(out bop, out left, out right))
-      {
-        var recLeft = left.SimplifyInternal(mdDecoder, IsArrayLength);
-        /*
-        if (recLeft == null)
-        {
-          return be;
-        }
-        */
-        var recRight = right.SimplifyInternal(mdDecoder, IsArrayLength);
-        /*
-        if (recRight == null)
-        {
-          return be;
-        }
-        */
-        // Handle cases as (x + 1) + 1 or (x -1) -1
-        ApplySimpleConstantPropagation(bop, ref recLeft, ref recRight, mdDecoder);
-
-        if (ApplyIdentities(mdDecoder, bop, ref recLeft, ref recRight))
-        {
-          #region Cases
-          if (recRight == null)
-          {
-            if (recLeft != null)
-            {
-              return recLeft;
-            }
-            // else we simplified both branches, and we give up by returning the original expression
-            else
-            {
-              return be;
-            }
-          }
-          else if (recLeft == null)
-          {
-            return recRight;
-          }
-
-          Contract.Assert(recLeft != null);
-          Contract.Assert(recRight != null);
-          #endregion
-        }
-        else
-        {
-          // Apply identities may modify one of the two to null
-          // We make sure this will not be the case
-          // This bug was found by Clousot
-          if (recLeft == null || recRight == null)
-          {
-            return be;
-          }
-
-          int k1, k2;
-          if (recLeft.IsConstantInt(out k1) && recRight.IsConstantInt(out k2))
-          {
-            #region All the cases
-            bool? truthValue = null;
-
-            // we do not do the *_un version because we should make the difference between unsigned and floats
-            switch (bop)
-            {
-              case BinaryOperator.Ceq:
-                truthValue = k1 == k2;
-                break;
-
-              case BinaryOperator.Cge:
-                truthValue = k1 >= k2;
-                break;
-
-              case BinaryOperator.Cgt:
-                truthValue = k1 > k2;
-                break;
-
-              case BinaryOperator.Cle:
-                truthValue = k1 <= k2;
-                break;
-
-              case BinaryOperator.Clt:
-                truthValue = k1 < k2;
-                break;
-
-              case BinaryOperator.Cne_Un:
-                truthValue = k1 != k2;
-                break;
+                currPC = cfg.Predecessors(currPC).First();
             }
 
-            if (truthValue.HasValue)
-            {
-              return BoxedExpression.ConstBool(truthValue.Value, mdDecoder);
-            }
-            #endregion
-          }
-
-          if (bop == BinaryOperator.Ceq || bop == BinaryOperator.Cne_Un)
-          {
-            #region The cases
-            // recLeft {==, !=} recRight ==> {"true", "false"} 
-            if (recLeft.Equals(recRight))
-            {
-              return BoxedExpression.ConstBool(bop == BinaryOperator.Ceq ? true : false, mdDecoder);
-            }
-
-            // Pattern matches (recLeftLeft { relOp } recRightRight) == {false, true}
-            BinaryOperator internalBop;
-            BoxedExpression recLeftLeft, recRightRight;
-            int k;
-            if (recLeft.IsBinaryExpression(out internalBop, out recLeftLeft, out recRightRight)
-              && internalBop.IsComparisonBinaryOperator()
-              // && recRight != null 
-              && recRight.IsConstantIntOrNull(out k))
-            {
-              if ((bop == BinaryOperator.Ceq && k != 0) || (bop == BinaryOperator.Cne_Un && k == 0))// true
-              {
-                return recLeft;
-              }
-              else  // false
-              {
-                BinaryOperator negatedOp;
-                if (internalBop.TryNegate(out negatedOp))
-                {
-                  return BoxedExpression.Binary(negatedOp, recLeftLeft, recRightRight);
-                }
-              }
-            }
-            #endregion
-          }
-
-          // a / k < a ==> a != 0
-          if(bop == BinaryOperator.Clt || bop == BinaryOperator.Cne_Un)
-          {
-            if(recLeft.IsBinary && recLeft.BinaryOp == BinaryOperator.Div && recLeft.BinaryRight.IsConstant && recLeft.BinaryLeft.Equals(recRight))
-            {
-              return BoxedExpression.Binary(BinaryOperator.Cne_Un, recLeft.BinaryLeft, BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder));
-            }
-          }
-
-#if false
-          if (bop.IsComparisonBinaryOperator())
-          {
-            var tmpLeft = recLeft;
-            var tmpRight = recRight;
-            if (ApplySimplifications(mdDecoder, ref recLeft, ref recRight))
-            {
-//             recLeft = tmpLeft;
-//              recRight = tmpRight;
-            }
-          }
-#endif
+            return currPC;
         }
-
-        Contract.Assert(recLeft != null); // Let us make sure when we reach this point the two are not null
-        Contract.Assert(recRight != null);
-
-        return left.Equals(recLeft) && right.Equals(recRight) ? be : BoxedExpression.Binary(bop, recLeft, recRight);
-      }
-
-      return be;
     }
-
-    private static bool ApplySimpleConstantPropagation<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(BinaryOperator bop, ref BoxedExpression recLeft, ref BoxedExpression recRight, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Requires(recLeft != null);
-      Contract.Ensures(recLeft != null);
-      Contract.Ensures(recRight != null);
-
-      int kRight;
-      if ((bop == BinaryOperator.Add || bop == BinaryOperator.Add_Ovf || bop == BinaryOperator.Sub || bop == BinaryOperator.Sub_Ovf)
-        && recRight.IsConstantInt(out kRight))
-      {
-        BinaryOperator leftOp;
-        BoxedExpression leftleft;
-        int kLeft;
-
-        // examples: (x + 1) + 1 or (x - 1) - 1 or (x + 1) - 1 or (x - 1) + 1
-        if (recLeft.IsBinaryExpressionExpOpConst(out leftOp, out leftleft, out kLeft)
-          && (leftOp == BinaryOperator.Add || leftOp == BinaryOperator.Sub))
-        {
-          if (kLeft == Int32.MinValue)
-          {
-            return false;
-          }
-
-          switch (bop)
-          {
-            case BinaryOperator.Add:
-            case BinaryOperator.Add_Ovf:
-            case BinaryOperator.Sub:
-            case BinaryOperator.Sub_Ovf:
-              {
-                if (leftOp == BinaryOperator.Sub)
-                {
-                  kLeft = -kLeft;
-                }
-
-                Contract.Assert(leftleft != null);
-                recLeft = leftleft;
-                recRight = BoxedExpression.Const(
-                  bop == BinaryOperator.Add ? kRight + kLeft : kRight - kLeft,
-                  mdDecoder.System_Int32, mdDecoder);
-              }
-              return true;
-
-
-            default:
-              {
-              }
-              break;
-          }
-        }
-      }
-
-      return false;
-    }
-
-    /// <summary>
-    /// If a parameter is null, then it means we applied some cancellation rule
-    /// </summary>
-    private static bool ApplyIdentities<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      BinaryOperator bop, ref BoxedExpression recLeft, ref BoxedExpression recRight)
-    {
-      Contract.Requires(recLeft != null);
-      Contract.Requires(recRight != null);
-
-      int value;
-
-      // We simplify identities
-      switch (bop)
-      {
-        // a +0 == 0 + a == a
-        case BinaryOperator.Add:
-        case BinaryOperator.Add_Ovf:
-        case BinaryOperator.Add_Ovf_Un:
-          {
-            recLeft = recLeft.IsConstantIntOrNull(out value) && value == 0 ? null : recLeft;
-            recRight = recRight.IsConstantIntOrNull(out value) && value == 0 ? null : recRight;
-
-            return true;
-          }
-
-        // a - 0 == a
-        case BinaryOperator.Sub:
-        case BinaryOperator.Sub_Ovf:
-        case BinaryOperator.Sub_Ovf_Un:
-          {
-            recRight = recRight.IsConstantIntOrNull(out value) && value == 0 ? null : recRight;
-
-            return true;
-          }
-
-        // a / 1 == a
-        case BinaryOperator.Div:
-        case BinaryOperator.Div_Un:
-          {
-            recRight = recRight.IsConstantIntOrNull(out value) && value == 1 ? null : recRight;
-
-            return true;
-          }
-
-        // a * 1 = a
-        case BinaryOperator.Mul:
-        case BinaryOperator.Mul_Ovf:
-        case BinaryOperator.Mul_Ovf_Un:
-          {
-            recRight = recRight.IsConstantIntOrNull(out value) && value == 1 ? null : recRight;
-
-            return true;
-          }
-
-        case BinaryOperator.Ceq:
-        case BinaryOperator.Cne_Un:
-          {
-            object type;
-            long k;
-            bool b1 = false, b2 = false;
-            if ((recLeft.TryGetType(out type) && recRight.IsConstantInt64(out k) && (b1 = true)) ||
-              (recRight.TryGetType(out type) && recLeft.IsConstantInt64(out k) && (b2 = true)))
-            {
-              if (mdDecoder.System_UInt16.Equals(type))
-              {
-                if (b1)
-                {
-                  recRight = BoxedExpression.Const((UInt16)k, mdDecoder.System_UInt16, mdDecoder);
-                }
-                else
-                {
-                  Contract.Assert(b2);
-                  recLeft = BoxedExpression.Const((UInt16)k, mdDecoder.System_UInt16, mdDecoder);
-                }
-
-                return true;
-              }
-
-              if (mdDecoder.System_UInt32.Equals(type))
-              {
-                if (b1)
-                {
-                  recRight = BoxedExpression.Const((UInt32)k, mdDecoder.System_UInt32, mdDecoder);
-                }
-                else
-                {
-                  Contract.Assert(b2);
-                  recLeft = BoxedExpression.Const((UInt32)k, mdDecoder.System_UInt32, mdDecoder);
-                }
-
-                return true;
-              }
-
-            }
-          }
-          break;
-
-        case BinaryOperator.LogicalOr:
-          {
-            // false || e == e
-            bool b;
-            recLeft = recLeft.IsConstantBool(out b) && !b ? null : recLeft;
-            recRight = recRight.IsConstantBool(out b) && !b ? null : recRight;
-
-            return recLeft == null || recRight == null;
-          }
-
-        case BinaryOperator.LogicalAnd:
-          {
-            // true && e == e
-            bool b;
-            recLeft = recLeft.IsConstantBool(out b) && b ? null : recLeft;
-            recRight = recRight.IsConstantBool(out b) && b ? null : recRight;
-
-            return recLeft == null || recRight == null;
-
-          }
-      }
-
-      return false;
-    }
-
-    private static bool ApplySimplifications<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      ref BoxedExpression left, ref BoxedExpression right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      if (ApplySimplificationsInternal(mdDecoder, ref left, ref right))
-      {
-        return true;
-      }
-      if (ApplySimplificationsInternal(mdDecoder, ref right, ref left))
-      {
-        // We swapped the operands to simplify them. We should correct it
-        var tmp = left;
-        left = right;
-        right = tmp;
-
-        return true;
-      }
-
-      return false;
-    }
-
-    private static bool ApplySimplificationsInternal<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      ref BoxedExpression left, ref BoxedExpression right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      Contract.Ensures(left != null);
-      Contract.Ensures(right != null);
-
-      BinaryOperator bop;
-      BoxedExpression l;
-      int k;
-      if (left.IsBinaryExpressionExpOpConst(out bop, out l, out k, false))
-      {
-        switch (bop)
-        {
-          case BinaryOperator.Mul:
-            {
-              if (/*l != null && */l.Equals(right))
-              {
-                right = BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder);
-                if (k == 1)
-                {
-                  left = right; // i.e., zero
-                }
-                else if (k == 2)
-                {
-                  left = l;
-                }
-                else
-                {
-                  left = BoxedExpression.Binary(BinaryOperator.Mul, BoxedExpression.Const(k - 1, mdDecoder.System_Int32, mdDecoder), l);
-                }
-
-                return true;
-              }
-              break;
-            }
-
-          default:
-            {
-              break;
-            }
-        }
-      }
-
-      return false;
-    }
-
-    class FrameworkVariablesInBoxedExpression : IBoxedExpressionVisitor
-    {
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.variablesMaybeWithRepetitions != null);
-      }
-
-      readonly private List<object> variablesMaybeWithRepetitions;
-
-      private Set<object> variables;
-
-      public Set<object> Variables
-      {
-        get
-        {
-          Contract.Ensures(Contract.Result<object>() != null);
-
-          if (variables == null)
-          {
-            this.variables = new Set<object>();
-            this.variables.AddRange(this.variablesMaybeWithRepetitions);
-          }
-
-          return this.variables;
-        }
-      }
-
-      public FrameworkVariablesInBoxedExpression()
-      {
-        this.variablesMaybeWithRepetitions = new List<object>();
-        this.variables = null;
-      }
-
-      #region IBoxedExpressionVisitor Members
-
-      public void Variable(object var, PathElement[] path, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(var);
-      }
-
-      public void Constant<Type>(Type type, object value, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-      }
-
-      public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        left.Dispatch(this);
-        right.Dispatch(this);
-      }
-
-      public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        argument.Dispatch(this);
-      }
-
-      public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-      }
-
-      public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        argument.Dispatch(this);
-      }
-
-      public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        array.Dispatch(this);
-        index.Dispatch(this);
-      }
-
-      public void Result<Type>(Type type, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-      }
-
-      public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        expression.Dispatch(this);
-      }
-
-      public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        expression.Dispatch(this);
-      }
-
-      public void Assert(BoxedExpression condition, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        condition.Dispatch(this);
-      }
-
-      public void Assume(BoxedExpression condition, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        condition.Dispatch(this);
-      }
-
-      public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        foreach (var statement in statements.Enumerate())
-        {
-          statement.Dispatch(this);
-        }
-      }
-
-      public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
-      {
-        variablesMaybeWithRepetitions.Add(parent.UnderlyingVariable);
-
-        boundVariable.Dispatch(this);
-        lower.Dispatch(this);
-        upper.Dispatch(this);
-        body.Dispatch(this);
-      }
-
-      #endregion
-    }
-
-    class VariablesInBoxedExpression : IBoxedExpressionVisitor
-    {
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.Variables!= null);
-      }
-
-      readonly public Set<object> Variables;
-      readonly public Set<BoxedExpression> VariablesAsBoxedExpressions;
-      public bool OnlyConstants { get; private set; }
-
-      public VariablesInBoxedExpression()
-      {
-        this.Variables = new Set<object>();
-        this.VariablesAsBoxedExpressions = new Set<BoxedExpression>();
-        this.OnlyConstants = true;
-      }
-
-      #region IBoxedExpressionVisitor Members
-
-      public void Variable(object var, PathElement[] path, BoxedExpression parent)
-      {
-        this.OnlyConstants = false;
-        Variables.Add(var);
-        if (path != null)
-        {
-          VariablesAsBoxedExpressions.Add(BoxedExpression.Var(var, path));
-        }
-      }
-
-      public void Constant<Type>(Type type, object value, BoxedExpression parent)
-      {
-      }
-
-      public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
-      {
-        left.Dispatch(this);
-        right.Dispatch(this);
-      }
-
-      public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
-      {
-        argument.Dispatch(this);
-      }
-
-      public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression parent)
-      {
-      }
-
-      public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression parent)
-      {
-        argument.Dispatch(this);
-      }
-
-      public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
-      {
-        this.OnlyConstants = false;
-
-        array.Dispatch(this);
-        index.Dispatch(this);
-      }
-
-      public void Result<Type>(Type type, BoxedExpression parent)
-      {
-        this.OnlyConstants = false;
-      }
-
-      public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
-      {
-        this.OnlyConstants = false;
-        expression.Dispatch(this);
-      }
-
-      public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
-      {
-        this.OnlyConstants = false;
-        expression.Dispatch(this);
-      }
-
-      public void Assert(BoxedExpression condition, BoxedExpression parent)
-      {
-        this.OnlyConstants = false;
-        condition.Dispatch(this);
-      }
-
-      public void Assume(BoxedExpression condition, BoxedExpression parent)
-      {
-        condition.Dispatch(this);
-      }
-
-      public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
-      {
-        foreach (var statement in statements.Enumerate())
-        {
-          statement.Dispatch(this);
-        }
-      }
-
-      public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
-      {
-        this.OnlyConstants = false;
-
-        boundVariable.Dispatch(this);
-        lower.Dispatch(this);
-        upper.Dispatch(this);
-        body.Dispatch(this);
-      }
-
-      #endregion
-    }
-
-    // 
-
-    class ConstantsInBoxedExpression : IBoxedExpressionVisitor
-    {
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.Constants != null);
-      }
-
-      readonly public Set<BoxedExpression> Constants;
-
-      public ConstantsInBoxedExpression()
-      {
-        this.Constants = new Set<BoxedExpression>();
-      }
-
-      #region IBoxedExpressionVisitor Members
-
-      public void Variable(object var, PathElement[] path, BoxedExpression parent)
-      {
-      }
-
-      public void Constant<Type>(Type type, object value, BoxedExpression parent)
-      {
-        this.Constants.Add(parent);
-      }
-
-      public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
-      {
-        left.Dispatch(this);
-        right.Dispatch(this);
-      }
-
-      public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
-      {
-        argument.Dispatch(this);
-      }
-
-      public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression parent)
-      {
-      }
-
-      public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression parent)
-      {
-        argument.Dispatch(this);
-      }
-
-      public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
-      {
-        array.Dispatch(this);
-        index.Dispatch(this);
-      }
-
-      public void Result<Type>(Type type, BoxedExpression parent)
-      {
-      }
-
-      public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
-      {
-        expression.Dispatch(this);
-      }
-
-      public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression parent)
-      {
-        expression.Dispatch(this);
-      }
-
-      public void Assert(BoxedExpression condition, BoxedExpression parent)
-      {
-        condition.Dispatch(this);
-      }
-
-      public void Assume(BoxedExpression condition, BoxedExpression parent)
-      {
-        condition.Dispatch(this);
-      }
-
-      public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
-      {
-        foreach (var statement in statements.Enumerate())
-        {
-          statement.Dispatch(this);
-        }
-      }
-
-      public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
-      {
-        boundVariable.Dispatch(this);
-        lower.Dispatch(this);
-        upper.Dispatch(this);
-        body.Dispatch(this);
-      }
-
-      #endregion
-    }
-
-     
-    class HasReturnValue : IBoxedExpressionVisitor
-    {
-      public bool Found { get; private set; }
-      public HasReturnValue()
-      {
-        this.Found = false;
-      }
-
-      public void Variable(object var, PathElement[] path, BoxedExpression original)
-      {
-      }
-
-      public void Constant<Type>(Type type, object value, BoxedExpression original)
-      {
-      }
-
-      public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression original)
-      {
-        left.Dispatch(this);
-        right.Dispatch(this);
-      }
-
-      public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression original)
-      {
-        argument.Dispatch(this);
-      }
-
-      public void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression original)
-      {
-      }
-
-      public void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression original)
-      {
-        argument.Dispatch(this);
-      }
-
-      public void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression original)
-      {
-        array.Dispatch(this);
-        index.Dispatch(this);
-      }
-
-      public void Result<Type>(Type type, BoxedExpression original)
-      {
-        this.Found = true;
-      }
-
-      public void Old<Type>(Type type, BoxedExpression expression, BoxedExpression original)
-      {
-        expression.Dispatch(this);
-      }
-
-      public void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression original)
-      {
-        expression.Dispatch(this);
-      }
-
-      public void Assert(BoxedExpression condition, BoxedExpression original)
-      {
-      }
-
-      public void Assume(BoxedExpression condition, BoxedExpression original)
-      {
-      }
-
-      public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression original)
-      {
-        for(var i = 0; i < statements.Count; i++)
-        {
-          statements[i].AssumeNotNull().Dispatch(this);
-        }
-      }
-
-      public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression original)
-      {
-        boundVariable.Dispatch(this);
-        lower.Dispatch(this);
-        upper.Dispatch(this);
-        body.Dispatch(this);
-      }
-    }
-
-  }
-
-  [ContractVerification(true)]
-  public static class ListOfBoxedExpressionsExtensions
-  {
-    public static BoxedExpression ToDisjunction(this List<BoxedExpression> disjuncts)
-    {
-      if (disjuncts == null || disjuncts.Count == 0)
-      {
-        return null;
-      }
-
-      var result = disjuncts[0];
-      Contract.Assume(result != null);
-
-      for (var i = 1; i < disjuncts.Count; i++)
-      {
-        var disjunct = disjuncts[i];
-        if (disjunct != null)
-        {
-          result = BoxedExpression.Binary(BinaryOperator.LogicalOr, result, disjunct);
-        }
-      }
-
-      return result;
-    }
-  }
-
-  public static class IDecodeMetaDataExtensions
-  {
-    public static bool IsReadOnly<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      FList<PathElement> accessPath)
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(mdDecoder != null);
-
-      var accessPathArray = accessPath.ToArray();
-
-      Contract.Assume(Contract.ForAll(accessPathArray, p => p != null));
-
-      if (accessPathArray.Length < 2)
-      {
-        return false;
-      }
-
-      Field f;
-
-      if (accessPathArray.Length == 2)
-      {
-        return accessPathArray[1].TryField(out f) && mdDecoder.IsReadonly(f);
-      }
-
-      Contract.Assert(accessPathArray.Length > 2, "trivial, but make it sure");
-
-      // F: HACK - We need to pass the value context to check if the field is an array!
-      return
-        accessPathArray[accessPathArray.Length - 1].IsDeref && accessPathArray[accessPathArray.Length - 2].TryField(out f) && mdDecoder.IsReadonly(f) ||
-        accessPathArray[accessPathArray.Length - 3].TryField(out f) && mdDecoder.IsReadonly(f) && accessPathArray[accessPathArray.Length - 1].ToString() == "Length";
-    }
-  }
-
-  [ContractVerification(true)]
-  public static class PathElementExtensions
-  {
-    public static bool ContainsStaticFieldAccess<Field>(this PathElement[] pathElement)
-    {
-      Contract.Requires(pathElement != null);
-
-      for(var i = 0; i < pathElement.Length; i++)
-      {
-        var element = pathElement[i];
-        Contract.Assume(element != null);
-
-        Field f;
-        if(element.IsStatic && element.TryField(out f))
-        {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    public static bool IsNaNCall(this PathElement[] path, out bool isFloat64)
-    {
-      isFloat64 = false;
-
-      if (path == null || path.Length != 2)
-      {
-        return false;
-      }
-
-      var candidate = path[1];
-
-      if(candidate == null)
-      {
-        return false;
-      }
-
-      if (candidate.IsMethodCall && candidate.IsStatic)
-      {
-        var str = candidate.ToString();
-        if (str.EndsWith("IsNaN"))
-        {
-          var strLowerCase = str.Split('.')[0].ToLower();
-          switch (strLowerCase)
-          {
-            case "float":
-            case "float32":
-            case "system.float32":
-            case "system.float":
-              {
-                isFloat64 = false;
-                return true;
-              }
-
-            case "double":
-            case "float64":
-            case "system.float64":
-            case "system.double":
-              {
-                isFloat64 = true;
-                return true;
-              }
-            default:
-              {
-                break;
-              }
-          }
-        }
-      }
-
-      return false;
-    }
-
-    public static bool IsInfinityCall(this PathElement[] path, out bool isFloat64, out bool isPlusInfinty, out bool isMinusInfinity)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out isPlusInfinty) || Contract.ValueAtReturn(out isMinusInfinity));
-
-      isFloat64 = isPlusInfinty = isMinusInfinity = false;
-      if (path != null && path.Length == 2)
-      {
-        var candidate = path[1];
-
-        if(candidate == null)
-        {
-          return false;
-        }
-
-        if (candidate.IsStatic && candidate.IsMethodCall)
-        {
-          var str = candidate.ToString();
-          if (str.EndsWith("Infinity"))
-          {
-            var split = str.ToLower().Split('.');
-            if (split.Length == 2)
-            {
-              switch (split[0])
-              {
-                case "float":
-                case "float32":
-                case "system.float32":
-                case "system.float":
-                  {
-                    isFloat64 = false;
-                    break;
-                  }
-
-                case "double":
-                case "float64":
-                case "system.float64":
-                case "system.double":
-                  {
-                    isFloat64 = true;
-                    break;
-                  }
-
-                default:
-                  {
-                    return false;
-                  }
-              }
-
-              switch (split[1])
-              {
-                case "isinfinity":
-                  {
-                    isPlusInfinty = true;
-                    isMinusInfinity = true;
-                    break;
-                  }
-
-                case "isminusinfinity":
-                  {
-                    isPlusInfinty = false;
-                    isMinusInfinity = true;
-                    break;
-                  }
-
-                case "isplusinfinity":
-                  {
-                    isPlusInfinty = true;
-                    isMinusInfinity = false;
-                    break;
-                  }
-
-                default:
-                  {
-                    return false;
-                  }
-              }
-
-              return true;
-            }
-          }
-        }
-      }
-
-      return false;
-    }
-  }
-
-  public static class APCExtensions
-  {
-    public static APC GetFirstSuccessorWithSourceContext(this APC pc, ICFG cfg)
-    {
-      Contract.Requires(cfg != null);
-
-      if (pc.HasRealSourceContext)
-      {
-        return pc;
-      }
-
-      var oldPC = pc;
-
-      for (var i = 0; i < 10; i++)
-      {
-        pc = cfg.Post(pc);
-        if (pc.HasRealSourceContext)
-        {
-          return pc;
-        }
-      }
-
-      return pc; // We failed. This shoulnd never happen
-    }
-
-    /*
-    // this recursive implementation caused stack overflow in mscorlib analysis
-    public static APC GetFirstPredecessorWithSourceContext(this APC pc, ICFG cfg)
-    {
-      Contract.Requires(cfg != null);
-
-      if (pc.HasRealSourceContext || cfg.Predecessors(pc).Count() == 0)
-      {
-        return pc;
-      }
-
-      var pre = cfg.Predecessors(pc).First();
-
-      if (pre.HasRealSourceContext)
-      {
-        return pre;
-      }
-      else
-      {
-        return pre.GetFirstPredecessorWithSourceContext(cfg);
-      }
-    }
-     */
-
-    public static APC GetFirstPredecessorWithSourceContext(this APC pc, ICFG cfg)
-    {
-      Contract.Requires(cfg != null);
-
-      var currPC = pc;
-
-      while (!currPC.HasRealSourceContext && cfg.Predecessors(currPC).Any())
-      {
-        currPC = cfg.Predecessors(currPC).First();
-      }
-
-      return currPC;
-    }
-
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/IBoxedExpressionVisitor.cs
+++ b/Microsoft.Research/CodeAnalysis/IBoxedExpressionVisitor.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,27 +9,27 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public interface IBoxedExpressionVisitor
-  {
-    void Variable(object var, PathElement[] path, BoxedExpression original);
-    void Constant<Type>(Type type, object value, BoxedExpression original);
-    void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression original);
-    void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression original);
-    void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression original);
-    void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression original);
-    void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression original);
+    public interface IBoxedExpressionVisitor
+    {
+        void Variable(object var, PathElement[] path, BoxedExpression original);
+        void Constant<Type>(Type type, object value, BoxedExpression original);
+        void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression original);
+        void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression original);
+        void SizeOf<Type>(Type type, int sizeAsConstant, BoxedExpression original);
+        void IsInst<Type>(Type type, BoxedExpression argument, BoxedExpression original);
+        void ArrayIndex<Type>(Type type, BoxedExpression array, BoxedExpression index, BoxedExpression original);
 
-    void Result<Type>(Type type, BoxedExpression original);
-    void Old<Type>(Type type, BoxedExpression expression, BoxedExpression original);
-    void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression original);
+        void Result<Type>(Type type, BoxedExpression original);
+        void Old<Type>(Type type, BoxedExpression expression, BoxedExpression original);
+        void ValueAtReturn<Type>(Type type, BoxedExpression expression, BoxedExpression original);
 
 
-    void Assert(BoxedExpression condition, BoxedExpression original);
+        void Assert(BoxedExpression condition, BoxedExpression original);
 
-    void Assume(BoxedExpression condition, BoxedExpression original);
+        void Assume(BoxedExpression condition, BoxedExpression original);
 
-    void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression original);
+        void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression original);
 
-    void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression original);
-  }
+        void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression original);
+    }
 }

--- a/Microsoft.Research/CodeAnalysis/IFrameworkLogOptions.cs
+++ b/Microsoft.Research/CodeAnalysis/IFrameworkLogOptions.cs
@@ -1,461 +1,449 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Research.CodeAnalysis {
-
-  public partial interface IFrameworkLogOptions {
-
-    /// <summary>
-    /// Print tracing information during DFA steps
-    /// </summary>
-    bool TraceDFA { get; }
-
-    /// <summary>
-    /// Trace the heap analysis phase of the framework
-    /// </summary>
-    bool TraceHeapAnalysis { get; }
-
-    /// <summary>
-    /// Trace the expression analysis phase of the framework
-    /// </summary>
-    bool TraceExpressionAnalysis { get; }
-
-    /// <summary>
-    /// Trace the egraph operations of the framework
-    /// </summary>
-    bool TraceEGraph { get; }
-
-    /// <summary>
-    /// Trace assumptions of the framework
-    /// </summary>
-    bool TraceAssumptions { get; }
-
-    /// <summary>
-    /// Trace weakest precondition paths
-    /// </summary>
-    bool TraceWP { get; }
-
-    /// <summary>
-    /// Emit the WP formula we cannot prove in the SMT-LIB format
-    /// </summary>
-    bool EmitSMT2Formula { get; }
-
-    bool TraceNumericalAnalysis { get; }
-
-    /// <summary>
-    /// Trace the execution of the partition analysis
-    /// </summary>
-    bool TracePartitionAnalysis { get; }
-
-    bool TraceInference { get; }
-
-    bool TraceChecks { get; }
-
-    /// <summary>
-    /// Trace, for each transfer function, its cost
-    /// </summary>
-    bool TraceTimings { get; }
-
-    /// <summary>
-    /// Trace, for each transfer function, its memory usage
-    /// </summary>
-    bool TraceMemoryConsumption { get; }
-
-    bool TraceMoveNext { get; }
-
-    /// <summary>
-    /// True if analysis framework should print IL of CFGs
-    /// </summary>
-    bool PrintIL { get; }
-
-    /// <summary>
-    /// If true, try to prioritize the warning messages
-    /// </summary>
-    bool PrioritizeWarnings { get; }
-
-    /// <summary>
-    /// Controls whether or not to print suggestions for requires
-    /// </summary>
-    bool SuggestRequires { get; }
-
-    /// <summary>
-    /// Suggest turning assertions into contracts
-    /// </summary>
-    bool SuggestAssertToContracts { get; }
-
-    /// <summary>
-    /// Controls whether or not to print suggestions on arrays 
-    /// - Eventually this will be merged with SuggestRequires, now we keep it separate for debugging/development
-    /// </summary>
-    bool SuggestRequiresForArrays { get; }
-
-    /// <summary>
-    /// Controls whether or not should output the suggestion for [Pure] for arrays
-    /// </summary>
-    bool SuggestRequiresPurityForArrays { get;  }
-
-    /// <summary>
-    /// Controls whether or not to print ensures suggestions
-    /// </summary>
-    bool SuggestEnsures(bool isProperty);
-
-    /// <summary>
-    /// Control whether or not to print return != null suggestions
-    /// </summary>
-    bool SuggestNonNullReturn { get; }
-
-    bool InferPreconditionsFromPostconditions { get; }
-
-    bool PropagateObjectInvariants { get; }
-
-    bool InferAssumesForBaseLining { get; }
-
-    /// <summary>
-    /// True if we should try to propagate inferred pre-conditions for the method <code>m</code>
-    /// </summary>
-    /// <param name="isGetterOrSetter">Is the current method a getter or a setter</param>
-    bool PropagateInferredRequires(bool isCurrentMethodGetterOrSetter);
-
-    /// <summary>
-    /// True iff we should try to propagate the inferred postconditions for the method <code>m</code>
-    /// </summary>
-    /// <param name="isGetterOrSetter">Is the current method a getter or a setter</param>
-    bool PropagateInferredEnsures(bool isCurrentMethodGetterOrSetter);
-
-    /// <summary>
-    /// True iff we want to propagate the ensures != null inferred for a method
-    /// </summary>
-    bool PropagateInferredNonNullReturn { get; }
-
-    bool PropagateInferredSymbolicReturn { get; }
-
-    bool PropagateRequiresPurityForArrays { get; }
-
-    bool PropagatedRequiresAreSufficient { get; }
-
-    bool CheckFalsePostconditions { get; }
-
-    /// <summary>
-    /// When printing CS files with contracts, limit output to visible items.
-    /// </summary>
-    bool OutputOnlyExternallyVisibleMembers { get; }
-
-    /// <summary>
-    /// The timeout, expressed in minutes, to stop the analysis
-    /// </summary>
-    int Timeout { get; }
-
-    /// <summary>
-    /// How many joins before widening ?
-    /// </summary>
-    int IterationsBeforeWidening { get; }
-
-    /// <summary>
-    /// How many variables before giving up the inference of Octagons?
-    /// </summary>
-    int MaxVarsForOctagonInference { get; }
-
-    int MaxVarsInSingleRenaming { get; }
-
-    bool IsAdaptiveAnalysis { get;  }
-
-    /// <summary>
-    /// Enforce the fair join
-    /// </summary>
-    bool EnforceFairJoin { get; }
-
-    bool TurnArgumentExceptionThrowsIntoAssertFalse { get; }
-
-    bool IgnoreExplicitAssumptions { get; }
-
-    /// <summary>
-    /// True iff we want to show the analysis phases
-    /// </summary>
-    bool ShowPhases { get; }
-
-    bool SufficientConditions { get; }
-  }
-
-  #region IFrameworkLogOptions contract binding
-  [ContractClass(typeof(IFrameworkLogOptionsContract))]
-  public partial interface IFrameworkLogOptions
-  {
-
-  }
-
-  [ContractClassFor(typeof(IFrameworkLogOptions))]
-  abstract class IFrameworkLogOptionsContract : IFrameworkLogOptions
-  {
-    #region IFrameworkLogOptions Members
-
-    public bool TraceDFA
+namespace Microsoft.Research.CodeAnalysis
+{
+    public partial interface IFrameworkLogOptions
     {
-      get { throw new NotImplementedException(); }
+        /// <summary>
+        /// Print tracing information during DFA steps
+        /// </summary>
+        bool TraceDFA { get; }
+
+        /// <summary>
+        /// Trace the heap analysis phase of the framework
+        /// </summary>
+        bool TraceHeapAnalysis { get; }
+
+        /// <summary>
+        /// Trace the expression analysis phase of the framework
+        /// </summary>
+        bool TraceExpressionAnalysis { get; }
+
+        /// <summary>
+        /// Trace the egraph operations of the framework
+        /// </summary>
+        bool TraceEGraph { get; }
+
+        /// <summary>
+        /// Trace assumptions of the framework
+        /// </summary>
+        bool TraceAssumptions { get; }
+
+        /// <summary>
+        /// Trace weakest precondition paths
+        /// </summary>
+        bool TraceWP { get; }
+
+        /// <summary>
+        /// Emit the WP formula we cannot prove in the SMT-LIB format
+        /// </summary>
+        bool EmitSMT2Formula { get; }
+
+        bool TraceNumericalAnalysis { get; }
+
+        /// <summary>
+        /// Trace the execution of the partition analysis
+        /// </summary>
+        bool TracePartitionAnalysis { get; }
+
+        bool TraceInference { get; }
+
+        bool TraceChecks { get; }
+
+        /// <summary>
+        /// Trace, for each transfer function, its cost
+        /// </summary>
+        bool TraceTimings { get; }
+
+        /// <summary>
+        /// Trace, for each transfer function, its memory usage
+        /// </summary>
+        bool TraceMemoryConsumption { get; }
+
+        bool TraceMoveNext { get; }
+
+        /// <summary>
+        /// True if analysis framework should print IL of CFGs
+        /// </summary>
+        bool PrintIL { get; }
+
+        /// <summary>
+        /// If true, try to prioritize the warning messages
+        /// </summary>
+        bool PrioritizeWarnings { get; }
+
+        /// <summary>
+        /// Controls whether or not to print suggestions for requires
+        /// </summary>
+        bool SuggestRequires { get; }
+
+        /// <summary>
+        /// Suggest turning assertions into contracts
+        /// </summary>
+        bool SuggestAssertToContracts { get; }
+
+        /// <summary>
+        /// Controls whether or not to print suggestions on arrays 
+        /// - Eventually this will be merged with SuggestRequires, now we keep it separate for debugging/development
+        /// </summary>
+        bool SuggestRequiresForArrays { get; }
+
+        /// <summary>
+        /// Controls whether or not should output the suggestion for [Pure] for arrays
+        /// </summary>
+        bool SuggestRequiresPurityForArrays { get; }
+
+        /// <summary>
+        /// Controls whether or not to print ensures suggestions
+        /// </summary>
+        bool SuggestEnsures(bool isProperty);
+
+        /// <summary>
+        /// Control whether or not to print return != null suggestions
+        /// </summary>
+        bool SuggestNonNullReturn { get; }
+
+        bool InferPreconditionsFromPostconditions { get; }
+
+        bool PropagateObjectInvariants { get; }
+
+        bool InferAssumesForBaseLining { get; }
+
+        /// <summary>
+        /// True if we should try to propagate inferred pre-conditions for the method <code>m</code>
+        /// </summary>
+        /// <param name="isGetterOrSetter">Is the current method a getter or a setter</param>
+        bool PropagateInferredRequires(bool isCurrentMethodGetterOrSetter);
+
+        /// <summary>
+        /// True iff we should try to propagate the inferred postconditions for the method <code>m</code>
+        /// </summary>
+        /// <param name="isGetterOrSetter">Is the current method a getter or a setter</param>
+        bool PropagateInferredEnsures(bool isCurrentMethodGetterOrSetter);
+
+        /// <summary>
+        /// True iff we want to propagate the ensures != null inferred for a method
+        /// </summary>
+        bool PropagateInferredNonNullReturn { get; }
+
+        bool PropagateInferredSymbolicReturn { get; }
+
+        bool PropagateRequiresPurityForArrays { get; }
+
+        bool PropagatedRequiresAreSufficient { get; }
+
+        bool CheckFalsePostconditions { get; }
+
+        /// <summary>
+        /// When printing CS files with contracts, limit output to visible items.
+        /// </summary>
+        bool OutputOnlyExternallyVisibleMembers { get; }
+
+        /// <summary>
+        /// The timeout, expressed in minutes, to stop the analysis
+        /// </summary>
+        int Timeout { get; }
+
+        /// <summary>
+        /// How many joins before widening ?
+        /// </summary>
+        int IterationsBeforeWidening { get; }
+
+        /// <summary>
+        /// How many variables before giving up the inference of Octagons?
+        /// </summary>
+        int MaxVarsForOctagonInference { get; }
+
+        int MaxVarsInSingleRenaming { get; }
+
+        bool IsAdaptiveAnalysis { get; }
+
+        /// <summary>
+        /// Enforce the fair join
+        /// </summary>
+        bool EnforceFairJoin { get; }
+
+        bool TurnArgumentExceptionThrowsIntoAssertFalse { get; }
+
+        bool IgnoreExplicitAssumptions { get; }
+
+        /// <summary>
+        /// True iff we want to show the analysis phases
+        /// </summary>
+        bool ShowPhases { get; }
+
+        bool SufficientConditions { get; }
     }
 
-    public bool TraceHeapAnalysis
+    #region IFrameworkLogOptions contract binding
+    [ContractClass(typeof(IFrameworkLogOptionsContract))]
+    public partial interface IFrameworkLogOptions
     {
-      get { throw new NotImplementedException(); }
     }
 
-    public bool TraceExpressionAnalysis
+    [ContractClassFor(typeof(IFrameworkLogOptions))]
+    internal abstract class IFrameworkLogOptionsContract : IFrameworkLogOptions
     {
-      get { throw new NotImplementedException(); }
+        #region IFrameworkLogOptions Members
+
+        public bool TraceDFA
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceHeapAnalysis
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceExpressionAnalysis
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceEGraph
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceAssumptions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceWP
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceNumericalAnalysis
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TracePartitionAnalysis
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceTimings
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool PrintIL
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool PrioritizeWarnings
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool SuggestRequires
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool SuggestAssertToContracts
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool SuggestRequiresForArrays
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool SuggestRequiresPurityForArrays { get { throw new NotImplementedException(); } }
+
+
+        public bool SuggestEnsures(bool isProperty)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SuggestNonNullReturn
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool OutputOnlyExternallyVisibleMembers
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool InferPreconditionsFromPostconditions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public int Timeout
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                throw new NotImplementedException();
+            }
+        }
+
+        public int IterationsBeforeWidening
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public int MaxVarsForOctagonInference
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool EnforceFairJoin
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
+
+        #region IFrameworkLogOptions Members
+
+        public bool TraceChecks
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool InferRequiresPurityForArrays
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceInference
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
+
+        #region No interesting contract
+
+        public bool PropagateInferredRequires(bool isCurrentMethodGetterOrSetter)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool PropagateSimpleRequires
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool PropagateInferredEnsures(bool isCurrentMethodGetterOrSetter)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool PropagateInferredNonNullReturn
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool PropagateRequiresPurityForArrays
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool PropagatedRequiresAreSufficient
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool EmitSMT2Formula
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool IgnoreExplicitAssumptions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool ShowPhases
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool TraceMemoryConsumption
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+
+        public bool CheckFalsePostconditions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool PropagateObjectInvariants
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool InferAssumesForBaseLining
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion
+
+        #region IFrameworkLogOptions Members
+
+
+        public bool TurnArgumentExceptionThrowsIntoAssertFalse
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
+
+        public bool PropagateInferredSymbolicReturn
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool SufficientConditions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TraceMoveNext { get { return default(bool); } }
+
+        public int MaxVarsInSingleRenaming
+        {
+            get { Contract.Ensures(Contract.Result<int>() >= 0); return 0; }
+        }
+
+
+        public bool IsAdaptiveAnalysis
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
-
-    public bool TraceEGraph
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TraceAssumptions
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TraceWP
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TraceNumericalAnalysis
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TracePartitionAnalysis
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TraceTimings
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool PrintIL
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool PrioritizeWarnings
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool SuggestRequires
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool SuggestAssertToContracts
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool SuggestRequiresForArrays
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public bool SuggestRequiresPurityForArrays { get { throw new NotImplementedException(); } }
-
-
-    public bool SuggestEnsures(bool isProperty)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool SuggestNonNullReturn
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool OutputOnlyExternallyVisibleMembers
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool InferPreconditionsFromPostconditions
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public int Timeout
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public int IterationsBeforeWidening
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public int MaxVarsForOctagonInference
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool EnforceFairJoin
-    {
-      get { throw new NotImplementedException(); }
-    }
-
     #endregion
-
-    #region IFrameworkLogOptions Members
-    
-    public bool TraceChecks {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool InferRequiresPurityForArrays
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TraceInference
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    #endregion
-
-    #region No interesting contract
-    
-    public bool PropagateInferredRequires(bool isCurrentMethodGetterOrSetter)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool PropagateSimpleRequires
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool PropagateInferredEnsures(bool isCurrentMethodGetterOrSetter)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool PropagateInferredNonNullReturn
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool PropagateRequiresPurityForArrays
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool PropagatedRequiresAreSufficient
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool EmitSMT2Formula
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool IgnoreExplicitAssumptions
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool ShowPhases
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool TraceMemoryConsumption
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-
-    public bool CheckFalsePostconditions
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool PropagateObjectInvariants
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool InferAssumesForBaseLining
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    #endregion
-
-    #region IFrameworkLogOptions Members
-
-
-    public bool TurnArgumentExceptionThrowsIntoAssertFalse
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    #endregion
-
-    public bool PropagateInferredSymbolicReturn
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool SufficientConditions
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TraceMoveNext { get { return default(bool); } }
-
-    public int MaxVarsInSingleRenaming
-    {
-      get { Contract.Ensures(Contract.Result<int>() >= 0); return 0; }
-    }
-
-
-    public bool IsAdaptiveAnalysis
-    {
-      get { throw new NotImplementedException(); }
-    }
-  }
-  #endregion
-
 }

--- a/Microsoft.Research/CodeAnalysis/ILogOptions.cs
+++ b/Microsoft.Research/CodeAnalysis/ILogOptions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -18,56 +7,54 @@ using System.Text;
 
 namespace Microsoft.Research.CodeAnalysis
 {
+    public interface ILogOptions : IFrameworkLogOptions
+    {
+        /// <summary>
+        /// depending on options, tells whether or not to print certain outcomes.
+        /// </summary>
+        bool PrintOutcome(ProofOutcome outcome);
 
-  public interface ILogOptions : IFrameworkLogOptions
-  {
+        bool ShowInferenceTrace { get; }
 
-    /// <summary>
-    /// depending on options, tells whether or not to print certain outcomes.
-    /// </summary>
-    bool PrintOutcome(ProofOutcome outcome);
+        bool IsRegression { get; }
 
-    bool ShowInferenceTrace { get; }
+        /// <summary>
+        /// True iff we want Clousot to check if Assume can be proven, and hence converted into asserts
+        /// </summary>
+        bool CheckAssumptions { get; }
 
-    bool IsRegression { get; }
+        /// <summary>
+        /// True iff we want Clousot to check if a condition is always true or false
+        /// </summary>
+        bool CheckConditions { get; }
 
-    /// <summary>
-    /// True iff we want Clousot to check if Assume can be proven, and hence converted into asserts
-    /// </summary>
-    bool CheckAssumptions { get; }
+        /// <summary>
+        /// True iff we want Clousot to check if Assume can be proven, and hence converted into asserts
+        /// OR 
+        /// iff we want Clousot to check if Assume is in contraddiction with what is known
+        /// </summary>
+        bool CheckAssumptionsAndContradictions { get; }
 
-    /// <summary>
-    /// True iff we want Clousot to check if a condition is always true or false
-    /// </summary>
-    bool CheckConditions { get; }
+        bool CheckExistentials { get; }
 
-    /// <summary>
-    /// True iff we want Clousot to check if Assume can be proven, and hence converted into asserts
-    /// OR 
-    /// iff we want Clousot to check if Assume is in contraddiction with what is known
-    /// </summary>
-    bool CheckAssumptionsAndContradictions { get; }
+        bool CheckInferredRequires { get; }
 
-    bool CheckExistentials { get; }
+        ExpressionCacheMode ExpCaching { get; }
 
-    bool CheckInferredRequires { get; }
+        bool UseWeakestPreconditions { get; }
 
-    ExpressionCacheMode ExpCaching { get; }
+        bool ShowUnprovenObligations { get; }
 
-    bool UseWeakestPreconditions { get; }
+        bool ShowPaths { get; }
 
-    bool ShowUnprovenObligations { get; }
+        int MaxPathSize { get; }
 
-    bool ShowPaths { get; }
+        int Steps { get; }
 
-    int MaxPathSize { get; }
+        bool ShowInvariants { get; }
 
-    int Steps { get; }
+        bool CheckEntryContradictions { get; }
 
-    bool ShowInvariants { get; }
-
-    bool CheckEntryContradictions { get; }
-
-    bool WarningsAsErrors { get; }
-  }
+        bool WarningsAsErrors { get; }
+    }
 }

--- a/Microsoft.Research/CodeAnalysis/IOutput.cs
+++ b/Microsoft.Research/CodeAnalysis/IOutput.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -18,59 +7,57 @@ using System.Text;
 using Microsoft.Research.DataStructures;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Research.CodeAnalysis 
+namespace Microsoft.Research.CodeAnalysis
 {
-
-
-  [ContractClass(typeof(IOutputContracts))]
-  public interface IOutput : ISimpleLineWriter
-  {
-    /// <summary>
-    /// For general output that are suggestions to the user
-    /// </summary>
-    void Suggestion(ClousotSuggestion.Kind type, string kind, APC pc, string suggestion, List<uint> causes, ClousotSuggestion.ExtraSuggestionInfo extraInfo);
-
-    void EmitError(System.CodeDom.Compiler.CompilerError error);
-
-    IFrameworkLogOptions LogOptions { get; }
-  }
-
-
-  #region Contracts for IOutput
-  [ContractClassFor(typeof(IOutput))]
-  abstract class IOutputContracts : IOutput
-  {
-    #region ISimpleLineWriter Members
-
-    public void WriteLine(string format, params object[] args)
+    [ContractClass(typeof(IOutputContracts))]
+    public interface IOutput : ISimpleLineWriter
     {
-      throw new NotImplementedException();
+        /// <summary>
+        /// For general output that are suggestions to the user
+        /// </summary>
+        void Suggestion(ClousotSuggestion.Kind type, string kind, APC pc, string suggestion, List<uint> causes, ClousotSuggestion.ExtraSuggestionInfo extraInfo);
+
+        void EmitError(System.CodeDom.Compiler.CompilerError error);
+
+        IFrameworkLogOptions LogOptions { get; }
     }
 
+
+    #region Contracts for IOutput
+    [ContractClassFor(typeof(IOutput))]
+    internal abstract class IOutputContracts : IOutput
+    {
+        #region ISimpleLineWriter Members
+
+        public void WriteLine(string format, params object[] args)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IOutput Members
+
+        public void Suggestion(ClousotSuggestion.Kind type, string kind, APC pc, string suggestion, List<uint> causes, ClousotSuggestion.ExtraSuggestionInfo extraInfo)
+        {
+        }
+
+        public void EmitError(System.CodeDom.Compiler.CompilerError error)
+        {
+            Contract.Requires(error != null);
+        }
+
+        public IFrameworkLogOptions LogOptions
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IFrameworkLogOptions>() != null);
+
+                return default(IFrameworkLogOptions);
+            }
+        }
+
+        #endregion
+    }
     #endregion
-
-    #region IOutput Members
-
-    public void Suggestion(ClousotSuggestion.Kind type, string kind, APC pc, string suggestion, List<uint> causes, ClousotSuggestion.ExtraSuggestionInfo extraInfo)
-    {
-    }
-
-    public void EmitError(System.CodeDom.Compiler.CompilerError error)
-    {
-      Contract.Requires(error != null);
-    }
-
-    public IFrameworkLogOptions LogOptions
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<IFrameworkLogOptions>() != null);
-
-        return default(IFrameworkLogOptions);
-      }
-    }
-
-    #endregion
-  }
-  #endregion
 }

--- a/Microsoft.Research/CodeAnalysis/Inference/Assume.cs
+++ b/Microsoft.Research/CodeAnalysis/Inference/Assume.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,212 +10,211 @@ using System.IO;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// The manager for candidate assume
-  /// </summary>
-  [ContractClass(typeof(IAssumeDispatcherContracts))]
-  public interface IAssumeDispatcher
-  {
     /// <summary>
-    /// Add the assume to the list of current assumptions
+    /// The manager for candidate assume
     /// </summary>
-    void AddEntryAssumes(ProofObligation obl, IEnumerable<BoxedExpression> entryAssumes);
-
-    /// <summary>
-    /// Add the assume to the list of current assumptions
-    /// Returns the warning contexts for the methods referring to the warning contexts
-    /// </summary>
-    IEnumerable<WarningContext> AddCalleeAssumes(ProofObligation obl, IEnumerable<IInferredCondition> calleeAssumes);
-
-    /// <summary>
-    /// Suggest the assumptions at entry point.
-    /// Returns how many assumptions have been suggested
-    /// </summary>
-    int SuggestEntryAssumes();
-
-    /// <summary>
-    /// Suggest the assumptions for calles
-    /// Returns how many assumptions have been suggested
-    /// </summary>
-    /// <returns></returns>
-    int SuggestCalleeAssumes(bool suggestCalleeAssumes, bool suggestNecessaryEnsures, bool includedisjunctions=false);
-
-    /// <summary>
-    /// Save assumes for later caching/baselining
-    /// </summary>
-    int PropagateAssumes();
-  }
-
-  #region Contracts
-
-  [ContractClassFor(typeof(IAssumeDispatcher))]
-  abstract class IAssumeDispatcherContracts : IAssumeDispatcher
-  {
-    public void AddEntryAssumes(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
+    [ContractClass(typeof(IAssumeDispatcherContracts))]
+    public interface IAssumeDispatcher
     {
-      Contract.Requires(obl != null);
-      Contract.Requires(assumes != null);
+        /// <summary>
+        /// Add the assume to the list of current assumptions
+        /// </summary>
+        void AddEntryAssumes(ProofObligation obl, IEnumerable<BoxedExpression> entryAssumes);
+
+        /// <summary>
+        /// Add the assume to the list of current assumptions
+        /// Returns the warning contexts for the methods referring to the warning contexts
+        /// </summary>
+        IEnumerable<WarningContext> AddCalleeAssumes(ProofObligation obl, IEnumerable<IInferredCondition> calleeAssumes);
+
+        /// <summary>
+        /// Suggest the assumptions at entry point.
+        /// Returns how many assumptions have been suggested
+        /// </summary>
+        int SuggestEntryAssumes();
+
+        /// <summary>
+        /// Suggest the assumptions for calles
+        /// Returns how many assumptions have been suggested
+        /// </summary>
+        /// <returns></returns>
+        int SuggestCalleeAssumes(bool suggestCalleeAssumes, bool suggestNecessaryEnsures, bool includedisjunctions = false);
+
+        /// <summary>
+        /// Save assumes for later caching/baselining
+        /// </summary>
+        int PropagateAssumes();
     }
 
-    public IEnumerable<WarningContext> AddCalleeAssumes(ProofObligation obl, IEnumerable<IInferredCondition> assumes)
+    #region Contracts
+
+    [ContractClassFor(typeof(IAssumeDispatcher))]
+    internal abstract class IAssumeDispatcherContracts : IAssumeDispatcher
     {
-      Contract.Requires(obl != null);
-      Contract.Requires(assumes != null);
+        public void AddEntryAssumes(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
+        {
+            Contract.Requires(obl != null);
+            Contract.Requires(assumes != null);
+        }
 
-      Contract.Ensures(Contract.Result<IEnumerable<WarningContext>>() != null);
+        public IEnumerable<WarningContext> AddCalleeAssumes(ProofObligation obl, IEnumerable<IInferredCondition> assumes)
+        {
+            Contract.Requires(obl != null);
+            Contract.Requires(assumes != null);
 
-      return null;
-    }
+            Contract.Ensures(Contract.Result<IEnumerable<WarningContext>>() != null);
+
+            return null;
+        }
 
 
-    public int SuggestEntryAssumes()
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
+        public int SuggestEntryAssumes()
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
 
-      return 0;
-    }
+            return 0;
+        }
 
-    public void PropagateAssumes()
-    {
-    }
+        public void PropagateAssumes()
+        {
+        }
 
-    int IAssumeDispatcher.PropagateAssumes()
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
+        int IAssumeDispatcher.PropagateAssumes()
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
 
-      throw new NotImplementedException();
-    }
+            throw new NotImplementedException();
+        }
 
-    public int SuggestCalleeAssumes(bool suggestCalleeAssumes, bool suggestNecessaryEnsures, bool includedisjunctions)
-    {
-      Contract.Requires(suggestCalleeAssumes || suggestNecessaryEnsures);
-      Contract.Ensures(Contract.Result<int>() >= 0);
+        public int SuggestCalleeAssumes(bool suggestCalleeAssumes, bool suggestNecessaryEnsures, bool includedisjunctions)
+        {
+            Contract.Requires(suggestCalleeAssumes || suggestNecessaryEnsures);
+            Contract.Ensures(Contract.Result<int>() >= 0);
 
-      return 0;
-    }
-  }
-  
-  #endregion
-
-  [ContractVerification(true)]
-  public class AssumeDispatcherProfiler
-    : IAssumeDispatcher
-  {
-    #region Object Invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.inner != null);
-      Contract.Invariant(this.profilingAlreadyCollected.Length == 2);
+            return 0;
+        }
     }
 
     #endregion
 
-    #region Statics
-
-    [ThreadStatic]
-    static private Statistics entryAssumeStatistics = new Statistics();
-    [ThreadStatic]
-    static private Statistics calleeAssumeStatistics = new Statistics();
-
-    #endregion
-
-    #region State
-
-    private readonly IAssumeDispatcher inner;
-    private readonly bool[] profilingAlreadyCollected;
-
-    #endregion
-
-    #region Constructor
-
-    public AssumeDispatcherProfiler(IAssumeDispatcher dispatcher)
+    [ContractVerification(true)]
+    public class AssumeDispatcherProfiler
+      : IAssumeDispatcher
     {
-      Contract.Requires(dispatcher != null);
+        #region Object Invariant
 
-      this.inner = dispatcher;
-      this.profilingAlreadyCollected = new bool[2];
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inner != null);
+            Contract.Invariant(profilingAlreadyCollected.Length == 2);
+        }
+
+        #endregion
+
+        #region Statics
+
+        [ThreadStatic]
+        static private Statistics entryAssumeStatistics = new Statistics();
+        [ThreadStatic]
+        static private Statistics calleeAssumeStatistics = new Statistics();
+
+        #endregion
+
+        #region State
+
+        private readonly IAssumeDispatcher inner;
+        private readonly bool[] profilingAlreadyCollected;
+
+        #endregion
+
+        #region Constructor
+
+        public AssumeDispatcherProfiler(IAssumeDispatcher dispatcher)
+        {
+            Contract.Requires(dispatcher != null);
+
+            inner = dispatcher;
+            profilingAlreadyCollected = new bool[2];
+        }
+
+        #endregion
+
+        #region Implementation of IPostCondtionDispatcher
+        public void AddEntryAssumes(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
+        {
+            entryAssumeStatistics.Generated += assumes.Count();
+            inner.AddEntryAssumes(obl, assumes);
+        }
+
+        public IEnumerable<WarningContext> AddCalleeAssumes(ProofObligation obl, IEnumerable<IInferredCondition> assumes)
+        {
+            calleeAssumeStatistics.Generated += assumes.Count();
+            return inner.AddCalleeAssumes(obl, assumes);
+        }
+
+        public int SuggestEntryAssumes()
+        {
+            return RecordProfilingInformation(inner.SuggestEntryAssumes(), 0, ref entryAssumeStatistics);
+        }
+
+        public int PropagateAssumes()
+        {
+            return RecordProfilingInformation(inner.PropagateAssumes(), 1, ref calleeAssumeStatistics);
+        }
+
+        public int SuggestCalleeAssumes(bool suggestCalleeAssumes, bool suggestNecessaryEnsures, bool includedisjunctions)
+        {
+            // We do not record the statistics, as we already do it when we propagate the assumptions
+            return inner.SuggestCalleeAssumes(suggestCalleeAssumes, suggestNecessaryEnsures, includedisjunctions);
+        }
+
+        #endregion
+
+        #region Dumping
+        public static void DumpStatistics(IOutput output)
+        {
+            Contract.Requires(output != null);
+
+            if (entryAssumeStatistics.Generated != 0)
+            {
+                output.WriteLine("Generated {0} entry assume(s) (suggested {1} after filtering)", entryAssumeStatistics.Generated, entryAssumeStatistics.Retained);
+            }
+            if (calleeAssumeStatistics.Generated != 0)
+            {
+                output.WriteLine("Generated {0} callee assume(s) ", calleeAssumeStatistics.Generated,
+                  calleeAssumeStatistics.Retained > 0 ? string.Format("suggested {0} after filtering", calleeAssumeStatistics.Retained) : String.Empty);
+            }
+        }
+
+        #endregion
+
+        #region Profiling
+
+        private int RecordProfilingInformation(int howMany, int who, ref Statistics statistics)
+        {
+            Contract.Requires(howMany >= 0);
+            Contract.Ensures(statistics.Retained >= Contract.OldValue(statistics.Retained));
+            Contract.Ensures(Contract.Result<int>() == howMany);
+
+            if (!profilingAlreadyCollected[who])
+            {
+                statistics.Retained += howMany;
+                profilingAlreadyCollected[who] = true;
+            }
+
+            return howMany;
+        }
+
+        #endregion
+
+
+
+
+        private struct Statistics
+        {
+            public int Generated;
+            public int Retained;
+        }
     }
-
-    #endregion
-
-    #region Implementation of IPostCondtionDispatcher
-    public void AddEntryAssumes(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
-    {
-      entryAssumeStatistics.Generated += assumes.Count();
-      this.inner.AddEntryAssumes(obl, assumes);
-    }
-
-    public IEnumerable<WarningContext> AddCalleeAssumes(ProofObligation obl, IEnumerable<IInferredCondition> assumes)
-    {
-      calleeAssumeStatistics.Generated += assumes.Count();
-      return this.inner.AddCalleeAssumes(obl, assumes);
-    }
-
-    public int SuggestEntryAssumes()
-    {
-      return RecordProfilingInformation(this.inner.SuggestEntryAssumes(), 0, ref entryAssumeStatistics);
-    }
-
-    public int PropagateAssumes()
-    {
-      return RecordProfilingInformation(this.inner.PropagateAssumes(), 1, ref calleeAssumeStatistics);
-    }
-
-    public int SuggestCalleeAssumes(bool suggestCalleeAssumes, bool suggestNecessaryEnsures, bool includedisjunctions)
-    {
-      // We do not record the statistics, as we already do it when we propagate the assumptions
-      return this.inner.SuggestCalleeAssumes(suggestCalleeAssumes, suggestNecessaryEnsures, includedisjunctions);
-    }
-
-    #endregion
-
-    #region Dumping
-    public static void DumpStatistics(IOutput output)
-    {
-      Contract.Requires(output != null);
-
-      if (entryAssumeStatistics.Generated != 0)
-      {
-        output.WriteLine("Generated {0} entry assume(s) (suggested {1} after filtering)", entryAssumeStatistics.Generated, entryAssumeStatistics.Retained);
-      }
-      if (calleeAssumeStatistics.Generated != 0)
-      {
-        output.WriteLine("Generated {0} callee assume(s) ", calleeAssumeStatistics.Generated, 
-          calleeAssumeStatistics.Retained > 0? string.Format("suggested {0} after filtering", calleeAssumeStatistics.Retained): String.Empty);
-      }
-
-    }
-
-    #endregion
-
-    #region Profiling
-
-    private int RecordProfilingInformation(int howMany, int who, ref Statistics statistics)
-    {
-      Contract.Requires(howMany >= 0);
-      Contract.Ensures(statistics.Retained >= Contract.OldValue(statistics.Retained));
-      Contract.Ensures(Contract.Result<int>() == howMany);
-
-      if (!this.profilingAlreadyCollected[who])
-      {
-        statistics.Retained += howMany;
-        this.profilingAlreadyCollected[who] = true;
-      }
-
-      return howMany;
-    }
-
-    #endregion
-
-
-
-
-    private struct Statistics
-    {
-      public int Generated;
-      public int Retained;
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Inference/CodeFixes.cs
+++ b/Microsoft.Research/CodeAnalysis/Inference/CodeFixes.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,552 +9,551 @@ using Microsoft.Research.CodeAnalysis.Expressions;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public enum CodeFixKind
-  {
-    ArrayInitialization,
-    ArrayOffByOne, 
-    ConstantInitialization, 
-    ExpressionInitialization, 
-    FloatingPointCast,
-    MethodCallResult, 
-    MethodCallResultNoCode, 
-    MethodShouldBePure,
-    NonOverflowingExpression, 
-    OffByOne, 
-    RemoveConstructor, 
-    StrengthenTest, 
-    Test, 
-    AssumeMethodResult, 
-    AssumeLocalInitialization,
-    BaselineAssume,
-  }
-
-  public interface ICodeFix
-  {
-    APC PC { get; }
-
-    ProofObligation Obligation { get; }
-
-    /// <returns>A string in the form "Code Fix: (some English explanation). Fix: [Add | Remove constructor] (some code) </returns>
-    string Suggest();
-    string SuggestCode();
-
-    string GetMessageForSourceObligation();
-
-    CodeFixKind Kind { get; }
-  }
-
-  public struct ParametersFixMethodCallReturnValue<Variable, ArgList, Method>
-    where ArgList : IIndexable<Variable>
-  {
-    private readonly IDecodeMethods<Method> mdDecoder;
-    public readonly ProofObligation obl;
-    public readonly APC pc;
-    public readonly Func<APC> pcWithSourceContext;
-    public readonly Variable dest;
-    public readonly ArgList args;
-    public readonly BoxedExpression condition;
-    public readonly List<BoxedExpression> premises;
-    public readonly Func<APC, Variable, FList<PathElement>> AccessPath;
-    public readonly Func<FList<PathElement>, bool> IsRootedInParameter;
-    public readonly Func<Variable, FList<PathElement>, BoxedExpression> MakeMethodCall;
-    public readonly Func<Variable, BoxedExpression> MakeEqualZero;
-    public readonly Method method;
-    public readonly Func<APC, BoxedExpression, bool, BoxedExpression> ReadAt;
-    public readonly ICFG cfg;
-
-    #region Constructor
-    public ParametersFixMethodCallReturnValue(ProofObligation obl, APC pc, Func<APC> pcWithSourceContext, Variable dest, ArgList args,
-      BoxedExpression condition, List<BoxedExpression> premises,
-      Method method,
-      IDecodeMethods<Method> mdDecoder,
-      ICFG cfg,
-      Func<APC,BoxedExpression,bool,BoxedExpression> ReadAt,
-      Func<APC, Variable, FList<PathElement>> AccessPath,
-      Func<FList<PathElement>, bool> IsRootedInParameter,
-      Func<Variable, FList<PathElement>, BoxedExpression> MakeMethodCall, Func<Variable, BoxedExpression> MakeEqualZero
-    )
+    public enum CodeFixKind
     {
-      Contract.Requires(mdDecoder != null);
-
-      this.obl = obl;
-      this.pc = pc;
-      this.pcWithSourceContext = pcWithSourceContext;
-      this.dest = dest;
-      this.args = args;
-      this.condition = condition;
-      this.premises = premises;
-      this.mdDecoder = mdDecoder;
-      this.cfg = cfg;
-      this.method = method;
-      this.ReadAt = ReadAt;
-      this.AccessPath = AccessPath;
-      this.IsRootedInParameter = IsRootedInParameter;
-      this.MakeMethodCall = MakeMethodCall;
-      this.MakeEqualZero = MakeEqualZero;
-    }
-    #endregion
-
-    public override string ToString()
-    {
-      return string.Format("Condition = {0}", condition);
+        ArrayInitialization,
+        ArrayOffByOne,
+        ConstantInitialization,
+        ExpressionInitialization,
+        FloatingPointCast,
+        MethodCallResult,
+        MethodCallResultNoCode,
+        MethodShouldBePure,
+        NonOverflowingExpression,
+        OffByOne,
+        RemoveConstructor,
+        StrengthenTest,
+        Test,
+        AssumeMethodResult,
+        AssumeLocalInitialization,
+        BaselineAssume,
     }
 
-    public bool CalleeIsProperty()
+    public interface ICodeFix
     {
-      Contract.Assume(this.mdDecoder != null);
-      return this.mdDecoder.IsPropertyGetter(this.method) || this.mdDecoder.IsPropertySetter(this.method);
+        APC PC { get; }
+
+        ProofObligation Obligation { get; }
+
+        /// <returns>A string in the form "Code Fix: (some English explanation). Fix: [Add | Remove constructor] (some code) </returns>
+        string Suggest();
+        string SuggestCode();
+
+        string GetMessageForSourceObligation();
+
+        CodeFixKind Kind { get; }
     }
 
-    public bool CalleeIsStaticMethod()
+    public struct ParametersFixMethodCallReturnValue<Variable, ArgList, Method>
+      where ArgList : IIndexable<Variable>
     {
-      Contract.Assume(this.mdDecoder != null);
-      return this.mdDecoder.IsStatic(this.method);
-    }
+        private readonly IDecodeMethods<Method> mdDecoder;
+        public readonly ProofObligation obl;
+        public readonly APC pc;
+        public readonly Func<APC> pcWithSourceContext;
+        public readonly Variable dest;
+        public readonly ArgList args;
+        public readonly BoxedExpression condition;
+        public readonly List<BoxedExpression> premises;
+        public readonly Func<APC, Variable, FList<PathElement>> AccessPath;
+        public readonly Func<FList<PathElement>, bool> IsRootedInParameter;
+        public readonly Func<Variable, FList<PathElement>, BoxedExpression> MakeMethodCall;
+        public readonly Func<Variable, BoxedExpression> MakeEqualZero;
+        public readonly Method method;
+        public readonly Func<APC, BoxedExpression, bool, BoxedExpression> ReadAt;
+        public readonly ICFG cfg;
 
-    public string MethodFullName()
-    {
-      Contract.Assume(this.mdDecoder != null);
-      return this.method != null ? this.mdDecoder.FullName(this.method) : null;
-    }
-    public string MethodName()
-    {
-      Contract.Assume(this.mdDecoder != null);
-      return this.method != null ? this.mdDecoder.Name(this.method) : null;
-    }
-
-  }
-
-  public struct ParametersSuggestNonOverflowingExpression<Variable>
-  {
-    public readonly APC pc;
-    public readonly APC pcWithSourceContext;
-    public readonly BoxedExpression exp;
-    public readonly IFactQuery<BoxedExpression, Variable> factQuery;
-    public readonly Func<APC, BoxedExpression, bool, BoxedExpression> Simplificator;
-    public readonly Func<Variable, IntervalStruct> TypeRange;
-
-    #region Constructor
-    public ParametersSuggestNonOverflowingExpression(APC pc, Func<APC, APC> pcWithSourceContext, BoxedExpression exp, IFactQuery<BoxedExpression, Variable> factQuery, Func<APC, BoxedExpression, bool, BoxedExpression> Simplificator, Func<Variable, IntervalStruct> TypeRange)
-    {
-      Contract.Requires(pcWithSourceContext != null);
-
-      this.pc = pc;
-      this.pcWithSourceContext = pcWithSourceContext(pc);
-      this.exp = exp;
-      this.factQuery = factQuery;
-      this.Simplificator = Simplificator;
-      this.TypeRange = TypeRange;
-    }
-    #endregion
-
-    public override string ToString()
-    {
-      return string.Format("Condition = {0}", this.exp);
-    }
-  }
-
-  public struct ParametersSuggestOffByOneFix<Variable>
-  {
-    public readonly ProofObligation obl;
-    public readonly APC pc;
-    public readonly APC pcWithSourceContext;
-    public readonly bool isArrayAccess;
-    public readonly BoxedExpression exp;
-    public readonly Func<Variable, FList<PathElement>> AccessPath;
-    public readonly Func<BoxedExpression, bool> IsArrayLength;
-    public readonly IFactQuery<BoxedExpression, Variable> factQuery;
-
-    #region Constructor
-    public ParametersSuggestOffByOneFix(ProofObligation obl, APC pc, Func<APC, APC> pcWithSourceContext, bool isArrayAccess, BoxedExpression exp, Func<Variable, FList<PathElement>> AccessPath, Func<BoxedExpression, bool> IsArrayLength, IFactQuery<BoxedExpression, Variable> factQuery)
-    {
-      Contract.Requires(pcWithSourceContext != null);
-
-      this.obl = obl;
-      this.pc = pc;
-      this.pcWithSourceContext = pcWithSourceContext(pc);
-      this.isArrayAccess = isArrayAccess;
-      this.exp = exp;
-      this.AccessPath = AccessPath;
-      this.IsArrayLength = IsArrayLength;
-      this.factQuery = factQuery;
-    }
-    #endregion
-
-    public override string ToString()
-    {
-      return string.Format("Condition = {0}", exp);
-    }
-  }
-
-  public struct InitializationFix<Variable>
-  {
-    public readonly ProofObligation obl;
-    public readonly APC pc;
-    private readonly BoxedExpression sourceExp;
-    public readonly Set<Variable> varsInSourceExp;
-    public readonly Variable dest;
-    private Optional<BoxedExpression> cached_SourceExp;
-
-    public InitializationFix(ProofObligation obl, APC pc, Variable dest, BoxedExpression sourceExp, Set<Variable> varsInSourceExp)
-    {
-      Contract.Requires(obl != null);
-      Contract.Requires(sourceExp != null);
-      Contract.Requires(varsInSourceExp != null);
-
-      this.obl = obl;
-      this.pc = pc;
-      this.dest = dest;
-      this.sourceExp = sourceExp;
-      this.varsInSourceExp = varsInSourceExp;
-      this.cached_SourceExp = default(Optional<BoxedExpression>);
-    }
-
-    public BoxedExpression SourceExp
-    {
-      get
-      {
-        if (!this.cached_SourceExp.IsValid)
+        #region Constructor
+        public ParametersFixMethodCallReturnValue(ProofObligation obl, APC pc, Func<APC> pcWithSourceContext, Variable dest, ArgList args,
+          BoxedExpression condition, List<BoxedExpression> premises,
+          Method method,
+          IDecodeMethods<Method> mdDecoder,
+          ICFG cfg,
+          Func<APC, BoxedExpression, bool, BoxedExpression> ReadAt,
+          Func<APC, Variable, FList<PathElement>> AccessPath,
+          Func<FList<PathElement>, bool> IsRootedInParameter,
+          Func<Variable, FList<PathElement>, BoxedExpression> MakeMethodCall, Func<Variable, BoxedExpression> MakeEqualZero
+        )
         {
-          var checkIsSourceLevelReadable = new SourceLevelReadableExpression<Variable>(null);
-          this.cached_SourceExp = checkIsSourceLevelReadable.Visit(this.sourceExp, new Void());
+            Contract.Requires(mdDecoder != null);
+
+            this.obl = obl;
+            this.pc = pc;
+            this.pcWithSourceContext = pcWithSourceContext;
+            this.dest = dest;
+            this.args = args;
+            this.condition = condition;
+            this.premises = premises;
+            this.mdDecoder = mdDecoder;
+            this.cfg = cfg;
+            this.method = method;
+            this.ReadAt = ReadAt;
+            this.AccessPath = AccessPath;
+            this.IsRootedInParameter = IsRootedInParameter;
+            this.MakeMethodCall = MakeMethodCall;
+            this.MakeEqualZero = MakeEqualZero;
+        }
+        #endregion
+
+        public override string ToString()
+        {
+            return string.Format("Condition = {0}", condition);
         }
 
-        return this.cached_SourceExp.Value;
-      }
-    }
-
-    public override string ToString()
-    {
-      return string.Format("fix of {0} init under condition {1}", dest, sourceExp);
-    }
-  }
-
-  public interface ICodeFixesManager
-  {
-    int SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Exp, Variable, ILogOptions>(
-          IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions> mdriver)
-          where Variable : IEquatable<Variable>
-          where Type : IEquatable<Type>
-          where ILogOptions : IFrameworkLogOptions;
-
-    bool TrySuggestInitializationFix<Variable>(ref InitializationFix<Variable> parameters);
-
-    bool TrySuggestConstantInititalizationFix(ProofObligation obl, APC pc, BoxedExpression dest, BoxedExpression oldInitialization, BoxedExpression newInitialization, BoxedExpression constraint);
-
-    bool TrySuggestConstantInitializationFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable>(
-      ProofObligation obl,
-      Func<APC> pc, BoxedExpression failingCondition, BoxedExpression falseCondition,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<Variable, BoxedExpression> VariableValueBeforeRenaming, Func<Variable, BoxedExpression> VariableName);
-
-    bool TrySuggestFixForMethodCallReturnValue<Variable, ArgList, Method>(ref ParametersFixMethodCallReturnValue<Variable, ArgList, Method> context)
-      where ArgList : IIndexable<Variable>;
-
-    bool TrySuggestLargerAllocation<Variable>(ProofObligation obl, Func<APC> definitionPC, APC failingConditionPC, BoxedExpression failingCondition, Variable array, Variable length, Func<Variable, BoxedExpression> Converter, IFactQuery<BoxedExpression, Variable> factQuery);
-      
-    bool TrySuggestTestFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      ProofObligation obl,
-      Func<APC> pc, BoxedExpression guard, BoxedExpression failingCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<BoxedExpression, bool> IsArrayLength);
-
-    bool TrySuggestTestStrengthening(
-      ProofObligation obl,
-      APC pc, BoxedExpression additionalGuard, bool strengthenNullCheck);
-
-    bool TrySuggestFloatingPointComparisonFix(
-      ProofObligation obl,
-      APC pc, BoxedExpression left, BoxedExpression right, ConcreteFloat leftType, ConcreteFloat rightType);
-
-    bool TrySuggestFixingConstructor(APC pc, string name, bool isConstructor, IEnumerable<MinimalProofObligation> obligations);
-
-    bool TrySuggestNonOverflowingExpression<Variable>(ref ParametersSuggestNonOverflowingExpression<Variable> context);
-
-    bool TrySuggestOffByOneFix<Variable>(ref ParametersSuggestOffByOneFix<Variable> context);
-
-    bool IsEnabled { get; }
-  }
-
-  /// <summary>
-  /// A code fix to embed an assumption
-  /// </summary>
-  public class AssumeCodeFix : ICodeFix
-  {
-    private readonly ProofObligation obl;
-
-    public AssumeCodeFix(ProofObligation obl)
-    {
-      Contract.Requires(obl != null);
-
-      this.obl = obl;
-    }
-
-    public string Suggest()
-    {
-      return string.Format("Entry point assumption. Fix: Add {0}", this.SuggestCode());
-    }
-
-    public string SuggestCode()
-    {
-      return string.Format("Contract.Assume({0});", obl.Condition);
-    }
-
-    public string GetMessageForSourceObligation()
-    {
-      return string.Format("The error arises when the following assumption does *not* hold on entry: {0}", obl.Condition);
-    }
-
-    public CodeFixKind Kind
-    {
-      get { return CodeFixKind.AssumeMethodResult; }
-    }
-
-    public APC PC
-    {
-      get { return this.obl.PC; }
-    }
-
-    public ProofObligation Obligation
-    {
-      get { return this.obl; }
-    }
-  }
-
-  public class CodeFixesProfiler
-    : ICodeFixesManager
-  {
-    #region Statics for profiling
-
-    [ThreadStatic]
-    static int InitializationFixes;
-    [ThreadStatic]
-    static int ReturnValuesFixes;
-    [ThreadStatic]
-    static int AllocationFixes;
-    [ThreadStatic]
-    static int TestFalseFixes;
-    [ThreadStatic]
-    static int TestStrenghteningFixes;
-    [ThreadStatic]
-    static int FloatComparisonMismatchesFixes;
-    [ThreadStatic]
-    static int RemoveConstructorFixes;
-    [ThreadStatic]
-    static int OverflowingExpressionFixes;
-    [ThreadStatic]
-    static int OffByOneFixes;
-
-    static int TotalFixesSuggested { get { return InitializationFixes + ReturnValuesFixes + AllocationFixes + TestFalseFixes + TestStrenghteningFixes + FloatComparisonMismatchesFixes + RemoveConstructorFixes + OverflowingExpressionFixes + OffByOneFixes; } }
-
-
-    public static void DumpStatistics(IOutput output)
-    {
-      Contract.Requires(output != null);
-
-      output.WriteLine("Detected {0} code fixes", TotalFixesSuggested);
-      output.WriteLine("Proof obligations with a code fix: {0}", ProofObligation.ProofObligationsWithCodeFix);
-    }
-
-    #endregion
-
-    #region Object invariant
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.inner != null);
-    }
-
-    #endregion
-
-    #region privates
-
-    readonly private ICodeFixesManager inner;
-    readonly private bool trace;
-
-    #endregion
-
-    #region Constructor
-
-    public CodeFixesProfiler(ICodeFixesManager inner, bool trace)
-    {
-      Contract.Requires(inner != null);
-      this.inner = inner;
-      this.trace = trace;
-    }
-
-    #endregion
-
-    #region Proxies
-    public int SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Exp, Variable, ILogOptions>(
-        IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions> mdriver)
-        where Variable : IEquatable<Variable>
-        where Type : IEquatable<Type>
-        where ILogOptions : IFrameworkLogOptions
-    {
-      return this.inner.SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions>(mdriver);
-    }
-
-    public bool TrySuggestInitializationFix<Variable>(ref InitializationFix<Variable> parameters)
-    {
-      return ProfileAndTrace("initialization", inner.TrySuggestInitializationFix(ref parameters), ref InitializationFixes);
-    }
-
-    public bool TrySuggestConstantInititalizationFix(ProofObligation obl, APC pc, BoxedExpression dest, BoxedExpression oldInitialization, BoxedExpression newInitialization, BoxedExpression constraint)
-    {
-      return ProfileAndTrace("Constant initialization", inner.TrySuggestConstantInititalizationFix(obl, pc, dest, oldInitialization, newInitialization, constraint), ref InitializationFixes);
-    }
-
-    public bool TrySuggestConstantInitializationFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable>(ProofObligation obl, Func<APC> pc, BoxedExpression failingCondition, BoxedExpression falseCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<Variable, BoxedExpression> VariableValueBeforeRenaming, Func<Variable, BoxedExpression> VariableName)
-    {
-      return ProfileAndTrace("Constant initialization", inner.TrySuggestConstantInitializationFix(obl, pc, failingCondition, falseCondition, metaDataDecoder, VariableValueBeforeRenaming, VariableName), ref InitializationFixes);
-    }
-
-    public bool TrySuggestFixForMethodCallReturnValue<Variable, ArgList, Method>(ref ParametersFixMethodCallReturnValue<Variable, ArgList, Method> context) where ArgList : IIndexable<Variable>
-    {
-      return ProfileAndTrace("Method call return value", inner.TrySuggestFixForMethodCallReturnValue(ref context), ref ReturnValuesFixes);
-    }
-
-    public bool TrySuggestLargerAllocation<Variable>(ProofObligation obl, Func<APC> pc, APC failingConditionPC, BoxedExpression failingCondition, Variable array, Variable length, Func<Variable, BoxedExpression> Converter, IFactQuery<BoxedExpression, Variable> factQuery)
-    {
-      return ProfileAndTrace("Larger allocation", inner.TrySuggestLargerAllocation(obl, pc, failingConditionPC, failingCondition, array, length, Converter, factQuery), ref AllocationFixes);
-    }
-
-    public bool TrySuggestTestFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(ProofObligation obl, Func<APC> pc, BoxedExpression guard, BoxedExpression failingCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<BoxedExpression, bool> IsArrayLength)
-    {
-      return ProfileAndTrace("Condition in a test", inner.TrySuggestTestFix(obl, pc, guard, failingCondition, metaDataDecoder, IsArrayLength), ref TestFalseFixes);
-    }
-
-    public bool TrySuggestTestStrengthening(ProofObligation obl, APC pc, BoxedExpression additionalGuard, bool strengthenNullCheck)
-    {
-      return ProfileAndTrace("Test strenghtening", inner.TrySuggestTestStrengthening(obl, pc, additionalGuard, strengthenNullCheck), ref TestStrenghteningFixes);
-    }
-
-    public bool TrySuggestFloatingPointComparisonFix(ProofObligation obl, APC pc, BoxedExpression left, BoxedExpression right, ConcreteFloat leftType, ConcreteFloat rightType)
-    {
-      return ProfileAndTrace("Floating point comparison", inner.TrySuggestFloatingPointComparisonFix(obl, pc, left, right, leftType, rightType), ref FloatComparisonMismatchesFixes);
-    }
-
-    public bool TrySuggestFixingConstructor(APC pc, string name, bool isConstructor, IEnumerable<MinimalProofObligation> obligations)
-    {
-      return ProfileAndTrace("Object constructor", inner.TrySuggestFixingConstructor(pc, name, isConstructor, obligations), ref RemoveConstructorFixes);
-    }
-
-    public bool TrySuggestNonOverflowingExpression<Variable>(ref ParametersSuggestNonOverflowingExpression<Variable> context)
-    {
-      return ProfileAndTrace("Non-overflowing expression", inner.TrySuggestNonOverflowingExpression(ref context), ref OverflowingExpressionFixes);
-    }
-
-    public bool TrySuggestOffByOneFix<Variable>(ref ParametersSuggestOffByOneFix<Variable> context)
-    {
-      return ProfileAndTrace("Off by one", inner.TrySuggestOffByOneFix(ref context), ref OffByOneFixes);
-    }
-    #endregion
-
-    #region Private
-
-    public bool ProfileAndTrace(string codefix, bool b, ref int value)
-    {
-      if (this.trace)
-      {
-        if (b)
+        public bool CalleeIsProperty()
         {
-          Console.WriteLine("  Found a code fix for {0}", codefix);
+            Contract.Assume(mdDecoder != null);
+            return mdDecoder.IsPropertyGetter(this.method) || mdDecoder.IsPropertySetter(this.method);
         }
-        else
+
+        public bool CalleeIsStaticMethod()
         {
-          Console.WriteLine("  Code fix inference for {0} failed", codefix);
+            Contract.Assume(mdDecoder != null);
+            return mdDecoder.IsStatic(this.method);
         }
-      }
 
-      return IncrementIfTrue(b, ref value);
+        public string MethodFullName()
+        {
+            Contract.Assume(mdDecoder != null);
+            return this.method != null ? mdDecoder.FullName(this.method) : null;
+        }
+        public string MethodName()
+        {
+            Contract.Assume(mdDecoder != null);
+            return this.method != null ? mdDecoder.Name(this.method) : null;
+        }
     }
 
-    private static bool IncrementIfTrue(bool b, ref int value)
+    public struct ParametersSuggestNonOverflowingExpression<Variable>
     {
-      if (b) value++;
+        public readonly APC pc;
+        public readonly APC pcWithSourceContext;
+        public readonly BoxedExpression exp;
+        public readonly IFactQuery<BoxedExpression, Variable> factQuery;
+        public readonly Func<APC, BoxedExpression, bool, BoxedExpression> Simplificator;
+        public readonly Func<Variable, IntervalStruct> TypeRange;
 
-      return b;
+        #region Constructor
+        public ParametersSuggestNonOverflowingExpression(APC pc, Func<APC, APC> pcWithSourceContext, BoxedExpression exp, IFactQuery<BoxedExpression, Variable> factQuery, Func<APC, BoxedExpression, bool, BoxedExpression> Simplificator, Func<Variable, IntervalStruct> TypeRange)
+        {
+            Contract.Requires(pcWithSourceContext != null);
+
+            this.pc = pc;
+            this.pcWithSourceContext = pcWithSourceContext(pc);
+            this.exp = exp;
+            this.factQuery = factQuery;
+            this.Simplificator = Simplificator;
+            this.TypeRange = TypeRange;
+        }
+        #endregion
+
+        public override string ToString()
+        {
+            return string.Format("Condition = {0}", this.exp);
+        }
     }
 
-    #endregion
-
-    public bool IsEnabled
+    public struct ParametersSuggestOffByOneFix<Variable>
     {
-      get { return this.inner.IsEnabled; }
-    }
-  }
+        public readonly ProofObligation obl;
+        public readonly APC pc;
+        public readonly APC pcWithSourceContext;
+        public readonly bool isArrayAccess;
+        public readonly BoxedExpression exp;
+        public readonly Func<Variable, FList<PathElement>> AccessPath;
+        public readonly Func<BoxedExpression, bool> IsArrayLength;
+        public readonly IFactQuery<BoxedExpression, Variable> factQuery;
 
-  [ContractVerification(false)]
-  public class DummyCodeFixesManager
-    : ICodeFixesManager
-  {
-    public int SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Exp, Variable, ILogOptions>(
-       IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions> mdriver)
-          where Variable : IEquatable<Variable>
-          where Type : IEquatable<Type>
-          where ILogOptions : IFrameworkLogOptions
+        #region Constructor
+        public ParametersSuggestOffByOneFix(ProofObligation obl, APC pc, Func<APC, APC> pcWithSourceContext, bool isArrayAccess, BoxedExpression exp, Func<Variable, FList<PathElement>> AccessPath, Func<BoxedExpression, bool> IsArrayLength, IFactQuery<BoxedExpression, Variable> factQuery)
+        {
+            Contract.Requires(pcWithSourceContext != null);
+
+            this.obl = obl;
+            this.pc = pc;
+            this.pcWithSourceContext = pcWithSourceContext(pc);
+            this.isArrayAccess = isArrayAccess;
+            this.exp = exp;
+            this.AccessPath = AccessPath;
+            this.IsArrayLength = IsArrayLength;
+            this.factQuery = factQuery;
+        }
+        #endregion
+
+        public override string ToString()
+        {
+            return string.Format("Condition = {0}", exp);
+        }
+    }
+
+    public struct InitializationFix<Variable>
     {
-      return 0;
+        public readonly ProofObligation obl;
+        public readonly APC pc;
+        private readonly BoxedExpression sourceExp;
+        public readonly Set<Variable> varsInSourceExp;
+        public readonly Variable dest;
+        private Optional<BoxedExpression> cached_SourceExp;
+
+        public InitializationFix(ProofObligation obl, APC pc, Variable dest, BoxedExpression sourceExp, Set<Variable> varsInSourceExp)
+        {
+            Contract.Requires(obl != null);
+            Contract.Requires(sourceExp != null);
+            Contract.Requires(varsInSourceExp != null);
+
+            this.obl = obl;
+            this.pc = pc;
+            this.dest = dest;
+            this.sourceExp = sourceExp;
+            this.varsInSourceExp = varsInSourceExp;
+            cached_SourceExp = default(Optional<BoxedExpression>);
+        }
+
+        public BoxedExpression SourceExp
+        {
+            get
+            {
+                if (!cached_SourceExp.IsValid)
+                {
+                    var checkIsSourceLevelReadable = new SourceLevelReadableExpression<Variable>(null);
+                    cached_SourceExp = checkIsSourceLevelReadable.Visit(sourceExp, new Void());
+                }
+
+                return cached_SourceExp.Value;
+            }
+        }
+
+        public override string ToString()
+        {
+            return string.Format("fix of {0} init under condition {1}", dest, sourceExp);
+        }
     }
 
-    public bool TrySuggestInitializationFix<Variable>(ref InitializationFix<Variable> parameters)
+    public interface ICodeFixesManager
     {
-      return false;
+        int SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Exp, Variable, ILogOptions>(
+              IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions> mdriver)
+              where Variable : IEquatable<Variable>
+              where Type : IEquatable<Type>
+              where ILogOptions : IFrameworkLogOptions;
+
+        bool TrySuggestInitializationFix<Variable>(ref InitializationFix<Variable> parameters);
+
+        bool TrySuggestConstantInititalizationFix(ProofObligation obl, APC pc, BoxedExpression dest, BoxedExpression oldInitialization, BoxedExpression newInitialization, BoxedExpression constraint);
+
+        bool TrySuggestConstantInitializationFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable>(
+          ProofObligation obl,
+          Func<APC> pc, BoxedExpression failingCondition, BoxedExpression falseCondition,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<Variable, BoxedExpression> VariableValueBeforeRenaming, Func<Variable, BoxedExpression> VariableName);
+
+        bool TrySuggestFixForMethodCallReturnValue<Variable, ArgList, Method>(ref ParametersFixMethodCallReturnValue<Variable, ArgList, Method> context)
+          where ArgList : IIndexable<Variable>;
+
+        bool TrySuggestLargerAllocation<Variable>(ProofObligation obl, Func<APC> definitionPC, APC failingConditionPC, BoxedExpression failingCondition, Variable array, Variable length, Func<Variable, BoxedExpression> Converter, IFactQuery<BoxedExpression, Variable> factQuery);
+
+        bool TrySuggestTestFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          ProofObligation obl,
+          Func<APC> pc, BoxedExpression guard, BoxedExpression failingCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<BoxedExpression, bool> IsArrayLength);
+
+        bool TrySuggestTestStrengthening(
+          ProofObligation obl,
+          APC pc, BoxedExpression additionalGuard, bool strengthenNullCheck);
+
+        bool TrySuggestFloatingPointComparisonFix(
+          ProofObligation obl,
+          APC pc, BoxedExpression left, BoxedExpression right, ConcreteFloat leftType, ConcreteFloat rightType);
+
+        bool TrySuggestFixingConstructor(APC pc, string name, bool isConstructor, IEnumerable<MinimalProofObligation> obligations);
+
+        bool TrySuggestNonOverflowingExpression<Variable>(ref ParametersSuggestNonOverflowingExpression<Variable> context);
+
+        bool TrySuggestOffByOneFix<Variable>(ref ParametersSuggestOffByOneFix<Variable> context);
+
+        bool IsEnabled { get; }
     }
 
-    public bool TrySuggestConstantInititalizationFix(ProofObligation obl, APC pc, BoxedExpression dest, BoxedExpression oldInitialization, BoxedExpression newInitialization, BoxedExpression constraint)
+    /// <summary>
+    /// A code fix to embed an assumption
+    /// </summary>
+    public class AssumeCodeFix : ICodeFix
     {
-      return false;
+        private readonly ProofObligation obl;
+
+        public AssumeCodeFix(ProofObligation obl)
+        {
+            Contract.Requires(obl != null);
+
+            this.obl = obl;
+        }
+
+        public string Suggest()
+        {
+            return string.Format("Entry point assumption. Fix: Add {0}", this.SuggestCode());
+        }
+
+        public string SuggestCode()
+        {
+            return string.Format("Contract.Assume({0});", obl.Condition);
+        }
+
+        public string GetMessageForSourceObligation()
+        {
+            return string.Format("The error arises when the following assumption does *not* hold on entry: {0}", obl.Condition);
+        }
+
+        public CodeFixKind Kind
+        {
+            get { return CodeFixKind.AssumeMethodResult; }
+        }
+
+        public APC PC
+        {
+            get { return obl.PC; }
+        }
+
+        public ProofObligation Obligation
+        {
+            get { return obl; }
+        }
     }
 
-    public bool TrySuggestConstantInitializationFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable>(ProofObligation obl, Func<APC> pc, BoxedExpression failingCondition, BoxedExpression falseCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<Variable, BoxedExpression> VariableValueBeforeRenaming, Func<Variable, BoxedExpression> VariableName)
+    public class CodeFixesProfiler
+      : ICodeFixesManager
     {
-      return false;
+        #region Statics for profiling
+
+        [ThreadStatic]
+        private static int InitializationFixes;
+        [ThreadStatic]
+        private static int ReturnValuesFixes;
+        [ThreadStatic]
+        private static int AllocationFixes;
+        [ThreadStatic]
+        private static int TestFalseFixes;
+        [ThreadStatic]
+        private static int TestStrenghteningFixes;
+        [ThreadStatic]
+        private static int FloatComparisonMismatchesFixes;
+        [ThreadStatic]
+        private static int RemoveConstructorFixes;
+        [ThreadStatic]
+        private static int OverflowingExpressionFixes;
+        [ThreadStatic]
+        private static int OffByOneFixes;
+
+        private static int TotalFixesSuggested { get { return InitializationFixes + ReturnValuesFixes + AllocationFixes + TestFalseFixes + TestStrenghteningFixes + FloatComparisonMismatchesFixes + RemoveConstructorFixes + OverflowingExpressionFixes + OffByOneFixes; } }
+
+
+        public static void DumpStatistics(IOutput output)
+        {
+            Contract.Requires(output != null);
+
+            output.WriteLine("Detected {0} code fixes", TotalFixesSuggested);
+            output.WriteLine("Proof obligations with a code fix: {0}", ProofObligation.ProofObligationsWithCodeFix);
+        }
+
+        #endregion
+
+        #region Object invariant
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inner != null);
+        }
+
+        #endregion
+
+        #region privates
+
+        readonly private ICodeFixesManager inner;
+        readonly private bool trace;
+
+        #endregion
+
+        #region Constructor
+
+        public CodeFixesProfiler(ICodeFixesManager inner, bool trace)
+        {
+            Contract.Requires(inner != null);
+            this.inner = inner;
+            this.trace = trace;
+        }
+
+        #endregion
+
+        #region Proxies
+        public int SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Exp, Variable, ILogOptions>(
+            IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions> mdriver)
+            where Variable : IEquatable<Variable>
+            where Type : IEquatable<Type>
+            where ILogOptions : IFrameworkLogOptions
+        {
+            return inner.SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions>(mdriver);
+        }
+
+        public bool TrySuggestInitializationFix<Variable>(ref InitializationFix<Variable> parameters)
+        {
+            return ProfileAndTrace("initialization", inner.TrySuggestInitializationFix(ref parameters), ref InitializationFixes);
+        }
+
+        public bool TrySuggestConstantInititalizationFix(ProofObligation obl, APC pc, BoxedExpression dest, BoxedExpression oldInitialization, BoxedExpression newInitialization, BoxedExpression constraint)
+        {
+            return ProfileAndTrace("Constant initialization", inner.TrySuggestConstantInititalizationFix(obl, pc, dest, oldInitialization, newInitialization, constraint), ref InitializationFixes);
+        }
+
+        public bool TrySuggestConstantInitializationFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable>(ProofObligation obl, Func<APC> pc, BoxedExpression failingCondition, BoxedExpression falseCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<Variable, BoxedExpression> VariableValueBeforeRenaming, Func<Variable, BoxedExpression> VariableName)
+        {
+            return ProfileAndTrace("Constant initialization", inner.TrySuggestConstantInitializationFix(obl, pc, failingCondition, falseCondition, metaDataDecoder, VariableValueBeforeRenaming, VariableName), ref InitializationFixes);
+        }
+
+        public bool TrySuggestFixForMethodCallReturnValue<Variable, ArgList, Method>(ref ParametersFixMethodCallReturnValue<Variable, ArgList, Method> context) where ArgList : IIndexable<Variable>
+        {
+            return ProfileAndTrace("Method call return value", inner.TrySuggestFixForMethodCallReturnValue(ref context), ref ReturnValuesFixes);
+        }
+
+        public bool TrySuggestLargerAllocation<Variable>(ProofObligation obl, Func<APC> pc, APC failingConditionPC, BoxedExpression failingCondition, Variable array, Variable length, Func<Variable, BoxedExpression> Converter, IFactQuery<BoxedExpression, Variable> factQuery)
+        {
+            return ProfileAndTrace("Larger allocation", inner.TrySuggestLargerAllocation(obl, pc, failingConditionPC, failingCondition, array, length, Converter, factQuery), ref AllocationFixes);
+        }
+
+        public bool TrySuggestTestFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(ProofObligation obl, Func<APC> pc, BoxedExpression guard, BoxedExpression failingCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<BoxedExpression, bool> IsArrayLength)
+        {
+            return ProfileAndTrace("Condition in a test", inner.TrySuggestTestFix(obl, pc, guard, failingCondition, metaDataDecoder, IsArrayLength), ref TestFalseFixes);
+        }
+
+        public bool TrySuggestTestStrengthening(ProofObligation obl, APC pc, BoxedExpression additionalGuard, bool strengthenNullCheck)
+        {
+            return ProfileAndTrace("Test strenghtening", inner.TrySuggestTestStrengthening(obl, pc, additionalGuard, strengthenNullCheck), ref TestStrenghteningFixes);
+        }
+
+        public bool TrySuggestFloatingPointComparisonFix(ProofObligation obl, APC pc, BoxedExpression left, BoxedExpression right, ConcreteFloat leftType, ConcreteFloat rightType)
+        {
+            return ProfileAndTrace("Floating point comparison", inner.TrySuggestFloatingPointComparisonFix(obl, pc, left, right, leftType, rightType), ref FloatComparisonMismatchesFixes);
+        }
+
+        public bool TrySuggestFixingConstructor(APC pc, string name, bool isConstructor, IEnumerable<MinimalProofObligation> obligations)
+        {
+            return ProfileAndTrace("Object constructor", inner.TrySuggestFixingConstructor(pc, name, isConstructor, obligations), ref RemoveConstructorFixes);
+        }
+
+        public bool TrySuggestNonOverflowingExpression<Variable>(ref ParametersSuggestNonOverflowingExpression<Variable> context)
+        {
+            return ProfileAndTrace("Non-overflowing expression", inner.TrySuggestNonOverflowingExpression(ref context), ref OverflowingExpressionFixes);
+        }
+
+        public bool TrySuggestOffByOneFix<Variable>(ref ParametersSuggestOffByOneFix<Variable> context)
+        {
+            return ProfileAndTrace("Off by one", inner.TrySuggestOffByOneFix(ref context), ref OffByOneFixes);
+        }
+        #endregion
+
+        #region Private
+
+        public bool ProfileAndTrace(string codefix, bool b, ref int value)
+        {
+            if (trace)
+            {
+                if (b)
+                {
+                    Console.WriteLine("  Found a code fix for {0}", codefix);
+                }
+                else
+                {
+                    Console.WriteLine("  Code fix inference for {0} failed", codefix);
+                }
+            }
+
+            return IncrementIfTrue(b, ref value);
+        }
+
+        private static bool IncrementIfTrue(bool b, ref int value)
+        {
+            if (b) value++;
+
+            return b;
+        }
+
+        #endregion
+
+        public bool IsEnabled
+        {
+            get { return inner.IsEnabled; }
+        }
     }
 
-    public bool TrySuggestFixForMethodCallReturnValue<Variable, ArgList, Method>(ref ParametersFixMethodCallReturnValue<Variable, ArgList, Method> context) where ArgList : IIndexable<Variable>
+    [ContractVerification(false)]
+    public class DummyCodeFixesManager
+      : ICodeFixesManager
     {
-      return false;
+        public int SuggestCodeFixes<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Exp, Variable, ILogOptions>(
+           IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, ExternalExpression<APC, Variable>, Variable, ILogOptions> mdriver)
+              where Variable : IEquatable<Variable>
+              where Type : IEquatable<Type>
+              where ILogOptions : IFrameworkLogOptions
+        {
+            return 0;
+        }
+
+        public bool TrySuggestInitializationFix<Variable>(ref InitializationFix<Variable> parameters)
+        {
+            return false;
+        }
+
+        public bool TrySuggestConstantInititalizationFix(ProofObligation obl, APC pc, BoxedExpression dest, BoxedExpression oldInitialization, BoxedExpression newInitialization, BoxedExpression constraint)
+        {
+            return false;
+        }
+
+        public bool TrySuggestConstantInitializationFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Variable>(ProofObligation obl, Func<APC> pc, BoxedExpression failingCondition, BoxedExpression falseCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<Variable, BoxedExpression> VariableValueBeforeRenaming, Func<Variable, BoxedExpression> VariableName)
+        {
+            return false;
+        }
+
+        public bool TrySuggestFixForMethodCallReturnValue<Variable, ArgList, Method>(ref ParametersFixMethodCallReturnValue<Variable, ArgList, Method> context) where ArgList : IIndexable<Variable>
+        {
+            return false;
+        }
+
+        public bool TrySuggestTestFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(ProofObligation obl, Func<APC> pc, BoxedExpression guard, BoxedExpression failingCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<BoxedExpression, bool> IsArrayLength)
+        {
+            return false;
+        }
+
+        public bool TrySuggestTestStrengthening(ProofObligation obl, APC pc, BoxedExpression additionalGuard, bool strengthenNullCheck)
+        {
+            return false;
+        }
+
+        public bool TrySuggestFloatingPointComparisonFix(ProofObligation obl, APC pc, BoxedExpression left, BoxedExpression right, ConcreteFloat leftType, ConcreteFloat rightType)
+        {
+            return false;
+        }
+
+        public bool TrySuggestFixingConstructor(APC pc, string name, bool isConstructor, IEnumerable<MinimalProofObligation> obligations)
+        {
+            return false;
+        }
+
+        public bool TrySuggestNonOverflowingExpression<Variable>(ref ParametersSuggestNonOverflowingExpression<Variable> context)
+        {
+            return false;
+        }
+
+        public bool TrySuggestOffByOneFix<Variable>(ref ParametersSuggestOffByOneFix<Variable> context)
+        {
+            return false;
+        }
+
+
+        public bool TrySuggestLargerAllocation<Variable>(ProofObligation obl, Func<APC> definitionPC, APC failingConditionPC, BoxedExpression failingCondition, Variable array, Variable length, Func<Variable, BoxedExpression> Converter, IFactQuery<BoxedExpression, Variable> factQuery)
+        {
+            return false;
+        }
+
+
+        public bool IsEnabled
+        {
+            get { return false; }
+        }
     }
-
-    public bool TrySuggestTestFix<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(ProofObligation obl, Func<APC> pc, BoxedExpression guard, BoxedExpression failingCondition, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder, Func<BoxedExpression, bool> IsArrayLength)
-    {
-      return false;
-    }
-
-    public bool TrySuggestTestStrengthening(ProofObligation obl, APC pc, BoxedExpression additionalGuard, bool strengthenNullCheck)
-    {
-      return false;
-    }
-
-    public bool TrySuggestFloatingPointComparisonFix(ProofObligation obl, APC pc, BoxedExpression left, BoxedExpression right, ConcreteFloat leftType, ConcreteFloat rightType)
-    {
-      return false;
-    }
-
-    public bool TrySuggestFixingConstructor(APC pc, string name, bool isConstructor, IEnumerable<MinimalProofObligation> obligations)
-    {
-      return false;
-    }
-
-    public bool TrySuggestNonOverflowingExpression<Variable>(ref ParametersSuggestNonOverflowingExpression<Variable> context)
-    {
-      return false;
-    }
-
-    public bool TrySuggestOffByOneFix<Variable>(ref ParametersSuggestOffByOneFix<Variable> context)
-    {
-      return false;
-    }
-
-
-    public bool TrySuggestLargerAllocation<Variable>(ProofObligation obl, Func<APC> definitionPC, APC failingConditionPC, BoxedExpression failingCondition, Variable array, Variable length, Func<Variable, BoxedExpression> Converter, IFactQuery<BoxedExpression, Variable> factQuery)
-    {
-      return false;
-    }
-
-
-    public bool IsEnabled
-    {
-      get { return false; }
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Inference/Contracts.cs
+++ b/Microsoft.Research/CodeAnalysis/Inference/Contracts.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,125 +10,124 @@ using Microsoft.Research.CodeAnalysis.Expressions;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  [ContractVerification(true)]
-  public class ContractInferenceManager
-  {
-    #region Object Invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariantMethod()
+    [ContractVerification(true)]
+    public class ContractInferenceManager
     {
-      Contract.Invariant(this.PreCondition != null);
-      Contract.Invariant(this.Assumptions != null);
-      Contract.Invariant(this.OverriddenMethodPreconditionDispatcher != null);
-      Contract.Invariant(this.Output != null);
+        #region Object Invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariantMethod()
+        {
+            Contract.Invariant(this.PreCondition != null);
+            Contract.Invariant(this.Assumptions != null);
+            Contract.Invariant(this.OverriddenMethodPreconditionDispatcher != null);
+            Contract.Invariant(this.Output != null);
+        }
+
+        #endregion
+
+        #region State
+
+        readonly public bool CanAddPreconditions;
+        readonly public PreconditionInferenceManager PreCondition;
+        readonly public IObjectInvariantDispatcher ObjectInvariant;
+        readonly public IPostconditionDispatcher PostCondition;
+        readonly public IAssumeDispatcher Assumptions;
+        readonly public ICodeFixesManager CodeFixesManager;
+        readonly public IOverriddenMethodPreconditionsDispatcher OverriddenMethodPreconditionDispatcher;
+
+        readonly public IOutput Output;
+
+        #endregion
+
+        #region Constructor
+
+        public ContractInferenceManager(bool CanAddPreconditions, IOverriddenMethodPreconditionsDispatcher overriddenMethodPreconditionsDispatcher, PreconditionInferenceManager precondition, IObjectInvariantDispatcher invariants, IPostconditionDispatcher postcondition, IAssumeDispatcher assumptions, ICodeFixesManager codefixesManager, IOutput output)
+        {
+            Contract.Requires(overriddenMethodPreconditionsDispatcher != null);
+            Contract.Requires(precondition != null);
+            Contract.Requires(invariants != null);
+            Contract.Requires(postcondition != null);
+            Contract.Requires(assumptions != null);
+            Contract.Requires(codefixesManager != null);
+            Contract.Requires(output != null);
+
+            this.CanAddPreconditions = CanAddPreconditions;
+            this.OverriddenMethodPreconditionDispatcher = overriddenMethodPreconditionsDispatcher;
+            this.PreCondition = precondition;
+            this.ObjectInvariant = invariants;
+            this.PostCondition = postcondition;
+            this.Assumptions = assumptions;
+            this.CodeFixesManager = codefixesManager;
+            this.Output = output;
+        }
+
+        #endregion
+
+        #region AddPreconditionOrAssume
+
+        public ProofOutcome AddPreconditionOrAssume(ProofObligation obl, IEnumerable<BoxedExpression> conditions, ProofOutcome outcome = ProofOutcome.Top)
+        {
+            Contract.Requires(conditions != null);
+            Contract.Requires(obl != null);
+
+            if (this.CanAddPreconditions)
+            {
+                Contract.Assume(this.PreCondition.Dispatch != null);
+                return this.PreCondition.Dispatch.AddPreconditions(obl, conditions, outcome);
+            }
+            else
+            {
+                this.Assumptions.AddEntryAssumes(obl, conditions);
+                this.OverriddenMethodPreconditionDispatcher.AddPotentialPreconditions(obl, conditions);
+
+                return outcome;
+            }
+        }
+
+        #endregion
+
+        #region Questions
+
+        public bool SuggestInferredRequires
+        {
+            get
+            {
+                return this.Output.LogOptions.SuggestRequires;
+            }
+        }
+
+        public bool SuggestInferredEnsures(bool isProperty)
+        {
+            return this.Output.LogOptions.SuggestEnsures(isProperty);
+        }
+
+        public bool PropagateInferredRequires(bool isProperty)
+        {
+            return this.Output.LogOptions.PropagateInferredRequires(isProperty);
+        }
+
+        public bool PropagateInferredEnsures(bool isProperty)
+        {
+            return this.Output.LogOptions.PropagateInferredEnsures(isProperty);
+        }
+
+        public bool InferPreconditionsFromPostconditions
+        {
+            get
+            {
+                return this.Output.LogOptions.InferPreconditionsFromPostconditions;
+            }
+        }
+
+        public bool CheckFalsePostconditions
+        {
+            get
+            {
+                return this.Output.LogOptions.CheckFalsePostconditions;
+            }
+        }
+
+        #endregion
     }
-    
-    #endregion
-
-    #region State
-
-    readonly public bool CanAddPreconditions;
-    readonly public PreconditionInferenceManager PreCondition;
-    readonly public IObjectInvariantDispatcher ObjectInvariant;
-    readonly public IPostconditionDispatcher PostCondition;
-    readonly public IAssumeDispatcher Assumptions;
-    readonly public ICodeFixesManager CodeFixesManager;
-    readonly public IOverriddenMethodPreconditionsDispatcher OverriddenMethodPreconditionDispatcher;
-
-    readonly public IOutput Output;
-
-    #endregion
-
-    #region Constructor
-
-    public ContractInferenceManager(bool CanAddPreconditions, IOverriddenMethodPreconditionsDispatcher overriddenMethodPreconditionsDispatcher, PreconditionInferenceManager precondition, IObjectInvariantDispatcher invariants, IPostconditionDispatcher postcondition, IAssumeDispatcher assumptions, ICodeFixesManager codefixesManager, IOutput output)
-    {
-      Contract.Requires(overriddenMethodPreconditionsDispatcher != null);
-      Contract.Requires(precondition != null);
-      Contract.Requires(invariants != null);
-      Contract.Requires(postcondition  != null);
-      Contract.Requires(assumptions != null);
-      Contract.Requires(codefixesManager != null);
-      Contract.Requires(output != null);
-
-      this.CanAddPreconditions = CanAddPreconditions;
-      this.OverriddenMethodPreconditionDispatcher = overriddenMethodPreconditionsDispatcher;
-      this.PreCondition = precondition;
-      this.ObjectInvariant = invariants;
-      this.PostCondition = postcondition;
-      this.Assumptions = assumptions;
-      this.CodeFixesManager = codefixesManager;
-      this.Output = output;
-    }
-
-    #endregion
-
-    #region AddPreconditionOrAssume
-
-    public ProofOutcome AddPreconditionOrAssume(ProofObligation obl, IEnumerable<BoxedExpression> conditions, ProofOutcome outcome = ProofOutcome.Top)
-    {
-      Contract.Requires(conditions != null);
-      Contract.Requires(obl != null);
-
-      if (this.CanAddPreconditions)
-      {
-        Contract.Assume(this.PreCondition.Dispatch != null);
-        return this.PreCondition.Dispatch.AddPreconditions(obl, conditions, outcome);
-      }
-      else
-      {
-        this.Assumptions.AddEntryAssumes(obl, conditions);
-        this.OverriddenMethodPreconditionDispatcher.AddPotentialPreconditions(obl, conditions);
-
-        return outcome;
-      }
-    }
-
-    #endregion
-
-    #region Questions
-
-    public bool SuggestInferredRequires
-    {
-      get
-      {
-        return this.Output.LogOptions.SuggestRequires;
-      }
-    }
-
-    public bool SuggestInferredEnsures(bool isProperty)
-    {
-      return this.Output.LogOptions.SuggestEnsures(isProperty);
-    }
-
-    public bool PropagateInferredRequires(bool isProperty)
-    {
-      return this.Output.LogOptions.PropagateInferredRequires(isProperty);
-    }
-
-    public bool PropagateInferredEnsures(bool isProperty)
-    {
-      return this.Output.LogOptions.PropagateInferredEnsures(isProperty);
-    }
-
-    public bool InferPreconditionsFromPostconditions
-    {
-      get
-      {
-        return this.Output.LogOptions.InferPreconditionsFromPostconditions;
-      }
-    }
-
-    public bool CheckFalsePostconditions
-    {
-      get
-      {
-        return this.Output.LogOptions.CheckFalsePostconditions;
-      }
-    }
-
-    #endregion
-  }
 }
-   

--- a/Microsoft.Research/CodeAnalysis/Inference/ObjectInvariants.cs
+++ b/Microsoft.Research/CodeAnalysis/Inference/ObjectInvariants.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,151 +9,150 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  [ContractClass(typeof(IObjectInvarariantDispatcherContracts))]
-  public interface IObjectInvariantDispatcher
-  {
-    /// <summary>
-    /// Add the object invariants to the list of current object invariants
-    /// </summary>
-    ProofOutcome AddObjectInvariants(ProofObligation obl, IEnumerable<BoxedExpression> objectInvariants, ProofOutcome originalOutcome);
-
-    /// <summary>
-    /// Returns the list of object invariants for this method
-    /// </summary>
-    IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GenerateObjectInvariants();
-
-    /// <summary>
-    /// Suggest the object invariants.
-    /// Returns how many object invariants have been suggested
-    /// </summary>
-    int SuggestObjectInvariants();
-
-    /// <summary>
-    /// Infer the object invariants.
-    /// Returns how many object invariants have been propagated to the callers
-    /// </summary>
-    /// <param name="asInvariant">if true, install as an invariant, otherwise as an assume</param>
-    int PropagateObjectInvariants(bool asInvariant);
-  }
-
-  #region Contracts
- 
-  [ContractClassFor(typeof(IObjectInvariantDispatcher))]
-  abstract class IObjectInvarariantDispatcherContracts : IObjectInvariantDispatcher
-  {
-    public ProofOutcome AddObjectInvariants(ProofObligation obl, IEnumerable<BoxedExpression> objectInvariants, ProofOutcome originalOutcome)
+    [ContractClass(typeof(IObjectInvarariantDispatcherContracts))]
+    public interface IObjectInvariantDispatcher
     {
-      Contract.Requires(obl != null);
-      Contract.Requires(objectInvariants != null);
+        /// <summary>
+        /// Add the object invariants to the list of current object invariants
+        /// </summary>
+        ProofOutcome AddObjectInvariants(ProofObligation obl, IEnumerable<BoxedExpression> objectInvariants, ProofOutcome originalOutcome);
 
-      return ProofOutcome.Top;
+        /// <summary>
+        /// Returns the list of object invariants for this method
+        /// </summary>
+        IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GenerateObjectInvariants();
+
+        /// <summary>
+        /// Suggest the object invariants.
+        /// Returns how many object invariants have been suggested
+        /// </summary>
+        int SuggestObjectInvariants();
+
+        /// <summary>
+        /// Infer the object invariants.
+        /// Returns how many object invariants have been propagated to the callers
+        /// </summary>
+        /// <param name="asInvariant">if true, install as an invariant, otherwise as an assume</param>
+        int PropagateObjectInvariants(bool asInvariant);
     }
 
-    public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GenerateObjectInvariants()
+    #region Contracts
+
+    [ContractClassFor(typeof(IObjectInvariantDispatcher))]
+    internal abstract class IObjectInvarariantDispatcherContracts : IObjectInvariantDispatcher
     {
-      Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>>() != null);
+        public ProofOutcome AddObjectInvariants(ProofObligation obl, IEnumerable<BoxedExpression> objectInvariants, ProofOutcome originalOutcome)
+        {
+            Contract.Requires(obl != null);
+            Contract.Requires(objectInvariants != null);
 
-      return null;
-    }
+            return ProofOutcome.Top;
+        }
 
-    public int SuggestObjectInvariants()
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
+        public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GenerateObjectInvariants()
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>>() != null);
 
-      return 0;
-    }
+            return null;
+        }
 
-    public int PropagateObjectInvariants(bool asInvariant)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
+        public int SuggestObjectInvariants()
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
 
-      return 0;
-    }
-  }
+            return 0;
+        }
 
-  #endregion
+        public int PropagateObjectInvariants(bool asInvariant)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
 
-  public class ObjectInvariantDispatcherProfiler : IObjectInvariantDispatcher
-  {
-
-    #region statics
-
-    [ThreadStatic]
-    static int retained;
-    [ThreadStatic]
-    static int generated;
-
-    #endregion
-
-    #region Private state
-
-    readonly IObjectInvariantDispatcher inner;
-    bool statsEmitted;
-
-    #endregion
-
-    #region Constructor
-
-    public ObjectInvariantDispatcherProfiler(IObjectInvariantDispatcher inner)
-    {
-      Contract.Requires(inner != null);
-
-      this.inner = inner;
-      this.statsEmitted = false;
-    }
-    
-    #endregion
-
-    #region Implementation
-    public ProofOutcome AddObjectInvariants(ProofObligation obl, IEnumerable<BoxedExpression> objectInvariants, ProofOutcome originalOutcome)
-    {
-      generated += objectInvariants.Count();
-      return this.inner.AddObjectInvariants(obl, objectInvariants, originalOutcome);
-    }
-
-    public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GenerateObjectInvariants()
-    {
-      var result = this.inner.GenerateObjectInvariants();
-      AddStatisticsForObjectInvariants(result.Count());
-
-      return result;
-    }
-
-    public int SuggestObjectInvariants()
-    {
-      return AddStatisticsForObjectInvariants(this.inner.SuggestObjectInvariants());
-    }
-
-    public int PropagateObjectInvariants(bool asInvariant)
-    {
-      return AddStatisticsForObjectInvariants(this.inner.PropagateObjectInvariants(asInvariant));
+            return 0;
+        }
     }
 
     #endregion
 
-    #region Dumping
-    public static void DumpStatistics(IOutput output)
+    public class ObjectInvariantDispatcherProfiler : IObjectInvariantDispatcher
     {
-      Contract.Requires(output != null);
+        #region statics
 
-      output.WriteLine("Inferred {0} object invariants", generated);
-      output.WriteLine("Retained {0} object invariants after filtering", retained);
+        [ThreadStatic]
+        private static int retained;
+        [ThreadStatic]
+        private static int generated;
+
+        #endregion
+
+        #region Private state
+
+        private readonly IObjectInvariantDispatcher inner;
+        private bool statsEmitted;
+
+        #endregion
+
+        #region Constructor
+
+        public ObjectInvariantDispatcherProfiler(IObjectInvariantDispatcher inner)
+        {
+            Contract.Requires(inner != null);
+
+            this.inner = inner;
+            statsEmitted = false;
+        }
+
+        #endregion
+
+        #region Implementation
+        public ProofOutcome AddObjectInvariants(ProofObligation obl, IEnumerable<BoxedExpression> objectInvariants, ProofOutcome originalOutcome)
+        {
+            generated += objectInvariants.Count();
+            return inner.AddObjectInvariants(obl, objectInvariants, originalOutcome);
+        }
+
+        public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GenerateObjectInvariants()
+        {
+            var result = inner.GenerateObjectInvariants();
+            AddStatisticsForObjectInvariants(result.Count());
+
+            return result;
+        }
+
+        public int SuggestObjectInvariants()
+        {
+            return AddStatisticsForObjectInvariants(inner.SuggestObjectInvariants());
+        }
+
+        public int PropagateObjectInvariants(bool asInvariant)
+        {
+            return AddStatisticsForObjectInvariants(inner.PropagateObjectInvariants(asInvariant));
+        }
+
+        #endregion
+
+        #region Dumping
+        public static void DumpStatistics(IOutput output)
+        {
+            Contract.Requires(output != null);
+
+            output.WriteLine("Inferred {0} object invariants", generated);
+            output.WriteLine("Retained {0} object invariants after filtering", retained);
+        }
+
+        #endregion
+
+        #region Private
+
+        private int AddStatisticsForObjectInvariants(int p)
+        {
+            if (!statsEmitted)
+            {
+                retained += p;
+                statsEmitted = true;
+            }
+
+            return p;
+        }
+        #endregion
     }
-
-    #endregion
-
-    #region Private
-
-    private int AddStatisticsForObjectInvariants(int p)
-    {
-      if (!this.statsEmitted)
-      {
-        retained += p;
-        this.statsEmitted = true;
-      }
-
-      return p;
-    }
-    #endregion
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Inference/OverriddenPreconditions.cs
+++ b/Microsoft.Research/CodeAnalysis/Inference/OverriddenPreconditions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,132 +9,132 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// The manager for candidate postconditions
-  /// </summary>
-  [ContractClass(typeof(IOverriddenMethodPreconditionsDispatcherContracts))]
-  public interface IOverriddenMethodPreconditionsDispatcher
-  {
     /// <summary>
-    /// Add the assume to the list of current assumptions
+    /// The manager for candidate postconditions
     /// </summary>
-    void AddPotentialPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions);
-
-    /// <summary>
-    /// Suggest the assumptions.
-    /// Returns how many assumptions have been suggested
-    /// </summary>
-    int SuggestPotentialPreconditions(IOutput output);
-  }
-
-  #region Contracts
-
-  [ContractClassFor(typeof(IOverriddenMethodPreconditionsDispatcher))]
-  abstract class IOverriddenMethodPreconditionsDispatcherContracts : IOverriddenMethodPreconditionsDispatcher
-  {
-    public void AddPotentialPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
+    [ContractClass(typeof(IOverriddenMethodPreconditionsDispatcherContracts))]
+    public interface IOverriddenMethodPreconditionsDispatcher
     {
-      Contract.Requires(obl != null);
-      Contract.Requires(assumes != null);
+        /// <summary>
+        /// Add the assume to the list of current assumptions
+        /// </summary>
+        void AddPotentialPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions);
+
+        /// <summary>
+        /// Suggest the assumptions.
+        /// Returns how many assumptions have been suggested
+        /// </summary>
+        int SuggestPotentialPreconditions(IOutput output);
     }
 
-    public int SuggestPotentialPreconditions(IOutput output)
+    #region Contracts
+
+    [ContractClassFor(typeof(IOverriddenMethodPreconditionsDispatcher))]
+    internal abstract class IOverriddenMethodPreconditionsDispatcherContracts : IOverriddenMethodPreconditionsDispatcher
     {
-      Contract.Requires(output != null);
-      Contract.Ensures(Contract.Result<int>() >= 0);
+        public void AddPotentialPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
+        {
+            Contract.Requires(obl != null);
+            Contract.Requires(assumes != null);
+        }
 
-      return 0;
-    }
-  }
+        public int SuggestPotentialPreconditions(IOutput output)
+        {
+            Contract.Requires(output != null);
+            Contract.Ensures(Contract.Result<int>() >= 0);
 
-  #endregion
-
-  [ContractVerification(true)]
-  public class OverriddenMethodPreconditionsDispatcherProfiler
-    : IOverriddenMethodPreconditionsDispatcher
-  {
-    #region Object Invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.inner != null);
+            return 0;
+        }
     }
 
     #endregion
 
-    #region Statics
-
-    [ThreadStatic]
-    static private int generated;
-    [ThreadStatic]
-    static private int retained;
-
-    #endregion
-
-    #region State
-
-    private readonly IOverriddenMethodPreconditionsDispatcher inner;
-    private bool profilingAlreadyCollected;
-
-    #endregion
-
-    #region Constructor
-
-    public OverriddenMethodPreconditionsDispatcherProfiler(IOverriddenMethodPreconditionsDispatcher dispatcher)
+    [ContractVerification(true)]
+    public class OverriddenMethodPreconditionsDispatcherProfiler
+      : IOverriddenMethodPreconditionsDispatcher
     {
-      Contract.Requires(dispatcher != null);
+        #region Object Invariant
 
-      this.inner = dispatcher;
-      this.profilingAlreadyCollected = false;
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inner != null);
+        }
+
+        #endregion
+
+        #region Statics
+
+        [ThreadStatic]
+        static private int generated;
+        [ThreadStatic]
+        static private int retained;
+
+        #endregion
+
+        #region State
+
+        private readonly IOverriddenMethodPreconditionsDispatcher inner;
+        private bool profilingAlreadyCollected;
+
+        #endregion
+
+        #region Constructor
+
+        public OverriddenMethodPreconditionsDispatcherProfiler(IOverriddenMethodPreconditionsDispatcher dispatcher)
+        {
+            Contract.Requires(dispatcher != null);
+
+            inner = dispatcher;
+            profilingAlreadyCollected = false;
+        }
+
+        #endregion
+
+        #region Implementation of IPostCondtionDispatcher
+        public void AddPotentialPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
+        {
+            generated += assumes.Count();
+            inner.AddPotentialPreconditions(obl, assumes);
+        }
+
+        public int SuggestPotentialPreconditions(IOutput output)
+        {
+            return RecordProfilingInformation(inner.SuggestPotentialPreconditions(output));
+        }
+
+        #endregion
+
+        #region Dumping
+        public static void DumpStatistics(IOutput output)
+        {
+            Contract.Requires(output != null);
+
+            if (generated != 0)
+            {
+                output.WriteLine("Detected {0} preconditions for base methods to suggest", generated);
+            }
+        }
+
+        #endregion
+
+        #region Profiling
+
+        private int RecordProfilingInformation(int howMany)
+        {
+            Contract.Requires(howMany >= 0);
+            Contract.Ensures(retained >= Contract.OldValue(retained));
+            Contract.Ensures(Contract.Result<int>() == howMany);
+
+            if (!profilingAlreadyCollected)
+            {
+                retained += howMany;
+                profilingAlreadyCollected = true;
+            }
+
+            return howMany;
+        }
+
+        #endregion
     }
-
-    #endregion
-
-    #region Implementation of IPostCondtionDispatcher
-    public void AddPotentialPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> assumes)
-    {
-      generated += assumes.Count();
-      this.inner.AddPotentialPreconditions(obl, assumes);
-    }
-
-    public int SuggestPotentialPreconditions(IOutput output)
-    {
-      return RecordProfilingInformation(this.inner.SuggestPotentialPreconditions(output));
-    }
-
-    #endregion
-
-    #region Dumping
-    public static void DumpStatistics(IOutput output)
-    {
-      Contract.Requires(output != null);
-
-      if (generated != 0)
-      {
-        output.WriteLine("Detected {0} preconditions for base methods to suggest", generated);
-      }
-    }
-
-    #endregion
-
-    #region Profiling
-
-    private int RecordProfilingInformation(int howMany)
-    {
-      Contract.Requires(howMany >= 0);
-      Contract.Ensures(retained >= Contract.OldValue(retained));
-      Contract.Ensures(Contract.Result<int>() == howMany);
-
-      if (!this.profilingAlreadyCollected)
-      {
-        retained += howMany;
-        this.profilingAlreadyCollected = true;
-      }
-
-      return howMany;
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Inference/Postconditions.cs
+++ b/Microsoft.Research/CodeAnalysis/Inference/Postconditions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,288 +10,288 @@ using System.IO;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// The manager for candidate postconditions
-  /// </summary>
-  [ContractClass(typeof(IPostConditionDispatcherContracts))]
-  public interface IPostconditionDispatcher
-  {
     /// <summary>
-    /// Add the postcondition to the list of current preconditions
+    /// The manager for candidate postconditions
     /// </summary>
-    void AddPostconditions(IEnumerable<BoxedExpression> postconditions);
-
-    /// <summary>
-    /// Report, for the given method, the set of non-null fields as inferred
-    /// </summary>
-    void AddNonNullFields(object method, IEnumerable<object> fields);
-
-    /// <summary>
-    /// Get the non-null fields at the method exit point
-    /// </summary>
-    IEnumerable<object> GetNonNullFields(object method);
-
-    /// <summary>
-    /// Returns the list of precondition for this method
-    /// </summary>
-    List<BoxedExpression> GeneratePostconditions();
-
-    /// <summary>
-    /// Suggest the postcondition.
-    /// Returns how many preconditions have been suggested
-    /// </summary>
-    int SuggestPostconditions();
-
-    /// <summary>
-    /// Suggests the postconditions for the constructors of the type currently analyzed
-    /// </summary>
-    int SuggestNonNullFieldsForConstructors();
-
-    /// <summary>
-    /// When all the constructors of a given type are analyzed, it gets the != null object invariants
-    /// </summary>
-    /// <returns></returns>
-    IEnumerable<BoxedExpression> SuggestNonNullObjectInvariantsFromConstructorsForward(bool doNotRecord = false);
-
-    /// <summary>
-    /// Infer the postcondition.
-    /// Returns how many postconditionss have been propagated to the callers
-    /// </summary>
-    int PropagatePostconditions();
-
-    /// <summary>
-    /// Infer postconditions for autoproperties, i.e., if we detect this.F != null, then it will attach the postcondition result != null to the autoproperty F
-    /// Returns how many postconditions have been installed
-    /// </summary>
-    /// <returns></returns>
-    int PropagatePostconditionsForProperties();
-
-    /// <summary>
-    /// Returns true if the method may return null directly (e.g. "return null" or indirectly (e.g., "return foo()" and we know that foo may return null)
-    /// </summary>
-    /// <returns></returns>
-    bool MayReturnNull(IFact facts, TimeOutChecker timeout);
-
-    /// <summary>
-    /// If we infer false for the method, and it contains user-postconditions, warn the user
-    /// </summary>
-    bool EmitWarningIfFalseIsInferred();
-  }
-
-  #region Contracts
-
-  [ContractClassFor(typeof(IPostconditionDispatcher))]
-  abstract class IPostConditionDispatcherContracts : IPostconditionDispatcher
-  {
-    public void AddPostconditions(IEnumerable<BoxedExpression> postconditions)
+    [ContractClass(typeof(IPostConditionDispatcherContracts))]
+    public interface IPostconditionDispatcher
     {
-      Contract.Requires(postconditions != null);
+        /// <summary>
+        /// Add the postcondition to the list of current preconditions
+        /// </summary>
+        void AddPostconditions(IEnumerable<BoxedExpression> postconditions);
+
+        /// <summary>
+        /// Report, for the given method, the set of non-null fields as inferred
+        /// </summary>
+        void AddNonNullFields(object method, IEnumerable<object> fields);
+
+        /// <summary>
+        /// Get the non-null fields at the method exit point
+        /// </summary>
+        IEnumerable<object> GetNonNullFields(object method);
+
+        /// <summary>
+        /// Returns the list of precondition for this method
+        /// </summary>
+        List<BoxedExpression> GeneratePostconditions();
+
+        /// <summary>
+        /// Suggest the postcondition.
+        /// Returns how many preconditions have been suggested
+        /// </summary>
+        int SuggestPostconditions();
+
+        /// <summary>
+        /// Suggests the postconditions for the constructors of the type currently analyzed
+        /// </summary>
+        int SuggestNonNullFieldsForConstructors();
+
+        /// <summary>
+        /// When all the constructors of a given type are analyzed, it gets the != null object invariants
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<BoxedExpression> SuggestNonNullObjectInvariantsFromConstructorsForward(bool doNotRecord = false);
+
+        /// <summary>
+        /// Infer the postcondition.
+        /// Returns how many postconditionss have been propagated to the callers
+        /// </summary>
+        int PropagatePostconditions();
+
+        /// <summary>
+        /// Infer postconditions for autoproperties, i.e., if we detect this.F != null, then it will attach the postcondition result != null to the autoproperty F
+        /// Returns how many postconditions have been installed
+        /// </summary>
+        /// <returns></returns>
+        int PropagatePostconditionsForProperties();
+
+        /// <summary>
+        /// Returns true if the method may return null directly (e.g. "return null" or indirectly (e.g., "return foo()" and we know that foo may return null)
+        /// </summary>
+        /// <returns></returns>
+        bool MayReturnNull(IFact facts, TimeOutChecker timeout);
+
+        /// <summary>
+        /// If we infer false for the method, and it contains user-postconditions, warn the user
+        /// </summary>
+        bool EmitWarningIfFalseIsInferred();
     }
 
-    public void AddNonNullFields(object method, IEnumerable<object> fields)
+    #region Contracts
+
+    [ContractClassFor(typeof(IPostconditionDispatcher))]
+    internal abstract class IPostConditionDispatcherContracts : IPostconditionDispatcher
     {
-      Contract.Requires(method != null);
-      throw new NotImplementedException();
+        public void AddPostconditions(IEnumerable<BoxedExpression> postconditions)
+        {
+            Contract.Requires(postconditions != null);
+        }
+
+        public void AddNonNullFields(object method, IEnumerable<object> fields)
+        {
+            Contract.Requires(method != null);
+            throw new NotImplementedException();
+        }
+        public IEnumerable<object> GetNonNullFields(object method)
+        {
+            Contract.Requires(method != null);
+
+            return null;
+        }
+        public List<BoxedExpression> GeneratePostconditions()
+        {
+            Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public int SuggestPostconditions()
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<BoxedExpression> SuggestNonNullObjectInvariantsFromConstructorsForward(bool doNotRecord)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<BoxedExpression>>() != null);
+
+            return null;
+        }
+
+        public int SuggestNonNullFieldsForConstructors()
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            throw new NotImplementedException();
+        }
+
+        public int PropagatePostconditions()
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            throw new NotImplementedException();
+        }
+
+        public int PropagatePostconditionsForProperties()
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            throw new NotImplementedException();
+        }
+
+        public bool MayReturnNull(IFact facts, TimeOutChecker timeout)
+        {
+            Contract.Requires(facts != null);
+            throw new NotImplementedException();
+        }
+
+        public bool EmitWarningIfFalseIsInferred()
+        {
+            throw new NotImplementedException();
+        }
     }
-    public IEnumerable<object> GetNonNullFields(object method)
-    {
-      Contract.Requires(method != null);
-
-      return null;
-    }
-    public List<BoxedExpression> GeneratePostconditions()
-    {
-      Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
-      
-      throw new NotImplementedException();
-    }
-
-    public int SuggestPostconditions()
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<BoxedExpression> SuggestNonNullObjectInvariantsFromConstructorsForward(bool doNotRecord)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<BoxedExpression>>() != null);
-
-      return null;
-    }
-
-    public int SuggestNonNullFieldsForConstructors()
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      throw new NotImplementedException();
-    }
-
-    public int PropagatePostconditions()
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      throw new NotImplementedException();
-    }
-
-    public int PropagatePostconditionsForProperties()
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      throw new NotImplementedException();
-    }
-
-    public bool MayReturnNull(IFact facts, TimeOutChecker timeout)
-    {
-      Contract.Requires(facts != null);
-      throw new NotImplementedException();
-    }
-
-    public bool EmitWarningIfFalseIsInferred()
-    {
-      throw new NotImplementedException();
-    }
-  }
-
-  #endregion
-
-  [ContractVerification(true)]
-  public class PostconditionDispatcherProfiler 
-    : IPostconditionDispatcher
-  {
-    #region Object Invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.inner != null);
-    }
-    
-    #endregion
-
-    #region Statics
-
-    [ThreadStatic]
-    static private int generated;
-    [ThreadStatic]
-    static private int retained;
 
     #endregion
 
-    #region State
-
-    private readonly IPostconditionDispatcher inner;
-    private bool profilingAlreadyCollected;
-
-    #endregion
-
-    #region Constructor
-
-    public PostconditionDispatcherProfiler(IPostconditionDispatcher dispatcher)
+    [ContractVerification(true)]
+    public class PostconditionDispatcherProfiler
+      : IPostconditionDispatcher
     {
-      Contract.Requires(dispatcher != null);
+        #region Object Invariant
 
-      this.inner = dispatcher;
-      this.profilingAlreadyCollected = false;
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inner != null);
+        }
+
+        #endregion
+
+        #region Statics
+
+        [ThreadStatic]
+        static private int generated;
+        [ThreadStatic]
+        static private int retained;
+
+        #endregion
+
+        #region State
+
+        private readonly IPostconditionDispatcher inner;
+        private bool profilingAlreadyCollected;
+
+        #endregion
+
+        #region Constructor
+
+        public PostconditionDispatcherProfiler(IPostconditionDispatcher dispatcher)
+        {
+            Contract.Requires(dispatcher != null);
+
+            inner = dispatcher;
+            profilingAlreadyCollected = false;
+        }
+
+        #endregion
+
+        #region Implementation of IPostConditionDispatcher
+        public void AddPostconditions(IEnumerable<BoxedExpression> postconditions)
+        {
+            generated += postconditions.Count();
+            inner.AddPostconditions(postconditions);
+        }
+
+        public void AddNonNullFields(object method, IEnumerable<object> fields)
+        {
+            inner.AddNonNullFields(method, fields);
+        }
+
+        public IEnumerable<object> GetNonNullFields(object method)
+        {
+            return inner.GetNonNullFields(method);
+        }
+
+        public List<BoxedExpression> GeneratePostconditions()
+        {
+            return inner.GeneratePostconditions();
+        }
+
+        public int SuggestPostconditions()
+        {
+            return RecordProfilingInformation(inner.SuggestPostconditions());
+        }
+
+        public int SuggestNonNullFieldsForConstructors()
+        {
+            return inner.SuggestNonNullFieldsForConstructors();
+        }
+
+        public IEnumerable<BoxedExpression> SuggestNonNullObjectInvariantsFromConstructorsForward(bool doNotRecord = false)
+        {
+            return inner.SuggestNonNullObjectInvariantsFromConstructorsForward(doNotRecord);
+        }
+
+        public int PropagatePostconditions()
+        {
+            return RecordProfilingInformation(inner.PropagatePostconditions());
+        }
+
+        public int PropagatePostconditionsForProperties()
+        {
+            return RecordProfilingInformation(inner.PropagatePostconditionsForProperties());
+        }
+
+        public bool MayReturnNull(IFact facts, TimeOutChecker timeout)
+        {
+            return RecordProfilingInformation(inner.MayReturnNull(facts, timeout));
+        }
+
+        public bool EmitWarningIfFalseIsInferred()
+        {
+            // We do not record conditions on emitted false
+            return inner.EmitWarningIfFalseIsInferred();
+        }
+
+        #endregion
+
+        #region Dumping
+        public static void DumpStatistics(IOutput output)
+        {
+            Contract.Requires(output != null);
+
+            if (generated != 0)
+            {
+                output.WriteLine("Discovered {0} postconditions to suggest", generated);
+                output.WriteLine("Retained {0} postconditions after filtering", retained);
+            }
+        }
+
+        #endregion
+
+        #region Profiling
+
+        private int RecordProfilingInformation(int howMany)
+        {
+            Contract.Requires(howMany >= 0);
+            Contract.Ensures(retained >= Contract.OldValue(retained));
+            Contract.Ensures(Contract.Result<int>() == howMany);
+
+            if (!profilingAlreadyCollected)
+            {
+                retained += howMany;
+                profilingAlreadyCollected = true;
+            }
+
+            return howMany;
+        }
+
+        private bool RecordProfilingInformation(bool mayReturnNull)
+        {
+            // We do not keep statistics for that -- for the moment?
+
+            return mayReturnNull;
+        }
+
+        #endregion
     }
-    
-    #endregion
-
-    #region Implementation of IPostConditionDispatcher
-    public void AddPostconditions(IEnumerable<BoxedExpression> postconditions)
-    {
-      generated += postconditions.Count();
-      this.inner.AddPostconditions(postconditions);
-    }
-
-    public void AddNonNullFields(object method, IEnumerable<object> fields)
-    {
-      this.inner.AddNonNullFields(method, fields);
-    }
-
-    public IEnumerable<object> GetNonNullFields(object method)
-    {
-      return this.inner.GetNonNullFields(method);
-    }
-
-    public List<BoxedExpression> GeneratePostconditions()
-    {
-      return this.inner.GeneratePostconditions();
-    }
-
-    public int SuggestPostconditions()
-    {
-      return RecordProfilingInformation(this.inner.SuggestPostconditions());
-    }
-
-    public int SuggestNonNullFieldsForConstructors()
-    {
-      return this.inner.SuggestNonNullFieldsForConstructors();
-    }
-
-    public IEnumerable<BoxedExpression> SuggestNonNullObjectInvariantsFromConstructorsForward(bool doNotRecord = false)
-    {
-      return this.inner.SuggestNonNullObjectInvariantsFromConstructorsForward(doNotRecord);
-    }
-
-    public int PropagatePostconditions()
-    {
-      return RecordProfilingInformation(this.inner.PropagatePostconditions());
-    }
-
-    public int PropagatePostconditionsForProperties()
-    {
-      return RecordProfilingInformation(this.inner.PropagatePostconditionsForProperties());
-    }
-
-    public bool MayReturnNull(IFact facts, TimeOutChecker timeout)
-    {
-      return RecordProfilingInformation(this.inner.MayReturnNull(facts, timeout));
-    }
-
-    public bool EmitWarningIfFalseIsInferred()
-    {
-      // We do not record conditions on emitted false
-      return this.inner.EmitWarningIfFalseIsInferred();
-    }
-    
-    #endregion
-
-    #region Dumping
-    public static void DumpStatistics(IOutput output)
-    {
-      Contract.Requires(output != null);
-
-      if (generated != 0)
-      {
-        output.WriteLine("Discovered {0} postconditions to suggest", generated);
-        output.WriteLine("Retained {0} postconditions after filtering", retained);
-      }
-    }
-    
-    #endregion
-
-    #region Profiling
-
-    private int RecordProfilingInformation(int howMany)
-    {
-      Contract.Requires(howMany >= 0);
-      Contract.Ensures(retained >= Contract.OldValue(retained));
-      Contract.Ensures(Contract.Result<int>() == howMany);
-
-      if (!this.profilingAlreadyCollected)
-      {
-        retained += howMany;
-        this.profilingAlreadyCollected = true;
-      }
-
-      return howMany;
-    }
-
-    private bool RecordProfilingInformation(bool mayReturnNull)
-    {
-       // We do not keep statistics for that -- for the moment?
-
-      return mayReturnNull;
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Inference/Preconditions.cs
+++ b/Microsoft.Research/CodeAnalysis/Inference/Preconditions.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,449 +11,445 @@ using System.Diagnostics;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  /// <summary>
-  /// The precondition discharger
-  /// </summary>
-  public interface IPreconditionInference
-  {
-    bool ShouldAddAssumeFalse { get; }
-    bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions conditions);
-  }
-
-  /// <summary>
-  /// The manager for candidate preconditions
-  /// </summary>
-  [ContractClass(typeof(IPreconditionDispatcherContracts))]
-  public interface IPreconditionDispatcher
-  {
     /// <summary>
-    /// Add the preconditions to the list of current preconditions
+    /// The precondition discharger
     /// </summary>
-    ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome);
-
-    /// <summary>
-    /// Returns the list of precondition for this method
-    /// </summary>
-    IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions();
-    
-    /// <summary>
-    /// Suggest the precondition.
-    /// Returns how many preconditions have been suggested
-    /// </summary>
-    int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput);
-
-    /// <summary>
-    /// Infer the precondition.
-    /// Returns how many preconditions have been propagated to the callers
-    /// </summary>
-    /// <param name="asPrecondition">if true, try to propagate as precondition, otherwise as assume</param>
-    int PropagatePreconditions(bool asPrecondition);
-
-    int NumberOfWarnings { get; }
-  }
-
-  public class PreconditionInferenceManager
-  {
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
+    public interface IPreconditionInference
     {
-      Contract.Invariant(this.Inference != null);
-      Contract.Invariant(this.Dispatch != null);
+        bool ShouldAddAssumeFalse { get; }
+        bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions conditions);
     }
 
-
-    public readonly IPreconditionInference Inference;
-    public readonly IPreconditionDispatcher Dispatch;
-
-    static private PreconditionInferenceManager dummy; // Thread-safe
-    static public PreconditionInferenceManager Dummy
+    /// <summary>
+    /// The manager for candidate preconditions
+    /// </summary>
+    [ContractClass(typeof(IPreconditionDispatcherContracts))]
+    public interface IPreconditionDispatcher
     {
-      get
-      {
-        if (dummy == null)
+        /// <summary>
+        /// Add the preconditions to the list of current preconditions
+        /// </summary>
+        ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome);
+
+        /// <summary>
+        /// Returns the list of precondition for this method
+        /// </summary>
+        IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions();
+
+        /// <summary>
+        /// Suggest the precondition.
+        /// Returns how many preconditions have been suggested
+        /// </summary>
+        int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput);
+
+        /// <summary>
+        /// Infer the precondition.
+        /// Returns how many preconditions have been propagated to the callers
+        /// </summary>
+        /// <param name="asPrecondition">if true, try to propagate as precondition, otherwise as assume</param>
+        int PropagatePreconditions(bool asPrecondition);
+
+        int NumberOfWarnings { get; }
+    }
+
+    public class PreconditionInferenceManager
+    {
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
         {
-          dummy = new PreconditionInferenceManager(new DummyIPreconditionInference(), new DummyIPreconditionDispatcher());
+            Contract.Invariant(this.Inference != null);
+            Contract.Invariant(this.Dispatch != null);
         }
-        return dummy;
-      }
-    }
-
-    public PreconditionInferenceManager(IPreconditionInference Inference, IPreconditionDispatcher Dispatcher)
-    {
-      Contract.Requires(Inference != null);
-      Contract.Requires(Dispatcher != null);
-
-      this.Inference = Inference;
-      this.Dispatch = Dispatcher;
-    }
-
-    #region Dummy implementations of the interfaces
-    class DummyIPreconditionInference : IPreconditionInference
-    {
-
-      public bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions preConditions)
-      {
-        preConditions = null;
-        return false;
-      }
-
-      public bool ShouldAddAssumeFalse
-      {
-        get { return false; }
-      }
-
-    }
-
-    class DummyIPreconditionDispatcher : IPreconditionDispatcher
-    {
-
-      public ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome)
-      {
-        return originalOutcome;
-      }
-
-      public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions()
-      {
-        return Enumerable.Empty<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>();
-      }
-
-      public int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput)
-      {
-        return 0;
-      }
-
-      public int PropagatePreconditions(bool asPrecondition)
-      {
-        return 0;
-      }
-
-      public int NumberOfWarnings
-      {
-        get { return 0; }
-      }
-    }
-    #endregion
-  }
-
-  #region Contracts for the interfaces
-
-  [ContractClassFor(typeof(IPreconditionDispatcher))]
-  abstract class IPreconditionDispatcherContracts
-    : IPreconditionDispatcher
-  {
-    public ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome)
-    {
-      Contract.Requires(obl != null);
-      Contract.Requires(preconditions != null);
-
-      return ProofOutcome.Top;
-    }
-
-    public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions()
-    {
-      Contract.Ensures(Contract.Result< IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>>() != null);
-      return null;
-    }
-
-    public int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-
-      return 0;
-    }
-
-    public int PropagatePreconditions(bool asPrecondition)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-
-      return 0;
-    }
-
-    public int NumberOfWarnings
-    {
-      get {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        return 0; 
-      }
-    }
-
-  }
-  
-  #endregion
 
 
-  #region Aggressive (yet unsound) Precondition Inference: Try to read preconditions in the prestate
-  public class AggressivePreconditionInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
-    : IPreconditionInference
-    where Variable : IEquatable<Variable>
-    where Expression : IEquatable<Expression>
-    where Type : IEquatable<Type>
-    where LogOptions : IFrameworkLogOptions
-  {
-    #region Invariant
+        public readonly IPreconditionInference Inference;
+        public readonly IPreconditionDispatcher Dispatch;
 
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.MethodDriver != null);
-    }
-
-    #endregion
-
-    #region State
-
-    protected readonly IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> MethodDriver;
-
-    #endregion
-
-    #region Constructor
-
-    public AggressivePreconditionInference(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> MethodDriver)
-    {
-      Contract.Requires(MethodDriver != null);
-
-      this.MethodDriver = MethodDriver;
-    }
-
-    #endregion
-
-    #region IPreconditionDischarger Members
-
-    virtual public bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions preConditions)
-    {
-      var preConds = PreconditionSuggestion.ExpressionsInPreState(obl.ConditionForPreconditionInference, this.MethodDriver.Context, this.MethodDriver.MetaDataDecoder, obl.PC, allowedKinds:ExpressionInPreStateKind.All);
-      preConditions = /*preConds == null ? null : */ preConds.Where(pre => pre.hasVariables).AsInferredPreconditions(isSufficient:true);
-      return /*preConditions != null && */ preConditions.Any();
-    }
-
-    #endregion
-
-    #region Overridden
-
-    public bool ShouldAddAssumeFalse
-    {
-      get { return false; }
-    }
-
-    public override string ToString()
-    {
-      return "Aggressive precondition inference";
-    }
-    #endregion
-
-  }
-
-  #endregion
-
-  #region Profiler for precondition Inference
-
-  [ContractVerification(true)]
-  public class PreconditionInferenceProfiler
-    : IPreconditionInference
-  {
-    #region state
-
-    readonly private IPreconditionInference inner;
-    [ThreadStatic]
-    static private int inferred;
-    [ThreadStatic]
-    static private TimeSpan inferenceTime;
-
-    [ThreadStatic]
-    static private int totalMethodsWithPreconditons;
-    [ThreadStatic]
-    static private int totalMethodsWithNecessaryPreconditions;
-
-    #endregion
-
-    #region invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.inner != null);
-      Contract.Invariant(inferred >= 0);
-      Contract.Invariant(totalMethodsWithPreconditons >= 0);
-    }
-
-    #endregion
-
-    public PreconditionInferenceProfiler(IPreconditionInference inner)
-    {
-      Contract.Requires(inner != null);
-
-      Contract.Assume(inferred >= 0, "it's a static variable: We believe at construction that other objects left it >= 0");
-
-      this.inner = inner;
-
-      Contract.Assume(totalMethodsWithPreconditons >= 0, "static invariant");
-    }
-
-    public bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions preConditions)
-    {
-      var watch = new Stopwatch();
-      watch.Start();
-      var result = inner.TryInferConditions(obl, codefixesManager, out preConditions);
-      watch.Stop();
-
-      inferenceTime += watch.Elapsed;
-
-      if (preConditions == null)
-      {
-        return false;
-      }
-
-      if (result) inferred += preConditions.Count();
-
-      return result;
-    }
-
-    public bool ShouldAddAssumeFalse
-    {
-      get { return this.inner.ShouldAddAssumeFalse; }
-    }
-
-    static public void NotifyMethodWithAPrecondition()
-    {
-      totalMethodsWithPreconditons++;
-    }
-
-    static public void NotifyCheckInferredRequiresResult(uint tops)
-    {
-      totalMethodsWithNecessaryPreconditions += tops == 0 ? 1 : 0;
-    }
-
-    static public void DumpStatistics(IOutput output)
-    {
-      Contract.Requires(output != null);
-
-      if (totalMethodsWithPreconditons > 0)
-      {
-        output.WriteLine("Methods with necessary preconditions: {0}", totalMethodsWithPreconditons);
-        if (totalMethodsWithNecessaryPreconditions > 0)
+        static private PreconditionInferenceManager dummy; // Thread-safe
+        static public PreconditionInferenceManager Dummy
         {
-          output.WriteLine("Methods where preconditions were also sufficient: {0}", totalMethodsWithNecessaryPreconditions);
+            get
+            {
+                if (dummy == null)
+                {
+                    dummy = new PreconditionInferenceManager(new DummyIPreconditionInference(), new DummyIPreconditionDispatcher());
+                }
+                return dummy;
+            }
         }
-        if (inferred > 0)
+
+        public PreconditionInferenceManager(IPreconditionInference Inference, IPreconditionDispatcher Dispatcher)
         {
-          output.WriteLine("Discovered {0} new candidate preconditions in {1}", inferred, inferenceTime);
+            Contract.Requires(Inference != null);
+            Contract.Requires(Dispatcher != null);
+
+            this.Inference = Inference;
+            this.Dispatch = Dispatcher;
         }
-      }
+
+        #region Dummy implementations of the interfaces
+        private class DummyIPreconditionInference : IPreconditionInference
+        {
+            public bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions preConditions)
+            {
+                preConditions = null;
+                return false;
+            }
+
+            public bool ShouldAddAssumeFalse
+            {
+                get { return false; }
+            }
+        }
+
+        private class DummyIPreconditionDispatcher : IPreconditionDispatcher
+        {
+            public ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome)
+            {
+                return originalOutcome;
+            }
+
+            public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions()
+            {
+                return Enumerable.Empty<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>();
+            }
+
+            public int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput)
+            {
+                return 0;
+            }
+
+            public int PropagatePreconditions(bool asPrecondition)
+            {
+                return 0;
+            }
+
+            public int NumberOfWarnings
+            {
+                get { return 0; }
+            }
+        }
+        #endregion
     }
-  }
-  
-  #endregion
 
-  #region Profiler for precondition Dispatching
-  
-  public class PreconditionDispatcherProfiler 
-    : IPreconditionDispatcher
-  {
+    #region Contracts for the interfaces
 
-    #region Invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
+    [ContractClassFor(typeof(IPreconditionDispatcher))]
+    internal abstract class IPreconditionDispatcherContracts
+      : IPreconditionDispatcher
     {
-      Contract.Invariant(this.inner != null);
-      Contract.Invariant(filtered >= 0);
+        public ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome)
+        {
+            Contract.Requires(obl != null);
+            Contract.Requires(preconditions != null);
+
+            return ProofOutcome.Top;
+        }
+
+        public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions()
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>>>() != null);
+            return null;
+        }
+
+        public int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+
+            return 0;
+        }
+
+        public int PropagatePreconditions(bool asPrecondition)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+
+            return 0;
+        }
+
+        public int NumberOfWarnings
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                return 0;
+            }
+        }
     }
-    
+
     #endregion
 
-    #region State
 
-    private readonly IPreconditionDispatcher inner;
-    private bool statisticsAlreadyCollected;
-    [ThreadStatic]
-    private static int filtered;
-    
+    #region Aggressive (yet unsound) Precondition Inference: Try to read preconditions in the prestate
+    public class AggressivePreconditionInference<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+      : IPreconditionInference
+      where Variable : IEquatable<Variable>
+      where Expression : IEquatable<Expression>
+      where Type : IEquatable<Type>
+      where LogOptions : IFrameworkLogOptions
+    {
+        #region Invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.MethodDriver != null);
+        }
+
+        #endregion
+
+        #region State
+
+        protected readonly IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> MethodDriver;
+
+        #endregion
+
+        #region Constructor
+
+        public AggressivePreconditionInference(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> MethodDriver)
+        {
+            Contract.Requires(MethodDriver != null);
+
+            this.MethodDriver = MethodDriver;
+        }
+
+        #endregion
+
+        #region IPreconditionDischarger Members
+
+        virtual public bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions preConditions)
+        {
+            var preConds = PreconditionSuggestion.ExpressionsInPreState(obl.ConditionForPreconditionInference, this.MethodDriver.Context, this.MethodDriver.MetaDataDecoder, obl.PC, allowedKinds: ExpressionInPreStateKind.All);
+            preConditions = /*preConds == null ? null : */ preConds.Where(pre => pre.hasVariables).AsInferredPreconditions(isSufficient: true);
+            return /*preConditions != null && */ preConditions.Any();
+        }
+
+        #endregion
+
+        #region Overridden
+
+        public bool ShouldAddAssumeFalse
+        {
+            get { return false; }
+        }
+
+        public override string ToString()
+        {
+            return "Aggressive precondition inference";
+        }
+        #endregion
+
+    }
+
     #endregion
 
-    #region Constructor
+    #region Profiler for precondition Inference
 
-    public PreconditionDispatcherProfiler(IPreconditionDispatcher dispatcher)
+    [ContractVerification(true)]
+    public class PreconditionInferenceProfiler
+      : IPreconditionInference
     {
-      Contract.Requires(dispatcher != null);
+        #region state
 
-      Contract.Assume(filtered>= 0, "it's a static variable: We believe at construction that other objects left it >= 0");
+        readonly private IPreconditionInference inner;
+        [ThreadStatic]
+        static private int inferred;
+        [ThreadStatic]
+        static private TimeSpan inferenceTime;
 
-      this.inner = dispatcher;
-      this.statisticsAlreadyCollected = false;
+        [ThreadStatic]
+        static private int totalMethodsWithPreconditons;
+        [ThreadStatic]
+        static private int totalMethodsWithNecessaryPreconditions;
+
+        #endregion
+
+        #region invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inner != null);
+            Contract.Invariant(inferred >= 0);
+            Contract.Invariant(totalMethodsWithPreconditons >= 0);
+        }
+
+        #endregion
+
+        public PreconditionInferenceProfiler(IPreconditionInference inner)
+        {
+            Contract.Requires(inner != null);
+
+            Contract.Assume(inferred >= 0, "it's a static variable: We believe at construction that other objects left it >= 0");
+
+            this.inner = inner;
+
+            Contract.Assume(totalMethodsWithPreconditons >= 0, "static invariant");
+        }
+
+        public bool TryInferConditions(ProofObligation obl, ICodeFixesManager codefixesManager, out InferredConditions preConditions)
+        {
+            var watch = new Stopwatch();
+            watch.Start();
+            var result = inner.TryInferConditions(obl, codefixesManager, out preConditions);
+            watch.Stop();
+
+            inferenceTime += watch.Elapsed;
+
+            if (preConditions == null)
+            {
+                return false;
+            }
+
+            if (result) inferred += preConditions.Count();
+
+            return result;
+        }
+
+        public bool ShouldAddAssumeFalse
+        {
+            get { return inner.ShouldAddAssumeFalse; }
+        }
+
+        static public void NotifyMethodWithAPrecondition()
+        {
+            totalMethodsWithPreconditons++;
+        }
+
+        static public void NotifyCheckInferredRequiresResult(uint tops)
+        {
+            totalMethodsWithNecessaryPreconditions += tops == 0 ? 1 : 0;
+        }
+
+        static public void DumpStatistics(IOutput output)
+        {
+            Contract.Requires(output != null);
+
+            if (totalMethodsWithPreconditons > 0)
+            {
+                output.WriteLine("Methods with necessary preconditions: {0}", totalMethodsWithPreconditons);
+                if (totalMethodsWithNecessaryPreconditions > 0)
+                {
+                    output.WriteLine("Methods where preconditions were also sufficient: {0}", totalMethodsWithNecessaryPreconditions);
+                }
+                if (inferred > 0)
+                {
+                    output.WriteLine("Discovered {0} new candidate preconditions in {1}", inferred, inferenceTime);
+                }
+            }
+        }
     }
-    
+
     #endregion
 
-    #region Statistics
+    #region Profiler for precondition Dispatching
 
-    public static void DumpStatistics(IOutput output)
+    public class PreconditionDispatcherProfiler
+      : IPreconditionDispatcher
     {
-      Contract.Requires(output != null);
+        #region Invariant
 
-      output.WriteLine("Retained {0} preconditions after filtering", filtered);
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(inner != null);
+            Contract.Invariant(filtered >= 0);
+        }
+
+        #endregion
+
+        #region State
+
+        private readonly IPreconditionDispatcher inner;
+        private bool statisticsAlreadyCollected;
+        [ThreadStatic]
+        private static int filtered;
+
+        #endregion
+
+        #region Constructor
+
+        public PreconditionDispatcherProfiler(IPreconditionDispatcher dispatcher)
+        {
+            Contract.Requires(dispatcher != null);
+
+            Contract.Assume(filtered >= 0, "it's a static variable: We believe at construction that other objects left it >= 0");
+
+            inner = dispatcher;
+            statisticsAlreadyCollected = false;
+        }
+
+        #endregion
+
+        #region Statistics
+
+        public static void DumpStatistics(IOutput output)
+        {
+            Contract.Requires(output != null);
+
+            output.WriteLine("Retained {0} preconditions after filtering", filtered);
+        }
+
+        #endregion
+
+        #region Implementations
+
+        public ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome)
+        {
+            return inner.AddPreconditions(obl, preconditions, originalOutcome);
+        }
+
+        public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions()
+        {
+            var result = inner.GeneratePreconditions();
+            AddStatistics(result.Count());
+
+            return result;
+        }
+
+        public int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput)
+        {
+            return AddStatistics(inner.SuggestPreconditions(treatSuggestionsAsWarnings, forceSuggestionOutput));
+        }
+
+        public int PropagatePreconditions(bool asPrecondition)
+        {
+            return AddStatistics(inner.PropagatePreconditions(asPrecondition));
+        }
+
+        public int NumberOfWarnings
+        {
+            get { return inner.NumberOfWarnings; }
+        }
+
+
+        #endregion
+
+        #region private methods
+
+        private int AddStatistics(int howmany)
+        {
+            Contract.Requires(howmany >= 0);
+
+            Contract.Ensures(Contract.Result<int>() == howmany);
+
+            if (!statisticsAlreadyCollected)
+            {
+                filtered += howmany;
+                statisticsAlreadyCollected = true;
+            }
+
+            return howmany;
+        }
+
+        private int AddStatisticsForObjectInvariants(int howmany)
+        {
+            // TODO: stats for object invariants
+
+            return howmany;
+        }
+        #endregion
     }
 
     #endregion
-
-    #region Implementations
-
-    public ProofOutcome AddPreconditions(ProofObligation obl, IEnumerable<BoxedExpression> preconditions, ProofOutcome originalOutcome)
-    {
-      return this.inner.AddPreconditions(obl, preconditions, originalOutcome);
-    }
-
-    public IEnumerable<KeyValuePair<BoxedExpression, IEnumerable<MinimalProofObligation>>> GeneratePreconditions()
-    {
-      var result = this.inner.GeneratePreconditions();
-      AddStatistics(result.Count());
-
-      return result;
-    }
-
-    public int SuggestPreconditions(bool treatSuggestionsAsWarnings, bool forceSuggestionOutput)
-    {
-      return AddStatistics(this.inner.SuggestPreconditions(treatSuggestionsAsWarnings, forceSuggestionOutput));
-    }
-
-    public int PropagatePreconditions(bool asPrecondition)
-    {
-      return AddStatistics(this.inner.PropagatePreconditions(asPrecondition));
-    }
-
-    public int NumberOfWarnings
-    {
-      get { return this.inner.NumberOfWarnings; }
-    }
-
-   
-    #endregion
-
-    #region private methods
-
-    private int AddStatistics(int howmany)
-    {
-      Contract.Requires(howmany >= 0);
-
-      Contract.Ensures(Contract.Result<int>() == howmany);
-
-      if (!statisticsAlreadyCollected)
-      {
-        filtered += howmany;
-        statisticsAlreadyCollected = true;
-      }
-
-      return howmany;
-    }
-
-    private int AddStatisticsForObjectInvariants(int howmany)
-    {
-      // TODO: stats for object invariants
-
-      return howmany;
-    }
-    #endregion
-  }
-
-  #endregion
 }

--- a/Microsoft.Research/CodeAnalysis/OptimisticHeapAbstraction.cs
+++ b/Microsoft.Research/CodeAnalysis/OptimisticHeapAbstraction.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Linq;
@@ -24,10071 +13,10055 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
+    using Temp = System.Int32; // Stack locations
+    using Dest = System.Int32; // Stack location
+    using Source = System.Int32; // Stack location
+    using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
+    using SubroutineEdge = Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>;
+    using EdgeData = IFunctionalMap<SymbolicValue, FList<SymbolicValue>>;
+    using System.Diagnostics.Contracts;
+    using System.Diagnostics.CodeAnalysis;
 
-  using Temp = System.Int32; // Stack locations
-  using Dest = System.Int32; // Stack location
-  using Source = System.Int32; // Stack location
-  using SubroutineContext = FList<Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>>;
-  using SubroutineEdge = Microsoft.Research.DataStructures.STuple<CFGBlock, CFGBlock, string>;
-  using EdgeData = IFunctionalMap<SymbolicValue, FList<SymbolicValue>>;
-  using System.Diagnostics.Contracts;
-  using System.Diagnostics.CodeAnalysis;
-
-  static class Extensions
-  {
-    /// <summary>
-    /// Returns true if the type is represented with "ValueOf" to get the contents, i.e.,
-    /// it is not a struct with fields.
-    /// </summary>
-    public static bool HasValueRepresentation<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Type type)
+    internal static class Extensions
     {
-      return !mdDecoder.IsStruct(type) || mdDecoder.IsPrimitive(type) || mdDecoder.IsEnum(type);
-    }
-
-    public static string ToString<T>(this IEnumerable<T> data, string separator)
-    {
-      var sb = new StringBuilder();
-      bool notFirst = false;
-      foreach (var elem in data)
-      {
-        if (notFirst)
+        /// <summary>
+        /// Returns true if the type is represented with "ValueOf" to get the contents, i.e.,
+        /// it is not a struct with fields.
+        /// </summary>
+        public static bool HasValueRepresentation<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Type type)
         {
-          sb.Append(separator);
+            return !mdDecoder.IsStruct(type) || mdDecoder.IsPrimitive(type) || mdDecoder.IsEnum(type);
         }
-        sb.Append(elem.ToString());
-        notFirst = true;
-      }
-      return sb.ToString();
-    }
-  }
 
-  public struct SymbolicValue : IEquatable<SymbolicValue>, IComparable<SymbolicValue>, IComparable
-  {
-    internal readonly ESymValue symbol;
-
-    public static int GetUniqueKey(SymbolicValue v) { return ESymValue.GetUniqueKey(v.symbol); }
-    public static int Compare(SymbolicValue left, SymbolicValue right) { return left.symbol.UniqueId - right.symbol.UniqueId; }
-
-    internal SymbolicValue(ESymValue symbol)
-    {
-      this.symbol = symbol;
-    }
-
-    #region IEquatable<SymbolicValue> Members
-
-    //^ [StateIndependent]
-    public bool Equals(SymbolicValue other)
-    {
-      return symbol == other.symbol;
-    }
-
-    public override int GetHashCode()
-    {
-      return symbol != null ? symbol.GlobalId : -1;
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj is SymbolicValue)
-      {
-        SymbolicValue that = (SymbolicValue)obj;
-        return this.symbol.Equals(that.symbol);
-      }
-      return false;
-    }
-    #endregion
-
-    public override string ToString()
-    {
-      if (symbol == null) return "<null>";
-      return symbol.ToString();
-    }
-
-    public bool IsNull
-    {
-      get { return symbol == null; }
-    }
-
-    public int MethodLocalKey { get { return this.symbol.UniqueId; } }
-
-    #region IComparable<SymbolicValue> Members
-
-    public Source CompareTo(SymbolicValue other)
-    {
-      return this.symbol.CompareTo(other.symbol);
-    }
-
-    #endregion
-
-    #region IComparable Members
-
-    public Source CompareTo(object obj)
-    {
-      if (obj is SymbolicValue)
-      {
-        return this.CompareTo((SymbolicValue)obj);
-      }
-      return 1;
-    }
-
-    #endregion
-  }
-
-  #region Path Elements
-  [Serializable]
-  public abstract class PathElement
-  {
-    public virtual bool IsBooleanTyped { get { return false; } }
-    public virtual bool IsDeref { get { return false; } }
-    public virtual bool IsMethodCall { get { return false; } }
-    public virtual bool IsGetter { get { return false; } }
-    public virtual bool IsStatic { get { return false; } }
-    public virtual bool IsUnmanagedPointer { get { return false; } }
-    public virtual bool IsManagedPointer { get { return false; } }
-    public virtual bool HasExtraDeref { get { return false; } }
-    public virtual bool IsParameter { get { return false; } }
-
-    public virtual bool IsParameterOut { get { return false; } }
-    public virtual bool IsReturnValue { get { return false; } }
-    public virtual bool IsParameterRef { get { return false; } }
-    public virtual bool IsModel { get { return false; } }
-    public abstract PathElement SubstituteElement(object from, object to);
-
-    /// <returns>The parameter in the path element, if any</returns>
-    public virtual bool TryParameter<Parameter>(out Parameter p)
-    {
-      p = default(Parameter);
-      return false;
-    }
-
-    /// <returns>The field in the PathElement, if any </returns>
-    public virtual bool TryField<Field>(out Field f)
-    {
-      f = default(Field);
-      return false;
-    }
-
-    public virtual bool TryMethod<Method>(out Method m)
-    {
-      m = default(Method);
-      return false;
-    }
-
-    /// <summary>
-    /// Returns the type of the result of the path element (if possible).
-    /// </summary>
-    public abstract bool TryGetResultType<Type>(out Type type);
-
-    /// <summary>
-    /// Set to the type name it should be cast to on output
-    /// </summary>
-    virtual public string CastTo { get { return ""; } } // default is: no cast
-
-    /// <summary>
-    /// returns true if the path element implicitly takes the address of the element, i.e,
-    /// local variable, parameter, or field (static or instance)
-    /// </summary>
-    public abstract bool IsAddressOf { get; }
-    public abstract Result Decode<Data, Result, Visitor, PC, Local, Parameter, Method, Field, Type>(PC label, Visitor query, Data data)
-      where Visitor : ICodeQuery<PC, Local, Parameter, Method, Field, Type, Data, Result>;
-
-    public abstract override string ToString();
-
-  }
-
-  public static class PathExtensions
-  {
-    public static Set<Field> FieldsIn<Field>(this FList<PathElement> path)
-    {
-      var result = new Set<Field>();
-      if (path != null)
-      {
-        foreach (var element in path.GetEnumerable())
+        public static string ToString<T>(this IEnumerable<T> data, string separator)
         {
-          Field f;
-          if (element.TryField(out f))
-          {
-            result.Add(f);
-          }
-        }
-      }
-
-      return result;
-    }
-
-    [ContractVerification(false)]
-    public static string ToCodeString(this PathElement[] path)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return PathToString(path);
-    }
-
-    public static string ToCodeString(this FList<PathElement> path)
-    {
-      return PathToString(path);
-    }
-
-    private static string PathToString(FList<PathElement> path)
-    {
-      var first = true;
-      var endsInAddressOf = false;
-      var sb = new StringBuilder();
-      var bEndsWithUnmanaged = false;
-
-      for (; path != null; path = path.Tail)
-      {
-        PathElement c = path.Head;
-        Contract.Assume(c != null);
-        if (c.IsMethodCall && !c.IsGetter && c.IsStatic)
-        {
-          var arg = sb.ToString();
-          sb = new StringBuilder();
-          sb.Append(c.ToString());
-          sb.Append('(');
-          sb.Append(arg);
-          sb.Append(')');
-          first = false;
-        }
-        else
-        {
-          if (!string.IsNullOrEmpty(c.CastTo))
-          {
-            var arg = sb.ToString();
-            sb = new StringBuilder();
-            sb.Append("((");
-            sb.Append(c.CastTo);
-            // this test is not pretty, it should be included in the CastTo field. But come on, unsafe pointers are not pretty either
-            if (bEndsWithUnmanaged)
-              sb.Append('*');
-            sb.Append(')');
-            sb.Append(arg);
-            sb.Append(')');
-          }
-
-          if (first)
-            first = false;
-          else
-          {
-            if (bEndsWithUnmanaged)
-              sb.Append("->");
-            else
-              sb.Append('.');
-          }
-
-          sb.Append(c.ToString());
-          if (c.IsMethodCall && !c.IsGetter)
-          {
-            sb.Append("()");
-          }
-        }
-        int iter = (c.IsAddressOf ? 1 : 0) + (c.IsUnmanagedPointer ? 1 : 0) + (c.IsManagedPointer ? 1 : 0);
-        bEndsWithUnmanaged = c.IsUnmanagedPointer;
-
-        if (c.IsAddressOf)
-        {
-          for (int j = 0; j < iter; ++j)
-          {
-            if (path.Tail != null)
+            var sb = new StringBuilder();
+            bool notFirst = false;
+            foreach (var elem in data)
             {
-              if (path.Tail.Head.IsDeref)
-              {
-                // skip deref
-                path = path.Tail;
-              }
-            }
-            else
-            {
-              // end of path
-              endsInAddressOf = true;
-            }
-          }
-        }
-      }
-      if (endsInAddressOf)
-      {
-        if (bEndsWithUnmanaged)
-          return sb.ToString(); // address of dereference = &*, so output nothing
-        else
-          return "&" + sb.ToString();
-      }
-      else
-      {
-        if (bEndsWithUnmanaged)
-          return "*" + sb.ToString();
-        else
-          return sb.ToString();
-      }
-    }
-
-    private static string PathToString(PathElement[] path)
-    {
-      Contract.Requires(path != null);
-      Contract.Requires(Contract.ForAll(path, p => p != null));
-
-      var first = true;
-      var endsInAddressOf = false;
-      var sb = new StringBuilder();
-      var bEndsWithUnmanaged = false;
-
-      if (path.Length == 1)
-      {
-        return path[0].ToString();
-      }
-
-      for (int i = 0; i < path.Length; i++)
-      {
-        var c = path[i];
-        if (c.IsMethodCall && !c.IsGetter && c.IsStatic)
-        {
-          var arg = sb.ToString();
-          sb = new StringBuilder();
-          sb.Append(c.ToString());
-          sb.Append('(');
-          sb.Append(arg);
-          sb.Append(')');
-          first = false;
-        }
-        else
-        {
-          if (!string.IsNullOrEmpty(c.CastTo))
-          {
-            var arg = sb.ToString();
-            sb = new StringBuilder();
-            sb.Append("((");
-            sb.Append(c.CastTo);
-            // this test is not pretty, it should be included in the CastTo field. But come on, unsafe pointers are not pretty either
-            if (bEndsWithUnmanaged)
-              sb.Append('*');
-            sb.Append(')');
-            sb.Append(arg);
-            sb.Append(')');
-          }
-
-          if (first)
-            first = false;
-          else
-          {
-            if (bEndsWithUnmanaged)
-              sb.Append("->");
-            else
-              sb.Append('.');
-          }
-
-          if (c.IsParameterOut)
-          {
-            sb.AppendFormat("Contract.ValueAtReturn(out {0})", c.ToString());
-          }
-          else
-          {
-            sb.Append(c.ToString());
-          }
-
-          if (c.IsMethodCall && !c.IsGetter)
-          {
-            sb.Append("()");
-          }
-        }
-        int iter = (c.IsAddressOf ? 1 : 0) + (c.IsUnmanagedPointer ? 1 : 0) + (c.IsManagedPointer ? 1 : 0);
-        bEndsWithUnmanaged = c.IsUnmanagedPointer;
-        //if (c.IsAddressOf) // can be a managed pointer (out parameter)
-        for (int j = 0; j < iter; ++j)
-        {
-          if (i + 1 < path.Length)
-          {
-            if (path[i + 1].IsDeref)
-            {
-              // skip deref
-              i++;
-            }
-          }
-          else
-          {
-            // end of path
-            endsInAddressOf = true;
-          }
-        }
-      }
-
-      if (endsInAddressOf)
-      {
-        if (bEndsWithUnmanaged)
-          return sb.ToString(); // address of dereference = &*, so output nothing
-        else
-          return "&" + sb.ToString();
-      }
-      else
-      {
-        if (bEndsWithUnmanaged)
-          return "*" + sb.ToString();
-        else
-          return sb.ToString();
-      }
-    }
-  }
-
-
-  #endregion
-
-  /// <summary>
-  /// This abstraction computes must aliasing while making optimistic assumptions about non-aliasing of unrelated
-  /// objects.
-  /// It produces a symbolic name for all intermediate values such that subsequent analyses can focus on value
-  /// relations rather than dealing with the stack and heap model of IL. 
-  /// </summary>
-  public class OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
-    : IAnalysis<APC, OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Domain, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Domain, OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Domain>, Unit>
-    where Type : IEquatable<Type>
-  {
-
-    #region Privates
-
-    struct TypeCache
-    {
-      private bool cacheIsValid;
-      private bool haveType;
-      private Type cache;
-      string fullName;
-
-      [ContractInvariantMethod]
-      [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(cache != null || !cacheIsValid || !haveType);
-      }
-
-      public TypeCache(string fullName)
-      {
-        cacheIsValid = false;
-        haveType = false;
-        cache = default(Type);
-        this.fullName = fullName;
-      }
-      public bool TryGet(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, out Type type)
-      {
-        Contract.Ensures(Contract.ValueAtReturn(out type) != null || !Contract.Result<bool>());
-
-        if (!cacheIsValid)
-        {
-          cacheIsValid = true;
-          haveType = mdDecoder.TryGetSystemType(fullName, out cache);
-        }
-        type = cache;
-        return haveType;
-      }
-    }
-
-    /// <summary>
-    /// This must be true, otherwise, we have renaming problems
-    /// </summary>
-    private const bool EagerCaching = true;
-
-    private readonly ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Temp, Temp, IStackContext<Field, Method>, Unit> stackLayer;
-
-    IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
-
-        return this.stackLayer.MetaDataDecoder;
-      }
-    }
-    IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder { get { return this.stackLayer.ContractDecoder; } }
-    IStackContext<Field, Method> context { get { return this.stackLayer.Decoder.Context; } }
-    Method currentMethod { get { return this.context.MethodContext.CurrentMethod; } }
-
-    private bool TryComputeFromJoinCache(Domain inDomain, Domain outDomain, APC joinPoint, out IFunctionalMap<ESymValue, FList<ESymValue>> forward)
-    {
-      IMergeInfo mi;
-      forward = null;
-      if (this.mergeInfoCache.TryGetValue(joinPoint, out mi))
-      {
-        if (mi != null)
-        {
-          if (outDomain.IsResultEGraph(mi))
-          {
-            if (inDomain.IsGraph1(mi))
-            {
-              forward = mi.ForwardG1Map;
-              return true;
-            }
-            if (inDomain.IsGraph2(mi))
-            {
-              forward = mi.ForwardG2Map;
-              return true;
-            }
-          }
-        }
-      }
-      return false;
-    }
-
-    Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, FList<SymbolicValue>>> forwardRenamings = new Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, FList<SymbolicValue>>>();
-
-    /// <summary>
-    /// Key1 is source APC, Key2 is target APC (edge). We use this so we can enumerate all targets of a particular block where we have renamings
-    /// </summary>
-    DoubleTable<APC, APC, Unit> renamePoints = new DoubleTable<APC, APC, Unit>();
-
-    /// <summary>
-    /// Maps join point -> incoming point -> IMergeInfo from joins. This is a way to cache renamings if possible.
-    /// If the points map to null, then it is the original incoming edge and is still valid, i.e., the identity renaming.
-    /// </summary>
-    Dictionary<APC, IMergeInfo> mergeInfoCache = new Dictionary<APC, IMergeInfo>();
-
-    #endregion
-
-    public OptimisticHeapAnalyzer(
-      ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Temp, Temp, IStackContext<Field, Method>, Unit> stackLayer,
-      bool debugEGraph)
-    {
-      Contract.Requires(stackLayer != null);
-
-      this.stackLayer = stackLayer;
-      if (debugEGraph) { Domain.Debug = true; }
-
-      // hack: NOOOOOOOOOOOOOOOOOOOO!
-      Domain.AbstractType.MetadataDecoder = this.mdDecoder;
-    }
-
-    #region Configuration
-
-    public bool TurnArgumentExceptionThrowsIntoAssertFalse { get; set; }
-    public bool IgnoreExplicitAssumptions { get; set; }
-    public bool TraceAssumptions { get; set; }
-
-    TypeCache ArgumentExceptionTypeCache = new TypeCache("System.ArgumentException");
-
-
-    #endregion
-
-    private IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Domain, Domain> GetVisitor()
-    {
-      return new Domain.AnalysisDecoder(this);
-    }
-
-    /// <summary>
-    /// Computes symbolic variable renamings on edges leading to join points
-    /// </summary>
-    public IFunctionalMap<SymbolicValue, FList<SymbolicValue>>/*?*/ EdgeRenaming(Pair<APC, APC> edge, bool joinPoint)
-    {
-      IFunctionalMap<SymbolicValue, FList<SymbolicValue>> result;
-      if (this.forwardRenamings.TryGetValue(edge, out result))
-      {
-        return result;
-      }
-      result = null;
-      // compute renaming.
-      Domain start;
-      
-      if(!this.PostStateLookup(edge.One, out start))
-      {
-        return null;
-      }
-
-      if (start.IsBottom) return null;
-
-      Domain end;
-      this.PreStateLookup(edge.Two, out end);
-      IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
-
-      if (/*start != null && */end != null)
-      {
-        // see if we can use cache from join
-        if (!TryComputeFromJoinCache(start, end, edge.Two, out forward))
-        {
-          IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
-          if (!start.LessEqual(end, out forward, out backward))
-          {
-            Contract.Assume(false, "egraphs in renaming are not related properly"); // means egraphs don't correspond
-            throw new Exception("Should never happen");
-          }
-          if (joinPoint && forward == null)
-          {
-            // make sure to still call edge conversion since abstract domains might perform some other juggling
-            // prior to the join
-            forward = start.GetForwardIdentityMap();
-          }
-        }
-        // special case if forward is null, we use that as identity map and don't have to rename
-        if (forward != null)
-        {
-          result = FunctionalIntKeyMap<SymbolicValue, FList<SymbolicValue>>.Empty(SymbolicValue.GetUniqueKey);
-          foreach (ESymValue source in forward.Keys)
-          {
-            // omit identities
-            FList<SymbolicValue> targets = null;
-            for (var origTargets = forward[source]; origTargets != null; origTargets = origTargets.Tail)
-            {
-              targets = targets.Cons(new SymbolicValue(origTargets.Head));
-            }
-            if (targets != null)
-            {
-              result = result.Add(new SymbolicValue(source), targets);
-            }
-          }
-        }
-      }
-
-      if (Domain.Debug && result != null)
-      {
-        this.PrintRenaming(" * ", Console.Out, s => s.ToString(), edge, result);
-      }
-      this.forwardRenamings.Add(edge, result);
-      return result;
-    }
-
-    public Domain InitialValue()
-    {
-      return new Domain(this);
-    }
-
-    /// <summary>
-    /// Because we need to have a uniform type for constructors (edge labels) in the egraph, we need to inject the various
-    /// types such as Local, Temp, Parameter, Field, into a new type Constructor. One tricky thing is that we want to avoid
-    /// allocating these wrappers over and over, so we need to have a table somewhere. We can't have the table on each instance
-    /// of the heap abstraction, and we don't want it static. What we will do is use a shared table among all the instances from
-    /// a common root.
-    ///
-    /// For each abstract location, we track its current type in the underlying type representation.
-    /// </summary>
-    public class Domain :
-      IAbstractValue<Domain>
-    {
-      #region Analsyis State private to this Domain value
-      /// <summary>
-      /// egraph == null represents bottom
-      ///
-      /// The egraph is used to keep track of must aliasing. It also associates a Type with each symbolic value
-      /// to do some type recovery that is useful in later phases.
-      /// </summary>
-      readonly EGraph<Constructor, AbstractType> egraph;
-
-      /// <summary>
-      /// We use this map to determine if a symbolic value is a constant and what type it has
-      /// </summary>
-      IFunctionalMap<ESymValue, Constructor> constantLookup;
-
-      /// <summary>
-      /// Captures objects and field addresses that have not been modified since entry
-      /// </summary>
-      IFunctionalSet<ESymValue> unmodifiedSinceEntry;
-
-      /// <summary>
-      /// Captures objects and field addresses that have not been modified since entry.
-      /// This set contains objects that have had fields updated, but the remaining fields
-      /// (not materialized) have not been updated.
-      /// </summary>
-      IFunctionalSet<ESymValue> unmodifiedSinceEntryForFields;
-
-      /// <summary>
-      /// A set of locations created at a call site that are assumed to be havoced. We use
-      /// this set in old rename computations within the post condition of that call.
-      /// Thus, the set only needs to be maintained at program points within contracts, but not 
-      /// once we hit the outermost method again.
-      /// </summary>
-      IFunctionalSet<ESymValue> modifiedAtCall;
-
-      /// <summary>
-      /// Old handling. We count the level of nested olds here
-      /// </summary>
-      int insideOld;
-
-      /// <summary>
-      /// When inside Old, we keep a second old domain state around. It is only initialized
-      /// when insideOld crosses from 0 to 1 and all nested olds use it. It gets set to null
-      /// when insideOld goes back to 0.
-      /// </summary>
-      Domain oldDomain;
-      APC beginOldPC;
-
-      internal Domain OldDomain { get { return this.oldDomain; } }
-      internal APC BeginOldPC { get { return this.beginOldPC; } }
-
-      #endregion
-
-      public bool IsBottomPlaceHolder(ESymValue value)
-      {
-        return this.egraph.BottomPlaceHolder == value;
-      }
-
-      #region Analysis State shared among all Domain values in a method
-
-      /// <summary>
-      /// Cache for function symbols uses as edge lables in the egraph
-      /// </summary>
-      private readonly WrapTable Constructors;
-
-      /// <summary>
-      /// Used to save the state at BeginOld APCs. This map is not per domain, but 
-      /// shared among all derived states from the initial method state.
-      /// </summary>
-      private readonly Dictionary<APC, Domain> BeginOldSavedStates;
-
-      private readonly OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
-      #endregion
-
-      #region Constructor representation for edges in EGraph
-      class WrapTable
-      {
-        Dictionary<Local, Constructor.Wrapper<Local>> locals;
-        Dictionary<Parameter, Constructor.Wrapper<Parameter>> parameters;
-        Dictionary<Field, Constructor.Wrapper<Field>> fields;
-        Dictionary<Method, Constructor.Wrapper<Method>> pseudoFields;
-        Dictionary<Temp, Constructor.Wrapper<Temp>> temps;
-        Dictionary<string, Constructor.Wrapper<string>> strings;
-        Dictionary<object, Constructor.Wrapper<object>> programConstants;
-        Dictionary<Method, Constructor.Wrapper<Method>> methodPointers;
-        Dictionary<Type, Constructor.Wrapper<Type>> typeDefaultValues;
-        Dictionary<BinaryOperator, Constructor.Wrapper<BinaryOperator>> binaryOps;
-        Dictionary<UnaryOperator, Constructor.Wrapper<UnaryOperator>> unaryOps;
-
-        int idgen;
-
-        private Constructor.Wrapper<T> For<T>(T value, Dictionary<T, Constructor.Wrapper<T>> cache)
-        {
-          Contract.Ensures(Contract.Result<Constructor.Wrapper<T>>() != null);
-
-          Constructor.Wrapper<T>/*?*/ result;
-          if (!cache.TryGetValue(value, out result))
-          {
-            result = Constructor.For(value, ref idgen, this.mdDecoder, this.contractDecoder);
-            cache.Add(value, result);
-          }
-          else
-          {
-            Contract.Assume(result != null);
-          }
-          return result;
-        }
-
-        public Constructor For(Local v) { return For(v, locals); }
-        public Constructor For(Parameter v) { return For(v, parameters); }
-        public Constructor For(Field v)
-        {
-          v = this.mdDecoder.Unspecialized(v);
-          return For(v, fields);
-        }
-        public Constructor For(Method v) { return For(v, pseudoFields); }
-        public Constructor For(Temp v) { return For(v, temps); }
-        public Constructor For(string v) { return For(v, strings); }
-        public Constructor For(BinaryOperator v) { return For(v, binaryOps); }
-        public Constructor For(UnaryOperator v) { return For(v, unaryOps); }
-        public Constructor ForConstant(object constant, Type type)
-        {
-          var c = For(constant, programConstants);
-          c.Type = type;
-          return c;
-        }
-        /// <summary>
-        /// Used by LdFtn
-        /// </summary>
-        /// <param name="method">the method</param>
-        /// <param name="type">UIntPtr</param>
-        public Constructor ForMethod(Method method, Type type)
-        {
-          var c = For(method, methodPointers);
-          c.Type = type;
-          return c;
-        }
-
-        /// <summary>
-        /// Used by InitObj
-        /// </summary>
-        /// <param name="method">the method</param>
-        /// <param name="type">UIntPtr</param>
-        public Constructor ForTypeDefaultValue(Type type)
-        {
-          Constructor.Wrapper<Type> c = For(type, typeDefaultValues);
-          return c;
-        }
-
-        /// <summary>
-        /// Returns true if the symbolic constant represents a program constant
-        /// </summary>
-        public bool IsConstantOrMethod(Constructor c)
-        {
-          Constructor.Wrapper<object> cwrapper = c as Constructor.Wrapper<object>;
-          if (cwrapper != null)
-          {
-            if (this.programConstants.ContainsKey(cwrapper.Value))
-            {
-              return true;
-            }
-          }
-          Constructor.Wrapper<Method> mwrapper = c as Constructor.Wrapper<Method>;
-          if (mwrapper != null)
-          {
-            if (this.methodPointers.ContainsKey(mwrapper.Value))
-            {
-              return true;
-            }
-          }
-          return false;
-        }
-
-        /// <summary>
-        /// Returns true if the symbolic constant represents a program constant
-        /// </summary>
-        public bool IsConstant(Constructor c, out Type type, out object value)
-        {
-          Constructor.Wrapper<object> cwrapper = c as Constructor.Wrapper<object>;
-          if (cwrapper != null)
-          {
-            if (this.programConstants.ContainsKey(cwrapper.Value))
-            {
-              type = cwrapper.Type;
-              value = cwrapper.Value;
-              Contract.Assume(!this.mdDecoder.Equal(type, this.mdDecoder.System_Int32) || value is Int32);
-              return true;
-            }
-          }
-          type = default(Type);
-          value = null;
-          return false;
-        }
-
-        /// <summary>
-        /// Used to indirect from address to value
-        /// </summary>
-        public readonly Constructor ValueOf;
-
-        /// <summary>
-        /// Used to retain old value across havocs
-        /// </summary>
-        public readonly Constructor OldValueOf;
-
-        /// <summary>
-        /// Special model field for structs used to have a symbolic identity
-        /// </summary>
-        public readonly Constructor StructId;
-
-        /// <summary>
-        /// Special model field for objects used to indicate a version (updated on mutation)
-        /// </summary>
-        public readonly Constructor ObjectVersion;
-
-        public readonly Constructor NullValue;
-        /// <summary>
-        /// Used as a pure function for array element addresses ElementAddr(array,index)
-        /// </summary>
-        public readonly Constructor ElementAddress;
-        /// <summary>
-        /// Model field for array length
-        /// </summary>
-        public readonly Constructor Length;
-        /// <summary>
-        /// Model field for writable extent of pointers
-        /// </summary>
-        public readonly Constructor WritableBytes;
-        /// <summary>
-        /// dummy struct address for all void values
-        /// </summary>
-        public readonly Constructor VoidAddr;
-        public readonly Constructor ZeroValue;
-        public readonly Constructor UnaryNot;
-        public readonly Constructor NeZero;
-        public readonly Constructor IsInst;
-        /// <summary>
-        /// Special way to cache box operations on same values
-        /// </summary>
-        public readonly Constructor BoxOperator;
-        /// <summary>
-        /// Special field in delegates to hold method pointer
-        /// </summary>
-        public readonly Constructor FunctionPointer;
-        /// <summary>
-        /// Special field in delegates to hold target object
-        /// </summary>
-        public readonly Constructor ClosureObject;
-        /// <summary>
-        /// Breadcrumb to tag values resulting from calls. (target doesn't matter)
-        /// </summary>
-        public readonly Constructor ResultOfCall;
-        /// <summary>
-        /// Breadcrumb to tag values resulting from pure calls. (target doesn't matter)
-        /// </summary>
-        public readonly Constructor ResultOfPureCall;
-        /// <summary>
-        /// Breadcrumb to tag values resulting from ldelem. (target doesn't matter)
-        /// </summary>
-        public readonly Constructor ResultOfLdelem;
-        /// <summary>
-        /// Breadcrumb to tag values resulting from cast. (target is original value being cast)
-        /// </summary>
-        public readonly Constructor ResultOfCast;
-        /// <summary>
-        /// Breadcrumb to tag values resulting from out parameters. (target does not matter)
-        /// </summary>
-        public readonly Constructor ResultOfOutParameter;
-
-        /// <summary>
-        /// Breadcrumb to tag values resulting for fields after calling a method on "this"
-        /// </summary>
-        public readonly Constructor ResultOfCallThisHavoc;
-
-        /// <summary>
-        /// Breadcrumb to tag values resulting from OldValue
-        /// </summary>
-        public readonly Constructor ResultOfOldValue;
-#if false
-        /// <summary>
-        /// Used to approximate hash consing across join points of ElementAddr(a,i)
-        /// </summary>
-        public readonly Constructor LastArrayIndex;
-        public readonly Constructor LastArrayElemAddress;
-#endif
-        readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-        readonly IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder;
-        public WrapTable(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder)
-        {
-          this.mdDecoder = mdDecoder;
-          this.contractDecoder = contractDecoder;
-
-          this.locals = new Dictionary<Local, Constructor.Wrapper<Local>>();
-          this.parameters = new Dictionary<Parameter, Constructor.Wrapper<Parameter>>();
-          this.fields = new Dictionary<Field, Constructor.Wrapper<Field>>();
-          this.pseudoFields = new Dictionary<Method, Constructor.Wrapper<Method>>();
-          this.temps = new Dictionary<int, Constructor.Wrapper<Temp>>();
-          this.strings = new Dictionary<string, Constructor.Wrapper<string>>();
-          this.programConstants = new Dictionary<object, Constructor.Wrapper<object>>();
-          this.methodPointers = new Dictionary<Method, Constructor.Wrapper<Method>>();
-          this.typeDefaultValues = new Dictionary<Type, Constructor.Wrapper<Type>>();
-          this.binaryOps = new Dictionary<BinaryOperator, Constructor.Wrapper<BinaryOperator>>();
-          this.unaryOps = new Dictionary<UnaryOperator, Constructor.Wrapper<UnaryOperator>>();
-
-
-          ValueOf = For("$Value");
-          OldValueOf = For("$OldValue");
-          StructId = For("$StructId");
-          ObjectVersion = For("$ObjectVersion");
-          NullValue = For("$Null");
-          ElementAddress = For("$Element");
-          Length = For("$Length");
-          WritableBytes = For("$WritableBytes");
-          VoidAddr = For("$VoidAddr");
-          UnaryNot = For("$UnaryNot");
-          IsInst = For("$IsInst");
-          NeZero = For("$NeZero");
-          BoxOperator = For("$Box");
-          FunctionPointer = For("$FnPtr");
-          ClosureObject = For("$Closure");
-
-          // Breadcrumbs: we use these to tag values (target doesn't matter)
-          ResultOfCall = For("$ResultOfCall");
-          ResultOfLdelem = For("$ResultOfLdElem");
-          ResultOfCast = For("$ResultOfCast");
-          ResultOfOutParameter = For("$ResultOfOut");
-          ResultOfCallThisHavoc = For("$ResultOfCallThisHavoc");
-          ResultOfPureCall = For("$ResultOfPureCall");
-          ResultOfOldValue = For("$ResultOfOldValue");
-
-          ZeroValue = ForConstant((int)0, this.mdDecoder.System_Int32);
-        }
-      }
-
-
-      [Serializable]
-      [ContractVerification(false)]
-      internal abstract class Constructor : IEquatable<Constructor>, IConstantInfo, IVisibilityCheck<Method>
-      {
-        public readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-
-        protected Constructor(ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-        {
-          this.mdDecoder = mdDecoder;
-        }
-
-        public abstract bool IsStackTemp { get; }
-
-        public abstract bool ActsAsField { get; }
-
-        public abstract bool IsVirtualMethod { get; }
-
-        public abstract bool KeepAsBottomField { get; }
-
-        public abstract bool ManifestField { get; }
-
-        public abstract Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder);
-
-        /// <param name="tryCompact">true if pure method accessors should be compressed to avoid the addres/ldind pair</param>
-        public abstract PathElementBase ToPathElement(bool tryCompact);
-
-        public abstract bool HasExtraDeref { get; }
-
-        public abstract bool IsAsVisibleAs(Method method);
-
-        public abstract bool IsVisibleFrom(Method method);
-
-        public abstract bool RootImpliesParameterOrResultOrStatic { get; }
-
-        public abstract bool IsTopOfStack(int stackDepth);
-
-        /// <summary>
-        /// For fields and properties, this return whether they are static. Otherwise false.
-        /// </summary>
-        public abstract bool IsStatic { get; }
-
-        [Serializable]
-        [ContractVerification(false)]
-        public class Wrapper<T> : Constructor
-        {
-
-          public readonly T Value;
-          private Type type;
-          public Type Type { get { return this.type; } set { this.type = value; } }
-
-          public Wrapper(T value, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-            : base(ref idgen, mdDecoder)
-          {
-            this.Value = value;
-          }
-
-          public override bool IsStackTemp
-          {
-            get
-            {
-              if (typeof(T).Equals(typeof(int))) return true;
-              return false;
-            }
-          }
-
-          public override bool ActsAsField
-          {
-            get
-            {
-              return (this.Value is Field);
-            }
-          }
-
-          public override bool KeepAsBottomField
-          {
-            get
-            {
-              string s = this.Value as string;
-              if (s == null) return true;
-              return (s != "$UnaryNot" && s != "$NeZero");
-            }
-          }
-
-          public override bool ManifestField
-          {
-            get
-            {
-              // manifest $Value and fields and pseudo fields
-              string s = this.Value as string;
-              if (s != null) { return s == "$Value" || s == "$Length"; }
-              return (this.Value is Field || this.Value is Method);
-            }
-          }
-
-          public override Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-          {
-            if (this.Value is Field)
-            {
-              return mdDecoder.ManagedPointer(mdDecoder.FieldType((Field)(object)this.Value));
-            }
-            throw new NotImplementedException();
-          }
-
-          public override bool IsStatic
-          {
-            get
-            {
-              if (this.Value is Field)
-              {
-                return this.mdDecoder.IsStatic((Field)(object)this.Value);
-              }
-              if (this.Value is Method)
-              {
-                return this.mdDecoder.IsStatic((Method)(object)this.Value);
-              }
-              return false;
-            }
-          }
-
-          public override bool IsVirtualMethod
-          {
-            get
-            {
-              if (this.Value is Method)
-              {
-                return this.mdDecoder.IsVirtual((Method)(object)this.Value);
-              }
-              return false;
-            }
-          }
-
-          //^ [Confined]
-          public override string ToString()
-          {
-            if (typeof(T).Equals(typeof(Temp)))
-            {
-              return String.Format("s{0}", Value);
-            }
-            if (typeof(T).Equals(typeof(Field)))
-            {
-              Field f = (Field)(object)Value;
-              if (mdDecoder.IsStatic(f))
-              {
-                //return String.Format("{0}.{1}", mdDecoder.FullName(mdDecoder.DeclaringType(f)), mdDecoder.Name(f));
-                return String.Format("{0}.{1}", OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, mdDecoder.DeclaringType(f)), mdDecoder.Name(f));
-              }
-              return mdDecoder.Name(f);
-            }
-            if (typeof(T).Equals(typeof(Method)))
-            {
-              Method m = (Method)(object)Value;
-              string name;
-
-              if (mdDecoder.IsPropertyGetter(m) || mdDecoder.IsPropertySetter(m))
-              {
-                Property prop = mdDecoder.GetPropertyFromAccessor(m);
-                if (prop != null)
+                if (notFirst)
                 {
-                  name = mdDecoder.Name(prop);
+                    sb.Append(separator);
+                }
+                sb.Append(elem.ToString());
+                notFirst = true;
+            }
+            return sb.ToString();
+        }
+    }
+
+    public struct SymbolicValue : IEquatable<SymbolicValue>, IComparable<SymbolicValue>, IComparable
+    {
+        internal readonly ESymValue symbol;
+
+        public static int GetUniqueKey(SymbolicValue v) { return ESymValue.GetUniqueKey(v.symbol); }
+        public static int Compare(SymbolicValue left, SymbolicValue right) { return left.symbol.UniqueId - right.symbol.UniqueId; }
+
+        internal SymbolicValue(ESymValue symbol)
+        {
+            this.symbol = symbol;
+        }
+
+        #region IEquatable<SymbolicValue> Members
+
+        //^ [StateIndependent]
+        public bool Equals(SymbolicValue other)
+        {
+            return symbol == other.symbol;
+        }
+
+        public override int GetHashCode()
+        {
+            return symbol != null ? symbol.GlobalId : -1;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is SymbolicValue)
+            {
+                SymbolicValue that = (SymbolicValue)obj;
+                return this.symbol.Equals(that.symbol);
+            }
+            return false;
+        }
+        #endregion
+
+        public override string ToString()
+        {
+            if (symbol == null) return "<null>";
+            return symbol.ToString();
+        }
+
+        public bool IsNull
+        {
+            get { return symbol == null; }
+        }
+
+        public int MethodLocalKey { get { return this.symbol.UniqueId; } }
+
+        #region IComparable<SymbolicValue> Members
+
+        public Source CompareTo(SymbolicValue other)
+        {
+            return this.symbol.CompareTo(other.symbol);
+        }
+
+        #endregion
+
+        #region IComparable Members
+
+        public Source CompareTo(object obj)
+        {
+            if (obj is SymbolicValue)
+            {
+                return this.CompareTo((SymbolicValue)obj);
+            }
+            return 1;
+        }
+
+        #endregion
+    }
+
+    #region Path Elements
+    [Serializable]
+    public abstract class PathElement
+    {
+        public virtual bool IsBooleanTyped { get { return false; } }
+        public virtual bool IsDeref { get { return false; } }
+        public virtual bool IsMethodCall { get { return false; } }
+        public virtual bool IsGetter { get { return false; } }
+        public virtual bool IsStatic { get { return false; } }
+        public virtual bool IsUnmanagedPointer { get { return false; } }
+        public virtual bool IsManagedPointer { get { return false; } }
+        public virtual bool HasExtraDeref { get { return false; } }
+        public virtual bool IsParameter { get { return false; } }
+
+        public virtual bool IsParameterOut { get { return false; } }
+        public virtual bool IsReturnValue { get { return false; } }
+        public virtual bool IsParameterRef { get { return false; } }
+        public virtual bool IsModel { get { return false; } }
+        public abstract PathElement SubstituteElement(object from, object to);
+
+        /// <returns>The parameter in the path element, if any</returns>
+        public virtual bool TryParameter<Parameter>(out Parameter p)
+        {
+            p = default(Parameter);
+            return false;
+        }
+
+        /// <returns>The field in the PathElement, if any </returns>
+        public virtual bool TryField<Field>(out Field f)
+        {
+            f = default(Field);
+            return false;
+        }
+
+        public virtual bool TryMethod<Method>(out Method m)
+        {
+            m = default(Method);
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the type of the result of the path element (if possible).
+        /// </summary>
+        public abstract bool TryGetResultType<Type>(out Type type);
+
+        /// <summary>
+        /// Set to the type name it should be cast to on output
+        /// </summary>
+        virtual public string CastTo { get { return ""; } } // default is: no cast
+
+        /// <summary>
+        /// returns true if the path element implicitly takes the address of the element, i.e,
+        /// local variable, parameter, or field (static or instance)
+        /// </summary>
+        public abstract bool IsAddressOf { get; }
+        public abstract Result Decode<Data, Result, Visitor, PC, Local, Parameter, Method, Field, Type>(PC label, Visitor query, Data data)
+          where Visitor : ICodeQuery<PC, Local, Parameter, Method, Field, Type, Data, Result>;
+
+        public abstract override string ToString();
+    }
+
+    public static class PathExtensions
+    {
+        public static Set<Field> FieldsIn<Field>(this FList<PathElement> path)
+        {
+            var result = new Set<Field>();
+            if (path != null)
+            {
+                foreach (var element in path.GetEnumerable())
+                {
+                    Field f;
+                    if (element.TryField(out f))
+                    {
+                        result.Add(f);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        [ContractVerification(false)]
+        public static string ToCodeString(this PathElement[] path)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            return PathToString(path);
+        }
+
+        public static string ToCodeString(this FList<PathElement> path)
+        {
+            return PathToString(path);
+        }
+
+        private static string PathToString(FList<PathElement> path)
+        {
+            var first = true;
+            var endsInAddressOf = false;
+            var sb = new StringBuilder();
+            var bEndsWithUnmanaged = false;
+
+            for (; path != null; path = path.Tail)
+            {
+                PathElement c = path.Head;
+                Contract.Assume(c != null);
+                if (c.IsMethodCall && !c.IsGetter && c.IsStatic)
+                {
+                    var arg = sb.ToString();
+                    sb = new StringBuilder();
+                    sb.Append(c.ToString());
+                    sb.Append('(');
+                    sb.Append(arg);
+                    sb.Append(')');
+                    first = false;
                 }
                 else
                 {
-                  name = mdDecoder.Name(m);
-                  if (name.StartsWith("get_") || name.StartsWith("set_"))
+                    if (!string.IsNullOrEmpty(c.CastTo))
+                    {
+                        var arg = sb.ToString();
+                        sb = new StringBuilder();
+                        sb.Append("((");
+                        sb.Append(c.CastTo);
+                        // this test is not pretty, it should be included in the CastTo field. But come on, unsafe pointers are not pretty either
+                        if (bEndsWithUnmanaged)
+                            sb.Append('*');
+                        sb.Append(')');
+                        sb.Append(arg);
+                        sb.Append(')');
+                    }
+
+                    if (first)
+                        first = false;
+                    else
+                    {
+                        if (bEndsWithUnmanaged)
+                            sb.Append("->");
+                        else
+                            sb.Append('.');
+                    }
+
+                    sb.Append(c.ToString());
+                    if (c.IsMethodCall && !c.IsGetter)
+                    {
+                        sb.Append("()");
+                    }
+                }
+                int iter = (c.IsAddressOf ? 1 : 0) + (c.IsUnmanagedPointer ? 1 : 0) + (c.IsManagedPointer ? 1 : 0);
+                bEndsWithUnmanaged = c.IsUnmanagedPointer;
+
+                if (c.IsAddressOf)
+                {
+                    for (int j = 0; j < iter; ++j)
+                    {
+                        if (path.Tail != null)
+                        {
+                            if (path.Tail.Head.IsDeref)
+                            {
+                                // skip deref
+                                path = path.Tail;
+                            }
+                        }
+                        else
+                        {
+                            // end of path
+                            endsInAddressOf = true;
+                        }
+                    }
+                }
+            }
+            if (endsInAddressOf)
+            {
+                if (bEndsWithUnmanaged)
+                    return sb.ToString(); // address of dereference = &*, so output nothing
+                else
+                    return "&" + sb.ToString();
+            }
+            else
+            {
+                if (bEndsWithUnmanaged)
+                    return "*" + sb.ToString();
+                else
+                    return sb.ToString();
+            }
+        }
+
+        private static string PathToString(PathElement[] path)
+        {
+            Contract.Requires(path != null);
+            Contract.Requires(Contract.ForAll(path, p => p != null));
+
+            var first = true;
+            var endsInAddressOf = false;
+            var sb = new StringBuilder();
+            var bEndsWithUnmanaged = false;
+
+            if (path.Length == 1)
+            {
+                return path[0].ToString();
+            }
+
+            for (int i = 0; i < path.Length; i++)
+            {
+                var c = path[i];
+                if (c.IsMethodCall && !c.IsGetter && c.IsStatic)
+                {
+                    var arg = sb.ToString();
+                    sb = new StringBuilder();
+                    sb.Append(c.ToString());
+                    sb.Append('(');
+                    sb.Append(arg);
+                    sb.Append(')');
+                    first = false;
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(c.CastTo))
+                    {
+                        var arg = sb.ToString();
+                        sb = new StringBuilder();
+                        sb.Append("((");
+                        sb.Append(c.CastTo);
+                        // this test is not pretty, it should be included in the CastTo field. But come on, unsafe pointers are not pretty either
+                        if (bEndsWithUnmanaged)
+                            sb.Append('*');
+                        sb.Append(')');
+                        sb.Append(arg);
+                        sb.Append(')');
+                    }
+
+                    if (first)
+                        first = false;
+                    else
+                    {
+                        if (bEndsWithUnmanaged)
+                            sb.Append("->");
+                        else
+                            sb.Append('.');
+                    }
+
+                    if (c.IsParameterOut)
+                    {
+                        sb.AppendFormat("Contract.ValueAtReturn(out {0})", c.ToString());
+                    }
+                    else
+                    {
+                        sb.Append(c.ToString());
+                    }
+
+                    if (c.IsMethodCall && !c.IsGetter)
+                    {
+                        sb.Append("()");
+                    }
+                }
+                int iter = (c.IsAddressOf ? 1 : 0) + (c.IsUnmanagedPointer ? 1 : 0) + (c.IsManagedPointer ? 1 : 0);
+                bEndsWithUnmanaged = c.IsUnmanagedPointer;
+                //if (c.IsAddressOf) // can be a managed pointer (out parameter)
+                for (int j = 0; j < iter; ++j)
+                {
+                    if (i + 1 < path.Length)
+                    {
+                        if (path[i + 1].IsDeref)
+                        {
+                            // skip deref
+                            i++;
+                        }
+                    }
+                    else
+                    {
+                        // end of path
+                        endsInAddressOf = true;
+                    }
+                }
+            }
+
+            if (endsInAddressOf)
+            {
+                if (bEndsWithUnmanaged)
+                    return sb.ToString(); // address of dereference = &*, so output nothing
+                else
+                    return "&" + sb.ToString();
+            }
+            else
+            {
+                if (bEndsWithUnmanaged)
+                    return "*" + sb.ToString();
+                else
+                    return sb.ToString();
+            }
+        }
+    }
+
+
+    #endregion
+
+    /// <summary>
+    /// This abstraction computes must aliasing while making optimistic assumptions about non-aliasing of unrelated
+    /// objects.
+    /// It produces a symbolic name for all intermediate values such that subsequent analyses can focus on value
+    /// relations rather than dealing with the stack and heap model of IL. 
+    /// </summary>
+    public class OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
+      : IAnalysis<APC, OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Domain, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Domain, OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Domain>, Unit>
+      where Type : IEquatable<Type>
+    {
+        #region Privates
+
+        private struct TypeCache
+        {
+            private bool cacheIsValid;
+            private bool haveType;
+            private Type cache;
+            private string fullName;
+
+            [ContractInvariantMethod]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(cache != null || !cacheIsValid || !haveType);
+            }
+
+            public TypeCache(string fullName)
+            {
+                cacheIsValid = false;
+                haveType = false;
+                cache = default(Type);
+                this.fullName = fullName;
+            }
+            public bool TryGet(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, out Type type)
+            {
+                Contract.Ensures(Contract.ValueAtReturn(out type) != null || !Contract.Result<bool>());
+
+                if (!cacheIsValid)
+                {
+                    cacheIsValid = true;
+                    haveType = mdDecoder.TryGetSystemType(fullName, out cache);
+                }
+                type = cache;
+                return haveType;
+            }
+        }
+
+        /// <summary>
+        /// This must be true, otherwise, we have renaming problems
+        /// </summary>
+        private const bool EagerCaching = true;
+
+        private readonly ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Temp, Temp, IStackContext<Field, Method>, Unit> stackLayer;
+
+        private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
+
+                return stackLayer.MetaDataDecoder;
+            }
+        }
+        private IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder { get { return stackLayer.ContractDecoder; } }
+        private IStackContext<Field, Method> context { get { return stackLayer.Decoder.Context; } }
+        private Method currentMethod { get { return this.context.MethodContext.CurrentMethod; } }
+
+        private bool TryComputeFromJoinCache(Domain inDomain, Domain outDomain, APC joinPoint, out IFunctionalMap<ESymValue, FList<ESymValue>> forward)
+        {
+            IMergeInfo mi;
+            forward = null;
+            if (mergeInfoCache.TryGetValue(joinPoint, out mi))
+            {
+                if (mi != null)
+                {
+                    if (outDomain.IsResultEGraph(mi))
+                    {
+                        if (inDomain.IsGraph1(mi))
+                        {
+                            forward = mi.ForwardG1Map;
+                            return true;
+                        }
+                        if (inDomain.IsGraph2(mi))
+                        {
+                            forward = mi.ForwardG2Map;
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        private Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, FList<SymbolicValue>>> forwardRenamings = new Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, FList<SymbolicValue>>>();
+
+        /// <summary>
+        /// Key1 is source APC, Key2 is target APC (edge). We use this so we can enumerate all targets of a particular block where we have renamings
+        /// </summary>
+        private DoubleTable<APC, APC, Unit> renamePoints = new DoubleTable<APC, APC, Unit>();
+
+        /// <summary>
+        /// Maps join point -> incoming point -> IMergeInfo from joins. This is a way to cache renamings if possible.
+        /// If the points map to null, then it is the original incoming edge and is still valid, i.e., the identity renaming.
+        /// </summary>
+        private Dictionary<APC, IMergeInfo> mergeInfoCache = new Dictionary<APC, IMergeInfo>();
+
+        #endregion
+
+        public OptimisticHeapAnalyzer(
+          ICodeLayer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Temp, Temp, IStackContext<Field, Method>, Unit> stackLayer,
+          bool debugEGraph)
+        {
+            Contract.Requires(stackLayer != null);
+
+            this.stackLayer = stackLayer;
+            if (debugEGraph) { Domain.Debug = true; }
+
+            // hack: NOOOOOOOOOOOOOOOOOOOO!
+            Domain.AbstractType.MetadataDecoder = this.mdDecoder;
+        }
+
+        #region Configuration
+
+        public bool TurnArgumentExceptionThrowsIntoAssertFalse { get; set; }
+        public bool IgnoreExplicitAssumptions { get; set; }
+        public bool TraceAssumptions { get; set; }
+
+        private TypeCache ArgumentExceptionTypeCache = new TypeCache("System.ArgumentException");
+
+
+        #endregion
+
+        private IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Domain, Domain> GetVisitor()
+        {
+            return new Domain.AnalysisDecoder(this);
+        }
+
+        /// <summary>
+        /// Computes symbolic variable renamings on edges leading to join points
+        /// </summary>
+        public IFunctionalMap<SymbolicValue, FList<SymbolicValue>>/*?*/ EdgeRenaming(Pair<APC, APC> edge, bool joinPoint)
+        {
+            IFunctionalMap<SymbolicValue, FList<SymbolicValue>> result;
+            if (forwardRenamings.TryGetValue(edge, out result))
+            {
+                return result;
+            }
+            result = null;
+            // compute renaming.
+            Domain start;
+
+            if (!this.PostStateLookup(edge.One, out start))
+            {
+                return null;
+            }
+
+            if (start.IsBottom) return null;
+
+            Domain end;
+            this.PreStateLookup(edge.Two, out end);
+            IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
+
+            if (/*start != null && */end != null)
+            {
+                // see if we can use cache from join
+                if (!TryComputeFromJoinCache(start, end, edge.Two, out forward))
+                {
+                    IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
+                    if (!start.LessEqual(end, out forward, out backward))
+                    {
+                        Contract.Assume(false, "egraphs in renaming are not related properly"); // means egraphs don't correspond
+                        throw new Exception("Should never happen");
+                    }
+                    if (joinPoint && forward == null)
+                    {
+                        // make sure to still call edge conversion since abstract domains might perform some other juggling
+                        // prior to the join
+                        forward = start.GetForwardIdentityMap();
+                    }
+                }
+                // special case if forward is null, we use that as identity map and don't have to rename
+                if (forward != null)
+                {
+                    result = FunctionalIntKeyMap<SymbolicValue, FList<SymbolicValue>>.Empty(SymbolicValue.GetUniqueKey);
+                    foreach (ESymValue source in forward.Keys)
+                    {
+                        // omit identities
+                        FList<SymbolicValue> targets = null;
+                        for (var origTargets = forward[source]; origTargets != null; origTargets = origTargets.Tail)
+                        {
+                            targets = targets.Cons(new SymbolicValue(origTargets.Head));
+                        }
+                        if (targets != null)
+                        {
+                            result = result.Add(new SymbolicValue(source), targets);
+                        }
+                    }
+                }
+            }
+
+            if (Domain.Debug && result != null)
+            {
+                this.PrintRenaming(" * ", Console.Out, s => s.ToString(), edge, result);
+            }
+            forwardRenamings.Add(edge, result);
+            return result;
+        }
+
+        public Domain InitialValue()
+        {
+            return new Domain(this);
+        }
+
+        /// <summary>
+        /// Because we need to have a uniform type for constructors (edge labels) in the egraph, we need to inject the various
+        /// types such as Local, Temp, Parameter, Field, into a new type Constructor. One tricky thing is that we want to avoid
+        /// allocating these wrappers over and over, so we need to have a table somewhere. We can't have the table on each instance
+        /// of the heap abstraction, and we don't want it static. What we will do is use a shared table among all the instances from
+        /// a common root.
+        ///
+        /// For each abstract location, we track its current type in the underlying type representation.
+        /// </summary>
+        public class Domain :
+          IAbstractValue<Domain>
+        {
+            #region Analsyis State private to this Domain value
+            /// <summary>
+            /// egraph == null represents bottom
+            ///
+            /// The egraph is used to keep track of must aliasing. It also associates a Type with each symbolic value
+            /// to do some type recovery that is useful in later phases.
+            /// </summary>
+            private readonly EGraph<Constructor, AbstractType> egraph;
+
+            /// <summary>
+            /// We use this map to determine if a symbolic value is a constant and what type it has
+            /// </summary>
+            private IFunctionalMap<ESymValue, Constructor> constantLookup;
+
+            /// <summary>
+            /// Captures objects and field addresses that have not been modified since entry
+            /// </summary>
+            private IFunctionalSet<ESymValue> unmodifiedSinceEntry;
+
+            /// <summary>
+            /// Captures objects and field addresses that have not been modified since entry.
+            /// This set contains objects that have had fields updated, but the remaining fields
+            /// (not materialized) have not been updated.
+            /// </summary>
+            private IFunctionalSet<ESymValue> unmodifiedSinceEntryForFields;
+
+            /// <summary>
+            /// A set of locations created at a call site that are assumed to be havoced. We use
+            /// this set in old rename computations within the post condition of that call.
+            /// Thus, the set only needs to be maintained at program points within contracts, but not 
+            /// once we hit the outermost method again.
+            /// </summary>
+            private IFunctionalSet<ESymValue> modifiedAtCall;
+
+            /// <summary>
+            /// Old handling. We count the level of nested olds here
+            /// </summary>
+            private int insideOld;
+
+            /// <summary>
+            /// When inside Old, we keep a second old domain state around. It is only initialized
+            /// when insideOld crosses from 0 to 1 and all nested olds use it. It gets set to null
+            /// when insideOld goes back to 0.
+            /// </summary>
+            private Domain oldDomain;
+            private APC beginOldPC;
+
+            internal Domain OldDomain { get { return oldDomain; } }
+            internal APC BeginOldPC { get { return beginOldPC; } }
+
+            #endregion
+
+            public bool IsBottomPlaceHolder(ESymValue value)
+            {
+                return egraph.BottomPlaceHolder == value;
+            }
+
+            #region Analysis State shared among all Domain values in a method
+
+            /// <summary>
+            /// Cache for function symbols uses as edge lables in the egraph
+            /// </summary>
+            private readonly WrapTable Constructors;
+
+            /// <summary>
+            /// Used to save the state at BeginOld APCs. This map is not per domain, but 
+            /// shared among all derived states from the initial method state.
+            /// </summary>
+            private readonly Dictionary<APC, Domain> BeginOldSavedStates;
+
+            private readonly OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
+            #endregion
+
+            #region Constructor representation for edges in EGraph
+            private class WrapTable
+            {
+                private Dictionary<Local, Constructor.Wrapper<Local>> locals;
+                private Dictionary<Parameter, Constructor.Wrapper<Parameter>> parameters;
+                private Dictionary<Field, Constructor.Wrapper<Field>> fields;
+                private Dictionary<Method, Constructor.Wrapper<Method>> pseudoFields;
+                private Dictionary<Temp, Constructor.Wrapper<Temp>> temps;
+                private Dictionary<string, Constructor.Wrapper<string>> strings;
+                private Dictionary<object, Constructor.Wrapper<object>> programConstants;
+                private Dictionary<Method, Constructor.Wrapper<Method>> methodPointers;
+                private Dictionary<Type, Constructor.Wrapper<Type>> typeDefaultValues;
+                private Dictionary<BinaryOperator, Constructor.Wrapper<BinaryOperator>> binaryOps;
+                private Dictionary<UnaryOperator, Constructor.Wrapper<UnaryOperator>> unaryOps;
+
+                private int idgen;
+
+                private Constructor.Wrapper<T> For<T>(T value, Dictionary<T, Constructor.Wrapper<T>> cache)
+                {
+                    Contract.Ensures(Contract.Result<Constructor.Wrapper<T>>() != null);
+
+                    Constructor.Wrapper<T>/*?*/ result;
+                    if (!cache.TryGetValue(value, out result))
+                    {
+                        result = Constructor.For(value, ref idgen, mdDecoder, contractDecoder);
+                        cache.Add(value, result);
+                    }
+                    else
+                    {
+                        Contract.Assume(result != null);
+                    }
+                    return result;
+                }
+
+                public Constructor For(Local v) { return For(v, locals); }
+                public Constructor For(Parameter v) { return For(v, parameters); }
+                public Constructor For(Field v)
+                {
+                    v = mdDecoder.Unspecialized(v);
+                    return For(v, fields);
+                }
+                public Constructor For(Method v) { return For(v, pseudoFields); }
+                public Constructor For(Temp v) { return For(v, temps); }
+                public Constructor For(string v) { return For(v, strings); }
+                public Constructor For(BinaryOperator v) { return For(v, binaryOps); }
+                public Constructor For(UnaryOperator v) { return For(v, unaryOps); }
+                public Constructor ForConstant(object constant, Type type)
+                {
+                    var c = For(constant, programConstants);
+                    c.Type = type;
+                    return c;
+                }
+                /// <summary>
+                /// Used by LdFtn
+                /// </summary>
+                /// <param name="method">the method</param>
+                /// <param name="type">UIntPtr</param>
+                public Constructor ForMethod(Method method, Type type)
+                {
+                    var c = For(method, methodPointers);
+                    c.Type = type;
+                    return c;
+                }
+
+                /// <summary>
+                /// Used by InitObj
+                /// </summary>
+                /// <param name="method">the method</param>
+                /// <param name="type">UIntPtr</param>
+                public Constructor ForTypeDefaultValue(Type type)
+                {
+                    Constructor.Wrapper<Type> c = For(type, typeDefaultValues);
+                    return c;
+                }
+
+                /// <summary>
+                /// Returns true if the symbolic constant represents a program constant
+                /// </summary>
+                public bool IsConstantOrMethod(Constructor c)
+                {
+                    Constructor.Wrapper<object> cwrapper = c as Constructor.Wrapper<object>;
+                    if (cwrapper != null)
+                    {
+                        if (programConstants.ContainsKey(cwrapper.Value))
+                        {
+                            return true;
+                        }
+                    }
+                    Constructor.Wrapper<Method> mwrapper = c as Constructor.Wrapper<Method>;
+                    if (mwrapper != null)
+                    {
+                        if (methodPointers.ContainsKey(mwrapper.Value))
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+
+                /// <summary>
+                /// Returns true if the symbolic constant represents a program constant
+                /// </summary>
+                public bool IsConstant(Constructor c, out Type type, out object value)
+                {
+                    Constructor.Wrapper<object> cwrapper = c as Constructor.Wrapper<object>;
+                    if (cwrapper != null)
+                    {
+                        if (programConstants.ContainsKey(cwrapper.Value))
+                        {
+                            type = cwrapper.Type;
+                            value = cwrapper.Value;
+                            Contract.Assume(!mdDecoder.Equal(type, mdDecoder.System_Int32) || value is Int32);
+                            return true;
+                        }
+                    }
+                    type = default(Type);
+                    value = null;
+                    return false;
+                }
+
+                /// <summary>
+                /// Used to indirect from address to value
+                /// </summary>
+                public readonly Constructor ValueOf;
+
+                /// <summary>
+                /// Used to retain old value across havocs
+                /// </summary>
+                public readonly Constructor OldValueOf;
+
+                /// <summary>
+                /// Special model field for structs used to have a symbolic identity
+                /// </summary>
+                public readonly Constructor StructId;
+
+                /// <summary>
+                /// Special model field for objects used to indicate a version (updated on mutation)
+                /// </summary>
+                public readonly Constructor ObjectVersion;
+
+                public readonly Constructor NullValue;
+                /// <summary>
+                /// Used as a pure function for array element addresses ElementAddr(array,index)
+                /// </summary>
+                public readonly Constructor ElementAddress;
+                /// <summary>
+                /// Model field for array length
+                /// </summary>
+                public readonly Constructor Length;
+                /// <summary>
+                /// Model field for writable extent of pointers
+                /// </summary>
+                public readonly Constructor WritableBytes;
+                /// <summary>
+                /// dummy struct address for all void values
+                /// </summary>
+                public readonly Constructor VoidAddr;
+                public readonly Constructor ZeroValue;
+                public readonly Constructor UnaryNot;
+                public readonly Constructor NeZero;
+                public readonly Constructor IsInst;
+                /// <summary>
+                /// Special way to cache box operations on same values
+                /// </summary>
+                public readonly Constructor BoxOperator;
+                /// <summary>
+                /// Special field in delegates to hold method pointer
+                /// </summary>
+                public readonly Constructor FunctionPointer;
+                /// <summary>
+                /// Special field in delegates to hold target object
+                /// </summary>
+                public readonly Constructor ClosureObject;
+                /// <summary>
+                /// Breadcrumb to tag values resulting from calls. (target doesn't matter)
+                /// </summary>
+                public readonly Constructor ResultOfCall;
+                /// <summary>
+                /// Breadcrumb to tag values resulting from pure calls. (target doesn't matter)
+                /// </summary>
+                public readonly Constructor ResultOfPureCall;
+                /// <summary>
+                /// Breadcrumb to tag values resulting from ldelem. (target doesn't matter)
+                /// </summary>
+                public readonly Constructor ResultOfLdelem;
+                /// <summary>
+                /// Breadcrumb to tag values resulting from cast. (target is original value being cast)
+                /// </summary>
+                public readonly Constructor ResultOfCast;
+                /// <summary>
+                /// Breadcrumb to tag values resulting from out parameters. (target does not matter)
+                /// </summary>
+                public readonly Constructor ResultOfOutParameter;
+
+                /// <summary>
+                /// Breadcrumb to tag values resulting for fields after calling a method on "this"
+                /// </summary>
+                public readonly Constructor ResultOfCallThisHavoc;
+
+                /// <summary>
+                /// Breadcrumb to tag values resulting from OldValue
+                /// </summary>
+                public readonly Constructor ResultOfOldValue;
+#if false
+                /// <summary>
+                /// Used to approximate hash consing across join points of ElementAddr(a,i)
+                /// </summary>
+                public readonly Constructor LastArrayIndex;
+                public readonly Constructor LastArrayElemAddress;
+#endif
+                private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+                private readonly IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder;
+                public WrapTable(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder)
+                {
+                    this.mdDecoder = mdDecoder;
+                    this.contractDecoder = contractDecoder;
+
+                    locals = new Dictionary<Local, Constructor.Wrapper<Local>>();
+                    parameters = new Dictionary<Parameter, Constructor.Wrapper<Parameter>>();
+                    fields = new Dictionary<Field, Constructor.Wrapper<Field>>();
+                    pseudoFields = new Dictionary<Method, Constructor.Wrapper<Method>>();
+                    temps = new Dictionary<int, Constructor.Wrapper<Temp>>();
+                    strings = new Dictionary<string, Constructor.Wrapper<string>>();
+                    programConstants = new Dictionary<object, Constructor.Wrapper<object>>();
+                    methodPointers = new Dictionary<Method, Constructor.Wrapper<Method>>();
+                    typeDefaultValues = new Dictionary<Type, Constructor.Wrapper<Type>>();
+                    binaryOps = new Dictionary<BinaryOperator, Constructor.Wrapper<BinaryOperator>>();
+                    unaryOps = new Dictionary<UnaryOperator, Constructor.Wrapper<UnaryOperator>>();
+
+
+                    ValueOf = For("$Value");
+                    OldValueOf = For("$OldValue");
+                    StructId = For("$StructId");
+                    ObjectVersion = For("$ObjectVersion");
+                    NullValue = For("$Null");
+                    ElementAddress = For("$Element");
+                    Length = For("$Length");
+                    WritableBytes = For("$WritableBytes");
+                    VoidAddr = For("$VoidAddr");
+                    UnaryNot = For("$UnaryNot");
+                    IsInst = For("$IsInst");
+                    NeZero = For("$NeZero");
+                    BoxOperator = For("$Box");
+                    FunctionPointer = For("$FnPtr");
+                    ClosureObject = For("$Closure");
+
+                    // Breadcrumbs: we use these to tag values (target doesn't matter)
+                    ResultOfCall = For("$ResultOfCall");
+                    ResultOfLdelem = For("$ResultOfLdElem");
+                    ResultOfCast = For("$ResultOfCast");
+                    ResultOfOutParameter = For("$ResultOfOut");
+                    ResultOfCallThisHavoc = For("$ResultOfCallThisHavoc");
+                    ResultOfPureCall = For("$ResultOfPureCall");
+                    ResultOfOldValue = For("$ResultOfOldValue");
+
+                    ZeroValue = ForConstant((int)0, this.mdDecoder.System_Int32);
+                }
+            }
+
+
+            [Serializable]
+            [ContractVerification(false)]
+            internal abstract class Constructor : IEquatable<Constructor>, IConstantInfo, IVisibilityCheck<Method>
+            {
+                public readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+
+                protected Constructor(ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                {
+                    this.mdDecoder = mdDecoder;
+                }
+
+                public abstract bool IsStackTemp { get; }
+
+                public abstract bool ActsAsField { get; }
+
+                public abstract bool IsVirtualMethod { get; }
+
+                public abstract bool KeepAsBottomField { get; }
+
+                public abstract bool ManifestField { get; }
+
+                public abstract Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder);
+
+                /// <param name="tryCompact">true if pure method accessors should be compressed to avoid the addres/ldind pair</param>
+                public abstract PathElementBase ToPathElement(bool tryCompact);
+
+                public abstract bool HasExtraDeref { get; }
+
+                public abstract bool IsAsVisibleAs(Method method);
+
+                public abstract bool IsVisibleFrom(Method method);
+
+                public abstract bool RootImpliesParameterOrResultOrStatic { get; }
+
+                public abstract bool IsTopOfStack(int stackDepth);
+
+                /// <summary>
+                /// For fields and properties, this return whether they are static. Otherwise false.
+                /// </summary>
+                public abstract bool IsStatic { get; }
+
+                [Serializable]
+                [ContractVerification(false)]
+                public class Wrapper<T> : Constructor
+                {
+                    public readonly T Value;
+                    private Type type;
+                    public Type Type { get { return type; } set { type = value; } }
+
+                    public Wrapper(T value, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                      : base(ref idgen, mdDecoder)
+                    {
+                        this.Value = value;
+                    }
+
+                    public override bool IsStackTemp
+                    {
+                        get
+                        {
+                            if (typeof(T).Equals(typeof(int))) return true;
+                            return false;
+                        }
+                    }
+
+                    public override bool ActsAsField
+                    {
+                        get
+                        {
+                            return (this.Value is Field);
+                        }
+                    }
+
+                    public override bool KeepAsBottomField
+                    {
+                        get
+                        {
+                            string s = this.Value as string;
+                            if (s == null) return true;
+                            return (s != "$UnaryNot" && s != "$NeZero");
+                        }
+                    }
+
+                    public override bool ManifestField
+                    {
+                        get
+                        {
+                            // manifest $Value and fields and pseudo fields
+                            string s = this.Value as string;
+                            if (s != null) { return s == "$Value" || s == "$Length"; }
+                            return (this.Value is Field || this.Value is Method);
+                        }
+                    }
+
+                    public override Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                    {
+                        if (this.Value is Field)
+                        {
+                            return mdDecoder.ManagedPointer(mdDecoder.FieldType((Field)(object)this.Value));
+                        }
+                        throw new NotImplementedException();
+                    }
+
+                    public override bool IsStatic
+                    {
+                        get
+                        {
+                            if (this.Value is Field)
+                            {
+                                return this.mdDecoder.IsStatic((Field)(object)this.Value);
+                            }
+                            if (this.Value is Method)
+                            {
+                                return this.mdDecoder.IsStatic((Method)(object)this.Value);
+                            }
+                            return false;
+                        }
+                    }
+
+                    public override bool IsVirtualMethod
+                    {
+                        get
+                        {
+                            if (this.Value is Method)
+                            {
+                                return this.mdDecoder.IsVirtual((Method)(object)this.Value);
+                            }
+                            return false;
+                        }
+                    }
+
+                    //^ [Confined]
+                    public override string ToString()
+                    {
+                        if (typeof(T).Equals(typeof(Temp)))
+                        {
+                            return String.Format("s{0}", Value);
+                        }
+                        if (typeof(T).Equals(typeof(Field)))
+                        {
+                            Field f = (Field)(object)Value;
+                            if (mdDecoder.IsStatic(f))
+                            {
+                                //return String.Format("{0}.{1}", mdDecoder.FullName(mdDecoder.DeclaringType(f)), mdDecoder.Name(f));
+                                return String.Format("{0}.{1}", OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, mdDecoder.DeclaringType(f)), mdDecoder.Name(f));
+                            }
+                            return mdDecoder.Name(f);
+                        }
+                        if (typeof(T).Equals(typeof(Method)))
+                        {
+                            Method m = (Method)(object)Value;
+                            string name;
+
+                            if (mdDecoder.IsPropertyGetter(m) || mdDecoder.IsPropertySetter(m))
+                            {
+                                Property prop = mdDecoder.GetPropertyFromAccessor(m);
+                                if (prop != null)
+                                {
+                                    name = mdDecoder.Name(prop);
+                                }
+                                else
+                                {
+                                    name = mdDecoder.Name(m);
+                                    if (name.StartsWith("get_") || name.StartsWith("set_"))
+                                    {
+                                        name = name.Substring(4);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                name = this.mdDecoder.Name(m);
+                            }
+                            if (mdDecoder.IsStatic(m))
+                            {
+                                //name = String.Format("{0}.{1}", mdDecoder.FullName(mdDecoder.DeclaringType(m)), name);
+                                name = String.Format("{0}.{1}", OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, mdDecoder.DeclaringType(m)), name);
+                            }
+                            return name;
+                        }
+                        if (typeof(T).Equals(typeof(Local)))
+                        {
+                            Local l = (Local)(object)Value;
+                            return mdDecoder.Name(l);
+                        }
+
+                        // Handle string constants.
+                        var stringConstant = Value as string;
+                        if (stringConstant != null && Type != null && Type.ToString() == "System.String")
+                        {
+                            using (var writer = new StringWriter())
+                            {
+                                using (var provider = System.CodeDom.Compiler.CodeDomProvider.CreateProvider("CSharp"))
+                                {
+                                    provider.GenerateCodeFromExpression(new System.CodeDom.CodePrimitiveExpression(stringConstant), writer, null);
+                                    return writer.ToString();
+                                }
+                            }
+                        }
+
+                        return Value.ToString();
+                    }
+
+                    [NonSerialized]
+                    protected PathElementBase pathElementCache;
+                    public override PathElementBase ToPathElement(bool tryCompact)
+                    {
+                        if (pathElementCache == null)
+                        {
+                            string value = Value as string;
+                            if (value != null)
+                            {
+                                if (value == "$Length")
+                                {
+                                    pathElementCache = new SpecialPathElement(SpecialPathElementKind.Length, this);
+                                }
+                                else if (value == "$Value")
+                                {
+                                    // don't cache this, as we have different types on each path element
+                                    return new SpecialPathElement(SpecialPathElementKind.Deref, this);
+                                }
+                                else if (value == "$WritableBytes")
+                                {
+                                    pathElementCache = new SpecialPathElement(SpecialPathElementKind.WritableBytes, this);
+                                }
+                            }
+                            else
+                            {
+                                pathElementCache = new PathElement<T>(this.Value, this.ToString(), this);
+                            }
+                        }
+                        return pathElementCache;
+                    }
+
+                    public override bool IsAsVisibleAs(Method method)
+                    {
+                        if (this.Value is Field)
+                        {
+                            Field f = (Field)(object)this.Value;
+                            return mdDecoder.IsAsVisibleAs(f, method);
+                        }
+
+                        if (this.Value is Method)
+                        {
+                            Method m = (Method)(object)this.Value;
+                            return mdDecoder.IsAsVisibleAs(m, method);
+                        }
+
+                        if (mdDecoder.IsConstructor(method) && this.Value is Parameter)
+                        {
+                            var name = mdDecoder.Name((Parameter)(object)this.Value);
+                            if (name == "this") return false;
+                        }
+                        return true;
+                    }
+
+                    public override bool RootImpliesParameterOrResultOrStatic
+                    {
+                        get
+                        {
+                            if (this.Value is Local)
+                            {
+                                return false;
+                            }
+
+                            if (this.Value is int)
+                            {
+                                var stackOffset = (int)(object)this.Value;
+                                return stackOffset == 0;
+                            }
+                            return true;
+#if false
+                            if (this.Value is Field)
+                            {
+                                return true;
+                                //Field f = (Field)(object)this.Value;
+                                //return !mdDecoder.IsStatic(f);
+                            }
+
+                            if (this.Value is Method)
+                            {
+                                return true;
+                                //Method m = (Method)(object)this.Value;
+                                //return !mdDecoder.IsStatic(m);
+                            }
+
+                            if (this.Value is Parameter)
+                            {
+                                return true;
+                            }
+
+
+                            if (this.Value is string)
+                            {
+                                // Special case, $Length, $Value or $WritteableByte, always visible
+                                return true;
+                            }
+                            return true;
+#endif
+                        }
+                    }
+
+                    public override bool IsTopOfStack(int localStackDepth)
+                    {
+                        if (this.Value is Local)
+                        {
+                            return false;
+                        }
+
+                        if (this.Value is int)
+                        {
+                            var stackOffset = (int)(object)this.Value;
+                            return stackOffset == localStackDepth - 1;
+                        }
+
+                        return false;
+                    }
+                    /// <summary>
+                    /// Tests only the last access, traverse the path if you want to be sure
+                    /// that the actual full element is visible
+                    /// </summary>
+                    public override bool IsVisibleFrom(Method method)
+                    {
+                        var declaringType = mdDecoder.DeclaringType(method);
+                        if (this.Value is Field)
+                        {
+                            Field f = (Field)(object)this.Value;
+                            return !mdDecoder.IsCompilerGenerated(f) && mdDecoder.IsVisibleFrom(f, declaringType);
+                        }
+
+                        if (this.Value is Method)
+                        {
+                            Method m = (Method)(object)this.Value;
+                            return mdDecoder.IsVisibleFrom(m, declaringType);
+                        }
+
+                        if (this.Value is Parameter)
+                        {
+                            Parameter p = (Parameter)(object)this.Value;
+                            return mdDecoder.Equal(mdDecoder.DeclaringMethod(p), method);
+                        }
+
+                        if (this.Value is Local)
+                        {
+                            Local l = (Local)(object)this.Value;
+                            var locs = mdDecoder.Locals(method);
+                            for (int i = 0; i < locs.Count; ++i)
+                            {
+                                if (locs[i].Equals(l))
+                                    return true;
+                            }
+                            return false;
+                        }
+
+                        if (this.Value is string)
+                        {
+                            // Special case, $Length, $Value or $WritteableByte, always visible
+                            return true;
+                        }
+
+                        return true;
+                    }
+
+                    public override bool HasExtraDeref
+                    {
+                        get { return this.Value is Local || this.Value is Field; }
+                    }
+                }
+
+                [Serializable]
+                public class PureMethodConstructor : Constructor.Wrapper<Method>
+                {
+                    private readonly bool isModel;
+                    private readonly bool actsAsField;
+
+                    public PureMethodConstructor(Method method, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder)
+                      : base(method, ref idgen, mdDecoder)
+                    {
+                        isModel = contractDecoder.IsModel(this.Value);
+                        actsAsField = mdDecoder.Parameters(method).Count <= 1;
+                    }
+
+                    [NonSerialized]
+                    private MethodCallPathElement uncompressedCache;
+
+                    public override bool ActsAsField
+                    {
+                        get
+                        {
+                            return true;
+                        }
+                    }
+
+                    public override Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                    {
+                        return mdDecoder.ManagedPointer(mdDecoder.ReturnType(this.Value));
+                    }
+
+                    public override PathElementBase ToPathElement(bool tryCompact)
+                    {
+                        if (!actsAsField) return null;
+                        if (tryCompact)
+                        {
+                            if (this.pathElementCache == null)
+                            {
+                                pathElementCache = new MethodCallPathElement(this.Value, this.IsGetter, this.IsBooleanTyped, this.mdDecoder.IsStatic(this.Value), isModel, this.ToString(), this, true);
+                            }
+                            return this.pathElementCache;
+                        }
+                        if (uncompressedCache == null)
+                        {
+                            uncompressedCache = new MethodCallPathElement(this.Value, this.IsGetter, this.IsBooleanTyped, this.mdDecoder.IsStatic(this.Value), isModel, this.ToString(), this, false);
+                        }
+                        return uncompressedCache;
+                    }
+
+                    private bool IsBooleanTyped
+                    {
+                        get
+                        {
+                            return this.mdDecoder.Equal(this.mdDecoder.ReturnType(this.Value), this.mdDecoder.System_Boolean);
+                        }
+                    }
+
+                    private bool IsGetter
+                    {
+                        get
+                        {
+                            return this.mdDecoder.IsPropertyGetter(this.Value);
+                        }
+                    }
+                }
+
+                [Serializable]
+                public class ParameterConstructor : Constructor.Wrapper<Parameter>
+                {
+                    private Parameter p { get { return this.Value; } }
+                    [NonSerialized]
+                    private int argumentIndex;
+
+                    [OnDeserialized]
+                    protected void OnDeserialized(StreamingContext context)
+                    {
+                        argumentIndex = this.mdDecoder.ArgumentIndex(this.p);
+                    }
+
+                    public ParameterConstructor(Parameter p, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                      : base(p, ref idgen, mdDecoder)
+                    {
+                        argumentIndex = mdDecoder.ArgumentIndex(p);
+                    }
+
+                    public override bool ActsAsField
+                    {
+                        get { return false; }
+                    }
+
+                    public override Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                    {
+                        throw new NotImplementedException();
+                    }
+
+                    public override bool Equals(object obj)
+                    {
+                        ParameterConstructor pc = obj as ParameterConstructor;
+                        if (pc == null) return false;
+                        return pc.argumentIndex == argumentIndex;
+                    }
+
+                    public override int GetHashCode()
+                    {
+                        return argumentIndex;
+                    }
+
+                    public override string ToString()
+                    {
+                        return mdDecoder.Name(p);
+                    }
+
+                    public override PathElementBase ToPathElement(bool tryCompact)
+                    {
+                        if (pathElementCache == null)
+                        {
+                            this.pathElementCache = new PathElement<Parameter>(this.p, this.mdDecoder.Name(this.p), this);
+                        }
+                        return pathElementCache;
+                    }
+
+                    public override bool HasExtraDeref
+                    {
+                        get { return /*true*/ false; } // Mic: parameter have an extra deref only if they are out or ref, but it's covered by the IsAddressOf field
+                    }
+                }
+
+                internal static Constructor.Wrapper<T> For<T>(T value, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder)
+                {
+                    Contract.Ensures(Contract.Result<Constructor.Wrapper<T>>() != null);
+
+                    if (value is Parameter)
+                    {
+                        return (Constructor.Wrapper<T>)(object)new ParameterConstructor((Parameter)(object)value, ref idgen, mdDecoder);
+                    }
+                    if (typeof(T).Equals(typeof(Method)) && value is Method)
+                    {
+                        return (Constructor.Wrapper<T>)(object)new PureMethodConstructor((Method)(object)value, ref idgen, mdDecoder, contractDecoder);
+                    }
+                    return new Constructor.Wrapper<T>(value, ref idgen, mdDecoder);
+                }
+
+                #region IEquatable<Constructor> Members
+
+                public bool Equals(Constructor other)
+                {
+                    return this == other;
+                }
+
+                #endregion
+            }
+            #endregion
+
+            #region PathElement Implementations
+            [Serializable]
+            internal abstract class PathElementBase : PathElement
+            {
+                internal readonly Constructor Constructor;
+                [NonSerialized]
+                protected bool hasExtraDeref; // locals and fields have an extra deref path
+                                              // we do not serialize hasExtraDeref because we can get this info from the Constructor (see OnDeserialized below)
+
+                // just after the deserialization
+                [OnDeserialized]
+                protected void OnDeserialized(StreamingContext context)
+                {
+                    this.hasExtraDeref = this.Constructor.HasExtraDeref;
+                }
+
+                protected PathElementBase(Constructor origConstructor)
+                {
+                    this.Constructor = origConstructor;
+                    this.hasExtraDeref = origConstructor.HasExtraDeref;
+                }
+
+                public override bool HasExtraDeref
+                {
+                    get
+                    {
+                        return hasExtraDeref;
+                    }
+                }
+
+                /// <summary>
+                /// The expected type is the type of the result of the path element so far. We use this so that we can
+                /// type "Deref" nodes by providing the non-address taken type of the prior element. E.g., paths must
+                /// start with a local, parameter, or static field which inherently know their own type.
+                /// </summary>
+                internal abstract bool TrySetType(Type expectedType, out Type value);
+            }
+
+            [Serializable]
+            [ContractVerification(false)]
+            internal class ReturnValuePathElement : PathElementBase
+            {
+                private Type type;
+                private string typeName;
+
+                public ReturnValuePathElement(Type type, string typeName, Constructor origC)
+                  : base(origC)
+                {
+                    this.type = type;
+                    this.typeName = typeName;
+                }
+
+                public override bool IsReturnValue { get { return true; } }
+
+                public override PathElement SubstituteElement(object from, object to)
+                {
+                    return this;
+                }
+
+                public override bool TryGetResultType<Type2>(out Type2 type)
+                {
+                    type = (Type2)(object)this.type;
+                    return true;
+                }
+
+                public override bool IsAddressOf
+                {
+                    get { return false; }
+                }
+
+                public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC label, Visitor query, Data data)
+                {
+                    return query.Ldresult(label, (Type2)(object)type, Unit.Value, Unit.Value, data);
+                }
+
+                public override string ToString()
+                {
+                    //          return String.Format("Contract.Result<{0}>()", this.typeName);
+                    return String.Format("Contract.Result<{0}>()", PrettyPrint(type.ToString()));
+                }
+
+                internal override bool TrySetType(Type expectedType, out Type value)
+                {
+                    throw new NotImplementedException();
+                }
+
+                private string PrettyPrint(string typeName)
+                {
+                    // We want to transform CCI string: "System.Func`2<type parameter.T,System.Object>[]" into ""System.Func<T,System.Object>[]"
+                    const string typePar = "type parameter.";
+
+                    // First, remove all the occorrunces of "type parameter."
+                    var result = typeName.Replace(typePar, "");
+
+                    if (!object.ReferenceEquals(result, typeName))
+                    {
+                        var str = new StringBuilder();
+                        for (var i = 0; i < result.Length; i++)
+                        {
+                            var curr = result[i];
+                            if (curr == '`')
+                            {
+                                // skip
+                                while (i < result.Length && char.IsDigit(result[i + 1]))
+                                {
+                                    i++;
+                                }
+                            }
+                            else
+                            {
+                                str.Append(curr);
+                            }
+                        }
+
+                        return str.ToString();
+                    }
+                    else
+                    {
+                        return typeName;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// NOTE: when used on a parameter, signifies ldarga. When ldarg is preferred, the special type ParameterPathElement
+            /// is used.
+            /// </summary>
+            /// <typeparam name="T"></typeparam>
+            [ContractVerification(false)]
+            [Serializable]
+            internal class PathElement<T> : PathElementBase
+            {
+                protected Type resultType;
+                protected string mCastPreviousTo;
+                private T element;
+                override public string CastTo { get { return mCastPreviousTo; } }
+                public T Element { get { return element; } }
+                protected bool isStatic;
+                protected bool isUnmanagedPointer, isManagedPointer;
+                public readonly string AsString;
+
+                [ContractInvariantMethod]
+                private void ObjectInvariant()
+                {
+                    Contract.Invariant(AsString != null);
+                }
+
+                public PathElement(T p, string s, Constructor c)
+                  : base(c)
+                {
+                    Contract.Requires(s != null);
+
+                    element = p;
+                    this.AsString = s;
+                    this.isStatic = false;
+                    this.isUnmanagedPointer = false;
+                    this.isManagedPointer = false;
+                }
+
+                public override bool IsAddressOf
+                {
+                    get { return true; }
+                }
+
+                public override bool IsStatic
+                {
+                    get
+                    {
+                        return this.isStatic;
+                    }
+                }
+
+                public override bool IsParameterRef
+                {
+                    get
+                    {
+                        return typeof(T) == typeof(Parameter);
+                    }
+                }
+
+                public override bool IsParameterOut
+                {
+                    get
+                    {
+                        return typeof(T) == typeof(Parameter) && this.Constructor.mdDecoder.IsOut((Parameter)(object)this.Element);
+                    }
+                }
+
+                private Type ResultType
+                {
+                    get
+                    {
+                        return resultType;
+                    }
+                }
+
+                public override bool TryParameter<Parameter2>(out Parameter2 p)
+                {
+                    if (typeof(T) == typeof(Parameter2))
+                    {
+                        p = (Parameter2)(object)this.Element;
+                        return true;
+                    }
+                    return base.TryParameter(out p);
+                }
+
+                public override bool TryField<Field2>(out Field2 f)
+                {
+                    if (typeof(T) == typeof(Field2))
+                    {
+                        f = (Field2)(object)this.Element;
+                        return true;
+                    }
+                    f = default(Field2);
+                    return false;
+                }
+
+                public override bool TryMethod<Method2>(out Method2 m)
+                {
+                    if (typeof(T) == typeof(Method2))
+                    {
+                        m = (Method2)(object)this.Element;
+                        return true;
+                    }
+
+                    return base.TryMethod(out m);
+                }
+
+                public override bool TryGetResultType<Type2>(out Type2 type)
+                {
+                    if (this.resultType is Type2)
+                    {
+                        type = (Type2)(object)this.resultType;
+                        return true;
+                    }
+                    type = default(Type2);
+                    return false;
+                }
+
+                public override bool IsUnmanagedPointer
+                {
+                    get
+                    {
+                        return isUnmanagedPointer;
+                    }
+                }
+
+                public override bool IsManagedPointer
+                {
+                    get
+                    {
+                        return isManagedPointer;
+                    }
+                }
+
+                internal override bool TrySetType(Type prevType, out Type value)
+                {
+                    var mdDecoder = this.Constructor.mdDecoder;
+
+                    if (typeof(T).Equals(typeof(Parameter)))
+                    {
+                        var p = (Parameter)(object)Element;
+                        var pt = mdDecoder.ParameterType(p);
+
+                        this.isUnmanagedPointer = mdDecoder.IsUnmanagedPointer(pt);
+                        this.isManagedPointer = mdDecoder.IsManagedPointer(pt);
+                        value = mdDecoder.ManagedPointer(pt);
+                        this.resultType = value;
+                        return true;
+                    }
+                    if (typeof(T).Equals(typeof(Field)))
+                    {
+                        var f = (Field)(object)Element;
+                        var ft = mdDecoder.FieldType(f);
+
+                        this.isStatic = mdDecoder.IsStatic(f);
+                        this.isUnmanagedPointer = mdDecoder.IsUnmanagedPointer(ft);
+                        this.isManagedPointer = mdDecoder.IsManagedPointer(ft);
+                        value = mdDecoder.ManagedPointer(ft);
+                        this.resultType = value;
+
+                        // Store the type we want to see prior to this access
+                        var dt = mdDecoder.DeclaringType(f);
+                        if (mdDecoder.IsManagedPointer(prevType) || mdDecoder.IsUnmanagedPointer(prevType))
+                            prevType = mdDecoder.ElementType(prevType);
+
+                        // HACK: get the unspecialized type until type instantiation is fixed in the heap analysis
+                        prevType = mdDecoder.Unspecialized(prevType);
+
+                        if (
+                          !mdDecoder.IsStatic(f) &&
+                          !dt.Equals(prevType) &&
+                          !(mdDecoder.DerivesFrom(prevType, dt) && (mdDecoder.IsProtected(f) || mdDecoder.IsPublic(f)))
+                          )
+                        {
+                            this.mCastPreviousTo = OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, dt);
+                        }
+
+                        return true;
+                    }
+                    if (typeof(T).Equals(typeof(Local)))
+                    {
+                        var l = (Local)(object)Element;
+                        var lt = mdDecoder.LocalType(l);
+
+                        this.isUnmanagedPointer = mdDecoder.IsUnmanagedPointer(lt);
+                        this.isManagedPointer = mdDecoder.IsManagedPointer(lt);
+                        value = mdDecoder.ManagedPointer(lt);
+                        this.resultType = value;
+
+                        return true;
+                    }
+                    if (typeof(T).Equals(typeof(Method)))
+                    {
+                        var m = (Method)(object)Element;
+                        if (this.IsAddressOf)
+                        {
+                            value = mdDecoder.ManagedPointer(mdDecoder.ReturnType(m));
+                        }
+                        else
+                        {
+                            value = mdDecoder.ReturnType(m);
+                        }
+                        this.resultType = value;
+
+                        // Store the type we want to see prior to this access
+                        if (mdDecoder.IsManagedPointer(prevType) || mdDecoder.IsUnmanagedPointer(prevType))
+                            prevType = mdDecoder.ElementType(prevType);
+
+                        // HACK: get the unspecialized type until type instantiation is fixed in the heap analysis
+                        prevType = mdDecoder.Unspecialized(prevType);
+
+                        var dt = mdDecoder.DeclaringType(m);
+                        if (
+                          !mdDecoder.IsStatic(m) &&
+                          !dt.Equals(prevType) &&
+                          !(mdDecoder.DerivesFrom(prevType, dt) && (mdDecoder.IsProtected(m) || mdDecoder.IsPublic(m)))
+                          )
+                        {
+                            this.mCastPreviousTo = OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, dt);
+                        }
+
+                        return true;
+                    }
+                    value = default(Type);
+                    this.resultType = value;
+                    return false;
+                }
+
+#if false
+                public override Result Decode<Data, Result, PC, Type2, Method2>(PC label, ICodeQuery<PC, Local, Parameter, Method2, Field, Type2, Data, Result> query, Data data)
+                {
+                    if (typeof(T).Equals(typeof(Method2)))
+                    {
+                        return query.Call(data, label, (Method2)(object)this.Element, true); // TODO: cleanup paths to just be expressions and keep track of virt flag
+                    }
+                    return query.Atomic(data, label);
+                }
+#endif
+                public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC pc, Visitor visitor, Data data)
+                {
+                    if (typeof(T).Equals(typeof(Field2)))
+                    {
+                        Field2 f = (Field2)(object)Element;
+                        if (this.isStatic)
+                        {
+                            return visitor.Ldsflda(pc, f, Unit.Value, data);
+                        }
+                        else
+                        {
+                            return visitor.Ldflda(pc, f, Unit.Value, Unit.Value, data);
+                        }
+                    }
+                    if (typeof(T).Equals(typeof(Local2)))
+                    {
+                        Local2 l = (Local2)(object)Element;
+                        return visitor.Ldloca(pc, l, Unit.Value, data);
+                    }
+                    if (typeof(T).Equals(typeof(Method2)))
+                    {
+                        Contract.Assume(!this.IsAddressOf);
+                        Method2 m = (Method2)(object)Element;
+                        var virt = this.Constructor.IsVirtualMethod;
+                        return visitor.Call(pc, m, false, virt, EmptyIndexable<Type2>.Empty, Unit.Value, EmptyIndexable<Unit>.Empty, data);
+                    }
+                    if (typeof(T).Equals(typeof(Parameter2)))
+                    {
+                        Parameter2 p = (Parameter2)(object)Element;
+                        return visitor.Ldarga(pc, p, false, Unit.Value, data);
+                    }
+                    throw new InvalidOperationException();
+                }
+
+                public virtual bool IsCallerVisible(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                {
+                    if (typeof(T).Equals(typeof(Parameter))) return true;
+                    return false;
+                }
+
+                public override string ToString()
+                {
+                    return AsString;
+                }
+
+                public override PathElement SubstituteElement(object from, object to)
+                {
+                    if (this.Element.Equals(from))
+                    {
+                        var copy = (PathElement<T>)this.MemberwiseClone();
+                        copy.element = (T)to;
+                        return copy;
+                    }
+                    return this;
+                }
+            }
+
+            /// <summary>
+            /// This class differs from PathElement of Parameter in that it decodes to ldarg, not ldarga. We optimize
+            /// the access paths to compress the ldarga,ldind into ldarg using this element.
+            /// </summary>
+            [Serializable]
+            private class ParameterPathElement : PathElement<Parameter>
+            {
+                public ParameterPathElement(Parameter p, string s, Constructor c, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+                  : base(p, s, c)
+                {
+                    Contract.Requires(s != null);
+
+                    Type ptype = mdDecoder.ParameterType(p);
+                    this.resultType = mdDecoder.ManagedPointer(ptype);
+
+                    if (mdDecoder.IsUnmanagedPointer(ptype))
+                        isUnmanagedPointer = true;
+                    else
+                        isUnmanagedPointer = false;
+
+                    if (mdDecoder.IsManagedPointer(ptype)
+                      /*|| mdDecoder.IsUnmanagedPointer(ptype)*/) // The unmanaged pointers are treated separately
+                    {
+                        isManagedPointer = true; // parameter is a pointer or a ref, so even its very node is a pointer
+                        if (mdDecoder.IsUnmanagedPointer(mdDecoder.ElementType(ptype))) // it is also an unmanaged pointer
+                            isUnmanagedPointer = true;
+                    }
+                    else
+                        isManagedPointer = false;
+                }
+
+                public override bool IsParameter
+                {
+                    get
+                    {
+                        return true;
+                    }
+                }
+
+                [ContractVerification(false)]
+                public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC pc, Visitor visitor, Data data)
+                {
+                    Parameter2 p = (Parameter2)(object)Element;
+                    return visitor.Ldarg(pc, p, false, Unit.Value, data);
+                }
+
+                public override bool IsAddressOf
+                {
+                    get
+                    {
+                        return false;
+                    }
+                }
+
+                /*private bool mbisManagedPointer;
+                public override bool IsManagedPointer
+                {
+                  get
                   {
-                    name = name.Substring(4);
+                    return mbisManagedPointer;
                   }
                 }
-              }
-              else
-              {
-                name = this.mdDecoder.Name(m);
-              }
-              if (mdDecoder.IsStatic(m))
-              {
-                //name = String.Format("{0}.{1}", mdDecoder.FullName(mdDecoder.DeclaringType(m)), name);
-                name = String.Format("{0}.{1}", OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, mdDecoder.DeclaringType(m)), name);
-              }
-              return name;
-            }
-            if (typeof(T).Equals(typeof(Local)))
-            {
-              Local l = (Local)(object)Value;
-              return mdDecoder.Name(l);
-            }
 
-            // Handle string constants.
-            var stringConstant = Value as string;
-            if (stringConstant != null && Type != null && Type.ToString() == "System.String")
-            {
-              using (var writer = new StringWriter())
-              {
-                using (var provider = System.CodeDom.Compiler.CodeDomProvider.CreateProvider("CSharp"))
+                private bool mbisUnmanagedPointer;
+                public override bool IsUnmanagedPointer
                 {
-                  provider.GenerateCodeFromExpression(new System.CodeDom.CodePrimitiveExpression(stringConstant), writer, null);
-                  return writer.ToString();
-                }
-              }
-            }
+                  get
+                  {
+                    return mbisUnmanagedPointer;
+                  }
+                }*/
 
-            return Value.ToString();
-          }
-
-          [NonSerialized]
-          protected PathElementBase pathElementCache;
-          public override PathElementBase ToPathElement(bool tryCompact)
-          {
-            if (pathElementCache == null)
-            {
-              string value = Value as string;
-              if (value != null)
-              {
-                if (value == "$Length")
+                public override bool IsCallerVisible(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
                 {
-                  pathElementCache = new SpecialPathElement(SpecialPathElementKind.Length, this);
+                    return true;
                 }
-                else if (value == "$Value")
+            }
+
+            [Serializable]
+            internal class MethodCallPathElement : PathElement<Method>
+            {
+                /// <summary>
+                /// True if this property represents the actual property call. Otherwise, it represents the pseudofield address
+                /// </summary>
+                private bool compressed;
+                private bool isGetter;
+                private bool isBooleanTyped;
+                private bool isModel;
+
+                internal MethodCallPathElement(Method method, bool isGetter, bool isBooleanTyped, bool isStatic, bool isModel, string s, Constructor c, bool compress)
+                  : base(method, s, c)
                 {
-                  // don't cache this, as we have different types on each path element
-                  return new SpecialPathElement(SpecialPathElementKind.Deref, this);
+                    Contract.Requires(s != null);
+
+                    compressed = compress;
+                    this.isGetter = isGetter;
+                    this.isBooleanTyped = isBooleanTyped;
+                    this.isStatic = isStatic;
+                    this.isModel = isModel;
                 }
-                else if (value == "$WritableBytes")
+
+                public override bool IsAddressOf
                 {
-                  pathElementCache = new SpecialPathElement(SpecialPathElementKind.WritableBytes, this);
+                    get
+                    {
+                        return !compressed;
+                    }
                 }
-              }
-              else
-              {
-                pathElementCache = new PathElement<T>(this.Value, this.ToString(), this);
-              }
-            }
-            return pathElementCache;
-          }
 
-          public override bool IsAsVisibleAs(Method method)
-          {
-            if (this.Value is Field)
-            {
-              Field f = (Field)(object)this.Value;
-              return mdDecoder.IsAsVisibleAs(f, method);
-            }
-
-            if (this.Value is Method)
-            {
-              Method m = (Method)(object)this.Value;
-              return mdDecoder.IsAsVisibleAs(m, method);
-            }
-
-            if (mdDecoder.IsConstructor(method) && this.Value is Parameter)
-            {
-              var name = mdDecoder.Name((Parameter)(object)this.Value);
-              if (name == "this") return false;
-            }
-            return true;
-          }
-
-          public override bool RootImpliesParameterOrResultOrStatic
-          {
-            get
-            {
-              if (this.Value is Local)
-              {
-                return false;
-              }
-
-              if (this.Value is int)
-              {
-                var stackOffset = (int)(object)this.Value;
-                return stackOffset == 0;
-              }
-              return true;
-#if false
-              if (this.Value is Field)
-              {
-                return true;
-                //Field f = (Field)(object)this.Value;
-                //return !mdDecoder.IsStatic(f);
-              }
-
-              if (this.Value is Method)
-              {
-                return true;
-                //Method m = (Method)(object)this.Value;
-                //return !mdDecoder.IsStatic(m);
-              }
-
-              if (this.Value is Parameter)
-              {
-                return true;
-              }
-
-
-              if (this.Value is string)
-              {
-                // Special case, $Length, $Value or $WritteableByte, always visible
-                return true;
-              }
-              return true;
-#endif
-            }
-          }
-
-          public override bool IsTopOfStack(int localStackDepth)
-          {
-            if (this.Value is Local)
-            {
-              return false;
-            }
-
-            if (this.Value is int)
-            {
-              var stackOffset = (int)(object)this.Value;
-              return stackOffset == localStackDepth - 1;
-            }
-
-            return false;
-          }
-          /// <summary>
-          /// Tests only the last access, traverse the path if you want to be sure
-          /// that the actual full element is visible
-          /// </summary>
-          public override bool IsVisibleFrom(Method method)
-          {
-            var declaringType = mdDecoder.DeclaringType(method);
-            if (this.Value is Field)
-            {
-              Field f = (Field)(object)this.Value;
-              return !mdDecoder.IsCompilerGenerated(f) && mdDecoder.IsVisibleFrom(f, declaringType);
-            }
-
-            if (this.Value is Method)
-            {
-              Method m = (Method)(object)this.Value;
-              return mdDecoder.IsVisibleFrom(m, declaringType);
-            }
-
-            if (this.Value is Parameter)
-            {
-              Parameter p = (Parameter)(object)this.Value;
-              return mdDecoder.Equal(mdDecoder.DeclaringMethod(p), method);
-            }
-
-            if (this.Value is Local)
-            {
-              Local l = (Local)(object)this.Value;
-              var locs = mdDecoder.Locals(method);
-              for (int i = 0; i < locs.Count; ++i)
-              {
-                if (locs[i].Equals(l))
-                  return true;
-              }
-              return false;
-            }
-
-            if (this.Value is string)
-            {
-              // Special case, $Length, $Value or $WritteableByte, always visible
-              return true;
-            }
-
-            return true;
-          }
-
-          public override bool HasExtraDeref
-          {
-            get { return this.Value is Local || this.Value is Field; }
-          }
-
-        }
-
-        [Serializable]
-        public class PureMethodConstructor : Constructor.Wrapper<Method>
-        {
-          private readonly bool isModel;
-          private readonly bool actsAsField;
-
-          public PureMethodConstructor(Method method, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder)
-            : base(method, ref idgen, mdDecoder)
-          {
-            this.isModel = contractDecoder.IsModel(this.Value);
-            this.actsAsField = mdDecoder.Parameters(method).Count <= 1;
-          }
-
-          [NonSerialized]
-          MethodCallPathElement uncompressedCache;
-
-          public override bool ActsAsField
-          {
-            get
-            {
-              return true;
-            }
-          }
-
-          public override Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-          {
-            return mdDecoder.ManagedPointer(mdDecoder.ReturnType(this.Value));
-          }
-
-          public override PathElementBase ToPathElement(bool tryCompact)
-          {
-            if (!actsAsField) return null;
-            if (tryCompact)
-            {
-              if (this.pathElementCache == null)
-              {
-                pathElementCache = new MethodCallPathElement(this.Value, this.IsGetter, this.IsBooleanTyped, this.mdDecoder.IsStatic(this.Value), this.isModel, this.ToString(), this, true);
-              }
-              return this.pathElementCache;
-            }
-            if (uncompressedCache == null)
-            {
-              uncompressedCache = new MethodCallPathElement(this.Value, this.IsGetter, this.IsBooleanTyped, this.mdDecoder.IsStatic(this.Value), this.isModel, this.ToString(), this, false);
-            }
-            return this.uncompressedCache;
-          }
-
-          private bool IsBooleanTyped
-          {
-            get
-            {
-              return this.mdDecoder.Equal(this.mdDecoder.ReturnType(this.Value), this.mdDecoder.System_Boolean);
-            }
-          }
-
-          private bool IsGetter
-          {
-            get
-            {
-              return this.mdDecoder.IsPropertyGetter(this.Value);
-            }
-          }
-
-        }
-
-        [Serializable]
-        public class ParameterConstructor : Constructor.Wrapper<Parameter>
-        {
-          Parameter p { get { return this.Value; } }
-          [NonSerialized]
-          int argumentIndex;
-
-          [OnDeserialized]
-          protected void OnDeserialized(StreamingContext context)
-          {
-            this.argumentIndex = this.mdDecoder.ArgumentIndex(this.p);
-          }
-
-          public ParameterConstructor(Parameter p, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-            : base(p, ref idgen, mdDecoder)
-          {
-            this.argumentIndex = mdDecoder.ArgumentIndex(p);
-          }
-
-          public override bool ActsAsField
-          {
-            get { return false; }
-          }
-
-          public override Type FieldAddressType(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-          {
-            throw new NotImplementedException();
-          }
-
-          public override bool Equals(object obj)
-          {
-            ParameterConstructor pc = obj as ParameterConstructor;
-            if (pc == null) return false;
-            return pc.argumentIndex == this.argumentIndex;
-          }
-
-          public override int GetHashCode()
-          {
-            return this.argumentIndex;
-          }
-
-          public override string ToString()
-          {
-            return mdDecoder.Name(p);
-          }
-
-          public override PathElementBase ToPathElement(bool tryCompact)
-          {
-            if (pathElementCache == null)
-            {
-              this.pathElementCache = new PathElement<Parameter>(this.p, this.mdDecoder.Name(this.p), this);
-            }
-            return pathElementCache;
-          }
-
-          public override bool HasExtraDeref
-          {
-            get { return /*true*/ false; } // Mic: parameter have an extra deref only if they are out or ref, but it's covered by the IsAddressOf field
-          }
-        }
-
-        internal static Constructor.Wrapper<T> For<T>(T value, ref int idgen, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder)
-        {
-          Contract.Ensures(Contract.Result<Constructor.Wrapper<T>>() != null);
-
-          if (value is Parameter)
-          {
-            return (Constructor.Wrapper<T>)(object)new ParameterConstructor((Parameter)(object)value, ref idgen, mdDecoder);
-          }
-          if (typeof(T).Equals(typeof(Method)) && value is Method)
-          {
-            return (Constructor.Wrapper<T>)(object)new PureMethodConstructor((Method)(object)value, ref idgen, mdDecoder, contractDecoder);
-          }
-          return new Constructor.Wrapper<T>(value, ref idgen, mdDecoder);
-        }
-
-        #region IEquatable<Constructor> Members
-
-        public bool Equals(Constructor other)
-        {
-          return this == other;
-        }
-
-        #endregion
-      }
-      #endregion
-
-      #region PathElement Implementations
-      [Serializable]
-      internal abstract class PathElementBase : PathElement
-      {
-        internal readonly Constructor Constructor;
-        [NonSerialized]
-        protected bool hasExtraDeref; // locals and fields have an extra deref path
-        // we do not serialize hasExtraDeref because we can get this info from the Constructor (see OnDeserialized below)
-
-        // just after the deserialization
-        [OnDeserialized]
-        protected void OnDeserialized(StreamingContext context)
-        {
-          this.hasExtraDeref = this.Constructor.HasExtraDeref;
-        }
-
-        protected PathElementBase(Constructor origConstructor)
-        {
-          this.Constructor = origConstructor;
-          this.hasExtraDeref = origConstructor.HasExtraDeref;
-        }
-
-        public override bool HasExtraDeref
-        {
-          get
-          {
-            return hasExtraDeref;
-          }
-        }
-
-        /// <summary>
-        /// The expected type is the type of the result of the path element so far. We use this so that we can
-        /// type "Deref" nodes by providing the non-address taken type of the prior element. E.g., paths must
-        /// start with a local, parameter, or static field which inherently know their own type.
-        /// </summary>
-        internal abstract bool TrySetType(Type expectedType, out Type value);
-
-      }
-
-      [Serializable]
-      [ContractVerification(false)]
-      internal class ReturnValuePathElement : PathElementBase
-      {
-        private Type type;
-        private string typeName;
-
-        public ReturnValuePathElement(Type type, string typeName, Constructor origC)
-          : base(origC)
-        {
-          this.type = type;
-          this.typeName = typeName;
-        }
-
-        public override bool IsReturnValue { get { return true; } }
-
-        public override PathElement SubstituteElement(object from, object to)
-        {
-          return this;
-        }
-
-        public override bool TryGetResultType<Type2>(out Type2 type)
-        {
-          type = (Type2)(object)this.type;
-          return true;
-        }
-
-        public override bool IsAddressOf
-        {
-          get { return false; }
-        }
-
-        public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC label, Visitor query, Data data)
-        {
-          return query.Ldresult(label, (Type2)(object)this.type, Unit.Value, Unit.Value, data);
-        }
-
-        public override string ToString()
-        {
-          //          return String.Format("Contract.Result<{0}>()", this.typeName);
-          return String.Format("Contract.Result<{0}>()", PrettyPrint(this.type.ToString()));
-        }
-
-        internal override bool TrySetType(Type expectedType, out Type value)
-        {
-          throw new NotImplementedException();
-        }
-
-        private string PrettyPrint(string typeName)
-        {
-          // We want to transform CCI string: "System.Func`2<type parameter.T,System.Object>[]" into ""System.Func<T,System.Object>[]"
-          const string typePar = "type parameter.";
-
-          // First, remove all the occorrunces of "type parameter."
-          var result = typeName.Replace(typePar, "");
-
-          if (!object.ReferenceEquals(result, typeName))
-          {
-            var str = new StringBuilder();
-            for (var i = 0; i < result.Length; i++)
-            {
-              var curr = result[i];
-              if (curr == '`')
-              {
-                // skip
-                while(i < result.Length && char.IsDigit(result[i+1]))
+                public override bool IsMethodCall
                 {
-                  i++;
+                    get
+                    {
+                        return true;
+                    }
                 }
-              }
-              else
-              {
-                str.Append(curr);
-              }
-            }
 
-            return str.ToString();
-          }
-          else
-          {
-            return typeName;
-          }
-        }
-
-      }
-
-      /// <summary>
-      /// NOTE: when used on a parameter, signifies ldarga. When ldarg is preferred, the special type ParameterPathElement
-      /// is used.
-      /// </summary>
-      /// <typeparam name="T"></typeparam>
-      [ContractVerification(false)]
-      [Serializable]
-      internal class PathElement<T> : PathElementBase
-      {
-        protected Type resultType;
-        protected string mCastPreviousTo;
-        private T element;
-        override public string CastTo { get { return mCastPreviousTo; } }
-        public T Element { get { return this.element; } }
-        protected bool isStatic;
-        protected bool isUnmanagedPointer, isManagedPointer;
-        public readonly string AsString;
-
-        [ContractInvariantMethod]
-        void ObjectInvariant()
-        {
-          Contract.Invariant(AsString != null);
-        }
-
-        public PathElement(T p, string s, Constructor c)
-          : base(c)
-        {
-          Contract.Requires(s != null);
-
-          this.element = p;
-          this.AsString = s;
-          this.isStatic = false;
-          this.isUnmanagedPointer = false;
-          this.isManagedPointer = false;
-        }
-
-        public override bool IsAddressOf
-        {
-          get { return true; }
-        }
-
-        public override bool IsStatic
-        {
-          get
-          {
-            return this.isStatic;
-          }
-        }
-
-        public override bool IsParameterRef
-        {
-          get
-          {
-            return typeof(T) == typeof(Parameter);
-          }
-        }
-
-        public override bool IsParameterOut
-        {
-          get
-          {
-            return typeof(T) == typeof(Parameter) && this.Constructor.mdDecoder.IsOut((Parameter)(object)this.Element);
-          }
-        }
-
-        Type ResultType
-        {
-          get
-          {
-            return resultType;
-          }
-        }
-
-        public override bool TryParameter<Parameter2>(out Parameter2 p)
-        {
-          if (typeof(T) == typeof(Parameter2))
-          {
-            p = (Parameter2)(object)this.Element;
-            return true;
-          }
-          return base.TryParameter(out p);
-        }
-
-        public override bool TryField<Field2>(out Field2 f)
-        {
-          if (typeof(T) == typeof(Field2))
-          {
-            f = (Field2)(object)this.Element;
-            return true;
-          }
-          f = default(Field2);
-          return false;
-        }
-
-        public override bool TryMethod<Method2>(out Method2 m)
-        {
-          if(typeof(T) == typeof(Method2))
-          {
-            m = (Method2)(object)this.Element;
-            return true;
-          }
-
-          return base.TryMethod(out m);
-        }
-
-        public override bool TryGetResultType<Type2>(out Type2 type)
-        {
-          if (this.resultType is Type2)
-          {
-            type = (Type2)(object)this.resultType;
-            return true;
-          }
-          type = default(Type2);
-          return false;
-        }
-
-        public override bool IsUnmanagedPointer
-        {
-          get
-          {
-            return isUnmanagedPointer;
-          }
-        }
-
-        public override bool IsManagedPointer
-        {
-          get
-          {
-            return isManagedPointer;
-          }
-        }
-
-        internal override bool TrySetType(Type prevType, out Type value)
-        {
-          var mdDecoder = this.Constructor.mdDecoder;
-
-          if (typeof(T).Equals(typeof(Parameter)))
-          {
-            var p = (Parameter)(object)Element;
-            var pt = mdDecoder.ParameterType(p);
-
-            this.isUnmanagedPointer = mdDecoder.IsUnmanagedPointer(pt);
-            this.isManagedPointer = mdDecoder.IsManagedPointer(pt);
-            value = mdDecoder.ManagedPointer(pt);
-            this.resultType = value;
-            return true;
-          }
-          if (typeof(T).Equals(typeof(Field)))
-          {
-            var f = (Field)(object)Element;
-            var ft = mdDecoder.FieldType(f);
-
-            this.isStatic = mdDecoder.IsStatic(f);
-            this.isUnmanagedPointer = mdDecoder.IsUnmanagedPointer(ft);
-            this.isManagedPointer = mdDecoder.IsManagedPointer(ft);
-            value = mdDecoder.ManagedPointer(ft);
-            this.resultType = value;
-
-            // Store the type we want to see prior to this access
-            var dt = mdDecoder.DeclaringType(f);
-            if (mdDecoder.IsManagedPointer(prevType) || mdDecoder.IsUnmanagedPointer(prevType))
-              prevType = mdDecoder.ElementType(prevType);
-
-            // HACK: get the unspecialized type until type instantiation is fixed in the heap analysis
-            prevType = mdDecoder.Unspecialized(prevType);
-
-            if (
-              !mdDecoder.IsStatic(f) &&
-              !dt.Equals(prevType) &&
-              !(mdDecoder.DerivesFrom(prevType, dt) && (mdDecoder.IsProtected(f) || mdDecoder.IsPublic(f)))
-              )
-            {
-              this.mCastPreviousTo = OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, dt);
-            }
-
-            return true;
-          }
-          if (typeof(T).Equals(typeof(Local)))
-          {
-            var l = (Local)(object)Element;
-            var lt = mdDecoder.LocalType(l);
-
-            this.isUnmanagedPointer = mdDecoder.IsUnmanagedPointer(lt);
-            this.isManagedPointer = mdDecoder.IsManagedPointer(lt);
-            value = mdDecoder.ManagedPointer(lt);
-            this.resultType = value;
-
-            return true;
-          }
-          if (typeof(T).Equals(typeof(Method)))
-          {
-            var m = (Method)(object)Element;
-            if (this.IsAddressOf)
-            {
-              value = mdDecoder.ManagedPointer(mdDecoder.ReturnType(m));
-            }
-            else
-            {
-              value = mdDecoder.ReturnType(m);
-            }
-            this.resultType = value;
-
-            // Store the type we want to see prior to this access
-            if (mdDecoder.IsManagedPointer(prevType) || mdDecoder.IsUnmanagedPointer(prevType))
-              prevType = mdDecoder.ElementType(prevType);
-
-            // HACK: get the unspecialized type until type instantiation is fixed in the heap analysis
-            prevType = mdDecoder.Unspecialized(prevType);
-
-            var dt = mdDecoder.DeclaringType(m);
-            if (
-              !mdDecoder.IsStatic(m) &&
-              !dt.Equals(prevType) &&
-              !(mdDecoder.DerivesFrom(prevType, dt) && (mdDecoder.IsProtected(m) || mdDecoder.IsPublic(m)))
-              )
-            {
-              this.mCastPreviousTo = OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, dt);
-            }
-
-            return true;
-          }
-          value = default(Type);
-          this.resultType = value;
-          return false;
-        }
-
-#if false
-        public override Result Decode<Data, Result, PC, Type2, Method2>(PC label, ICodeQuery<PC, Local, Parameter, Method2, Field, Type2, Data, Result> query, Data data)
-        {
-          if (typeof(T).Equals(typeof(Method2)))
-          {
-            return query.Call(data, label, (Method2)(object)this.Element, true); // TODO: cleanup paths to just be expressions and keep track of virt flag
-          }
-          return query.Atomic(data, label);
-        }
-#endif
-        public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC pc, Visitor visitor, Data data)
-        {
-          if (typeof(T).Equals(typeof(Field2)))
-          {
-            Field2 f = (Field2)(object)Element;
-            if (this.isStatic)
-            {
-              return visitor.Ldsflda(pc, f, Unit.Value, data);
-            }
-            else
-            {
-              return visitor.Ldflda(pc, f, Unit.Value, Unit.Value, data);
-            }
-          }
-          if (typeof(T).Equals(typeof(Local2)))
-          {
-            Local2 l = (Local2)(object)Element;
-            return visitor.Ldloca(pc, l, Unit.Value, data);
-          }
-          if (typeof(T).Equals(typeof(Method2)))
-          {
-            Contract.Assume(!this.IsAddressOf);
-            Method2 m = (Method2)(object)Element;
-            var virt = this.Constructor.IsVirtualMethod;
-            return visitor.Call(pc, m, false, virt, EmptyIndexable<Type2>.Empty, Unit.Value, EmptyIndexable<Unit>.Empty, data);
-          }
-          if (typeof(T).Equals(typeof(Parameter2)))
-          {
-            Parameter2 p = (Parameter2)(object)Element;
-            return visitor.Ldarga(pc, p, false, Unit.Value, data);
-          }
-          throw new InvalidOperationException();
-        }
-
-        public virtual bool IsCallerVisible(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-        {
-          if (typeof(T).Equals(typeof(Parameter))) return true;
-          return false;
-        }
-
-        public override string ToString()
-        {
-          return AsString;
-        }
-
-        public override PathElement SubstituteElement(object from, object to)
-        {
-          if (this.Element.Equals(from))
-          {
-            var copy = (PathElement<T>)this.MemberwiseClone();
-            copy.element = (T)to;
-            return copy;
-          }
-          return this;
-        }
-      }
-
-      /// <summary>
-      /// This class differs from PathElement of Parameter in that it decodes to ldarg, not ldarga. We optimize
-      /// the access paths to compress the ldarga,ldind into ldarg using this element.
-      /// </summary>
-      [Serializable]
-      class ParameterPathElement : PathElement<Parameter>
-      {
-        public ParameterPathElement(Parameter p, string s, Constructor c, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-          : base(p, s, c)
-        {
-          Contract.Requires(s != null);
-
-          Type ptype = mdDecoder.ParameterType(p);
-          this.resultType = mdDecoder.ManagedPointer(ptype);
-
-          if (mdDecoder.IsUnmanagedPointer(ptype))
-            isUnmanagedPointer = true;
-          else
-            isUnmanagedPointer = false;
-
-          if (mdDecoder.IsManagedPointer(ptype)
-            /*|| mdDecoder.IsUnmanagedPointer(ptype)*/) // The unmanaged pointers are treated separately
-          {
-            isManagedPointer = true; // parameter is a pointer or a ref, so even its very node is a pointer
-            if (mdDecoder.IsUnmanagedPointer(mdDecoder.ElementType(ptype))) // it is also an unmanaged pointer
-              isUnmanagedPointer = true;
-          }
-          else
-            isManagedPointer = false;
-        }
-
-        public override bool IsParameter
-        {
-          get
-          {
-            return true;
-          }
-        }
-
-        [ContractVerification(false)]
-        public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC pc, Visitor visitor, Data data)
-        {
-          Parameter2 p = (Parameter2)(object)Element;
-          return visitor.Ldarg(pc, p, false, Unit.Value, data);
-        }
-
-        public override bool IsAddressOf
-        {
-          get
-          {
-            return false;
-          }
-        }
-
-        /*private bool mbisManagedPointer;
-        public override bool IsManagedPointer
-        {
-          get
-          {
-            return mbisManagedPointer;
-          }
-        }
-
-        private bool mbisUnmanagedPointer;
-        public override bool IsUnmanagedPointer
-        {
-          get
-          {
-            return mbisUnmanagedPointer;
-          }
-        }*/
-
-        public override bool IsCallerVisible(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-        {
-          return true;
-        }
-      }
-
-      [Serializable]
-      internal class MethodCallPathElement : PathElement<Method>
-      {
-        /// <summary>
-        /// True if this property represents the actual property call. Otherwise, it represents the pseudofield address
-        /// </summary>
-        bool compressed;
-        bool isGetter;
-        bool isBooleanTyped;
-        bool isModel;
-
-        internal MethodCallPathElement(Method method, bool isGetter, bool isBooleanTyped, bool isStatic, bool isModel, string s, Constructor c, bool compress)
-          : base(method, s, c)
-        {
-          Contract.Requires(s != null);
-
-          this.compressed = compress;
-          this.isGetter = isGetter;
-          this.isBooleanTyped = isBooleanTyped;
-          this.isStatic = isStatic;
-          this.isModel = isModel;
-        }
-
-        public override bool IsAddressOf
-        {
-          get
-          {
-            return !compressed;
-          }
-        }
-
-        public override bool IsMethodCall
-        {
-          get
-          {
-            return true;
-          }
-        }
-
-        public override bool IsModel
-        {
-          get
-          {
-            return this.isModel;
-          }
-        }
-
-        public override bool IsGetter
-        {
-          get
-          {
-            return this.isGetter;
-          }
-        }
-
-        public override bool IsBooleanTyped
-        {
-          get
-          {
-            return this.isBooleanTyped;
-          }
-        }
-
-      }
-
-      [Serializable]
-      class SpecialPathElement : PathElement<SpecialPathElementKind>
-      {
-        object type; // used for Deref nodes
-
-        public SpecialPathElement(SpecialPathElementKind k, Constructor c)
-          : base(k, k.ToString(), c)
-        {
-          mCastPreviousTo = "";
-        }
-
-        public override bool IsAddressOf
-        {
-          get
-          {
-            return false;
-          }
-        }
-
-        public override bool IsDeref
-        {
-          get
-          {
-            return this.Element == SpecialPathElementKind.Deref;
-          }
-        }
-
-        public override bool TryGetResultType<Type2>(out Type2 type)
-        {
-          if (this.type is Type2)
-          {
-            type = (Type2)this.type;
-            return true;
-          }
-          type = default(Type2);
-          return false;
-        }
-
-        internal override bool TrySetType(Type prevType, out Type result)
-        {
-          var mdDecoder = this.Constructor.mdDecoder;
-
-          switch (this.Element)
-          {
-            case SpecialPathElementKind.Deref:
-              if (mdDecoder.IsManagedPointer(prevType))
-              {
-                var type = mdDecoder.ElementType(prevType);
-                this.type = type;
-                result = type;
-                return true;
-              }
-              if (mdDecoder.IsUnmanagedPointer(prevType))
-              {
-                var type = mdDecoder.ElementType(prevType);
-                this.type = type;
-                result = type;
-                return true;
-              }
-              result = default(Type);
-              return false;
-
-            case SpecialPathElementKind.Length:
-              // Mic: if it's not an array, cast it to array (string.Length does not use this particular case)
-              if (!mdDecoder.IsArray(prevType) && !mdDecoder.System_String.Equals(prevType))
-                mCastPreviousTo = "System.Array";
-              else
-                mCastPreviousTo = ""; // reset because the variable is somewhat shared
-              result = mdDecoder.System_Int32;
-              return true;
-
-            case SpecialPathElementKind.WritableBytes:
-              result = mdDecoder.System_Int32;
-              return true;
-
-            default:
-              result = default(Type);
-              return false;
-          }
-        }
-
-        public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC pc, Visitor visitor, Data data)
-        {
-          switch (this.Element)
-          {
-            case SpecialPathElementKind.Deref:
-              return visitor.Ldind(pc, (Type2)type, false, Unit.Value, Unit.Value, data);
-
-            case SpecialPathElementKind.Length:
-              return visitor.Ldlen(pc, Unit.Value, Unit.Value, data);
-
-            case SpecialPathElementKind.WritableBytes:
-              return visitor.Unary(pc, UnaryOperator.WritableBytes, false, true, Unit.Value, Unit.Value, data);
-
-            default:
-              throw new NotImplementedException("Unknown kind");
-          }
-        }
-      }
-
-      [Serializable]
-      internal enum SpecialPathElementKind
-      {
-        WritableBytes,
-        Length,
-        Deref
-      }
-
-      public static bool IsRootedInParameter(FList<PathElement> path)
-      {
-        Contract.Requires(path != null);
-
-        return path.Head is PathElement<Parameter>;
-      }
-
-      public static bool IsRootedInReturnValue(FList<PathElement> path)
-      {
-        Contract.Requires(path != null);
-        return path.Head is ReturnValuePathElement;
-      }
-
-      #endregion
-
-      #region Privates
-
-      /// <summary>
-      /// Copy Constructor
-      /// </summary>
-      private Domain(
-        EGraph<Constructor, AbstractType> newEgraph,
-        IFunctionalMap<ESymValue, Constructor> constantMap,
-        IFunctionalSet<ESymValue> unmodifiedSinceEntry,
-        IFunctionalSet<ESymValue> unmodifiedSinceEntryForFields,
-        IFunctionalSet<ESymValue> modifiedAtCall,
-        Domain from,
-        Domain oldDomain)
-      {
-        this.egraph = newEgraph;
-        this.Constructors = from.Constructors;
-        this.parent = from.parent;
-        this.BeginOldSavedStates = from.BeginOldSavedStates;
-        this.constantLookup = constantMap;
-        this.unmodifiedSinceEntry = unmodifiedSinceEntry;
-        this.unmodifiedSinceEntryForFields = unmodifiedSinceEntryForFields;
-        this.modifiedAtCall = modifiedAtCall;
-        this.insideOld = from.insideOld;
-        this.oldDomain = oldDomain;
-        this.beginOldPC = from.beginOldPC;
-      }
-
-      private ESymValue Globals { get { return this.egraph.Root; } }
-
-
-      public ESymValue Null
-      {
-        get
-        {
-          return this.egraph[this.Constructors.NullValue];
-        }
-      }
-
-      public ESymValue Zero
-      {
-        get
-        {
-          return this.egraph[this.Constructors.ZeroValue];
-        }
-      }
-
-      public ESymValue VoidAddr
-      {
-        get
-        {
-          return this.egraph[this.Constructors.VoidAddr];
-        }
-      }
-
-      private void SetType(ESymValue sv, FlatDomain<Type> t)
-      {
-        AbstractType at = this.egraph[sv];
-        if (!at.IsZero)
-        {
-          this.egraph[sv] = at.With(t);
-        }
-      }
-      private void SetTypeIfUnknown(ESymValue sv, FlatDomain<Type> t)
-      {
-        AbstractType at = this.egraph[sv];
-        if (!at.IsZero)
-        {
-          if (!at.Type.IsNormal || at.Type.Equals(this.mdDecoder.System_IntPtr) || at.Type.Equals(this.mdDecoder.System_UIntPtr))
-          {
-            this.egraph[sv] = at.With(t);
-          }
-        }
-      }
-
-      private ESymValue ConstantValue(object constant, Type t)
-      {
-        Constructor c = Constructors.ForConstant(constant, t);
-        ESymValue cval = this.egraph.TryLookup(c);
-        if (cval == null)
-        {
-          cval = this.egraph[c];
-          SetType(cval, t);
-          this.constantLookup = this.constantLookup.Add(cval, c);
-        }
-        return cval;
-      }
-
-      private ESymValue MethodPointer(Method method, Type t)
-      {
-        Constructor c = Constructors.ForMethod(method, t);
-        ESymValue cval = this.egraph.TryLookup(c);
-        if (cval == null)
-        {
-          cval = this.egraph[c];
-          SetType(cval, t);
-          this.constantLookup = this.constantLookup.Add(cval, c);
-        }
-        return cval;
-      }
-
-      private ESymValue TypeDefaultValue(Type t)
-      {
-        Constructor c = Constructors.ForTypeDefaultValue(t);
-        return this.egraph[c];
-      }
-
-      internal bool IsMethodPointer(ESymValue sval, out Method method)
-      {
-        Constructor.Wrapper<Method> mcon = this.constantLookup[sval] as Constructor.Wrapper<Method>;
-        if (mcon != null) { method = mcon.Value; return true; }
-        method = default(Method);
-        return false;
-      }
-
-      private ESymValue Address(Constructor v, Type t)
-      {
-        ESymValue addr = this.egraph.TryLookup(v);
-        if (addr == null)
-        {
-          addr = this.egraph[v];
-          SetType(addr, t);
-        }
-        return addr;
-      }
-
-      private ESymValue Address(Constructor v)
-      {
-        return this.egraph[v];
-      }
-
-      ESymValue Address(Temp t)
-      {
-        return Address(Constructors.For(t));
-      }
-
-      ESymValue Address(Parameter p)
-      {
-        Constructor loc = Constructors.For(p);
-        ESymValue addr = this.egraph.TryLookup(loc);
-        if (addr == null)
-        {
-          addr = this.egraph[loc];
-          SetType(addr, mdDecoder.ManagedPointer(mdDecoder.ParameterType(p)));
-        }
-        return addr;
-      }
-
-      ESymValue Address(Local l)
-      {
-        Constructor loc = Constructors.For(l);
-        ESymValue addr = this.egraph.TryLookup(loc);
-        if (addr == null)
-        {
-          addr = this.egraph[loc];
-          SetType(addr, mdDecoder.ManagedPointer(mdDecoder.LocalType(l)));
-        }
-        return addr;
-      }
-
-      private ESymValue TryAddress(Constructor v)
-      {
-        return this.egraph.TryLookup(v);
-      }
-
-      private ESymValue Value(ESymValue loc)
-      {
-        bool fresh;
-        ESymValue result = this.egraph.LookupOrManifest(this.Constructors.ValueOf, loc, out fresh);
-        if (fresh && this.IsUnmodified(loc))
-        {
-          // make sure to propagate unmodified property
-          this.MakeUnmodified(result);
-        }
-        return result;
-      }
-
-      private ESymValue TryValue(ESymValue loc)
-      {
-        ESymValue result = this.egraph.TryLookup(this.Constructors.ValueOf, loc);
-        //if (result != null && this.IsZero(result)) return this.Zero;
-        return result;
-      }
-
-      /// <summary>
-      /// Like TryValue, but checks if address is a struct address. In that case, it returns
-      /// the address itself.
-      /// </summary>
-      private ESymValue TryCorrespondingValue(ESymValue loc)
-      {
-        if (IsStructAddress(this.egraph[loc])) return loc;
-        return TryValue(loc);
-      }
-
-      private ESymValue Value(Parameter v)
-      {
-        return Value(Address(Constructors.For(v)));
-      }
-
-      private ESymValue Value(Temp v)
-      {
-        return Value(Address(Constructors.For(v)));
-      }
-
-      internal FList<PathElement> GetBestAccessPath(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress, bool allowLocal, bool preferLocal,
-        Predicate<FList<PathElement>> additionalFilter = null)
-      {
-        Contract.Requires(filter != null);
-
-        FList<PathElement> shortestParamPath = null;
-        FList<PathElement> shortestLocalPath = null;
-        FList<PathElement> backupPath = null;
-        FList<PathElement> returnPath = null;
-
-        foreach (var p in GetAccessPathsFiltered(sv, filter, compress))
-        {
-          if (p != null)
-          {
-            var path = p.Coerce<PathElementBase, PathElement>();
-            if (additionalFilter != null && additionalFilter(path) == false) continue;
-            if (path.Head is PathElement<Parameter>)
-            {
-              if (shortestParamPath == null || shortestParamPath.Length() > path.Length())
-              {
-                shortestParamPath = path;
-              }
-            }
-            else if (/*Mic: change to the true meaning: if accessibility should not be tested from outside (was: !accessedFrom.IsValid)*/
-              (filter.AllowLocal && allowLocal) // TODO MAF: changed meaning, review
-              && path.Head is PathElement<Local>)
-            {
-              if (filter.AllowCompilerLocal || !path.Head.ToString().Contains("$"))
-              {
-                if (shortestLocalPath == null || shortestLocalPath.Length() > path.Length())
+                public override bool IsModel
                 {
-                  shortestLocalPath = path;
+                    get
+                    {
+                        return isModel;
+                    }
                 }
-              }
-            }
-            else if (path.Head is PathElement<Field> && p.Head.Constructor.IsStatic)
-            {
-              // static field 
-              if (backupPath == null || backupPath.Length() > path.Length())
-              {
-                backupPath = path;
-              }
-            }
-            else if (path.Head is PathElement<Method> && p.Head.Constructor.IsStatic)
-            {
-              // static property 
-              if (backupPath == null || backupPath.Length() > path.Length())
-              {
-                backupPath = path;
-              }
-            }
-            else if (path.Head.IsReturnValue)
-            {
-              returnPath = path;
-            }
-          }
-        }
 
-        if (returnPath != null) { return returnPath; }
-        if (preferLocal && shortestLocalPath != null) { return shortestLocalPath; }
-        if (shortestParamPath != null) { return shortestParamPath; }
-        // emit local path if we don't have visibility issues
-        if (allowLocal && shortestLocalPath != null) { return shortestLocalPath; }
-        if (backupPath != null) { return backupPath; }
-        return null;
-      }
-
-      private bool TryPropagateTypeInfo(FList<PathElementBase> path, AccessPathFilter<Method, Type> filter, out FList<PathElementBase> result)
-      {
-        if (path == null)
-        {
-          result = null;
-          return true;
-        }
-
-        var mdd = this.mdDecoder;
-
-        Type headTypeRef;
-        PathElementBase head = path.Head;
-        if (filter != null && filter.AllowReturnValue && head.Constructor.IsTopOfStack(filter.LocalStackDepth))
-        {
-          if(mdd.System_Void.Equals(filter.ReturnValueType))
-          {
-            result = null;
-            return false;
-          }
-
-          // replace it with Return value
-          head = new ReturnValuePathElement(filter.ReturnValueType, mdd.Name(filter.ReturnValueType), head.Constructor);
-          headTypeRef = mdd.ManagedPointer(filter.ReturnValueType);
-        }
-        else
-        {
-          if (!head.TrySetType(mdd.System_IntPtr, out headTypeRef))
-          {
-            result = null;
-            return false;
-          }
-        }
-        FList<PathElementBase> tail;
-        if (!TryPropagateTypeInfoRecurse(path.Tail, headTypeRef, out tail))
-        {
-          result = null;
-          return false;
-        }
-
-        // Compress parameter head ldarga,ldind into ldarg
-        if (head.IsAddressOf && head is PathElement<Parameter> && tail != null && tail.Head.IsDeref)
-        {
-          var pe = (PathElement<Parameter>)head;
-          Contract.Assume(pe.AsString != null, "follows from the object invariant of pe, which we do not assume here");
-          result = tail.Tail.Cons(new ParameterPathElement(pe.Element, pe.AsString, pe.Constructor, mdd));
-          return true;
-        }
-        else
-        {
-          if (head is ReturnValuePathElement && tail != null && tail.Head.IsDeref)
-          {
-            result = tail.Tail.Cons(head);
-          }
-          else
-          {
-            result = tail.Cons(head);
-          }
-          return true;
-        }
-      }
-
-      private bool TryPropagateTypeInfoRecurse(FList<PathElementBase> path, Type prevType, out FList<PathElementBase> result)
-      {
-        if (path == null)
-        {
-          result = null;
-          return true;
-        }
-
-        var head = path.Head;
-        if (!head.TrySetType(prevType, out prevType))
-        {
-          result = null;
-          return false;
-        }
-
-        FList<PathElementBase> recursive_result;
-        if (TryPropagateTypeInfoRecurse(path.Tail, prevType, out recursive_result))
-        {
-          result = recursive_result.Cons(head);
-          return true;
-        }
-        else
-        {
-          result = null;
-          return false;
-        }
-
-      }
-
-      private IEnumerable<FList<PathElementBase>> GetAccessPathsTyped(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress)
-      {
-        Set<ESymValue> visited = new Set<ESymValue>();
-
-        foreach (var path in GetAccessPathsRaw(sv, null, visited, filter, compress))
-        {
-          FList<PathElementBase> result;
-          if (TryPropagateTypeInfo(path, filter, out result))
-          {
-            yield return result;
-          }
-        }
-      }
-
-      internal IEnumerable<FList<PathElementBase>> GetAccessPathsFiltered(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress)
-      {
-        foreach (var path in GetAccessPathsTyped(sv, filter, compress))
-        {
-          if (PathIsVisibleAccordingToFilter(path, filter))
-          {
-            yield return path;
-          }
-        }
-      }
-
-      // Mic: check the existence of the elements in the fullpath
-      private class ErrorMemberDoesNotExist : Exception { }
-
-      /// <summary>
-      /// Check for getters only, not setters
-      /// Returns false if the property does not exist in the type (or base classes as protected)
-      /// </summary>
-      public bool CheckPropertyExists(Type t, string name, bool allowPrivate)
-      {
-        // for now treat t as unspecialized
-        t = mdDecoder.Unspecialized(t);
-
-        foreach (var prop in mdDecoder.Properties(t))
-        {
-          if (mdDecoder.Name(prop) == name)
-          {
-            Method getter;
-            if (mdDecoder.HasGetter(prop, out getter))
-            {
-              if (!allowPrivate && mdDecoder.IsPrivate(getter))
-                return false;
-              return true; // found
-            }
-            else
-              return false;
-          }
-        }
-
-        // check in the base class, protected or public
-        if (mdDecoder.HasBaseClass(t))
-          return CheckPropertyExists(mdDecoder.BaseClass(t), name, false);
-        else
-          return false;
-      }
-
-      /// <summary>
-      /// Returns false if the property does not exist in the type (or base classes as protected)
-      /// </summary>
-      public bool CheckPropertyExists(Type t, Property prop, bool allowPrivate)
-      {
-        // for now treat t as unspecialized
-        t = mdDecoder.Unspecialized(t);
-
-        foreach (var p in mdDecoder.Properties(t))
-        {
-          if (mdDecoder.Equal(prop, p))
-            //if (mdDecoder.Name(p) == mdDecoder.Name(prop))
-            return true; // found
-        }
-
-        // check in the base class, protected or public
-        if (mdDecoder.HasBaseClass(t))
-          return CheckPropertyExists(mdDecoder.BaseClass(t), prop, false);
-        else
-          return false;
-      }
-
-      /// <summary>
-      /// Returns false if the method does not exist in the type (or base classes as protected)
-      /// </summary>
-      public bool CheckMethodExists(Type t, Method meth, bool allowPrivate)
-      {
-        // for now treat t as unspecialized
-        t = mdDecoder.Unspecialized(t);
-
-        foreach (var m in mdDecoder.Methods(t))
-        {
-          if (mdDecoder.Equal(m, meth))
-            //if (mdDecoder.Name(meth) == mdDecoder.Name(m))
-            return true; // found
-        }
-
-        // check in the base class, protected or public
-        if (mdDecoder.HasBaseClass(t))
-          return CheckMethodExists(mdDecoder.BaseClass(t), meth, false);
-        else
-          return false;
-      }
-
-      /// <summary>
-      /// Returns false if the field does not exist in the type (or base classes as protected)
-      /// </summary>
-      public bool CheckFieldExists(Type t, Field field, bool allowPrivate)
-      {
-        // for now treat t as unspecialized
-        t = mdDecoder.Unspecialized(t);
-
-        foreach (var f in mdDecoder.Fields(t))
-        {
-          if (mdDecoder.Equal(f, field))
-            //if (mdDecoder.Name(f) == mdDecoder.Name(field))
-            return true; // found
-        }
-
-        // check in the base class, protected or public
-        if (mdDecoder.HasBaseClass(t))
-          return CheckFieldExists(mdDecoder.BaseClass(t), field, false);
-        else
-          return false;
-      }
-
-      /// <summary>
-      /// Test for the CS1540 rule
-      /// </summary>
-      /// <param name="C">Class from which the call is made</param>
-      /// <param name="ST">Type of the accessed object</param>
-      /// <param name="DT">Declaring type of the field accessed in the accessed object</param>
-      /// <param name="accessProtected">Allow or not to access protected members</param>
-      /// <returns>Returns false if the error would occur.</returns>
-      private bool CheckFor1540(Type C, Type ST, Type DT, bool accessProtected)
-      {
-        if (C == null || ST == null || DT == null)
-          return true; // Type in another assembly, System...
-
-        if (C.Equals(ST) && ST.Equals(DT))
-          return true; // the field is in the declaring type, ok
-
-        // Check for the CS1540
-        if (accessProtected && mdDecoder.DerivesFrom(ST, DT))
-        {
-          // the field is accessed because of derivation and protected
-          // Check if the owner is from the C hierarchy
-          if (!mdDecoder.DerivesFrom(ST, C))
-            return false;
-        }
-
-        return true;
-      }
-
-      /// <summary>
-      /// Input path must be typed!!!!
-      /// </summary>
-      private bool PathIsVisibleAccordingToFilter(FList<PathElementBase> path, AccessPathFilter<Method, Type> filter)
-      {
-        if (path == null /*|| path.Length() == 0 */|| !filter.HasVisibilityMember)
-          return true;
-
-        Method mfrom = filter.VisibilityMember;
-        Type declaringFrom = mdDecoder.DeclaringType(mfrom);
-
-        Type t = default(Type);
-        Type prev_type;
-        bool first = true;
-        for (; path != null; path = path.Tail, first = false)
-        {
-          prev_type = t;
-
-          PathElement pelem = path.Head;
-
-          //** Mic: NOTE:
-          // I removed all the tests I made for the accessibility since it is no longer
-          // necessary: the "CastTo" facility in PathElement allows to cast locally in
-          // path output, so accesses are always guaranteed to be ok.
-
-          //if (pelem is SpecialPathElement) // Deref, length, writteable bytes
-          //{
-          //  SpecialPathElement spe = pelem as SpecialPathElement;
-          //  var spek = spe.Element;
-          //  if (spek == SpecialPathElementKind.Length)
-          //  {
-          //    // Check if previous type has a length property
-          //    // Mic: TODO: cf. above
-          //    if (mdDecoder.IsArray(prev_type))
-          //      continue; // accept
-
-          //    if (prev_type != null && !prev_type.Equals(default(Type)))
-          //    {
-          //      if (!CheckPropertyExists(prev_type, "Length", true))
-          //        return false;
-          //    }
-          //  }
-          //  continue;
-          //}
-
-          if (!pelem.TryGetResultType(out t)) return true; // avoid problems downstream
-
-          // Mic: HACK: 'while' because at some places, CCI reports a type "type@@"!?
-          while (mdDecoder.IsManagedPointer(t))
-            t = mdDecoder.ElementType(t); // we skip deref, so don't care about pointer or not
-
-          if (pelem.ToString() == "this")
-            continue; // always accessible
-
-          if (pelem is PathElement<Method>)
-          {
-            PathElement<Method> pelem_meth = pelem as PathElement<Method>;
-            Method m = pelem_meth.Element;
-
-            // cf. note above
-            //if (!first)
-            //{
-            //  if (!CheckMethodExists(prev_type, m, true))
-            //    return false;
-            //}
-
-            if (!mdDecoder.IsVisibleFrom(m, declaringFrom))
-              return false;
-
-            if (!first)
-            {
-              Type C = mdDecoder.DeclaringType(mfrom);
-              Type ST = prev_type;
-              Type DT = mdDecoder.DeclaringType(m);
-
-              if (!CheckFor1540(C, ST, DT, mdDecoder.IsProtected(m)))
-                return false;
-            }
-          }
-          else if (pelem is PathElement<Property>)
-          {
-            PathElement<Property> pelem_prop = pelem as PathElement<Property>;
-            Property p = pelem_prop.Element;
-
-            // cf. note above
-            //if (!first)
-            //{
-            //  if (!CheckPropertyExists(prev_type, p, true))
-            //    return false;
-            //}
-
-            Method m;
-            if (!mdDecoder.HasGetter(p, out m))
-              mdDecoder.HasSetter(p, out m);
-
-            if (!mdDecoder.IsVisibleFrom(m, declaringFrom))
-              return false;
-
-            if (!first)
-            {
-              Type C = mdDecoder.DeclaringType(mfrom);
-              Type ST = prev_type;
-              Type DT = mdDecoder.DeclaringType(m);
-
-              if (!CheckFor1540(C, ST, DT, mdDecoder.IsProtected(m)))
-                return false;
-            }
-          }
-          else if (pelem is PathElement<Field>)
-          {
-            PathElement<Field> pelem_f = pelem as PathElement<Field>;
-            Field f = pelem_f.Element;
-
-            // cf. note above
-            //if (!first)
-            //{
-            //  if (!CheckFieldExists(prev_type, f, true))
-            //    return false;
-            //}
-
-            if (!mdDecoder.IsVisibleFrom(f, declaringFrom))
-              return false;
-
-            if (filter.AvoidCompilerGenerated && (mdDecoder.IsCompilerGenerated(f) || mdDecoder.IsCompilerGenerated(mdDecoder.DeclaringType(f))))
-            {
-              return false;
-            }
-
-            if (!first)
-            {
-              Type C = mdDecoder.DeclaringType(mfrom);
-              Type ST = prev_type;
-              Type DT = mdDecoder.DeclaringType(f);
-
-              if (!CheckFor1540(C, ST, DT, mdDecoder.IsProtected(f)))
-                return false;
-            }
-          }
-        }
-
-        return true;
-      }
-
-      /// <summary>
-      /// Completes the path back to a local/parameter if possible.
-      /// </summary>
-      IEnumerable<FList<PathElementBase>> GetAccessPathsRaw(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress)
-      {
-        Set<ESymValue> visited = new Set<ESymValue>();
-
-        return GetAccessPathsRaw(sv, null, visited, filter, compress);
-      }
-
-      IEnumerable<FList<PathElementBase>> GetAccessPathsRaw(ESymValue sv, FList<PathElementBase> path, Set<ESymValue> visited, AccessPathFilter<Method, Type> filter, bool compress)
-      {
-        if (sv == this.egraph.Root)
-        {
-          yield return path;
-          yield break;
-        }
-        if (visited.Contains(sv))
-        {
-          // already visited 
-          yield break;
-        }
-        visited.Add(sv);
-        foreach (EGraphTerm<Constructor> et in this.egraph.EqTerms(sv))
-        {
-          if (et.Function is Constructor.Wrapper<object>) continue; // ignore program constants (0x0, 1, etc.)
-          PathElementBase next = et.Function.ToPathElement(compress);
-
-          if (next == null // element we don't understand ($array element e.g.)
-              || filter.FilterOutPathElement(et.Function))
-#if false
-            || (accessedFrom.IsValid && accessedFrom.GetOption == AccessPathFilter<Method>.Option.FROM_CALLING_METHOD && !et.Function.IsAsVisibleAs(accessedFrom.Value)) // don't want (not as visible as the caller)
-            || (accessedFrom.IsValid && accessedFrom.GetOption == AccessPathFilter<Method>.Option.FROM_INSIDE_METHOD && !et.Function.IsVisibleFrom (accessedFrom.Value))) // don't want, not as visible as the context in which it is used
-#endif
-          {
-            continue;
-          }
-          FList<PathElementBase> newPath;
-          // Filter out extra deref on method calls to properties
-          if (path != null && compress && next is PathElement<Method> && path.Head.IsDeref)
-          {
-            newPath = path.Tail.Cons(next); // remove extra deref
-          }
-          else
-          {
-            newPath = path.Cons(next);
-          }
-
-          foreach (FList<PathElementBase> fullpath in GetAccessPathsRaw(et.Args[0], newPath, visited, filter, compress))
-          {
-#if false
-// MAF TODO move this to separate Filtered method
-            // Double check if the path is valid, because the previous calls to IsVisibleFrom or IsAsVisibleAs only take the last path element into account
-            // Here, the entire path is checked (check for the CS1540 error, and also for the issue with contracts inferred after wild casts)
-            if (accessedFrom.GetOption != AccessPathFilter<Method>.Option.NO_FILTER)
-            {
-              if (PathVisibleFrom(fullpath, accessedFrom.Value))
-                yield return fullpath;
-            }
-            else
-#endif
-            yield return fullpath;
-          }
-        }
-      }
-
-
-      void HavocIfStruct(ESymValue address)
-      {
-        AbstractType prevType = this.egraph[address];
-        if (prevType.IsBottom || (prevType.IsNormal && mdDecoder.IsStruct(prevType.Value)))
-        {
-          Havoc(address);
-        }
-      }
-
-      /// <summary>
-      /// Don't forget to havoc array elements too and struct ids
-      /// </summary>
-      void HavocMutableFields(Constructor accessedVia, ESymValue address, ref IFunctionalSet<ESymValue> havoced)
-      {
-        Contract.Ensures(havoced != null);
-
-        HavocFields(accessedVia, address, ref havoced, false);
-      }
-
-      /// <summary>
-      /// Used on this in constructors
-      /// </summary>
-      void HavocAllFields(ESymValue address, ref IFunctionalSet<ESymValue> havoced)
-      {
-        HavocFields(null, address, ref havoced, true);
-      }
-
-      void HavocFields(ESymValue address, IEnumerable<Field> fields, ref IFunctionalSet<ESymValue> havoced)
-      {
-        foreach (var field in fields)
-        {
-          HavocConstructor(null, address, Constructors.For(field), ref havoced, false);
-        }
-      }
-
-      /// <summary>
-      /// </summary>
-      /// <param name="address"></param>
-      /// <param name="havoced"></param>
-      /// <param name="havocImmutable"></param>
-      void HavocFields(Constructor accessedVia, ESymValue address, ref IFunctionalSet<ESymValue> havoced, bool havocImmutable)
-      {
-        Contract.Ensures(havoced != null);
-
-        if (havoced.Contains(address)) return; // no need to repeatedly havoc
-        havoced = havoced.Add(address);
-        this.MakeTotallyModified(address);
-        foreach (Constructor c in this.egraph.Functions(address))
-        {
-          HavocConstructor(accessedVia, address, c, ref havoced, havocImmutable);
-        }
-      }
-
-      private void HavocConstructor(Constructor accessedVia, ESymValue address, Constructor c, ref IFunctionalSet<ESymValue> havoced, bool havocImmutable)
-      {
-        Contract.Ensures(havoced != null);
-
-        if (c == Constructors.ValueOf)
-        {
-          // retain as old value
-          this.egraph[Constructors.OldValueOf, address] = this.egraph[c, address];
-        }
-        if (c == Constructors.ValueOf ||
-            c == Constructors.ObjectVersion ||
-            c == Constructors.StructId)
-        {
-          this.egraph.Eliminate(c, address);
-          havoced = havoced.Add(address);
-          return;
-        }
-
-        Constructor.Wrapper<Field> field = c as Constructor.Wrapper<Field>;
-        if (field != null && field != accessedVia)
-        {
-          if (!havocImmutable && mdDecoder.IsReadonly(field.Value))
-            return;
-          // havoc the value/nested struct
-          HavocFields(accessedVia, this.egraph[c, address], ref havoced, havocImmutable);
-          return;
-        }
-        Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
-        if (method != null && method != accessedVia)
-        {
-          // havoc the value/nested struct
-          HavocFields(accessedVia, this.egraph[c, address], ref havoced, havocImmutable);
-          return;
-        }
-      }
-
-
-      void HavocPseudoFields(ESymValue address)
-      {
-        IFunctionalSet<ESymValue> havoced = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-        HavocPseudoFields((Constructor)null, address, ref havoced);
-      }
-
-      void HavocPseudoFields(Constructor except, ESymValue address, ref IFunctionalSet<ESymValue> havoced)
-      {
-        Contract.Requires(havoced != null);
-        Contract.Ensures(havoced != null);
-
-        if (havoced.Contains(address)) return; // no need to repeatedly havoc
-        havoced = havoced.Add(address);
-
-        // remove object from unmodified set
-        if (this.IsUnmodified(address))
-        {
-          this.MakeModified(address);
-          this.RetainForUnmodifiedFields(address);
-        }
-
-        // havoc struct/object Id
-        this.egraph.Eliminate(Constructors.ObjectVersion, address);
-        this.egraph.Eliminate(Constructors.StructId, address);
-
-        foreach (Constructor c in this.egraph.Functions(address))
-        {
-          if (c == except) continue;
-          Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
-          if (method != null)
-          {
-            // havoc the value/nested struct
-            HavocMutableFields(except, this.egraph[c, address], ref havoced);
-            continue;
-          }
-        }
-      }
-
-      void HavocPseudoFields(IEnumerable<Method> getters, ESymValue address)
-      {
-        IFunctionalSet<ESymValue> havoced = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-        HavocPseudoFields((Constructor)null, getters, address, ref havoced);
-      }
-
-      void HavocPseudoFields(Constructor except, IEnumerable<Method> getters, ESymValue address, ref IFunctionalSet<ESymValue> havoced)
-      {
-        Contract.Requires(getters != null);
-
-        if (havoced.Contains(address)) return; // no need to repeatedly havoc
-        havoced = havoced.Add(address);
-
-        // remove object from unmodified set
-        if (this.IsUnmodified(address))
-        {
-          this.MakeModified(address);
-          this.RetainForUnmodifiedFields(address);
-        }
-
-        // havoc struct/object Id
-        this.egraph.Eliminate(Constructors.ObjectVersion, address);
-        this.egraph.Eliminate(Constructors.StructId, address);
-
-        foreach (var getter in getters)
-        {
-          // havoc the value/nested struct
-          HavocMutableFields(except, this.egraph[Constructors.For(getter), address], ref havoced);
-        }
-      }
-
-      void HavocModelProperties(ESymValue address, ref IFunctionalSet<ESymValue> havoced)
-      {
-        if (havoced.Contains(address)) return; // no need to repeatedly havoc
-        havoced = havoced.Add(address);
-
-        // remove object from unmodified set
-        if (this.IsUnmodified(address))
-        {
-          this.MakeModified(address);
-          this.RetainForUnmodifiedFields(address);
-        }
-
-#if false
-        // havoc struct/object Id
-        this.egraph.Eliminate(Constructors.ObjectVersion, address);
-        this.egraph.Eliminate(Constructors.StructId, address);
-#endif
-
-        foreach (Constructor c in this.egraph.Functions(address))
-        {
-          Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
-          if (method != null && this.parent.contractDecoder.IsModel(method.Value))
-          {
-            // havoc the value/nested struct
-            HavocMutableFields(null, this.egraph[c, address], ref havoced);
-            continue;
-          }
-        }
-      }
-
-
-      void Havoc(ESymValue address)
-      {
-        this.egraph.EliminateAll(address);
-      }
-
-      void Havoc(Temp t)
-      {
-        Havoc(Address(t));
-      }
-
-      /// <summary>
-      /// Assume given value is true/false
-      /// </summary>
-      Domain Assume(Temp t, bool truth)
-      {
-        return Assume(this.Value(t), truth);
-      }
-
-      Domain Assume(ESymValue eSymValue, bool polarity)
-      {
-        Contract.Ensures(Contract.Result<Domain>() != null);
-
-        if (polarity == false)
-        {
-          if (this.IsNonZero(eSymValue))
-          {
-            // contradiction
-            return Bottom;
-          }
-          // assume esymvalue to be zero
-          this.egraph[eSymValue] = this.egraph[eSymValue].ButZero;
-          // recurse
-          foreach (EGraphTerm<Constructor> eterm in this.egraph.EqTerms(eSymValue))
-          {
-            if (eterm.Function == Constructors.UnaryNot)
-            {
-              return Assume(eterm.Args[0], true);
-            }
-            if (eterm.Function == Constructors.NeZero)
-            {
-              return Assume(eterm.Args[0], false);
-            }
-          }
-        }
-        else
-        {
-          // assume esymvalue to be non-zero.
-          if (this.egraph[eSymValue].IsZero)
-          {
-            // contradiction
-            return Bottom;
-          }
-          // recurse
-          foreach (EGraphTerm<Constructor> eterm in this.egraph.EqTerms(eSymValue))
-          {
-            if (eterm.Function == Constructors.UnaryNot)
-            {
-              return Assume(eterm.Args[0], false);
-            }
-            if (eterm.Function == Constructors.NeZero)
-            {
-              return Assume(eterm.Args[0], true);
-            }
-          }
-        }
-        return this;
-      }
-
-      private bool IsNonZero(ESymValue eSymValue)
-      {
-        foreach (var eterm in this.egraph.EqTerms(eSymValue))
-        {
-          Constructor.Wrapper<object> cons = eterm.Function as Constructor.Wrapper<object>;
-          if (cons != null)
-          {
-            // grab constant
-            if (cons.Value is int)
-            {
-              int value = (int)cons.Value;
-              if (value != 0) return true;
-            }
-          }
-        }
-        return false;
-      }
-
-
-      void AssignNull(Temp t)
-      {
-        AssignNull(Address(Constructors.For(t)));
-      }
-
-      void AssignNull(ESymValue addr)
-      {
-        Havoc(addr);
-        this.egraph[Constructors.ValueOf, addr] = Null;
-      }
-
-      void AssignZero(ESymValue addr)
-      {
-        this.egraph[Constructors.ValueOf, addr] = Zero;
-      }
-
-      void AssignZeroEquivalent(ESymValue dest, Type t)
-      {
-        if (mdDecoder.IsReferenceConstrained(t))
-        {
-          AssignNull(dest);
-        }
-        else if (mdDecoder.HasValueRepresentation(t))
-        {
-          AssignZero(dest);
-        }
-        // TODO initialize struct fields?
-      }
-
-      internal bool IsStructAddress(AbstractType ltype)
-      {
-        if (!ltype.IsNormal) return false;
-        Type type = ltype.Value;
-        if (mdDecoder.IsManagedPointer(type) || mdDecoder.IsUnmanagedPointer(type))
-        {
-          type = mdDecoder.ElementType(type);
-          return !mdDecoder.HasValueRepresentation(type);
-        }
-        return false;
-      }
-      private FlatDomain<Type> TargetType(FlatDomain<Type> addrType)
-      {
-        if (!addrType.IsNormal) return addrType;
-        Type type = addrType.Value;
-        if (mdDecoder.IsManagedPointer(type) || mdDecoder.IsUnmanagedPointer(type))
-        {
-          return mdDecoder.ElementType(type);
-        }
-        return FlatDomain<Type>.TopValue;
-      }
-      bool IsStructWithFields(FlatDomain<Type> valueType)
-      {
-        if (!valueType.IsNormal) return false;
-        Type type = valueType.Value;
-        return !mdDecoder.HasValueRepresentation(type);
-      }
-
-      private void Assign(ESymValue address, FlatDomain<Type> addrType)
-      {
-        Havoc(address);
-        SetType(address, addrType);
-        FlatDomain<Type> targetType = TargetType(addrType);
-        if (!IsStructWithFields(targetType))
-        {
-          ESymValue fresh = egraph.FreshSymbol();
-          SetType(fresh, targetType);
-          this.egraph[Constructors.ValueOf, address] = fresh;
-          // if typeOfValue is an array or string, we need to possibly manifest the length
-          if (targetType.IsNormal)
-          {
-            if (NeedsArrayLengthManifested(targetType.Value))
-            {
-              this.ManifestArrayLength(fresh);
-            }
-            else if (this.mdDecoder.IsManagedPointer(targetType.Value) || this.mdDecoder.IsUnmanagedPointer(targetType.Value))
-            {
-              this.ManifestWritableBytes(fresh);
-            }
-          }
-
-        }
-      }
-
-
-      bool NeedsArrayLengthManifested(Type type)
-      {
-        return this.mdDecoder.IsArray(type) || this.mdDecoder.System_String.Equals(type); // || this.IsIEnumerable(type);
-      }
-
-      TypeCache IEnumerableType = new TypeCache("System.Collections.IEnumerable");
-      TypeCache IEnumerable1Type = new TypeCache("System.Collections.Generic.IEnumerable`1");
-
-      private bool IsIEnumerable(Type type)
-      {
-        Type ienumerable;
-        if (IEnumerable1Type.TryGet(this.mdDecoder, out ienumerable))
-        {
-          if (mdDecoder.DerivesFrom(type, ienumerable)) return true;
-        }
-        if (IEnumerableType.TryGet(this.mdDecoder, out ienumerable))
-        {
-          if (mdDecoder.DerivesFrom(type, ienumerable)) return true;
-        }
-        return false;
-      }
-
-      public bool DerivesFromIEnumerable(Type t)
-      {
-        if (IsIEnumerable(t)) return true;
-        foreach (var intf in mdDecoder.Interfaces(t))
-        {
-          if (IsIEnumerable(intf)) return true;
-        }
-        return false;
-      }
-
-      private void AssignValue(ESymValue address, FlatDomain<Type> typeOfValue, Type fromType)
-      {
-        Havoc(address);
-        SetType(address, (typeOfValue.IsNormal) ? mdDecoder.ManagedPointer(typeOfValue.Value) : typeOfValue);
-        if (!IsStructWithFields(typeOfValue))
-        {
-          ESymValue fresh = egraph.FreshSymbol();
-          SetType(fresh, typeOfValue);
-          this.egraph[Constructors.ValueOf, address] = fresh;
-          // if typeOfValue is an array, we need to possibly manifest the length
-          if (typeOfValue.IsNormal)
-          {
-            if (NeedsArrayLengthManifested(typeOfValue.Value))
-            {
-              this.ManifestArrayLength(fresh);
-            }
-            if (!mdDecoder.IsArray(typeOfValue.Value) && DerivesFromIEnumerable(typeOfValue.Value))
-            {
-              this.ManifestModel(fresh, typeOfValue.Value, fromType: fromType);
-            }
-
-            else if (this.mdDecoder.IsManagedPointer(typeOfValue.Value) || this.mdDecoder.IsUnmanagedPointer(typeOfValue.Value))
-            {
-              this.ManifestWritableBytes(fresh);
-            }
-          }
-        }
-      }
-
-
-      private void ManifestModel(ESymValue value, Type type, Type fromType)
-      {
-        ManifestModel(value, type, false, fromType: fromType);
-      }
-      private void ManifestModel(ESymValue value, Type type, bool isArray, Type fromType)
-      {
-        // First try to find model property in given type. If it is an array type, synthesize one
-
-        ManifestModelProperties(value, type, isArray, fromType: fromType);
-        if (this.mdDecoder.IsInterface(type))
-        // [MAF] 
-        // Types must explicitly implement the model for IEnumerable in mscorlib
-        // Right now, this works only for types defined in mscorlib.Contracts. TODO... fix for all types.
-        {
-          foreach (var intf in mdDecoder.Interfaces(type))
-          {
-            ManifestModelProperties(value, intf, isArray, fromType: fromType);
-          }
-        }
-
-        if (mdDecoder.IsArray(type))
-        {
-          // arrays are magically implementing IEnumerable<T>
-          foreach (var intf in mdDecoder.Interfaces(type))
-          {
-            if (this.IsIEnumerable(intf))
-            {
-              ManifestModel(value, intf, true, fromType: fromType);
-            }
-          }
-        }
-      }
-
-      private void ManifestModelProperties(ESymValue value, Type type, bool isArray, Type fromType)
-      {
-        foreach (var modelMethod in parent.contractDecoder.ModelMethods(type))
-        {
-          // manifest the property
-          Type propertyType;
-          ESymValue propAddr = this.PseudoFieldAddress(value, modelMethod, out propertyType, false, fromType: fromType);
-          ESymValue modelValue;
-          if (isArray)
-          {
-            // model value is the actual array
-            this.egraph[Constructors.ValueOf, propAddr] = value;
-            modelValue = value;
-          }
-          else
-          {
-            modelValue = this.Value(propAddr); // manifest value
-          }
-          if (mdDecoder.IsManagedPointer(propertyType) && mdDecoder.IsArray(mdDecoder.ElementType(propertyType)))
-          {
-            ManifestArrayLength(modelValue);
-          }
-        }
-        return;
-
-      }
-
-      /// <summary>
-      /// Create a fresh value, but retain nullness and WritableBytes if possible
-      /// </summary>
-      private void AssignValueAndNullnessAtConv_IU(ESymValue address, bool unsigned, AbstractType typeOfValueAndNullness, ESymValue sourceValue)
-      {
-        Havoc(address);
-        FlatDomain<Type> typeOfValue = typeOfValueAndNullness.Type;
-        if (!IsStructWithFields(typeOfValue))
-        {
-          ESymValue fresh = egraph.FreshSymbol();
-          // fix up type if source is string, then dest is char*, otherwise, use IntPtr,UIntPtr
-          if (typeOfValue.IsNormal)
-          {
-            if (this.mdDecoder.Equal(typeOfValue.Value, this.mdDecoder.System_String))
-            {
-              typeOfValueAndNullness = new AbstractType(this.mdDecoder.UnmanagedPointer(this.mdDecoder.System_Char), typeOfValueAndNullness.IsZero);
-              typeOfValue = typeOfValueAndNullness.Type;
-            }
-            else
-            {
-              if (unsigned)
-              {
-                typeOfValueAndNullness = new AbstractType(this.mdDecoder.System_UIntPtr, typeOfValueAndNullness.IsZero);
-              }
-              else
-              {
-                typeOfValueAndNullness = new AbstractType(this.mdDecoder.System_IntPtr, typeOfValueAndNullness.IsZero);
-              }
-            }
-          }
-          SetType(address, (typeOfValue.IsNormal) ? mdDecoder.ManagedPointer(typeOfValue.Value) : typeOfValue);
-          this.egraph[fresh] = typeOfValueAndNullness;
-          this.egraph[Constructors.ValueOf, address] = fresh;
-          // retain WritableBytes if present in source
-          ESymValue sourceWritableBytes = this.egraph.TryLookup(this.Constructors.WritableBytes, sourceValue);
-          if (sourceWritableBytes != null)
-          {
-            this.egraph[this.Constructors.WritableBytes, fresh] = sourceWritableBytes;
-          }
-          else
-          {
-            // manifest if necessary
-            if (typeOfValue.IsNormal)
-            {
-              if (this.mdDecoder.IsManagedPointer(typeOfValue.Value) || this.mdDecoder.IsUnmanagedPointer(typeOfValue.Value))
-              {
-                this.ManifestWritableBytes(fresh);
-              }
-            }
-            //if (this.mdDecoder.IsArray(typeOfValue.Value) || mdDecoder.Equal(typeOfValue.Value, mdDecoder.System_String))
-            //{
-            //              this.ManifestArrayLength(fresh);
-            //}
-          }
-        }
-        else
-        {
-          SetType(address, (typeOfValue.IsNormal) ? mdDecoder.ManagedPointer(typeOfValue.Value) : typeOfValue);
-        }
-      }
-
-      void AssignConst(Temp dest, Type typeOfConst, object constant)
-      {
-        ESymValue addr = Address(Constructors.For(dest));
-        AssignConst(addr, typeOfConst, constant);
-      }
-
-      void AssignConst(ESymValue addr, Type typeOfConst, object constant)
-      {
-        ESymValue cval = ConstantValue(constant, typeOfConst);
-        SetType(addr, mdDecoder.ManagedPointer(typeOfConst));
-        this.egraph[Constructors.ValueOf, addr] = cval;
-        string stringConst = constant as String;
-        if (stringConst != null)
-        {
-          this.egraph[Constructors.Length, cval] = ConstantValue(stringConst.Length, this.mdDecoder.System_Int32);
-        }
-      }
-
-      void Assign(Parameter dest, Type typeOfValue, Type fromType)
-      {
-        ESymValue addr = Address(Constructors.For(dest));
-        AssignValue(addr, typeOfValue, fromType: fromType);
-      }
-
-      void CopyParameterIntoShadow(Parameter p)
-      {
-        ESymValue shadowAddr = Address(Constructors.For("$paramShadow_" + this.mdDecoder.Name(p)));
-        CopyValue(shadowAddr, Address(Constructors.For(p)));
-      }
-
-      public ESymValue OldValueAddress(Parameter p)
-      {
-        return Address(Constructors.For("$paramShadow_" + this.mdDecoder.Name(p)));
-      }
-
-      void AssignTokenValue<T>(Temp dest, Type typeOfToken, T token)
-      {
-        var addr = Address(dest);
-        ESymValue cval = ConstantValue((object)token, typeOfToken);
-        SetType(addr, mdDecoder.ManagedPointer(typeOfToken));
-        this.egraph[Constructors.StructId, addr] = cval;
-      }
-
-      void AssignMethodPointer(Temp dest, Type uintPtr, Method method)
-      {
-        var addr = Address(dest);
-        ESymValue cval = MethodPointer(method, uintPtr);
-        SetType(addr, mdDecoder.ManagedPointer(uintPtr));
-        this.egraph[Constructors.ValueOf, addr] = cval;
-      }
-
-      void AssignValue(Temp dest, FlatDomain<Type> typeOfValue, Type fromType)
-      {
-        ESymValue addr = Address(Constructors.For(dest));
-        AssignValue(addr, typeOfValue, fromType: fromType);
-      }
-
-      /// <summary>
-      /// Same as AssignValue, but leave behind a breadcrumb on result value to indicate
-      /// that we materialized it.
-      /// </summary>
-      void AssignReturnValue(Temp dest, Type typeOfValue, Type fromType)
-      {
-        AssignValue(dest, typeOfValue, fromType: fromType);
-#if false
-        // F: I did it
-                MaterializeAccordingToType(Address(dest), mdDecoder.ManagedPointer(typeOfValue), -1, Constructors.ResultOfCall, fromType, overrideFromType:true);
-#endif
-        MaterializeAccordingToType(Address(dest), mdDecoder.ManagedPointer(typeOfValue), 0, Constructors.ResultOfCall, fromType, overrideFromType: false);
-      }
-
-      void AssignValueAndNullnessAtConv_IU(Temp dest, Temp source, bool unsigned)
-      {
-        AbstractType typeOfValueAndNullness = CurrentType(source);
-        ESymValue addr = Address(Constructors.For(dest));
-        AssignValueAndNullnessAtConv_IU(addr, unsigned, typeOfValueAndNullness, Value(source));
-      }
-
-      void AssignSpecialUnary(Temp dest, Constructor op, Temp source, FlatDomain<Type> typeOfValue, Type fromType)
-      {
-        ESymValue result = GetSpecialUnary(op, source, typeOfValue);
-        AssignSpecialUnary(dest, result, typeOfValue, fromType: fromType);
-      }
-
-      void AssignSpecialUnary(Temp dest, ESymValue result, FlatDomain<Type> typeOfValue, Type fromType)
-      {
-        ESymValue destaddr = this.Address(dest);
-        AssignValue(destaddr, typeOfValue, fromType: fromType);
-        this.egraph[Constructors.ValueOf, destaddr] = result;
-      }
-
-      ESymValue GetSpecialUnary(Constructor op, Temp source, FlatDomain<Type> type)
-      {
-        ESymValue src = this.Value(source);
-        var result = this.egraph[op, src];
-        SetType(result, type);
-        return result;
-      }
-
-      ESymValue GetIsInstValue(Type t, Temp source)
-      {
-        ESymValue src = this.Value(source);
-        ESymValue tval = ConstantValue((object)t, mdDecoder.System_Type);
-        var result = this.egraph[Constructors.IsInst, src, tval];
-        SetType(result, t);
-        return result;
-      }
-
-      void AssignIsInst(Type t, Temp source, Temp dest, Type fromType)
-      {
-        var isInstVal = GetIsInstValue(t, source);
-        ESymValue destaddr = this.Address(dest);
-        AssignValue(destaddr, t, fromType: fromType);
-        this.egraph[Constructors.ValueOf, destaddr] = isInstVal;
-      }
-
-      void AssignTop(Temp dest)
-      {
-        AssignValue(dest, mdDecoder.System_Void, default(Type)); // should not materialize anything in this case.
-      }
-
-      AbstractType CurrentType(ESymValue address)
-      {
-        return this.egraph[address];
-      }
-
-      AbstractType CurrentType(Temp t)
-      {
-        return CurrentType(Value(Address(this.Constructors.For(t))));
-      }
-
-      ESymValue LookupAddressAndManifestType(ESymValue sv, Constructor c, Type/*!*/ type, out bool fresh)
-      {
-        ESymValue addr = egraph.TryLookup(c, sv);
-        if (addr != null)
-        {
-          fresh = false;
-          return addr;
-        }
-        // manifest
-        fresh = true;
-        addr = egraph[c, sv];
-        SetType(addr, type);
-        return addr;
-      }
-
-      public void AssignPureUnary(int dest, UnaryOperator op, FlatDomain<Type> typeOpt, int arg)
-      {
-        var c = this.Constructors.For(op);
-        Type type;
-        if (typeOpt.IsNormal)
-        {
-          type = typeOpt.Value;
-        }
-        else
-        {
-          type = mdDecoder.System_Int32;
-        }
-        var result = this.egraph.TryLookup(c, Value(arg));
-        if (result == null)
-        {
-          result = this.egraph[c, Value(arg)];
-          this.egraph[result] = AbstractType.TopValue.With(type);
-        }
-        var destAddr = Address(dest);
-        SetType(destAddr, mdDecoder.ManagedPointer(type));
-        this.egraph[Constructors.ValueOf, destAddr] = result;
-      }
-
-      public void AssignPureBinary(int dest, BinaryOperator op, FlatDomain<Type> typeOpt, int arg1, int arg2)
-      {
-        var args = new ESymValue[] { Value(arg1), Value(arg2) };
-        var c = this.Constructors.For(op);
-        bool fresh;
-        Type type;
-        if (typeOpt.IsNormal)
-        {
-          type = typeOpt.Value;
-        }
-        else
-        {
-          type = mdDecoder.System_Int32;
-        }
-        var result = LookupAddressAndManifestType(args, c, type, out fresh);
-        var destAddr = Address(dest);
-        SetType(destAddr, mdDecoder.ManagedPointer(type));
-        this.egraph[Constructors.ValueOf, destAddr] = result;
-        if (this.mdDecoder.IsUnmanagedPointer(type))
-        {
-          this.ManifestWritableBytes(result);
-        }
-      }
-
-
-      ESymValue LookupAddressAndManifestType(ESymValue[] args, Constructor c, Type/*!*/ type, out bool fresh)
-      {
-        ESymValue addr = egraph.TryLookup(c, args);
-        if (addr != null)
-        {
-          fresh = false;
-          return addr;
-        }
-        // manifest
-        fresh = true;
-        Contract.Assume(args.Length > 1);
-        addr = egraph[c, args];
-        SetType(addr, type);
-        return addr;
-      }
-
-      private void CopyValue(ESymValue destAddr, ESymValue srcAddr)
-      {
-        AbstractType abstype = this.egraph[srcAddr];
-        CopyValue(destAddr, srcAddr, abstype.Type);
-      }
-
-      private void CopyValue(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType)
-      {
-        CopyValue(destAddr, srcAddr, addrType, true, false);
-      }
-
-      private void CopyOldValue(APC pc, Temp dest, Temp source, Domain target, bool atEndOld)
-      {
-        CopyOldValue(pc, target.Address(dest), this.Address(source), target, atEndOld);
-      }
-
-      private void CopyOldValue(APC pc, ESymValue destAddr, ESymValue srcAddr, Domain target, bool atEndOld)
-      {
-        AbstractType abstype = this.egraph[srcAddr];
-        CopyOldValue(pc, destAddr, srcAddr, abstype.Type, target, atEndOld);
-      }
-
-      private void CopyOldValue(APC pc, ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, Domain target, bool atEndOld)
-      {
-        CopyOldValue(pc, destAddr, srcAddr, addrType, true, atEndOld, target);
-      }
-
-      private void CopyValueAndCast(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType)
-      {
-        CopyValue(destAddr, srcAddr, addrType, true, true);
-      }
-
-      private void CopyValue(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, bool setTargetAddrType, bool cast)
-      {
-        this.MakeTotallyModified(destAddr);
-        if (destAddr != srcAddr) { HavocIfStruct(destAddr); }
-        if (setTargetAddrType) SetType(destAddr, addrType);
-        SetValue(destAddr, srcAddr, addrType, cast);
-      }
-
-      private void SetValue(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, bool cast)
-      {
-        FlatDomain<Type> elementType = TargetType(addrType);
-        if (IsStructWithFields(elementType))
-        {
-          CopyStructValue(destAddr, srcAddr, elementType.Value);
-        }
-        else
-        {
-          CopyPrimValue(destAddr, srcAddr, cast, elementType);
-        }
-      }
-
-      private void CopyPrimValue(ESymValue destAddr, ESymValue srcAddr, bool cast, FlatDomain<Type> elementType)
-      {
-        ESymValue svalue = this.egraph[Constructors.ValueOf, srcAddr];
-        if (cast)
-        {
-          SetType(svalue, elementType);
-        }
-        else
-        {
-          SetTypeIfUnknown(svalue, elementType);
-        }
-        if (elementType.IsNormal)
-        {
-          if (NeedsArrayLengthManifested(elementType.Value))
-          {
-            // manifest array length
-            this.ManifestArrayLength(svalue);
-          }
-          else if (this.mdDecoder.IsManagedPointer(elementType.Value) || this.mdDecoder.IsUnmanagedPointer(elementType.Value))
-          {
-            this.ManifestWritableBytes(svalue);
-          }
-        }
-        this.egraph[Constructors.ValueOf, destAddr] = svalue;
-      }
-
-      private void CopyOldValue(APC pc, ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, bool setTargetAddrType, bool atEndOld, Domain target)
-      {
-        target.MakeTotallyModified(destAddr);
-        if (destAddr != srcAddr) { target.HavocIfStruct(destAddr); }
-        if (setTargetAddrType) target.SetType(destAddr, addrType);
-        FlatDomain<Type> elementType = TargetType(addrType);
-        if (IsStructWithFields(elementType))
-        {
-          CopyOldStructValue(pc, destAddr, srcAddr, elementType.Value, target, atEndOld);
-        }
-        else if (atEndOld && elementType.IsNormal && mdDecoder.IsManagedPointer(elementType.Value))
-        {
-          // special case. Copying @T to @T, this usually means that we need to make a deep copy
-          // recurse on both sides.
-          srcAddr = this.TryValue(srcAddr);
-          if (srcAddr == null) return;
-          destAddr = target.Value(destAddr);
-          CopyOldValue(pc, destAddr, srcAddr, elementType, setTargetAddrType, atEndOld, target);
-        }
-        else
-        {
-          ESymValue svalue = this.egraph.TryLookup(Constructors.ValueOf, srcAddr);
-          if (svalue == null)
-          {
-            if (this.egraph.IsConstant)
-            {
-              return;
-            }
-            svalue = this.egraph[Constructors.ValueOf, srcAddr]; // manifest
-          }
-
-          CopyOldValueToDest(pc, destAddr, svalue, addrType, target);
-        }
-      }
-
-      private void CopyOldValueToDest(APC pc, ESymValue destAddr, ESymValue svalue, FlatDomain<Type> addrType, Domain target)
-      {
-        //
-        // enumerate through all access paths in old state for old value and try to find an unmodified
-        // accesspath in the new state. This would correspond to the same value in the new state.
-        //
-        bool callInsideContract;
-        if (pc.IsInsideEnsuresAtCall(out callInsideContract) || pc.IsInsideInvariantAtCall(out callInsideContract))
-        {
-          Type constType;
-          object constValue;
-          if (this.IsConstant(svalue, out constType, out constValue))
-          {
-            // just look up the new constant
-            var newConstant = target.ConstantValue(constValue, constType);
-            target.CopyNonStructWithFieldValue(destAddr, newConstant, addrType);
-            return;
-          }
-          // must be inside ensures around call
-          ESymValue best = null;
-
-          foreach (var accesspath in this.GetAccessPathsRaw(svalue, AccessPathFilter<Method, Type>.NoFilter, false))
-          {
-            ESymValue candidate;
-            if (FindOldCandidateAfterCall(target, accesspath, callInsideContract, out candidate))
-            {
-              if (best == null)
-              {
-                best = candidate;
-              }
-              else
-              {
-                if (candidate.GlobalId < best.GlobalId)
+                public override bool IsGetter
                 {
-                  best = candidate;
+                    get
+                    {
+                        return isGetter;
+                    }
                 }
-              }
-            }
-          }
-          if (best != null)
-          {
-            target.CopyNonStructWithFieldValue(destAddr, best, addrType);
-            return;
-          }
-        }
-        else
-        {
-          // must be inside ensures on exit
-          foreach (var accesspath in this.GetAccessPathsRaw(svalue, AccessPathFilter<Method, Type>.NoFilter, false))
-          {
-            ESymValue targetSym;
-            if (target.PathExistsUnmodifiedSinceEntry(accesspath, out targetSym))
-            {
-              target.CopyNonStructWithFieldValue(destAddr, targetSym, addrType);
-              return;
-            }
-          }
-        }
-        // backup approach
-        if (target.IsValidSymbol(svalue))
-        {
-          target.CopyNonStructWithFieldValue(destAddr, svalue, addrType);
-        }
-        else
-        {
-          target.Assign(destAddr, addrType);
-        }
-        return;
-      }
 
-      private static bool FindOldCandidateAfterCall(Domain target, FList<PathElementBase> accesspath, bool callInsideContract, out ESymValue candidate)
-      {
-        if (callInsideContract)
-        {
-          // call couldn't modify anything
-          return target.PathExistsAtCall(accesspath, out candidate);
-        }
-        else
-        {
-          return target.PathExistsUnmodifiedAtCall(accesspath, out candidate);
-        }
-      }
-
-      private static void CopyStructId(APC pc, ESymValue destAddr, ESymValue srcAddr, Domain source, Domain target)
-      {
-        // TODO: do the same as in oldvalue copy, but we need access paths to struct ids
-#if true
-        target.ManifestStructId(destAddr);
-#else
-        ESymValue identity = this.egraph[Constructors.StructId, srcAddr];
-        //
-        // enumerate through all access paths in old state for old value and try to find an unmodified
-        // accesspath in the new state. This would correspond to the same value in the new state.
-        //
-        if (pc.InsideEnsuresAtCall)
-        {
-          // must be inside ensures around call
-          foreach (var accesspath in this.GetAccessPaths(identity, new Optional<Method>(), false))
-          {
-            ESymValue targetSym;
-            if (target.PathExistsUnmodifiedAtCall(accesspath, out targetSym))
-            {
-              target.CopyNonStructWithFieldValue(destAddr, targetSym, addrType);
-              return;
-            }
-          }
-        }
-        else
-        {
-          // must be inside ensures on exit
-          foreach (var accesspath in this.GetAccessPaths(identity, new Optional<Method>(), false))
-          {
-            ESymValue targetSym;
-            if (target.PathExistsUnmodifiedSinceEntry(accesspath, out targetSym))
-            {
-              target.CopyNonStructWithFieldValue(destAddr, targetSym, addrType);
-              return;
-            }
-          }
-        }
-        // backup approach
-        if (target.IsValidSymbol(identity))
-        {
-          target.CopyNonStructWithFieldValue(destAddr, identity, addrType);
-        }
-        else
-        {
-          target.AssignValue(destAddr, addrType);
-        }
-#endif
-      }
-
-      private void CopyStructValue(ESymValue destAddr, ESymValue srcAddr, Type type)
-      //^ requires mdDecoder.IsStruct(type);
-      {
-        if (destAddr == null) return;
-        // copy struct id
-        this.egraph[Constructors.StructId, destAddr] = this.egraph[Constructors.StructId, srcAddr];
-
-        foreach (Constructor key in this.egraph.Functions(srcAddr))
-        {
-          if (!key.ActsAsField) continue;
-          Type t = key.FieldAddressType(mdDecoder);
-
-          ESymValue destFld = this.egraph[key, destAddr];
-          ESymValue srcFld = this.egraph[key, srcAddr];
-          CopyValue(destFld, srcFld, t);
-        }
-      }
-
-      private void CopyOldStructValue(APC pc, ESymValue destAddr, ESymValue srcAddr, Type type, Domain target, bool atEndOld)
-      //^ requires mdDecoder.IsStruct(type);
-      {
-        if (destAddr == null) return;
-        // copy old struct id
-        CopyStructId(pc, destAddr, srcAddr, this, target);
-
-        foreach (Constructor key in this.egraph.Functions(srcAddr))
-        {
-          if (!key.ActsAsField) continue;
-          Type t = key.FieldAddressType(mdDecoder);
-
-          ESymValue destFld = target.egraph[key, destAddr];
-          ESymValue srcFld = this.egraph[key, srcAddr];
-          CopyOldValue(pc, destFld, srcFld, t, target, atEndOld);
-        }
-      }
-
-
-      private ESymValue FieldAddress(ESymValue ptr, Field f)
-      {
-        Type fieldAddressType;
-        return FieldAddress(ptr, f, out fieldAddressType);
-      }
-
-      private ESymValue FieldAddress(ESymValue ptr, Field f, out Type fieldAddressType)
-      {
-        fieldAddressType = mdDecoder.ManagedPointer(mdDecoder.FieldType(f));
-        bool fresh;
-        ESymValue fldaddr = LookupAddressAndManifestType(ptr, Constructors.For(f), fieldAddressType, out fresh);
-        if (fresh)
-        {
-          if (this.IsUnmodifiedForFields(ptr) || this.mdDecoder.IsReadonly(f))
-          {
-            this.MakeUnmodified(fldaddr);
-          }
-          if (this.IsModifiedAtCall(ptr))
-          {
-            this.modifiedAtCall = this.modifiedAtCall.Add(fldaddr);
-          }
-        }
-        return fldaddr;
-      }
-
-      private ESymValue PseudoFieldAddress(ESymValue value, Method m, Type fromType)
-      {
-        Type psuedoFieldAddressType;
-        return PseudoFieldAddress(value, m, out psuedoFieldAddressType, false, fromType: fromType);
-      }
-
-      private ESymValue PseudoFieldAddress(ESymValue[] args, Method m, out Type pseudoFieldAddressType, bool materializeStructFields, Type fromType)
-      {
-        if (args.Length == 0)
-        {
-          return PseudoFieldAddress(Globals, m, out pseudoFieldAddressType, materializeStructFields, fromType: fromType);
-        }
-        if (args.Length == 1)
-        {
-          return PseudoFieldAddress(args[0], m, out pseudoFieldAddressType, materializeStructFields, fromType: fromType);
-        }
-        pseudoFieldAddressType = mdDecoder.ManagedPointer(mdDecoder.ReturnType(m));
-        m = mdDecoder.Unspecialized(m);
-        bool fresh;
-        ESymValue fldaddr = LookupAddressAndManifestType(args, Constructors.For(m), pseudoFieldAddressType, out fresh);
-        if (fresh)
-        {
-          if (AreUnmodified(args))
-          {
-            this.MakeUnmodified(fldaddr);
-          }
-          if (AnyAreModifiedAtCall(args))
-          {
-            this.modifiedAtCall = this.modifiedAtCall.Add(fldaddr);
-          }
-          if (materializeStructFields)
-          {
-            MaterializeAccordingToType(fldaddr, pseudoFieldAddressType, 0, Constructors.ResultOfPureCall, fromType: fromType);
-          }
-        }
-        return fldaddr;
-      }
-
-      private ESymValue PseudoFieldAddress(ESymValue value, Method m, out Type pseudoFieldAddressType, bool materialize, Type fromType)
-      {
-        var returnType = mdDecoder.ReturnType(m);
-        pseudoFieldAddressType = mdDecoder.ManagedPointer(returnType);
-        m = mdDecoder.Unspecialized(m);
-        bool fresh;
-        ESymValue fldaddr = LookupAddressAndManifestType(value, Constructors.For(m), pseudoFieldAddressType, out fresh);
-        if (fresh)
-        {
-          if (this.IsUnmodified(value))
-          {
-            this.MakeUnmodified(fldaddr);
-          }
-          if (this.IsModifiedAtCall(value))
-          {
-            this.modifiedAtCall = this.modifiedAtCall.Add(fldaddr);
-          }
-        }
-        if (materialize)
-        {
-          MaterializeAccordingToType(fldaddr, pseudoFieldAddressType, 0, Constructors.ResultOfPureCall, fromType: fromType);
-        }
-        return fldaddr;
-      }
-
-      public void MaterializeOutParameterAccordingToType(ESymValue value, Type t, int depth, Type fromType)
-      {
-        MaterializeAccordingToType(value, t, depth, Constructors.ResultOfOutParameter, fromType: fromType);
-      }
-
-      public void MaterializeThisAtCallAccordingToType(ESymValue value, Type t, int depth, Type fromType)
-      {
-        MaterializeAccordingToType(value, t, depth, Constructors.ResultOfCallThisHavoc, fromType: fromType);
-      }
-
-
-      public void MaterializeNewObjAccordingToType(ESymValue value, Type t, int depth, Type fromType)
-      {
-        MaterializeAccordingToType(value, t, depth, null, fromType: fromType);
-      }
-
-      // F: I added overrideFromType
-      private void MaterializeAccordingToType(ESymValue value, Type t, int depth, Constructor breadCrumb, Type fromType, bool overrideFromType = false)
-      {
-        SetType(value, t);
-        if (depth > 2) return;
-        if (mdDecoder.IsManagedPointer(t))
-        {
-          Type elementType = mdDecoder.ElementType(t);
-          if (!mdDecoder.HasValueRepresentation(elementType))
-          {
-            // manifest struct id
-            this.ManifestStructId(value);
-            // manifest field addresses
-            foreach (Field f in mdDecoder.Fields(elementType))
-            {
-              if (mdDecoder.IsStatic(f)) continue;
-              if (!mdDecoder.IsVisibleFrom(f, fromType)) continue;
-              // manifest the field
-              Type fieldType;
-              ESymValue fieldAddr = FieldAddress(value, f, out fieldType);
-              MaterializeAccordingToType(fieldAddr, fieldType, depth + 1, null, fromType, overrideFromType);
-            }
-            foreach (Property p in mdDecoder.Properties(elementType))
-            {
-              if (mdDecoder.IsStatic(p)) continue;
-              Method getter;
-              if (!mdDecoder.HasGetter(p, out getter)) continue;
-              if (mdDecoder.Parameters(getter).Count > 0) continue;
-              if (!mdDecoder.IsVisibleFrom(getter, fromType)) continue;
-              // skip string.get_Length, as we use $Length for that
-              if (mdDecoder.Equal(elementType, mdDecoder.System_String) && mdDecoder.Name(getter) == "get_Length")
-              {
-                continue;
-              }
-
-              // manifest the pseudo field
-              Type propertyType;
-              ESymValue pseudoFieldAddr = PseudoFieldAddress(value, getter, out propertyType, false, fromType: fromType);
-              MaterializeAccordingToType(pseudoFieldAddr, propertyType, depth + 1, null, fromType, overrideFromType);
-            }
-            foreach (var m in parent.contractDecoder.ModelMethods(elementType))
-            {
-              if (mdDecoder.IsStatic(m)) continue;
-              // manifest the pseudo field
-              Type propertyType;
-              ESymValue pseudoFieldAddr = PseudoFieldAddress(value, m, out propertyType, false, fromType: fromType);
-              MaterializeAccordingToType(pseudoFieldAddr, propertyType, depth + 1, null, fromType, overrideFromType);
-            }
-          }
-          else
-          {
-            // manifest the value
-            var derefedValue = Value(value);
-            MaterializeAccordingToType(derefedValue, elementType, depth + 1, null, fromType, overrideFromType);
-            if (breadCrumb != null)
-            {
-              // leave breadcrumb
-              egraph[breadCrumb, derefedValue] = Zero;
-            }
-          }
-          return;
-        }
-
-        if (!mdDecoder.IsArray(t) && DerivesFromIEnumerable(t))
-        {
-          ManifestModel(value, t, fromType: fromType);
-        }
-
-        if (mdDecoder.IsClass(t))
-        {
-          foreach (Field f in mdDecoder.Fields(t))
-          {
-            if (mdDecoder.IsStatic(f)) continue;
-            if (overrideFromType || mdDecoder.IsVisibleFrom(f, fromType))
-            {
-              // manifest the field
-              Type fieldType;
-              ESymValue fieldAddr = this.FieldAddress(value, f, out fieldType);
-              MaterializeAccordingToType(fieldAddr, fieldType, depth + 1, breadCrumb, fromType, overrideFromType);
-            }
-          }
-          if (breadCrumb == Constructors.ResultOfCallThisHavoc && mdDecoder.HasBaseClass(t))
-          {
-            // materialize base fields
-            var baseType = mdDecoder.BaseClass(t);
-            foreach (Field f in mdDecoder.Fields(baseType))
-            {
-              if (mdDecoder.IsStatic(f)) continue;
-              if (mdDecoder.IsVisibleFrom(f, fromType))
-              {
-                // manifest the field
-                Type fieldType;
-                ESymValue fieldAddr = this.FieldAddress(value, f, out fieldType);
-                MaterializeAccordingToType(fieldAddr, fieldType, depth + 1, breadCrumb, fromType, overrideFromType);
-              }
-            }
-          }
-        }
-
-        foreach (Property p in mdDecoder.Properties(t))
-        {
-          if (mdDecoder.IsStatic(p)) continue;
-          Method getter;
-          if (!mdDecoder.HasGetter(p, out getter)) continue;
-          if (mdDecoder.Parameters(getter).Count > 0) continue;
-          if (!mdDecoder.IsVisibleFrom(getter, fromType)) continue;
-          // skip string.get_Length, as we use $Length for that
-          if (mdDecoder.Equal(t, mdDecoder.System_String) && mdDecoder.Name(getter) == "get_Length")
-          {
-            continue;
-          }
-
-          // manifest the pseudo field
-          Type propertyType;
-          ESymValue pseudoFieldAddr = PseudoFieldAddress(value, getter, out propertyType, false, fromType: fromType);
-          MaterializeAccordingToType(pseudoFieldAddr, propertyType, depth + 1, null, fromType, overrideFromType);
-
-          // manifest aliased interface properties
-          foreach (var intfmethod in mdDecoder.ImplementedMethods(getter))
-          {
-            var normalizedMethod = mdDecoder.Unspecialized(intfmethod);
-            this.egraph[Constructors.For(normalizedMethod), value] = pseudoFieldAddr;
-          }
-        }
-
-        if (NeedsArrayLengthManifested(t))
-        {
-          ManifestArrayLength(value);
-          return;
-        }
-
-        if (mdDecoder.IsUnmanagedPointer(t))
-        {
-          ManifestWritableBytes(value);
-          return;
-        }
-      }
-
-
-      #region Unmodified since entry
-      private void MakeUnmodified(ESymValue value)
-      {
-        this.unmodifiedSinceEntry = this.unmodifiedSinceEntry.Add(value);
-      }
-
-      private void MakeModified(ESymValue value)
-      {
-        this.unmodifiedSinceEntry = this.unmodifiedSinceEntry.Remove(value);
-      }
-
-      private void MakeTotallyModified(ESymValue value)
-      {
-        this.unmodifiedSinceEntry = this.unmodifiedSinceEntry.Remove(value);
-        this.unmodifiedSinceEntryForFields = this.unmodifiedSinceEntryForFields.Remove(value);
-      }
-
-      private void RetainForUnmodifiedFields(ESymValue value)
-      {
-        this.unmodifiedSinceEntryForFields = this.unmodifiedSinceEntryForFields.Add(value);
-      }
-
-      private bool IsUnmodified(ESymValue value)
-      {
-        return this.unmodifiedSinceEntry.Contains(value);
-      }
-
-      private bool AreUnmodified(ESymValue[] values)
-      {
-        for (int i = 0; i < values.Length; i++)
-        {
-          if (!IsUnmodified(values[i])) return false;
-        }
-        return true;
-      }
-
-      private bool AnyAreModifiedAtCall(ESymValue[] values)
-      {
-        for (int i = 0; i < values.Length; i++)
-        {
-          if (IsModifiedAtCall(values[i])) return true;
-        }
-        return false;
-      }
-
-      private bool IsUnmodifiedForFields(ESymValue value)
-      {
-        return this.unmodifiedSinceEntry.Contains(value) || this.unmodifiedSinceEntryForFields.Contains(value);
-      }
-      #endregion
-
-      #region Array support
-      private ESymValue ElementAddress(ESymValue array, ESymValue index, Type/*!*/ elementAddrType)
-      {
-        var arrayversion = this.egraph[Constructors.ObjectVersion, array];
-        var args = new[] { arrayversion, index };
-        var elementAddr = this.egraph.TryLookup(Constructors.ElementAddress, args);
-
-        if (elementAddr == null)
-        {
-          elementAddr = this.egraph[Constructors.ElementAddress, args]; // manifest
-          SetType(elementAddr, elementAddrType);
-          // leave breadcrumb
-          this.egraph[Constructors.ResultOfLdelem, elementAddr] = this.Zero;
-        }
-        return elementAddr;
-      }
-
-
-      void AssignArrayLength(ESymValue destAddr, ESymValue array)
-      {
-        ESymValue len = egraph[Constructors.Length, array];
-        SetType(len, mdDecoder.System_Int32);
-        egraph[Constructors.ValueOf, destAddr] = len;
-        SetType(destAddr, mdDecoder.ManagedPointer(mdDecoder.System_Int32));
-      }
-
-      void AssignWritableBytes(ESymValue destAddr, ESymValue pointer)
-      {
-        ESymValue len = egraph[Constructors.WritableBytes, pointer];
-        SetType(len, mdDecoder.System_UInt64);
-        egraph[Constructors.ValueOf, destAddr] = len;
-        SetType(destAddr, mdDecoder.ManagedPointer(mdDecoder.System_UInt64));
-      }
-
-      ESymValue CreateArray(Type type, ESymValue len)
-      {
-        ESymValue array = egraph.FreshSymbol();
-        egraph[Constructors.Length, array] = len;
-        SetType(array, mdDecoder.ArrayType(type, 1));
-        return array;
-      }
-
-      ESymValue LocalAlloc(ESymValue len)
-      {
-        ESymValue buffer = egraph.FreshSymbol();
-        egraph[Constructors.WritableBytes, buffer] = len;
-        SetType(buffer, mdDecoder.System_UIntPtr);
-        return buffer;
-      }
-
-      #endregion
-
-      ESymValue CreateObject(Type type)
-      {
-        ESymValue obj = egraph.FreshSymbol();
-        SetType(obj, type);
-        return obj;
-      }
-
-      /// <returns>The address of a new value object</returns>
-      ESymValue CreateValue(Type type)
-      {
-        ESymValue addr = egraph.FreshSymbol();
-        SetType(addr, this.mdDecoder.ManagedPointer(type));
-        return addr;
-      }
-
-      private void CopyStackAddress(ESymValue destAddr, Temp temporaryForWhichAddressIsTaken)
-      {
-        ESymValue srcAddr = Address(temporaryForWhichAddressIsTaken);
-        this.egraph[Constructors.ValueOf, destAddr] = srcAddr;
-        AbstractType atype = CurrentType(srcAddr);
-        FlatDomain<Type> addrType;
-        if (atype.IsNormal)
-        {
-          addrType = mdDecoder.ManagedPointer(atype.Type.Value);
-        }
-        else
-        {
-          addrType = new FlatDomain<Type>();
-        }
-        SetType(destAddr, addrType);
-      }
-
-      private void CopyAddress(ESymValue destAddr, ESymValue srcAddr, Type typeOfAddressValue)
-      {
-        this.egraph[Constructors.ValueOf, destAddr] = srcAddr;
-        SetType(destAddr, mdDecoder.ManagedPointer(typeOfAddressValue));
-      }
-
-        /// <summary>
-        /// Like copy, but leaves ResultOfOldValue breadcrumb
-        /// </summary>
-      void CopyOld(Temp dest, Temp source, Type type)
-      {
-          Copy(dest, source);
-          if (!IsStructWithFields(type))
-          {
-              // leave breadcrumb
-              var derefedValue = this.Value(dest);
-              this.egraph[Constructors.ResultOfOldValue, derefedValue] = Null;
-          }
-      }
-
-      void Copy(Temp dest, Temp source)
-      {
-        ESymValue destAddr = Address(Constructors.For(dest));
-        ESymValue srcAddr = Address(Constructors.For(source));
-        CopyValue(destAddr, srcAddr);
-      }
-
-      #region Operator Type Conversions
-
-      /// <summary>
-      /// Currently, we don't take nullness/zeroness into account
-      /// </summary>
-      FlatDomain<Type> BinaryResultType(BinaryOperator op, AbstractType t1, AbstractType t2)
-      {
-        switch (op)
-        {
-          case BinaryOperator.Add:
-          case BinaryOperator.Add_Ovf:
-          case BinaryOperator.Add_Ovf_Un:
-            if (t1.IsNormal &&
-                (mdDecoder.IsUnmanagedPointer(t1.Value)))
-            {
-              return t1.Type;
-            }
-            if (t2.IsNormal && (mdDecoder.IsUnmanagedPointer(t2.Value)))
-            {
-              return t2.Type;
-            }
-            if (t1.IsNormal && mdDecoder.IsManagedPointer(t1.Value))
-            {
-              return mdDecoder.UnmanagedPointer(mdDecoder.ElementType(t1.Value));
-            }
-            if (t1.IsZero) return t2.Type;
-            return t1.Type;
-
-          case BinaryOperator.Sub:
-          case BinaryOperator.Sub_Ovf:
-          case BinaryOperator.Sub_Ovf_Un:
-            if (t1.IsNormal && (mdDecoder.IsUnmanagedPointer(t1.Value)))
-            {
-              if (t2.IsNormal && (mdDecoder.IsUnmanagedPointer(t2.Value)))
-              {
-                return mdDecoder.System_Int32;
-              }
-              return t1.Type;
-            }
-            if (t2.IsNormal && (mdDecoder.IsUnmanagedPointer(t2.Value)))
-            {
-              return t2.Type;
-            }
-            if (t1.IsNormal && mdDecoder.IsManagedPointer(t1.Value))
-            {
-              return mdDecoder.UnmanagedPointer(mdDecoder.ElementType(t1.Value));
-            }
-            return t1.Type;
-
-          case BinaryOperator.Ceq:
-          case BinaryOperator.Cobjeq:
-          case BinaryOperator.Cge:
-          case BinaryOperator.Cge_Un:
-          case BinaryOperator.Cgt:
-          case BinaryOperator.Cgt_Un:
-          case BinaryOperator.Cle:
-          case BinaryOperator.Cle_Un:
-          case BinaryOperator.Clt:
-          case BinaryOperator.Clt_Un:
-          case BinaryOperator.Cne_Un:
-            return mdDecoder.System_Boolean;
-
-          default:
-            return t1.Type;
-        }
-      }
-
-      Type UnaryResultType(UnaryOperator op, AbstractType type)
-      {
-        switch (op)
-        {
-          case UnaryOperator.Conv_i1: return this.mdDecoder.System_Int8;
-          case UnaryOperator.Conv_i2: return this.mdDecoder.System_Int16;
-          case UnaryOperator.Conv_i4: return this.mdDecoder.System_Int32;
-          case UnaryOperator.Conv_i8: return this.mdDecoder.System_Int64;
-          case UnaryOperator.Conv_u1: return this.mdDecoder.System_UInt8;
-          case UnaryOperator.Conv_u2: return this.mdDecoder.System_UInt16;
-          case UnaryOperator.Conv_u4: return this.mdDecoder.System_UInt32;
-          case UnaryOperator.Conv_u8:
-          case UnaryOperator.WritableBytes:
-            return this.mdDecoder.System_UInt64;
-          case UnaryOperator.Conv_r8:
-          case UnaryOperator.Conv_r_un:
-            return this.mdDecoder.System_Double;
-          case UnaryOperator.Conv_r4:
-            return this.mdDecoder.System_Single;
-          case UnaryOperator.Conv_dec:
-            return this.mdDecoder.System_Decimal;
-        }
-        if (type.IsNormal)
-        {
-          return type.Value;
-        }
-        return mdDecoder.System_Int32;
-      }
-
-      #endregion
-
-      #region Metadata helpers
-      bool IsPointer(Type t)
-      {
-        return mdDecoder.IsManagedPointer(t) || mdDecoder.IsUnmanagedPointer(t);
-      }
-      #endregion
-
-      [ThreadStatic]
-      private static bool debug;
-
-      private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder { get { return parent.mdDecoder; } }
-
-      /// <summary>
-      /// Determines if the temporary refers to "this"
-      /// </summary>
-      private bool IsThis(Method method, Temp arg)
-      {
-        if (mdDecoder.IsStatic(method)) return false;
-        ESymValue thisValue = this.Value(this.mdDecoder.This(method));
-        ESymValue argValue = this.Value(arg);
-        return thisValue == argValue;
-      }
-
-      private void ManifestArrayLength(ESymValue arrayValue)
-      {
-        ESymValue len = egraph[Constructors.Length, arrayValue];
-        SetType(len, mdDecoder.System_Int32);
-      }
-
-      private void ManifestWritableBytes(ESymValue pointerValue)
-      {
-        ESymValue len = egraph[Constructors.WritableBytes, pointerValue];
-        SetType(len, mdDecoder.System_UInt64);
-      }
-
-      private void AddOldSavedState(APC pc, Domain data)
-      {
-        this.BeginOldSavedStates[pc] = data;
-      }
-
-      private Domain GetStateAt(APC aPC)
-      {
-        Domain d;
-        this.parent.PreStateLookup(aPC, out d);
-        return d;
-      }
-
-      private bool IsValidSymbol(ESymValue sv)
-      {
-        return this.egraph.IsValidSymbolc(sv);
-      }
-
-      private void CopyNonStructWithFieldValue(ESymValue address, ESymValue sv, FlatDomain<Type> addressType)
-      {
-        this.egraph[Constructors.ValueOf, address] = sv;
-        SetType(address, addressType);
-      }
-
-      private Domain GetSavedStateAtBeginOld(APC matchingBegin)
-      {
-        return this.BeginOldSavedStates[matchingBegin];
-      }
-
-      #endregion // Privates
-
-      #region Debugging
-      public static bool Debug
-      {
-        get { return debug; }
-        set { debug = value; EGraph<Constructor, AbstractType>.DoDebug = value; }
-      }
-
-      public IEnumerable<ESymValue> Variables
-      {
-        get
-        {
-          return this.egraph.SymbolicValues;
-        }
-      }
-      #endregion
-
-      /// <summary>
-      /// Constructing the initial domain value for a method
-      /// </summary>
-      /// <param name="parent"></param>
-      [ContractVerification(false)]
-      internal Domain(OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent)
-      {
-        this.parent = parent;
-        this.egraph = new EGraph<Constructor, AbstractType>(AbstractType.TopValue, AbstractType.BottomValue);
-        this.constantLookup = FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey);
-        this.unmodifiedSinceEntry = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-        this.unmodifiedSinceEntryForFields = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-        this.modifiedAtCall = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-
-        this.Constructors = new WrapTable(parent.mdDecoder, parent.contractDecoder);
-        this.BeginOldSavedStates = new Dictionary<APC, Domain>();
-        // manifest some constants with special properties
-        ESymValue nullvalue = this.egraph.FreshSymbol();
-        this.egraph[Constructors.NullValue] = nullvalue;
-        this.egraph[nullvalue] = AbstractType.BottomValue;
-        ESymValue zerovalue = this.ConstantValue(0, mdDecoder.System_Int32);
-        // fix type to remember it is 0
-        this.egraph[zerovalue] = new AbstractType(mdDecoder.System_Int32, true);
-
-        ESymValue voidaddr = this.VoidAddr;
-      }
-
-      internal Type GetArrayElementType(Type type, int array)
-      {
-        Type elementType = type;
-        if (!mdDecoder.IsStruct(type))
-        {
-          ESymValue arrayval = this.Value(array);
-          AbstractType at = this.GetType(arrayval);
-          if (at.IsNormal && mdDecoder.IsArray(at.Value))
-          {
-            elementType = mdDecoder.ElementType(at.Value);
-            if (elementType == null) elementType = type;
-          }
-        }
-        return elementType;
-      }
-
-      #region Heap analysis per instruction actions
-
-      /// <summary>
-      /// Performs the actual heap analysis for each instruction kind
-      /// </summary>
-      internal struct AnalysisDecoder : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Domain, Domain>
-      {
-        [ContractInvariantMethod]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-        private void ObjectInvariant()
-        {
-          Contract.Invariant(this.parent != null);
-        }
-
-
-        #region Privates
-        private OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
-        #endregion
-
-        public AnalysisDecoder(OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent)
-        {
-          this.parent = parent;
-
-          Contract.Assume(this.parent != null);
-        }
-
-        IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder { get { return this.parent.contractDecoder; } }
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-        {
-          get
-          {
-            Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
-            return this.parent.mdDecoder;
-          }
-        }
-
-        #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>> Members
-
-        public Domain Arglist(APC pc, int dest, Domain data)
-        {
-          var arghandletype = data.mdDecoder.System_RuntimeArgumentHandle;
-          data.AssignValue(dest, arghandletype, this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignValue(dest, arghandletype, this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-
-        public Domain Binary(APC pc, BinaryOperator op, int dest, Temp s1, Temp s2, Domain data)
-        {
-          Contract.Assume(s2 > s1);// F: Added
-
-          data = BinaryEffect(pc, op, dest, s1, s2, data, this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain = BinaryEffect(pc, op, dest, s1, s2, data.oldDomain, this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-        private static Domain BinaryEffect(APC pc, BinaryOperator op, int dest, Temp s1, Temp s2, Domain data, Type fromType)
-        {
-          Contract.Requires(s2 > s1); // F: Added from Clousot precondition suggestion
-
-          System.Diagnostics.Debug.Assert(s2 > s1);
-          FlatDomain<Type> resultType = data.BinaryResultType(op, data.CurrentType(s1), data.CurrentType(s2));
-          ESymValue sv1, sv2;
-          //
-          // Capture comparisons against zero/null and record them so that we can refine
-          // branches for nullness.
-          //
-          switch (op)
-          {
-            case BinaryOperator.Ceq:
-            case BinaryOperator.Cobjeq:
-              sv1 = data.Value(s1);
-              if (data.IsZero(sv1))
-              {
-                // result is true/non-zero if s2 is zero, false/zero otherwise
-                // thus we can use unaryNot here
-                data.AssignSpecialUnary(dest, data.Constructors.UnaryNot, s2, resultType, fromType: fromType);
-              }
-              else
-              {
-                sv2 = data.Value(s2);
-                if (data.IsZero(sv2))
+                public override bool IsBooleanTyped
                 {
-                  // result is true/non-zero if s1 is zero, false/zero otherwise
-                  // thus we can use unaryNot here
-                  data.AssignSpecialUnary(dest, data.Constructors.UnaryNot, s1, resultType, fromType: fromType);
+                    get
+                    {
+                        return isBooleanTyped;
+                    }
                 }
-                else
-                  goto default;
-              }
-              break;
+            }
 
-            case BinaryOperator.Cne_Un:
-              sv1 = data.Value(s1);
-              if (data.IsZero(sv1))
-              {
-                data.AssignSpecialUnary(dest, data.Constructors.NeZero, s2, resultType, fromType: fromType);
-              }
-              else
-              {
-                sv2 = data.Value(s2);
-                if (data.IsZero(sv2))
+            [Serializable]
+            private class SpecialPathElement : PathElement<SpecialPathElementKind>
+            {
+                private object type; // used for Deref nodes
+
+                public SpecialPathElement(SpecialPathElementKind k, Constructor c)
+                  : base(k, k.ToString(), c)
                 {
-                  data.AssignSpecialUnary(dest, data.Constructors.NeZero, s1, resultType, fromType: fromType);
+                    mCastPreviousTo = "";
                 }
-                else
-                  goto default;
-              }
-              break;
 
-            default:
-              data.AssignPureBinary(dest, op, resultType, s1, s2);
-              break;
-          }
-          data.Havoc(s2);
-          return data;
-        }
-
-        public Domain BranchCond(APC pc, APC target, BranchOperator bop, int value1, int value2, Domain data)
-        {
-          throw new NotImplementedException("Should not see Branches, should see Assumes");
-        }
-
-        public Domain BranchTrue(APC pc, APC target, int cond, Domain data)
-        {
-          throw new NotImplementedException("Should not see Branches, should see Assumes");
-        }
-
-        public Domain BranchFalse(APC pc, APC target, int cond, Domain data)
-        {
-          throw new NotImplementedException("Should not see Branches, should see Assumes");
-        }
-
-        public Domain Branch(APC pc, APC target, bool leave, Domain data)
-        {
-          throw new NotImplementedException("Should not see Branches, should see Assumes");
-        }
-
-        public Domain Break(APC pc, Domain data)
-        {
-          return data;
-        }
-
-        public Domain Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Temp dest, ArgList args, Domain data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<int>
-        {
-          Type declaringType = mdDecoder.DeclaringType(method);
-          if (data.oldDomain != null)
-          {
-            // perform call in old state and map result back
-            data.oldDomain = CallFactored(pc, method, tail, virt, extraVarargs, dest, args, data.oldDomain, declaringType, false);
-
-            if (!mdDecoder.IsVoidMethod(method))
-            {
-              data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
-            }
-            return data;
-          }
-          else
-          {
-            return CallFactored<TypeList, ArgList>(pc, method, tail, virt, extraVarargs, dest, args, data, declaringType, false);
-          }
-        }
-
-        private Type CurrentMethodDeclaringType
-        {
-          get
-          {
-            return this.mdDecoder.DeclaringType(this.parent.currentMethod);
-          }
-        }
-        [ContractVerification(false)]
-        private Domain CallFactored<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Temp dest, ArgList args, Domain data, Type methodDeclaringType, bool constrainedCall)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<int>
-        {
-          Contract.Assume(args.Count >= mdDecoder.Parameters(method).Count + extraVarargs.Count);
-          Contract.Assume(args.Count <= mdDecoder.Parameters(method).Count + extraVarargs.Count + 1);
-          Contract.Assume(!mdDecoder.IsStatic(method) || args.Count == mdDecoder.Parameters(method).Count + extraVarargs.Count);
-
-          Type declaringType = methodDeclaringType;
-
-          if (!pc.InsideContract)
-          {
-            data.ResetModifiedAtCall();
-          }
-
-          #region Compute a type map for type instantiations
-          var substitution = ComputeTypeInstantiationMap(pc, method);
-          #endregion
-          #region Devirtualize as far as possible
-          bool dereferenceThis = false;
-          if (virt)
-          {
-            if (mdDecoder.IsStruct(methodDeclaringType))
-            {
-              // constrained call virt. Let's use the constraint to find the better method implementing the method
-              DevirtualizeImplementingMethod(methodDeclaringType, ref method);
-            }
-            else
-            {
-              // figure out if constrained call and we know it's a reference type
-              if (constrainedCall)
-              {
-                var specialized = Specialize(substitution, methodDeclaringType);
-                if (mdDecoder.IsReferenceType(specialized))
+                public override bool IsAddressOf
                 {
-                  // need extra dereference of "this"
-                  dereferenceThis = true;
+                    get
+                    {
+                        return false;
+                    }
                 }
-              }
-              // let's use the receiver
-              ESymValue obj = data.Value(args[0]);
-              if (dereferenceThis)
-              {
-                obj = data.Value(obj);
-              }
-              var thisType = data.GetType(obj);
-              if (thisType.IsNormal)
-              {
-                // find method in thisType that implements method.
-                DevirtualizeImplementingMethod(thisType.Value, ref method);
-              }
-            }
-          }
-          #endregion
 
-          #region Special case methods
-          string methodName = mdDecoder.Name(method);
-          if (args.Count > 0)
-          {
-            if ((mdDecoder.Equal(declaringType, mdDecoder.System_String) ||
-              mdDecoder.Equal(declaringType, mdDecoder.System_Array))
-              && (methodName == "get_Length" || methodName == "get_LongLength"))
-            {
-              // assign length to dest
-              data.AssignArrayLength(data.Address(dest), data.Value(args[0]));
-              return data;
-            }
-            if (mdDecoder.Equal(declaringType, mdDecoder.System_Object)
-              && methodName == "MemberwiseClone")
-            {
-              Type thisType = data.GetType(data.Value(args[0])).Value;
-              ESymValue obj = data.CreateObject(thisType);
-              data.CopyStructValue(obj, data.Value(args[0]), thisType); // cheat. Use struct copy to do memberwise copy here.
-              data.CopyAddress(data.Address(dest), obj, thisType);
-              return data;
+                public override bool IsDeref
+                {
+                    get
+                    {
+                        return this.Element == SpecialPathElementKind.Deref;
+                    }
+                }
+
+                public override bool TryGetResultType<Type2>(out Type2 type)
+                {
+                    if (this.type is Type2)
+                    {
+                        type = (Type2)this.type;
+                        return true;
+                    }
+                    type = default(Type2);
+                    return false;
+                }
+
+                internal override bool TrySetType(Type prevType, out Type result)
+                {
+                    var mdDecoder = this.Constructor.mdDecoder;
+
+                    switch (this.Element)
+                    {
+                        case SpecialPathElementKind.Deref:
+                            if (mdDecoder.IsManagedPointer(prevType))
+                            {
+                                var type = mdDecoder.ElementType(prevType);
+                                this.type = type;
+                                result = type;
+                                return true;
+                            }
+                            if (mdDecoder.IsUnmanagedPointer(prevType))
+                            {
+                                var type = mdDecoder.ElementType(prevType);
+                                this.type = type;
+                                result = type;
+                                return true;
+                            }
+                            result = default(Type);
+                            return false;
+
+                        case SpecialPathElementKind.Length:
+                            // Mic: if it's not an array, cast it to array (string.Length does not use this particular case)
+                            if (!mdDecoder.IsArray(prevType) && !mdDecoder.System_String.Equals(prevType))
+                                mCastPreviousTo = "System.Array";
+                            else
+                                mCastPreviousTo = ""; // reset because the variable is somewhat shared
+                            result = mdDecoder.System_Int32;
+                            return true;
+
+                        case SpecialPathElementKind.WritableBytes:
+                            result = mdDecoder.System_Int32;
+                            return true;
+
+                        default:
+                            result = default(Type);
+                            return false;
+                    }
+                }
+
+                public override Result Decode<Data, Result, Visitor, PC, Local2, Parameter2, Method2, Field2, Type2>(PC pc, Visitor visitor, Data data)
+                {
+                    switch (this.Element)
+                    {
+                        case SpecialPathElementKind.Deref:
+                            return visitor.Ldind(pc, (Type2)type, false, Unit.Value, Unit.Value, data);
+
+                        case SpecialPathElementKind.Length:
+                            return visitor.Ldlen(pc, Unit.Value, Unit.Value, data);
+
+                        case SpecialPathElementKind.WritableBytes:
+                            return visitor.Unary(pc, UnaryOperator.WritableBytes, false, true, Unit.Value, Unit.Value, data);
+
+                        default:
+                            throw new NotImplementedException("Unknown kind");
+                    }
+                }
             }
 
-            #region Identity functions
-
-            // Array.GetLowerBound(0), assume it is 0
-            if (methodName == "GetLowerBound" && mdDecoder.Name(declaringType) == "Array" && args.Count > 1)
+            [Serializable]
+            internal enum SpecialPathElementKind
             {
-              ESymValue arg = data.Value(args[1]);
-              if (data.IsZero(arg))
-              {
-                data.CopyNonStructWithFieldValue(data.Address(dest), arg, mdDecoder.ManagedPointer(mdDecoder.System_Int32));
-                return data;
-              }
+                WritableBytes,
+                Length,
+                Deref
+            }
+
+            public static bool IsRootedInParameter(FList<PathElement> path)
+            {
+                Contract.Requires(path != null);
+
+                return path.Head is PathElement<Parameter>;
+            }
+
+            public static bool IsRootedInReturnValue(FList<PathElement> path)
+            {
+                Contract.Requires(path != null);
+                return path.Head is ReturnValuePathElement;
             }
 
             #endregion
-          }
-          if (extraVarargs.Count == 0 && !mdDecoder.IsVoid(mdDecoder.ReturnType(method)) && (contractDecoder.IsPure(method) || contractDecoder.IsModel(method)))
-          {
-            // NOTE: Need to check whether the method is a model method because IsHeapIndependent might not be able to find the property that the model method (getter)
-            // belongs to.
-            var nonOutArgs = GetNonOutArgs(method);
-            if (args.Count <= 1 && nonOutArgs == args.Count)
+
+            #region Privates
+
+            /// <summary>
+            /// Copy Constructor
+            /// </summary>
+            private Domain(
+              EGraph<Constructor, AbstractType> newEgraph,
+              IFunctionalMap<ESymValue, Constructor> constantMap,
+              IFunctionalSet<ESymValue> unmodifiedSinceEntry,
+              IFunctionalSet<ESymValue> unmodifiedSinceEntryForFields,
+              IFunctionalSet<ESymValue> modifiedAtCall,
+              Domain from,
+              Domain oldDomain)
             {
-              // treat like a field provided it isn't marked as fresh
-              if (contractDecoder.IsFreshResult(method))
-              {
-                data.AssignReturnValue(dest, mdDecoder.ReturnType(method), this.CurrentMethodDeclaringType); // void is handled by assign
-                return data;
-              }
-              ESymValue obj;
-              if (args.Count == 0)
-              {
-                Contract.Assume(mdDecoder.IsStatic(method));
-                obj = data.Globals;
-              }
-              else if (mdDecoder.IsStatic(method) && !mdDecoder.HasValueRepresentation(mdDecoder.ParameterType(mdDecoder.Parameters(method)[0])))
-              {
-                // struct by value parameter
-                obj = data.StructId(data.Address(args[0]));
-              }
-              else
-              {
-                obj = null;
-                if (!mdDecoder.IsStatic(method) && !mdDecoder.HasValueRepresentation(mdDecoder.DeclaringType(method)) && IsStructValue(data, args[0]))
-                {
-                  // struct instance call
-                  // special case if we have a value on the stack rather than the address
-                  obj = data.Address(args[0]); // use the address of the stack local
-                }
-                if (obj == null) {
-                  // ordinary non-struct parameter or by-ref struct
-                  obj = data.Value(args[0]);
-                  if (dereferenceThis)
-                  {
-                    obj = data.Value(obj);
-                  }
-                }
-              }
-              Type pseudoFieldAddressType;
-              ESymValue fieldAddr = data.PseudoFieldAddress(obj, method, out pseudoFieldAddressType, true, this.CurrentMethodDeclaringType);
-              data.CopyValue(data.Address(dest), fieldAddr, pseudoFieldAddressType);
-              return data;
+                egraph = newEgraph;
+                Constructors = from.Constructors;
+                parent = from.parent;
+                BeginOldSavedStates = from.BeginOldSavedStates;
+                constantLookup = constantMap;
+                this.unmodifiedSinceEntry = unmodifiedSinceEntry;
+                this.unmodifiedSinceEntryForFields = unmodifiedSinceEntryForFields;
+                this.modifiedAtCall = modifiedAtCall;
+                insideOld = from.insideOld;
+                this.oldDomain = oldDomain;
+                beginOldPC = from.beginOldPC;
             }
-            else
+
+            private ESymValue Globals { get { return egraph.Root; } }
+
+
+            public ESymValue Null
             {
-              // multi variable uninterpreted function
-              ESymValue[] symArgs = new ESymValue[nonOutArgs];
-              for (int i = 0, index = 0; i < args.Count; i++)
-              {
-                bool isOut;
-
-                var key = KeyForPureFunctionArgument(method, i, args[i], data, substitution, out isOut);
-                if (!isOut)
+                get
                 {
-                  symArgs[index++] = key;
+                    return egraph[Constructors.NullValue];
                 }
-              }
-
-              Type pseudoFieldAddressType;
-              ESymValue fieldAddr = data.PseudoFieldAddress(symArgs, method, out pseudoFieldAddressType, true, this.CurrentMethodDeclaringType);
-              AssignAllOutParameters(data, fieldAddr, method, args);
-              data.CopyValue(data.Address(dest), fieldAddr, pseudoFieldAddressType);
-              return data;
-
             }
-          }
-          if (mdDecoder.IsPropertySetter(method))
-          {
-            Property property = mdDecoder.GetPropertyFromAccessor(method);
-            if (args.Count <= 2)
-            {
-              Method getter;
-              if (mdDecoder.HasGetter(property, out getter))
-              {
-                // treat like a field
-                Type pseudoFieldAddressType;
-                ESymValue obj;
-                ESymValue valueAddr;
-                if (args.Count == 1)
-                {
-                  Contract.Assume(mdDecoder.IsStatic(getter));
-                  obj = data.Globals;
-                  valueAddr = data.Address(args[0]);
-                }
-                else
-                {
-                  obj = data.Value(args[0]);
-                  if (dereferenceThis)
-                  {
-                    obj = data.Value(obj);
-                  }
-                  valueAddr = data.Address(args[1]);
-                }
 
-                // havoc whatever the setter havocs if we are inside the same class
-                if (this.mdDecoder.Equal(this.mdDecoder.DeclaringType(this.parent.currentMethod), this.mdDecoder.Unspecialized(this.mdDecoder.DeclaringType(method))))
+            public ESymValue Zero
+            {
+                get
                 {
-                  data.HavocUp(obj, ref data.modifiedAtCall, false);
-                  if (mdDecoder.IsAutoPropertyMember(method))
-                  {
-                    // set the backing field
-                    foreach (var backingField in this.parent.context.MethodContext.Modifies(method))
+                    return egraph[Constructors.ZeroValue];
+                }
+            }
+
+            public ESymValue VoidAddr
+            {
+                get
+                {
+                    return egraph[Constructors.VoidAddr];
+                }
+            }
+
+            private void SetType(ESymValue sv, FlatDomain<Type> t)
+            {
+                AbstractType at = egraph[sv];
+                if (!at.IsZero)
+                {
+                    egraph[sv] = at.With(t);
+                }
+            }
+            private void SetTypeIfUnknown(ESymValue sv, FlatDomain<Type> t)
+            {
+                AbstractType at = egraph[sv];
+                if (!at.IsZero)
+                {
+                    if (!at.Type.IsNormal || at.Type.Equals(this.mdDecoder.System_IntPtr) || at.Type.Equals(this.mdDecoder.System_UIntPtr))
                     {
-                      Type backingFieldAddressType;
-                      ESymValue backingFieldAddr = data.FieldAddress(obj, backingField, out backingFieldAddressType);
-                      data.CopyValue(backingFieldAddr, valueAddr, backingFieldAddressType);
+                        egraph[sv] = at.With(t);
                     }
-                  }
-                  else
-                  {
-                    data.HavocFields(obj, this.parent.context.MethodContext.Modifies(method), ref data.modifiedAtCall);
-                  }
                 }
-
-                ESymValue fieldAddr = data.PseudoFieldAddress(obj, getter, out pseudoFieldAddressType, true, this.CurrentMethodDeclaringType);
-                data.CopyValue(fieldAddr, valueAddr, pseudoFieldAddressType);
-                // don't forget to set dest, otherwise downstream decoding will miss some void address
-                data.AssignValue(dest, mdDecoder.System_Void, this.CurrentMethodDeclaringType); // void is handled by assign
-
-                return data;
-              }
             }
-            else // args > 2
+
+            private ESymValue ConstantValue(object constant, Type t)
             {
-              Method getter;
-              if (mdDecoder.HasGetter(property, out getter))
-              {
-                // multi variable uninterpreted function
-                var nonOutArgs = GetNonOutArgs(method) - 1;
-                ESymValue[] symArgs = new ESymValue[nonOutArgs];
-                for (int i = 0, index = 0; i < args.Count - 1; i++)
+                Constructor c = Constructors.ForConstant(constant, t);
+                ESymValue cval = egraph.TryLookup(c);
+                if (cval == null)
                 {
-                  bool isOut;
-                  Contract.Assume(!mdDecoder.IsStatic(method) || i < mdDecoder.Parameters(method).Count, "assuming IL is well-formed");
+                    cval = egraph[c];
+                    SetType(cval, t);
+                    constantLookup = constantLookup.Add(cval, c);
+                }
+                return cval;
+            }
 
-                  var key = KeyForPureFunctionArgument(method, i, args[i], data, substitution, out isOut);
-                  if (!isOut)
-                  {
-                    symArgs[index++] = key;
-                  }
+            private ESymValue MethodPointer(Method method, Type t)
+            {
+                Constructor c = Constructors.ForMethod(method, t);
+                ESymValue cval = egraph.TryLookup(c);
+                if (cval == null)
+                {
+                    cval = egraph[c];
+                    SetType(cval, t);
+                    constantLookup = constantLookup.Add(cval, c);
+                }
+                return cval;
+            }
+
+            private ESymValue TypeDefaultValue(Type t)
+            {
+                Constructor c = Constructors.ForTypeDefaultValue(t);
+                return egraph[c];
+            }
+
+            internal bool IsMethodPointer(ESymValue sval, out Method method)
+            {
+                Constructor.Wrapper<Method> mcon = constantLookup[sval] as Constructor.Wrapper<Method>;
+                if (mcon != null) { method = mcon.Value; return true; }
+                method = default(Method);
+                return false;
+            }
+
+            private ESymValue Address(Constructor v, Type t)
+            {
+                ESymValue addr = egraph.TryLookup(v);
+                if (addr == null)
+                {
+                    addr = egraph[v];
+                    SetType(addr, t);
+                }
+                return addr;
+            }
+
+            private ESymValue Address(Constructor v)
+            {
+                return egraph[v];
+            }
+
+            private ESymValue Address(Temp t)
+            {
+                return Address(Constructors.For(t));
+            }
+
+            private ESymValue Address(Parameter p)
+            {
+                Constructor loc = Constructors.For(p);
+                ESymValue addr = egraph.TryLookup(loc);
+                if (addr == null)
+                {
+                    addr = egraph[loc];
+                    SetType(addr, mdDecoder.ManagedPointer(mdDecoder.ParameterType(p)));
+                }
+                return addr;
+            }
+
+            private ESymValue Address(Local l)
+            {
+                Constructor loc = Constructors.For(l);
+                ESymValue addr = egraph.TryLookup(loc);
+                if (addr == null)
+                {
+                    addr = egraph[loc];
+                    SetType(addr, mdDecoder.ManagedPointer(mdDecoder.LocalType(l)));
+                }
+                return addr;
+            }
+
+            private ESymValue TryAddress(Constructor v)
+            {
+                return egraph.TryLookup(v);
+            }
+
+            private ESymValue Value(ESymValue loc)
+            {
+                bool fresh;
+                ESymValue result = egraph.LookupOrManifest(Constructors.ValueOf, loc, out fresh);
+                if (fresh && this.IsUnmodified(loc))
+                {
+                    // make sure to propagate unmodified property
+                    this.MakeUnmodified(result);
+                }
+                return result;
+            }
+
+            private ESymValue TryValue(ESymValue loc)
+            {
+                ESymValue result = egraph.TryLookup(Constructors.ValueOf, loc);
+                //if (result != null && this.IsZero(result)) return this.Zero;
+                return result;
+            }
+
+            /// <summary>
+            /// Like TryValue, but checks if address is a struct address. In that case, it returns
+            /// the address itself.
+            /// </summary>
+            private ESymValue TryCorrespondingValue(ESymValue loc)
+            {
+                if (IsStructAddress(egraph[loc])) return loc;
+                return TryValue(loc);
+            }
+
+            private ESymValue Value(Parameter v)
+            {
+                return Value(Address(Constructors.For(v)));
+            }
+
+            private ESymValue Value(Temp v)
+            {
+                return Value(Address(Constructors.For(v)));
+            }
+
+            internal FList<PathElement> GetBestAccessPath(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress, bool allowLocal, bool preferLocal,
+              Predicate<FList<PathElement>> additionalFilter = null)
+            {
+                Contract.Requires(filter != null);
+
+                FList<PathElement> shortestParamPath = null;
+                FList<PathElement> shortestLocalPath = null;
+                FList<PathElement> backupPath = null;
+                FList<PathElement> returnPath = null;
+
+                foreach (var p in GetAccessPathsFiltered(sv, filter, compress))
+                {
+                    if (p != null)
+                    {
+                        var path = p.Coerce<PathElementBase, PathElement>();
+                        if (additionalFilter != null && additionalFilter(path) == false) continue;
+                        if (path.Head is PathElement<Parameter>)
+                        {
+                            if (shortestParamPath == null || shortestParamPath.Length() > path.Length())
+                            {
+                                shortestParamPath = path;
+                            }
+                        }
+                        else if (/*Mic: change to the true meaning: if accessibility should not be tested from outside (was: !accessedFrom.IsValid)*/
+                          (filter.AllowLocal && allowLocal) // TODO MAF: changed meaning, review
+                          && path.Head is PathElement<Local>)
+                        {
+                            if (filter.AllowCompilerLocal || !path.Head.ToString().Contains("$"))
+                            {
+                                if (shortestLocalPath == null || shortestLocalPath.Length() > path.Length())
+                                {
+                                    shortestLocalPath = path;
+                                }
+                            }
+                        }
+                        else if (path.Head is PathElement<Field> && p.Head.Constructor.IsStatic)
+                        {
+                            // static field 
+                            if (backupPath == null || backupPath.Length() > path.Length())
+                            {
+                                backupPath = path;
+                            }
+                        }
+                        else if (path.Head is PathElement<Method> && p.Head.Constructor.IsStatic)
+                        {
+                            // static property 
+                            if (backupPath == null || backupPath.Length() > path.Length())
+                            {
+                                backupPath = path;
+                            }
+                        }
+                        else if (path.Head.IsReturnValue)
+                        {
+                            returnPath = path;
+                        }
+                    }
                 }
 
-                ESymValue obj = data.Value(args[0]);
-                if (dereferenceThis)
-                {
-                  obj = data.Value(obj);
-                }
-                Type pseudoFieldAddressType;
-                ESymValue fieldAddr = data.PseudoFieldAddress(symArgs, getter, out pseudoFieldAddressType, false, this.CurrentMethodDeclaringType);
-                AssignAllOutParameters(data, fieldAddr, method, args);
-                var valueAddress = data.Address(args[args.Count - 1]);
-                data.CopyValue(fieldAddr, valueAddress, pseudoFieldAddressType);
+                if (returnPath != null) { return returnPath; }
+                if (preferLocal && shortestLocalPath != null) { return shortestLocalPath; }
+                if (shortestParamPath != null) { return shortestParamPath; }
+                // emit local path if we don't have visibility issues
+                if (allowLocal && shortestLocalPath != null) { return shortestLocalPath; }
+                if (backupPath != null) { return backupPath; }
+                return null;
+            }
 
-                // havoc whatever the setter havocs if we are inside the same class
-                if (this.mdDecoder.Equal(this.mdDecoder.DeclaringType(this.parent.currentMethod), this.mdDecoder.Unspecialized(this.mdDecoder.DeclaringType(method))))
+            private bool TryPropagateTypeInfo(FList<PathElementBase> path, AccessPathFilter<Method, Type> filter, out FList<PathElementBase> result)
+            {
+                if (path == null)
                 {
-                  data.HavocUp(obj, ref data.modifiedAtCall, false);
-                  data.HavocFields(obj, this.parent.context.MethodContext.Modifies(method), ref data.modifiedAtCall);
+                    result = null;
+                    return true;
+                }
+
+                var mdd = this.mdDecoder;
+
+                Type headTypeRef;
+                PathElementBase head = path.Head;
+                if (filter != null && filter.AllowReturnValue && head.Constructor.IsTopOfStack(filter.LocalStackDepth))
+                {
+                    if (mdd.System_Void.Equals(filter.ReturnValueType))
+                    {
+                        result = null;
+                        return false;
+                    }
+
+                    // replace it with Return value
+                    head = new ReturnValuePathElement(filter.ReturnValueType, mdd.Name(filter.ReturnValueType), head.Constructor);
+                    headTypeRef = mdd.ManagedPointer(filter.ReturnValueType);
                 }
                 else
                 {
-                  data.HavocModelProperties(obj, ref data.modifiedAtCall);
+                    if (!head.TrySetType(mdd.System_IntPtr, out headTypeRef))
+                    {
+                        result = null;
+                        return false;
+                    }
                 }
-
-              }
-              else
-              {
-                // no getter, what should we do?
-              }
-              // don't forget to set dest, otherwise downstream decoding will miss some void address
-              data.AssignValue(dest, mdDecoder.System_Void, this.CurrentMethodDeclaringType); // void is handled by assign
-
-              return data;
-            }
-          }
-          #endregion
-
-          bool insideConstructor = this.mdDecoder.IsConstructor(this.parent.currentMethod);
-
-          #region Havoc parameters
-          HavocParameters<TypeList, ArgList>(pc, method, extraVarargs, args, data, declaringType, insideConstructor, false, dereferenceThis);
-          #endregion
-
-          // Deal with return type
-          data.AssignReturnValue(dest, mdDecoder.ReturnType(method), this.CurrentMethodDeclaringType); // void is handled by assign
-
-          return data;
-        }
-
-        private bool IsStructValue(Domain data, Temp source)
-        {
-          var raddr = data.Address(source);
-          var rtype = data.GetType(raddr);
-          if (rtype.IsNormal)
-          {
-            if (mdDecoder.IsManagedPointer(rtype.Value) && !mdDecoder.IsManagedPointer(mdDecoder.ElementType(rtype.Value)))
-            {
-              return true;
-            }
-          }
-          return false;
-        }
-        
-        private void AssignAllOutParameters<ArgList>(Domain data, ESymValue fieldAddr, Method method, ArgList args)
-          where ArgList : IIndexable<int>
-        {
-          int index = 0;
-          if (!mdDecoder.IsStatic(method)) { index++; } // skip this parameter actual
-
-          foreach (var p in mdDecoder.Parameters(method).Enumerate())
-          {
-            if (mdDecoder.IsOut(p))
-            {
-              // we grab a pseudo sub structure of fieldAddr as the value of this out parameter
-              var parameterType = mdDecoder.ParameterType(p);
-              var outFieldAddress = data.PseudoFieldAddressOfOutParameter(index, fieldAddr, parameterType, this.CurrentMethodDeclaringType);
-              Contract.Assume(index < args.Count, "invariant assuming bytecode is well formed and number of arguments at calls is correct");
-              var dest = data.Value(args[index]);
-              data.CopyValue(dest, outFieldAddress, parameterType);
-            }
-            index++;
-          }
-        }
-
-        private int GetNonOutArgs(Method method)
-        {
-          int count = this.mdDecoder.IsStatic(method) ? 0 : 1;
-          foreach (var p in mdDecoder.Parameters(method).Enumerate())
-          {
-            if (!mdDecoder.IsOut(p)) count++;
-          }
-          return count;
-        }
-
-        private Func<Type, Type> Compose(IFunctionalMap<Type, Type> map, Func<Type, Type> inner)
-        {
-          if (map.Count == 0) return inner;
-          if (inner == null)
-          {
-            return (type) => (map.Contains(type)) ? map[type] : type;
-          }
-          return (type) =>
-          {
-            type = inner(type);
-            if (map.Contains(type)) return map[type];
-            return type;
-          };
-        }
-
-        private Func<Type, Type> ComputeTypeInstantiationMap(APC pc, Method method)
-        {
-          Func<Type, Type> substitution = null;
-          for (var context = pc.SubroutineContext; context != null; context = context.Tail)
-          {
-            Method calledMethod;
-            bool isNewObj;
-            bool isVirtualCall;
-            if (context.Head.One.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall))
-            {
-              IFunctionalMap<Type, Type> map = FunctionalMap<Type, Type>.Empty;
-              mdDecoder.IsSpecialized(calledMethod, ref map);
-              substitution = Compose(map, substitution);
-            }
-            else if (context.Head.Two.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall))
-            {
-              IFunctionalMap<Type, Type> map = FunctionalMap<Type, Type>.Empty;
-              mdDecoder.IsSpecialized(calledMethod, ref map);
-              substitution = Compose(map, substitution);
-            }
-          }
-          return substitution;
-        }
-
-        [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!mdDecoder.IsStatic(method) || index < mdDecoder.Parameters(method).Count")]
-        private ESymValue KeyForPureFunctionArgument(Method method, int index, Temp arg, Domain data, Func<Type, Type> specialization, out bool isOut)
-        {
-          Contract.Requires(index >= 0);
-          Contract.Requires(index <= mdDecoder.Parameters(method).Count);
-          Contract.Requires(!mdDecoder.IsStatic(method) || index < mdDecoder.Parameters(method).Count);
-
-          bool isPrimitive;
-          bool isByRef;
-          Type type;
-          bool isThis;
-          if (!ParameterHasValueRepresentation(method, index, specialization, out isPrimitive, out isOut, out isByRef, out type, out isThis))
-          {
-            if (isThis && isByRef && IsStructValue(data, arg))
-            {
-              // special case for calls on structs, where we have the struct value on the stack rather than the address
-              return data.StructId(data.Address(arg));
-            }
-            if (!isByRef)
-            {
-              // struct by value parameter
-              return data.StructId(data.Address(arg));
-            }
-            else
-            {
-              // struct by ref
-              return data.StructId(data.Value(arg));
-            }
-          }
-          else
-          {
-            // ordinary non-struct parameter (but possibly primitive)
-            var ptr = data.Value(arg);
-            if (isByRef)
-            {
-              ptr = data.Value(ptr);
-            }
-            if (isPrimitive || IsImmutableType(type) || contractDecoder.IsMutableHeapIndependent(method))
-            {
-              return ptr;
-            }
-            else
-            {
-              return data.ObjectVersion(ptr);
-            }
-          }
-        }
-
-        private bool IsImmutableType(Type type)
-        {
-          return this.mdDecoder.IsDelegate(type);
-        }
-
-        private void DevirtualizeImplementingMethod(Type type, ref Method method)
-        {
-          Method implementing;
-          if (mdDecoder.TryGetImplementingMethod(type, method, out implementing))
-          {
-            method = implementing;
-          }
-        }
-
-
-        Type Specialize(Func<Type, Type> specialization, Type type)
-        {
-          if (specialization != null)
-          {
-            return specialization(type);
-          }
-          return type;
-        }
-
-        private bool ParameterHasValueRepresentation(Method method, int paramIndex, Func<Type, Type> specialization, out bool isPrimitive, out bool isOut, out bool isByRef, out Type type, out bool isThis)
-        {
-          Contract.Requires(paramIndex >= 0);
-          Contract.Requires(paramIndex <= mdDecoder.Parameters(method).Count);
-          Contract.Requires(!mdDecoder.IsStatic(method) || paramIndex < mdDecoder.Parameters(method).Count);
-
-          if (mdDecoder.IsStatic(method))
-          {
-            isThis = false;
-            var parameter = mdDecoder.Parameters(method)[paramIndex];
-            type = mdDecoder.ParameterType(parameter);
-            type = Specialize(specialization, type);
-            isOut = mdDecoder.IsOut(parameter);
-            if (mdDecoder.IsManagedPointer(type))
-            {
-              isByRef = true;
-              type = mdDecoder.ElementType(type);
-            }
-            else
-            {
-              isByRef = false;
-            }
-            isPrimitive = mdDecoder.IsPrimitive(type);
-            return mdDecoder.HasValueRepresentation(type);
-          }
-          else
-          {
-            // shift
-            if (paramIndex == 0)
-            {
-              // instance arg 
-              isThis = true;
-              isOut = false;
-              type = mdDecoder.DeclaringType(method);
-              isPrimitive = mdDecoder.IsPrimitive(type);
-              var hasValueRep = mdDecoder.HasValueRepresentation(type);
-              if (isPrimitive || !hasValueRep)
-              {
-                isByRef = true;
-              }
-              else
-              {
-                isByRef = false;
-              }
-              return hasValueRep;
-            }
-            else
-            {
-              isThis = false;
-              var parameter = mdDecoder.Parameters(method)[paramIndex - 1];
-              type = mdDecoder.ParameterType(parameter);
-              type = Specialize(specialization, type);
-              if (mdDecoder.IsManagedPointer(type))
-              {
-                isByRef = true;
-                type = mdDecoder.ElementType(type);
-              }
-              else
-              {
-                isByRef = false;
-              }
-              isPrimitive = mdDecoder.IsPrimitive(type);
-              isOut = mdDecoder.IsOut(parameter);
-              return mdDecoder.HasValueRepresentation(type);
-            }
-          }
-        }
-
-        [ContractVerification(false)]
-        private void HavocParameters<TypeList, ArgList>(
-          APC pc,
-          Method method,
-          TypeList extraVarargs,
-          ArgList args,
-          Domain data,
-          Type declaringType,
-          bool insideConstructor,
-          bool thisArgMissing, // this happens in newObj
-          bool derefThis // true if constrained virtcall and we know it's on a reference type
-        )
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<int>
-        {
-          // Deal with by-ref parameters: note, we have to handle "this" and varargs too here.
-          IIndexable<Parameter> parameters = this.mdDecoder.Parameters(method);
-          IIndexable<Parameter> genericMethodParameters = null;
-          if (this.mdDecoder.IsSpecialized(method))
-          {
-            genericMethodParameters = this.mdDecoder.Parameters(this.mdDecoder.Unspecialized(method));
-            Contract.Assume(parameters.Count == genericMethodParameters.Count);
-          }
-
-          for (int i = 0, param = 0, optThis = 0; i < args.Count; i++)
-          {
-            Contract.Assert(param <= i);
-            Contract.Assert(optThis <= 1);
-
-            // find type corresponding to args[i]
-            bool isOut = false;
-            bool materializeAfterCall = true;
-            bool isNonFirstThis = false;
-            Temp arg = args[i];
-            Type pt;
-            bool isGenericArgType = false;
-            bool isThisConstructorCall = false; // constructor call on same class : this(...)
-
-            if (i == 0 && !thisArgMissing && !mdDecoder.IsStatic(method))
-            {
-              optThis = 1;
-              Parameter thisParam = mdDecoder.This(method);
-              pt = mdDecoder.ParameterType(thisParam);
-              if (this.mdDecoder.IsConstructor(method))
-              {
-                // a base call is a constructor call from a constructor with "this", and the target constructor is declared in a different type
-                if (insideConstructor &&
-                    data.IsThis(this.parent.currentMethod, arg)
-                  )
+                FList<PathElementBase> tail;
+                if (!TryPropagateTypeInfoRecurse(path.Tail, headTypeRef, out tail))
                 {
-                  if (TypesEqualModuloInstantiation(declaringType, this.mdDecoder.DeclaringType(this.parent.currentMethod)))
-                  {
-                    // havoc even readonly fields.
-                    isThisConstructorCall = true;
-                  }
-                  else
-                  {
-                    // base call, don't havoc "this"
-                    ESymValue pvalue = data.Value(arg);
-                    var ptype = data.GetType(pvalue);
-                    if (ptype.IsNormal) { pt = ptype.Value; }
-                    data.MaterializeThisAtCallAccordingToType(pvalue, pt, 0, this.CurrentMethodDeclaringType);
-                    continue;
-                  }
+                    result = null;
+                    return false;
                 }
-                if (this.mdDecoder.IsStruct(declaringType))
+
+                // Compress parameter head ldarga,ldind into ldarg
+                if (head.IsAddressOf && head is PathElement<Parameter> && tail != null && tail.Head.IsDeref)
                 {
-                  // a struct constructor call is similar to newObj, so we should materialize here
-                  isOut = true;
+                    var pe = (PathElement<Parameter>)head;
+                    Contract.Assume(pe.AsString != null, "follows from the object invariant of pe, which we do not assume here");
+                    result = tail.Tail.Cons(new ParameterPathElement(pe.Element, pe.AsString, pe.Constructor, mdd));
+                    return true;
                 }
-              }
-              if (mdDecoder.IsPrimitive(declaringType) || mdDecoder.Equal(declaringType, mdDecoder.System_Object))
-              {
-                // primitive types (Int32,...) are mostly structs and we call their methods by ref, but
-                // they don't change the value, so let's not havoc them
-                // Furthermore, let's materialize their value
-                // Also, methods on them don't change the receiver.
-                if (mdDecoder.IsStruct(declaringType))
+                else
                 {
-                  data.Value(data.Value(args[0]));
+                    if (head is ReturnValuePathElement && tail != null && tail.Head.IsDeref)
+                    {
+                        result = tail.Tail.Cons(head);
+                    }
+                    else
+                    {
+                        result = tail.Cons(head);
+                    }
+                    return true;
                 }
-                continue;
-              }
-              if (data.IsThis(this.parent.currentMethod, arg))
-              {
-                // call on this. rematerialize fields afterwards
-                materializeAfterCall = true;
-              }
             }
-            else if (param < parameters.Count)
-            {
-              // non-first parameter or non-instance: don't havoc "this" argument
-              if (data.IsThis(this.parent.currentMethod, arg)) { isNonFirstThis = true; }
 
-              Parameter p = parameters[param];
-              isOut = mdDecoder.IsOut(p);
-              pt = mdDecoder.ParameterType(p);
-              if (genericMethodParameters != null)
-              {
-                Contract.Assume(parameters.Count == genericMethodParameters.Count, "Clousot should be able to prove this");
-                Parameter gp = genericMethodParameters[param];
-                var gpt = mdDecoder.ParameterType(gp);
-                isGenericArgType = (mdDecoder.IsFormalTypeParameter(gpt) || mdDecoder.IsMethodFormalTypeParameter(gpt));
-              }
-              param++;
-            }
-            else
+            private bool TryPropagateTypeInfoRecurse(FList<PathElementBase> path, Type prevType, out FList<PathElementBase> result)
             {
-              // vararg parameter: don't havoc "this" argument
-              if (data.IsThis(this.parent.currentMethod, arg)) { continue; }
-
-              Contract.Assume(i - param - optThis < extraVarargs.Count, "assuming IL is well-formed");
-              pt = extraVarargs[i - param - optThis];
-            }
-            // havoc the parameter if it isn't a struct, the method isn't pure, and the method isn't a method on object.
-            // and we are not in a contract
-            if (!pc.InsideContract)
-            {
-              bool aggressive = AggressiveUpHavocMethod(method);
-              if (aggressive || isOut || MustHavocParameter(i, method, declaringType, pt, isGenericArgType, isNonFirstThis))
-              {
-                ESymValue pvalue = data.Value(arg);
-                if (derefThis && i == 0 && optThis == 1)
+                if (path == null)
                 {
-                  pvalue = data.Value(pvalue);
+                    result = null;
+                    return true;
                 }
-                var ptype = data.GetType(pvalue);
-                if (ptype.IsNormal)
+
+                var head = path.Head;
+                if (!head.TrySetType(prevType, out prevType))
                 {
-                  pt = ptype.Value; // specialize type so we can materialize more meaningful fields
+                    result = null;
+                    return false;
                 }
-                data.HavocObjectAtCall(pvalue, ref data.modifiedAtCall, aggressive, isThisConstructorCall);
-                if (isOut)
+
+                FList<PathElementBase> recursive_result;
+                if (TryPropagateTypeInfoRecurse(path.Tail, prevType, out recursive_result))
                 {
-                  // materialize
-                  data.MaterializeOutParameterAccordingToType(pvalue, pt, 0, this.CurrentMethodDeclaringType);
+                    result = recursive_result.Cons(head);
+                    return true;
                 }
-                else if (materializeAfterCall)
+                else
                 {
-                  data.MaterializeThisAtCallAccordingToType(pvalue, pt, 0, this.CurrentMethodDeclaringType);
+                    result = null;
+                    return false;
                 }
-              }
             }
-            // consume the args
-            data.Havoc(arg);
-          }
-        }
 
-        /// <summary>
-        /// Duplicate in ControlFlow.cs
-        /// </summary>
-        /// <param name="method"></param>
-        /// <returns></returns>
-        private bool AggressiveUpHavocMethod(Method method)
-        {
-          var t = mdDecoder.DeclaringType(method);
-          if (mdDecoder.Name(t) != "Monitor") return false;
-          var name = mdDecoder.Name(method);
-          if (name == "Exit" || name == "Wait") return true;
-          return false;
-        }
-
-
-
-        private bool TypesEqualModuloInstantiation(Type a, Type b)
-        {
-          a = mdDecoder.Unspecialized(a);
-          b = mdDecoder.Unspecialized(b);
-          return this.mdDecoder.Equal(a, b);
-        }
-
-        private bool MustHavocParameter(int parameterPosition, Method method, Type declaringType, Type pt, bool parameterHasGenericType, bool nonFirstThis)
-        {
-          Contract.Requires(parameterPosition >= 0);
-
-          // parameters of generic type in generic code are generally not havoced, so use that heuristic here
-          if (parameterHasGenericType) return false;
-          if (mdDecoder.IsStruct(pt)) return false;
-          if (contractDecoder.IsPure(method)) return false;
-          if (mdDecoder.IsPure(method, parameterPosition)) return false;
-          if (mdDecoder.Equal(declaringType, mdDecoder.System_Object)) return false;
-          if (IsImmutable(pt)) return false; // immutable types not modded
-          if (nonFirstThis) return false; // this passed as arg usually not modded
-          if (mdDecoder.Equal(pt, mdDecoder.System_Object)) return false; // object typed parameters usually not modded
-          return true;
-        }
-
-        private bool IsImmutable(Type pt)
-        {
-          if (mdDecoder.Equal(pt, mdDecoder.System_String)) return true;
-          return false;
-        }
-
-        public Domain Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, int dest, int fp, ArgList args, Domain data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<int>
-        {
-          if (data.oldDomain == null)
-          {
-            return CalliEffect(pc, returnType, argTypes, tail, isInstance, dest, fp, args, data);
-          }
-          else
-          {
-            // perform call on old state and map result back (if any)
-            data.oldDomain = CalliEffect(pc, returnType, argTypes, tail, isInstance, dest, fp, args, data.oldDomain);
-            if (!mdDecoder.IsVoid(returnType))
+            private IEnumerable<FList<PathElementBase>> GetAccessPathsTyped(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress)
             {
-              data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                Set<ESymValue> visited = new Set<ESymValue>();
+
+                foreach (var path in GetAccessPathsRaw(sv, null, visited, filter, compress))
+                {
+                    FList<PathElementBase> result;
+                    if (TryPropagateTypeInfo(path, filter, out result))
+                    {
+                        yield return result;
+                    }
+                }
             }
-            return data;
-          }
-        }
-        [ContractVerification(false)]
-        private Domain CalliEffect<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, int dest, int fp, ArgList args, Domain data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<int>
-        {
-          Contract.Assume(args.Count >= argTypes.Count);
-          Contract.Assume(args.Count <= argTypes.Count + 1);
-          Contract.Assume(!isInstance || args.Count == argTypes.Count + 1);
-          Contract.Assume(isInstance || args.Count == argTypes.Count);
 
-          // Deal with by-ref parameters
-          for (int i = 0; i < args.Count; i++)
-          {
-            Temp arg = args[i];
-            // find type corresponding to args[i]
-            Type pt;
-            if (isInstance)
+            internal IEnumerable<FList<PathElementBase>> GetAccessPathsFiltered(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress)
             {
-              if (i > 0)
-              {
-                pt = argTypes[i - 1];
-              }
-              else
-              {
-                // no static type info, must grab it from our state:
-                var self = data.Value(arg);
-                var atype = data.GetType(self);
+                foreach (var path in GetAccessPathsTyped(sv, filter, compress))
+                {
+                    if (PathIsVisibleAccordingToFilter(path, filter))
+                    {
+                        yield return path;
+                    }
+                }
+            }
+
+            // Mic: check the existence of the elements in the fullpath
+            private class ErrorMemberDoesNotExist : Exception { }
+
+            /// <summary>
+            /// Check for getters only, not setters
+            /// Returns false if the property does not exist in the type (or base classes as protected)
+            /// </summary>
+            public bool CheckPropertyExists(Type t, string name, bool allowPrivate)
+            {
+                // for now treat t as unspecialized
+                t = mdDecoder.Unspecialized(t);
+
+                foreach (var prop in mdDecoder.Properties(t))
+                {
+                    if (mdDecoder.Name(prop) == name)
+                    {
+                        Method getter;
+                        if (mdDecoder.HasGetter(prop, out getter))
+                        {
+                            if (!allowPrivate && mdDecoder.IsPrivate(getter))
+                                return false;
+                            return true; // found
+                        }
+                        else
+                            return false;
+                    }
+                }
+
+                // check in the base class, protected or public
+                if (mdDecoder.HasBaseClass(t))
+                    return CheckPropertyExists(mdDecoder.BaseClass(t), name, false);
+                else
+                    return false;
+            }
+
+            /// <summary>
+            /// Returns false if the property does not exist in the type (or base classes as protected)
+            /// </summary>
+            public bool CheckPropertyExists(Type t, Property prop, bool allowPrivate)
+            {
+                // for now treat t as unspecialized
+                t = mdDecoder.Unspecialized(t);
+
+                foreach (var p in mdDecoder.Properties(t))
+                {
+                    if (mdDecoder.Equal(prop, p))
+                        //if (mdDecoder.Name(p) == mdDecoder.Name(prop))
+                        return true; // found
+                }
+
+                // check in the base class, protected or public
+                if (mdDecoder.HasBaseClass(t))
+                    return CheckPropertyExists(mdDecoder.BaseClass(t), prop, false);
+                else
+                    return false;
+            }
+
+            /// <summary>
+            /// Returns false if the method does not exist in the type (or base classes as protected)
+            /// </summary>
+            public bool CheckMethodExists(Type t, Method meth, bool allowPrivate)
+            {
+                // for now treat t as unspecialized
+                t = mdDecoder.Unspecialized(t);
+
+                foreach (var m in mdDecoder.Methods(t))
+                {
+                    if (mdDecoder.Equal(m, meth))
+                        //if (mdDecoder.Name(meth) == mdDecoder.Name(m))
+                        return true; // found
+                }
+
+                // check in the base class, protected or public
+                if (mdDecoder.HasBaseClass(t))
+                    return CheckMethodExists(mdDecoder.BaseClass(t), meth, false);
+                else
+                    return false;
+            }
+
+            /// <summary>
+            /// Returns false if the field does not exist in the type (or base classes as protected)
+            /// </summary>
+            public bool CheckFieldExists(Type t, Field field, bool allowPrivate)
+            {
+                // for now treat t as unspecialized
+                t = mdDecoder.Unspecialized(t);
+
+                foreach (var f in mdDecoder.Fields(t))
+                {
+                    if (mdDecoder.Equal(f, field))
+                        //if (mdDecoder.Name(f) == mdDecoder.Name(field))
+                        return true; // found
+                }
+
+                // check in the base class, protected or public
+                if (mdDecoder.HasBaseClass(t))
+                    return CheckFieldExists(mdDecoder.BaseClass(t), field, false);
+                else
+                    return false;
+            }
+
+            /// <summary>
+            /// Test for the CS1540 rule
+            /// </summary>
+            /// <param name="C">Class from which the call is made</param>
+            /// <param name="ST">Type of the accessed object</param>
+            /// <param name="DT">Declaring type of the field accessed in the accessed object</param>
+            /// <param name="accessProtected">Allow or not to access protected members</param>
+            /// <returns>Returns false if the error would occur.</returns>
+            private bool CheckFor1540(Type C, Type ST, Type DT, bool accessProtected)
+            {
+                if (C == null || ST == null || DT == null)
+                    return true; // Type in another assembly, System...
+
+                if (C.Equals(ST) && ST.Equals(DT))
+                    return true; // the field is in the declaring type, ok
+
+                // Check for the CS1540
+                if (accessProtected && mdDecoder.DerivesFrom(ST, DT))
+                {
+                    // the field is accessed because of derivation and protected
+                    // Check if the owner is from the C hierarchy
+                    if (!mdDecoder.DerivesFrom(ST, C))
+                        return false;
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Input path must be typed!!!!
+            /// </summary>
+            private bool PathIsVisibleAccordingToFilter(FList<PathElementBase> path, AccessPathFilter<Method, Type> filter)
+            {
+                if (path == null /*|| path.Length() == 0 */|| !filter.HasVisibilityMember)
+                    return true;
+
+                Method mfrom = filter.VisibilityMember;
+                Type declaringFrom = mdDecoder.DeclaringType(mfrom);
+
+                Type t = default(Type);
+                Type prev_type;
+                bool first = true;
+                for (; path != null; path = path.Tail, first = false)
+                {
+                    prev_type = t;
+
+                    PathElement pelem = path.Head;
+
+                    //** Mic: NOTE:
+                    // I removed all the tests I made for the accessibility since it is no longer
+                    // necessary: the "CastTo" facility in PathElement allows to cast locally in
+                    // path output, so accesses are always guaranteed to be ok.
+
+                    //if (pelem is SpecialPathElement) // Deref, length, writteable bytes
+                    //{
+                    //  SpecialPathElement spe = pelem as SpecialPathElement;
+                    //  var spek = spe.Element;
+                    //  if (spek == SpecialPathElementKind.Length)
+                    //  {
+                    //    // Check if previous type has a length property
+                    //    // Mic: TODO: cf. above
+                    //    if (mdDecoder.IsArray(prev_type))
+                    //      continue; // accept
+
+                    //    if (prev_type != null && !prev_type.Equals(default(Type)))
+                    //    {
+                    //      if (!CheckPropertyExists(prev_type, "Length", true))
+                    //        return false;
+                    //    }
+                    //  }
+                    //  continue;
+                    //}
+
+                    if (!pelem.TryGetResultType(out t)) return true; // avoid problems downstream
+
+                    // Mic: HACK: 'while' because at some places, CCI reports a type "type@@"!?
+                    while (mdDecoder.IsManagedPointer(t))
+                        t = mdDecoder.ElementType(t); // we skip deref, so don't care about pointer or not
+
+                    if (pelem.ToString() == "this")
+                        continue; // always accessible
+
+                    if (pelem is PathElement<Method>)
+                    {
+                        PathElement<Method> pelem_meth = pelem as PathElement<Method>;
+                        Method m = pelem_meth.Element;
+
+                        // cf. note above
+                        //if (!first)
+                        //{
+                        //  if (!CheckMethodExists(prev_type, m, true))
+                        //    return false;
+                        //}
+
+                        if (!mdDecoder.IsVisibleFrom(m, declaringFrom))
+                            return false;
+
+                        if (!first)
+                        {
+                            Type C = mdDecoder.DeclaringType(mfrom);
+                            Type ST = prev_type;
+                            Type DT = mdDecoder.DeclaringType(m);
+
+                            if (!CheckFor1540(C, ST, DT, mdDecoder.IsProtected(m)))
+                                return false;
+                        }
+                    }
+                    else if (pelem is PathElement<Property>)
+                    {
+                        PathElement<Property> pelem_prop = pelem as PathElement<Property>;
+                        Property p = pelem_prop.Element;
+
+                        // cf. note above
+                        //if (!first)
+                        //{
+                        //  if (!CheckPropertyExists(prev_type, p, true))
+                        //    return false;
+                        //}
+
+                        Method m;
+                        if (!mdDecoder.HasGetter(p, out m))
+                            mdDecoder.HasSetter(p, out m);
+
+                        if (!mdDecoder.IsVisibleFrom(m, declaringFrom))
+                            return false;
+
+                        if (!first)
+                        {
+                            Type C = mdDecoder.DeclaringType(mfrom);
+                            Type ST = prev_type;
+                            Type DT = mdDecoder.DeclaringType(m);
+
+                            if (!CheckFor1540(C, ST, DT, mdDecoder.IsProtected(m)))
+                                return false;
+                        }
+                    }
+                    else if (pelem is PathElement<Field>)
+                    {
+                        PathElement<Field> pelem_f = pelem as PathElement<Field>;
+                        Field f = pelem_f.Element;
+
+                        // cf. note above
+                        //if (!first)
+                        //{
+                        //  if (!CheckFieldExists(prev_type, f, true))
+                        //    return false;
+                        //}
+
+                        if (!mdDecoder.IsVisibleFrom(f, declaringFrom))
+                            return false;
+
+                        if (filter.AvoidCompilerGenerated && (mdDecoder.IsCompilerGenerated(f) || mdDecoder.IsCompilerGenerated(mdDecoder.DeclaringType(f))))
+                        {
+                            return false;
+                        }
+
+                        if (!first)
+                        {
+                            Type C = mdDecoder.DeclaringType(mfrom);
+                            Type ST = prev_type;
+                            Type DT = mdDecoder.DeclaringType(f);
+
+                            if (!CheckFor1540(C, ST, DT, mdDecoder.IsProtected(f)))
+                                return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Completes the path back to a local/parameter if possible.
+            /// </summary>
+            private IEnumerable<FList<PathElementBase>> GetAccessPathsRaw(ESymValue sv, AccessPathFilter<Method, Type> filter, bool compress)
+            {
+                Set<ESymValue> visited = new Set<ESymValue>();
+
+                return GetAccessPathsRaw(sv, null, visited, filter, compress);
+            }
+
+            private IEnumerable<FList<PathElementBase>> GetAccessPathsRaw(ESymValue sv, FList<PathElementBase> path, Set<ESymValue> visited, AccessPathFilter<Method, Type> filter, bool compress)
+            {
+                if (sv == egraph.Root)
+                {
+                    yield return path;
+                    yield break;
+                }
+                if (visited.Contains(sv))
+                {
+                    // already visited 
+                    yield break;
+                }
+                visited.Add(sv);
+                foreach (EGraphTerm<Constructor> et in egraph.EqTerms(sv))
+                {
+                    if (et.Function is Constructor.Wrapper<object>) continue; // ignore program constants (0x0, 1, etc.)
+                    PathElementBase next = et.Function.ToPathElement(compress);
+
+                    if (next == null // element we don't understand ($array element e.g.)
+                        || filter.FilterOutPathElement(et.Function))
+#if false
+            || (accessedFrom.IsValid && accessedFrom.GetOption == AccessPathFilter<Method>.Option.FROM_CALLING_METHOD && !et.Function.IsAsVisibleAs(accessedFrom.Value)) // don't want (not as visible as the caller)
+            || (accessedFrom.IsValid && accessedFrom.GetOption == AccessPathFilter<Method>.Option.FROM_INSIDE_METHOD && !et.Function.IsVisibleFrom(accessedFrom.Value))) // don't want, not as visible as the context in which it is used
+#endif
+                    {
+                        continue;
+                    }
+                    FList<PathElementBase> newPath;
+                    // Filter out extra deref on method calls to properties
+                    if (path != null && compress && next is PathElement<Method> && path.Head.IsDeref)
+                    {
+                        newPath = path.Tail.Cons(next); // remove extra deref
+                    }
+                    else
+                    {
+                        newPath = path.Cons(next);
+                    }
+
+                    foreach (FList<PathElementBase> fullpath in GetAccessPathsRaw(et.Args[0], newPath, visited, filter, compress))
+                    {
+#if false
+                        // MAF TODO move this to separate Filtered method
+                        // Double check if the path is valid, because the previous calls to IsVisibleFrom or IsAsVisibleAs only take the last path element into account
+                        // Here, the entire path is checked (check for the CS1540 error, and also for the issue with contracts inferred after wild casts)
+                        if (accessedFrom.GetOption != AccessPathFilter<Method>.Option.NO_FILTER)
+                        {
+                            if (PathVisibleFrom(fullpath, accessedFrom.Value))
+                                yield return fullpath;
+                        }
+                        else
+#endif
+                        yield return fullpath;
+                    }
+                }
+            }
+
+
+            private void HavocIfStruct(ESymValue address)
+            {
+                AbstractType prevType = egraph[address];
+                if (prevType.IsBottom || (prevType.IsNormal && mdDecoder.IsStruct(prevType.Value)))
+                {
+                    Havoc(address);
+                }
+            }
+
+            /// <summary>
+            /// Don't forget to havoc array elements too and struct ids
+            /// </summary>
+            private void HavocMutableFields(Constructor accessedVia, ESymValue address, ref IFunctionalSet<ESymValue> havoced)
+            {
+                Contract.Ensures(havoced != null);
+
+                HavocFields(accessedVia, address, ref havoced, false);
+            }
+
+            /// <summary>
+            /// Used on this in constructors
+            /// </summary>
+            private void HavocAllFields(ESymValue address, ref IFunctionalSet<ESymValue> havoced)
+            {
+                HavocFields(null, address, ref havoced, true);
+            }
+
+            private void HavocFields(ESymValue address, IEnumerable<Field> fields, ref IFunctionalSet<ESymValue> havoced)
+            {
+                foreach (var field in fields)
+                {
+                    HavocConstructor(null, address, Constructors.For(field), ref havoced, false);
+                }
+            }
+
+            /// <summary>
+            /// </summary>
+            /// <param name="address"></param>
+            /// <param name="havoced"></param>
+            /// <param name="havocImmutable"></param>
+            private void HavocFields(Constructor accessedVia, ESymValue address, ref IFunctionalSet<ESymValue> havoced, bool havocImmutable)
+            {
+                Contract.Ensures(havoced != null);
+
+                if (havoced.Contains(address)) return; // no need to repeatedly havoc
+                havoced = havoced.Add(address);
+                this.MakeTotallyModified(address);
+                foreach (Constructor c in egraph.Functions(address))
+                {
+                    HavocConstructor(accessedVia, address, c, ref havoced, havocImmutable);
+                }
+            }
+
+            private void HavocConstructor(Constructor accessedVia, ESymValue address, Constructor c, ref IFunctionalSet<ESymValue> havoced, bool havocImmutable)
+            {
+                Contract.Ensures(havoced != null);
+
+                if (c == Constructors.ValueOf)
+                {
+                    // retain as old value
+                    egraph[Constructors.OldValueOf, address] = egraph[c, address];
+                }
+                if (c == Constructors.ValueOf ||
+                    c == Constructors.ObjectVersion ||
+                    c == Constructors.StructId)
+                {
+                    egraph.Eliminate(c, address);
+                    havoced = havoced.Add(address);
+                    return;
+                }
+
+                Constructor.Wrapper<Field> field = c as Constructor.Wrapper<Field>;
+                if (field != null && field != accessedVia)
+                {
+                    if (!havocImmutable && mdDecoder.IsReadonly(field.Value))
+                        return;
+                    // havoc the value/nested struct
+                    HavocFields(accessedVia, egraph[c, address], ref havoced, havocImmutable);
+                    return;
+                }
+                Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
+                if (method != null && method != accessedVia)
+                {
+                    // havoc the value/nested struct
+                    HavocFields(accessedVia, egraph[c, address], ref havoced, havocImmutable);
+                    return;
+                }
+            }
+
+
+            private void HavocPseudoFields(ESymValue address)
+            {
+                IFunctionalSet<ESymValue> havoced = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+                HavocPseudoFields((Constructor)null, address, ref havoced);
+            }
+
+            private void HavocPseudoFields(Constructor except, ESymValue address, ref IFunctionalSet<ESymValue> havoced)
+            {
+                Contract.Requires(havoced != null);
+                Contract.Ensures(havoced != null);
+
+                if (havoced.Contains(address)) return; // no need to repeatedly havoc
+                havoced = havoced.Add(address);
+
+                // remove object from unmodified set
+                if (this.IsUnmodified(address))
+                {
+                    this.MakeModified(address);
+                    this.RetainForUnmodifiedFields(address);
+                }
+
+                // havoc struct/object Id
+                egraph.Eliminate(Constructors.ObjectVersion, address);
+                egraph.Eliminate(Constructors.StructId, address);
+
+                foreach (Constructor c in egraph.Functions(address))
+                {
+                    if (c == except) continue;
+                    Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
+                    if (method != null)
+                    {
+                        // havoc the value/nested struct
+                        HavocMutableFields(except, egraph[c, address], ref havoced);
+                        continue;
+                    }
+                }
+            }
+
+            private void HavocPseudoFields(IEnumerable<Method> getters, ESymValue address)
+            {
+                IFunctionalSet<ESymValue> havoced = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+                HavocPseudoFields((Constructor)null, getters, address, ref havoced);
+            }
+
+            private void HavocPseudoFields(Constructor except, IEnumerable<Method> getters, ESymValue address, ref IFunctionalSet<ESymValue> havoced)
+            {
+                Contract.Requires(getters != null);
+
+                if (havoced.Contains(address)) return; // no need to repeatedly havoc
+                havoced = havoced.Add(address);
+
+                // remove object from unmodified set
+                if (this.IsUnmodified(address))
+                {
+                    this.MakeModified(address);
+                    this.RetainForUnmodifiedFields(address);
+                }
+
+                // havoc struct/object Id
+                egraph.Eliminate(Constructors.ObjectVersion, address);
+                egraph.Eliminate(Constructors.StructId, address);
+
+                foreach (var getter in getters)
+                {
+                    // havoc the value/nested struct
+                    HavocMutableFields(except, egraph[Constructors.For(getter), address], ref havoced);
+                }
+            }
+
+            private void HavocModelProperties(ESymValue address, ref IFunctionalSet<ESymValue> havoced)
+            {
+                if (havoced.Contains(address)) return; // no need to repeatedly havoc
+                havoced = havoced.Add(address);
+
+                // remove object from unmodified set
+                if (this.IsUnmodified(address))
+                {
+                    this.MakeModified(address);
+                    this.RetainForUnmodifiedFields(address);
+                }
+
+#if false
+                // havoc struct/object Id
+                egraph.Eliminate(Constructors.ObjectVersion, address);
+                egraph.Eliminate(Constructors.StructId, address);
+#endif
+
+                foreach (Constructor c in egraph.Functions(address))
+                {
+                    Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
+                    if (method != null && parent.contractDecoder.IsModel(method.Value))
+                    {
+                        // havoc the value/nested struct
+                        HavocMutableFields(null, egraph[c, address], ref havoced);
+                        continue;
+                    }
+                }
+            }
+
+
+            private void Havoc(ESymValue address)
+            {
+                egraph.EliminateAll(address);
+            }
+
+            private void Havoc(Temp t)
+            {
+                Havoc(Address(t));
+            }
+
+            /// <summary>
+            /// Assume given value is true/false
+            /// </summary>
+            private Domain Assume(Temp t, bool truth)
+            {
+                return Assume(this.Value(t), truth);
+            }
+
+            private Domain Assume(ESymValue eSymValue, bool polarity)
+            {
+                Contract.Ensures(Contract.Result<Domain>() != null);
+
+                if (polarity == false)
+                {
+                    if (this.IsNonZero(eSymValue))
+                    {
+                        // contradiction
+                        return Bottom;
+                    }
+                    // assume esymvalue to be zero
+                    egraph[eSymValue] = egraph[eSymValue].ButZero;
+                    // recurse
+                    foreach (EGraphTerm<Constructor> eterm in egraph.EqTerms(eSymValue))
+                    {
+                        if (eterm.Function == Constructors.UnaryNot)
+                        {
+                            return Assume(eterm.Args[0], true);
+                        }
+                        if (eterm.Function == Constructors.NeZero)
+                        {
+                            return Assume(eterm.Args[0], false);
+                        }
+                    }
+                }
+                else
+                {
+                    // assume esymvalue to be non-zero.
+                    if (egraph[eSymValue].IsZero)
+                    {
+                        // contradiction
+                        return Bottom;
+                    }
+                    // recurse
+                    foreach (EGraphTerm<Constructor> eterm in egraph.EqTerms(eSymValue))
+                    {
+                        if (eterm.Function == Constructors.UnaryNot)
+                        {
+                            return Assume(eterm.Args[0], false);
+                        }
+                        if (eterm.Function == Constructors.NeZero)
+                        {
+                            return Assume(eterm.Args[0], true);
+                        }
+                    }
+                }
+                return this;
+            }
+
+            private bool IsNonZero(ESymValue eSymValue)
+            {
+                foreach (var eterm in egraph.EqTerms(eSymValue))
+                {
+                    Constructor.Wrapper<object> cons = eterm.Function as Constructor.Wrapper<object>;
+                    if (cons != null)
+                    {
+                        // grab constant
+                        if (cons.Value is int)
+                        {
+                            int value = (int)cons.Value;
+                            if (value != 0) return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+
+            private void AssignNull(Temp t)
+            {
+                AssignNull(Address(Constructors.For(t)));
+            }
+
+            private void AssignNull(ESymValue addr)
+            {
+                Havoc(addr);
+                egraph[Constructors.ValueOf, addr] = Null;
+            }
+
+            private void AssignZero(ESymValue addr)
+            {
+                egraph[Constructors.ValueOf, addr] = Zero;
+            }
+
+            private void AssignZeroEquivalent(ESymValue dest, Type t)
+            {
+                if (mdDecoder.IsReferenceConstrained(t))
+                {
+                    AssignNull(dest);
+                }
+                else if (mdDecoder.HasValueRepresentation(t))
+                {
+                    AssignZero(dest);
+                }
+                // TODO initialize struct fields?
+            }
+
+            internal bool IsStructAddress(AbstractType ltype)
+            {
+                if (!ltype.IsNormal) return false;
+                Type type = ltype.Value;
+                if (mdDecoder.IsManagedPointer(type) || mdDecoder.IsUnmanagedPointer(type))
+                {
+                    type = mdDecoder.ElementType(type);
+                    return !mdDecoder.HasValueRepresentation(type);
+                }
+                return false;
+            }
+            private FlatDomain<Type> TargetType(FlatDomain<Type> addrType)
+            {
+                if (!addrType.IsNormal) return addrType;
+                Type type = addrType.Value;
+                if (mdDecoder.IsManagedPointer(type) || mdDecoder.IsUnmanagedPointer(type))
+                {
+                    return mdDecoder.ElementType(type);
+                }
+                return FlatDomain<Type>.TopValue;
+            }
+            private bool IsStructWithFields(FlatDomain<Type> valueType)
+            {
+                if (!valueType.IsNormal) return false;
+                Type type = valueType.Value;
+                return !mdDecoder.HasValueRepresentation(type);
+            }
+
+            private void Assign(ESymValue address, FlatDomain<Type> addrType)
+            {
+                Havoc(address);
+                SetType(address, addrType);
+                FlatDomain<Type> targetType = TargetType(addrType);
+                if (!IsStructWithFields(targetType))
+                {
+                    ESymValue fresh = egraph.FreshSymbol();
+                    SetType(fresh, targetType);
+                    egraph[Constructors.ValueOf, address] = fresh;
+                    // if typeOfValue is an array or string, we need to possibly manifest the length
+                    if (targetType.IsNormal)
+                    {
+                        if (NeedsArrayLengthManifested(targetType.Value))
+                        {
+                            this.ManifestArrayLength(fresh);
+                        }
+                        else if (this.mdDecoder.IsManagedPointer(targetType.Value) || this.mdDecoder.IsUnmanagedPointer(targetType.Value))
+                        {
+                            this.ManifestWritableBytes(fresh);
+                        }
+                    }
+                }
+            }
+
+
+            private bool NeedsArrayLengthManifested(Type type)
+            {
+                return this.mdDecoder.IsArray(type) || this.mdDecoder.System_String.Equals(type); // || this.IsIEnumerable(type);
+            }
+
+            private TypeCache IEnumerableType = new TypeCache("System.Collections.IEnumerable");
+            private TypeCache IEnumerable1Type = new TypeCache("System.Collections.Generic.IEnumerable`1");
+
+            private bool IsIEnumerable(Type type)
+            {
+                Type ienumerable;
+                if (IEnumerable1Type.TryGet(this.mdDecoder, out ienumerable))
+                {
+                    if (mdDecoder.DerivesFrom(type, ienumerable)) return true;
+                }
+                if (IEnumerableType.TryGet(this.mdDecoder, out ienumerable))
+                {
+                    if (mdDecoder.DerivesFrom(type, ienumerable)) return true;
+                }
+                return false;
+            }
+
+            public bool DerivesFromIEnumerable(Type t)
+            {
+                if (IsIEnumerable(t)) return true;
+                foreach (var intf in mdDecoder.Interfaces(t))
+                {
+                    if (IsIEnumerable(intf)) return true;
+                }
+                return false;
+            }
+
+            private void AssignValue(ESymValue address, FlatDomain<Type> typeOfValue, Type fromType)
+            {
+                Havoc(address);
+                SetType(address, (typeOfValue.IsNormal) ? mdDecoder.ManagedPointer(typeOfValue.Value) : typeOfValue);
+                if (!IsStructWithFields(typeOfValue))
+                {
+                    ESymValue fresh = egraph.FreshSymbol();
+                    SetType(fresh, typeOfValue);
+                    egraph[Constructors.ValueOf, address] = fresh;
+                    // if typeOfValue is an array, we need to possibly manifest the length
+                    if (typeOfValue.IsNormal)
+                    {
+                        if (NeedsArrayLengthManifested(typeOfValue.Value))
+                        {
+                            this.ManifestArrayLength(fresh);
+                        }
+                        if (!mdDecoder.IsArray(typeOfValue.Value) && DerivesFromIEnumerable(typeOfValue.Value))
+                        {
+                            this.ManifestModel(fresh, typeOfValue.Value, fromType: fromType);
+                        }
+
+                        else if (this.mdDecoder.IsManagedPointer(typeOfValue.Value) || this.mdDecoder.IsUnmanagedPointer(typeOfValue.Value))
+                        {
+                            this.ManifestWritableBytes(fresh);
+                        }
+                    }
+                }
+            }
+
+
+            private void ManifestModel(ESymValue value, Type type, Type fromType)
+            {
+                ManifestModel(value, type, false, fromType: fromType);
+            }
+            private void ManifestModel(ESymValue value, Type type, bool isArray, Type fromType)
+            {
+                // First try to find model property in given type. If it is an array type, synthesize one
+
+                ManifestModelProperties(value, type, isArray, fromType: fromType);
+                if (this.mdDecoder.IsInterface(type))
+                // [MAF] 
+                // Types must explicitly implement the model for IEnumerable in mscorlib
+                // Right now, this works only for types defined in mscorlib.Contracts. TODO... fix for all types.
+                {
+                    foreach (var intf in mdDecoder.Interfaces(type))
+                    {
+                        ManifestModelProperties(value, intf, isArray, fromType: fromType);
+                    }
+                }
+
+                if (mdDecoder.IsArray(type))
+                {
+                    // arrays are magically implementing IEnumerable<T>
+                    foreach (var intf in mdDecoder.Interfaces(type))
+                    {
+                        if (this.IsIEnumerable(intf))
+                        {
+                            ManifestModel(value, intf, true, fromType: fromType);
+                        }
+                    }
+                }
+            }
+
+            private void ManifestModelProperties(ESymValue value, Type type, bool isArray, Type fromType)
+            {
+                foreach (var modelMethod in parent.contractDecoder.ModelMethods(type))
+                {
+                    // manifest the property
+                    Type propertyType;
+                    ESymValue propAddr = this.PseudoFieldAddress(value, modelMethod, out propertyType, false, fromType: fromType);
+                    ESymValue modelValue;
+                    if (isArray)
+                    {
+                        // model value is the actual array
+                        egraph[Constructors.ValueOf, propAddr] = value;
+                        modelValue = value;
+                    }
+                    else
+                    {
+                        modelValue = this.Value(propAddr); // manifest value
+                    }
+                    if (mdDecoder.IsManagedPointer(propertyType) && mdDecoder.IsArray(mdDecoder.ElementType(propertyType)))
+                    {
+                        ManifestArrayLength(modelValue);
+                    }
+                }
+                return;
+            }
+
+            /// <summary>
+            /// Create a fresh value, but retain nullness and WritableBytes if possible
+            /// </summary>
+            private void AssignValueAndNullnessAtConv_IU(ESymValue address, bool unsigned, AbstractType typeOfValueAndNullness, ESymValue sourceValue)
+            {
+                Havoc(address);
+                FlatDomain<Type> typeOfValue = typeOfValueAndNullness.Type;
+                if (!IsStructWithFields(typeOfValue))
+                {
+                    ESymValue fresh = egraph.FreshSymbol();
+                    // fix up type if source is string, then dest is char*, otherwise, use IntPtr,UIntPtr
+                    if (typeOfValue.IsNormal)
+                    {
+                        if (this.mdDecoder.Equal(typeOfValue.Value, this.mdDecoder.System_String))
+                        {
+                            typeOfValueAndNullness = new AbstractType(this.mdDecoder.UnmanagedPointer(this.mdDecoder.System_Char), typeOfValueAndNullness.IsZero);
+                            typeOfValue = typeOfValueAndNullness.Type;
+                        }
+                        else
+                        {
+                            if (unsigned)
+                            {
+                                typeOfValueAndNullness = new AbstractType(this.mdDecoder.System_UIntPtr, typeOfValueAndNullness.IsZero);
+                            }
+                            else
+                            {
+                                typeOfValueAndNullness = new AbstractType(this.mdDecoder.System_IntPtr, typeOfValueAndNullness.IsZero);
+                            }
+                        }
+                    }
+                    SetType(address, (typeOfValue.IsNormal) ? mdDecoder.ManagedPointer(typeOfValue.Value) : typeOfValue);
+                    egraph[fresh] = typeOfValueAndNullness;
+                    egraph[Constructors.ValueOf, address] = fresh;
+                    // retain WritableBytes if present in source
+                    ESymValue sourceWritableBytes = egraph.TryLookup(Constructors.WritableBytes, sourceValue);
+                    if (sourceWritableBytes != null)
+                    {
+                        egraph[Constructors.WritableBytes, fresh] = sourceWritableBytes;
+                    }
+                    else
+                    {
+                        // manifest if necessary
+                        if (typeOfValue.IsNormal)
+                        {
+                            if (this.mdDecoder.IsManagedPointer(typeOfValue.Value) || this.mdDecoder.IsUnmanagedPointer(typeOfValue.Value))
+                            {
+                                this.ManifestWritableBytes(fresh);
+                            }
+                        }
+                        //if (this.mdDecoder.IsArray(typeOfValue.Value) || mdDecoder.Equal(typeOfValue.Value, mdDecoder.System_String))
+                        //{
+                        //              this.ManifestArrayLength(fresh);
+                        //}
+                    }
+                }
+                else
+                {
+                    SetType(address, (typeOfValue.IsNormal) ? mdDecoder.ManagedPointer(typeOfValue.Value) : typeOfValue);
+                }
+            }
+
+            private void AssignConst(Temp dest, Type typeOfConst, object constant)
+            {
+                ESymValue addr = Address(Constructors.For(dest));
+                AssignConst(addr, typeOfConst, constant);
+            }
+
+            private void AssignConst(ESymValue addr, Type typeOfConst, object constant)
+            {
+                ESymValue cval = ConstantValue(constant, typeOfConst);
+                SetType(addr, mdDecoder.ManagedPointer(typeOfConst));
+                egraph[Constructors.ValueOf, addr] = cval;
+                string stringConst = constant as String;
+                if (stringConst != null)
+                {
+                    egraph[Constructors.Length, cval] = ConstantValue(stringConst.Length, this.mdDecoder.System_Int32);
+                }
+            }
+
+            private void Assign(Parameter dest, Type typeOfValue, Type fromType)
+            {
+                ESymValue addr = Address(Constructors.For(dest));
+                AssignValue(addr, typeOfValue, fromType: fromType);
+            }
+
+            private void CopyParameterIntoShadow(Parameter p)
+            {
+                ESymValue shadowAddr = Address(Constructors.For("$paramShadow_" + this.mdDecoder.Name(p)));
+                CopyValue(shadowAddr, Address(Constructors.For(p)));
+            }
+
+            public ESymValue OldValueAddress(Parameter p)
+            {
+                return Address(Constructors.For("$paramShadow_" + this.mdDecoder.Name(p)));
+            }
+
+            private void AssignTokenValue<T>(Temp dest, Type typeOfToken, T token)
+            {
+                var addr = Address(dest);
+                ESymValue cval = ConstantValue((object)token, typeOfToken);
+                SetType(addr, mdDecoder.ManagedPointer(typeOfToken));
+                egraph[Constructors.StructId, addr] = cval;
+            }
+
+            private void AssignMethodPointer(Temp dest, Type uintPtr, Method method)
+            {
+                var addr = Address(dest);
+                ESymValue cval = MethodPointer(method, uintPtr);
+                SetType(addr, mdDecoder.ManagedPointer(uintPtr));
+                egraph[Constructors.ValueOf, addr] = cval;
+            }
+
+            private void AssignValue(Temp dest, FlatDomain<Type> typeOfValue, Type fromType)
+            {
+                ESymValue addr = Address(Constructors.For(dest));
+                AssignValue(addr, typeOfValue, fromType: fromType);
+            }
+
+            /// <summary>
+            /// Same as AssignValue, but leave behind a breadcrumb on result value to indicate
+            /// that we materialized it.
+            /// </summary>
+            private void AssignReturnValue(Temp dest, Type typeOfValue, Type fromType)
+            {
+                AssignValue(dest, typeOfValue, fromType: fromType);
+#if false
+                // F: I did it
+                MaterializeAccordingToType(Address(dest), mdDecoder.ManagedPointer(typeOfValue), -1, Constructors.ResultOfCall, fromType, overrideFromType: true);
+#endif
+                MaterializeAccordingToType(Address(dest), mdDecoder.ManagedPointer(typeOfValue), 0, Constructors.ResultOfCall, fromType, overrideFromType: false);
+            }
+
+            private void AssignValueAndNullnessAtConv_IU(Temp dest, Temp source, bool unsigned)
+            {
+                AbstractType typeOfValueAndNullness = CurrentType(source);
+                ESymValue addr = Address(Constructors.For(dest));
+                AssignValueAndNullnessAtConv_IU(addr, unsigned, typeOfValueAndNullness, Value(source));
+            }
+
+            private void AssignSpecialUnary(Temp dest, Constructor op, Temp source, FlatDomain<Type> typeOfValue, Type fromType)
+            {
+                ESymValue result = GetSpecialUnary(op, source, typeOfValue);
+                AssignSpecialUnary(dest, result, typeOfValue, fromType: fromType);
+            }
+
+            private void AssignSpecialUnary(Temp dest, ESymValue result, FlatDomain<Type> typeOfValue, Type fromType)
+            {
+                ESymValue destaddr = this.Address(dest);
+                AssignValue(destaddr, typeOfValue, fromType: fromType);
+                egraph[Constructors.ValueOf, destaddr] = result;
+            }
+
+            private ESymValue GetSpecialUnary(Constructor op, Temp source, FlatDomain<Type> type)
+            {
+                ESymValue src = this.Value(source);
+                var result = egraph[op, src];
+                SetType(result, type);
+                return result;
+            }
+
+            private ESymValue GetIsInstValue(Type t, Temp source)
+            {
+                ESymValue src = this.Value(source);
+                ESymValue tval = ConstantValue((object)t, mdDecoder.System_Type);
+                var result = egraph[Constructors.IsInst, src, tval];
+                SetType(result, t);
+                return result;
+            }
+
+            private void AssignIsInst(Type t, Temp source, Temp dest, Type fromType)
+            {
+                var isInstVal = GetIsInstValue(t, source);
+                ESymValue destaddr = this.Address(dest);
+                AssignValue(destaddr, t, fromType: fromType);
+                egraph[Constructors.ValueOf, destaddr] = isInstVal;
+            }
+
+            private void AssignTop(Temp dest)
+            {
+                AssignValue(dest, mdDecoder.System_Void, default(Type)); // should not materialize anything in this case.
+            }
+
+            private AbstractType CurrentType(ESymValue address)
+            {
+                return egraph[address];
+            }
+
+            private AbstractType CurrentType(Temp t)
+            {
+                return CurrentType(Value(Address(Constructors.For(t))));
+            }
+
+            private ESymValue LookupAddressAndManifestType(ESymValue sv, Constructor c, Type/*!*/ type, out bool fresh)
+            {
+                ESymValue addr = egraph.TryLookup(c, sv);
+                if (addr != null)
+                {
+                    fresh = false;
+                    return addr;
+                }
+                // manifest
+                fresh = true;
+                addr = egraph[c, sv];
+                SetType(addr, type);
+                return addr;
+            }
+
+            public void AssignPureUnary(int dest, UnaryOperator op, FlatDomain<Type> typeOpt, int arg)
+            {
+                var c = Constructors.For(op);
+                Type type;
+                if (typeOpt.IsNormal)
+                {
+                    type = typeOpt.Value;
+                }
+                else
+                {
+                    type = mdDecoder.System_Int32;
+                }
+                var result = egraph.TryLookup(c, Value(arg));
+                if (result == null)
+                {
+                    result = egraph[c, Value(arg)];
+                    egraph[result] = AbstractType.TopValue.With(type);
+                }
+                var destAddr = Address(dest);
+                SetType(destAddr, mdDecoder.ManagedPointer(type));
+                egraph[Constructors.ValueOf, destAddr] = result;
+            }
+
+            public void AssignPureBinary(int dest, BinaryOperator op, FlatDomain<Type> typeOpt, int arg1, int arg2)
+            {
+                var args = new ESymValue[] { Value(arg1), Value(arg2) };
+                var c = Constructors.For(op);
+                bool fresh;
+                Type type;
+                if (typeOpt.IsNormal)
+                {
+                    type = typeOpt.Value;
+                }
+                else
+                {
+                    type = mdDecoder.System_Int32;
+                }
+                var result = LookupAddressAndManifestType(args, c, type, out fresh);
+                var destAddr = Address(dest);
+                SetType(destAddr, mdDecoder.ManagedPointer(type));
+                egraph[Constructors.ValueOf, destAddr] = result;
+                if (this.mdDecoder.IsUnmanagedPointer(type))
+                {
+                    this.ManifestWritableBytes(result);
+                }
+            }
+
+
+            private ESymValue LookupAddressAndManifestType(ESymValue[] args, Constructor c, Type/*!*/ type, out bool fresh)
+            {
+                ESymValue addr = egraph.TryLookup(c, args);
+                if (addr != null)
+                {
+                    fresh = false;
+                    return addr;
+                }
+                // manifest
+                fresh = true;
+                Contract.Assume(args.Length > 1);
+                addr = egraph[c, args];
+                SetType(addr, type);
+                return addr;
+            }
+
+            private void CopyValue(ESymValue destAddr, ESymValue srcAddr)
+            {
+                AbstractType abstype = egraph[srcAddr];
+                CopyValue(destAddr, srcAddr, abstype.Type);
+            }
+
+            private void CopyValue(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType)
+            {
+                CopyValue(destAddr, srcAddr, addrType, true, false);
+            }
+
+            private void CopyOldValue(APC pc, Temp dest, Temp source, Domain target, bool atEndOld)
+            {
+                CopyOldValue(pc, target.Address(dest), this.Address(source), target, atEndOld);
+            }
+
+            private void CopyOldValue(APC pc, ESymValue destAddr, ESymValue srcAddr, Domain target, bool atEndOld)
+            {
+                AbstractType abstype = egraph[srcAddr];
+                CopyOldValue(pc, destAddr, srcAddr, abstype.Type, target, atEndOld);
+            }
+
+            private void CopyOldValue(APC pc, ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, Domain target, bool atEndOld)
+            {
+                CopyOldValue(pc, destAddr, srcAddr, addrType, true, atEndOld, target);
+            }
+
+            private void CopyValueAndCast(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType)
+            {
+                CopyValue(destAddr, srcAddr, addrType, true, true);
+            }
+
+            private void CopyValue(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, bool setTargetAddrType, bool cast)
+            {
+                this.MakeTotallyModified(destAddr);
+                if (destAddr != srcAddr) { HavocIfStruct(destAddr); }
+                if (setTargetAddrType) SetType(destAddr, addrType);
+                SetValue(destAddr, srcAddr, addrType, cast);
+            }
+
+            private void SetValue(ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, bool cast)
+            {
+                FlatDomain<Type> elementType = TargetType(addrType);
+                if (IsStructWithFields(elementType))
+                {
+                    CopyStructValue(destAddr, srcAddr, elementType.Value);
+                }
+                else
+                {
+                    CopyPrimValue(destAddr, srcAddr, cast, elementType);
+                }
+            }
+
+            private void CopyPrimValue(ESymValue destAddr, ESymValue srcAddr, bool cast, FlatDomain<Type> elementType)
+            {
+                ESymValue svalue = egraph[Constructors.ValueOf, srcAddr];
+                if (cast)
+                {
+                    SetType(svalue, elementType);
+                }
+                else
+                {
+                    SetTypeIfUnknown(svalue, elementType);
+                }
+                if (elementType.IsNormal)
+                {
+                    if (NeedsArrayLengthManifested(elementType.Value))
+                    {
+                        // manifest array length
+                        this.ManifestArrayLength(svalue);
+                    }
+                    else if (this.mdDecoder.IsManagedPointer(elementType.Value) || this.mdDecoder.IsUnmanagedPointer(elementType.Value))
+                    {
+                        this.ManifestWritableBytes(svalue);
+                    }
+                }
+                egraph[Constructors.ValueOf, destAddr] = svalue;
+            }
+
+            private void CopyOldValue(APC pc, ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> addrType, bool setTargetAddrType, bool atEndOld, Domain target)
+            {
+                target.MakeTotallyModified(destAddr);
+                if (destAddr != srcAddr) { target.HavocIfStruct(destAddr); }
+                if (setTargetAddrType) target.SetType(destAddr, addrType);
+                FlatDomain<Type> elementType = TargetType(addrType);
+                if (IsStructWithFields(elementType))
+                {
+                    CopyOldStructValue(pc, destAddr, srcAddr, elementType.Value, target, atEndOld);
+                }
+                else if (atEndOld && elementType.IsNormal && mdDecoder.IsManagedPointer(elementType.Value))
+                {
+                    // special case. Copying @T to @T, this usually means that we need to make a deep copy
+                    // recurse on both sides.
+                    srcAddr = this.TryValue(srcAddr);
+                    if (srcAddr == null) return;
+                    destAddr = target.Value(destAddr);
+                    CopyOldValue(pc, destAddr, srcAddr, elementType, setTargetAddrType, atEndOld, target);
+                }
+                else
+                {
+                    ESymValue svalue = egraph.TryLookup(Constructors.ValueOf, srcAddr);
+                    if (svalue == null)
+                    {
+                        if (egraph.IsConstant)
+                        {
+                            return;
+                        }
+                        svalue = egraph[Constructors.ValueOf, srcAddr]; // manifest
+                    }
+
+                    CopyOldValueToDest(pc, destAddr, svalue, addrType, target);
+                }
+            }
+
+            private void CopyOldValueToDest(APC pc, ESymValue destAddr, ESymValue svalue, FlatDomain<Type> addrType, Domain target)
+            {
+                //
+                // enumerate through all access paths in old state for old value and try to find an unmodified
+                // accesspath in the new state. This would correspond to the same value in the new state.
+                //
+                bool callInsideContract;
+                if (pc.IsInsideEnsuresAtCall(out callInsideContract) || pc.IsInsideInvariantAtCall(out callInsideContract))
+                {
+                    Type constType;
+                    object constValue;
+                    if (this.IsConstant(svalue, out constType, out constValue))
+                    {
+                        // just look up the new constant
+                        var newConstant = target.ConstantValue(constValue, constType);
+                        target.CopyNonStructWithFieldValue(destAddr, newConstant, addrType);
+                        return;
+                    }
+                    // must be inside ensures around call
+                    ESymValue best = null;
+
+                    foreach (var accesspath in this.GetAccessPathsRaw(svalue, AccessPathFilter<Method, Type>.NoFilter, false))
+                    {
+                        ESymValue candidate;
+                        if (FindOldCandidateAfterCall(target, accesspath, callInsideContract, out candidate))
+                        {
+                            if (best == null)
+                            {
+                                best = candidate;
+                            }
+                            else
+                            {
+                                if (candidate.GlobalId < best.GlobalId)
+                                {
+                                    best = candidate;
+                                }
+                            }
+                        }
+                    }
+                    if (best != null)
+                    {
+                        target.CopyNonStructWithFieldValue(destAddr, best, addrType);
+                        return;
+                    }
+                }
+                else
+                {
+                    // must be inside ensures on exit
+                    foreach (var accesspath in this.GetAccessPathsRaw(svalue, AccessPathFilter<Method, Type>.NoFilter, false))
+                    {
+                        ESymValue targetSym;
+                        if (target.PathExistsUnmodifiedSinceEntry(accesspath, out targetSym))
+                        {
+                            target.CopyNonStructWithFieldValue(destAddr, targetSym, addrType);
+                            return;
+                        }
+                    }
+                }
+                // backup approach
+                if (target.IsValidSymbol(svalue))
+                {
+                    target.CopyNonStructWithFieldValue(destAddr, svalue, addrType);
+                }
+                else
+                {
+                    target.Assign(destAddr, addrType);
+                }
+                return;
+            }
+
+            private static bool FindOldCandidateAfterCall(Domain target, FList<PathElementBase> accesspath, bool callInsideContract, out ESymValue candidate)
+            {
+                if (callInsideContract)
+                {
+                    // call couldn't modify anything
+                    return target.PathExistsAtCall(accesspath, out candidate);
+                }
+                else
+                {
+                    return target.PathExistsUnmodifiedAtCall(accesspath, out candidate);
+                }
+            }
+
+            private static void CopyStructId(APC pc, ESymValue destAddr, ESymValue srcAddr, Domain source, Domain target)
+            {
+                // TODO: do the same as in oldvalue copy, but we need access paths to struct ids
+#if true
+                target.ManifestStructId(destAddr);
+#else
+                ESymValue identity = egraph[Constructors.StructId, srcAddr];
+                //
+                // enumerate through all access paths in old state for old value and try to find an unmodified
+                // accesspath in the new state. This would correspond to the same value in the new state.
+                //
+                if (pc.InsideEnsuresAtCall)
+                {
+                    // must be inside ensures around call
+                    foreach (var accesspath in this.GetAccessPaths(identity, new Optional<Method>(), false))
+                    {
+                        ESymValue targetSym;
+                        if (target.PathExistsUnmodifiedAtCall(accesspath, out targetSym))
+                        {
+                            target.CopyNonStructWithFieldValue(destAddr, targetSym, addrType);
+                            return;
+                        }
+                    }
+                }
+                else
+                {
+                    // must be inside ensures on exit
+                    foreach (var accesspath in this.GetAccessPaths(identity, new Optional<Method>(), false))
+                    {
+                        ESymValue targetSym;
+                        if (target.PathExistsUnmodifiedSinceEntry(accesspath, out targetSym))
+                        {
+                            target.CopyNonStructWithFieldValue(destAddr, targetSym, addrType);
+                            return;
+                        }
+                    }
+                }
+                // backup approach
+                if (target.IsValidSymbol(identity))
+                {
+                    target.CopyNonStructWithFieldValue(destAddr, identity, addrType);
+                }
+                else
+                {
+                    target.AssignValue(destAddr, addrType);
+                }
+#endif
+            }
+
+            private void CopyStructValue(ESymValue destAddr, ESymValue srcAddr, Type type)
+            //^ requires mdDecoder.IsStruct(type);
+            {
+                if (destAddr == null) return;
+                // copy struct id
+                egraph[Constructors.StructId, destAddr] = egraph[Constructors.StructId, srcAddr];
+
+                foreach (Constructor key in egraph.Functions(srcAddr))
+                {
+                    if (!key.ActsAsField) continue;
+                    Type t = key.FieldAddressType(mdDecoder);
+
+                    ESymValue destFld = egraph[key, destAddr];
+                    ESymValue srcFld = egraph[key, srcAddr];
+                    CopyValue(destFld, srcFld, t);
+                }
+            }
+
+            private void CopyOldStructValue(APC pc, ESymValue destAddr, ESymValue srcAddr, Type type, Domain target, bool atEndOld)
+            //^ requires mdDecoder.IsStruct(type);
+            {
+                if (destAddr == null) return;
+                // copy old struct id
+                CopyStructId(pc, destAddr, srcAddr, this, target);
+
+                foreach (Constructor key in egraph.Functions(srcAddr))
+                {
+                    if (!key.ActsAsField) continue;
+                    Type t = key.FieldAddressType(mdDecoder);
+
+                    ESymValue destFld = target.egraph[key, destAddr];
+                    ESymValue srcFld = egraph[key, srcAddr];
+                    CopyOldValue(pc, destFld, srcFld, t, target, atEndOld);
+                }
+            }
+
+
+            private ESymValue FieldAddress(ESymValue ptr, Field f)
+            {
+                Type fieldAddressType;
+                return FieldAddress(ptr, f, out fieldAddressType);
+            }
+
+            private ESymValue FieldAddress(ESymValue ptr, Field f, out Type fieldAddressType)
+            {
+                fieldAddressType = mdDecoder.ManagedPointer(mdDecoder.FieldType(f));
+                bool fresh;
+                ESymValue fldaddr = LookupAddressAndManifestType(ptr, Constructors.For(f), fieldAddressType, out fresh);
+                if (fresh)
+                {
+                    if (this.IsUnmodifiedForFields(ptr) || this.mdDecoder.IsReadonly(f))
+                    {
+                        this.MakeUnmodified(fldaddr);
+                    }
+                    if (this.IsModifiedAtCall(ptr))
+                    {
+                        modifiedAtCall = modifiedAtCall.Add(fldaddr);
+                    }
+                }
+                return fldaddr;
+            }
+
+            private ESymValue PseudoFieldAddress(ESymValue value, Method m, Type fromType)
+            {
+                Type psuedoFieldAddressType;
+                return PseudoFieldAddress(value, m, out psuedoFieldAddressType, false, fromType: fromType);
+            }
+
+            private ESymValue PseudoFieldAddress(ESymValue[] args, Method m, out Type pseudoFieldAddressType, bool materializeStructFields, Type fromType)
+            {
+                if (args.Length == 0)
+                {
+                    return PseudoFieldAddress(Globals, m, out pseudoFieldAddressType, materializeStructFields, fromType: fromType);
+                }
+                if (args.Length == 1)
+                {
+                    return PseudoFieldAddress(args[0], m, out pseudoFieldAddressType, materializeStructFields, fromType: fromType);
+                }
+                pseudoFieldAddressType = mdDecoder.ManagedPointer(mdDecoder.ReturnType(m));
+                m = mdDecoder.Unspecialized(m);
+                bool fresh;
+                ESymValue fldaddr = LookupAddressAndManifestType(args, Constructors.For(m), pseudoFieldAddressType, out fresh);
+                if (fresh)
+                {
+                    if (AreUnmodified(args))
+                    {
+                        this.MakeUnmodified(fldaddr);
+                    }
+                    if (AnyAreModifiedAtCall(args))
+                    {
+                        modifiedAtCall = modifiedAtCall.Add(fldaddr);
+                    }
+                    if (materializeStructFields)
+                    {
+                        MaterializeAccordingToType(fldaddr, pseudoFieldAddressType, 0, Constructors.ResultOfPureCall, fromType: fromType);
+                    }
+                }
+                return fldaddr;
+            }
+
+            private ESymValue PseudoFieldAddress(ESymValue value, Method m, out Type pseudoFieldAddressType, bool materialize, Type fromType)
+            {
+                var returnType = mdDecoder.ReturnType(m);
+                pseudoFieldAddressType = mdDecoder.ManagedPointer(returnType);
+                m = mdDecoder.Unspecialized(m);
+                bool fresh;
+                ESymValue fldaddr = LookupAddressAndManifestType(value, Constructors.For(m), pseudoFieldAddressType, out fresh);
+                if (fresh)
+                {
+                    if (this.IsUnmodified(value))
+                    {
+                        this.MakeUnmodified(fldaddr);
+                    }
+                    if (this.IsModifiedAtCall(value))
+                    {
+                        modifiedAtCall = modifiedAtCall.Add(fldaddr);
+                    }
+                }
+                if (materialize)
+                {
+                    MaterializeAccordingToType(fldaddr, pseudoFieldAddressType, 0, Constructors.ResultOfPureCall, fromType: fromType);
+                }
+                return fldaddr;
+            }
+
+            public void MaterializeOutParameterAccordingToType(ESymValue value, Type t, int depth, Type fromType)
+            {
+                MaterializeAccordingToType(value, t, depth, Constructors.ResultOfOutParameter, fromType: fromType);
+            }
+
+            public void MaterializeThisAtCallAccordingToType(ESymValue value, Type t, int depth, Type fromType)
+            {
+                MaterializeAccordingToType(value, t, depth, Constructors.ResultOfCallThisHavoc, fromType: fromType);
+            }
+
+
+            public void MaterializeNewObjAccordingToType(ESymValue value, Type t, int depth, Type fromType)
+            {
+                MaterializeAccordingToType(value, t, depth, null, fromType: fromType);
+            }
+
+            // F: I added overrideFromType
+            private void MaterializeAccordingToType(ESymValue value, Type t, int depth, Constructor breadCrumb, Type fromType, bool overrideFromType = false)
+            {
+                SetType(value, t);
+                if (depth > 2) return;
+                if (mdDecoder.IsManagedPointer(t))
+                {
+                    Type elementType = mdDecoder.ElementType(t);
+                    if (!mdDecoder.HasValueRepresentation(elementType))
+                    {
+                        // manifest struct id
+                        this.ManifestStructId(value);
+                        // manifest field addresses
+                        foreach (Field f in mdDecoder.Fields(elementType))
+                        {
+                            if (mdDecoder.IsStatic(f)) continue;
+                            if (!mdDecoder.IsVisibleFrom(f, fromType)) continue;
+                            // manifest the field
+                            Type fieldType;
+                            ESymValue fieldAddr = FieldAddress(value, f, out fieldType);
+                            MaterializeAccordingToType(fieldAddr, fieldType, depth + 1, null, fromType, overrideFromType);
+                        }
+                        foreach (Property p in mdDecoder.Properties(elementType))
+                        {
+                            if (mdDecoder.IsStatic(p)) continue;
+                            Method getter;
+                            if (!mdDecoder.HasGetter(p, out getter)) continue;
+                            if (mdDecoder.Parameters(getter).Count > 0) continue;
+                            if (!mdDecoder.IsVisibleFrom(getter, fromType)) continue;
+                            // skip string.get_Length, as we use $Length for that
+                            if (mdDecoder.Equal(elementType, mdDecoder.System_String) && mdDecoder.Name(getter) == "get_Length")
+                            {
+                                continue;
+                            }
+
+                            // manifest the pseudo field
+                            Type propertyType;
+                            ESymValue pseudoFieldAddr = PseudoFieldAddress(value, getter, out propertyType, false, fromType: fromType);
+                            MaterializeAccordingToType(pseudoFieldAddr, propertyType, depth + 1, null, fromType, overrideFromType);
+                        }
+                        foreach (var m in parent.contractDecoder.ModelMethods(elementType))
+                        {
+                            if (mdDecoder.IsStatic(m)) continue;
+                            // manifest the pseudo field
+                            Type propertyType;
+                            ESymValue pseudoFieldAddr = PseudoFieldAddress(value, m, out propertyType, false, fromType: fromType);
+                            MaterializeAccordingToType(pseudoFieldAddr, propertyType, depth + 1, null, fromType, overrideFromType);
+                        }
+                    }
+                    else
+                    {
+                        // manifest the value
+                        var derefedValue = Value(value);
+                        MaterializeAccordingToType(derefedValue, elementType, depth + 1, null, fromType, overrideFromType);
+                        if (breadCrumb != null)
+                        {
+                            // leave breadcrumb
+                            egraph[breadCrumb, derefedValue] = Zero;
+                        }
+                    }
+                    return;
+                }
+
+                if (!mdDecoder.IsArray(t) && DerivesFromIEnumerable(t))
+                {
+                    ManifestModel(value, t, fromType: fromType);
+                }
+
+                if (mdDecoder.IsClass(t))
+                {
+                    foreach (Field f in mdDecoder.Fields(t))
+                    {
+                        if (mdDecoder.IsStatic(f)) continue;
+                        if (overrideFromType || mdDecoder.IsVisibleFrom(f, fromType))
+                        {
+                            // manifest the field
+                            Type fieldType;
+                            ESymValue fieldAddr = this.FieldAddress(value, f, out fieldType);
+                            MaterializeAccordingToType(fieldAddr, fieldType, depth + 1, breadCrumb, fromType, overrideFromType);
+                        }
+                    }
+                    if (breadCrumb == Constructors.ResultOfCallThisHavoc && mdDecoder.HasBaseClass(t))
+                    {
+                        // materialize base fields
+                        var baseType = mdDecoder.BaseClass(t);
+                        foreach (Field f in mdDecoder.Fields(baseType))
+                        {
+                            if (mdDecoder.IsStatic(f)) continue;
+                            if (mdDecoder.IsVisibleFrom(f, fromType))
+                            {
+                                // manifest the field
+                                Type fieldType;
+                                ESymValue fieldAddr = this.FieldAddress(value, f, out fieldType);
+                                MaterializeAccordingToType(fieldAddr, fieldType, depth + 1, breadCrumb, fromType, overrideFromType);
+                            }
+                        }
+                    }
+                }
+
+                foreach (Property p in mdDecoder.Properties(t))
+                {
+                    if (mdDecoder.IsStatic(p)) continue;
+                    Method getter;
+                    if (!mdDecoder.HasGetter(p, out getter)) continue;
+                    if (mdDecoder.Parameters(getter).Count > 0) continue;
+                    if (!mdDecoder.IsVisibleFrom(getter, fromType)) continue;
+                    // skip string.get_Length, as we use $Length for that
+                    if (mdDecoder.Equal(t, mdDecoder.System_String) && mdDecoder.Name(getter) == "get_Length")
+                    {
+                        continue;
+                    }
+
+                    // manifest the pseudo field
+                    Type propertyType;
+                    ESymValue pseudoFieldAddr = PseudoFieldAddress(value, getter, out propertyType, false, fromType: fromType);
+                    MaterializeAccordingToType(pseudoFieldAddr, propertyType, depth + 1, null, fromType, overrideFromType);
+
+                    // manifest aliased interface properties
+                    foreach (var intfmethod in mdDecoder.ImplementedMethods(getter))
+                    {
+                        var normalizedMethod = mdDecoder.Unspecialized(intfmethod);
+                        egraph[Constructors.For(normalizedMethod), value] = pseudoFieldAddr;
+                    }
+                }
+
+                if (NeedsArrayLengthManifested(t))
+                {
+                    ManifestArrayLength(value);
+                    return;
+                }
+
+                if (mdDecoder.IsUnmanagedPointer(t))
+                {
+                    ManifestWritableBytes(value);
+                    return;
+                }
+            }
+
+
+            #region Unmodified since entry
+            private void MakeUnmodified(ESymValue value)
+            {
+                unmodifiedSinceEntry = unmodifiedSinceEntry.Add(value);
+            }
+
+            private void MakeModified(ESymValue value)
+            {
+                unmodifiedSinceEntry = unmodifiedSinceEntry.Remove(value);
+            }
+
+            private void MakeTotallyModified(ESymValue value)
+            {
+                unmodifiedSinceEntry = unmodifiedSinceEntry.Remove(value);
+                unmodifiedSinceEntryForFields = unmodifiedSinceEntryForFields.Remove(value);
+            }
+
+            private void RetainForUnmodifiedFields(ESymValue value)
+            {
+                unmodifiedSinceEntryForFields = unmodifiedSinceEntryForFields.Add(value);
+            }
+
+            private bool IsUnmodified(ESymValue value)
+            {
+                return unmodifiedSinceEntry.Contains(value);
+            }
+
+            private bool AreUnmodified(ESymValue[] values)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    if (!IsUnmodified(values[i])) return false;
+                }
+                return true;
+            }
+
+            private bool AnyAreModifiedAtCall(ESymValue[] values)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    if (IsModifiedAtCall(values[i])) return true;
+                }
+                return false;
+            }
+
+            private bool IsUnmodifiedForFields(ESymValue value)
+            {
+                return unmodifiedSinceEntry.Contains(value) || unmodifiedSinceEntryForFields.Contains(value);
+            }
+            #endregion
+
+            #region Array support
+            private ESymValue ElementAddress(ESymValue array, ESymValue index, Type/*!*/ elementAddrType)
+            {
+                var arrayversion = egraph[Constructors.ObjectVersion, array];
+                var args = new[] { arrayversion, index };
+                var elementAddr = egraph.TryLookup(Constructors.ElementAddress, args);
+
+                if (elementAddr == null)
+                {
+                    elementAddr = egraph[Constructors.ElementAddress, args]; // manifest
+                    SetType(elementAddr, elementAddrType);
+                    // leave breadcrumb
+                    egraph[Constructors.ResultOfLdelem, elementAddr] = this.Zero;
+                }
+                return elementAddr;
+            }
+
+
+            private void AssignArrayLength(ESymValue destAddr, ESymValue array)
+            {
+                ESymValue len = egraph[Constructors.Length, array];
+                SetType(len, mdDecoder.System_Int32);
+                egraph[Constructors.ValueOf, destAddr] = len;
+                SetType(destAddr, mdDecoder.ManagedPointer(mdDecoder.System_Int32));
+            }
+
+            private void AssignWritableBytes(ESymValue destAddr, ESymValue pointer)
+            {
+                ESymValue len = egraph[Constructors.WritableBytes, pointer];
+                SetType(len, mdDecoder.System_UInt64);
+                egraph[Constructors.ValueOf, destAddr] = len;
+                SetType(destAddr, mdDecoder.ManagedPointer(mdDecoder.System_UInt64));
+            }
+
+            private ESymValue CreateArray(Type type, ESymValue len)
+            {
+                ESymValue array = egraph.FreshSymbol();
+                egraph[Constructors.Length, array] = len;
+                SetType(array, mdDecoder.ArrayType(type, 1));
+                return array;
+            }
+
+            private ESymValue LocalAlloc(ESymValue len)
+            {
+                ESymValue buffer = egraph.FreshSymbol();
+                egraph[Constructors.WritableBytes, buffer] = len;
+                SetType(buffer, mdDecoder.System_UIntPtr);
+                return buffer;
+            }
+
+            #endregion
+
+            private ESymValue CreateObject(Type type)
+            {
+                ESymValue obj = egraph.FreshSymbol();
+                SetType(obj, type);
+                return obj;
+            }
+
+            /// <returns>The address of a new value object</returns>
+            private ESymValue CreateValue(Type type)
+            {
+                ESymValue addr = egraph.FreshSymbol();
+                SetType(addr, this.mdDecoder.ManagedPointer(type));
+                return addr;
+            }
+
+            private void CopyStackAddress(ESymValue destAddr, Temp temporaryForWhichAddressIsTaken)
+            {
+                ESymValue srcAddr = Address(temporaryForWhichAddressIsTaken);
+                egraph[Constructors.ValueOf, destAddr] = srcAddr;
+                AbstractType atype = CurrentType(srcAddr);
+                FlatDomain<Type> addrType;
                 if (atype.IsNormal)
                 {
-                  pt = atype.Value;
+                    addrType = mdDecoder.ManagedPointer(atype.Type.Value);
                 }
                 else
                 {
-                  pt = mdDecoder.System_Object;
+                    addrType = new FlatDomain<Type>();
                 }
-              }
+                SetType(destAddr, addrType);
             }
-            else
+
+            private void CopyAddress(ESymValue destAddr, ESymValue srcAddr, Type typeOfAddressValue)
             {
-              pt = argTypes[i];
+                egraph[Constructors.ValueOf, destAddr] = srcAddr;
+                SetType(destAddr, mdDecoder.ManagedPointer(typeOfAddressValue));
             }
-            if (!mdDecoder.IsStruct(pt))
+
+            /// <summary>
+            /// Like copy, but leaves ResultOfOldValue breadcrumb
+            /// </summary>
+            private void CopyOld(Temp dest, Temp source, Type type)
             {
-              data.ResetModifiedAtCall();
-              data.HavocObjectAtCall(data.Value(arg), ref data.modifiedAtCall, false, false);
+                Copy(dest, source);
+                if (!IsStructWithFields(type))
+                {
+                    // leave breadcrumb
+                    var derefedValue = this.Value(dest);
+                    egraph[Constructors.ResultOfOldValue, derefedValue] = Null;
+                }
             }
-            // consume the args
-            data.Havoc(arg);
-          }
-          // Deal with result
-          data.AssignValue(dest, returnType, this.CurrentMethodDeclaringType);
 
-          return data;
-        }
+            private void Copy(Temp dest, Temp source)
+            {
+                ESymValue destAddr = Address(Constructors.For(dest));
+                ESymValue srcAddr = Address(Constructors.For(source));
+                CopyValue(destAddr, srcAddr);
+            }
 
-        public Domain Ckfinite(APC pc, int dest, int source, Domain data)
-        {
-          data.Copy(dest, source);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.Copy(dest, source);
-          }
-          return data;
-        }
+            #region Operator Type Conversions
 
-        public Domain Cpblk(APC pc, bool @volatile, int destaddr, int srcaddr, int len, Domain data)
-        {
+            /// <summary>
+            /// Currently, we don't take nullness/zeroness into account
+            /// </summary>
+            private FlatDomain<Type> BinaryResultType(BinaryOperator op, AbstractType t1, AbstractType t2)
+            {
+                switch (op)
+                {
+                    case BinaryOperator.Add:
+                    case BinaryOperator.Add_Ovf:
+                    case BinaryOperator.Add_Ovf_Un:
+                        if (t1.IsNormal &&
+                            (mdDecoder.IsUnmanagedPointer(t1.Value)))
+                        {
+                            return t1.Type;
+                        }
+                        if (t2.IsNormal && (mdDecoder.IsUnmanagedPointer(t2.Value)))
+                        {
+                            return t2.Type;
+                        }
+                        if (t1.IsNormal && mdDecoder.IsManagedPointer(t1.Value))
+                        {
+                            return mdDecoder.UnmanagedPointer(mdDecoder.ElementType(t1.Value));
+                        }
+                        if (t1.IsZero) return t2.Type;
+                        return t1.Type;
 
-          Contract.Assume(data.insideOld == 0);
-          // consume the args
-          data.Havoc(destaddr);
-          data.Havoc(srcaddr);
-          data.Havoc(len);
-          return data;
-        }
+                    case BinaryOperator.Sub:
+                    case BinaryOperator.Sub_Ovf:
+                    case BinaryOperator.Sub_Ovf_Un:
+                        if (t1.IsNormal && (mdDecoder.IsUnmanagedPointer(t1.Value)))
+                        {
+                            if (t2.IsNormal && (mdDecoder.IsUnmanagedPointer(t2.Value)))
+                            {
+                                return mdDecoder.System_Int32;
+                            }
+                            return t1.Type;
+                        }
+                        if (t2.IsNormal && (mdDecoder.IsUnmanagedPointer(t2.Value)))
+                        {
+                            return t2.Type;
+                        }
+                        if (t1.IsNormal && mdDecoder.IsManagedPointer(t1.Value))
+                        {
+                            return mdDecoder.UnmanagedPointer(mdDecoder.ElementType(t1.Value));
+                        }
+                        return t1.Type;
 
-        public Domain Endfilter(APC pc, int decision, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-          data.Havoc(decision);
-          return data;
-        }
+                    case BinaryOperator.Ceq:
+                    case BinaryOperator.Cobjeq:
+                    case BinaryOperator.Cge:
+                    case BinaryOperator.Cge_Un:
+                    case BinaryOperator.Cgt:
+                    case BinaryOperator.Cgt_Un:
+                    case BinaryOperator.Cle:
+                    case BinaryOperator.Cle_Un:
+                    case BinaryOperator.Clt:
+                    case BinaryOperator.Clt_Un:
+                    case BinaryOperator.Cne_Un:
+                        return mdDecoder.System_Boolean;
 
-        public Domain Endfinally(APC pc, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
+                    default:
+                        return t1.Type;
+                }
+            }
 
-          return data;
-        }
+            private Type UnaryResultType(UnaryOperator op, AbstractType type)
+            {
+                switch (op)
+                {
+                    case UnaryOperator.Conv_i1: return this.mdDecoder.System_Int8;
+                    case UnaryOperator.Conv_i2: return this.mdDecoder.System_Int16;
+                    case UnaryOperator.Conv_i4: return this.mdDecoder.System_Int32;
+                    case UnaryOperator.Conv_i8: return this.mdDecoder.System_Int64;
+                    case UnaryOperator.Conv_u1: return this.mdDecoder.System_UInt8;
+                    case UnaryOperator.Conv_u2: return this.mdDecoder.System_UInt16;
+                    case UnaryOperator.Conv_u4: return this.mdDecoder.System_UInt32;
+                    case UnaryOperator.Conv_u8:
+                    case UnaryOperator.WritableBytes:
+                        return this.mdDecoder.System_UInt64;
+                    case UnaryOperator.Conv_r8:
+                    case UnaryOperator.Conv_r_un:
+                        return this.mdDecoder.System_Double;
+                    case UnaryOperator.Conv_r4:
+                        return this.mdDecoder.System_Single;
+                    case UnaryOperator.Conv_dec:
+                        return this.mdDecoder.System_Decimal;
+                }
+                if (type.IsNormal)
+                {
+                    return type.Value;
+                }
+                return mdDecoder.System_Int32;
+            }
 
-        public Domain Initblk(APC pc, bool @volatile, int destaddr, int value, int len, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
+            #endregion
 
-          // consume the args
-          data.Havoc(destaddr);
-          data.Havoc(value);
-          data.Havoc(len);
-          return data;
-        }
+            #region Metadata helpers
+            private bool IsPointer(Type t)
+            {
+                return mdDecoder.IsManagedPointer(t) || mdDecoder.IsUnmanagedPointer(t);
+            }
+            #endregion
 
-        public Domain Jmp(APC pc, Method method, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
+            [ThreadStatic]
+            private static bool debug;
 
-          return data;
-        }
+            private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder { get { return parent.mdDecoder; } }
 
-        public Domain Ldarg(APC pc, Parameter argument, bool isOld, int dest, Domain data)
-        {
-          LdargEffect(argument, isOld, dest, data);
-          if (data.oldDomain != null)
-          {
-            LdargEffect(argument, isOld, dest, data.oldDomain);
-          }
-          return data;
-        }
+            /// <summary>
+            /// Determines if the temporary refers to "this"
+            /// </summary>
+            private bool IsThis(Method method, Temp arg)
+            {
+                if (mdDecoder.IsStatic(method)) return false;
+                ESymValue thisValue = this.Value(this.mdDecoder.This(method));
+                ESymValue argValue = this.Value(arg);
+                return thisValue == argValue;
+            }
 
-        private void LdargEffect(Parameter argument, bool isOld, int dest, Domain data)
-        {
-          if (isOld)
-          {
-            data.CopyValue(data.Address(dest), data.OldValueAddress(argument), mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
-          }
-          else
-          {
-            data.CopyValue(data.Address(dest), data.Address(argument), mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
-          }
-        }
+            private void ManifestArrayLength(ESymValue arrayValue)
+            {
+                ESymValue len = egraph[Constructors.Length, arrayValue];
+                SetType(len, mdDecoder.System_Int32);
+            }
 
-        public Domain Ldarga(APC pc, Parameter argument, bool isOld, int dest, Domain data)
-        {
-          // if we do this in the old state, we find the parameter shadow.
-          LdargaEffect(argument, isOld, dest, data);
-          if (data.oldDomain != null)
-          {
-            LdargaEffect(argument, isOld, dest, data.oldDomain);
-          }
-          return data;
-        }
+            private void ManifestWritableBytes(ESymValue pointerValue)
+            {
+                ESymValue len = egraph[Constructors.WritableBytes, pointerValue];
+                SetType(len, mdDecoder.System_UInt64);
+            }
 
-        private void LdargaEffect(Parameter argument, bool isOld, int dest, Domain data)
-        {
-          var address = isOld ? data.OldValueAddress(argument) : data.Address(argument);
+            private void AddOldSavedState(APC pc, Domain data)
+            {
+                BeginOldSavedStates[pc] = data;
+            }
 
-          data.CopyAddress(data.Address(dest), address, mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
-          data.ManifestWritableBytes(data.Value(dest));
-        }
+            private Domain GetStateAt(APC aPC)
+            {
+                Domain d;
+                parent.PreStateLookup(aPC, out d);
+                return d;
+            }
 
-        public Domain Ldconst(APC pc, object constant, Type type, int dest, Domain data)
-        {
-          data.AssignConst(dest, type, constant);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignConst(dest, type, constant);
-          }
-          return data;
-        }
+            private bool IsValidSymbol(ESymValue sv)
+            {
+                return egraph.IsValidSymbolc(sv);
+            }
 
-        public Domain Ldnull(APC pc, int dest, Domain data)
-        {
-          data.AssignNull(dest);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignNull(dest);
-          }
-          return data;
-        }
+            private void CopyNonStructWithFieldValue(ESymValue address, ESymValue sv, FlatDomain<Type> addressType)
+            {
+                egraph[Constructors.ValueOf, address] = sv;
+                SetType(address, addressType);
+            }
 
-        public Domain Ldftn(APC pc, Method method, int dest, Domain data)
-        {
-          data.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
-          }
-          return data;
-        }
+            private Domain GetSavedStateAtBeginOld(APC matchingBegin)
+            {
+                return BeginOldSavedStates[matchingBegin];
+            }
 
-        /// <summary>
-        /// Note: type here only indicates CLR runtime type, not the actual content type if it is an object type.
-        /// </summary>
-        public Domain Ldind(APC pc, Type type, bool @volatile, int dest, int ptr, Domain data)
-        {
+            #endregion // Privates
 
-          if (data.oldDomain != null)
-          {
-            // perform in old state and map to new state
-            LdindEffect(type, dest, ptr, data.oldDomain);
-            data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
-          }
-          else
-          {
-            LdindEffect(type, dest, ptr, data);
-          }
-          return data;
-        }
+            #region Debugging
+            public static bool Debug
+            {
+                get { return debug; }
+                set { debug = value; EGraph<Constructor, AbstractType>.DoDebug = value; }
+            }
 
-        private void LdindEffect(Type type, int dest, int ptr, Domain data)
-        {
-          ESymValue srcPtr = data.Value(ptr);
-          ESymValue destAddr = data.Address(dest);
-          if (mdDecoder.Equal(type, mdDecoder.System_Object))
-          {
-            // ldind.ref has no type information
-            data.CopyValue(destAddr, srcPtr, data.GetType(srcPtr).Type);
-          }
-          else
-          {
-            data.CopyValue(destAddr, srcPtr, mdDecoder.ManagedPointer(type));
-          }
-        }
-        public Domain Ldobj(APC pc, Type type, bool @volatile, int dest, int ptr, Domain data)
-        {
-          return data;
-        }
+            public IEnumerable<ESymValue> Variables
+            {
+                get
+                {
+                    return egraph.SymbolicValues;
+                }
+            }
+            #endregion
+
+            /// <summary>
+            /// Constructing the initial domain value for a method
+            /// </summary>
+            /// <param name="parent"></param>
+            [ContractVerification(false)]
+            internal Domain(OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent)
+            {
+                this.parent = parent;
+                egraph = new EGraph<Constructor, AbstractType>(AbstractType.TopValue, AbstractType.BottomValue);
+                constantLookup = FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey);
+                unmodifiedSinceEntry = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+                unmodifiedSinceEntryForFields = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+                modifiedAtCall = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+
+                Constructors = new WrapTable(parent.mdDecoder, parent.contractDecoder);
+                BeginOldSavedStates = new Dictionary<APC, Domain>();
+                // manifest some constants with special properties
+                ESymValue nullvalue = egraph.FreshSymbol();
+                egraph[Constructors.NullValue] = nullvalue;
+                egraph[nullvalue] = AbstractType.BottomValue;
+                ESymValue zerovalue = this.ConstantValue(0, mdDecoder.System_Int32);
+                // fix type to remember it is 0
+                egraph[zerovalue] = new AbstractType(mdDecoder.System_Int32, true);
+
+                ESymValue voidaddr = this.VoidAddr;
+            }
+
+            internal Type GetArrayElementType(Type type, int array)
+            {
+                Type elementType = type;
+                if (!mdDecoder.IsStruct(type))
+                {
+                    ESymValue arrayval = this.Value(array);
+                    AbstractType at = this.GetType(arrayval);
+                    if (at.IsNormal && mdDecoder.IsArray(at.Value))
+                    {
+                        elementType = mdDecoder.ElementType(at.Value);
+                        if (elementType == null) elementType = type;
+                    }
+                }
+                return elementType;
+            }
+
+            #region Heap analysis per instruction actions
+
+            /// <summary>
+            /// Performs the actual heap analysis for each instruction kind
+            /// </summary>
+            internal struct AnalysisDecoder : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Domain, Domain>
+            {
+                [ContractInvariantMethod]
+                [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+                private void ObjectInvariant()
+                {
+                    Contract.Invariant(parent != null);
+                }
+
+
+                #region Privates
+                private OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
+                #endregion
+
+                public AnalysisDecoder(OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent)
+                {
+                    this.parent = parent;
+
+                    Contract.Assume(this.parent != null);
+                }
+
+                private IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder { get { return parent.contractDecoder; } }
+                private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+                {
+                    get
+                    {
+                        Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
+                        return parent.mdDecoder;
+                    }
+                }
+
+                #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>> Members
+
+                public Domain Arglist(APC pc, int dest, Domain data)
+                {
+                    var arghandletype = data.mdDecoder.System_RuntimeArgumentHandle;
+                    data.AssignValue(dest, arghandletype, this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignValue(dest, arghandletype, this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+
+                public Domain Binary(APC pc, BinaryOperator op, int dest, Temp s1, Temp s2, Domain data)
+                {
+                    Contract.Assume(s2 > s1);// F: Added
+
+                    data = BinaryEffect(pc, op, dest, s1, s2, data, this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain = BinaryEffect(pc, op, dest, s1, s2, data.oldDomain, this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+                private static Domain BinaryEffect(APC pc, BinaryOperator op, int dest, Temp s1, Temp s2, Domain data, Type fromType)
+                {
+                    Contract.Requires(s2 > s1); // F: Added from Clousot precondition suggestion
+
+                    System.Diagnostics.Debug.Assert(s2 > s1);
+                    FlatDomain<Type> resultType = data.BinaryResultType(op, data.CurrentType(s1), data.CurrentType(s2));
+                    ESymValue sv1, sv2;
+                    //
+                    // Capture comparisons against zero/null and record them so that we can refine
+                    // branches for nullness.
+                    //
+                    switch (op)
+                    {
+                        case BinaryOperator.Ceq:
+                        case BinaryOperator.Cobjeq:
+                            sv1 = data.Value(s1);
+                            if (data.IsZero(sv1))
+                            {
+                                // result is true/non-zero if s2 is zero, false/zero otherwise
+                                // thus we can use unaryNot here
+                                data.AssignSpecialUnary(dest, data.Constructors.UnaryNot, s2, resultType, fromType: fromType);
+                            }
+                            else
+                            {
+                                sv2 = data.Value(s2);
+                                if (data.IsZero(sv2))
+                                {
+                                    // result is true/non-zero if s1 is zero, false/zero otherwise
+                                    // thus we can use unaryNot here
+                                    data.AssignSpecialUnary(dest, data.Constructors.UnaryNot, s1, resultType, fromType: fromType);
+                                }
+                                else
+                                    goto default;
+                            }
+                            break;
+
+                        case BinaryOperator.Cne_Un:
+                            sv1 = data.Value(s1);
+                            if (data.IsZero(sv1))
+                            {
+                                data.AssignSpecialUnary(dest, data.Constructors.NeZero, s2, resultType, fromType: fromType);
+                            }
+                            else
+                            {
+                                sv2 = data.Value(s2);
+                                if (data.IsZero(sv2))
+                                {
+                                    data.AssignSpecialUnary(dest, data.Constructors.NeZero, s1, resultType, fromType: fromType);
+                                }
+                                else
+                                    goto default;
+                            }
+                            break;
+
+                        default:
+                            data.AssignPureBinary(dest, op, resultType, s1, s2);
+                            break;
+                    }
+                    data.Havoc(s2);
+                    return data;
+                }
+
+                public Domain BranchCond(APC pc, APC target, BranchOperator bop, int value1, int value2, Domain data)
+                {
+                    throw new NotImplementedException("Should not see Branches, should see Assumes");
+                }
+
+                public Domain BranchTrue(APC pc, APC target, int cond, Domain data)
+                {
+                    throw new NotImplementedException("Should not see Branches, should see Assumes");
+                }
+
+                public Domain BranchFalse(APC pc, APC target, int cond, Domain data)
+                {
+                    throw new NotImplementedException("Should not see Branches, should see Assumes");
+                }
+
+                public Domain Branch(APC pc, APC target, bool leave, Domain data)
+                {
+                    throw new NotImplementedException("Should not see Branches, should see Assumes");
+                }
+
+                public Domain Break(APC pc, Domain data)
+                {
+                    return data;
+                }
+
+                public Domain Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Temp dest, ArgList args, Domain data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<int>
+                {
+                    Type declaringType = mdDecoder.DeclaringType(method);
+                    if (data.oldDomain != null)
+                    {
+                        // perform call in old state and map result back
+                        data.oldDomain = CallFactored(pc, method, tail, virt, extraVarargs, dest, args, data.oldDomain, declaringType, false);
+
+                        if (!mdDecoder.IsVoidMethod(method))
+                        {
+                            data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                        }
+                        return data;
+                    }
+                    else
+                    {
+                        return CallFactored<TypeList, ArgList>(pc, method, tail, virt, extraVarargs, dest, args, data, declaringType, false);
+                    }
+                }
+
+                private Type CurrentMethodDeclaringType
+                {
+                    get
+                    {
+                        return this.mdDecoder.DeclaringType(parent.currentMethod);
+                    }
+                }
+                [ContractVerification(false)]
+                private Domain CallFactored<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Temp dest, ArgList args, Domain data, Type methodDeclaringType, bool constrainedCall)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<int>
+                {
+                    Contract.Assume(args.Count >= mdDecoder.Parameters(method).Count + extraVarargs.Count);
+                    Contract.Assume(args.Count <= mdDecoder.Parameters(method).Count + extraVarargs.Count + 1);
+                    Contract.Assume(!mdDecoder.IsStatic(method) || args.Count == mdDecoder.Parameters(method).Count + extraVarargs.Count);
+
+                    Type declaringType = methodDeclaringType;
+
+                    if (!pc.InsideContract)
+                    {
+                        data.ResetModifiedAtCall();
+                    }
+
+                    #region Compute a type map for type instantiations
+                    var substitution = ComputeTypeInstantiationMap(pc, method);
+                    #endregion
+                    #region Devirtualize as far as possible
+                    bool dereferenceThis = false;
+                    if (virt)
+                    {
+                        if (mdDecoder.IsStruct(methodDeclaringType))
+                        {
+                            // constrained call virt. Let's use the constraint to find the better method implementing the method
+                            DevirtualizeImplementingMethod(methodDeclaringType, ref method);
+                        }
+                        else
+                        {
+                            // figure out if constrained call and we know it's a reference type
+                            if (constrainedCall)
+                            {
+                                var specialized = Specialize(substitution, methodDeclaringType);
+                                if (mdDecoder.IsReferenceType(specialized))
+                                {
+                                    // need extra dereference of "this"
+                                    dereferenceThis = true;
+                                }
+                            }
+                            // let's use the receiver
+                            ESymValue obj = data.Value(args[0]);
+                            if (dereferenceThis)
+                            {
+                                obj = data.Value(obj);
+                            }
+                            var thisType = data.GetType(obj);
+                            if (thisType.IsNormal)
+                            {
+                                // find method in thisType that implements method.
+                                DevirtualizeImplementingMethod(thisType.Value, ref method);
+                            }
+                        }
+                    }
+                    #endregion
+
+                    #region Special case methods
+                    string methodName = mdDecoder.Name(method);
+                    if (args.Count > 0)
+                    {
+                        if ((mdDecoder.Equal(declaringType, mdDecoder.System_String) ||
+                          mdDecoder.Equal(declaringType, mdDecoder.System_Array))
+                          && (methodName == "get_Length" || methodName == "get_LongLength"))
+                        {
+                            // assign length to dest
+                            data.AssignArrayLength(data.Address(dest), data.Value(args[0]));
+                            return data;
+                        }
+                        if (mdDecoder.Equal(declaringType, mdDecoder.System_Object)
+                          && methodName == "MemberwiseClone")
+                        {
+                            Type thisType = data.GetType(data.Value(args[0])).Value;
+                            ESymValue obj = data.CreateObject(thisType);
+                            data.CopyStructValue(obj, data.Value(args[0]), thisType); // cheat. Use struct copy to do memberwise copy here.
+                            data.CopyAddress(data.Address(dest), obj, thisType);
+                            return data;
+                        }
+
+                        #region Identity functions
+
+                        // Array.GetLowerBound(0), assume it is 0
+                        if (methodName == "GetLowerBound" && mdDecoder.Name(declaringType) == "Array" && args.Count > 1)
+                        {
+                            ESymValue arg = data.Value(args[1]);
+                            if (data.IsZero(arg))
+                            {
+                                data.CopyNonStructWithFieldValue(data.Address(dest), arg, mdDecoder.ManagedPointer(mdDecoder.System_Int32));
+                                return data;
+                            }
+                        }
+
+                        #endregion
+                    }
+                    if (extraVarargs.Count == 0 && !mdDecoder.IsVoid(mdDecoder.ReturnType(method)) && (contractDecoder.IsPure(method) || contractDecoder.IsModel(method)))
+                    {
+                        // NOTE: Need to check whether the method is a model method because IsHeapIndependent might not be able to find the property that the model method (getter)
+                        // belongs to.
+                        var nonOutArgs = GetNonOutArgs(method);
+                        if (args.Count <= 1 && nonOutArgs == args.Count)
+                        {
+                            // treat like a field provided it isn't marked as fresh
+                            if (contractDecoder.IsFreshResult(method))
+                            {
+                                data.AssignReturnValue(dest, mdDecoder.ReturnType(method), this.CurrentMethodDeclaringType); // void is handled by assign
+                                return data;
+                            }
+                            ESymValue obj;
+                            if (args.Count == 0)
+                            {
+                                Contract.Assume(mdDecoder.IsStatic(method));
+                                obj = data.Globals;
+                            }
+                            else if (mdDecoder.IsStatic(method) && !mdDecoder.HasValueRepresentation(mdDecoder.ParameterType(mdDecoder.Parameters(method)[0])))
+                            {
+                                // struct by value parameter
+                                obj = data.StructId(data.Address(args[0]));
+                            }
+                            else
+                            {
+                                obj = null;
+                                if (!mdDecoder.IsStatic(method) && !mdDecoder.HasValueRepresentation(mdDecoder.DeclaringType(method)) && IsStructValue(data, args[0]))
+                                {
+                                    // struct instance call
+                                    // special case if we have a value on the stack rather than the address
+                                    obj = data.Address(args[0]); // use the address of the stack local
+                                }
+                                if (obj == null)
+                                {
+                                    // ordinary non-struct parameter or by-ref struct
+                                    obj = data.Value(args[0]);
+                                    if (dereferenceThis)
+                                    {
+                                        obj = data.Value(obj);
+                                    }
+                                }
+                            }
+                            Type pseudoFieldAddressType;
+                            ESymValue fieldAddr = data.PseudoFieldAddress(obj, method, out pseudoFieldAddressType, true, this.CurrentMethodDeclaringType);
+                            data.CopyValue(data.Address(dest), fieldAddr, pseudoFieldAddressType);
+                            return data;
+                        }
+                        else
+                        {
+                            // multi variable uninterpreted function
+                            ESymValue[] symArgs = new ESymValue[nonOutArgs];
+                            for (int i = 0, index = 0; i < args.Count; i++)
+                            {
+                                bool isOut;
+
+                                var key = KeyForPureFunctionArgument(method, i, args[i], data, substitution, out isOut);
+                                if (!isOut)
+                                {
+                                    symArgs[index++] = key;
+                                }
+                            }
+
+                            Type pseudoFieldAddressType;
+                            ESymValue fieldAddr = data.PseudoFieldAddress(symArgs, method, out pseudoFieldAddressType, true, this.CurrentMethodDeclaringType);
+                            AssignAllOutParameters(data, fieldAddr, method, args);
+                            data.CopyValue(data.Address(dest), fieldAddr, pseudoFieldAddressType);
+                            return data;
+                        }
+                    }
+                    if (mdDecoder.IsPropertySetter(method))
+                    {
+                        Property property = mdDecoder.GetPropertyFromAccessor(method);
+                        if (args.Count <= 2)
+                        {
+                            Method getter;
+                            if (mdDecoder.HasGetter(property, out getter))
+                            {
+                                // treat like a field
+                                Type pseudoFieldAddressType;
+                                ESymValue obj;
+                                ESymValue valueAddr;
+                                if (args.Count == 1)
+                                {
+                                    Contract.Assume(mdDecoder.IsStatic(getter));
+                                    obj = data.Globals;
+                                    valueAddr = data.Address(args[0]);
+                                }
+                                else
+                                {
+                                    obj = data.Value(args[0]);
+                                    if (dereferenceThis)
+                                    {
+                                        obj = data.Value(obj);
+                                    }
+                                    valueAddr = data.Address(args[1]);
+                                }
+
+                                // havoc whatever the setter havocs if we are inside the same class
+                                if (this.mdDecoder.Equal(this.mdDecoder.DeclaringType(parent.currentMethod), this.mdDecoder.Unspecialized(this.mdDecoder.DeclaringType(method))))
+                                {
+                                    data.HavocUp(obj, ref data.modifiedAtCall, false);
+                                    if (mdDecoder.IsAutoPropertyMember(method))
+                                    {
+                                        // set the backing field
+                                        foreach (var backingField in parent.context.MethodContext.Modifies(method))
+                                        {
+                                            Type backingFieldAddressType;
+                                            ESymValue backingFieldAddr = data.FieldAddress(obj, backingField, out backingFieldAddressType);
+                                            data.CopyValue(backingFieldAddr, valueAddr, backingFieldAddressType);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        data.HavocFields(obj, parent.context.MethodContext.Modifies(method), ref data.modifiedAtCall);
+                                    }
+                                }
+
+                                ESymValue fieldAddr = data.PseudoFieldAddress(obj, getter, out pseudoFieldAddressType, true, this.CurrentMethodDeclaringType);
+                                data.CopyValue(fieldAddr, valueAddr, pseudoFieldAddressType);
+                                // don't forget to set dest, otherwise downstream decoding will miss some void address
+                                data.AssignValue(dest, mdDecoder.System_Void, this.CurrentMethodDeclaringType); // void is handled by assign
+
+                                return data;
+                            }
+                        }
+                        else // args > 2
+                        {
+                            Method getter;
+                            if (mdDecoder.HasGetter(property, out getter))
+                            {
+                                // multi variable uninterpreted function
+                                var nonOutArgs = GetNonOutArgs(method) - 1;
+                                ESymValue[] symArgs = new ESymValue[nonOutArgs];
+                                for (int i = 0, index = 0; i < args.Count - 1; i++)
+                                {
+                                    bool isOut;
+                                    Contract.Assume(!mdDecoder.IsStatic(method) || i < mdDecoder.Parameters(method).Count, "assuming IL is well-formed");
+
+                                    var key = KeyForPureFunctionArgument(method, i, args[i], data, substitution, out isOut);
+                                    if (!isOut)
+                                    {
+                                        symArgs[index++] = key;
+                                    }
+                                }
+
+                                ESymValue obj = data.Value(args[0]);
+                                if (dereferenceThis)
+                                {
+                                    obj = data.Value(obj);
+                                }
+                                Type pseudoFieldAddressType;
+                                ESymValue fieldAddr = data.PseudoFieldAddress(symArgs, getter, out pseudoFieldAddressType, false, this.CurrentMethodDeclaringType);
+                                AssignAllOutParameters(data, fieldAddr, method, args);
+                                var valueAddress = data.Address(args[args.Count - 1]);
+                                data.CopyValue(fieldAddr, valueAddress, pseudoFieldAddressType);
+
+                                // havoc whatever the setter havocs if we are inside the same class
+                                if (this.mdDecoder.Equal(this.mdDecoder.DeclaringType(parent.currentMethod), this.mdDecoder.Unspecialized(this.mdDecoder.DeclaringType(method))))
+                                {
+                                    data.HavocUp(obj, ref data.modifiedAtCall, false);
+                                    data.HavocFields(obj, parent.context.MethodContext.Modifies(method), ref data.modifiedAtCall);
+                                }
+                                else
+                                {
+                                    data.HavocModelProperties(obj, ref data.modifiedAtCall);
+                                }
+                            }
+                            else
+                            {
+                                // no getter, what should we do?
+                            }
+                            // don't forget to set dest, otherwise downstream decoding will miss some void address
+                            data.AssignValue(dest, mdDecoder.System_Void, this.CurrentMethodDeclaringType); // void is handled by assign
+
+                            return data;
+                        }
+                    }
+                    #endregion
+
+                    bool insideConstructor = this.mdDecoder.IsConstructor(parent.currentMethod);
+
+                    #region Havoc parameters
+                    HavocParameters<TypeList, ArgList>(pc, method, extraVarargs, args, data, declaringType, insideConstructor, false, dereferenceThis);
+                    #endregion
+
+                    // Deal with return type
+                    data.AssignReturnValue(dest, mdDecoder.ReturnType(method), this.CurrentMethodDeclaringType); // void is handled by assign
+
+                    return data;
+                }
+
+                private bool IsStructValue(Domain data, Temp source)
+                {
+                    var raddr = data.Address(source);
+                    var rtype = data.GetType(raddr);
+                    if (rtype.IsNormal)
+                    {
+                        if (mdDecoder.IsManagedPointer(rtype.Value) && !mdDecoder.IsManagedPointer(mdDecoder.ElementType(rtype.Value)))
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+
+                private void AssignAllOutParameters<ArgList>(Domain data, ESymValue fieldAddr, Method method, ArgList args)
+                  where ArgList : IIndexable<int>
+                {
+                    int index = 0;
+                    if (!mdDecoder.IsStatic(method)) { index++; } // skip this parameter actual
+
+                    foreach (var p in mdDecoder.Parameters(method).Enumerate())
+                    {
+                        if (mdDecoder.IsOut(p))
+                        {
+                            // we grab a pseudo sub structure of fieldAddr as the value of this out parameter
+                            var parameterType = mdDecoder.ParameterType(p);
+                            var outFieldAddress = data.PseudoFieldAddressOfOutParameter(index, fieldAddr, parameterType, this.CurrentMethodDeclaringType);
+                            Contract.Assume(index < args.Count, "invariant assuming bytecode is well formed and number of arguments at calls is correct");
+                            var dest = data.Value(args[index]);
+                            data.CopyValue(dest, outFieldAddress, parameterType);
+                        }
+                        index++;
+                    }
+                }
+
+                private int GetNonOutArgs(Method method)
+                {
+                    int count = this.mdDecoder.IsStatic(method) ? 0 : 1;
+                    foreach (var p in mdDecoder.Parameters(method).Enumerate())
+                    {
+                        if (!mdDecoder.IsOut(p)) count++;
+                    }
+                    return count;
+                }
+
+                private Func<Type, Type> Compose(IFunctionalMap<Type, Type> map, Func<Type, Type> inner)
+                {
+                    if (map.Count == 0) return inner;
+                    if (inner == null)
+                    {
+                        return (type) => (map.Contains(type)) ? map[type] : type;
+                    }
+                    return (type) =>
+                    {
+                        type = inner(type);
+                        if (map.Contains(type)) return map[type];
+                        return type;
+                    };
+                }
+
+                private Func<Type, Type> ComputeTypeInstantiationMap(APC pc, Method method)
+                {
+                    Func<Type, Type> substitution = null;
+                    for (var context = pc.SubroutineContext; context != null; context = context.Tail)
+                    {
+                        Method calledMethod;
+                        bool isNewObj;
+                        bool isVirtualCall;
+                        if (context.Head.One.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall))
+                        {
+                            IFunctionalMap<Type, Type> map = FunctionalMap<Type, Type>.Empty;
+                            mdDecoder.IsSpecialized(calledMethod, ref map);
+                            substitution = Compose(map, substitution);
+                        }
+                        else if (context.Head.Two.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall))
+                        {
+                            IFunctionalMap<Type, Type> map = FunctionalMap<Type, Type>.Empty;
+                            mdDecoder.IsSpecialized(calledMethod, ref map);
+                            substitution = Compose(map, substitution);
+                        }
+                    }
+                    return substitution;
+                }
+
+                [SuppressMessage("Microsoft.Contracts", "RequiresAtCall-!mdDecoder.IsStatic(method) || index < mdDecoder.Parameters(method).Count")]
+                private ESymValue KeyForPureFunctionArgument(Method method, int index, Temp arg, Domain data, Func<Type, Type> specialization, out bool isOut)
+                {
+                    Contract.Requires(index >= 0);
+                    Contract.Requires(index <= mdDecoder.Parameters(method).Count);
+                    Contract.Requires(!mdDecoder.IsStatic(method) || index < mdDecoder.Parameters(method).Count);
+
+                    bool isPrimitive;
+                    bool isByRef;
+                    Type type;
+                    bool isThis;
+                    if (!ParameterHasValueRepresentation(method, index, specialization, out isPrimitive, out isOut, out isByRef, out type, out isThis))
+                    {
+                        if (isThis && isByRef && IsStructValue(data, arg))
+                        {
+                            // special case for calls on structs, where we have the struct value on the stack rather than the address
+                            return data.StructId(data.Address(arg));
+                        }
+                        if (!isByRef)
+                        {
+                            // struct by value parameter
+                            return data.StructId(data.Address(arg));
+                        }
+                        else
+                        {
+                            // struct by ref
+                            return data.StructId(data.Value(arg));
+                        }
+                    }
+                    else
+                    {
+                        // ordinary non-struct parameter (but possibly primitive)
+                        var ptr = data.Value(arg);
+                        if (isByRef)
+                        {
+                            ptr = data.Value(ptr);
+                        }
+                        if (isPrimitive || IsImmutableType(type) || contractDecoder.IsMutableHeapIndependent(method))
+                        {
+                            return ptr;
+                        }
+                        else
+                        {
+                            return data.ObjectVersion(ptr);
+                        }
+                    }
+                }
+
+                private bool IsImmutableType(Type type)
+                {
+                    return this.mdDecoder.IsDelegate(type);
+                }
+
+                private void DevirtualizeImplementingMethod(Type type, ref Method method)
+                {
+                    Method implementing;
+                    if (mdDecoder.TryGetImplementingMethod(type, method, out implementing))
+                    {
+                        method = implementing;
+                    }
+                }
+
+
+                private Type Specialize(Func<Type, Type> specialization, Type type)
+                {
+                    if (specialization != null)
+                    {
+                        return specialization(type);
+                    }
+                    return type;
+                }
+
+                private bool ParameterHasValueRepresentation(Method method, int paramIndex, Func<Type, Type> specialization, out bool isPrimitive, out bool isOut, out bool isByRef, out Type type, out bool isThis)
+                {
+                    Contract.Requires(paramIndex >= 0);
+                    Contract.Requires(paramIndex <= mdDecoder.Parameters(method).Count);
+                    Contract.Requires(!mdDecoder.IsStatic(method) || paramIndex < mdDecoder.Parameters(method).Count);
+
+                    if (mdDecoder.IsStatic(method))
+                    {
+                        isThis = false;
+                        var parameter = mdDecoder.Parameters(method)[paramIndex];
+                        type = mdDecoder.ParameterType(parameter);
+                        type = Specialize(specialization, type);
+                        isOut = mdDecoder.IsOut(parameter);
+                        if (mdDecoder.IsManagedPointer(type))
+                        {
+                            isByRef = true;
+                            type = mdDecoder.ElementType(type);
+                        }
+                        else
+                        {
+                            isByRef = false;
+                        }
+                        isPrimitive = mdDecoder.IsPrimitive(type);
+                        return mdDecoder.HasValueRepresentation(type);
+                    }
+                    else
+                    {
+                        // shift
+                        if (paramIndex == 0)
+                        {
+                            // instance arg 
+                            isThis = true;
+                            isOut = false;
+                            type = mdDecoder.DeclaringType(method);
+                            isPrimitive = mdDecoder.IsPrimitive(type);
+                            var hasValueRep = mdDecoder.HasValueRepresentation(type);
+                            if (isPrimitive || !hasValueRep)
+                            {
+                                isByRef = true;
+                            }
+                            else
+                            {
+                                isByRef = false;
+                            }
+                            return hasValueRep;
+                        }
+                        else
+                        {
+                            isThis = false;
+                            var parameter = mdDecoder.Parameters(method)[paramIndex - 1];
+                            type = mdDecoder.ParameterType(parameter);
+                            type = Specialize(specialization, type);
+                            if (mdDecoder.IsManagedPointer(type))
+                            {
+                                isByRef = true;
+                                type = mdDecoder.ElementType(type);
+                            }
+                            else
+                            {
+                                isByRef = false;
+                            }
+                            isPrimitive = mdDecoder.IsPrimitive(type);
+                            isOut = mdDecoder.IsOut(parameter);
+                            return mdDecoder.HasValueRepresentation(type);
+                        }
+                    }
+                }
+
+                [ContractVerification(false)]
+                private void HavocParameters<TypeList, ArgList>(
+                  APC pc,
+                  Method method,
+                  TypeList extraVarargs,
+                  ArgList args,
+                  Domain data,
+                  Type declaringType,
+                  bool insideConstructor,
+                  bool thisArgMissing, // this happens in newObj
+                  bool derefThis // true if constrained virtcall and we know it's on a reference type
+                )
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<int>
+                {
+                    // Deal with by-ref parameters: note, we have to handle "this" and varargs too here.
+                    IIndexable<Parameter> parameters = this.mdDecoder.Parameters(method);
+                    IIndexable<Parameter> genericMethodParameters = null;
+                    if (this.mdDecoder.IsSpecialized(method))
+                    {
+                        genericMethodParameters = this.mdDecoder.Parameters(this.mdDecoder.Unspecialized(method));
+                        Contract.Assume(parameters.Count == genericMethodParameters.Count);
+                    }
+
+                    for (int i = 0, param = 0, optThis = 0; i < args.Count; i++)
+                    {
+                        Contract.Assert(param <= i);
+                        Contract.Assert(optThis <= 1);
+
+                        // find type corresponding to args[i]
+                        bool isOut = false;
+                        bool materializeAfterCall = true;
+                        bool isNonFirstThis = false;
+                        Temp arg = args[i];
+                        Type pt;
+                        bool isGenericArgType = false;
+                        bool isThisConstructorCall = false; // constructor call on same class : this(...)
+
+                        if (i == 0 && !thisArgMissing && !mdDecoder.IsStatic(method))
+                        {
+                            optThis = 1;
+                            Parameter thisParam = mdDecoder.This(method);
+                            pt = mdDecoder.ParameterType(thisParam);
+                            if (this.mdDecoder.IsConstructor(method))
+                            {
+                                // a base call is a constructor call from a constructor with "this", and the target constructor is declared in a different type
+                                if (insideConstructor &&
+                                    data.IsThis(parent.currentMethod, arg)
+                                  )
+                                {
+                                    if (TypesEqualModuloInstantiation(declaringType, this.mdDecoder.DeclaringType(parent.currentMethod)))
+                                    {
+                                        // havoc even readonly fields.
+                                        isThisConstructorCall = true;
+                                    }
+                                    else
+                                    {
+                                        // base call, don't havoc "this"
+                                        ESymValue pvalue = data.Value(arg);
+                                        var ptype = data.GetType(pvalue);
+                                        if (ptype.IsNormal) { pt = ptype.Value; }
+                                        data.MaterializeThisAtCallAccordingToType(pvalue, pt, 0, this.CurrentMethodDeclaringType);
+                                        continue;
+                                    }
+                                }
+                                if (this.mdDecoder.IsStruct(declaringType))
+                                {
+                                    // a struct constructor call is similar to newObj, so we should materialize here
+                                    isOut = true;
+                                }
+                            }
+                            if (mdDecoder.IsPrimitive(declaringType) || mdDecoder.Equal(declaringType, mdDecoder.System_Object))
+                            {
+                                // primitive types (Int32,...) are mostly structs and we call their methods by ref, but
+                                // they don't change the value, so let's not havoc them
+                                // Furthermore, let's materialize their value
+                                // Also, methods on them don't change the receiver.
+                                if (mdDecoder.IsStruct(declaringType))
+                                {
+                                    data.Value(data.Value(args[0]));
+                                }
+                                continue;
+                            }
+                            if (data.IsThis(parent.currentMethod, arg))
+                            {
+                                // call on this. rematerialize fields afterwards
+                                materializeAfterCall = true;
+                            }
+                        }
+                        else if (param < parameters.Count)
+                        {
+                            // non-first parameter or non-instance: don't havoc "this" argument
+                            if (data.IsThis(parent.currentMethod, arg)) { isNonFirstThis = true; }
+
+                            Parameter p = parameters[param];
+                            isOut = mdDecoder.IsOut(p);
+                            pt = mdDecoder.ParameterType(p);
+                            if (genericMethodParameters != null)
+                            {
+                                Contract.Assume(parameters.Count == genericMethodParameters.Count, "Clousot should be able to prove this");
+                                Parameter gp = genericMethodParameters[param];
+                                var gpt = mdDecoder.ParameterType(gp);
+                                isGenericArgType = (mdDecoder.IsFormalTypeParameter(gpt) || mdDecoder.IsMethodFormalTypeParameter(gpt));
+                            }
+                            param++;
+                        }
+                        else
+                        {
+                            // vararg parameter: don't havoc "this" argument
+                            if (data.IsThis(parent.currentMethod, arg)) { continue; }
+
+                            Contract.Assume(i - param - optThis < extraVarargs.Count, "assuming IL is well-formed");
+                            pt = extraVarargs[i - param - optThis];
+                        }
+                        // havoc the parameter if it isn't a struct, the method isn't pure, and the method isn't a method on object.
+                        // and we are not in a contract
+                        if (!pc.InsideContract)
+                        {
+                            bool aggressive = AggressiveUpHavocMethod(method);
+                            if (aggressive || isOut || MustHavocParameter(i, method, declaringType, pt, isGenericArgType, isNonFirstThis))
+                            {
+                                ESymValue pvalue = data.Value(arg);
+                                if (derefThis && i == 0 && optThis == 1)
+                                {
+                                    pvalue = data.Value(pvalue);
+                                }
+                                var ptype = data.GetType(pvalue);
+                                if (ptype.IsNormal)
+                                {
+                                    pt = ptype.Value; // specialize type so we can materialize more meaningful fields
+                                }
+                                data.HavocObjectAtCall(pvalue, ref data.modifiedAtCall, aggressive, isThisConstructorCall);
+                                if (isOut)
+                                {
+                                    // materialize
+                                    data.MaterializeOutParameterAccordingToType(pvalue, pt, 0, this.CurrentMethodDeclaringType);
+                                }
+                                else if (materializeAfterCall)
+                                {
+                                    data.MaterializeThisAtCallAccordingToType(pvalue, pt, 0, this.CurrentMethodDeclaringType);
+                                }
+                            }
+                        }
+                        // consume the args
+                        data.Havoc(arg);
+                    }
+                }
+
+                /// <summary>
+                /// Duplicate in ControlFlow.cs
+                /// </summary>
+                /// <param name="method"></param>
+                /// <returns></returns>
+                private bool AggressiveUpHavocMethod(Method method)
+                {
+                    var t = mdDecoder.DeclaringType(method);
+                    if (mdDecoder.Name(t) != "Monitor") return false;
+                    var name = mdDecoder.Name(method);
+                    if (name == "Exit" || name == "Wait") return true;
+                    return false;
+                }
 
 
 
-        public Domain Ldloc(APC pc, Local local, int dest, Domain data)
-        {
-          LdlocEffect(local, dest, data);
-          if (data.oldDomain != null)
-          {
-            // local variables were likely assigned since the old program point and need to be 
-            // read from the current state.
-            data.CopyValueToOldState(data.oldDomain.beginOldPC, mdDecoder.LocalType(local), dest, dest, data.oldDomain);
-          }
-          return data;
-        }
+                private bool TypesEqualModuloInstantiation(Type a, Type b)
+                {
+                    a = mdDecoder.Unspecialized(a);
+                    b = mdDecoder.Unspecialized(b);
+                    return this.mdDecoder.Equal(a, b);
+                }
 
-        private void LdlocEffect(Local local, int dest, Domain data)
-        {
-          data.CopyValue(data.Address(dest), data.Address(local), mdDecoder.ManagedPointer(mdDecoder.LocalType(local)));
-        }
+                private bool MustHavocParameter(int parameterPosition, Method method, Type declaringType, Type pt, bool parameterHasGenericType, bool nonFirstThis)
+                {
+                    Contract.Requires(parameterPosition >= 0);
 
-        public Domain Ldloca(APC pc, Local local, int dest, Domain data)
-        {
-          LdlocaEffect(local, dest, data);
-          if (data.oldDomain != null)
-          {
-            LdlocaEffect(local, dest, data.oldDomain);
-          }
-          return data;
-        }
+                    // parameters of generic type in generic code are generally not havoced, so use that heuristic here
+                    if (parameterHasGenericType) return false;
+                    if (mdDecoder.IsStruct(pt)) return false;
+                    if (contractDecoder.IsPure(method)) return false;
+                    if (mdDecoder.IsPure(method, parameterPosition)) return false;
+                    if (mdDecoder.Equal(declaringType, mdDecoder.System_Object)) return false;
+                    if (IsImmutable(pt)) return false; // immutable types not modded
+                    if (nonFirstThis) return false; // this passed as arg usually not modded
+                    if (mdDecoder.Equal(pt, mdDecoder.System_Object)) return false; // object typed parameters usually not modded
+                    return true;
+                }
 
-        private void LdlocaEffect(Local local, int dest, Domain data)
-        {
-          data.CopyAddress(data.Address(dest), data.Address(local), mdDecoder.ManagedPointer(mdDecoder.LocalType(local)));
-          data.ManifestWritableBytes(data.Value(dest));
-        }
+                private bool IsImmutable(Type pt)
+                {
+                    if (mdDecoder.Equal(pt, mdDecoder.System_String)) return true;
+                    return false;
+                }
 
-        public Domain Localloc(APC pc, int dest, int size, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
+                public Domain Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, int dest, int fp, ArgList args, Domain data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<int>
+                {
+                    if (data.oldDomain == null)
+                    {
+                        return CalliEffect(pc, returnType, argTypes, tail, isInstance, dest, fp, args, data);
+                    }
+                    else
+                    {
+                        // perform call on old state and map result back (if any)
+                        data.oldDomain = CalliEffect(pc, returnType, argTypes, tail, isInstance, dest, fp, args, data.oldDomain);
+                        if (!mdDecoder.IsVoid(returnType))
+                        {
+                            data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                        }
+                        return data;
+                    }
+                }
+                [ContractVerification(false)]
+                private Domain CalliEffect<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, int dest, int fp, ArgList args, Domain data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<int>
+                {
+                    Contract.Assume(args.Count >= argTypes.Count);
+                    Contract.Assume(args.Count <= argTypes.Count + 1);
+                    Contract.Assume(!isInstance || args.Count == argTypes.Count + 1);
+                    Contract.Assume(isInstance || args.Count == argTypes.Count);
 
-          ESymValue buffer = data.LocalAlloc(data.Value(size));
-          data.CopyAddress(data.Address(dest), buffer, mdDecoder.System_UIntPtr);
+                    // Deal with by-ref parameters
+                    for (int i = 0; i < args.Count; i++)
+                    {
+                        Temp arg = args[i];
+                        // find type corresponding to args[i]
+                        Type pt;
+                        if (isInstance)
+                        {
+                            if (i > 0)
+                            {
+                                pt = argTypes[i - 1];
+                            }
+                            else
+                            {
+                                // no static type info, must grab it from our state:
+                                var self = data.Value(arg);
+                                var atype = data.GetType(self);
+                                if (atype.IsNormal)
+                                {
+                                    pt = atype.Value;
+                                }
+                                else
+                                {
+                                    pt = mdDecoder.System_Object;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            pt = argTypes[i];
+                        }
+                        if (!mdDecoder.IsStruct(pt))
+                        {
+                            data.ResetModifiedAtCall();
+                            data.HavocObjectAtCall(data.Value(arg), ref data.modifiedAtCall, false, false);
+                        }
+                        // consume the args
+                        data.Havoc(arg);
+                    }
+                    // Deal with result
+                    data.AssignValue(dest, returnType, this.CurrentMethodDeclaringType);
 
-          return data;
-        }
+                    return data;
+                }
 
-        public Domain Nop(APC pc, Domain data)
-        {
-          return data;
-        }
+                public Domain Ckfinite(APC pc, int dest, int source, Domain data)
+                {
+                    data.Copy(dest, source);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.Copy(dest, source);
+                    }
+                    return data;
+                }
 
-        public Domain Pop(APC pc, int source, Domain data)
-        {
-          data.Havoc(source);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.Havoc(source);
-          }
-          return data;
-        }
+                public Domain Cpblk(APC pc, bool @volatile, int destaddr, int srcaddr, int len, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+                    // consume the args
+                    data.Havoc(destaddr);
+                    data.Havoc(srcaddr);
+                    data.Havoc(len);
+                    return data;
+                }
 
-        public Domain Return(APC pc, int source, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-          data.Havoc(source);
-          return data;
-        }
+                public Domain Endfilter(APC pc, int decision, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+                    data.Havoc(decision);
+                    return data;
+                }
 
-        public Domain Starg(APC pc, Parameter argument, int source, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-          data.CopyValue(data.Address(argument), data.Address(source), mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
-          data.Havoc(source);
-          return data;
-        }
+                public Domain Endfinally(APC pc, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
 
-        public Domain Stind(APC pc, Type type, bool @volatile, int ptr, int value, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-          ESymValue valueAddr = data.Address(value);
-          ESymValue destAddr = data.Value(ptr);
-          if (mdDecoder.Equal(type, mdDecoder.System_Object))
-          {
-            // no info on type ldind.ref
-            data.CopyValue(destAddr, valueAddr, data.GetType(valueAddr).Type, false, false);
-          }
-          else
-          {
-            data.CopyValue(destAddr, valueAddr, mdDecoder.ManagedPointer(type), false, false);
-          }
-          data.Havoc(ptr);
-          data.Havoc(value);
-          return data;
-        }
+                    return data;
+                }
 
-        public Domain Stloc(APC pc, Local local, int source, Domain data)
-        {
-          StlocEffect(local, source, data);
-          if (data.oldDomain != null)
-          {
-            StlocEffect(local, source, data.oldDomain);
-          }
-          return data;
-        }
+                public Domain Initblk(APC pc, bool @volatile, int destaddr, int value, int len, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
 
-        private void StlocEffect(Local local, int source, Domain data)
-        {
-          data.CopyValue(data.Address(local), data.Address(source), this.mdDecoder.ManagedPointer(this.mdDecoder.LocalType(local)));
-          data.Havoc(source);
-        }
+                    // consume the args
+                    data.Havoc(destaddr);
+                    data.Havoc(value);
+                    data.Havoc(len);
+                    return data;
+                }
 
-        public Domain Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, int value, Domain data)
-        {
-          throw new NotImplementedException("Should only see assumes");
-        }
+                public Domain Jmp(APC pc, Method method, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
 
-        public Domain Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, int dest, int source, Domain data)
-        {
-          UnaryEffect(op, dest, source, data);
-          if (data.oldDomain != null)
-          {
-            UnaryEffect(op, dest, source, data.oldDomain);
-          }
-          return data;
-        }
+                    return data;
+                }
 
-        private void UnaryEffect(UnaryOperator op, int dest, int source, Domain data)
-        {
-          switch (op)
-          {
-            case UnaryOperator.WritableBytes:
-              data.AssignWritableBytes(data.Address(dest), data.Value(source));
-              break;
+                public Domain Ldarg(APC pc, Parameter argument, bool isOld, int dest, Domain data)
+                {
+                    LdargEffect(argument, isOld, dest, data);
+                    if (data.oldDomain != null)
+                    {
+                        LdargEffect(argument, isOld, dest, data.oldDomain);
+                    }
+                    return data;
+                }
 
-            case UnaryOperator.Conv_u:
-              // retain type and nullness
-              //var type = data.GetType(data.Value(source));
-              //if (type.IsNormal && parent.mdDecoder.IsStruct(type.Value))
-              //{
-              //  goto default;
-              //}
-              data.AssignValueAndNullnessAtConv_IU(dest, source, true);
-              break;
+                private void LdargEffect(Parameter argument, bool isOld, int dest, Domain data)
+                {
+                    if (isOld)
+                    {
+                        data.CopyValue(data.Address(dest), data.OldValueAddress(argument), mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
+                    }
+                    else
+                    {
+                        data.CopyValue(data.Address(dest), data.Address(argument), mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
+                    }
+                }
 
-            case UnaryOperator.Conv_i:
-              // retain type and nullness
-              data.AssignValueAndNullnessAtConv_IU(dest, source, false);
-              break;
+                public Domain Ldarga(APC pc, Parameter argument, bool isOld, int dest, Domain data)
+                {
+                    // if we do this in the old state, we find the parameter shadow.
+                    LdargaEffect(argument, isOld, dest, data);
+                    if (data.oldDomain != null)
+                    {
+                        LdargaEffect(argument, isOld, dest, data.oldDomain);
+                    }
+                    return data;
+                }
 
-            case UnaryOperator.Not:
-              data.AssignSpecialUnary(dest, data.Constructors.UnaryNot, source, mdDecoder.System_Int32, this.CurrentMethodDeclaringType);
-              break;
+                private void LdargaEffect(Parameter argument, bool isOld, int dest, Domain data)
+                {
+                    var address = isOld ? data.OldValueAddress(argument) : data.Address(argument);
 
-            default:
-              data.AssignPureUnary(dest, op, data.UnaryResultType(op, data.CurrentType(source)), source);
-              break;
-          }
-        }
+                    data.CopyAddress(data.Address(dest), address, mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
+                    data.ManifestWritableBytes(data.Value(dest));
+                }
 
-        public Domain Box(APC pc, Type type, int dest, int source, Domain data)
-        {
-          BoxEffect(type, dest, source, data);
-          if (data.oldDomain != null)
-          {
-            BoxEffect(type, dest, source, data.oldDomain);
-          }
-          return data;
-        }
+                public Domain Ldconst(APC pc, object constant, Type type, int dest, Domain data)
+                {
+                    data.AssignConst(dest, type, constant);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignConst(dest, type, constant);
+                    }
+                    return data;
+                }
 
-        private void BoxEffect(Type type, int dest, int source, Domain data)
-        {
+                public Domain Ldnull(APC pc, int dest, Domain data)
+                {
+                    data.AssignNull(dest);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignNull(dest);
+                    }
+                    return data;
+                }
+
+                public Domain Ldftn(APC pc, Method method, int dest, Domain data)
+                {
+                    data.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
+                    }
+                    return data;
+                }
+
+                /// <summary>
+                /// Note: type here only indicates CLR runtime type, not the actual content type if it is an object type.
+                /// </summary>
+                public Domain Ldind(APC pc, Type type, bool @volatile, int dest, int ptr, Domain data)
+                {
+                    if (data.oldDomain != null)
+                    {
+                        // perform in old state and map to new state
+                        LdindEffect(type, dest, ptr, data.oldDomain);
+                        data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                    }
+                    else
+                    {
+                        LdindEffect(type, dest, ptr, data);
+                    }
+                    return data;
+                }
+
+                private void LdindEffect(Type type, int dest, int ptr, Domain data)
+                {
+                    ESymValue srcPtr = data.Value(ptr);
+                    ESymValue destAddr = data.Address(dest);
+                    if (mdDecoder.Equal(type, mdDecoder.System_Object))
+                    {
+                        // ldind.ref has no type information
+                        data.CopyValue(destAddr, srcPtr, data.GetType(srcPtr).Type);
+                    }
+                    else
+                    {
+                        data.CopyValue(destAddr, srcPtr, mdDecoder.ManagedPointer(type));
+                    }
+                }
+                public Domain Ldobj(APC pc, Type type, bool @volatile, int dest, int ptr, Domain data)
+                {
+                    return data;
+                }
+
+
+
+                public Domain Ldloc(APC pc, Local local, int dest, Domain data)
+                {
+                    LdlocEffect(local, dest, data);
+                    if (data.oldDomain != null)
+                    {
+                        // local variables were likely assigned since the old program point and need to be 
+                        // read from the current state.
+                        data.CopyValueToOldState(data.oldDomain.beginOldPC, mdDecoder.LocalType(local), dest, dest, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void LdlocEffect(Local local, int dest, Domain data)
+                {
+                    data.CopyValue(data.Address(dest), data.Address(local), mdDecoder.ManagedPointer(mdDecoder.LocalType(local)));
+                }
+
+                public Domain Ldloca(APC pc, Local local, int dest, Domain data)
+                {
+                    LdlocaEffect(local, dest, data);
+                    if (data.oldDomain != null)
+                    {
+                        LdlocaEffect(local, dest, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void LdlocaEffect(Local local, int dest, Domain data)
+                {
+                    data.CopyAddress(data.Address(dest), data.Address(local), mdDecoder.ManagedPointer(mdDecoder.LocalType(local)));
+                    data.ManifestWritableBytes(data.Value(dest));
+                }
+
+                public Domain Localloc(APC pc, int dest, int size, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+
+                    ESymValue buffer = data.LocalAlloc(data.Value(size));
+                    data.CopyAddress(data.Address(dest), buffer, mdDecoder.System_UIntPtr);
+
+                    return data;
+                }
+
+                public Domain Nop(APC pc, Domain data)
+                {
+                    return data;
+                }
+
+                public Domain Pop(APC pc, int source, Domain data)
+                {
+                    data.Havoc(source);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.Havoc(source);
+                    }
+                    return data;
+                }
+
+                public Domain Return(APC pc, int source, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+                    data.Havoc(source);
+                    return data;
+                }
+
+                public Domain Starg(APC pc, Parameter argument, int source, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+                    data.CopyValue(data.Address(argument), data.Address(source), mdDecoder.ManagedPointer(mdDecoder.ParameterType(argument)));
+                    data.Havoc(source);
+                    return data;
+                }
+
+                public Domain Stind(APC pc, Type type, bool @volatile, int ptr, int value, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+                    ESymValue valueAddr = data.Address(value);
+                    ESymValue destAddr = data.Value(ptr);
+                    if (mdDecoder.Equal(type, mdDecoder.System_Object))
+                    {
+                        // no info on type ldind.ref
+                        data.CopyValue(destAddr, valueAddr, data.GetType(valueAddr).Type, false, false);
+                    }
+                    else
+                    {
+                        data.CopyValue(destAddr, valueAddr, mdDecoder.ManagedPointer(type), false, false);
+                    }
+                    data.Havoc(ptr);
+                    data.Havoc(value);
+                    return data;
+                }
+
+                public Domain Stloc(APC pc, Local local, int source, Domain data)
+                {
+                    StlocEffect(local, source, data);
+                    if (data.oldDomain != null)
+                    {
+                        StlocEffect(local, source, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void StlocEffect(Local local, int source, Domain data)
+                {
+                    data.CopyValue(data.Address(local), data.Address(source), this.mdDecoder.ManagedPointer(this.mdDecoder.LocalType(local)));
+                    data.Havoc(source);
+                }
+
+                public Domain Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, int value, Domain data)
+                {
+                    throw new NotImplementedException("Should only see assumes");
+                }
+
+                public Domain Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, int dest, int source, Domain data)
+                {
+                    UnaryEffect(op, dest, source, data);
+                    if (data.oldDomain != null)
+                    {
+                        UnaryEffect(op, dest, source, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void UnaryEffect(UnaryOperator op, int dest, int source, Domain data)
+                {
+                    switch (op)
+                    {
+                        case UnaryOperator.WritableBytes:
+                            data.AssignWritableBytes(data.Address(dest), data.Value(source));
+                            break;
+
+                        case UnaryOperator.Conv_u:
+                            // retain type and nullness
+                            //var type = data.GetType(data.Value(source));
+                            //if (type.IsNormal && parent.mdDecoder.IsStruct(type.Value))
+                            //{
+                            //  goto default;
+                            //}
+                            data.AssignValueAndNullnessAtConv_IU(dest, source, true);
+                            break;
+
+                        case UnaryOperator.Conv_i:
+                            // retain type and nullness
+                            data.AssignValueAndNullnessAtConv_IU(dest, source, false);
+                            break;
+
+                        case UnaryOperator.Not:
+                            data.AssignSpecialUnary(dest, data.Constructors.UnaryNot, source, mdDecoder.System_Int32, this.CurrentMethodDeclaringType);
+                            break;
+
+                        default:
+                            data.AssignPureUnary(dest, op, data.UnaryResultType(op, data.CurrentType(source)), source);
+                            break;
+                    }
+                }
+
+                public Domain Box(APC pc, Type type, int dest, int source, Domain data)
+                {
+                    BoxEffect(type, dest, source, data);
+                    if (data.oldDomain != null)
+                    {
+                        BoxEffect(type, dest, source, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void BoxEffect(Type type, int dest, int source, Domain data)
+                {
 #if false
-          if (this.mdDecoder.IsStruct(type))
-          {
-            // definitely a struct
-            data.AssignValue(dest, mdDecoder.System_Object);
-          }
-          else
+                    if (this.mdDecoder.IsStruct(type))
+                    {
+                        // definitely a struct
+                        data.AssignValue(dest, mdDecoder.System_Object);
+                    }
+                    else
 #endif
-          if (this.mdDecoder.IsReferenceConstrained(type))
-          {
-            // definitely a reference type
-            data.Copy(dest, source); // noop
-          }
-          else
-          {
-            var sourceAddress = data.Address(source);
-            var objecttype = mdDecoder.System_Object;
-            var specialBoxValue = data.GetSpecialUnary(data.Constructors.BoxOperator, source, objecttype);
-            data.SetValue(specialBoxValue, sourceAddress, mdDecoder.ManagedPointer(type), false);
-            data.AssignSpecialUnary(dest, specialBoxValue, objecttype, this.CurrentMethodDeclaringType);
-          }
-        }
-
-        public Domain ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, int dest, ArgList args, Domain data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<int>
-        {
-          if (data.oldDomain != null)
-          {
-            // perform call in old state and map result back
-            data.oldDomain = CallFactored<TypeList, ArgList>(pc, method, tail, true, extraVarargs, dest, args, data.oldDomain, constraint, true);
-            if (!mdDecoder.IsVoidMethod(method))
-            {
-              data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
-            }
-            return data;
-          }
-          else
-          {
-            return CallFactored<TypeList, ArgList>(pc, method, tail, true, extraVarargs, dest, args, data, constraint, true);
-          }
-        }
-
-        public Domain Castclass(APC pc, Type type, int dest, int obj, Domain data)
-        {
-          CastclassEffect(type, dest, obj, data);
-          if (data.oldDomain != null)
-          {
-            CastclassEffect(type, dest, obj, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void CastclassEffect(Type type, int dest, int obj, Domain data)
-        {
-          ESymValue destaddr = data.Address(dest);
-          Type targetAddrType = mdDecoder.ManagedPointer(type);
-          data.CopyValueAndCast(destaddr, data.Address(obj), targetAddrType);
-        }
-
-        public Domain Cpobj(APC pc, Type type, int destptr, int srcptr, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-          data.CopyValue(data.Value(destptr), data.Value(srcptr), mdDecoder.ManagedPointer(type));
-          data.Havoc(destptr);
-          data.Havoc(srcptr);
-          return data;
-        }
-
-        public Domain Initobj(APC pc, Type type, int ptr, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-          // sets all fields of the given struct to null or
-          // if generic and of reference type, the entire thing to null
-          ESymValue destaddr = data.Value(ptr);
-          data.InitObj(destaddr, type);
-          data.Havoc(ptr);
-          return data;
-        }
-
-        public Domain Isinst(APC pc, Type type, int dest, int obj, Domain data)
-        {
-          IsInstEffect(type, dest, obj, data);
-          if (data.oldDomain != null)
-          {
-            IsInstEffect(type, dest, obj, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void IsInstEffect(Type type, int dest, int source, Domain data)
-        {
-          if (mdDecoder.IsStruct(type))
-          {
-            data.AssignValue(dest, mdDecoder.System_Object, this.CurrentMethodDeclaringType);
-          }
-          else
-          {
-            var value = data.Value(source);
-            var stype = data.GetType(value);
-            if (stype.IsNormal)
-            {
-              if (this.mdDecoder.DerivesFromIgnoringTypeArguments(stype.Value, type))
-              {
-                // will succeed
-                data.Copy(dest, source);
-                return;
-              }
-            }
-            data.AssignIsInst(type, source, dest, this.CurrentMethodDeclaringType);
-          }
-        }
-
-        public Domain Ldelem(APC pc, Type type, int dest, int array, int index, Domain data)
-        {
-          Contract.Assume(index > array, "needed by LdelemEffect below");
-
-          if (data.oldDomain != null)
-          {
-            LdelemEffect(type, dest, array, index, data.oldDomain);
-            data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
-          }
-          else
-          {
-            LdelemEffect(type, dest, array, index, data);
-          }
-          return data;
-        }
-
-        private void LdelemEffect(Type type, int dest, int array, int index, Domain data)
-        {
-          Contract.Requires(index > array);// F: Added from Clousot precondition suggestion
-
-          Type elementType = data.GetArrayElementType(type, array);
-          Type elementAddrType = mdDecoder.ManagedPointer(elementType);
-          data.CopyValue(data.Address(dest), data.ElementAddress(data.Value(array), data.Value(index), elementAddrType), elementAddrType);
-          System.Diagnostics.Debug.Assert(index > array);
-          data.Havoc(index);
-        }
-
-
-        public Domain Ldelema(APC pc, Type type, bool @readonly, int dest, int array, int index, Domain data)
-        {
-          Contract.Assume(index > array, "needed by LdelemaEffect below");
-
-          LdelemaEffect(type, dest, array, index, data);
-          if (data.oldDomain != null)
-          {
-            LdelemaEffect(type, dest, array, index, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void LdelemaEffect(Type type, int dest, int array, int index, Domain data)
-        {
-          Contract.Requires(index > array);
-
-          Type elementAddrType = mdDecoder.ManagedPointer(type);
-          data.CopyAddress(data.Address(dest), data.ElementAddress(data.Value(array), data.Value(index), elementAddrType), elementAddrType);
-          data.ManifestWritableBytes(data.Value(dest));
-          System.Diagnostics.Debug.Assert(index > array);
-          data.Havoc(index);
-        }
-
-        public Domain Ldfld(APC pc, Field field, bool @volatile, int dest, int obj, Domain data)
-        {
-          if (data.oldDomain != null)
-          {
-            // perform on old state and copy back
-            LdfldEffect(field, dest, obj, data.oldDomain);
-            data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
-          }
-          else
-          {
-            LdfldEffect(field, dest, obj, data);
-          }
-          return data;
-        }
-
-        /// <summary>
-        /// There are 2 cases to handle here.
-        /// 1) the common case is that there is a pointer on the stack (to an object or a struct)
-        /// 2) the uncommon case, when there is an actual struct value on the stack.
-        /// </summary>
-        private void LdfldEffect(Field field, int dest, int obj, Domain data)
-        {
-          Type declaringType = mdDecoder.DeclaringType(field);
-          ESymValue source;
-          if (mdDecoder.IsStruct(declaringType))
-          {
-            // inspect the stack type
-            AbstractType objType = data.GetType(data.Address(obj));
-            if (objType.IsNormal && mdDecoder.IsManagedPointer(objType.Value) && mdDecoder.IsStruct(mdDecoder.ElementType(objType.Value)))
-            {
-              // use address of stack instead for struct
-              source = data.Address(obj);
-            }
-            else
-            {
-              source = data.Value(obj);
-            }
-          }
-          else
-          {
-            source = data.Value(obj);
-          }
-          Type fieldAddressType;
-          ESymValue fieldAddr = data.FieldAddress(source, field, out fieldAddressType);
-          data.CopyValue(data.Address(dest), fieldAddr, fieldAddressType);
-        }
-
-        public Domain Ldflda(APC pc, Field field, int dest, int obj, Domain data)
-        {
-          LdfldaEffect(pc, field, dest, obj, data);
-          if (data.oldDomain != null)
-          {
-            LdfldaEffect(pc, field, dest, obj, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void LdfldaEffect(APC pc, Field field, int dest, int obj, Domain data)
-        {
-          var objectValue = data.Value(obj);
-          Type fieldAddressType;
-          ESymValue fieldAddr = data.FieldAddress(objectValue, field, out fieldAddressType);
-          data.CopyAddress(data.Address(dest), fieldAddr, fieldAddressType);
-          // invalidate properties that may depend on "field" unless we are in a contract
-          if (!pc.InsideContract)
-          {
-            if (this.mdDecoder.Equal(this.mdDecoder.DeclaringType(this.parent.currentMethod),
-                                     this.mdDecoder.Unspecialized(this.mdDecoder.DeclaringType(field))))
-            {
-              data.HavocPseudoFields(this.parent.context.MethodContext.AffectedGetters(field), objectValue);
-              // data.HavocUp(objectValue);
-            }
-          }
-          data.ManifestWritableBytes(data.Value(dest));
-        }
-
-        public Domain Ldlen(APC pc, int dest, int array, Domain data)
-        {
-          LdlenEffect(dest, array, data);
-          if (data.oldDomain != null)
-          {
-            LdlenEffect(dest, array, data.oldDomain);
-          }
-          return data;
-        }
-
-        private static void LdlenEffect(int dest, int array, Domain data)
-        {
-          data.AssignArrayLength(data.Address(dest), data.Value(array));
-        }
-
-        public Domain Ldsfld(APC pc, Field field, bool @volatile, int dest, Domain data)
-        {
-          if (data.oldDomain != null)
-          {
-            // perform on old state and copy back
-            LdsfldEffect(field, dest, data.oldDomain);
-            data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
-          }
-          else
-          {
-            LdsfldEffect(field, dest, data);
-          }
-          return data;
-        }
-
-        private void LdsfldEffect(Field field, int dest, Domain data)
-        {
-          ESymValue fieldAddr = data.TryGetFieldAddress(data.Globals, field);
-
-          // handle the static anonymous delegate caches as follows:
-          //  - the lazy initialization causes us trouble if we merge the init/uninit branches
-          //  - so we try to detect when we don't know the closure being loaded and in that case set the result to null
-          //  - this will analyze the uninit branch and ignore the init branch at the merge (because OptHeap understands null)
-          if (ReInitCachedDelegate(fieldAddr, field, data) || ReInitDynamicCallSite(fieldAddr, field, data))
-          {
-            // make sure to take the initializing path
-            data.AssignNull(dest);
-            return;
-          }
-
-          Type fieldAddrType;
-          fieldAddr = data.FieldAddress(data.Globals, field, out fieldAddrType);
-          data.CopyValue(data.Address(dest), fieldAddr, fieldAddrType);
-        }
-
-        private bool ReInitDynamicCallSite(ESymValue fieldAddr, Field field, Domain data)
-        {
-          var declType = mdDecoder.DeclaringType(field);
-          declType = mdDecoder.Unspecialized(declType);
-          if (!this.mdDecoder.IsCompilerGenerated(declType)) return false;
-          if (!this.mdDecoder.Name(field).Contains("__Site")) return false;
-          if (fieldAddr == null)
-          {
-            // first time we see it          
-            return true;
-          }
-          var val = data.TryValue(fieldAddr);
-          if (val == null) return true;
-          var typ = data.GetType(val);
-          if (!typ.IsNormal) return true;
-          var callsite = mdDecoder.Unspecialized(typ.Value);
-          if (!mdDecoder.Name(callsite).StartsWith("CallSite")) return true;
-          return false;
-        }
-
-        private bool IsCachedDelegate(Field field)
-        {
-          Contract.Requires(field != null);
-
-          // old-style cached delegates
-          if (mdDecoder.IsCompilerGenerated(field) &&
-              mdDecoder.Name(field).Contains("__CachedAnonymousMethodDelegate"))
-          {
-            return true;
-          }
-
-          // Roslyn-style cached delegates
-          var declType = mdDecoder.DeclaringType(field);
-          if (mdDecoder.IsCompilerGenerated(declType) &&
-              mdDecoder.Name(declType) == "<>c" &&
-              mdDecoder.Name(field).StartsWith("<>9__"))
-          {
-            return true;
-          }
-
-          return false;
-        }
-
-        private bool ReInitCachedDelegate(ESymValue fieldAddr, Field field, Domain data)
-        {
-          if (!IsCachedDelegate(field))
-            return false;
-
-          if (fieldAddr == null)
-          {
-            // first time we see it
-            return true;
-          }
-          var val = data.TryValue(fieldAddr);
-          if (val == null) return true;
-          ESymValue targetObject;
-          Method targetMethod;
-          if (!data.IsDelegateValue(val, out targetObject, out targetMethod)) return true;
-
-          return false;
-        }
-
-        public Domain Ldsflda(APC pc, Field field, int dest, Domain data)
-        {
-          LdsfldaEffect(field, dest, data);
-          if (data.oldDomain != null)
-          {
-            LdsfldaEffect(field, dest, data.oldDomain);
-          }
-          return data;
-        }
-
-        private static void LdsfldaEffect(Field field, int dest, Domain data)
-        {
-          Type fieldAddrType;
-          ESymValue fieldAddr = data.FieldAddress(data.Globals, field, out fieldAddrType);
-
-          data.CopyAddress(data.Address(dest), fieldAddr, fieldAddrType);
-          data.ManifestWritableBytes(data.Value(dest));
-        }
-
-        public Domain Ldtypetoken(APC pc, Type type, int dest, Domain data)
-        {
-          data.AssignTokenValue(dest, mdDecoder.System_RuntimeTypeHandle, type);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignTokenValue(dest, mdDecoder.System_RuntimeTypeHandle, type);
-          }
-          return data;
-        }
-
-        public Domain Ldfieldtoken(APC pc, Field field, int dest, Domain data)
-        {
-          data.AssignTokenValue(dest, mdDecoder.System_RuntimeFieldHandle, field);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignTokenValue(dest, mdDecoder.System_RuntimeFieldHandle, field);
-          }
-          return data;
-        }
-
-        public Domain Ldmethodtoken(APC pc, Method method, int dest, Domain data)
-        {
-          data.AssignTokenValue(dest, mdDecoder.System_RuntimeMethodHandle, method);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignTokenValue(dest, mdDecoder.System_RuntimeMethodHandle, method);
-          }
-          return data;
-        }
-
-        public Domain Ldvirtftn(APC pc, Method method, int dest, int obj, Domain data)
-        {
-          data.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
-          }
-          return data;
-        }
-
-        public Domain Mkrefany(APC pc, Type type, int dest, int obj, Domain data)
-        {
-          data.AssignValue(dest, mdDecoder.System_DynamicallyTypedReference, this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignValue(dest, mdDecoder.System_DynamicallyTypedReference, this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-
-        public Domain Newarray<ArgList>(APC pc, Type type, int dest, ArgList lengths, Domain data)
-          where ArgList : IIndexable<int>
-        {
-          NewarrayEffect<ArgList>(type, dest, lengths, data);
-          if (data.oldDomain != null)
-          {
-            NewarrayEffect<ArgList>(type, dest, lengths, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void NewarrayEffect<ArgList>(Type type, int dest, ArgList lengths, Domain data) where ArgList : IIndexable<int>
-        {
-          if (lengths.Count == 1)
-          {
-            ESymValue array = data.CreateArray(type, data.Value(lengths[0]));
-            data.CopyAddress(data.Address(dest), array, mdDecoder.ArrayType(type, 1));
-          }
-          else
-          {
-            data.AssignValue(dest, type, this.CurrentMethodDeclaringType);
-          }
-        }
-
-        public Domain Newobj<ArgList>(APC pc, Method ctor, int dest, ArgList args, Domain data)
-          where ArgList : IIndexable<int>
-        {
-          NewobjEffect<ArgList>(pc, ctor, dest, args, data);
-          if (data.oldDomain != null)
-          {
-            NewobjEffect<ArgList>(pc, ctor, dest, args, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void NewobjEffect<ArgList>(APC pc, Method ctor, int dest, ArgList args, Domain data) where ArgList : IIndexable<int>
-        {
-          var savedClosure = args.Count >= 2 ? data.TryValue(data.Address(args[0])) : null;
-          var savedFnPtr = args.Count >= 2 ? data.TryValue(data.Address(args[1])) : null;
-
-          Type declaringType = mdDecoder.DeclaringType(ctor);
-          if (mdDecoder.IsStruct(declaringType))
-          {
-            ESymValue addr = data.CreateValue(declaringType);
-            data.MaterializeNewObjAccordingToType(addr, mdDecoder.ManagedPointer(declaringType), 0, this.CurrentMethodDeclaringType);
-
-            this.HavocParameters(pc, ctor, EmptyIndexable<Type>.Empty, args, data, declaringType, false, true, false);
-
-            data.CopyValue(data.Address(dest), addr, mdDecoder.ManagedPointer(declaringType));
-          }
-          else
-          {
-            ESymValue obj = data.CreateObject(declaringType);
-            data.MaterializeNewObjAccordingToType(obj, declaringType, 0, this.CurrentMethodDeclaringType);
-            if (mdDecoder.IsDelegate(declaringType) && savedFnPtr != null)
-            {
-              data.SetDelegateDetails(obj, savedClosure, savedFnPtr);
-            }
-            this.HavocParameters(pc, ctor, EmptyIndexable<Type>.Empty, args, data, declaringType, false, true, false);
-
-            data.CopyAddress(data.Address(dest), obj, declaringType);
-          }
-        }
-
-        public Domain Refanytype(APC pc, int dest, int source, Domain data)
-        {
-          data.AssignValue(dest, mdDecoder.System_Type, this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignValue(dest, mdDecoder.System_Type, this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-
-        public Domain Refanyval(APC pc, Type type, int dest, int source, Domain data)
-        {
-          data.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-
-        public Domain Rethrow(APC pc, Domain data)
-        {
-          return data.Bottom;
-        }
-
-        public Domain Sizeof(APC pc, Type type, int dest, Domain data)
-        {
-          data.AssignValue(dest, mdDecoder.System_Int32, this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignValue(dest, mdDecoder.System_Int32, this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-
-        public Domain Stelem(APC pc, Type type, int array, int index, int value, Domain data)
-        {
-          // can happen in old state due to params calls
-          StelemEffect(type, array, index, value, data);
-          if (data.oldDomain != null)
-          {
-            StelemEffect(type, array, index, value, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void StelemEffect(Type type, int array, int index, int value, Domain data)
-        {
-          Type elementAddrType = mdDecoder.ManagedPointer(type);
-          var arrayValue = data.Value(array);
-          var indexValue = data.Value(index);
-          data.HavocArrayAtIndex(arrayValue, indexValue);
-          data.CopyValue(data.ElementAddress(arrayValue, indexValue, elementAddrType), data.Address(value), elementAddrType);
-          data.Havoc(array);
-          data.Havoc(index);
-          data.Havoc(value);
-        }
-
-        public Domain Stfld(APC pc, Field field, bool @volatile, int obj, int value, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-
-          data.CopyValue(data.FieldAddress(data.Value(obj), field), data.Address(value));
-          // invalidate properties that may depend on "field"
-          if (!mdDecoder.IsCompilerGenerated(field))
-          {
-            data.HavocPseudoFields(data.Value(obj));
-          }
-          data.Havoc(obj);
-          data.Havoc(value);
-          return data;
-        }
-
-        public Domain Stsfld(APC pc, Field field, bool @volatile, int value, Domain data)
-        {
-          Contract.Assume(data.insideOld == 0);
-
-          data.CopyValue(data.FieldAddress(data.Globals, field), data.Address(value));
-          data.Havoc(value);
-          return data;
-        }
-
-        public Domain Throw(APC pc, int exn, Domain data)
-        {
-          data.Havoc(exn);
-          return data.Bottom;
-        }
-
-        public Domain Unbox(APC pc, Type type, int dest, int obj, Domain data)
-        {
-          data.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-
-        public Domain Unboxany(APC pc, Type type, int dest, int obj, Domain data)
-        {
-          if (this.mdDecoder.IsReferenceConstrained(type))
-          {
-            // acts like a cast
-            return Castclass(pc, type, dest, obj, data);
-          }
-          data.AssignValue(dest, type, this.CurrentMethodDeclaringType);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain.AssignValue(dest, type, this.CurrentMethodDeclaringType);
-          }
-          return data;
-        }
-
-        #endregion
-
-        #region IVisitSynthIL<int,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>> Members
-
-        private Domain AssertEffect(APC pc, string tag, int source, Domain data)
-        {
-          data = data.Assume(source, true);
-          if (!data.IsBottom)
-          {
-            data.Havoc(source);
-          }
-          return data;
-        }
-        public Domain Assert(APC pc, string tag, int source, object provenance, Domain data)
-        {
-          data = AssertEffect(pc, tag, source, data);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain = AssertEffect(pc, tag, source, data.oldDomain);
-          }
-          return data;
-        }
-
-        private static Domain AssumeEffect(APC pc, string tag, int source, Domain data)
-        {
-          if (tag == "false")
-          {
-            data = data.Assume(source, false);
-          }
-          else
-          {
-            data = data.Assume(source, true);
-          }
-          if (!data.IsBottom)
-          {
-            data.Havoc(source);
-          }
-          return data;
-        }
-
-        public Domain Assume(APC pc, string tag, int source, object provenance, Domain data)
-        {
-          if (this.parent.IgnoreExplicitAssumptions && tag == "assume")
-          {
-            return data;
-          }
-          data = AssumeEffect(pc, tag, source, data);
-          if (data.oldDomain != null)
-          {
-            data.oldDomain = AssumeEffect(pc, tag, source, data.oldDomain);
-          }
-          return data;
-        }
-
-        private void MaterializeLocal(Local l, Domain data, Method method)
-        {
-          var t = mdDecoder.LocalType(l);
-          data.AssignZeroEquivalent(data.Address(l), t);
-
-          // Added by Francesco: Materialize up to one depth
+                    if (this.mdDecoder.IsReferenceConstrained(type))
+                    {
+                        // definitely a reference type
+                        data.Copy(dest, source); // noop
+                    }
+                    else
+                    {
+                        var sourceAddress = data.Address(source);
+                        var objecttype = mdDecoder.System_Object;
+                        var specialBoxValue = data.GetSpecialUnary(data.Constructors.BoxOperator, source, objecttype);
+                        data.SetValue(specialBoxValue, sourceAddress, mdDecoder.ManagedPointer(type), false);
+                        data.AssignSpecialUnary(dest, specialBoxValue, objecttype, this.CurrentMethodDeclaringType);
+                    }
+                }
+
+                public Domain ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, int dest, ArgList args, Domain data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<int>
+                {
+                    if (data.oldDomain != null)
+                    {
+                        // perform call in old state and map result back
+                        data.oldDomain = CallFactored<TypeList, ArgList>(pc, method, tail, true, extraVarargs, dest, args, data.oldDomain, constraint, true);
+                        if (!mdDecoder.IsVoidMethod(method))
+                        {
+                            data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                        }
+                        return data;
+                    }
+                    else
+                    {
+                        return CallFactored<TypeList, ArgList>(pc, method, tail, true, extraVarargs, dest, args, data, constraint, true);
+                    }
+                }
+
+                public Domain Castclass(APC pc, Type type, int dest, int obj, Domain data)
+                {
+                    CastclassEffect(type, dest, obj, data);
+                    if (data.oldDomain != null)
+                    {
+                        CastclassEffect(type, dest, obj, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void CastclassEffect(Type type, int dest, int obj, Domain data)
+                {
+                    ESymValue destaddr = data.Address(dest);
+                    Type targetAddrType = mdDecoder.ManagedPointer(type);
+                    data.CopyValueAndCast(destaddr, data.Address(obj), targetAddrType);
+                }
+
+                public Domain Cpobj(APC pc, Type type, int destptr, int srcptr, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+                    data.CopyValue(data.Value(destptr), data.Value(srcptr), mdDecoder.ManagedPointer(type));
+                    data.Havoc(destptr);
+                    data.Havoc(srcptr);
+                    return data;
+                }
+
+                public Domain Initobj(APC pc, Type type, int ptr, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+                    // sets all fields of the given struct to null or
+                    // if generic and of reference type, the entire thing to null
+                    ESymValue destaddr = data.Value(ptr);
+                    data.InitObj(destaddr, type);
+                    data.Havoc(ptr);
+                    return data;
+                }
+
+                public Domain Isinst(APC pc, Type type, int dest, int obj, Domain data)
+                {
+                    IsInstEffect(type, dest, obj, data);
+                    if (data.oldDomain != null)
+                    {
+                        IsInstEffect(type, dest, obj, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void IsInstEffect(Type type, int dest, int source, Domain data)
+                {
+                    if (mdDecoder.IsStruct(type))
+                    {
+                        data.AssignValue(dest, mdDecoder.System_Object, this.CurrentMethodDeclaringType);
+                    }
+                    else
+                    {
+                        var value = data.Value(source);
+                        var stype = data.GetType(value);
+                        if (stype.IsNormal)
+                        {
+                            if (this.mdDecoder.DerivesFromIgnoringTypeArguments(stype.Value, type))
+                            {
+                                // will succeed
+                                data.Copy(dest, source);
+                                return;
+                            }
+                        }
+                        data.AssignIsInst(type, source, dest, this.CurrentMethodDeclaringType);
+                    }
+                }
+
+                public Domain Ldelem(APC pc, Type type, int dest, int array, int index, Domain data)
+                {
+                    Contract.Assume(index > array, "needed by LdelemEffect below");
+
+                    if (data.oldDomain != null)
+                    {
+                        LdelemEffect(type, dest, array, index, data.oldDomain);
+                        data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                    }
+                    else
+                    {
+                        LdelemEffect(type, dest, array, index, data);
+                    }
+                    return data;
+                }
+
+                private void LdelemEffect(Type type, int dest, int array, int index, Domain data)
+                {
+                    Contract.Requires(index > array);// F: Added from Clousot precondition suggestion
+
+                    Type elementType = data.GetArrayElementType(type, array);
+                    Type elementAddrType = mdDecoder.ManagedPointer(elementType);
+                    data.CopyValue(data.Address(dest), data.ElementAddress(data.Value(array), data.Value(index), elementAddrType), elementAddrType);
+                    System.Diagnostics.Debug.Assert(index > array);
+                    data.Havoc(index);
+                }
+
+
+                public Domain Ldelema(APC pc, Type type, bool @readonly, int dest, int array, int index, Domain data)
+                {
+                    Contract.Assume(index > array, "needed by LdelemaEffect below");
+
+                    LdelemaEffect(type, dest, array, index, data);
+                    if (data.oldDomain != null)
+                    {
+                        LdelemaEffect(type, dest, array, index, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void LdelemaEffect(Type type, int dest, int array, int index, Domain data)
+                {
+                    Contract.Requires(index > array);
+
+                    Type elementAddrType = mdDecoder.ManagedPointer(type);
+                    data.CopyAddress(data.Address(dest), data.ElementAddress(data.Value(array), data.Value(index), elementAddrType), elementAddrType);
+                    data.ManifestWritableBytes(data.Value(dest));
+                    System.Diagnostics.Debug.Assert(index > array);
+                    data.Havoc(index);
+                }
+
+                public Domain Ldfld(APC pc, Field field, bool @volatile, int dest, int obj, Domain data)
+                {
+                    if (data.oldDomain != null)
+                    {
+                        // perform on old state and copy back
+                        LdfldEffect(field, dest, obj, data.oldDomain);
+                        data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                    }
+                    else
+                    {
+                        LdfldEffect(field, dest, obj, data);
+                    }
+                    return data;
+                }
+
+                /// <summary>
+                /// There are 2 cases to handle here.
+                /// 1) the common case is that there is a pointer on the stack (to an object or a struct)
+                /// 2) the uncommon case, when there is an actual struct value on the stack.
+                /// </summary>
+                private void LdfldEffect(Field field, int dest, int obj, Domain data)
+                {
+                    Type declaringType = mdDecoder.DeclaringType(field);
+                    ESymValue source;
+                    if (mdDecoder.IsStruct(declaringType))
+                    {
+                        // inspect the stack type
+                        AbstractType objType = data.GetType(data.Address(obj));
+                        if (objType.IsNormal && mdDecoder.IsManagedPointer(objType.Value) && mdDecoder.IsStruct(mdDecoder.ElementType(objType.Value)))
+                        {
+                            // use address of stack instead for struct
+                            source = data.Address(obj);
+                        }
+                        else
+                        {
+                            source = data.Value(obj);
+                        }
+                    }
+                    else
+                    {
+                        source = data.Value(obj);
+                    }
+                    Type fieldAddressType;
+                    ESymValue fieldAddr = data.FieldAddress(source, field, out fieldAddressType);
+                    data.CopyValue(data.Address(dest), fieldAddr, fieldAddressType);
+                }
+
+                public Domain Ldflda(APC pc, Field field, int dest, int obj, Domain data)
+                {
+                    LdfldaEffect(pc, field, dest, obj, data);
+                    if (data.oldDomain != null)
+                    {
+                        LdfldaEffect(pc, field, dest, obj, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void LdfldaEffect(APC pc, Field field, int dest, int obj, Domain data)
+                {
+                    var objectValue = data.Value(obj);
+                    Type fieldAddressType;
+                    ESymValue fieldAddr = data.FieldAddress(objectValue, field, out fieldAddressType);
+                    data.CopyAddress(data.Address(dest), fieldAddr, fieldAddressType);
+                    // invalidate properties that may depend on "field" unless we are in a contract
+                    if (!pc.InsideContract)
+                    {
+                        if (this.mdDecoder.Equal(this.mdDecoder.DeclaringType(parent.currentMethod),
+                                                 this.mdDecoder.Unspecialized(this.mdDecoder.DeclaringType(field))))
+                        {
+                            data.HavocPseudoFields(parent.context.MethodContext.AffectedGetters(field), objectValue);
+                            // data.HavocUp(objectValue);
+                        }
+                    }
+                    data.ManifestWritableBytes(data.Value(dest));
+                }
+
+                public Domain Ldlen(APC pc, int dest, int array, Domain data)
+                {
+                    LdlenEffect(dest, array, data);
+                    if (data.oldDomain != null)
+                    {
+                        LdlenEffect(dest, array, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private static void LdlenEffect(int dest, int array, Domain data)
+                {
+                    data.AssignArrayLength(data.Address(dest), data.Value(array));
+                }
+
+                public Domain Ldsfld(APC pc, Field field, bool @volatile, int dest, Domain data)
+                {
+                    if (data.oldDomain != null)
+                    {
+                        // perform on old state and copy back
+                        LdsfldEffect(field, dest, data.oldDomain);
+                        data.oldDomain.CopyOldValue(data.oldDomain.beginOldPC, dest, dest, data, true);
+                    }
+                    else
+                    {
+                        LdsfldEffect(field, dest, data);
+                    }
+                    return data;
+                }
+
+                private void LdsfldEffect(Field field, int dest, Domain data)
+                {
+                    ESymValue fieldAddr = data.TryGetFieldAddress(data.Globals, field);
+
+                    // handle the static anonymous delegate caches as follows:
+                    //  - the lazy initialization causes us trouble if we merge the init/uninit branches
+                    //  - so we try to detect when we don't know the closure being loaded and in that case set the result to null
+                    //  - this will analyze the uninit branch and ignore the init branch at the merge (because OptHeap understands null)
+                    if (ReInitCachedDelegate(fieldAddr, field, data) || ReInitDynamicCallSite(fieldAddr, field, data))
+                    {
+                        // make sure to take the initializing path
+                        data.AssignNull(dest);
+                        return;
+                    }
+
+                    Type fieldAddrType;
+                    fieldAddr = data.FieldAddress(data.Globals, field, out fieldAddrType);
+                    data.CopyValue(data.Address(dest), fieldAddr, fieldAddrType);
+                }
+
+                private bool ReInitDynamicCallSite(ESymValue fieldAddr, Field field, Domain data)
+                {
+                    var declType = mdDecoder.DeclaringType(field);
+                    declType = mdDecoder.Unspecialized(declType);
+                    if (!this.mdDecoder.IsCompilerGenerated(declType)) return false;
+                    if (!this.mdDecoder.Name(field).Contains("__Site")) return false;
+                    if (fieldAddr == null)
+                    {
+                        // first time we see it          
+                        return true;
+                    }
+                    var val = data.TryValue(fieldAddr);
+                    if (val == null) return true;
+                    var typ = data.GetType(val);
+                    if (!typ.IsNormal) return true;
+                    var callsite = mdDecoder.Unspecialized(typ.Value);
+                    if (!mdDecoder.Name(callsite).StartsWith("CallSite")) return true;
+                    return false;
+                }
+
+                private bool IsCachedDelegate(Field field)
+                {
+                    Contract.Requires(field != null);
+
+                    // old-style cached delegates
+                    if (mdDecoder.IsCompilerGenerated(field) &&
+                        mdDecoder.Name(field).Contains("__CachedAnonymousMethodDelegate"))
+                    {
+                        return true;
+                    }
+
+                    // Roslyn-style cached delegates
+                    var declType = mdDecoder.DeclaringType(field);
+                    if (mdDecoder.IsCompilerGenerated(declType) &&
+                        mdDecoder.Name(declType) == "<>c" &&
+                        mdDecoder.Name(field).StartsWith("<>9__"))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                private bool ReInitCachedDelegate(ESymValue fieldAddr, Field field, Domain data)
+                {
+                    if (!IsCachedDelegate(field))
+                        return false;
+
+                    if (fieldAddr == null)
+                    {
+                        // first time we see it
+                        return true;
+                    }
+                    var val = data.TryValue(fieldAddr);
+                    if (val == null) return true;
+                    ESymValue targetObject;
+                    Method targetMethod;
+                    if (!data.IsDelegateValue(val, out targetObject, out targetMethod)) return true;
+
+                    return false;
+                }
+
+                public Domain Ldsflda(APC pc, Field field, int dest, Domain data)
+                {
+                    LdsfldaEffect(field, dest, data);
+                    if (data.oldDomain != null)
+                    {
+                        LdsfldaEffect(field, dest, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private static void LdsfldaEffect(Field field, int dest, Domain data)
+                {
+                    Type fieldAddrType;
+                    ESymValue fieldAddr = data.FieldAddress(data.Globals, field, out fieldAddrType);
+
+                    data.CopyAddress(data.Address(dest), fieldAddr, fieldAddrType);
+                    data.ManifestWritableBytes(data.Value(dest));
+                }
+
+                public Domain Ldtypetoken(APC pc, Type type, int dest, Domain data)
+                {
+                    data.AssignTokenValue(dest, mdDecoder.System_RuntimeTypeHandle, type);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignTokenValue(dest, mdDecoder.System_RuntimeTypeHandle, type);
+                    }
+                    return data;
+                }
+
+                public Domain Ldfieldtoken(APC pc, Field field, int dest, Domain data)
+                {
+                    data.AssignTokenValue(dest, mdDecoder.System_RuntimeFieldHandle, field);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignTokenValue(dest, mdDecoder.System_RuntimeFieldHandle, field);
+                    }
+                    return data;
+                }
+
+                public Domain Ldmethodtoken(APC pc, Method method, int dest, Domain data)
+                {
+                    data.AssignTokenValue(dest, mdDecoder.System_RuntimeMethodHandle, method);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignTokenValue(dest, mdDecoder.System_RuntimeMethodHandle, method);
+                    }
+                    return data;
+                }
+
+                public Domain Ldvirtftn(APC pc, Method method, int dest, int obj, Domain data)
+                {
+                    data.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignMethodPointer(dest, mdDecoder.System_UIntPtr, method);
+                    }
+                    return data;
+                }
+
+                public Domain Mkrefany(APC pc, Type type, int dest, int obj, Domain data)
+                {
+                    data.AssignValue(dest, mdDecoder.System_DynamicallyTypedReference, this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignValue(dest, mdDecoder.System_DynamicallyTypedReference, this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+
+                public Domain Newarray<ArgList>(APC pc, Type type, int dest, ArgList lengths, Domain data)
+                  where ArgList : IIndexable<int>
+                {
+                    NewarrayEffect<ArgList>(type, dest, lengths, data);
+                    if (data.oldDomain != null)
+                    {
+                        NewarrayEffect<ArgList>(type, dest, lengths, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void NewarrayEffect<ArgList>(Type type, int dest, ArgList lengths, Domain data) where ArgList : IIndexable<int>
+                {
+                    if (lengths.Count == 1)
+                    {
+                        ESymValue array = data.CreateArray(type, data.Value(lengths[0]));
+                        data.CopyAddress(data.Address(dest), array, mdDecoder.ArrayType(type, 1));
+                    }
+                    else
+                    {
+                        data.AssignValue(dest, type, this.CurrentMethodDeclaringType);
+                    }
+                }
+
+                public Domain Newobj<ArgList>(APC pc, Method ctor, int dest, ArgList args, Domain data)
+                  where ArgList : IIndexable<int>
+                {
+                    NewobjEffect<ArgList>(pc, ctor, dest, args, data);
+                    if (data.oldDomain != null)
+                    {
+                        NewobjEffect<ArgList>(pc, ctor, dest, args, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void NewobjEffect<ArgList>(APC pc, Method ctor, int dest, ArgList args, Domain data) where ArgList : IIndexable<int>
+                {
+                    var savedClosure = args.Count >= 2 ? data.TryValue(data.Address(args[0])) : null;
+                    var savedFnPtr = args.Count >= 2 ? data.TryValue(data.Address(args[1])) : null;
+
+                    Type declaringType = mdDecoder.DeclaringType(ctor);
+                    if (mdDecoder.IsStruct(declaringType))
+                    {
+                        ESymValue addr = data.CreateValue(declaringType);
+                        data.MaterializeNewObjAccordingToType(addr, mdDecoder.ManagedPointer(declaringType), 0, this.CurrentMethodDeclaringType);
+
+                        this.HavocParameters(pc, ctor, EmptyIndexable<Type>.Empty, args, data, declaringType, false, true, false);
+
+                        data.CopyValue(data.Address(dest), addr, mdDecoder.ManagedPointer(declaringType));
+                    }
+                    else
+                    {
+                        ESymValue obj = data.CreateObject(declaringType);
+                        data.MaterializeNewObjAccordingToType(obj, declaringType, 0, this.CurrentMethodDeclaringType);
+                        if (mdDecoder.IsDelegate(declaringType) && savedFnPtr != null)
+                        {
+                            data.SetDelegateDetails(obj, savedClosure, savedFnPtr);
+                        }
+                        this.HavocParameters(pc, ctor, EmptyIndexable<Type>.Empty, args, data, declaringType, false, true, false);
+
+                        data.CopyAddress(data.Address(dest), obj, declaringType);
+                    }
+                }
+
+                public Domain Refanytype(APC pc, int dest, int source, Domain data)
+                {
+                    data.AssignValue(dest, mdDecoder.System_Type, this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignValue(dest, mdDecoder.System_Type, this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+
+                public Domain Refanyval(APC pc, Type type, int dest, int source, Domain data)
+                {
+                    data.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+
+                public Domain Rethrow(APC pc, Domain data)
+                {
+                    return data.Bottom;
+                }
+
+                public Domain Sizeof(APC pc, Type type, int dest, Domain data)
+                {
+                    data.AssignValue(dest, mdDecoder.System_Int32, this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignValue(dest, mdDecoder.System_Int32, this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+
+                public Domain Stelem(APC pc, Type type, int array, int index, int value, Domain data)
+                {
+                    // can happen in old state due to params calls
+                    StelemEffect(type, array, index, value, data);
+                    if (data.oldDomain != null)
+                    {
+                        StelemEffect(type, array, index, value, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void StelemEffect(Type type, int array, int index, int value, Domain data)
+                {
+                    Type elementAddrType = mdDecoder.ManagedPointer(type);
+                    var arrayValue = data.Value(array);
+                    var indexValue = data.Value(index);
+                    data.HavocArrayAtIndex(arrayValue, indexValue);
+                    data.CopyValue(data.ElementAddress(arrayValue, indexValue, elementAddrType), data.Address(value), elementAddrType);
+                    data.Havoc(array);
+                    data.Havoc(index);
+                    data.Havoc(value);
+                }
+
+                public Domain Stfld(APC pc, Field field, bool @volatile, int obj, int value, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+
+                    data.CopyValue(data.FieldAddress(data.Value(obj), field), data.Address(value));
+                    // invalidate properties that may depend on "field"
+                    if (!mdDecoder.IsCompilerGenerated(field))
+                    {
+                        data.HavocPseudoFields(data.Value(obj));
+                    }
+                    data.Havoc(obj);
+                    data.Havoc(value);
+                    return data;
+                }
+
+                public Domain Stsfld(APC pc, Field field, bool @volatile, int value, Domain data)
+                {
+                    Contract.Assume(data.insideOld == 0);
+
+                    data.CopyValue(data.FieldAddress(data.Globals, field), data.Address(value));
+                    data.Havoc(value);
+                    return data;
+                }
+
+                public Domain Throw(APC pc, int exn, Domain data)
+                {
+                    data.Havoc(exn);
+                    return data.Bottom;
+                }
+
+                public Domain Unbox(APC pc, Type type, int dest, int obj, Domain data)
+                {
+                    data.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignValue(dest, mdDecoder.ManagedPointer(type), this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+
+                public Domain Unboxany(APC pc, Type type, int dest, int obj, Domain data)
+                {
+                    if (this.mdDecoder.IsReferenceConstrained(type))
+                    {
+                        // acts like a cast
+                        return Castclass(pc, type, dest, obj, data);
+                    }
+                    data.AssignValue(dest, type, this.CurrentMethodDeclaringType);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain.AssignValue(dest, type, this.CurrentMethodDeclaringType);
+                    }
+                    return data;
+                }
+
+                #endregion
+
+                #region IVisitSynthIL<int,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>,OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>> Members
+
+                private Domain AssertEffect(APC pc, string tag, int source, Domain data)
+                {
+                    data = data.Assume(source, true);
+                    if (!data.IsBottom)
+                    {
+                        data.Havoc(source);
+                    }
+                    return data;
+                }
+                public Domain Assert(APC pc, string tag, int source, object provenance, Domain data)
+                {
+                    data = AssertEffect(pc, tag, source, data);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain = AssertEffect(pc, tag, source, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private static Domain AssumeEffect(APC pc, string tag, int source, Domain data)
+                {
+                    if (tag == "false")
+                    {
+                        data = data.Assume(source, false);
+                    }
+                    else
+                    {
+                        data = data.Assume(source, true);
+                    }
+                    if (!data.IsBottom)
+                    {
+                        data.Havoc(source);
+                    }
+                    return data;
+                }
+
+                public Domain Assume(APC pc, string tag, int source, object provenance, Domain data)
+                {
+                    if (parent.IgnoreExplicitAssumptions && tag == "assume")
+                    {
+                        return data;
+                    }
+                    data = AssumeEffect(pc, tag, source, data);
+                    if (data.oldDomain != null)
+                    {
+                        data.oldDomain = AssumeEffect(pc, tag, source, data.oldDomain);
+                    }
+                    return data;
+                }
+
+                private void MaterializeLocal(Local l, Domain data, Method method)
+                {
+                    var t = mdDecoder.LocalType(l);
+                    data.AssignZeroEquivalent(data.Address(l), t);
+
+                    // Added by Francesco: Materialize up to one depth
 #if false
-          if (mdDecoder.IsClass(t))
-          {
-            foreach (var field in mdDecoder.Fields(t))
-            {
-              Type fieldType;
-              var fieldAddress = data.FieldAddress(data.Address(l), field, out fieldType);
-              data.MakeUnmodified(fieldAddress);
-              data.SetType(fieldAddress, fieldType);
-            }
-          } 
+                    if (mdDecoder.IsClass(t))
+                    {
+                        foreach (var field in mdDecoder.Fields(t))
+                        {
+                            Type fieldType;
+                            var fieldAddress = data.FieldAddress(data.Address(l), field, out fieldType);
+                            data.MakeUnmodified(fieldAddress);
+                            data.SetType(fieldAddress, fieldType);
+                        }
+                    }
 #endif
-        }
-
-        private void MaterializeParameter(Parameter p, Domain data, Type fromType, bool aggressiveMaterialization)
-        {
-          var t = mdDecoder.ParameterType(p);
-          data.Assign(p, t, this.CurrentMethodDeclaringType);
-          MaterializeParameterInfo(data.Address(p), mdDecoder.ManagedPointer(t), 0, data, fromType, aggressiveMaterialization);
-          data.CopyParameterIntoShadow(p);
-        }
-
-        private void MaterializeParameterInfo(ESymValue value, Type t, int depth, Domain data, Type fromType, bool aggressiveMaterialization)
-        {
-          data.MakeUnmodified(value);
-          data.SetType(value, t);
-          if (depth > 2 && !aggressiveMaterialization) return;
-          if (depth > 5) return;
-          if (mdDecoder.IsManagedPointer(t))
-          {
-            Type elementType = mdDecoder.ElementType(t);
-            if (!mdDecoder.HasValueRepresentation(elementType))
-            {
-              // manifest struct Id
-              data.ManifestStructId(value);
-              // manifest field addresses
-              foreach (Field f in mdDecoder.Fields(elementType))
-              {
-                if (mdDecoder.IsStatic(f)) continue;
-                if (mdDecoder.IsVisibleFrom(f, fromType))
-                {
-                  // manifest the field
-                  Type fieldType;
-                  ESymValue fieldAddr = data.FieldAddress(value, f, out fieldType);
-                  MaterializeParameterInfo(fieldAddr, fieldType, depth + 1, data, fromType, aggressiveMaterialization);
                 }
-              }
-              ManifestProperties(value, depth + 1, data, fromType, aggressiveMaterialization, elementType);
-            }
-            else
-            {
-              // manifest the value
-              MaterializeParameterInfo(data.Value(value), elementType, depth + 1, data, fromType, aggressiveMaterialization);
-            }
-            return;
-          }
 
-          if (data.DerivesFromIEnumerable(t))
-          {
-            ManifestProperties(value, depth, data, fromType, true, t);
-          }
-
-          if (mdDecoder.IsClass(t))
-          {
-            foreach (Field f in mdDecoder.Fields(t))
-            {
-              if (mdDecoder.IsStatic(f)) continue;
-              if (mdDecoder.IsVisibleFrom(f, fromType))
-              {
-                // manifest the field
-                Type fieldType;
-                ESymValue fieldAddr = data.FieldAddress(value, f, out fieldType);
-                MaterializeParameterInfo(fieldAddr, fieldType, depth + 1, data, fromType, aggressiveMaterialization);
-              }
-            }
-            if (aggressiveMaterialization && mdDecoder.HasBaseClass(t))
-            {
-              // materialize base fields
-              var baseType = mdDecoder.BaseClass(t);
-              foreach (Field f in mdDecoder.Fields(baseType))
-              {
-                if (mdDecoder.IsStatic(f)) continue;
-                if (mdDecoder.IsVisibleFrom(f, fromType))
+                private void MaterializeParameter(Parameter p, Domain data, Type fromType, bool aggressiveMaterialization)
                 {
-                  // manifest the field
-                  Type fieldType;
-                  ESymValue fieldAddr = data.FieldAddress(value, f, out fieldType);
-                  MaterializeParameterInfo(fieldAddr, fieldType, depth + 1, data, fromType, aggressiveMaterialization);
+                    var t = mdDecoder.ParameterType(p);
+                    data.Assign(p, t, this.CurrentMethodDeclaringType);
+                    MaterializeParameterInfo(data.Address(p), mdDecoder.ManagedPointer(t), 0, data, fromType, aggressiveMaterialization);
+                    data.CopyParameterIntoShadow(p);
                 }
-              }
-            }
-            return;
-          }
 
-          if (data.NeedsArrayLengthManifested(t))
-          {
-            data.ManifestArrayLength(value);
-            return;
-          }
-
-          if (mdDecoder.IsUnmanagedPointer(t))
-          {
-            data.ManifestWritableBytes(value);
-            return;
-          }
-        }
-
-
-        private bool IsIEnumerable(Type t)
-        {
-          return mdDecoder.Name(t).Contains("IEnumerable");
-        }
-
-        private void ManifestProperties(ESymValue value, int depth, Domain data, Type fromType, bool aggressiveMaterialization, Type type)
-        {
-          Contract.Requires(data != null);
-
-#if false
-          if (!mdDecoder.IsArray(type) && data.DerivesFromIEnumerable(type))
-          {
-            data.ManifestModel(value, type);
-          }
-#endif
-          foreach (Property p in mdDecoder.Properties(type))
-          {
-            if (mdDecoder.IsStatic(p)) continue;
-            Method getter;
-            if (!mdDecoder.HasGetter(p, out getter)) continue;
-
-            // skip string.get_Length, as we use $Length for that
-            if (mdDecoder.Equal(type, mdDecoder.System_String) && mdDecoder.Name(getter) == "get_Length") {
-              continue;
-            }
-            if (mdDecoder.IsVisibleFrom(getter, fromType))
-            {
-              if (mdDecoder.Parameters(getter).Count > 0) continue;
-
-              // manifest the property
-              Type propertyType;
-              ESymValue propAddr = data.PseudoFieldAddress(value, getter, out propertyType, false, this.CurrentMethodDeclaringType);
-              MaterializeParameterInfo(propAddr, propertyType, depth + 1, data, fromType, aggressiveMaterialization);
-            }
-          }
-          foreach (var m in parent.contractDecoder.ModelMethods(type))
-          {
-            if (mdDecoder.IsVisibleFrom(m, fromType))
-            {
-              // manifest the method
-              Type methodType;
-              ESymValue propAddr = data.PseudoFieldAddress(value, m, out methodType, false, this.CurrentMethodDeclaringType);
-              MaterializeParameterInfo(propAddr, methodType, depth + 1, data, fromType, aggressiveMaterialization);
-            }
-          }
-          if (this.mdDecoder.IsInterface(type))
-          {
-            foreach (var intf in mdDecoder.Interfaces(type))
-            {
-              if (mdDecoder.IsVisibleFrom(intf, fromType))
-              {
-                ManifestProperties(value, depth, data, fromType, aggressiveMaterialization, intf);
-              }
-            }
-          }
-        }
-
-        public Domain Entry(APC pc, Method method, Domain data)
-        {
-          Contract.Assume(data.oldDomain == null);
-
-          // meterialize all locals
-          IIndexable<Local> locals = this.mdDecoder.Locals(method);
-          for (int i = 0; i < locals.Count; i++)
-          {
-            MaterializeLocal(locals[i], data, method);
-          }
-          var declaringType = mdDecoder.DeclaringType(method);
-
-          // materialize all parameters.
-          IIndexable<Parameter> parameters = this.mdDecoder.Parameters(method);
-          for (int i = 0; i < parameters.Count; i++)
-          {
-            MaterializeParameter(parameters[i], data, declaringType, false);
-          }
-          // this
-          if (!mdDecoder.IsStatic(method))
-          {
-            MaterializeParameter(this.mdDecoder.This(method), data, declaringType, true);
-          }
-          // for constructors, set all fields to 0
-          if (this.mdDecoder.IsConstructor(method))
-          {
-            Parameter thisParam = this.mdDecoder.This(method);
-            ESymValue thisValue = data.Value(thisParam);
-            foreach (Field f in this.mdDecoder.Fields(declaringType))
-            {
-              if (mdDecoder.IsStatic(f)) continue;
-              Type fieldType = mdDecoder.FieldType(f);
-              if (mdDecoder.IsStruct(fieldType))
-              {
-                data.AssignConst(data.FieldAddress(thisValue, f), fieldType, 0);
-              }
-              else
-              {
-                data.AssignNull(data.FieldAddress(thisValue, f));
-              }
-            }
-            foreach (Property p in this.mdDecoder.Properties(declaringType))
-            {
-              if (mdDecoder.IsStatic(p)) continue;
-              Method getter;
-              if (mdDecoder.HasGetter(p, out getter))
-              {
-                // REVIEW: really IsCompilerGenerated ? Not the opposite ? [MAF:3/26/2013]
-                if (mdDecoder.IsCompilerGenerated(getter) && mdDecoder.Parameters(getter).Count == 0)
+                private void MaterializeParameterInfo(ESymValue value, Type t, int depth, Domain data, Type fromType, bool aggressiveMaterialization)
                 {
-                  Type propType = mdDecoder.ReturnType(getter);
-                  if (mdDecoder.IsStruct(propType))
-                  {
-                    data.AssignConst(data.PseudoFieldAddress(thisValue, getter, this.CurrentMethodDeclaringType), propType, 0);
-                  }
-                  else
-                  {
-                    data.AssignNull(data.PseudoFieldAddress(thisValue, getter, this.CurrentMethodDeclaringType));
-                  }
+                    data.MakeUnmodified(value);
+                    data.SetType(value, t);
+                    if (depth > 2 && !aggressiveMaterialization) return;
+                    if (depth > 5) return;
+                    if (mdDecoder.IsManagedPointer(t))
+                    {
+                        Type elementType = mdDecoder.ElementType(t);
+                        if (!mdDecoder.HasValueRepresentation(elementType))
+                        {
+                            // manifest struct Id
+                            data.ManifestStructId(value);
+                            // manifest field addresses
+                            foreach (Field f in mdDecoder.Fields(elementType))
+                            {
+                                if (mdDecoder.IsStatic(f)) continue;
+                                if (mdDecoder.IsVisibleFrom(f, fromType))
+                                {
+                                    // manifest the field
+                                    Type fieldType;
+                                    ESymValue fieldAddr = data.FieldAddress(value, f, out fieldType);
+                                    MaterializeParameterInfo(fieldAddr, fieldType, depth + 1, data, fromType, aggressiveMaterialization);
+                                }
+                            }
+                            ManifestProperties(value, depth + 1, data, fromType, aggressiveMaterialization, elementType);
+                        }
+                        else
+                        {
+                            // manifest the value
+                            MaterializeParameterInfo(data.Value(value), elementType, depth + 1, data, fromType, aggressiveMaterialization);
+                        }
+                        return;
+                    }
+
+                    if (data.DerivesFromIEnumerable(t))
+                    {
+                        ManifestProperties(value, depth, data, fromType, true, t);
+                    }
+
+                    if (mdDecoder.IsClass(t))
+                    {
+                        foreach (Field f in mdDecoder.Fields(t))
+                        {
+                            if (mdDecoder.IsStatic(f)) continue;
+                            if (mdDecoder.IsVisibleFrom(f, fromType))
+                            {
+                                // manifest the field
+                                Type fieldType;
+                                ESymValue fieldAddr = data.FieldAddress(value, f, out fieldType);
+                                MaterializeParameterInfo(fieldAddr, fieldType, depth + 1, data, fromType, aggressiveMaterialization);
+                            }
+                        }
+                        if (aggressiveMaterialization && mdDecoder.HasBaseClass(t))
+                        {
+                            // materialize base fields
+                            var baseType = mdDecoder.BaseClass(t);
+                            foreach (Field f in mdDecoder.Fields(baseType))
+                            {
+                                if (mdDecoder.IsStatic(f)) continue;
+                                if (mdDecoder.IsVisibleFrom(f, fromType))
+                                {
+                                    // manifest the field
+                                    Type fieldType;
+                                    ESymValue fieldAddr = data.FieldAddress(value, f, out fieldType);
+                                    MaterializeParameterInfo(fieldAddr, fieldType, depth + 1, data, fromType, aggressiveMaterialization);
+                                }
+                            }
+                        }
+                        return;
+                    }
+
+                    if (data.NeedsArrayLengthManifested(t))
+                    {
+                        data.ManifestArrayLength(value);
+                        return;
+                    }
+
+                    if (mdDecoder.IsUnmanagedPointer(t))
+                    {
+                        data.ManifestWritableBytes(value);
+                        return;
+                    }
                 }
-              }
-            }
-          }
-          else if (MethodToBeSimulated(method))
-          {
-            InitializePhantonFields(method, data);
-          }
-          return data;
-        }
 
-        private bool IsMoveNext(Method method)
-        {
-          string name = this.mdDecoder.Name(method);
-          bool nameMatch = name == "MoveNext";
-          if (!nameMatch) return false;
-          foreach (Method m in mdDecoder.OverriddenAndImplementedMethods(method))
-          {
-            Type t = mdDecoder.DeclaringType(m);
-            string n = mdDecoder.Name(t);
-            Contract.Assume(n != null);
-            if (n.Contains("Enumerable") || n.Contains("Enumerator")) return true;
-          }
-          return false;
-        }
 
-        private bool MethodToBeSimulated(Method method)
-        {
-          foreach (Attribute attr in mdDecoder.GetAttributes(method))
-          {
-            Type attrType = mdDecoder.AttributeType(attr);
-            string attrName = mdDecoder.Name(attrType);
-            if (attrName == "SimulationMethod")
-            {
-              return true;
-            }
-          }
-          return false;
-        }
-
-        private void InitializePhantonFields(Method method, Domain data)
-        {
-          Parameter thisParam = this.mdDecoder.This(method);
-          ESymValue thisValue = data.Value(thisParam);
-          string mname = mdDecoder.Name(method);
-          foreach (Field f in this.mdDecoder.Fields(this.mdDecoder.DeclaringType(method)))
-          {
-            foreach (Attribute attr in mdDecoder.GetAttributes(f))
-            {
-              Type attrType = mdDecoder.AttributeType(attr);
-              if (mdDecoder.Name(attrType) == "PhantonField")
-              {
-                IIndexable<object> args = mdDecoder.PositionalArguments(attr);
-                if (args != null && args.Count == 1 && (string)args[0] == mname)
+                private bool IsIEnumerable(Type t)
                 {
-                  data.FieldAddress(thisValue, f);
-                  break;
+                    return mdDecoder.Name(t).Contains("IEnumerable");
                 }
-              }
-            }
-          }
-        }
 
-        public Domain Ldstack(APC pc, int offset, int dest, int source, bool isOld, Domain data)
-        {
-          if (isOld)
-          {
-            // New implementation using CopyOldValue
-            Domain oldState = FindOldState(pc, data);
-
-            if(oldState == null)
-            {
-              return data;
-            }
-
-            oldState.CopyOldValue(pc, dest, source, data, false);
-            if (data.oldDomain != null)
-            {
-              oldState.CopyOldValue(pc, dest, source, data.oldDomain, false);
-            }
-          }
-          else
-          {
-            data.Copy(dest, source);
-            if (data.oldDomain != null)
-            {
-              data.oldDomain.Copy(dest, source);
-            }
-          }
-          return data;
-        }
-
-        private static void LdstackaEffect(APC pc, int offset, int dest, int source, Domain data)
-        {
-          data.CopyStackAddress(data.Address(dest), source);
-        }
-        public Domain Ldstacka(APC pc, int offset, int dest, int source, Type type, bool isOld, Domain data)
-        {
-          if (isOld)
-          {
-            // it makes no sense to take the address of the actual old stack location since this really means we'll
-            // eventually read something from there. So what we do is create a dummy new location into which we make a shallow
-            // copy of the old stack locations data and then produce a pointer to that dummy location.
-            Type dummyLocType = mdDecoder.ManagedPointer(type);
-
-            Domain oldState = FindOldState(pc, data);
-
-            if(oldState == null)
-            {
-              return data;
-            }
-
-            var oldStackAddress = oldState.Address(source);
-            var dummyDest = data.CreateValue(type);
-            oldState.CopyOldValue(pc, dummyDest, oldStackAddress, data, true);
-            data.CopyAddress(data.Address(dest), dummyDest, dummyLocType);
-
-            if (data.oldDomain != null)
-            {
-              var addrType = mdDecoder.ManagedPointer(dummyLocType);
-              oldState.CopyOldValueToDest(pc, data.oldDomain.Address(dest), oldStackAddress, addrType, data.oldDomain);
-            }
-          }
-          else
-          {
-            LdstackaEffect(pc, offset, dest, source, data);
-            if (data.oldDomain != null)
-            {
-              LdstackaEffect(pc, offset, dest, source, data.oldDomain);
-            }
-          }
-          return data;
-        }
-
-        public static Domain FindOldState(APC pc, Domain data)
-        {
-          Contract.Requires(data != null);
-
-          // walk the subroutine context to determine if we are in an ensures of a method exit, or at a call-return
-          // and grab the correct context pc for that state.
-          SubroutineContext scontext = pc.SubroutineContext;
-          while (scontext != null)
-          {
-            SubroutineEdge head = scontext.Head;
-            if (head.Three == "exit")
-            {
-              // inside method exit.
-              Domain oldState = data.GetStateAt(new APC(head.One.Subroutine.EntryAfterRequires, 0, scontext.Tail));
-              return oldState;
-            }
-            if (head.Three.StartsWith("after") || head.Three.StartsWith("assumeInvariant"))
-            {
-              // after call or after newObj
-              // we are in an ensures around a method call. Find the calling context and the from block, which is the method call
-              Domain oldState = data.GetStateAt(new APC(head.One, 0, scontext.Tail));
-              return oldState;
-            }
-            scontext = scontext.Tail;
-          }
-          return null;
-        }
-
-        /// <summary>
-        /// This is were OLD semantics are actually implemented.
-        ///
-        /// Here, we have to distinguish 2 cases
-        /// 1) we are evaluating the ensures assert at the end of a method
-        /// 2) we are evaluating the ensures assume at the end of a call
-        ///
-        /// For 1), we find the heap state at the beginning of the current method, after pre-conditions have been evaluated.
-        /// For 2), we find the heap state at the call instruction of the call on the subroutine stack
-        ///
-        /// We clone the found heap state and return it as the current state for the evaluation of the instructions modelling
-        /// the "old" expression.
-        ///
-        /// We also have to store away our current state so as to retrieve it at the matchin EndOld.
-        ///
-        /// Note about DFA dependency. if the data flow state changes that we look up here, then we will re-evaluate this point
-        /// as well because the call site or method entry point dominates the current pc.
-        /// </summary>
-        public Domain BeginOld(APC pc, APC matchingEnd, Domain data)
-        {
-          // Nested begin old can happen if we use a property in an old context and the property itself has a post condition
-          // with old wrapping.
-          if (data.insideOld++ == 0)
-          {
-            Domain oldDomain = FindOldState(pc, data);
-            if (oldDomain == null)
-            {
-              throw new InvalidOperationException("begin_old in weird calling context");
-            }
-            oldDomain = oldDomain.Clone();
-            oldDomain.beginOldPC = pc;
-            data.oldDomain = oldDomain;
-          }
-          Contract.Assume(data.insideOld > 0);
+                private void ManifestProperties(ESymValue value, int depth, Domain data, Type fromType, bool aggressiveMaterialization, Type type)
+                {
+                    Contract.Requires(data != null);
 
 #if false
-          // Store away the current state so we can retrieve it at the matching EndOld.
-          data.AddOldSavedState(pc, data);
-
-          data = oldDomain.Clone();
-          data.inOld = true;
+                    if (!mdDecoder.IsArray(type) && data.DerivesFromIEnumerable(type))
+                    {
+                        data.ManifestModel(value, type);
+                    }
 #endif
-          return data;
-        }
-
-        /// <summary>
-        /// Here we have to load source in the current "old" state, then retrieve the dataflow state for the matching
-        /// BeginOld. We then have 2 situations
-        /// 1) the source symbol from the "old" state is known in the retrieved state. If so, we assign it to dest in the
-        ///    retrieved state.
-        /// 2) the source symbol from the "old" state is NOT known in the retrieved state. If so, we assign a fresh
-        ///    symbol to dest in the retrieved state.
-        ///
-        /// In both cases, we continue with the retrieved state.
-        /// </summary>
-        public Domain EndOld(APC pc, APC matchingBegin, Type type, Temp dest, Temp source, Domain data)
-        {
-          Contract.Assume(data.insideOld > 0);
-
-          Domain oldDomain = data.oldDomain;
-
-          if (--data.insideOld == 0)
-          {
-            // outermost end old
-            data.oldDomain = null;
-          }
-          data.CopyOld(dest, source, type);
-          return data;
-        }
-
-        public Domain Ldresult(APC pc, Type type, int dest, int source, Domain data)
-        {
-          return this.Ldstack(pc, 0 /* not important */, dest, source, false, data);
-        }
-
-        #endregion
-      }
-      #endregion
-
-
-      #region IAbstractValue<OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>> Members
-
-      public Domain Top
-      {
-        get
-        {
-          return new Domain(this.egraph.Top,
-                            FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey),
-                            FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
-                            FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
-                            FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
-                            this, null);
-        }
-      }
-
-      [ThreadStatic] // Because this.egraph.Bottom is ThreadStatic
-      private static Domain BottomValue;
-
-      public Domain Bottom
-      {
-        get
-        {
-          if (BottomValue == null)
-          {
-            BottomValue = new Domain(this.egraph.Bottom,
-                                     FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey),
-                                     FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
-                                     FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
-                                     FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
-                                     this, null);
-            Bottom.ImmutableVersion();
-          }
-          return BottomValue;
-        }
-      }
-
-      public bool IsTop
-      {
-        get { return this.egraph.IsTop; }
-      }
-
-      public bool IsBottom
-      {
-        get
-        {
-          return this == BottomValue || this.egraph.IsBottom
-            || this.oldDomain != null && this.oldDomain.IsBottom;
-        }
-      }
-
-      public Domain ImmutableVersion()
-      {
-        this.egraph.ImmutableVersion(); // mark immutable
-        return this;
-      }
-
-      public Domain Clone()
-      {
-        Contract.Ensures(Contract.Result<Domain>() != null);
-
-        return new Domain(this.egraph.Clone(),
-                          this.constantLookup,
-                          this.unmodifiedSinceEntry,
-                          this.unmodifiedSinceEntryForFields,
-                          this.modifiedAtCall,
-                          this,
-                          this.oldDomain == null ? null : this.oldDomain.Clone()
-                   );
-      }
-
-      public Domain Join(Domain newState, out bool weaker, bool widen)
-      {
-        IMergeInfo mi;
-        return this.Join(newState, out weaker, out mi, widen);
-      }
-
-      internal Domain Join(Domain newState, out bool weaker, out IMergeInfo mergeInfo, bool widen)
-      {
-        EGraph<Constructor, AbstractType> newEgraph = this.egraph.Join(newState.egraph, out mergeInfo, widen);
-        weaker = mergeInfo.Changed;
-        IFunctionalSet<ESymValue> newUnmodifiedSinceEntry, newUnmodifiedSinceEntryForFields, newModifiedAtCall;
-        ComputeJoinOfSets(mergeInfo, this, newState, out newUnmodifiedSinceEntry, out newUnmodifiedSinceEntryForFields, out newModifiedAtCall, ref weaker);
-
-        Domain oldDomainJoin = null;
-        if (this.oldDomain != null)
-        {
-          Contract.Assume(newState.oldDomain != null);
-          bool weaker2;
-          IMergeInfo mergeInfo2;
-          oldDomainJoin = this.oldDomain.Join(newState.oldDomain, out weaker2, out mergeInfo2, widen);
-        }
-        return new Domain(newEgraph, RecomputeConstantMap(newEgraph),
-                          newUnmodifiedSinceEntry,
-                          newUnmodifiedSinceEntryForFields,
-                          newModifiedAtCall,
-                          this, oldDomainJoin);
-      }
-
-      private void ComputeJoinOfSets(IMergeInfo mergeInfo, Domain oldState, Domain newState, out IFunctionalSet<ESymValue> resultUnmodifiedSinceEntry, out IFunctionalSet<ESymValue> resultUnmodifiedSinceEntryForFields, out IFunctionalSet<ESymValue> resultModifiedAtCall, ref bool weaker)
-      {
-        resultUnmodifiedSinceEntry = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-        resultUnmodifiedSinceEntryForFields = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-        resultModifiedAtCall = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-
-        foreach (var tuple in mergeInfo.MergeTriples)
-        {
-          var oldsym = tuple.One;
-          var newsym = tuple.Two;
-          var resultsym = tuple.Three;
-
-          // Must be able to handle oldsym or newsym being null. 
-          // This happens when we materialize one or the other.
-          bool oldUnmodifiedSinceEntry = SetContains(oldState.unmodifiedSinceEntry, oldsym);
-          bool oldUnmodifiedSinceEntryForFields = SetContains(oldState.unmodifiedSinceEntryForFields, oldsym);
-          bool oldModifiedAtCall = SetContains(oldState.modifiedAtCall, oldsym);
-
-          #region Unmodified
-          if (oldUnmodifiedSinceEntry)
-          {
-            // newsym == null means we manifested it. Let's assume that it wasn't modified on the new branch!
-            if (newsym == null || newState.IsBottomPlaceHolder(newsym) || SetContains(newState.unmodifiedSinceEntry, newsym))
-            {
-              // found intersection
-              resultUnmodifiedSinceEntry = resultUnmodifiedSinceEntry.Add(resultsym);
-            }
-            else
-            {
-              // check if newState has the symbol in the ForFields set
-              if (SetContains(newState.unmodifiedSinceEntryForFields, newsym))
-              {
-                // add it to the result ForFields set
-                resultUnmodifiedSinceEntryForFields = resultUnmodifiedSinceEntryForFields.Add(resultsym);
-              }
-            }
-          }
-
-          #endregion
-
-          #region Modified
-          if (oldModifiedAtCall)
-          {
-            // just rename from old to result. We don't care about join, as this set only matters
-            // within scope of call + ensures.
-            resultModifiedAtCall = resultModifiedAtCall.Add(resultsym);
-          }
-          #endregion
-
-        }
-        #region Check if join is weaker
-        if (SetCount(oldState.unmodifiedSinceEntry) > resultUnmodifiedSinceEntry.Count)
-        {
-          // weaker join
-          weaker = true;
-          if (Domain.Debug)
-          {
-            Console.WriteLine("---Result changed due to fewer unmodified locations since entry");
-          }
-        }
-        else if (SetCount(oldState.unmodifiedSinceEntryForFields) > resultUnmodifiedSinceEntryForFields.Count)
-        {
-          // weaker join
-          weaker = true;
-          if (Domain.Debug)
-          {
-            Console.WriteLine("---Result changed due to fewer unmodified locations for fields since entry");
-          }
-        }
-        #endregion
-      }
-
-
-
-
-      private static bool SetContains(IFunctionalSet<ESymValue> set, ESymValue value)
-      {
-        if (set == null) return false;
-        if (value == null) return false;
-        return set.Contains(value);
-      }
-
-      private static int SetCount(IFunctionalSet<ESymValue> set)
-      {
-        if (set == null) return 0;
-        return set.Count;
-      }
-
-      IFunctionalMap<ESymValue, Constructor> RecomputeConstantMap(EGraph<Constructor, AbstractType> egraph)
-      {
-        IFunctionalMap<ESymValue, Constructor> result = FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey);
-
-        foreach (Constructor c in egraph.Constants)
-        {
-          if (Constructors.IsConstantOrMethod(c))
-          {
-            result = result.Add(egraph[c], c);
-          }
-        }
-        return result;
-      }
-
-      public Domain Meet(Domain b)
-      {
-        EGraph<Constructor, AbstractType> newEgraph = this.egraph.Meet(b.egraph);
-        return new Domain(newEgraph, RecomputeConstantMap(newEgraph),
-                          ComputeMeetUnmodifiedSinceEntry(),
-                          ComputeMeetUnmodifiedSinceEntry(),
-                          null,
-                          this, this.oldDomain);
-        // NOTE: do we need to meet oldDomains ?
-      }
-
-      private IFunctionalSet<ESymValue> ComputeMeetUnmodifiedSinceEntry()
-      {
-        throw new NotImplementedException();
-      }
-
-      public void Dump(TextWriter tw)
-      {
-        this.egraph.Dump(tw);
-        tw.WriteLine("Unmodified locs");
-        foreach (ESymValue sv in this.unmodifiedSinceEntry.Elements)
-        {
-          tw.Write(sv); tw.Write(' ');
-        }
-        tw.WriteLine();
-        tw.WriteLine("Unmodified locs for fields");
-        foreach (ESymValue sv in this.unmodifiedSinceEntryForFields.Elements)
-        {
-          tw.Write(sv); tw.Write(' ');
-        }
-        tw.WriteLine();
-        if (this.modifiedAtCall != null)
-        {
-          tw.WriteLine("Modified locs at last call");
-          foreach (ESymValue sv in this.modifiedAtCall.Elements)
-          {
-            tw.Write(sv); tw.Write(' ');
-          }
-          tw.WriteLine();
-        }
-        if (this.oldDomain != null)
-        {
-          tw.WriteLine("## has old domain");
-          this.oldDomain.egraph.Dump(tw);
-          tw.WriteLine("## end old domain");
-        }
-      }
-
-      public bool LessEqual(Domain that)
-      {
-        return this.egraph.LessEqual(that.egraph);
-      }
-
-      public bool LessEqual(Domain that,
-                            out IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward,
-                            out IFunctionalMap<ESymValue, ESymValue>/*?*/ backward)
-      {
-        Contract.Requires(that != null);
-
-        return this.egraph.LessEqual(that.egraph, out forward, out backward);
-      }
-
-      #endregion
-
-      #region Accessors for Heap Abstraction Results
-      /// <summary>
-      /// Represents the CLR type of a symbolic value as well as wether the value is known to be zero/null
-      /// </summary>
-      internal struct AbstractType : IAbstractValueForEGraph<AbstractType>, IEquatable<AbstractType>
-      {
-        private readonly bool isZero;
-        private readonly FlatDomain<Type> value;
-
-        public AbstractType(FlatDomain<Type> value, bool isZero)
-        {
-          this.value = value;
-          this.isZero = isZero;
-        }
-
-        #region Forwarding to FlatDomainOE<Type>
-
-        public AbstractType Top { get { return new AbstractType(FlatDomain<Type>.TopValue, false); } }
-        public AbstractType Bottom { get { return new AbstractType(FlatDomain<Type>.BottomValue, true); } }
-        public bool IsTop { get { return !isZero && value.IsTop; } }
-        public bool IsBottom { get { return isZero && value.IsBottom; } }
-        public AbstractType ImmutableVersion() { return this; }
-        public AbstractType Clone() { return this; }
-        public AbstractType Join(AbstractType that, out bool weaker, bool widen)
-        {
-          // special hack: if one of the two values is Zero, we ignore the type and treat it as bottom
-          if (that.isZero)
-          {
-            weaker = false;
-            if (this.value.IsBottom)
-            {
-              return new AbstractType(that.value, this.isZero);
-            }
-            return this;
-          }
-          else if (this.isZero)
-          {
-            weaker = true;
-            if (that.value.IsBottom)
-            {
-              return new AbstractType(this.value, that.isZero);
-            }
-            return that;
-          }
-          else
-          {
-            FlatDomain<Type> resultType = value.Join(that.value, out weaker, widen);
-            RecoverResultTypeInfo(ref resultType, this.value, that.value);
-            return new AbstractType(resultType, false);
-          }
-        }
-
-        [ThreadStatic]
-        internal static IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder;
-
-        private static void RecoverResultTypeInfo(ref FlatDomain<Type> resultType, FlatDomain<Type> thisType, FlatDomain<Type> thatType)
-        {
-          if (resultType.IsTop)
-          {
-            if (thisType.IsNormal && thatType.IsNormal)
-            {
-              Type t1 = thisType.Value;
-              Type t2 = thatType.Value;
-              // check if we have T@ and T*
-              if (MetadataDecoder.IsManagedPointer(t1) && MetadataDecoder.IsUnmanagedPointer(t2) &&
-                  MetadataDecoder.ElementType(t1).Equals(MetadataDecoder.ElementType(t2)))
-              {
-                resultType = thatType;
-                return;
-              }
-              // check if we have T* and T@
-              if (MetadataDecoder.IsUnmanagedPointer(t1) && MetadataDecoder.IsManagedPointer(t2) &&
-                  MetadataDecoder.ElementType(t1).Equals(MetadataDecoder.ElementType(t2)))
-              {
-                resultType = thisType;
-                return;
-              }
-            }
-          }
-        }
-
-        public AbstractType Meet(AbstractType that) { return new AbstractType(value.Meet(that.value), this.isZero || that.isZero); }
-        public bool LessEqual(AbstractType that)
-        {
-          return this.isZero || !that.isZero && TypeLeq(ref that);
-        }
-
-        private bool TypeLeq(ref AbstractType that)
-        {
-          if (value.LessEqual(that.value)) return true;
-          // recover if there are managed/unmanaged pointer differences:
-          // T@ <= T*
-          if (this.value.IsNormal && that.value.IsNormal)
-          {
-            Type t1 = this.value.Value;
-            Type t2 = that.value.Value;
-            // check if we have T@ and T*
-            if (MetadataDecoder.IsManagedPointer(t1) && MetadataDecoder.IsUnmanagedPointer(t2) &&
-                MetadataDecoder.ElementType(t1).Equals(MetadataDecoder.ElementType(t2)))
-            {
-              return true;
-            }
-          }
-          return false;
-        }
-
-        public void Dump(TextWriter tw)
-        {
-          if (isZero) { tw.Write("(Zero) "); }
-          value.Dump(tw);
-        }
-
-        public static readonly AbstractType TopValue = new AbstractType(FlatDomain<Type>.TopValue, false); // Thread-safe because MetadataDecoder is ThreadStatic
-        //        public static AbstractType ForManifestedFieldValue { get { return new AbstractType(FlatDomain<Type>.BottomValue, false); } }
-        public static AbstractType ForManifestedFieldValue { get { return TopValue; } }
-        public static readonly AbstractType BottomValue = new AbstractType(FlatDomain<Type>.BottomValue, true); // Thread-safe because MetadataDecoder is ThreadStatic
-        public Type Value { get { return this.value.Value; } }
-        public bool IsNormal { get { return this.value.IsNormal; } }
-
-        #endregion Forwarding to FlatDomain<Type>
-
-        // public static implicit operator AbstractType(Type type) { return new AbstractType(type); }
-
-        public FlatDomain<Type> Type { get { return this.value; } }
-
-        public override string ToString()
-        {
-          if (isZero) { return "(Zero) " + value.ToString(); }
-          return value.ToString();
-        }
-
-
-        #region IAbstractValueForEGraph<AbstractType> Members
-
-        public bool HasAllBottomFields
-        {
-          get { return this.isZero; }
-        }
-
-        public AbstractType ForManifestedField()
-        {
-          return ForManifestedFieldValue;
-        }
-
-        #endregion
-
-        internal AbstractType With(FlatDomain<Type> type)
-        {
-          return new AbstractType(type, this.isZero);
-        }
-
-        internal AbstractType ButZero
-        {
-          get
-          {
-            return new AbstractType(this.value, true);
-          }
-        }
-        internal bool IsZero { get { return this.isZero; } }
-
-
-
-        #region IEquatable<AbstractType> Members
-
-        public bool Equals(AbstractType that)
-        {
-          return this.isZero == that.isZero && this.value.Equals(that.value);
-        }
-
-        #endregion
-
-
-      }
-
-      internal AbstractType GetType(ESymValue value)
-      {
-        return this.egraph[value];
-      }
-
-      internal bool TryGetArrayLength(ESymValue arrayValue, out ESymValue lengthValue)
-      {
-        lengthValue = egraph.TryLookup(Constructors.Length, arrayValue);
-        return lengthValue != null;
-      }
-
-      internal bool TryGetWritableBytes(ESymValue arrayValue, out ESymValue lengthValue)
-      {
-        lengthValue = egraph.TryLookup(Constructors.WritableBytes, arrayValue);
-        return lengthValue != null;
-      }
-
-      internal bool IsZero(ESymValue value)
-      {
-        return egraph[value].IsZero;
-      }
-
-      internal bool IsConstant(ESymValue sv, out Type type, out object value)
-      {
-        Constructor c = this.constantLookup[sv];
-        if (c != null)
-        {
-          return this.Constructors.IsConstant(c, out type, out value); // may fail because constantLookup also contains method pointers which we do not treat as constants
-        }
-        type = default(Type);
-        value = null;
-        return false;
-      }
-
-      /// <summary>
-      /// Besides getting the path, it also propagates type info in preparation for path decoding as MSIL code
-      /// </summary>
-      internal FList<PathElement> GetAccessPathList(ESymValue sv, AccessPathFilter<Method, Type> filter, bool allowLocal, bool preferLocal)
-      {
-        var path = GetBestAccessPath(sv, filter, true, allowLocal, preferLocal);
-        return path;
-      }
-
-      private bool TryGetCorrespondingValueAbstraction(Constructor v, out SymbolicValue sv)
-      {
-        if (this.IsBottom) { goto noValue; }
-        ESymValue addr = TryAddress(v);
-        if (addr == null) goto noValue;
-
-        var value = TryCorrespondingValue(addr); // provides Value indirection or address depending on addr type.
-
-        if (value == null) goto noValue;
-        sv = new SymbolicValue(value);
-        return true;
-
-      noValue: ;
-        sv = default(SymbolicValue);
-        return false;
-      }
-
-      internal ESymValue TopOfStackValue()
-      {
-        if (this.IsBottom) { goto noValue; }
-        ESymValue addr = TryAddress(Constructors.For((Temp)0));
-        if (addr == null) goto noValue;
-
-        var value = TryCorrespondingValue(addr); // provides Value indirection or address depending on addr type.
-
-        if (value == null) goto noValue;
-        return value;
-
-      noValue: ;
-        return null;
-      }
-
-      internal ESymValue LoadValue(Temp v)
-      {
-        return Value(v);
-      }
-
-      internal SymbolicValue LoadValue(ESymValue addr)
-      {
-        return new SymbolicValue(Value(addr));
-      }
-
-      internal SymbolicValue TryLoadValue(ESymValue addr)
-      {
-        var value = this.TryValue(addr);
-        if (value != null) return new SymbolicValue(value);
-        else return new SymbolicValue(addr);
-      }
-
-      /// <summary>
-      /// For struct values, we return the address of the local. For everything else,
-      /// including primitives, we return the value
-      /// </summary>
-      internal bool TryGetCorrespondingValueAbstraction(Temp v, out SymbolicValue sv)
-      {
-        return TryGetCorrespondingValueAbstraction(Constructors.For(v), out sv);
-      }
-
-      /// <summary>
-      /// For struct values, we return the address of the local. For everything else,
-      /// including primitives, we return the value
-      /// </summary>
-      internal bool TryGetCorrespondingValueAbstraction(Local v, out SymbolicValue sv)
-      {
-        return TryGetCorrespondingValueAbstraction(Constructors.For(v), out sv);
-      }
-
-      internal bool TryGetUnboxedValue(Temp v, out SymbolicValue result)
-      {
-        var address = this.Address(v);
-        var box = this.TryValue(address);
-        return TryGetUnboxedValue(box, out result);
-      }
-
-      internal bool TryGetUnboxedValue(ESymValue box, out SymbolicValue result)
-      {
-        if (box != null)
-        {
-          var unbox = this.TryValue(box);
-          if (unbox != null && this.egraph.TryLookup(this.Constructors.BoxOperator, unbox) == box)
-          {
-            result = new SymbolicValue(unbox);
-            return true;
-          }
-        }
-        result = default(SymbolicValue);
-        return false;
-      }
-
-      /// <summary>
-      /// Returns address of entity
-      /// </summary>
-      private bool TryGetCorrespondingAddressAbstraction(Constructor v, out SymbolicValue sv)
-      {
-        ESymValue addr = TryAddress(v);
-        if (addr == null)
-        {
-          sv = default(SymbolicValue);
-          return false;
-        }
-        sv = new SymbolicValue(addr);
-        return true;
-      }
-
-      /// <summary>
-      /// Returns address of Local
-      /// </summary>
-      internal bool TryGetCorrespondingAddressAbstraction(Local v, out SymbolicValue sv)
-      {
-        return TryGetCorrespondingAddressAbstraction(Constructors.For(v), out sv);
-      }
-
-      /// <summary>
-      /// For struct values, we return the address of the local. For everything else,
-      /// including primitives, we return the value
-      /// </summary>
-      internal bool TryGetCorrespondingValueAbstraction(Parameter v, out SymbolicValue sv)
-      {
-        return TryGetCorrespondingValueAbstraction(Constructors.For(v), out sv);
-      }
-
-      /// <summary>
-      /// Returns address value of parameter
-      /// </summary>
-      internal bool TryGetCorrespondingAddressAbstraction(Parameter v, out SymbolicValue sv)
-      {
-        return TryGetCorrespondingAddressAbstraction(Constructors.For(v), out sv);
-      }
-
-      /// <summary>
-      /// Returns an access path from a parameter or local to the given value.
-      /// </summary>
-      internal string GetAccessPath(ESymValue sv)
-      {
-        var path = GetBestAccessPath(sv, AccessPathFilter<Method, Type>.NoFilter, true, true, false);
-        if (path == null) { return null; }
-        return path.ToCodeString();
-      }
-
-
-      internal bool IsResultEGraph(IMergeInfo mi)
-      {
-        return mi.IsResult(this.egraph);
-      }
-
-      internal bool IsGraph1(IMergeInfo mi)
-      {
-        return mi.IsGraph1(this.egraph);
-      }
-
-      internal bool IsGraph2(IMergeInfo mi)
-      {
-        return mi.IsGraph2(this.egraph);
-      }
-      #endregion
-
-
-      internal bool IsUnmodifiedSinceEntry(ESymValue sym)
-      {
-        return IsUnmodified(sym);
-      }
-
-      /// <summary>
-      /// True if it is a parameter, static field, or static method (getter)
-      /// </summary>
-      /// <param name="pathElement">Head of path to test!</param>
-      /// <param name="sym">on success, contains the corresponding address (for parameter or field), and 
-      /// actual value for property</param>
-      internal bool IsTopLevelVisibleAtMethodEntry(PathElement pathElement, out ESymValue sym)
-      {
-        if (pathElement.IsReturnValue)
-        {
-          sym = default(ESymValue);
-          return false;
-        }
-        bool unmodified;
-        sym = AccessPathHead(pathElement, out unmodified, false, false);
-        return unmodified;
-      }
-
-      internal ESymValue AccessPathHead(PathElement pathElement, out bool unModifiedSinceEntry, bool useModifiedSet, bool includeLocals)
-      {
-        PathElement<Parameter> p = pathElement as PathElement<Parameter>;
-        unModifiedSinceEntry = true; // cheating for static fields and properties
-        ESymValue sym;
-        if (p != null)
-        {
-          sym = this.Address(p.Element);
-          if (useModifiedSet)
-          {
-            unModifiedSinceEntry = !SetContains(this.modifiedAtCall, sym);
-          }
-          else
-          {
-            unModifiedSinceEntry = this.IsUnmodifiedSinceEntry(sym);
-          }
-          if (!p.IsAddressOf)
-          {
-            // compressed parameter ldarga,ldind
-            sym = this.Value(sym);
-          }
-          return sym;
-        }
-        if (includeLocals)
-        {
-          PathElement<Local> l = pathElement as PathElement<Local>;
-          if (l != null)
-          {
-            sym = this.Address(l.Element);
-            return sym;
-          }
-        }
-        PathElement<Field> f = pathElement as PathElement<Field>;
-        if (f != null) // must be static if first element
-        {
-          sym = this.FieldAddress(this.egraph.Root, f.Element);
-          return sym;
-        }
-        PathElement<Method> m = pathElement as PathElement<Method>;
-        if (m != null) // must be static if first element
-        {
-          Type pseudoFieldAddressType;
-          // recall that paths have a stripped out deref for pseudo fields (getters)
-          var pseudoFieldAddress = this.PseudoFieldAddress(this.egraph.Root, m.Element, out pseudoFieldAddressType, false, default(Type)); // shouldn't try to materialize
-          if (mdDecoder.HasValueRepresentation(mdDecoder.ElementType(pseudoFieldAddressType)))
-          {
-            sym = this.Value(pseudoFieldAddress);
-          }
-          else
-          {
-            sym = pseudoFieldAddress;
-          }
-          return sym;
-        }
-        return null;
-      }
-
-      internal ESymValue TryAccessOldValue(ESymValue sym, PathElement pathElement)
-      {
-
-        PathElementBase pbase = (PathElementBase)pathElement;
-        Contract.Assume(pbase.Constructor == Constructors.ValueOf); // F: made into an assumption
-        //System.Diagnostics.Debug.Assert(pbase.Constructor == Constructors.ValueOf);
-        return this.egraph.TryLookup(Constructors.OldValueOf, sym);
-      }
-
-      internal ESymValue TryAccess(ESymValue sym, PathElement pathElement)
-      {
-        PathElementBase pbase = (PathElementBase)pathElement;
-        ESymValue value = this.egraph.TryLookup(pbase.Constructor, sym);
-        if (value == null) return null;
-        // since we stripped out the extra deref on Method getter pseudo fields, we have to perform
-        // the extra deref here
-        PathElement<Method> pseudoField = pbase as PathElement<Method>;
-        if (pseudoField != null && !pseudoField.IsAddressOf)
-        {
-          return this.TryCorrespondingValue(value);
-        }
-        // extra deref on compressed parameter paths
-        ParameterPathElement parameter = pbase as ParameterPathElement;
-        if (parameter != null)
-        {
-          return this.TryCorrespondingValue(value);
-        }
-        return value;
-      }
-
-      internal bool CheckIfPathUnmodified(ESymValue sym, FList<PathElement> path)
-      {
-        while (path != null)
-        {
-          if (sym == null) return true; // not materialized
-          if (path.Head.IsDeref)
-          {
-            if (!this.IsUnmodifiedSinceEntry(sym)) return false;
-          }
-          else
-          {
-            // handle the case of a property getter/pure method. We have to check the location
-            // explicitly
-            var pseudoField = path.Head as MethodCallPathElement;
-            if (pseudoField != null && !pseudoField.IsAddressOf)
-            {
-              ESymValue pseudoFieldAddress = this.egraph.TryLookup(pseudoField.Constructor, sym);
-              if (pseudoFieldAddress == null) return false; // can't check
-              if (!this.IsUnmodifiedSinceEntry(pseudoFieldAddress)) return false;
-            }
-          }
-          sym = this.TryAccess(sym, path.Head);
-          path = path.Tail;
-        }
-        return true;
-      }
-
-      internal bool TryGetFieldAddress(SymbolicValue obj, Field field, out SymbolicValue address)
-      {
-        ESymValue addr = this.TryGetFieldAddress(obj.symbol, field);
-        if (addr != null) { address = new SymbolicValue(addr); return true; }
-        address = default(SymbolicValue);
-        return false;
-      }
-
-      private ESymValue TryGetFieldAddress(ESymValue obj, Field field)
-      {
-        return egraph.TryLookup(Constructors.For(field), obj);
-      }
-
-      internal bool TryLoadIndirect(SymbolicValue addr, out SymbolicValue value)
-      {
-        ESymValue val = this.egraph.TryLookup(Constructors.ValueOf, addr.symbol);
-        if (val != null) { value = new SymbolicValue(val); return true; }
-        value = default(SymbolicValue);
-        return false;
-      }
-
-
-      internal bool PathExistsUnmodifiedSinceEntry(FList<PathElementBase> accesspath, out ESymValue targetSym)
-      {
-        targetSym = null;
-
-        bool unmodified;
-        ESymValue sym = AccessPathHead(accesspath.Head, out unmodified, false, false);
-        if (sym == null || !unmodified)
-        {
-          return false;
-        }
-
-        var path = accesspath.Tail;
-        while (path != null)
-        {
-          if (path.Head.IsDeref)
-          {
-            if (!this.IsUnmodifiedSinceEntry(sym)) return false;
-          }
-          sym = this.TryAccess(sym, path.Head);
-          if (sym == null) return false;
-          path = path.Tail;
-        }
-        targetSym = sym;
-        return true;
-      }
-
-      internal void ResetModifiedAtCall()
-      {
-        this.modifiedAtCall = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
-      }
-
-      /// <summary>
-      /// Try to find a target value corresponding to old value. We are allowed to traverse 1 $OldValue
-      /// </summary>
-      /// <param name="accesspath"></param>
-      /// <param name="targetSym"></param>
-      /// <returns></returns>
-      internal bool PathExistsUnmodifiedAtCall(FList<PathElementBase> accesspath, out ESymValue targetSym)
-      {
-        targetSym = null;
-
-        bool unmodified;
-        ESymValue sym = AccessPathHead(accesspath.Head, out unmodified, true, true);
-        if (sym == null || !unmodified)
-        {
-          return false;
-        }
-
-        var path = accesspath.Tail;
-        while (path != null)
-        {
-          if (path.Head.IsDeref)
-          {
-            if (this.IsModifiedAtCall(sym))
-            {
-              sym = this.TryAccessOldValue(sym, path.Head);
-              if (sym == null) return false;
-              else
-              {
-                // continue
-                path = path.Tail;
-                continue;
-              }
-            }
-          }
-          sym = this.TryAccess(sym, path.Head);
-          if (sym == null) return false;
-          path = path.Tail;
-        }
-        targetSym = sym;
-        return true;
-      }
-
-      /// <summary>
-      /// Try to find a target value corresponding to old value. Call did not modify anything
-      /// </summary>
-      internal bool PathExistsAtCall(FList<PathElementBase> accesspath, out ESymValue targetSym)
-      {
-        targetSym = null;
-
-        bool unmodified;
-        ESymValue sym = AccessPathHead(accesspath.Head, out unmodified, true, true);
-        if (sym == null)
-        {
-          return false;
-        }
-
-        var path = accesspath.Tail;
-        while (path != null)
-        {
-          sym = this.TryAccess(sym, path.Head);
-          if (sym == null) return false;
-          path = path.Tail;
-        }
-        targetSym = sym;
-        return true;
-      }
-
-
-      private bool IsModifiedAtCall(ESymValue sym)
-      {
-        return (this.modifiedAtCall != null && this.modifiedAtCall.Contains(sym));
-      }
-
-      internal PathContextFlags PathContexts(ESymValue eSymValue)
-      {
-        Set<ESymValue> visited = new Set<ESymValue>();
-        return AccumulatePathContexts(eSymValue, PathContextFlags.None, visited);
-      }
-
-      PathContextFlags AccumulatePathContexts(ESymValue sv, PathContextFlags sofar, Set<ESymValue> visited)
-      {
-        if (sofar == PathContextFlags.All) return sofar;
-        if (visited.Contains(sv)) return sofar;
-        visited.Add(sv);
-        // check if this value directly is tagged
-        if (egraph.TryLookup(Constructors.ResultOfCall, sv) != null) { sofar |= PathContextFlags.ViaMethodReturn; }
-        if (egraph.TryLookup(Constructors.ResultOfLdelem, sv) != null) { sofar |= PathContextFlags.ViaArray; }
-        if (egraph.TryLookup(Constructors.ResultOfPureCall, sv) != null) { sofar |= PathContextFlags.ViaPureMethodReturn; }
-        if (egraph.TryLookup(Constructors.ResultOfCast, sv) != null) { sofar |= PathContextFlags.ViaCast; }
-        if (egraph.TryLookup(Constructors.ResultOfOutParameter, sv) != null) { sofar |= PathContextFlags.ViaOutParameter; }
-        if (egraph.TryLookup(Constructors.ResultOfCallThisHavoc, sv) != null) { sofar |= PathContextFlags.ViaCallThisHavoc; }
-        if (egraph.TryLookup(Constructors.ResultOfOldValue, sv) != null) { sofar |= PathContextFlags.ViaOldValue; }
-
-        if (sofar == PathContextFlags.All) return sofar;
-        // look through access paths
-        foreach (var eterm in egraph.EqTerms(sv))
-        {
-          var constructor = eterm.Function;
-          if (constructor.ActsAsField)
-          {
-            sofar |= PathContextFlags.ViaField;
-            sofar = AccumulatePathContexts(eterm.Args[0], sofar, visited);
-          }
-          else if (
-              constructor == Constructors.ValueOf ||
-              constructor == Constructors.WritableBytes ||
-              constructor == Constructors.Length
-             )
-          {
-            sofar = AccumulatePathContexts(eterm.Args[0], sofar, visited);
-          }
-          if (sofar == PathContextFlags.All) return sofar;
-        }
-        // look through array access paths
-        foreach (var eterm in egraph.EqMultiTerms(sv))
-        {
-          var constructor = eterm.Function;
-          if (
-              constructor == Constructors.ElementAddress
-             )
-          {
-            sofar = AccumulatePathContexts(eterm.Args[0], sofar, visited);
-          }
-          if (sofar == PathContextFlags.All) return sofar;
-        }
-        return sofar;
-      }
-
-      internal ESymValue StructId(ESymValue structAddr)
-      {
-        return this.egraph[Constructors.StructId, structAddr];
-      }
-
-      internal ESymValue ObjectVersion(ESymValue objectPtr)
-      {
-        return this.egraph[Constructors.ObjectVersion, objectPtr];
-      }
-
-      internal void ManifestStructId(ESymValue structAddr)
-      {
-        var dummy = StructId(structAddr);
-      }
-
-      internal void HavocArrayAtIndex(ESymValue arrayValue, ESymValue indexValue)
-      {
-        // TODO: be smarter about what needs to be havoced in the future.
-        // for now, we havoc everything.
-        //
-        // We could be smarter whenever we see a constant index, we could leave all distinct 
-        // constant elements untouched (carry them forward to the new version)
-        this.egraph.Eliminate(Constructors.ObjectVersion, arrayValue);
-      }
-
-      internal IFunctionalMap<ESymValue, FList<ESymValue>> GetForwardIdentityMap()
-      {
-        return this.egraph.GetForwardIdentityMap();
-      }
-
-      internal void HavocObjectAtCall(ESymValue obj, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields, bool havocReadonlyFields)
-      {
-        this.HavocFields(null, obj, ref havocedAtCall, havocReadonlyFields);
-        this.HavocUp(obj, ref havocedAtCall, havocFields);
-      }
-
-      /// <summary>
-      /// Consider access paths to this object from other objects and mutate their object reference
-      /// </summary>
-      private void HavocUp(ESymValue obj, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields)
-      {
-        Contract.Requires(havocedAtCall != null);
-        Contract.Ensures(havocedAtCall != null);
-
-        // invariant: obj in havocedAtCall
-        foreach (var term in this.egraph.EqTerms(obj))
-        {
-          var c = term.Function;
-          if (c == Constructors.ValueOf)
-          {
-            HavocUpField(term.Args[0], ref havocedAtCall, havocFields);
-          }
-        }
-      }
-
-      private void HavocUpField(ESymValue addr, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields)
-      {
-        Contract.Requires(havocedAtCall != null);
-        Contract.Ensures(havocedAtCall != null);
-
-        foreach (var term in this.egraph.EqTerms(addr))
-        {
-          var c = term.Function;
-
-          Constructor.Wrapper<Field> field = c as Constructor.Wrapper<Field>;
-          if (field != null)
-          {
-            HavocUpObjectVersion(c, term.Args[0], ref havocedAtCall, havocFields);
-            continue;
-          }
-          Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
-          if (method != null)
-          {
-            // havoc up, provided this is an instance method
-            if (!mdDecoder.IsStatic(method.Value) && mdDecoder.IsPropertyGetter(method.Value) && mdDecoder.Name(method.Value) != "get_Current")
-            {
-              HavocUpObjectVersion(c, term.Args[0], ref havocedAtCall, havocFields);
-            }
-            continue;
-          }
-
-        }
-      }
-
-      private void HavocUpObjectVersion(Constructor accessedVia, ESymValue obj, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields)
-      {
-        Contract.Requires(havocedAtCall != null);
-        Contract.Ensures(havocedAtCall != null);
-
-        if (havocedAtCall.Contains(obj)) return; // guard against cycles
-
-        this.egraph.Eliminate(Constructors.ObjectVersion, obj);
-
-        if (havocFields)
-        {
-          this.HavocMutableFields(accessedVia, obj, ref havocedAtCall);
-        }
-        else
-        {
-          this.HavocPseudoFields(accessedVia, obj, ref havocedAtCall);
-        }
-        this.HavocUp(obj, ref havocedAtCall, false); // only havoc fields up one level
-      }
-
-      internal void CopyValueToOldState(APC pc, Type type, int dest, int source, Domain target)
-      {
-        var destAddr = target.Address(dest);
-        var srcAddr = this.Address(source);
-        Type addrType;
-        var currType = this.GetType(srcAddr);
-        if (currType.IsNormal)
-        {
-          addrType = currType.Value;
-        }
-        else
-        {
-          addrType = mdDecoder.ManagedPointer(type);
-        }
-        CopyValueToOldState(pc, addrType, destAddr, srcAddr, target);
-      }
-
-      internal void CopyValueToOldState(APC pc, Type addrType, ESymValue destAddr, ESymValue srcAddr, Domain target)
-      {
-        target.MakeTotallyModified(destAddr);
-
-        if (destAddr != srcAddr) { target.HavocIfStruct(destAddr); }
-        target.SetType(destAddr, addrType);
-        FlatDomain<Type> elementType = TargetType(addrType);
-
-        if (IsStructWithFields(elementType))
-        {
-          this.CopyStructValueToOldState(pc, destAddr, srcAddr, elementType, target);
-        }
-        else
-        {
-          ESymValue svalue = this.egraph.TryLookup(Constructors.ValueOf, srcAddr);
-          if (svalue == null)
-          {
-            if (this.egraph.IsConstant)
-            {
-              return;
-            }
-            svalue = this.egraph[Constructors.ValueOf, srcAddr]; // manifest
-          }
-
-          this.CopyPrimitiveValueToOldState(pc, addrType, destAddr, svalue, target);
-        }
-      }
-
-      private void CopyPrimitiveValueToOldState(APC pc, Type addrType, ESymValue destAddr, ESymValue svalue, Domain target)
-      {
-        // just grab the value and see if it is valid
-        if (target.IsValidSymbol(svalue))
-        {
-          target.CopyNonStructWithFieldValue(destAddr, svalue, addrType);
-        }
-        else
-        {
-          target.Assign(destAddr, addrType);
-        }
-      }
-
-
-
-      private void CopyStructValueToOldState(APC pc, ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> type, Domain target)
-      {
-        if (destAddr == null) return;
-        // copy old struct id
-        CopyStructId(pc, destAddr, srcAddr, this, target);
-
-        foreach (Constructor key in this.egraph.Functions(srcAddr))
-        {
-          if (!key.ActsAsField) continue;
-          Type t = key.FieldAddressType(mdDecoder);
-
-          ESymValue destFld = target.egraph[key, destAddr];
-          ESymValue srcFld = this.egraph[key, srcAddr];
-          CopyValueToOldState(pc, t, destFld, srcFld, target);
-        }
-      }
-
-
-      internal ESymValue PseudoFieldAddressOfOutParameter(int index, ESymValue fieldAddr, Type parameterType, Type fromType)
-      {
-        var pseudoField = Constructors.ForConstant(index, mdDecoder.System_Int32);
-        var result = this.egraph[pseudoField, fieldAddr];
-        MaterializeAccordingToType(result, parameterType, 2, Constructors.ResultOfOutParameter, fromType: fromType);
-        return result;
-      }
-
-      internal void SetDelegateDetails(ESymValue obj, ESymValue closure, ESymValue fnPtrValue)
-      {
-        this.egraph[Constructors.FunctionPointer, obj] = fnPtrValue;
-        if (closure != null)
-        {
-          this.egraph[Constructors.ClosureObject, obj] = closure;
-        }
-      }
-
-      internal bool IsPureFunctionCall(SymbolicValue value, out Method method, out SymbolicValue[] args)
-      {
-        // we are given the "value", but the egraph stores the address. so we first have to get up one level
-        foreach (var addr in this.egraph.EqTerms(value.symbol))
-        {
-          if (addr.Function == Constructors.ValueOf)
-          {
-            var fldAddr = addr.Args[0];
-            foreach (var term in this.egraph.EqTerms(fldAddr))
-            {
-              var methodCtor = term.Function as Constructor.PureMethodConstructor;
-              if (methodCtor != null)
-              {
-                method = methodCtor.Value;
-                args = new SymbolicValue[term.Args.Length];
-                for (int i = 0; i < term.Args.Length; i++)
-                {
-                  args[i] = new SymbolicValue(term.Args[i]);
+                    foreach (Property p in mdDecoder.Properties(type))
+                    {
+                        if (mdDecoder.IsStatic(p)) continue;
+                        Method getter;
+                        if (!mdDecoder.HasGetter(p, out getter)) continue;
+
+                        // skip string.get_Length, as we use $Length for that
+                        if (mdDecoder.Equal(type, mdDecoder.System_String) && mdDecoder.Name(getter) == "get_Length")
+                        {
+                            continue;
+                        }
+                        if (mdDecoder.IsVisibleFrom(getter, fromType))
+                        {
+                            if (mdDecoder.Parameters(getter).Count > 0) continue;
+
+                            // manifest the property
+                            Type propertyType;
+                            ESymValue propAddr = data.PseudoFieldAddress(value, getter, out propertyType, false, this.CurrentMethodDeclaringType);
+                            MaterializeParameterInfo(propAddr, propertyType, depth + 1, data, fromType, aggressiveMaterialization);
+                        }
+                    }
+                    foreach (var m in parent.contractDecoder.ModelMethods(type))
+                    {
+                        if (mdDecoder.IsVisibleFrom(m, fromType))
+                        {
+                            // manifest the method
+                            Type methodType;
+                            ESymValue propAddr = data.PseudoFieldAddress(value, m, out methodType, false, this.CurrentMethodDeclaringType);
+                            MaterializeParameterInfo(propAddr, methodType, depth + 1, data, fromType, aggressiveMaterialization);
+                        }
+                    }
+                    if (this.mdDecoder.IsInterface(type))
+                    {
+                        foreach (var intf in mdDecoder.Interfaces(type))
+                        {
+                            if (mdDecoder.IsVisibleFrom(intf, fromType))
+                            {
+                                ManifestProperties(value, depth, data, fromType, aggressiveMaterialization, intf);
+                            }
+                        }
+                    }
                 }
-                return true;
-              }
-            }
-            foreach (var term in this.egraph.EqMultiTerms(fldAddr))
-            {
-              var methodCtor = term.Function as Constructor.PureMethodConstructor;
-              if (methodCtor != null)
-              {
-                method = methodCtor.Value;
-                args = new SymbolicValue[term.Args.Length];
-                for (int i = 0; i < term.Args.Length; i++)
+
+                public Domain Entry(APC pc, Method method, Domain data)
                 {
-                  args[i] = new SymbolicValue(term.Args[i]);
+                    Contract.Assume(data.oldDomain == null);
+
+                    // meterialize all locals
+                    IIndexable<Local> locals = this.mdDecoder.Locals(method);
+                    for (int i = 0; i < locals.Count; i++)
+                    {
+                        MaterializeLocal(locals[i], data, method);
+                    }
+                    var declaringType = mdDecoder.DeclaringType(method);
+
+                    // materialize all parameters.
+                    IIndexable<Parameter> parameters = this.mdDecoder.Parameters(method);
+                    for (int i = 0; i < parameters.Count; i++)
+                    {
+                        MaterializeParameter(parameters[i], data, declaringType, false);
+                    }
+                    // this
+                    if (!mdDecoder.IsStatic(method))
+                    {
+                        MaterializeParameter(this.mdDecoder.This(method), data, declaringType, true);
+                    }
+                    // for constructors, set all fields to 0
+                    if (this.mdDecoder.IsConstructor(method))
+                    {
+                        Parameter thisParam = this.mdDecoder.This(method);
+                        ESymValue thisValue = data.Value(thisParam);
+                        foreach (Field f in this.mdDecoder.Fields(declaringType))
+                        {
+                            if (mdDecoder.IsStatic(f)) continue;
+                            Type fieldType = mdDecoder.FieldType(f);
+                            if (mdDecoder.IsStruct(fieldType))
+                            {
+                                data.AssignConst(data.FieldAddress(thisValue, f), fieldType, 0);
+                            }
+                            else
+                            {
+                                data.AssignNull(data.FieldAddress(thisValue, f));
+                            }
+                        }
+                        foreach (Property p in this.mdDecoder.Properties(declaringType))
+                        {
+                            if (mdDecoder.IsStatic(p)) continue;
+                            Method getter;
+                            if (mdDecoder.HasGetter(p, out getter))
+                            {
+                                // REVIEW: really IsCompilerGenerated ? Not the opposite ? [MAF:3/26/2013]
+                                if (mdDecoder.IsCompilerGenerated(getter) && mdDecoder.Parameters(getter).Count == 0)
+                                {
+                                    Type propType = mdDecoder.ReturnType(getter);
+                                    if (mdDecoder.IsStruct(propType))
+                                    {
+                                        data.AssignConst(data.PseudoFieldAddress(thisValue, getter, this.CurrentMethodDeclaringType), propType, 0);
+                                    }
+                                    else
+                                    {
+                                        data.AssignNull(data.PseudoFieldAddress(thisValue, getter, this.CurrentMethodDeclaringType));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else if (MethodToBeSimulated(method))
+                    {
+                        InitializePhantonFields(method, data);
+                    }
+                    return data;
                 }
-                return true;
-              }
+
+                private bool IsMoveNext(Method method)
+                {
+                    string name = this.mdDecoder.Name(method);
+                    bool nameMatch = name == "MoveNext";
+                    if (!nameMatch) return false;
+                    foreach (Method m in mdDecoder.OverriddenAndImplementedMethods(method))
+                    {
+                        Type t = mdDecoder.DeclaringType(m);
+                        string n = mdDecoder.Name(t);
+                        Contract.Assume(n != null);
+                        if (n.Contains("Enumerable") || n.Contains("Enumerator")) return true;
+                    }
+                    return false;
+                }
+
+                private bool MethodToBeSimulated(Method method)
+                {
+                    foreach (Attribute attr in mdDecoder.GetAttributes(method))
+                    {
+                        Type attrType = mdDecoder.AttributeType(attr);
+                        string attrName = mdDecoder.Name(attrType);
+                        if (attrName == "SimulationMethod")
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+
+                private void InitializePhantonFields(Method method, Domain data)
+                {
+                    Parameter thisParam = this.mdDecoder.This(method);
+                    ESymValue thisValue = data.Value(thisParam);
+                    string mname = mdDecoder.Name(method);
+                    foreach (Field f in this.mdDecoder.Fields(this.mdDecoder.DeclaringType(method)))
+                    {
+                        foreach (Attribute attr in mdDecoder.GetAttributes(f))
+                        {
+                            Type attrType = mdDecoder.AttributeType(attr);
+                            if (mdDecoder.Name(attrType) == "PhantonField")
+                            {
+                                IIndexable<object> args = mdDecoder.PositionalArguments(attr);
+                                if (args != null && args.Count == 1 && (string)args[0] == mname)
+                                {
+                                    data.FieldAddress(thisValue, f);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                public Domain Ldstack(APC pc, int offset, int dest, int source, bool isOld, Domain data)
+                {
+                    if (isOld)
+                    {
+                        // New implementation using CopyOldValue
+                        Domain oldState = FindOldState(pc, data);
+
+                        if (oldState == null)
+                        {
+                            return data;
+                        }
+
+                        oldState.CopyOldValue(pc, dest, source, data, false);
+                        if (data.oldDomain != null)
+                        {
+                            oldState.CopyOldValue(pc, dest, source, data.oldDomain, false);
+                        }
+                    }
+                    else
+                    {
+                        data.Copy(dest, source);
+                        if (data.oldDomain != null)
+                        {
+                            data.oldDomain.Copy(dest, source);
+                        }
+                    }
+                    return data;
+                }
+
+                private static void LdstackaEffect(APC pc, int offset, int dest, int source, Domain data)
+                {
+                    data.CopyStackAddress(data.Address(dest), source);
+                }
+                public Domain Ldstacka(APC pc, int offset, int dest, int source, Type type, bool isOld, Domain data)
+                {
+                    if (isOld)
+                    {
+                        // it makes no sense to take the address of the actual old stack location since this really means we'll
+                        // eventually read something from there. So what we do is create a dummy new location into which we make a shallow
+                        // copy of the old stack locations data and then produce a pointer to that dummy location.
+                        Type dummyLocType = mdDecoder.ManagedPointer(type);
+
+                        Domain oldState = FindOldState(pc, data);
+
+                        if (oldState == null)
+                        {
+                            return data;
+                        }
+
+                        var oldStackAddress = oldState.Address(source);
+                        var dummyDest = data.CreateValue(type);
+                        oldState.CopyOldValue(pc, dummyDest, oldStackAddress, data, true);
+                        data.CopyAddress(data.Address(dest), dummyDest, dummyLocType);
+
+                        if (data.oldDomain != null)
+                        {
+                            var addrType = mdDecoder.ManagedPointer(dummyLocType);
+                            oldState.CopyOldValueToDest(pc, data.oldDomain.Address(dest), oldStackAddress, addrType, data.oldDomain);
+                        }
+                    }
+                    else
+                    {
+                        LdstackaEffect(pc, offset, dest, source, data);
+                        if (data.oldDomain != null)
+                        {
+                            LdstackaEffect(pc, offset, dest, source, data.oldDomain);
+                        }
+                    }
+                    return data;
+                }
+
+                public static Domain FindOldState(APC pc, Domain data)
+                {
+                    Contract.Requires(data != null);
+
+                    // walk the subroutine context to determine if we are in an ensures of a method exit, or at a call-return
+                    // and grab the correct context pc for that state.
+                    SubroutineContext scontext = pc.SubroutineContext;
+                    while (scontext != null)
+                    {
+                        SubroutineEdge head = scontext.Head;
+                        if (head.Three == "exit")
+                        {
+                            // inside method exit.
+                            Domain oldState = data.GetStateAt(new APC(head.One.Subroutine.EntryAfterRequires, 0, scontext.Tail));
+                            return oldState;
+                        }
+                        if (head.Three.StartsWith("after") || head.Three.StartsWith("assumeInvariant"))
+                        {
+                            // after call or after newObj
+                            // we are in an ensures around a method call. Find the calling context and the from block, which is the method call
+                            Domain oldState = data.GetStateAt(new APC(head.One, 0, scontext.Tail));
+                            return oldState;
+                        }
+                        scontext = scontext.Tail;
+                    }
+                    return null;
+                }
+
+                /// <summary>
+                /// This is were OLD semantics are actually implemented.
+                ///
+                /// Here, we have to distinguish 2 cases
+                /// 1) we are evaluating the ensures assert at the end of a method
+                /// 2) we are evaluating the ensures assume at the end of a call
+                ///
+                /// For 1), we find the heap state at the beginning of the current method, after pre-conditions have been evaluated.
+                /// For 2), we find the heap state at the call instruction of the call on the subroutine stack
+                ///
+                /// We clone the found heap state and return it as the current state for the evaluation of the instructions modelling
+                /// the "old" expression.
+                ///
+                /// We also have to store away our current state so as to retrieve it at the matchin EndOld.
+                ///
+                /// Note about DFA dependency. if the data flow state changes that we look up here, then we will re-evaluate this point
+                /// as well because the call site or method entry point dominates the current pc.
+                /// </summary>
+                public Domain BeginOld(APC pc, APC matchingEnd, Domain data)
+                {
+                    // Nested begin old can happen if we use a property in an old context and the property itself has a post condition
+                    // with old wrapping.
+                    if (data.insideOld++ == 0)
+                    {
+                        Domain oldDomain = FindOldState(pc, data);
+                        if (oldDomain == null)
+                        {
+                            throw new InvalidOperationException("begin_old in weird calling context");
+                        }
+                        oldDomain = oldDomain.Clone();
+                        oldDomain.beginOldPC = pc;
+                        data.oldDomain = oldDomain;
+                    }
+                    Contract.Assume(data.insideOld > 0);
+
+#if false
+                    // Store away the current state so we can retrieve it at the matching EndOld.
+                    data.AddOldSavedState(pc, data);
+
+                    data = oldDomain.Clone();
+                    data.inOld = true;
+#endif
+                    return data;
+                }
+
+                /// <summary>
+                /// Here we have to load source in the current "old" state, then retrieve the dataflow state for the matching
+                /// BeginOld. We then have 2 situations
+                /// 1) the source symbol from the "old" state is known in the retrieved state. If so, we assign it to dest in the
+                ///    retrieved state.
+                /// 2) the source symbol from the "old" state is NOT known in the retrieved state. If so, we assign a fresh
+                ///    symbol to dest in the retrieved state.
+                ///
+                /// In both cases, we continue with the retrieved state.
+                /// </summary>
+                public Domain EndOld(APC pc, APC matchingBegin, Type type, Temp dest, Temp source, Domain data)
+                {
+                    Contract.Assume(data.insideOld > 0);
+
+                    Domain oldDomain = data.oldDomain;
+
+                    if (--data.insideOld == 0)
+                    {
+                        // outermost end old
+                        data.oldDomain = null;
+                    }
+                    data.CopyOld(dest, source, type);
+                    return data;
+                }
+
+                public Domain Ldresult(APC pc, Type type, int dest, int source, Domain data)
+                {
+                    return this.Ldstack(pc, 0 /* not important */, dest, source, false, data);
+                }
+
+                #endregion
             }
-          }
-        }
-        method = default(Method);
-        args = null;
-        return false;
-      }
+            #endregion
 
-      internal bool IsDelegateValue(SymbolicValue value, out SymbolicValue targetObject, out Method targetMethod)
-      {
-        ESymValue closure;
-        var result = IsDelegateValue(value.symbol, out closure, out targetMethod);
-        targetObject = new SymbolicValue(closure);
-        return result;
-      }
 
-      internal bool IsDelegateValue(ESymValue value, out ESymValue targetObject, out Method targetMethod)
-      {
-        var fnptr = this.egraph.TryLookup(Constructors.FunctionPointer, value);
-        if (fnptr != null)
-        {
-          if (this.IsMethodPointer(fnptr, out targetMethod))
-          {
-            targetObject = this.egraph.TryLookup(Constructors.ClosureObject, value);
-            return true;
-          }
-        }
-        targetMethod = default(Method);
-        targetObject = default(ESymValue);
-        return false;
-      }
+            #region IAbstractValue<OptimisticHeapAbstraction<APC,Local,Parameter,Method,Field,Type>> Members
 
-      internal bool TryGetArrayFromArrayElementAddress(SymbolicValue elementAddress, out SymbolicValue array, out SymbolicValue index)
-      {
-        foreach (var candidate in this.egraph.EqMultiTerms(elementAddress.symbol))
-        {
-          if (candidate.Function == Constructors.ElementAddress)
-          {
-            index = new SymbolicValue(candidate.Args[1]);
-            // grab object version and then find corresponding object
-            return TryGetObjectFromObjectVersion(new SymbolicValue(candidate.Args[0]), out array);
-          }
-        }
-        array = default(SymbolicValue);
-        index = default(SymbolicValue);
-        return false;
-      }
-
-      internal bool TryGetObjectFromObjectVersion(SymbolicValue objectVersion, out SymbolicValue objectValue)
-      {
-        foreach (var obj in this.egraph.EqTerms(objectVersion.symbol))
-        {
-          if (obj.Function == Constructors.ObjectVersion)
-          {
-            objectValue = new SymbolicValue(obj.Args[0]);
-            return true;
-          }
-        }
-        objectValue = default(SymbolicValue);
-        return false;
-      }
-
-      internal ESymValue TryGetPropertyNamed(ESymValue pointer, string propertyName)
-      {
-        foreach (var ctor in this.egraph.Functions(pointer))
-        {
-          var method = ctor as Constructor.PureMethodConstructor;
-          if (method == null) continue;
-          if (this.mdDecoder.IsPropertyGetter(method.Value))
-          {
-            Property prop = this.mdDecoder.GetPropertyFromAccessor(method.Value);
-            if (prop != null && this.mdDecoder.Name(prop) == propertyName)
+            public Domain Top
             {
-              return this.TryValue(this.egraph[ctor, pointer]);
+                get
+                {
+                    return new Domain(egraph.Top,
+                                      FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey),
+                                      FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
+                                      FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
+                                      FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
+                                      this, null);
+                }
             }
-          }
-        }
-        return null;
-      }
 
-      internal ESymValue TryGetModelMethod(ESymValue pointer, string modelMethodName)
-      {
-        foreach (var ctor in this.egraph.Functions(pointer))
-        {
-          var method = ctor as Constructor.PureMethodConstructor;
-          if (method == null) continue;
-          if (!this.mdDecoder.IsPropertyGetter(method.Value)) continue;
-          var methodName = this.mdDecoder.Name(method.Value).Substring(4);
-          if (!methodName.Equals(modelMethodName)) continue;
-          var t = this.mdDecoder.DeclaringType(method.Value);
-          foreach (var modelMethod in this.parent.contractDecoder.ModelMethods(t))
-          {
-            if (this.mdDecoder.IsPropertyGetter(modelMethod))
+            [ThreadStatic] // Because this.egraph.Bottom is ThreadStatic
+            private static Domain BottomValue;
+
+            public Domain Bottom
             {
-              var name = this.mdDecoder.Name(modelMethod);
-              if (4 < name.Length && name.Substring(4).Equals(modelMethodName))
-              {
-                var result = this.TryValue(this.egraph[ctor, pointer]);
+                get
+                {
+                    if (BottomValue == null)
+                    {
+                        BottomValue = new Domain(egraph.Bottom,
+                                                 FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey),
+                                                 FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
+                                                 FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
+                                                 FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey),
+                                                 this, null);
+                        Bottom.ImmutableVersion();
+                    }
+                    return BottomValue;
+                }
+            }
+
+            public bool IsTop
+            {
+                get { return egraph.IsTop; }
+            }
+
+            public bool IsBottom
+            {
+                get
+                {
+                    return this == BottomValue || egraph.IsBottom
+                      || oldDomain != null && oldDomain.IsBottom;
+                }
+            }
+
+            public Domain ImmutableVersion()
+            {
+                egraph.ImmutableVersion(); // mark immutable
+                return this;
+            }
+
+            public Domain Clone()
+            {
+                Contract.Ensures(Contract.Result<Domain>() != null);
+
+                return new Domain(egraph.Clone(),
+                                  constantLookup,
+                                  unmodifiedSinceEntry,
+                                  unmodifiedSinceEntryForFields,
+                                  modifiedAtCall,
+                                  this,
+                                  oldDomain == null ? null : oldDomain.Clone()
+                           );
+            }
+
+            public Domain Join(Domain newState, out bool weaker, bool widen)
+            {
+                IMergeInfo mi;
+                return this.Join(newState, out weaker, out mi, widen);
+            }
+
+            internal Domain Join(Domain newState, out bool weaker, out IMergeInfo mergeInfo, bool widen)
+            {
+                EGraph<Constructor, AbstractType> newEgraph = egraph.Join(newState.egraph, out mergeInfo, widen);
+                weaker = mergeInfo.Changed;
+                IFunctionalSet<ESymValue> newUnmodifiedSinceEntry, newUnmodifiedSinceEntryForFields, newModifiedAtCall;
+                ComputeJoinOfSets(mergeInfo, this, newState, out newUnmodifiedSinceEntry, out newUnmodifiedSinceEntryForFields, out newModifiedAtCall, ref weaker);
+
+                Domain oldDomainJoin = null;
+                if (oldDomain != null)
+                {
+                    Contract.Assume(newState.oldDomain != null);
+                    bool weaker2;
+                    IMergeInfo mergeInfo2;
+                    oldDomainJoin = oldDomain.Join(newState.oldDomain, out weaker2, out mergeInfo2, widen);
+                }
+                return new Domain(newEgraph, RecomputeConstantMap(newEgraph),
+                                  newUnmodifiedSinceEntry,
+                                  newUnmodifiedSinceEntryForFields,
+                                  newModifiedAtCall,
+                                  this, oldDomainJoin);
+            }
+
+            private void ComputeJoinOfSets(IMergeInfo mergeInfo, Domain oldState, Domain newState, out IFunctionalSet<ESymValue> resultUnmodifiedSinceEntry, out IFunctionalSet<ESymValue> resultUnmodifiedSinceEntryForFields, out IFunctionalSet<ESymValue> resultModifiedAtCall, ref bool weaker)
+            {
+                resultUnmodifiedSinceEntry = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+                resultUnmodifiedSinceEntryForFields = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+                resultModifiedAtCall = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+
+                foreach (var tuple in mergeInfo.MergeTriples)
+                {
+                    var oldsym = tuple.One;
+                    var newsym = tuple.Two;
+                    var resultsym = tuple.Three;
+
+                    // Must be able to handle oldsym or newsym being null. 
+                    // This happens when we materialize one or the other.
+                    bool oldUnmodifiedSinceEntry = SetContains(oldState.unmodifiedSinceEntry, oldsym);
+                    bool oldUnmodifiedSinceEntryForFields = SetContains(oldState.unmodifiedSinceEntryForFields, oldsym);
+                    bool oldModifiedAtCall = SetContains(oldState.modifiedAtCall, oldsym);
+
+                    #region Unmodified
+                    if (oldUnmodifiedSinceEntry)
+                    {
+                        // newsym == null means we manifested it. Let's assume that it wasn't modified on the new branch!
+                        if (newsym == null || newState.IsBottomPlaceHolder(newsym) || SetContains(newState.unmodifiedSinceEntry, newsym))
+                        {
+                            // found intersection
+                            resultUnmodifiedSinceEntry = resultUnmodifiedSinceEntry.Add(resultsym);
+                        }
+                        else
+                        {
+                            // check if newState has the symbol in the ForFields set
+                            if (SetContains(newState.unmodifiedSinceEntryForFields, newsym))
+                            {
+                                // add it to the result ForFields set
+                                resultUnmodifiedSinceEntryForFields = resultUnmodifiedSinceEntryForFields.Add(resultsym);
+                            }
+                        }
+                    }
+
+                    #endregion
+
+                    #region Modified
+                    if (oldModifiedAtCall)
+                    {
+                        // just rename from old to result. We don't care about join, as this set only matters
+                        // within scope of call + ensures.
+                        resultModifiedAtCall = resultModifiedAtCall.Add(resultsym);
+                    }
+                    #endregion
+
+                }
+                #region Check if join is weaker
+                if (SetCount(oldState.unmodifiedSinceEntry) > resultUnmodifiedSinceEntry.Count)
+                {
+                    // weaker join
+                    weaker = true;
+                    if (Domain.Debug)
+                    {
+                        Console.WriteLine("---Result changed due to fewer unmodified locations since entry");
+                    }
+                }
+                else if (SetCount(oldState.unmodifiedSinceEntryForFields) > resultUnmodifiedSinceEntryForFields.Count)
+                {
+                    // weaker join
+                    weaker = true;
+                    if (Domain.Debug)
+                    {
+                        Console.WriteLine("---Result changed due to fewer unmodified locations for fields since entry");
+                    }
+                }
+                #endregion
+            }
+
+
+
+
+            private static bool SetContains(IFunctionalSet<ESymValue> set, ESymValue value)
+            {
+                if (set == null) return false;
+                if (value == null) return false;
+                return set.Contains(value);
+            }
+
+            private static int SetCount(IFunctionalSet<ESymValue> set)
+            {
+                if (set == null) return 0;
+                return set.Count;
+            }
+
+            private IFunctionalMap<ESymValue, Constructor> RecomputeConstantMap(EGraph<Constructor, AbstractType> egraph)
+            {
+                IFunctionalMap<ESymValue, Constructor> result = FunctionalIntKeyMap<ESymValue, Constructor>.Empty(ESymValue.GetUniqueKey);
+
+                foreach (Constructor c in egraph.Constants)
+                {
+                    if (Constructors.IsConstantOrMethod(c))
+                    {
+                        result = result.Add(egraph[c], c);
+                    }
+                }
                 return result;
-              }
             }
-          }
+
+            public Domain Meet(Domain b)
+            {
+                EGraph<Constructor, AbstractType> newEgraph = egraph.Meet(b.egraph);
+                return new Domain(newEgraph, RecomputeConstantMap(newEgraph),
+                                  ComputeMeetUnmodifiedSinceEntry(),
+                                  ComputeMeetUnmodifiedSinceEntry(),
+                                  null,
+                                  this, oldDomain);
+                // NOTE: do we need to meet oldDomains ?
+            }
+
+            private IFunctionalSet<ESymValue> ComputeMeetUnmodifiedSinceEntry()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dump(TextWriter tw)
+            {
+                egraph.Dump(tw);
+                tw.WriteLine("Unmodified locs");
+                foreach (ESymValue sv in unmodifiedSinceEntry.Elements)
+                {
+                    tw.Write(sv); tw.Write(' ');
+                }
+                tw.WriteLine();
+                tw.WriteLine("Unmodified locs for fields");
+                foreach (ESymValue sv in unmodifiedSinceEntryForFields.Elements)
+                {
+                    tw.Write(sv); tw.Write(' ');
+                }
+                tw.WriteLine();
+                if (modifiedAtCall != null)
+                {
+                    tw.WriteLine("Modified locs at last call");
+                    foreach (ESymValue sv in modifiedAtCall.Elements)
+                    {
+                        tw.Write(sv); tw.Write(' ');
+                    }
+                    tw.WriteLine();
+                }
+                if (oldDomain != null)
+                {
+                    tw.WriteLine("## has old domain");
+                    oldDomain.egraph.Dump(tw);
+                    tw.WriteLine("## end old domain");
+                }
+            }
+
+            public bool LessEqual(Domain that)
+            {
+                return egraph.LessEqual(that.egraph);
+            }
+
+            public bool LessEqual(Domain that,
+                                  out IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward,
+                                  out IFunctionalMap<ESymValue, ESymValue>/*?*/ backward)
+            {
+                Contract.Requires(that != null);
+
+                return egraph.LessEqual(that.egraph, out forward, out backward);
+            }
+
+            #endregion
+
+            #region Accessors for Heap Abstraction Results
+            /// <summary>
+            /// Represents the CLR type of a symbolic value as well as wether the value is known to be zero/null
+            /// </summary>
+            internal struct AbstractType : IAbstractValueForEGraph<AbstractType>, IEquatable<AbstractType>
+            {
+                private readonly bool isZero;
+                private readonly FlatDomain<Type> value;
+
+                public AbstractType(FlatDomain<Type> value, bool isZero)
+                {
+                    this.value = value;
+                    this.isZero = isZero;
+                }
+
+                #region Forwarding to FlatDomainOE<Type>
+
+                public AbstractType Top { get { return new AbstractType(FlatDomain<Type>.TopValue, false); } }
+                public AbstractType Bottom { get { return new AbstractType(FlatDomain<Type>.BottomValue, true); } }
+                public bool IsTop { get { return !isZero && value.IsTop; } }
+                public bool IsBottom { get { return isZero && value.IsBottom; } }
+                public AbstractType ImmutableVersion() { return this; }
+                public AbstractType Clone() { return this; }
+                public AbstractType Join(AbstractType that, out bool weaker, bool widen)
+                {
+                    // special hack: if one of the two values is Zero, we ignore the type and treat it as bottom
+                    if (that.isZero)
+                    {
+                        weaker = false;
+                        if (value.IsBottom)
+                        {
+                            return new AbstractType(that.value, isZero);
+                        }
+                        return this;
+                    }
+                    else if (isZero)
+                    {
+                        weaker = true;
+                        if (that.value.IsBottom)
+                        {
+                            return new AbstractType(value, that.isZero);
+                        }
+                        return that;
+                    }
+                    else
+                    {
+                        FlatDomain<Type> resultType = value.Join(that.value, out weaker, widen);
+                        RecoverResultTypeInfo(ref resultType, value, that.value);
+                        return new AbstractType(resultType, false);
+                    }
+                }
+
+                [ThreadStatic]
+                internal static IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder;
+
+                private static void RecoverResultTypeInfo(ref FlatDomain<Type> resultType, FlatDomain<Type> thisType, FlatDomain<Type> thatType)
+                {
+                    if (resultType.IsTop)
+                    {
+                        if (thisType.IsNormal && thatType.IsNormal)
+                        {
+                            Type t1 = thisType.Value;
+                            Type t2 = thatType.Value;
+                            // check if we have T@ and T*
+                            if (MetadataDecoder.IsManagedPointer(t1) && MetadataDecoder.IsUnmanagedPointer(t2) &&
+                                MetadataDecoder.ElementType(t1).Equals(MetadataDecoder.ElementType(t2)))
+                            {
+                                resultType = thatType;
+                                return;
+                            }
+                            // check if we have T* and T@
+                            if (MetadataDecoder.IsUnmanagedPointer(t1) && MetadataDecoder.IsManagedPointer(t2) &&
+                                MetadataDecoder.ElementType(t1).Equals(MetadataDecoder.ElementType(t2)))
+                            {
+                                resultType = thisType;
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                public AbstractType Meet(AbstractType that) { return new AbstractType(value.Meet(that.value), isZero || that.isZero); }
+                public bool LessEqual(AbstractType that)
+                {
+                    return isZero || !that.isZero && TypeLeq(ref that);
+                }
+
+                private bool TypeLeq(ref AbstractType that)
+                {
+                    if (value.LessEqual(that.value)) return true;
+                    // recover if there are managed/unmanaged pointer differences:
+                    // T@ <= T*
+                    if (value.IsNormal && that.value.IsNormal)
+                    {
+                        Type t1 = value.Value;
+                        Type t2 = that.value.Value;
+                        // check if we have T@ and T*
+                        if (MetadataDecoder.IsManagedPointer(t1) && MetadataDecoder.IsUnmanagedPointer(t2) &&
+                            MetadataDecoder.ElementType(t1).Equals(MetadataDecoder.ElementType(t2)))
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+
+                public void Dump(TextWriter tw)
+                {
+                    if (isZero) { tw.Write("(Zero) "); }
+                    value.Dump(tw);
+                }
+
+                public static readonly AbstractType TopValue = new AbstractType(FlatDomain<Type>.TopValue, false); // Thread-safe because MetadataDecoder is ThreadStatic
+                                                                                                                   //        public static AbstractType ForManifestedFieldValue { get { return new AbstractType(FlatDomain<Type>.BottomValue, false); } }
+                public static AbstractType ForManifestedFieldValue { get { return TopValue; } }
+                public static readonly AbstractType BottomValue = new AbstractType(FlatDomain<Type>.BottomValue, true); // Thread-safe because MetadataDecoder is ThreadStatic
+                public Type Value { get { return value.Value; } }
+                public bool IsNormal { get { return value.IsNormal; } }
+
+                #endregion Forwarding to FlatDomain<Type>
+
+                // public static implicit operator AbstractType(Type type) { return new AbstractType(type); }
+
+                public FlatDomain<Type> Type { get { return value; } }
+
+                public override string ToString()
+                {
+                    if (isZero) { return "(Zero) " + value.ToString(); }
+                    return value.ToString();
+                }
+
+
+                #region IAbstractValueForEGraph<AbstractType> Members
+
+                public bool HasAllBottomFields
+                {
+                    get { return isZero; }
+                }
+
+                public AbstractType ForManifestedField()
+                {
+                    return ForManifestedFieldValue;
+                }
+
+                #endregion
+
+                internal AbstractType With(FlatDomain<Type> type)
+                {
+                    return new AbstractType(type, isZero);
+                }
+
+                internal AbstractType ButZero
+                {
+                    get
+                    {
+                        return new AbstractType(value, true);
+                    }
+                }
+                internal bool IsZero { get { return isZero; } }
+
+
+
+                #region IEquatable<AbstractType> Members
+
+                public bool Equals(AbstractType that)
+                {
+                    return isZero == that.isZero && value.Equals(that.value);
+                }
+
+                #endregion
+            }
+
+            internal AbstractType GetType(ESymValue value)
+            {
+                return egraph[value];
+            }
+
+            internal bool TryGetArrayLength(ESymValue arrayValue, out ESymValue lengthValue)
+            {
+                lengthValue = egraph.TryLookup(Constructors.Length, arrayValue);
+                return lengthValue != null;
+            }
+
+            internal bool TryGetWritableBytes(ESymValue arrayValue, out ESymValue lengthValue)
+            {
+                lengthValue = egraph.TryLookup(Constructors.WritableBytes, arrayValue);
+                return lengthValue != null;
+            }
+
+            internal bool IsZero(ESymValue value)
+            {
+                return egraph[value].IsZero;
+            }
+
+            internal bool IsConstant(ESymValue sv, out Type type, out object value)
+            {
+                Constructor c = constantLookup[sv];
+                if (c != null)
+                {
+                    return Constructors.IsConstant(c, out type, out value); // may fail because constantLookup also contains method pointers which we do not treat as constants
+                }
+                type = default(Type);
+                value = null;
+                return false;
+            }
+
+            /// <summary>
+            /// Besides getting the path, it also propagates type info in preparation for path decoding as MSIL code
+            /// </summary>
+            internal FList<PathElement> GetAccessPathList(ESymValue sv, AccessPathFilter<Method, Type> filter, bool allowLocal, bool preferLocal)
+            {
+                var path = GetBestAccessPath(sv, filter, true, allowLocal, preferLocal);
+                return path;
+            }
+
+            private bool TryGetCorrespondingValueAbstraction(Constructor v, out SymbolicValue sv)
+            {
+                if (this.IsBottom) { goto noValue; }
+                ESymValue addr = TryAddress(v);
+                if (addr == null) goto noValue;
+
+                var value = TryCorrespondingValue(addr); // provides Value indirection or address depending on addr type.
+
+                if (value == null) goto noValue;
+                sv = new SymbolicValue(value);
+                return true;
+
+            noValue:;
+                sv = default(SymbolicValue);
+                return false;
+            }
+
+            internal ESymValue TopOfStackValue()
+            {
+                if (this.IsBottom) { goto noValue; }
+                ESymValue addr = TryAddress(Constructors.For((Temp)0));
+                if (addr == null) goto noValue;
+
+                var value = TryCorrespondingValue(addr); // provides Value indirection or address depending on addr type.
+
+                if (value == null) goto noValue;
+                return value;
+
+            noValue:;
+                return null;
+            }
+
+            internal ESymValue LoadValue(Temp v)
+            {
+                return Value(v);
+            }
+
+            internal SymbolicValue LoadValue(ESymValue addr)
+            {
+                return new SymbolicValue(Value(addr));
+            }
+
+            internal SymbolicValue TryLoadValue(ESymValue addr)
+            {
+                var value = this.TryValue(addr);
+                if (value != null) return new SymbolicValue(value);
+                else return new SymbolicValue(addr);
+            }
+
+            /// <summary>
+            /// For struct values, we return the address of the local. For everything else,
+            /// including primitives, we return the value
+            /// </summary>
+            internal bool TryGetCorrespondingValueAbstraction(Temp v, out SymbolicValue sv)
+            {
+                return TryGetCorrespondingValueAbstraction(Constructors.For(v), out sv);
+            }
+
+            /// <summary>
+            /// For struct values, we return the address of the local. For everything else,
+            /// including primitives, we return the value
+            /// </summary>
+            internal bool TryGetCorrespondingValueAbstraction(Local v, out SymbolicValue sv)
+            {
+                return TryGetCorrespondingValueAbstraction(Constructors.For(v), out sv);
+            }
+
+            internal bool TryGetUnboxedValue(Temp v, out SymbolicValue result)
+            {
+                var address = this.Address(v);
+                var box = this.TryValue(address);
+                return TryGetUnboxedValue(box, out result);
+            }
+
+            internal bool TryGetUnboxedValue(ESymValue box, out SymbolicValue result)
+            {
+                if (box != null)
+                {
+                    var unbox = this.TryValue(box);
+                    if (unbox != null && egraph.TryLookup(Constructors.BoxOperator, unbox) == box)
+                    {
+                        result = new SymbolicValue(unbox);
+                        return true;
+                    }
+                }
+                result = default(SymbolicValue);
+                return false;
+            }
+
+            /// <summary>
+            /// Returns address of entity
+            /// </summary>
+            private bool TryGetCorrespondingAddressAbstraction(Constructor v, out SymbolicValue sv)
+            {
+                ESymValue addr = TryAddress(v);
+                if (addr == null)
+                {
+                    sv = default(SymbolicValue);
+                    return false;
+                }
+                sv = new SymbolicValue(addr);
+                return true;
+            }
+
+            /// <summary>
+            /// Returns address of Local
+            /// </summary>
+            internal bool TryGetCorrespondingAddressAbstraction(Local v, out SymbolicValue sv)
+            {
+                return TryGetCorrespondingAddressAbstraction(Constructors.For(v), out sv);
+            }
+
+            /// <summary>
+            /// For struct values, we return the address of the local. For everything else,
+            /// including primitives, we return the value
+            /// </summary>
+            internal bool TryGetCorrespondingValueAbstraction(Parameter v, out SymbolicValue sv)
+            {
+                return TryGetCorrespondingValueAbstraction(Constructors.For(v), out sv);
+            }
+
+            /// <summary>
+            /// Returns address value of parameter
+            /// </summary>
+            internal bool TryGetCorrespondingAddressAbstraction(Parameter v, out SymbolicValue sv)
+            {
+                return TryGetCorrespondingAddressAbstraction(Constructors.For(v), out sv);
+            }
+
+            /// <summary>
+            /// Returns an access path from a parameter or local to the given value.
+            /// </summary>
+            internal string GetAccessPath(ESymValue sv)
+            {
+                var path = GetBestAccessPath(sv, AccessPathFilter<Method, Type>.NoFilter, true, true, false);
+                if (path == null) { return null; }
+                return path.ToCodeString();
+            }
+
+
+            internal bool IsResultEGraph(IMergeInfo mi)
+            {
+                return mi.IsResult(egraph);
+            }
+
+            internal bool IsGraph1(IMergeInfo mi)
+            {
+                return mi.IsGraph1(egraph);
+            }
+
+            internal bool IsGraph2(IMergeInfo mi)
+            {
+                return mi.IsGraph2(egraph);
+            }
+            #endregion
+
+
+            internal bool IsUnmodifiedSinceEntry(ESymValue sym)
+            {
+                return IsUnmodified(sym);
+            }
+
+            /// <summary>
+            /// True if it is a parameter, static field, or static method (getter)
+            /// </summary>
+            /// <param name="pathElement">Head of path to test!</param>
+            /// <param name="sym">on success, contains the corresponding address (for parameter or field), and 
+            /// actual value for property</param>
+            internal bool IsTopLevelVisibleAtMethodEntry(PathElement pathElement, out ESymValue sym)
+            {
+                if (pathElement.IsReturnValue)
+                {
+                    sym = default(ESymValue);
+                    return false;
+                }
+                bool unmodified;
+                sym = AccessPathHead(pathElement, out unmodified, false, false);
+                return unmodified;
+            }
+
+            internal ESymValue AccessPathHead(PathElement pathElement, out bool unModifiedSinceEntry, bool useModifiedSet, bool includeLocals)
+            {
+                PathElement<Parameter> p = pathElement as PathElement<Parameter>;
+                unModifiedSinceEntry = true; // cheating for static fields and properties
+                ESymValue sym;
+                if (p != null)
+                {
+                    sym = this.Address(p.Element);
+                    if (useModifiedSet)
+                    {
+                        unModifiedSinceEntry = !SetContains(modifiedAtCall, sym);
+                    }
+                    else
+                    {
+                        unModifiedSinceEntry = this.IsUnmodifiedSinceEntry(sym);
+                    }
+                    if (!p.IsAddressOf)
+                    {
+                        // compressed parameter ldarga,ldind
+                        sym = this.Value(sym);
+                    }
+                    return sym;
+                }
+                if (includeLocals)
+                {
+                    PathElement<Local> l = pathElement as PathElement<Local>;
+                    if (l != null)
+                    {
+                        sym = this.Address(l.Element);
+                        return sym;
+                    }
+                }
+                PathElement<Field> f = pathElement as PathElement<Field>;
+                if (f != null) // must be static if first element
+                {
+                    sym = this.FieldAddress(egraph.Root, f.Element);
+                    return sym;
+                }
+                PathElement<Method> m = pathElement as PathElement<Method>;
+                if (m != null) // must be static if first element
+                {
+                    Type pseudoFieldAddressType;
+                    // recall that paths have a stripped out deref for pseudo fields (getters)
+                    var pseudoFieldAddress = this.PseudoFieldAddress(egraph.Root, m.Element, out pseudoFieldAddressType, false, default(Type)); // shouldn't try to materialize
+                    if (mdDecoder.HasValueRepresentation(mdDecoder.ElementType(pseudoFieldAddressType)))
+                    {
+                        sym = this.Value(pseudoFieldAddress);
+                    }
+                    else
+                    {
+                        sym = pseudoFieldAddress;
+                    }
+                    return sym;
+                }
+                return null;
+            }
+
+            internal ESymValue TryAccessOldValue(ESymValue sym, PathElement pathElement)
+            {
+                PathElementBase pbase = (PathElementBase)pathElement;
+                Contract.Assume(pbase.Constructor == Constructors.ValueOf); // F: made into an assumption
+                                                                            //System.Diagnostics.Debug.Assert(pbase.Constructor == Constructors.ValueOf);
+                return egraph.TryLookup(Constructors.OldValueOf, sym);
+            }
+
+            internal ESymValue TryAccess(ESymValue sym, PathElement pathElement)
+            {
+                PathElementBase pbase = (PathElementBase)pathElement;
+                ESymValue value = egraph.TryLookup(pbase.Constructor, sym);
+                if (value == null) return null;
+                // since we stripped out the extra deref on Method getter pseudo fields, we have to perform
+                // the extra deref here
+                PathElement<Method> pseudoField = pbase as PathElement<Method>;
+                if (pseudoField != null && !pseudoField.IsAddressOf)
+                {
+                    return this.TryCorrespondingValue(value);
+                }
+                // extra deref on compressed parameter paths
+                ParameterPathElement parameter = pbase as ParameterPathElement;
+                if (parameter != null)
+                {
+                    return this.TryCorrespondingValue(value);
+                }
+                return value;
+            }
+
+            internal bool CheckIfPathUnmodified(ESymValue sym, FList<PathElement> path)
+            {
+                while (path != null)
+                {
+                    if (sym == null) return true; // not materialized
+                    if (path.Head.IsDeref)
+                    {
+                        if (!this.IsUnmodifiedSinceEntry(sym)) return false;
+                    }
+                    else
+                    {
+                        // handle the case of a property getter/pure method. We have to check the location
+                        // explicitly
+                        var pseudoField = path.Head as MethodCallPathElement;
+                        if (pseudoField != null && !pseudoField.IsAddressOf)
+                        {
+                            ESymValue pseudoFieldAddress = egraph.TryLookup(pseudoField.Constructor, sym);
+                            if (pseudoFieldAddress == null) return false; // can't check
+                            if (!this.IsUnmodifiedSinceEntry(pseudoFieldAddress)) return false;
+                        }
+                    }
+                    sym = this.TryAccess(sym, path.Head);
+                    path = path.Tail;
+                }
+                return true;
+            }
+
+            internal bool TryGetFieldAddress(SymbolicValue obj, Field field, out SymbolicValue address)
+            {
+                ESymValue addr = this.TryGetFieldAddress(obj.symbol, field);
+                if (addr != null) { address = new SymbolicValue(addr); return true; }
+                address = default(SymbolicValue);
+                return false;
+            }
+
+            private ESymValue TryGetFieldAddress(ESymValue obj, Field field)
+            {
+                return egraph.TryLookup(Constructors.For(field), obj);
+            }
+
+            internal bool TryLoadIndirect(SymbolicValue addr, out SymbolicValue value)
+            {
+                ESymValue val = egraph.TryLookup(Constructors.ValueOf, addr.symbol);
+                if (val != null) { value = new SymbolicValue(val); return true; }
+                value = default(SymbolicValue);
+                return false;
+            }
+
+
+            internal bool PathExistsUnmodifiedSinceEntry(FList<PathElementBase> accesspath, out ESymValue targetSym)
+            {
+                targetSym = null;
+
+                bool unmodified;
+                ESymValue sym = AccessPathHead(accesspath.Head, out unmodified, false, false);
+                if (sym == null || !unmodified)
+                {
+                    return false;
+                }
+
+                var path = accesspath.Tail;
+                while (path != null)
+                {
+                    if (path.Head.IsDeref)
+                    {
+                        if (!this.IsUnmodifiedSinceEntry(sym)) return false;
+                    }
+                    sym = this.TryAccess(sym, path.Head);
+                    if (sym == null) return false;
+                    path = path.Tail;
+                }
+                targetSym = sym;
+                return true;
+            }
+
+            internal void ResetModifiedAtCall()
+            {
+                modifiedAtCall = FunctionalSet<ESymValue>.Empty(ESymValue.GetUniqueKey);
+            }
+
+            /// <summary>
+            /// Try to find a target value corresponding to old value. We are allowed to traverse 1 $OldValue
+            /// </summary>
+            /// <param name="accesspath"></param>
+            /// <param name="targetSym"></param>
+            /// <returns></returns>
+            internal bool PathExistsUnmodifiedAtCall(FList<PathElementBase> accesspath, out ESymValue targetSym)
+            {
+                targetSym = null;
+
+                bool unmodified;
+                ESymValue sym = AccessPathHead(accesspath.Head, out unmodified, true, true);
+                if (sym == null || !unmodified)
+                {
+                    return false;
+                }
+
+                var path = accesspath.Tail;
+                while (path != null)
+                {
+                    if (path.Head.IsDeref)
+                    {
+                        if (this.IsModifiedAtCall(sym))
+                        {
+                            sym = this.TryAccessOldValue(sym, path.Head);
+                            if (sym == null) return false;
+                            else
+                            {
+                                // continue
+                                path = path.Tail;
+                                continue;
+                            }
+                        }
+                    }
+                    sym = this.TryAccess(sym, path.Head);
+                    if (sym == null) return false;
+                    path = path.Tail;
+                }
+                targetSym = sym;
+                return true;
+            }
+
+            /// <summary>
+            /// Try to find a target value corresponding to old value. Call did not modify anything
+            /// </summary>
+            internal bool PathExistsAtCall(FList<PathElementBase> accesspath, out ESymValue targetSym)
+            {
+                targetSym = null;
+
+                bool unmodified;
+                ESymValue sym = AccessPathHead(accesspath.Head, out unmodified, true, true);
+                if (sym == null)
+                {
+                    return false;
+                }
+
+                var path = accesspath.Tail;
+                while (path != null)
+                {
+                    sym = this.TryAccess(sym, path.Head);
+                    if (sym == null) return false;
+                    path = path.Tail;
+                }
+                targetSym = sym;
+                return true;
+            }
+
+
+            private bool IsModifiedAtCall(ESymValue sym)
+            {
+                return (modifiedAtCall != null && modifiedAtCall.Contains(sym));
+            }
+
+            internal PathContextFlags PathContexts(ESymValue eSymValue)
+            {
+                Set<ESymValue> visited = new Set<ESymValue>();
+                return AccumulatePathContexts(eSymValue, PathContextFlags.None, visited);
+            }
+
+            private PathContextFlags AccumulatePathContexts(ESymValue sv, PathContextFlags sofar, Set<ESymValue> visited)
+            {
+                if (sofar == PathContextFlags.All) return sofar;
+                if (visited.Contains(sv)) return sofar;
+                visited.Add(sv);
+                // check if this value directly is tagged
+                if (egraph.TryLookup(Constructors.ResultOfCall, sv) != null) { sofar |= PathContextFlags.ViaMethodReturn; }
+                if (egraph.TryLookup(Constructors.ResultOfLdelem, sv) != null) { sofar |= PathContextFlags.ViaArray; }
+                if (egraph.TryLookup(Constructors.ResultOfPureCall, sv) != null) { sofar |= PathContextFlags.ViaPureMethodReturn; }
+                if (egraph.TryLookup(Constructors.ResultOfCast, sv) != null) { sofar |= PathContextFlags.ViaCast; }
+                if (egraph.TryLookup(Constructors.ResultOfOutParameter, sv) != null) { sofar |= PathContextFlags.ViaOutParameter; }
+                if (egraph.TryLookup(Constructors.ResultOfCallThisHavoc, sv) != null) { sofar |= PathContextFlags.ViaCallThisHavoc; }
+                if (egraph.TryLookup(Constructors.ResultOfOldValue, sv) != null) { sofar |= PathContextFlags.ViaOldValue; }
+
+                if (sofar == PathContextFlags.All) return sofar;
+                // look through access paths
+                foreach (var eterm in egraph.EqTerms(sv))
+                {
+                    var constructor = eterm.Function;
+                    if (constructor.ActsAsField)
+                    {
+                        sofar |= PathContextFlags.ViaField;
+                        sofar = AccumulatePathContexts(eterm.Args[0], sofar, visited);
+                    }
+                    else if (
+                        constructor == Constructors.ValueOf ||
+                        constructor == Constructors.WritableBytes ||
+                        constructor == Constructors.Length
+                       )
+                    {
+                        sofar = AccumulatePathContexts(eterm.Args[0], sofar, visited);
+                    }
+                    if (sofar == PathContextFlags.All) return sofar;
+                }
+                // look through array access paths
+                foreach (var eterm in egraph.EqMultiTerms(sv))
+                {
+                    var constructor = eterm.Function;
+                    if (
+                        constructor == Constructors.ElementAddress
+                       )
+                    {
+                        sofar = AccumulatePathContexts(eterm.Args[0], sofar, visited);
+                    }
+                    if (sofar == PathContextFlags.All) return sofar;
+                }
+                return sofar;
+            }
+
+            internal ESymValue StructId(ESymValue structAddr)
+            {
+                return egraph[Constructors.StructId, structAddr];
+            }
+
+            internal ESymValue ObjectVersion(ESymValue objectPtr)
+            {
+                return egraph[Constructors.ObjectVersion, objectPtr];
+            }
+
+            internal void ManifestStructId(ESymValue structAddr)
+            {
+                var dummy = StructId(structAddr);
+            }
+
+            internal void HavocArrayAtIndex(ESymValue arrayValue, ESymValue indexValue)
+            {
+                // TODO: be smarter about what needs to be havoced in the future.
+                // for now, we havoc everything.
+                //
+                // We could be smarter whenever we see a constant index, we could leave all distinct 
+                // constant elements untouched (carry them forward to the new version)
+                egraph.Eliminate(Constructors.ObjectVersion, arrayValue);
+            }
+
+            internal IFunctionalMap<ESymValue, FList<ESymValue>> GetForwardIdentityMap()
+            {
+                return egraph.GetForwardIdentityMap();
+            }
+
+            internal void HavocObjectAtCall(ESymValue obj, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields, bool havocReadonlyFields)
+            {
+                this.HavocFields(null, obj, ref havocedAtCall, havocReadonlyFields);
+                this.HavocUp(obj, ref havocedAtCall, havocFields);
+            }
+
+            /// <summary>
+            /// Consider access paths to this object from other objects and mutate their object reference
+            /// </summary>
+            private void HavocUp(ESymValue obj, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields)
+            {
+                Contract.Requires(havocedAtCall != null);
+                Contract.Ensures(havocedAtCall != null);
+
+                // invariant: obj in havocedAtCall
+                foreach (var term in egraph.EqTerms(obj))
+                {
+                    var c = term.Function;
+                    if (c == Constructors.ValueOf)
+                    {
+                        HavocUpField(term.Args[0], ref havocedAtCall, havocFields);
+                    }
+                }
+            }
+
+            private void HavocUpField(ESymValue addr, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields)
+            {
+                Contract.Requires(havocedAtCall != null);
+                Contract.Ensures(havocedAtCall != null);
+
+                foreach (var term in egraph.EqTerms(addr))
+                {
+                    var c = term.Function;
+
+                    Constructor.Wrapper<Field> field = c as Constructor.Wrapper<Field>;
+                    if (field != null)
+                    {
+                        HavocUpObjectVersion(c, term.Args[0], ref havocedAtCall, havocFields);
+                        continue;
+                    }
+                    Constructor.Wrapper<Method> method = c as Constructor.Wrapper<Method>;
+                    if (method != null)
+                    {
+                        // havoc up, provided this is an instance method
+                        if (!mdDecoder.IsStatic(method.Value) && mdDecoder.IsPropertyGetter(method.Value) && mdDecoder.Name(method.Value) != "get_Current")
+                        {
+                            HavocUpObjectVersion(c, term.Args[0], ref havocedAtCall, havocFields);
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            private void HavocUpObjectVersion(Constructor accessedVia, ESymValue obj, ref IFunctionalSet<ESymValue> havocedAtCall, bool havocFields)
+            {
+                Contract.Requires(havocedAtCall != null);
+                Contract.Ensures(havocedAtCall != null);
+
+                if (havocedAtCall.Contains(obj)) return; // guard against cycles
+
+                egraph.Eliminate(Constructors.ObjectVersion, obj);
+
+                if (havocFields)
+                {
+                    this.HavocMutableFields(accessedVia, obj, ref havocedAtCall);
+                }
+                else
+                {
+                    this.HavocPseudoFields(accessedVia, obj, ref havocedAtCall);
+                }
+                this.HavocUp(obj, ref havocedAtCall, false); // only havoc fields up one level
+            }
+
+            internal void CopyValueToOldState(APC pc, Type type, int dest, int source, Domain target)
+            {
+                var destAddr = target.Address(dest);
+                var srcAddr = this.Address(source);
+                Type addrType;
+                var currType = this.GetType(srcAddr);
+                if (currType.IsNormal)
+                {
+                    addrType = currType.Value;
+                }
+                else
+                {
+                    addrType = mdDecoder.ManagedPointer(type);
+                }
+                CopyValueToOldState(pc, addrType, destAddr, srcAddr, target);
+            }
+
+            internal void CopyValueToOldState(APC pc, Type addrType, ESymValue destAddr, ESymValue srcAddr, Domain target)
+            {
+                target.MakeTotallyModified(destAddr);
+
+                if (destAddr != srcAddr) { target.HavocIfStruct(destAddr); }
+                target.SetType(destAddr, addrType);
+                FlatDomain<Type> elementType = TargetType(addrType);
+
+                if (IsStructWithFields(elementType))
+                {
+                    this.CopyStructValueToOldState(pc, destAddr, srcAddr, elementType, target);
+                }
+                else
+                {
+                    ESymValue svalue = egraph.TryLookup(Constructors.ValueOf, srcAddr);
+                    if (svalue == null)
+                    {
+                        if (egraph.IsConstant)
+                        {
+                            return;
+                        }
+                        svalue = egraph[Constructors.ValueOf, srcAddr]; // manifest
+                    }
+
+                    this.CopyPrimitiveValueToOldState(pc, addrType, destAddr, svalue, target);
+                }
+            }
+
+            private void CopyPrimitiveValueToOldState(APC pc, Type addrType, ESymValue destAddr, ESymValue svalue, Domain target)
+            {
+                // just grab the value and see if it is valid
+                if (target.IsValidSymbol(svalue))
+                {
+                    target.CopyNonStructWithFieldValue(destAddr, svalue, addrType);
+                }
+                else
+                {
+                    target.Assign(destAddr, addrType);
+                }
+            }
+
+
+
+            private void CopyStructValueToOldState(APC pc, ESymValue destAddr, ESymValue srcAddr, FlatDomain<Type> type, Domain target)
+            {
+                if (destAddr == null) return;
+                // copy old struct id
+                CopyStructId(pc, destAddr, srcAddr, this, target);
+
+                foreach (Constructor key in egraph.Functions(srcAddr))
+                {
+                    if (!key.ActsAsField) continue;
+                    Type t = key.FieldAddressType(mdDecoder);
+
+                    ESymValue destFld = target.egraph[key, destAddr];
+                    ESymValue srcFld = egraph[key, srcAddr];
+                    CopyValueToOldState(pc, t, destFld, srcFld, target);
+                }
+            }
+
+
+            internal ESymValue PseudoFieldAddressOfOutParameter(int index, ESymValue fieldAddr, Type parameterType, Type fromType)
+            {
+                var pseudoField = Constructors.ForConstant(index, mdDecoder.System_Int32);
+                var result = egraph[pseudoField, fieldAddr];
+                MaterializeAccordingToType(result, parameterType, 2, Constructors.ResultOfOutParameter, fromType: fromType);
+                return result;
+            }
+
+            internal void SetDelegateDetails(ESymValue obj, ESymValue closure, ESymValue fnPtrValue)
+            {
+                egraph[Constructors.FunctionPointer, obj] = fnPtrValue;
+                if (closure != null)
+                {
+                    egraph[Constructors.ClosureObject, obj] = closure;
+                }
+            }
+
+            internal bool IsPureFunctionCall(SymbolicValue value, out Method method, out SymbolicValue[] args)
+            {
+                // we are given the "value", but the egraph stores the address. so we first have to get up one level
+                foreach (var addr in egraph.EqTerms(value.symbol))
+                {
+                    if (addr.Function == Constructors.ValueOf)
+                    {
+                        var fldAddr = addr.Args[0];
+                        foreach (var term in egraph.EqTerms(fldAddr))
+                        {
+                            var methodCtor = term.Function as Constructor.PureMethodConstructor;
+                            if (methodCtor != null)
+                            {
+                                method = methodCtor.Value;
+                                args = new SymbolicValue[term.Args.Length];
+                                for (int i = 0; i < term.Args.Length; i++)
+                                {
+                                    args[i] = new SymbolicValue(term.Args[i]);
+                                }
+                                return true;
+                            }
+                        }
+                        foreach (var term in egraph.EqMultiTerms(fldAddr))
+                        {
+                            var methodCtor = term.Function as Constructor.PureMethodConstructor;
+                            if (methodCtor != null)
+                            {
+                                method = methodCtor.Value;
+                                args = new SymbolicValue[term.Args.Length];
+                                for (int i = 0; i < term.Args.Length; i++)
+                                {
+                                    args[i] = new SymbolicValue(term.Args[i]);
+                                }
+                                return true;
+                            }
+                        }
+                    }
+                }
+                method = default(Method);
+                args = null;
+                return false;
+            }
+
+            internal bool IsDelegateValue(SymbolicValue value, out SymbolicValue targetObject, out Method targetMethod)
+            {
+                ESymValue closure;
+                var result = IsDelegateValue(value.symbol, out closure, out targetMethod);
+                targetObject = new SymbolicValue(closure);
+                return result;
+            }
+
+            internal bool IsDelegateValue(ESymValue value, out ESymValue targetObject, out Method targetMethod)
+            {
+                var fnptr = egraph.TryLookup(Constructors.FunctionPointer, value);
+                if (fnptr != null)
+                {
+                    if (this.IsMethodPointer(fnptr, out targetMethod))
+                    {
+                        targetObject = egraph.TryLookup(Constructors.ClosureObject, value);
+                        return true;
+                    }
+                }
+                targetMethod = default(Method);
+                targetObject = default(ESymValue);
+                return false;
+            }
+
+            internal bool TryGetArrayFromArrayElementAddress(SymbolicValue elementAddress, out SymbolicValue array, out SymbolicValue index)
+            {
+                foreach (var candidate in egraph.EqMultiTerms(elementAddress.symbol))
+                {
+                    if (candidate.Function == Constructors.ElementAddress)
+                    {
+                        index = new SymbolicValue(candidate.Args[1]);
+                        // grab object version and then find corresponding object
+                        return TryGetObjectFromObjectVersion(new SymbolicValue(candidate.Args[0]), out array);
+                    }
+                }
+                array = default(SymbolicValue);
+                index = default(SymbolicValue);
+                return false;
+            }
+
+            internal bool TryGetObjectFromObjectVersion(SymbolicValue objectVersion, out SymbolicValue objectValue)
+            {
+                foreach (var obj in egraph.EqTerms(objectVersion.symbol))
+                {
+                    if (obj.Function == Constructors.ObjectVersion)
+                    {
+                        objectValue = new SymbolicValue(obj.Args[0]);
+                        return true;
+                    }
+                }
+                objectValue = default(SymbolicValue);
+                return false;
+            }
+
+            internal ESymValue TryGetPropertyNamed(ESymValue pointer, string propertyName)
+            {
+                foreach (var ctor in egraph.Functions(pointer))
+                {
+                    var method = ctor as Constructor.PureMethodConstructor;
+                    if (method == null) continue;
+                    if (this.mdDecoder.IsPropertyGetter(method.Value))
+                    {
+                        Property prop = this.mdDecoder.GetPropertyFromAccessor(method.Value);
+                        if (prop != null && this.mdDecoder.Name(prop) == propertyName)
+                        {
+                            return this.TryValue(egraph[ctor, pointer]);
+                        }
+                    }
+                }
+                return null;
+            }
+
+            internal ESymValue TryGetModelMethod(ESymValue pointer, string modelMethodName)
+            {
+                foreach (var ctor in egraph.Functions(pointer))
+                {
+                    var method = ctor as Constructor.PureMethodConstructor;
+                    if (method == null) continue;
+                    if (!this.mdDecoder.IsPropertyGetter(method.Value)) continue;
+                    var methodName = this.mdDecoder.Name(method.Value).Substring(4);
+                    if (!methodName.Equals(modelMethodName)) continue;
+                    var t = this.mdDecoder.DeclaringType(method.Value);
+                    foreach (var modelMethod in parent.contractDecoder.ModelMethods(t))
+                    {
+                        if (this.mdDecoder.IsPropertyGetter(modelMethod))
+                        {
+                            var name = this.mdDecoder.Name(modelMethod);
+                            if (4 < name.Length && name.Substring(4).Equals(modelMethodName))
+                            {
+                                var result = this.TryValue(egraph[ctor, pointer]);
+                                return result;
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+
+
+            internal void InitObj(ESymValue destaddr, Type type)
+            {
+                Havoc(destaddr);
+                SetType(destaddr, this.mdDecoder.ManagedPointer(type));
+                egraph[Constructors.ValueOf, destaddr] = this.TypeDefaultValue(type);
+                foreach (Field f in mdDecoder.Fields(type))
+                {
+                    ESymValue fldaddr = this.FieldAddress(destaddr, f);
+                    this.AssignZeroEquivalent(fldaddr, mdDecoder.FieldType(f));
+                }
+                if (this.mdDecoder.IsReferenceConstrained(type))
+                {
+                    this.AssignZeroEquivalent(destaddr, type);
+                }
+            }
+
+            /// <summary>
+            /// Returns the reversed access path witness.
+            /// </summary>
+            internal FList<ESymValue> AccessPathWitnessReversed(Domain d, FList<PathElement> ap)
+            {
+                Contract.Requires(ap != null);
+                Contract.Ensures(Contract.Result<FList<ESymValue>>() == null || Contract.Result<FList<ESymValue>>().Length() == ap.Length());
+
+                var result = FList<ESymValue>.Empty;
+                bool unmodifiedSinceEntry;
+                var head = d.AccessPathHead(ap.Head, out unmodifiedSinceEntry, true, true);
+                if (head == null) return null;
+                result = result.Cons(head);
+                ap = ap.Tail;
+                var current = head;
+                while (ap != null)
+                {
+                    var next = d.TryAccess(current, ap.Head);
+                    if (next == null) return null;
+                    result = result.Cons(next);
+                    ap = ap.Tail;
+                    current = next;
+                }
+                return result;
+            }
         }
-        return null;
-      }
 
 
-      internal void InitObj(ESymValue destaddr, Type type)
-      {
-        Havoc(destaddr);
-        SetType(destaddr, this.mdDecoder.ManagedPointer(type));
-        this.egraph[Constructors.ValueOf, destaddr] = this.TypeDefaultValue(type);
-        foreach (Field f in mdDecoder.Fields(type))
+        #region IAnalysis<APC,OptimisticHeapAnalyzer<Label,Local,Parameter,Method,Field,Type>,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,OptimisticHeapAnalyzer<Label,Local,Parameter,Method,Field,Type>,OptimisticHeapAnalyzer<Label,Local,Parameter,Method,Field,Type>>> Members
+
+        public Domain Join(Pair<APC, APC> edge, Domain newState, Domain prevState, out bool weaker, bool widen)
         {
-          ESymValue fldaddr = this.FieldAddress(destaddr, f);
-          this.AssignZeroEquivalent(fldaddr, mdDecoder.FieldType(f));
-        }
-        if (this.mdDecoder.IsReferenceConstrained(type))
-        {
-          this.AssignZeroEquivalent(destaddr, type);
-        }
-      }
+            if (Domain.Debug)
+            {
+                Console.WriteLine("---------OPT join at {0}", edge.ToString());
+                Console.WriteLine("---------Existing state:");
+                prevState.Dump(Console.Out);
+                Console.WriteLine("---------New state:");
+                newState.Dump(Console.Out);
+            }
+            IMergeInfo mi;
+            Domain result = prevState.Join(newState, out weaker, out mi, widen);
+            // update mergeinfo cache
+            // We must change the entry from being null, as this is not a single pre-decessor point
+            if (weaker)
+            {
+                IMergeInfo existingMI;
+                if (mergeInfoCache.TryGetValue(edge.Two, out existingMI))
+                {
+                    if (existingMI == null)
+                    {
+                        mergeInfoCache[edge.Two] = mi;
+                    }
+                }
+            }
+            else
+            {
+                // update with info, as next state is in fact the merged state.
+                mergeInfoCache[edge.Two] = mi;
+            }
 
-      /// <summary>
-      /// Returns the reversed access path witness.
-      /// </summary>
-      internal FList<ESymValue> AccessPathWitnessReversed(Domain d, FList<PathElement> ap)
-      {
-        Contract.Requires(ap != null);
-        Contract.Ensures(Contract.Result<FList<ESymValue>>() == null || Contract.Result<FList<ESymValue>>().Length() == ap.Length());
-
-        var result = FList<ESymValue>.Empty;
-        bool unmodifiedSinceEntry;
-        var head = d.AccessPathHead(ap.Head, out unmodifiedSinceEntry, true, true);
-        if (head == null) return null;
-        result = result.Cons(head);
-        ap = ap.Tail;
-        var current = head;
-        while (ap != null)
-        {
-          var next = d.TryAccess(current, ap.Head);
-          if (next == null) return null;
-          result = result.Cons(next);
-          ap = ap.Tail;
-          current = next;
-        }
-        return result;
-      }
-    }
-
-
-    #region IAnalysis<APC,OptimisticHeapAnalyzer<Label,Local,Parameter,Method,Field,Type>,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,OptimisticHeapAnalyzer<Label,Local,Parameter,Method,Field,Type>,OptimisticHeapAnalyzer<Label,Local,Parameter,Method,Field,Type>>> Members
-
-    public Domain Join(Pair<APC, APC> edge, Domain newState, Domain prevState, out bool weaker, bool widen)
-    {
-      if (Domain.Debug)
-      {
-        Console.WriteLine("---------OPT join at {0}", edge.ToString());
-        Console.WriteLine("---------Existing state:");
-        prevState.Dump(Console.Out);
-        Console.WriteLine("---------New state:");
-        newState.Dump(Console.Out);
-      }
-      IMergeInfo mi;
-      Domain result = prevState.Join(newState, out weaker, out mi, widen);
-      // update mergeinfo cache
-      // We must change the entry from being null, as this is not a single pre-decessor point
-      if (weaker)
-      {
-        IMergeInfo existingMI;
-        if (this.mergeInfoCache.TryGetValue(edge.Two, out existingMI))
-        {
-          if (existingMI == null)
-          {
-            this.mergeInfoCache[edge.Two] = mi;
-          }
-        }
-      }
-      else
-      {
-        // update with info, as next state is in fact the merged state.
-        this.mergeInfoCache[edge.Two] = mi;
-      }
-
-      if (Domain.Debug)
-      {
-        Console.WriteLine("---------Result state: changed = {0} (widen = {1})", weaker, widen);
-        result.Dump(Console.Out);
-        Console.WriteLine("------------------------------------");
-      }
-      return result;
-    }
-
-    /// <summary>
-    /// Record the edges on which we perform renamings.
-    /// </summary>
-    public Domain EdgeConversion(APC from, APC next, bool joinPoint, Unit edgeData, Domain edgestate)
-    {
-      if (joinPoint || !EagerCaching)
-      {
-        this.renamePoints[from, next] = Unit.Value;
-        // record first incoming edge
-        if (!this.mergeInfoCache.ContainsKey(next))
-        {
-          this.mergeInfoCache.Add(next, null); // sentinel for 1st and eventually only edge into join point
-        }
-      }
-
-      if (Domain.Debug)
-      {
-        Console.WriteLine("---------Edge Conversion on {0}->{1}", from, next);
-        edgestate.Dump(Console.Out);
-        Console.WriteLine("------------------------------------");
-      }
-      return edgestate;
-    }
-
-    public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, Domain, Domain> Visitor()
-    {
-      return this.GetVisitor();
-    }
-
-    IFixpointInfo<APC, Domain> fixpointInfo;
-
-    bool PreStateLookup(APC label, out Domain ifFound) {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
-
-      Contract.Assume(this.fixpointInfo != null);
-
-      return this.fixpointInfo.PreState(label, out ifFound); 
-    }
-    bool PostStateLookup(APC label, out Domain ifFound) {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
-
-      Contract.Assume(this.fixpointInfo != null);
-
-      return this.fixpointInfo.PostState(label, out ifFound);
-    }
-
-    public bool IsUnreachable(APC pc)
-    {
-      Contract.Assume(this.fixpointInfo != null);
-
-      Domain d;
-      if (!this.fixpointInfo.PreState(pc, out d) || d.IsBottom)
-      {
-        return true;
-      }
-      return false;
-    }
-
-    public IEnumerable<SubroutineContext> GetContexts(CFGBlock block)
-    {
-      Contract.Assume(this.fixpointInfo != null);
-
-      return this.fixpointInfo.CachedContexts(block);
-    }
-
-    Domain GetPreState(APC at)
-    {
-      Domain d;
-      PreStateLookup(at, out d);
-      return d;
-    }
-
-    public Predicate<APC> CacheStates(IFixpointInfo<APC, Domain> fixpointInfo)
-    {
-      this.fixpointInfo = fixpointInfo;
-      return delegate(APC pc) { return EagerCaching; };
-    }
-
-    public void Dump(Pair<Domain, TextWriter> statetw)
-    {
-      statetw.One.Dump(statetw.Two);
-    }
-
-    public void Dump(APC apc)
-    {
-      var prestate = GetPreState(apc);
-      if (prestate != null)
-      {
-        Console.WriteLine(@"<egraph state=""pre"">");
-        prestate.Dump(Console.Out);
-        Console.WriteLine("</egraph>");
-      }
-
-      Domain poststate;
-      PostStateLookup(apc, out poststate);
-      if (poststate != null)
-      {
-        Console.WriteLine(@"<egraph state=""post"">");
-        poststate.Dump(Console.Out);
-        Console.WriteLine("</egraph>");
-      }
-    }
-
-    public Domain ImmutableVersion(Domain d)
-    {
-      return d.ImmutableVersion();
-    }
-
-    public Domain MutableVersion(Domain d)
-    {
-      if (d.IsBottom) return d; // cannot have a mutable version of bottom
-      return d.Clone();
-    }
-
-    public bool IsBottom(APC pc, Domain d)
-    {
-      return d.IsBottom;
-    }
-
-    public bool IsTop(APC pc, Domain d)
-    {
-      return d.IsTop;
-    }
-
-    #endregion
-
-    #region ILDecoder
-    struct SymbolicAdapter<Data, Result, Visitor> : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Data, Result>
-      where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Data, Result>
-    {
-      public SymbolicAdapter(
-        OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent,
-        Visitor delegatee
-      )
-      {
-        this.parent = parent;
-        this.delegatee = delegatee;
-      }
-
-      #region Privates
-      OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
-      Visitor delegatee;
-
-      bool IsZero(APC pc, SymbolicValue sv)
-      {
-        // lookup the given source in the egraph for this program point
-        Domain d;
-        if (!this.parent.PreStateLookup(pc, out d))
-        {
-          return false;
-        }
-        return d.IsZero(sv.symbol);
-      }
-
-      SymbolicValue ConvertSource(APC pc, Temp source)
-      {
-        // lookup the given source in the egraph for this program point
-        Domain d;
-        if (!this.parent.PreStateLookup(pc, out d) || d.IsBottom)
-        {
-          return default(SymbolicValue);
-        }
-        // handle the special case of a return void here. The source is -1 in that case.
-        if (source < 0)
-        {
-          return new SymbolicValue(d.VoidAddr);
-        }
-        SymbolicValue result;
-        d.TryGetCorrespondingValueAbstraction(source, out result);
-        return result;
-      }
-
-      [Pure]
-      bool HasSourceType(APC pc, Temp source, out Type type, out SymbolicValue falseSymValue)
-      {
-        // lookup the given source in the egraph for this program point
-        falseSymValue = default(SymbolicValue);
-        Domain d;
-        if (!this.parent.PreStateLookup(pc, out d) || d.IsBottom)
-        {
-          type = default(Type);
-          return false;
-        }
-        SymbolicValue result;
-        if (!d.TryGetCorrespondingValueAbstraction(source, out result))
-        {
-          type = default(Type);
-          return false;
-        }
-        var at = d.GetType(result.symbol);
-        if (at.IsNormal)
-        {
-          type = at.Value;
-          falseSymValue = new SymbolicValue(d.Zero);
-          return true;
-        }
-        type = default(Type);
-        return false;
-      }
-
-
-      SymbolicValue ConvertOldSource(APC pc, Temp source)
-      {
-        // lookup the given source in the egraph for this program point
-        Domain d;
-        if (!this.parent.PreStateLookup(pc, out d) || d.IsBottom)
-        {
-          return default(SymbolicValue);
-        }
-        // handle the special case of a return void here. The source is -1 in that case.
-        if (source < 0)
-        {
-          return new SymbolicValue(d.VoidAddr);
-        }
-        Domain old = Domain.AnalysisDecoder.FindOldState(pc, d);
-        if (old != null)
-        {
-          SymbolicValue result;
-          old.TryGetCorrespondingValueAbstraction(source, out result);
-          return result;
-        }
-        return new SymbolicValue(d.VoidAddr);
-      }
-
-      /// <summary>
-      /// Temp holds the address of a primitive typed struct
-      /// Lookup the temp in the pre-state, and the struct value in the post state.
-      /// </summary>
-      SymbolicValue ConvertSourceDeref(APC pc, Temp source)
-      {
-        // lookup the given source in the egraph for this program point
-        Domain d;
-        if (!this.parent.PreStateLookup(pc, out d))
-        {
-          return default(SymbolicValue);
-        }
-        // handle the special case of a return void here. The source is -1 in that case.
-        if (source < 0)
-        {
-          return new SymbolicValue(d.VoidAddr);
-        }
-        ESymValue refvalue = d.LoadValue(source);
-        if (!this.parent.PostStateLookup(pc, out d))
-        {
-          return default(SymbolicValue);
-        }
-        return d.TryLoadValue(refvalue);
-      }
-
-      SymbolicValue TryConvertUnbox(APC pc, Temp source)
-      {
-        // lookup the given source in the egraph for this program point
-        Domain d;
-        if (!this.parent.PreStateLookup(pc, out d))
-        {
-          return default(SymbolicValue);
-        }
-        // handle the special case of a return void here. The source is -1 in that case.
-        if (source < 0)
-        {
-          return new SymbolicValue(d.VoidAddr);
-        }
-        SymbolicValue result;
-        if (!d.TryGetUnboxedValue(source, out result))
-        {
-          d.TryGetCorrespondingValueAbstraction(source, out result);
-        }
-        return result;
-      }
-
-      struct Sources<ArgList> : IIndexable<SymbolicValue>
-        where ArgList : IIndexable<Temp>
-      {
-        private ArgList underlying;
-        private readonly Domain astate;
-
-        public Sources(ArgList underlying, Domain astate)
-        {
-          this.underlying = underlying;
-          this.astate = astate;
+            if (Domain.Debug)
+            {
+                Console.WriteLine("---------Result state: changed = {0} (widen = {1})", weaker, widen);
+                result.Dump(Console.Out);
+                Console.WriteLine("------------------------------------");
+            }
+            return result;
         }
 
-        #region IIndexable<SymbolicValue> Members
-
-        public int Count
+        /// <summary>
+        /// Record the edges on which we perform renamings.
+        /// </summary>
+        public Domain EdgeConversion(APC from, APC next, bool joinPoint, Unit edgeData, Domain edgestate)
         {
-          get
-          {
-            Contract.Ensures(Contract.Result<int>() == underlying.Count);
+            if (joinPoint || !EagerCaching)
+            {
+                renamePoints[from, next] = Unit.Value;
+                // record first incoming edge
+                if (!mergeInfoCache.ContainsKey(next))
+                {
+                    mergeInfoCache.Add(next, null); // sentinel for 1st and eventually only edge into join point
+                }
+            }
 
-            return underlying.Count;
-          }
+            if (Domain.Debug)
+            {
+                Console.WriteLine("---------Edge Conversion on {0}->{1}", from, next);
+                edgestate.Dump(Console.Out);
+                Console.WriteLine("------------------------------------");
+            }
+            return edgestate;
         }
 
-        public SymbolicValue this[int index]
+        public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, Domain, Domain> Visitor()
         {
-          get
-          {
-            Contract.Assert(index < this.Count);
-            Contract.Assert(this.Count == this.underlying.Count);
-            return Map(underlying[index]);
-          }
+            return this.GetVisitor();
         }
 
-        private SymbolicValue Map(Temp temp)
+        private IFixpointInfo<APC, Domain> fixpointInfo;
+
+        private bool PreStateLookup(APC label, out Domain ifFound)
         {
-          if (astate == null) return default(SymbolicValue);
-          SymbolicValue result;
-          this.astate.TryGetCorrespondingValueAbstraction(temp, out result);
-          return result;
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
+
+            Contract.Assume(fixpointInfo != null);
+
+            return fixpointInfo.PreState(label, out ifFound);
+        }
+        private bool PostStateLookup(APC label, out Domain ifFound)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out ifFound) != null);
+
+            Contract.Assume(fixpointInfo != null);
+
+            return fixpointInfo.PostState(label, out ifFound);
+        }
+
+        public bool IsUnreachable(APC pc)
+        {
+            Contract.Assume(fixpointInfo != null);
+
+            Domain d;
+            if (!fixpointInfo.PreState(pc, out d) || d.IsBottom)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public IEnumerable<SubroutineContext> GetContexts(CFGBlock block)
+        {
+            Contract.Assume(fixpointInfo != null);
+
+            return fixpointInfo.CachedContexts(block);
+        }
+
+        private Domain GetPreState(APC at)
+        {
+            Domain d;
+            PreStateLookup(at, out d);
+            return d;
+        }
+
+        public Predicate<APC> CacheStates(IFixpointInfo<APC, Domain> fixpointInfo)
+        {
+            this.fixpointInfo = fixpointInfo;
+            return delegate (APC pc) { return EagerCaching; };
+        }
+
+        public void Dump(Pair<Domain, TextWriter> statetw)
+        {
+            statetw.One.Dump(statetw.Two);
+        }
+
+        public void Dump(APC apc)
+        {
+            var prestate = GetPreState(apc);
+            if (prestate != null)
+            {
+                Console.WriteLine(@"<egraph state=""pre"">");
+                prestate.Dump(Console.Out);
+                Console.WriteLine("</egraph>");
+            }
+
+            Domain poststate;
+            PostStateLookup(apc, out poststate);
+            if (poststate != null)
+            {
+                Console.WriteLine(@"<egraph state=""post"">");
+                poststate.Dump(Console.Out);
+                Console.WriteLine("</egraph>");
+            }
+        }
+
+        public Domain ImmutableVersion(Domain d)
+        {
+            return d.ImmutableVersion();
+        }
+
+        public Domain MutableVersion(Domain d)
+        {
+            if (d.IsBottom) return d; // cannot have a mutable version of bottom
+            return d.Clone();
+        }
+
+        public bool IsBottom(APC pc, Domain d)
+        {
+            return d.IsBottom;
+        }
+
+        public bool IsTop(APC pc, Domain d)
+        {
+            return d.IsTop;
         }
 
         #endregion
 
-      }
-
-      bool TryGetPostState(APC pc, out Domain postState)
-      {
-        return this.parent.PostStateLookup(pc, out postState);
-      }
-      bool TryGetPreState(APC pc, out Domain preState)
-      {
-        return this.parent.PreStateLookup(pc, out preState);
-      }
-
-      bool InsideOld(APC pc)
-      {
-        Domain prestate;
-        if (TryGetPreState(pc, out prestate))
+        #region ILDecoder
+        private struct SymbolicAdapter<Data, Result, Visitor> : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Data, Result>
+          where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Data, Result>
         {
-          if (prestate.OldDomain != null)
-          {
-            return true;
-          }
-        }
-        return false;
-      }
-
-      SymbolicValue ConvertDest(APC pc, Temp dest)
-      {
-        Domain postState;
-        if (!this.parent.PostStateLookup(pc, out postState))
-        {
-          return default(SymbolicValue);
-        }
-        SymbolicValue result;
-        postState.TryGetCorrespondingValueAbstraction(dest, out result);
-        return result;
-      }
-
-      SymbolicValue ConvertOldDest(APC pc, Temp dest)
-      {
-        Domain postState;
-        if (!this.parent.PostStateLookup(pc, out postState))
-        {
-          return default(SymbolicValue);
-        }
-        postState = postState.OldDomain;
-        Contract.Assume(postState != null);
-        SymbolicValue result;
-        postState.TryGetCorrespondingValueAbstraction(dest, out result);
-        return result;
-      }
-
-      Sources<ArgList> ConvertSources<ArgList>(APC pc, ArgList sources)
-        where ArgList : IIndexable<Temp>
-      {
-        return new Sources<ArgList>(sources, this.parent.GetPreState(pc));
-      }
-      #endregion
-
-      #region MSIL delegation
-      public Result Assert(APC pc, string tag, Source condition, object provenance, Data data)
-      {
-        return delegatee.Assert(pc, tag, ConvertSource(pc, condition), provenance, data);
-      }
-
-      public Result Assume(APC pc, string tag, Source source, object provenance, Data data)
-      {
-        if (this.parent.IgnoreExplicitAssumptions && tag == "assume")
-        {
-          return delegatee.Nop(pc, data);
-        }
-        SymbolicValue sv = ConvertSource(pc, source);
-        return delegatee.Assume(pc, tag, sv, provenance, data);
-      }
-
-      public Result Arglist(APC pc, Dest dest, Data data)
-      {
-        return delegatee.Arglist(pc, ConvertDest(pc, dest), data);
-      }
-
-      public Result Binary(APC pc, BinaryOperator op, Dest dest, Source s1, Source s2, Data data)
-      {
-        switch (op)
-        {
-          case BinaryOperator.Cobjeq:
-            // handle boxing/unboxing here
-            var value1 = TryConvertUnbox(pc, s1);
-            var value2 = TryConvertUnbox(pc, s2);
-            return delegatee.Binary(pc, op, ConvertDest(pc, dest), value1, value2, data);
-
-          default:
-            return delegatee.Binary(pc, op, ConvertDest(pc, dest), ConvertSource(pc, s1), ConvertSource(pc, s2), data);
-        }
-      }
-
-      public Result BranchCond(APC pc, APC target, BranchOperator bop, Source value1, Source value2, Data data)
-      {
-        return delegatee.BranchCond(pc, target, bop, ConvertSource(pc, value1), ConvertSource(pc, value2), data);
-      }
-
-      public Result BranchTrue(APC pc, APC target, Source cond, Data data)
-      {
-        return delegatee.BranchTrue(pc, target, ConvertSource(pc, cond), data);
-      }
-
-      public Result BranchFalse(APC pc, APC target, Source cond, Data data)
-      {
-        return delegatee.BranchFalse(pc, target, ConvertSource(pc, cond), data);
-      }
-
-      public Result Branch(APC pc, APC target, bool leave, Data data)
-      {
-        return delegatee.Branch(pc, target, leave, data);
-      }
-
-      public Result Break(APC pc, Data data)
-      {
-        return delegatee.Break(pc, data);
-      }
-
-      public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        if (!parent.mdDecoder.IsVoidMethod(method) && InsideOld(pc))
-        {
-          // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
-          return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
-        }
-        return DelegateCall<TypeList, ArgList>(pc, method, tail, virt, extraVarargs, dest, args, data);
-      }
-
-      private Result DelegateCall<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<int>
-      {
-        Type declaringType = parent.mdDecoder.DeclaringType(method);
-        if (args.Count == 2)
-        {
-          var methodName = parent.mdDecoder.Name(method);
-          if (methodName == "Equals")
-          {
-            // special case equal here
-            // NOTE: mdDecoder may classify String as primitive
-            if (parent.mdDecoder.IsStruct(declaringType) && !parent.mdDecoder.IsStatic(method) && parent.mdDecoder.HasValueRepresentation(declaringType))
+            public SymbolicAdapter(
+              OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent,
+              Visitor delegatee
+            )
             {
-              return delegatee.Binary(pc, BinaryOperator.Cobjeq, ConvertDest(pc, dest), ConvertSourceDeref(pc, args[0]), TryConvertUnbox(pc, args[1]), data);
+                this.parent = parent;
+                this.delegatee = delegatee;
+            }
+
+            #region Privates
+            private OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
+            private Visitor delegatee;
+
+            private bool IsZero(APC pc, SymbolicValue sv)
+            {
+                // lookup the given source in the egraph for this program point
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d))
+                {
+                    return false;
+                }
+                return d.IsZero(sv.symbol);
+            }
+
+            private SymbolicValue ConvertSource(APC pc, Temp source)
+            {
+                // lookup the given source in the egraph for this program point
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d) || d.IsBottom)
+                {
+                    return default(SymbolicValue);
+                }
+                // handle the special case of a return void here. The source is -1 in that case.
+                if (source < 0)
+                {
+                    return new SymbolicValue(d.VoidAddr);
+                }
+                SymbolicValue result;
+                d.TryGetCorrespondingValueAbstraction(source, out result);
+                return result;
+            }
+
+            [Pure]
+            private bool HasSourceType(APC pc, Temp source, out Type type, out SymbolicValue falseSymValue)
+            {
+                // lookup the given source in the egraph for this program point
+                falseSymValue = default(SymbolicValue);
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d) || d.IsBottom)
+                {
+                    type = default(Type);
+                    return false;
+                }
+                SymbolicValue result;
+                if (!d.TryGetCorrespondingValueAbstraction(source, out result))
+                {
+                    type = default(Type);
+                    return false;
+                }
+                var at = d.GetType(result.symbol);
+                if (at.IsNormal)
+                {
+                    type = at.Value;
+                    falseSymValue = new SymbolicValue(d.Zero);
+                    return true;
+                }
+                type = default(Type);
+                return false;
+            }
+
+
+            private SymbolicValue ConvertOldSource(APC pc, Temp source)
+            {
+                // lookup the given source in the egraph for this program point
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d) || d.IsBottom)
+                {
+                    return default(SymbolicValue);
+                }
+                // handle the special case of a return void here. The source is -1 in that case.
+                if (source < 0)
+                {
+                    return new SymbolicValue(d.VoidAddr);
+                }
+                Domain old = Domain.AnalysisDecoder.FindOldState(pc, d);
+                if (old != null)
+                {
+                    SymbolicValue result;
+                    old.TryGetCorrespondingValueAbstraction(source, out result);
+                    return result;
+                }
+                return new SymbolicValue(d.VoidAddr);
+            }
+
+            /// <summary>
+            /// Temp holds the address of a primitive typed struct
+            /// Lookup the temp in the pre-state, and the struct value in the post state.
+            /// </summary>
+            private SymbolicValue ConvertSourceDeref(APC pc, Temp source)
+            {
+                // lookup the given source in the egraph for this program point
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d))
+                {
+                    return default(SymbolicValue);
+                }
+                // handle the special case of a return void here. The source is -1 in that case.
+                if (source < 0)
+                {
+                    return new SymbolicValue(d.VoidAddr);
+                }
+                ESymValue refvalue = d.LoadValue(source);
+                if (!parent.PostStateLookup(pc, out d))
+                {
+                    return default(SymbolicValue);
+                }
+                return d.TryLoadValue(refvalue);
+            }
+
+            private SymbolicValue TryConvertUnbox(APC pc, Temp source)
+            {
+                // lookup the given source in the egraph for this program point
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d))
+                {
+                    return default(SymbolicValue);
+                }
+                // handle the special case of a return void here. The source is -1 in that case.
+                if (source < 0)
+                {
+                    return new SymbolicValue(d.VoidAddr);
+                }
+                SymbolicValue result;
+                if (!d.TryGetUnboxedValue(source, out result))
+                {
+                    d.TryGetCorrespondingValueAbstraction(source, out result);
+                }
+                return result;
+            }
+
+            private struct Sources<ArgList> : IIndexable<SymbolicValue>
+              where ArgList : IIndexable<Temp>
+            {
+                private ArgList underlying;
+                private readonly Domain astate;
+
+                public Sources(ArgList underlying, Domain astate)
+                {
+                    this.underlying = underlying;
+                    this.astate = astate;
+                }
+
+                #region IIndexable<SymbolicValue> Members
+
+                public int Count
+                {
+                    get
+                    {
+                        Contract.Ensures(Contract.Result<int>() == underlying.Count);
+
+                        return underlying.Count;
+                    }
+                }
+
+                public SymbolicValue this[int index]
+                {
+                    get
+                    {
+                        Contract.Assert(index < this.Count);
+                        Contract.Assert(this.Count == underlying.Count);
+                        return Map(underlying[index]);
+                    }
+                }
+
+                private SymbolicValue Map(Temp temp)
+                {
+                    if (astate == null) return default(SymbolicValue);
+                    SymbolicValue result;
+                    astate.TryGetCorrespondingValueAbstraction(temp, out result);
+                    return result;
+                }
+
+                #endregion
+            }
+
+            private bool TryGetPostState(APC pc, out Domain postState)
+            {
+                return parent.PostStateLookup(pc, out postState);
+            }
+            private bool TryGetPreState(APC pc, out Domain preState)
+            {
+                return parent.PreStateLookup(pc, out preState);
+            }
+
+            private bool InsideOld(APC pc)
+            {
+                Domain prestate;
+                if (TryGetPreState(pc, out prestate))
+                {
+                    if (prestate.OldDomain != null)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            private SymbolicValue ConvertDest(APC pc, Temp dest)
+            {
+                Domain postState;
+                if (!parent.PostStateLookup(pc, out postState))
+                {
+                    return default(SymbolicValue);
+                }
+                SymbolicValue result;
+                postState.TryGetCorrespondingValueAbstraction(dest, out result);
+                return result;
+            }
+
+            private SymbolicValue ConvertOldDest(APC pc, Temp dest)
+            {
+                Domain postState;
+                if (!parent.PostStateLookup(pc, out postState))
+                {
+                    return default(SymbolicValue);
+                }
+                postState = postState.OldDomain;
+                Contract.Assume(postState != null);
+                SymbolicValue result;
+                postState.TryGetCorrespondingValueAbstraction(dest, out result);
+                return result;
+            }
+
+            private Sources<ArgList> ConvertSources<ArgList>(APC pc, ArgList sources)
+              where ArgList : IIndexable<Temp>
+            {
+                return new Sources<ArgList>(sources, parent.GetPreState(pc));
+            }
+            #endregion
+
+            #region MSIL delegation
+            public Result Assert(APC pc, string tag, Source condition, object provenance, Data data)
+            {
+                return delegatee.Assert(pc, tag, ConvertSource(pc, condition), provenance, data);
+            }
+
+            public Result Assume(APC pc, string tag, Source source, object provenance, Data data)
+            {
+                if (parent.IgnoreExplicitAssumptions && tag == "assume")
+                {
+                    return delegatee.Nop(pc, data);
+                }
+                SymbolicValue sv = ConvertSource(pc, source);
+                return delegatee.Assume(pc, tag, sv, provenance, data);
+            }
+
+            public Result Arglist(APC pc, Dest dest, Data data)
+            {
+                return delegatee.Arglist(pc, ConvertDest(pc, dest), data);
+            }
+
+            public Result Binary(APC pc, BinaryOperator op, Dest dest, Source s1, Source s2, Data data)
+            {
+                switch (op)
+                {
+                    case BinaryOperator.Cobjeq:
+                        // handle boxing/unboxing here
+                        var value1 = TryConvertUnbox(pc, s1);
+                        var value2 = TryConvertUnbox(pc, s2);
+                        return delegatee.Binary(pc, op, ConvertDest(pc, dest), value1, value2, data);
+
+                    default:
+                        return delegatee.Binary(pc, op, ConvertDest(pc, dest), ConvertSource(pc, s1), ConvertSource(pc, s2), data);
+                }
+            }
+
+            public Result BranchCond(APC pc, APC target, BranchOperator bop, Source value1, Source value2, Data data)
+            {
+                return delegatee.BranchCond(pc, target, bop, ConvertSource(pc, value1), ConvertSource(pc, value2), data);
+            }
+
+            public Result BranchTrue(APC pc, APC target, Source cond, Data data)
+            {
+                return delegatee.BranchTrue(pc, target, ConvertSource(pc, cond), data);
+            }
+
+            public Result BranchFalse(APC pc, APC target, Source cond, Data data)
+            {
+                return delegatee.BranchFalse(pc, target, ConvertSource(pc, cond), data);
+            }
+
+            public Result Branch(APC pc, APC target, bool leave, Data data)
+            {
+                return delegatee.Branch(pc, target, leave, data);
+            }
+
+            public Result Break(APC pc, Data data)
+            {
+                return delegatee.Break(pc, data);
+            }
+
+            public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                if (!parent.mdDecoder.IsVoidMethod(method) && InsideOld(pc))
+                {
+                    // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
+                    return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
+                }
+                return DelegateCall<TypeList, ArgList>(pc, method, tail, virt, extraVarargs, dest, args, data);
+            }
+
+            private Result DelegateCall<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<int>
+            {
+                Type declaringType = parent.mdDecoder.DeclaringType(method);
+                if (args.Count == 2)
+                {
+                    var methodName = parent.mdDecoder.Name(method);
+                    if (methodName == "Equals")
+                    {
+                        // special case equal here
+                        // NOTE: mdDecoder may classify String as primitive
+                        if (parent.mdDecoder.IsStruct(declaringType) && !parent.mdDecoder.IsStatic(method) && parent.mdDecoder.HasValueRepresentation(declaringType))
+                        {
+                            return delegatee.Binary(pc, BinaryOperator.Cobjeq, ConvertDest(pc, dest), ConvertSourceDeref(pc, args[0]), TryConvertUnbox(pc, args[1]), data);
+                        }
+                        else
+                        {
+                            return delegatee.Binary(pc, BinaryOperator.Cobjeq, ConvertDest(pc, dest), TryConvertUnbox(pc, args[0]), TryConvertUnbox(pc, args[1]), data);
+                        }
+                    }
+                    else if (parent.mdDecoder.IsReferenceType(parent.mdDecoder.DeclaringType(method)) || parent.mdDecoder.IsNativePointerType(parent.mdDecoder.DeclaringType(method)))
+                    {
+                        if (methodName == "op_Inequality")
+                        {
+                            return delegatee.Binary(pc, BinaryOperator.Cne_Un, ConvertDest(pc, dest), ConvertSource(pc, args[0]), ConvertSource(pc, args[1]), data);
+                        }
+                        else if (methodName == "op_Equality")
+                        {
+                            if (parent.mdDecoder.IsNativePointerType(parent.mdDecoder.DeclaringType(method)))
+                            {
+                                return delegatee.Binary(pc, BinaryOperator.Ceq, ConvertDest(pc, dest), ConvertSource(pc, args[0]), ConvertSource(pc, args[1]), data);
+                            }
+                            else
+                            {
+                                return delegatee.Binary(pc, BinaryOperator.Cobjeq, ConvertDest(pc, dest), ConvertSource(pc, args[0]), ConvertSource(pc, args[1]), data);
+                            }
+                        }
+                    }
+                }
+                return delegatee.Call(pc, method, tail, virt, extraVarargs, ConvertDest(pc, dest), ConvertSources(pc, args), data);
+            }
+
+            public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                if (!parent.mdDecoder.IsVoid(returnType) && InsideOld(pc))
+                {
+                    // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
+                    return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
+                }
+
+                return delegatee.Calli(pc, returnType, argTypes, tail, isInstance, ConvertDest(pc, dest), ConvertSource(pc, fp), ConvertSources(pc, args), data);
+            }
+
+            public Result Ckfinite(APC pc, Dest dest, Source source, Data data)
+            {
+                return delegatee.Ckfinite(pc, ConvertDest(pc, dest), ConvertSource(pc, source), data);
+            }
+
+            public Result Cpblk(APC pc, bool @volatile, Source destaddr, Source srcaddr, Source len, Data data)
+            {
+                return delegatee.Cpblk(pc, @volatile, ConvertSource(pc, destaddr), ConvertSource(pc, srcaddr), ConvertSource(pc, len), data);
+            }
+
+            public Result Endfilter(APC pc, Source decision, Data data)
+            {
+                return delegatee.Endfilter(pc, ConvertSource(pc, decision), data);
+            }
+
+            public Result Endfinally(APC pc, Data data)
+            {
+                return delegatee.Endfinally(pc, data);
+            }
+
+            public Result Entry(APC pc, Method method, Data data)
+            {
+                return delegatee.Entry(pc, method, data);
+            }
+
+            public Result Initblk(APC pc, bool @volatile, Source destaddr, Source value, Source len, Data data)
+            {
+                return delegatee.Initblk(pc, @volatile, ConvertSource(pc, destaddr), ConvertSource(pc, value), ConvertSource(pc, len), data);
+            }
+
+            public Result Jmp(APC pc, Method method, Data data)
+            {
+                return delegatee.Jmp(pc, method, data);
+            }
+
+            public Result Ldarg(APC pc, Parameter argument, bool isOld, Dest dest, Data data)
+            {
+                return delegatee.Ldarg(pc, argument, isOld, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldarga(APC pc, Parameter argument, bool isOld, Dest dest, Data data)
+            {
+                return delegatee.Ldarga(pc, argument, isOld, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldconst(APC pc, object constant, Type type, Dest dest, Data data)
+            {
+                return delegatee.Ldconst(pc, constant, type, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldnull(APC pc, Dest dest, Data data)
+            {
+                return delegatee.Ldnull(pc, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldftn(APC pc, Method method, Dest dest, Data data)
+            {
+                return delegatee.Ldftn(pc, method, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldind(APC pc, Type type, bool @volatile, Dest dest, Source ptr, Data data)
+            {
+                if (InsideOld(pc))
+                {
+                    // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
+                    return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
+                }
+
+                return delegatee.Ldind(pc, type, @volatile, ConvertDest(pc, dest), ConvertSource(pc, ptr), data);
+            }
+
+            public Result Ldloc(APC pc, Local local, Dest dest, Data data)
+            {
+                return delegatee.Ldloc(pc, local, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldloca(APC pc, Local local, Dest dest, Data data)
+            {
+                return delegatee.Ldloca(pc, local, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldresult(APC pc, Type type, int dest, int source, Data data)
+            {
+                return delegatee.Ldresult(pc, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
+            }
+
+            public Result Ldstack(APC pc, int offset, Dest dest, Source source, bool isOld, Data data)
+            {
+                if (isOld)
+                {
+                    return delegatee.Ldstack(pc, offset, ConvertDest(pc, dest), ConvertOldSource(pc, source), isOld, data);
+                }
+                else
+                {
+                    return delegatee.Ldstack(pc, offset, ConvertDest(pc, dest), ConvertSource(pc, source), isOld, data);
+                }
+            }
+
+            public Result Ldstacka(APC pc, int offset, Dest dest, Source source, Type type, bool old, Data data)
+            {
+                return delegatee.Ldstacka(pc, offset, ConvertDest(pc, dest), ConvertSource(pc, source), type, old, data);
+            }
+
+            public Result Localloc(APC pc, Dest dest, Source size, Data data)
+            {
+                return delegatee.Localloc(pc, ConvertDest(pc, dest), ConvertSource(pc, size), data);
+            }
+
+            public Result Nop(APC pc, Data data)
+            {
+                return delegatee.Nop(pc, data);
+            }
+
+            public Result Pop(APC pc, Source source, Data data)
+            {
+                return delegatee.Pop(pc, ConvertSource(pc, source), data);
+            }
+
+            public Result Return(APC pc, Source source, Data data)
+            {
+                return delegatee.Return(pc, ConvertSource(pc, source), data);
+            }
+
+            public Result Starg(APC pc, Parameter argument, Source source, Data data)
+            {
+                return delegatee.Starg(pc, argument, ConvertSource(pc, source), data);
+            }
+
+            public Result Stind(APC pc, Type type, bool @volatile, Source ptr, Source value, Data data)
+            {
+                return delegatee.Stind(pc, type, @volatile, ConvertSource(pc, ptr), ConvertSource(pc, value), data);
+            }
+
+            public Result Stloc(APC pc, Local local, Source source, Data data)
+            {
+                return delegatee.Stloc(pc, local, ConvertSource(pc, source), data);
+            }
+
+            public Result Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, Source value, Data data)
+            {
+                return delegatee.Switch(pc, type, cases, ConvertSource(pc, value), data);
+            }
+
+            public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Source source, Data data)
+            {
+                return delegatee.Unary(pc, op, overflow, unsigned, ConvertDest(pc, dest), ConvertSource(pc, source), data);
+            }
+
+            public Result Box(APC pc, Type type, Dest dest, Source source, Data data)
+            {
+                return delegatee.Box(pc, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
+            }
+
+            public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                if (!parent.mdDecoder.IsVoidMethod(method) && InsideOld(pc))
+                {
+                    // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
+                    return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
+                }
+
+                return delegatee.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, ConvertDest(pc, dest), ConvertSources(pc, args), data);
+            }
+
+            public Result Castclass(APC pc, Type type, Dest dest, Source obj, Data data)
+            {
+                return delegatee.Castclass(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            public Result Cpobj(APC pc, Type type, Source destptr, Source srcptr, Data data)
+            {
+                return delegatee.Cpobj(pc, type, ConvertSource(pc, destptr), ConvertSource(pc, srcptr), data);
+            }
+
+            public Result Initobj(APC pc, Type type, Source ptr, Data data)
+            {
+                return delegatee.Initobj(pc, type, ConvertSource(pc, ptr), data);
+            }
+
+            public Result Isinst(APC pc, Type type, Dest dest, Source obj, Data data)
+            {
+                return delegatee.Isinst(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            private Type ArrayElementType(APC pc, Type type, Source array)
+            {
+                if (parent.mdDecoder.IsStruct(type)) return type;
+                Domain domain;
+                if (!parent.PreStateLookup(pc, out domain))
+                {
+                    return type;
+                }
+                return domain.GetArrayElementType(type, array);
+            }
+
+            public Result Ldelem(APC pc, Type type, Dest dest, Source array, Source index, Data data)
+            {
+                if (InsideOld(pc))
+                {
+                    // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
+                    return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
+                }
+                type = ArrayElementType(pc, type, array);
+                return delegatee.Ldelem(pc, type, ConvertDest(pc, dest), ConvertSource(pc, array), ConvertSource(pc, index), data);
+            }
+
+            public Result Ldelema(APC pc, Type type, bool @readonly, Dest dest, Source array, Source index, Data data)
+            {
+                type = ArrayElementType(pc, type, array);
+                return delegatee.Ldelema(pc, type, @readonly, ConvertDest(pc, dest), ConvertSource(pc, array), ConvertSource(pc, index), data);
+            }
+
+            public Result Ldfld(APC pc, Field field, bool @volatile, Dest dest, Source obj, Data data)
+            {
+                if (InsideOld(pc))
+                {
+                    // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
+                    return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
+                }
+
+                return delegatee.Ldfld(pc, field, @volatile, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            public Result Ldflda(APC pc, Field field, Dest dest, Source obj, Data data)
+            {
+                return delegatee.Ldflda(pc, field, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            public Result Ldlen(APC pc, Dest dest, Source array, Data data)
+            {
+                return delegatee.Ldlen(pc, ConvertDest(pc, dest), ConvertSource(pc, array), data);
+            }
+
+            public Result Ldsfld(APC pc, Field field, bool @volatile, Dest dest, Data data)
+            {
+                if (InsideOld(pc))
+                {
+                    // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
+                    return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
+                }
+
+                return delegatee.Ldsfld(pc, field, @volatile, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldsflda(APC pc, Field field, Dest dest, Data data)
+            {
+                return delegatee.Ldsflda(pc, field, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldtypetoken(APC pc, Type type, Dest dest, Data data)
+            {
+                return delegatee.Ldtypetoken(pc, type, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldfieldtoken(APC pc, Field field, Dest dest, Data data)
+            {
+                return delegatee.Ldfieldtoken(pc, field, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldmethodtoken(APC pc, Method method, Dest dest, Data data)
+            {
+                return delegatee.Ldmethodtoken(pc, method, ConvertDest(pc, dest), data);
+            }
+
+            public Result Ldvirtftn(APC pc, Method method, Dest dest, Source obj, Data data)
+            {
+                return delegatee.Ldvirtftn(pc, method, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            public Result Mkrefany(APC pc, Type type, Dest dest, Source obj, Data data)
+            {
+                return delegatee.Mkrefany(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            public Result Newarray<ArgList>(APC pc, Type type, Dest dest, ArgList lengths, Data data)
+              where ArgList : IIndexable<Source>
+            {
+                return delegatee.Newarray(pc, type, ConvertDest(pc, dest), ConvertSources(pc, lengths), data);
+            }
+
+            public Result Newobj<ArgList>(APC pc, Method ctor, Dest dest, ArgList args, Data data)
+              where ArgList : IIndexable<Source>
+            {
+                return delegatee.Newobj(pc, ctor, ConvertDest(pc, dest), ConvertSources(pc, args), data);
+            }
+
+            public Result Refanytype(APC pc, Dest dest, Source source, Data data)
+            {
+                return delegatee.Refanytype(pc, ConvertDest(pc, dest), ConvertSource(pc, source), data);
+            }
+
+            public Result Refanyval(APC pc, Type type, Dest dest, Source source, Data data)
+            {
+                return delegatee.Refanyval(pc, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
+            }
+
+            public Result Rethrow(APC pc, Data data)
+            {
+                return delegatee.Rethrow(pc, data);
+            }
+
+            public Result Sizeof(APC pc, Type type, Dest dest, Data data)
+            {
+                return delegatee.Sizeof(pc, type, ConvertDest(pc, dest), data);
+            }
+
+            public Result Stelem(APC pc, Type type, Source array, Source index, Source value, Data data)
+            {
+                type = ArrayElementType(pc, type, array);
+                return delegatee.Stelem(pc, type, ConvertSource(pc, array), ConvertSource(pc, index), ConvertSource(pc, value), data);
+            }
+
+            public Result Stfld(APC pc, Field field, bool @volatile, Source obj, Source value, Data data)
+            {
+                return delegatee.Stfld(pc, field, @volatile, ConvertSource(pc, obj), ConvertSource(pc, value), data);
+            }
+
+            public Result Stsfld(APC pc, Field field, bool @volatile, Source value, Data data)
+            {
+                return delegatee.Stsfld(pc, field, @volatile, ConvertSource(pc, value), data);
+            }
+
+            public Result Throw(APC pc, Source exn, Data data)
+            {
+                if (parent.TurnArgumentExceptionThrowsIntoAssertFalse)
+                {
+                    Type argExcType;
+                    if (parent.ArgumentExceptionTypeCache.TryGet(parent.mdDecoder, out argExcType))
+                    {
+                        Type type;
+                        SymbolicValue falseSymValue;
+                        if (HasSourceType(pc, exn, out type, out falseSymValue))
+                        {
+                            if (parent.mdDecoder.DerivesFrom(type, argExcType))
+                            {
+                                // turn into assert false.
+                                //return delegatee.Assert(pc, "assert", falseSymValue, null, data);
+                                return delegatee.Assert(pc, "assert", falseSymValue, "throw instruction", data);
+                            }
+                        }
+                    }
+                }
+                return delegatee.Throw(pc, ConvertSource(pc, exn), data);
+            }
+
+            public Result Unbox(APC pc, Type type, Dest dest, Source obj, Data data)
+            {
+                return delegatee.Unbox(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            public Result Unboxany(APC pc, Type type, Dest dest, Source obj, Data data)
+            {
+                return delegatee.Unboxany(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
+            }
+
+            #region IVisitSynthIL<APC,Method,int,int,Data,Result> Members
+
+
+            public Result BeginOld(APC pc, APC matchingEnd, Data data)
+            {
+                return delegatee.BeginOld(pc, matchingEnd, data);
+            }
+
+            public Result EndOld(APC pc, APC matchingBegin, Type type, int dest, int source, Data data)
+            {
+                return delegatee.Nop(pc, data);
+                //        return delegatee.EndOld(pc, matchingBegin, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
+            }
+
+            #endregion
+            #endregion
+        }
+
+        private class ValueContext<Context>
+          : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
+          , IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>
+          where Context : IStackContext<Field, Method>
+        {
+            #region Privates
+            private OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
+            private Context underlying;
+            #endregion
+
+            public ValueContext(
+              OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent,
+              Context underlying
+            )
+            {
+                this.parent = parent;
+                this.underlying = underlying;
+            }
+
+            #region IValueContext<APC,Method,Type,SymbolicValue> Members
+
+            IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>.ValueContext { get { return this; } }
+
+            public bool TryZero(APC at, out SymbolicValue value)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d) || d.IsBottom)
+                {
+                    value = default(SymbolicValue);
+                    return false;
+                }
+                value = new SymbolicValue(d.Zero);
+                return true;
+            }
+
+            public bool TryNull(APC at, out SymbolicValue value)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d) || d.IsBottom)
+                {
+                    value = default(SymbolicValue);
+                    return false;
+                }
+                value = new SymbolicValue(d.Null);
+                return true;
+            }
+
+            public FlatDomain<Type> GetType(APC at, SymbolicValue v)
+            {
+                try
+                {
+                    Domain d;
+                    if (!parent.PreStateLookup(at, out d) || d.IsBottom)
+                    {
+                        return FlatDomain<Type>.TopValue;
+                    }
+                    return d.GetType(v.symbol).Type;
+                }
+                catch (NullReferenceException)
+                {
+#if DEBUG
+                    Console.WriteLine("[OptimisticHeapAnalysis]: Found a Null pointer exception in GetType for {0} @ PC = {1}. Returning Top type", v, at);
+#endif
+                    return FlatDomain<Type>.TopValue; // Should we return Bottom?
+                }
+            }
+
+            public bool TryGetArrayLength(APC at, SymbolicValue array, out SymbolicValue length)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    length = default(SymbolicValue);
+                    return false;
+                }
+                ESymValue len;
+                bool success = d.TryGetArrayLength(array.symbol, out len);
+                length = new SymbolicValue(len);
+                return success;
+            }
+
+            public bool TryGetModelArray(APC at, SymbolicValue enumerable, out SymbolicValue modelArray)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    modelArray = default(SymbolicValue);
+                    return false;
+                }
+                ESymValue model = d.TryGetModelMethod(enumerable.symbol, "Model");
+                if (model == null)
+                {
+                    model = d.TryGetModelMethod(enumerable.symbol, "System.Collections.IEnumerable.Model");
+                }
+                modelArray = new SymbolicValue(model);
+                return model != null;
+            }
+
+            public bool TryGetObjectFromObjectVersion(APC at, SymbolicValue objectVersion, out SymbolicValue objectValue)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    objectValue = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetObjectFromObjectVersion(objectVersion, out objectValue);
+            }
+
+            public bool TryGetArrayFromElementAddress(APC at, SymbolicValue elementAddress, out SymbolicValue array, out SymbolicValue index)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    array = default(SymbolicValue);
+                    index = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetArrayFromArrayElementAddress(elementAddress, out array, out index);
+            }
+
+            public bool TryUnbox(APC pc, SymbolicValue box, out SymbolicValue contents)
+            {
+                // lookup the given source in the egraph for this program point
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d))
+                {
+                    contents = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetUnboxedValue(box.symbol, out contents);
+            }
+
+            public bool TryGetWritableBytes(APC at, SymbolicValue pointer, out SymbolicValue length)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    length = default(SymbolicValue);
+                    return false;
+                }
+                ESymValue len;
+                bool success = d.TryGetWritableBytes(pointer.symbol, out len);
+                length = new SymbolicValue(len);
+                return success;
+            }
+
+            public bool IsZero(APC at, SymbolicValue value)
+            {
+                Domain entry = parent.GetPreState(at);
+                if (entry == null) return true; // unreached
+                return entry.IsZero(value.symbol);
+            }
+
+            public bool TryStackValue(APC at, Temp stackIndex, out SymbolicValue sv)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    sv = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetCorrespondingValueAbstraction(stackIndex, out sv);
+            }
+
+            public bool TryLocalValue(APC at, Local local, out SymbolicValue sv)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    sv = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetCorrespondingValueAbstraction(local, out sv);
+            }
+
+            public bool TryLocalAddress(APC at, Local local, out SymbolicValue sv)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    sv = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetCorrespondingAddressAbstraction(local, out sv);
+            }
+
+            public bool TryParameterAddress(APC at, Parameter parameter, out SymbolicValue sv)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    sv = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetCorrespondingAddressAbstraction(parameter, out sv);
+            }
+
+            public bool TryParameterValue(APC at, Parameter parameter, out SymbolicValue sv)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    sv = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetCorrespondingValueAbstraction(parameter, out sv);
+            }
+
+            public bool TryFieldAddress(APC at, SymbolicValue obj, Field field, out SymbolicValue address)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    address = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryGetFieldAddress(obj, field, out address);
+            }
+
+            public bool TryLoadIndirect(APC at, SymbolicValue addr, out SymbolicValue value)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    value = default(SymbolicValue);
+                    return false;
+                }
+                return d.TryLoadIndirect(addr, out value);
+            }
+
+            public bool TryResultValue(APC at, out SymbolicValue resultValue)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    resultValue = default(SymbolicValue);
+                    return false;
+                }
+
+                return d.TryGetCorrespondingValueAbstraction(0, out resultValue); // top of stack
+            }
+
+            public bool IsPureFunctionCall(APC at, SymbolicValue value, out Method method, out SymbolicValue[] args)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    method = default(Method);
+                    args = null;
+                    return false;
+                }
+                return d.IsPureFunctionCall(value, out method, out args);
+            }
+
+            public bool IsDelegateValue(APC at, SymbolicValue value, out SymbolicValue targetObject, out Method targetMethod)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    targetMethod = default(Method);
+                    targetObject = default(SymbolicValue);
+                    return false;
+                }
+                return d.IsDelegateValue(value, out targetObject, out targetMethod);
+            }
+
+            public bool IsValid(SymbolicValue sv)
+            {
+                return sv.symbol != null;
+            }
+
+            public string AccessPath(APC at, SymbolicValue value)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+                return d.GetAccessPath(value.symbol);
+            }
+
+            public FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall = default(Type))
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+
+                return AccessPathList(at, value, allowLocal, preferLocal, allowReturnValueFromCall, d);
+            }
+
+            private FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall, Domain d)
+            {
+                AccessPathFilter<Method, Type> opt;
+                if (allowReturnValueFromCall != null && !allowReturnValueFromCall.Equals(default(Type)))
+                {
+                    var stackDepth = parent.context.StackContext.LocalStackDepth(at);
+                    // use the stackDepth in the filter to determine if the value is the top-of-the-stack
+
+
+                    opt = AccessPathFilter<Method, Type>.IsVisibleFromMethodOrCalledPost(this.MethodContext.CurrentMethod, allowReturnValueFromCall, stackDepth);
+                }
+                else
+                {
+                    opt = AccessPathFilter<Method, Type>.IsVisibleFrom(this.MethodContext.CurrentMethod);
+                }
+                return d.GetAccessPathList(value.symbol, opt, allowLocal, preferLocal);
+            }
+
+            public FList<PathElement> AccessPathListAndWitness(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, out FList<SymbolicValue> witness, Type allowReturnValueFromCall = default(Type))
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+
+                var ap = AccessPathList(at, value, allowLocal, preferLocal, allowReturnValueFromCall, d);
+                if (ap == null) { witness = null; return null; }
+
+                var rev = d.AccessPathWitnessReversed(d, ap);
+                if (rev == null)
+                {
+                    // something is wrong
+                    witness = null;
+                    return null;
+                }
+                witness = rev.Reverse(sv => new SymbolicValue(sv));
+                return ap;
+            }
+
+            public IEnumerable<FList<PathElement>> AccessPaths(APC at, SymbolicValue value, AccessPathFilter<Method, Type> filter)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+                foreach (var path in d.GetAccessPathsFiltered(value.symbol, filter, true))
+                {
+                    yield return path.Coerce<Domain.PathElementBase, PathElement>();
+                }
+            }
+
+            public FList<PathElement> VisibleAccessPathListFromPre(APC at, SymbolicValue value)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    return null;
+                }
+                var opt = AccessPathFilter<Method, Type>.FromPrecondition(this.MethodContext.CurrentMethod);
+                return d.GetBestAccessPath(value.symbol, opt, true, false, false, path => PathSuitableInRequires(at, path));
+            }
+
+            public FList<PathElement> VisibleAccessPathListFromPost(APC at, SymbolicValue value, bool allowReturnValue = true)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    return null;
+                }
+                var opt = AccessPathFilter<Method, Type>.FromPostcondition(this.MethodContext.CurrentMethod, parent.mdDecoder.ReturnType(this.MethodContext.CurrentMethod));
+                return d.GetBestAccessPath(value.symbol, opt, true, false, false, path => PathSuitableInEnsures(at, path, allowReturnValue));
+            }
+
+
+            public bool PathUnmodifiedSinceEntry(APC at, FList<PathElement> path)
+            {
+                if (path == null) return false;
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+                ESymValue sym;
+                if (d.IsTopLevelVisibleAtMethodEntry(path.Head, out sym))
+                {
+                    return d.CheckIfPathUnmodified(sym, path.Tail);
+                }
+                return false;
+            }
+
+            public bool PathSuitableInRequires(APC at, FList<PathElement> path)
+            {
+                if (path == null) return false;
+                var pe = path.Head as Domain.MethodCallPathElement;
+                if (pe != null)
+                {
+                    // must be a static property. Ignore it.
+                    return false;
+                }
+                return PathUnmodifiedSinceEntry(at, path);
+            }
+
+            public bool PathSuitableInEnsures(APC at, FList<PathElement> path, bool allowReturnValue)
+            {
+                if (path == null) return false;
+                var pe = path.Head as Domain.MethodCallPathElement;
+                if (pe != null)
+                {
+                    // must be a static property. Ignore it.
+                    return false;
+                }
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+                ESymValue sym;
+                if (d.IsTopLevelVisibleAtMethodEntry(path.Head, out sym))
+                {
+                    return true;
+                }
+                if (allowReturnValue && path.Head.IsReturnValue) return true;
+                return false;
+            }
+
+
+            public bool IsConstant(APC at, SymbolicValue sv, out Type type, out object value)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+                return d.IsConstant(sv.symbol, out type, out value);
+            }
+
+            public bool IsRuntimeType(APC at, SymbolicValue sv, out Type type)
+            {
+                SymbolicValue[] args;
+                Method method;
+
+                type = default(Type);
+                if (!IsPureFunctionCall(at, sv, out method, out args)) return false;
+                if (parent.mdDecoder.Name(method) != "GetTypeFromHandle") return false;
+                Type dummy;
+                object value;
+                if (args.Length != 1) return false;
+                if (!IsConstant(at, args[0], out dummy, out value)) return false;
+                if (!(value is Type)) return false;
+
+                type = (Type)value;
+                return true;
+            }
+
+            public bool IsRootedInParameter(FList<PathElement> path)
+            {
+                return Domain.IsRootedInParameter(path);
+            }
+
+            public bool IsRootedInReturnValue(FList<PathElement> path)
+            {
+                return Domain.IsRootedInReturnValue(path);
+            }
+
+            public PathContextFlags PathContexts(APC at, SymbolicValue sv)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(at, out d))
+                {
+                    throw new ArgumentException("pc was not visited");
+                }
+                return d.PathContexts(sv.symbol);
+            }
+
+            #endregion
+
+            #region IMethodContext<Method> Members
+            public IStackContextData<Field, Method> StackContext { get { return underlying.StackContext; } }
+            public IMethodContextData<Field, Method> MethodContext { get { return underlying.MethodContext; } }
+
+            #endregion
+        }
+
+        private class Decoder<ContextData> :
+          IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
+          where ContextData : IStackContext<Field, Method>
+        {
+            #region Privates
+            private OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
+            private IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, ContextData, Unit> underlying;
+            #endregion
+
+            public Decoder(
+              OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent,
+              IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, ContextData, Unit> underlying
+              )
+            {
+                this.parent = parent;
+                this.underlying = underlying;
+            }
+
+            #region IMSILDecoder<APC,Local,Parameter,Method,Field,Type,SymbolicValue,SymbolicValue> Members
+
+            public Result ForwardDecode<Data, Result, Visitor>(APC lab, Visitor visitor, Data data) where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Data, Result>
+            {
+                return underlying.ForwardDecode<Data, Result, SymbolicAdapter<Data, Result, Visitor>>(lab, new SymbolicAdapter<Data, Result, Visitor>(parent, visitor), data);
+            }
+
+            private ValueContext<ContextData> context;
+            public IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue> Context
+            {
+                get
+                {
+                    if (context == null)
+                    {
+                        context = new ValueContext<ContextData>(parent, underlying.Context);
+                    }
+                    return context;
+                }
+            }
+
+            public EdgeData EdgeData(APC from, APC to)
+            {
+                // avoid renaming when not necessary
+                if (!parent.renamePoints.ContainsKey(from, to)) return null;
+
+                // optizmize identity renaming
+                if (parent.mergeInfoCache.ContainsKey(to) && parent.mergeInfoCache[to] == null)
+                {
+                    return null;
+                }
+
+                // revisit the issue of the fact that EdgeRenaming may provide different info based on whether it is a join point or not.
+                return parent.EdgeRenaming(new Pair<APC, APC>(from, to), context.MethodContext.CFG.IsJoinPoint(to));
+            }
+
+            public void Display(TextWriter tw, string prefix, EdgeData edgeData)
+            {
+                if (edgeData == null) return;
+                edgeData.Visit(delegate (SymbolicValue key, FList<SymbolicValue> targets)
+                {
+                    tw.Write("  {0} -> ", key);
+                    foreach (var target in targets.GetEnumerable())
+                    {
+                        tw.Write("{0} ", target);
+                    }
+                    tw.WriteLine();
+                    return VisitStatus.ContinueVisit;
+                });
+            }
+
+            public bool IsUnreachable(APC pc)
+            {
+                return parent.IsUnreachable(pc);
+            }
+            #endregion
+
+        }
+
+        #endregion
+
+        public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
+          GetDecoder<Context>(
+            IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Context, Unit> underlying
+          )
+          where Context : IStackContext<Field, Method>
+        {
+            return new Decoder<Context>(this, underlying);
+        }
+
+        #region Value adapter
+#if false
+        class ValueDriver<AState> :
+          IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, AState, AState>, Unit>
+        {
+            IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>> valuedriver;
+            OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
+            IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState> delegatee;
+
+            public ValueDriver(
+              IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>> valuedriver,
+              OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent
+            )
+            {
+                this.valuedriver = valuedriver;
+                this.parent = parent;
+            }
+
+            #region IAnalysis<APC,AState,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,AState,AState>> Members
+
+
+            /// <summary>
+            /// This is the trickiest part of the whole abstraction. Along the given edge, the heap state was possibly renamed, and
+            /// a single symbolic name might correspond to multiple names in the target state. We have to perform the same renaming
+            /// and constraining of the abstract state here.
+            /// </summary>
+            /// <param name="edge">Edge along there might be renaming of the egraph symbolic values</param>
+            /// <param name="state">Abstract client state</param>
+            /// <returns>New abstract client state renamed to target vocabulary</returns>
+            public AState EdgeConversion(APC from, APC next, bool joinPoint, Unit edgeData, AState state)
+            {
+                // We only need to do the renaming if next is a join point since we cached all 
+                // original program states.
+                if (!parent.renamePoints.ContainsKey(from, next)) return state;
+
+                // optimize Identity renaming case
+                if (parent.mergeInfoCache.ContainsKey(next) && parent.mergeInfoCache[next] == null)
+                {
+                    return state;
+                }
+
+                Pair<APC, APC> edge = new Pair<APC, APC>(from, next);
+                IFunctionalMap<SymbolicValue, FList<SymbolicValue>>/*?*/ renaming = parent.EdgeRenaming(edge, joinPoint);
+
+                if (renaming != null)
+                {
+                    state = valuedriver.ParallelAssign(edge, renaming, state);
+                }
+                else
+                {
+                    // identity renaming
+                }
+
+                return state;
+            }
+
+            /// <summary>
+            /// The states joined already use the same variable vocabulary, as th Edge renaming has already happened.
+            /// Thus, we can just use the original joiner, no need to interpose.
+            /// </summary>
+            public AState Join(Pair<APC, APC> edge, AState newState, AState prevState, out bool weaker, bool widen)
+            {
+                return valuedriver.Join(edge, newState, prevState, out weaker, widen);
+            }
+
+            public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, AState, AState> Visitor()
+            {
+                delegatee = valuedriver.Visitor();
+
+                return new SymbolicAdapter<AState, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>>(parent, delegatee);
+            }
+
+            public Predicate<APC> CacheStates(IFixpointInfo<APC, AState> fixpointInfo)
+            {
+                return valuedriver.CacheStates(fixpointInfo);
+            }
+
+            public void Dump(Pair<AState, TextWriter> stateAndWriter)
+            {
+                valuedriver.Dump(stateAndWriter);
+            }
+
+            public AState ImmutableVersion(AState state)
+            {
+                return valuedriver.ImmutableVersion(state);
+            }
+
+            public AState MutableVersion(AState state)
+            {
+                return valuedriver.MutableVersion(state);
+            }
+
+            public bool IsBottom(APC pc, AState state)
+            {
+                Domain d;
+                if (!parent.PreStateLookup(pc, out d))
+                {
+                    return true;
+                }
+                if (d.IsBottom) return true;
+                return valuedriver.IsBottom(pc, state);
+            }
+
+            #endregion
+
+
+
+        }
+#endif
+        #endregion
+
+#if false
+        public IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, AState, AState>, Unit>
+          GetValueDriver<AState>(
+            IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>> valuedriver)
+        {
+            return new ValueDriver<AState>(valuedriver, this);
+        }
+#endif
+
+        public BlockInfoPrinter<APC> GetEdgePrinter()
+        {
+            Converter<SymbolicValue, string> sourcePrinter = delegate (SymbolicValue sv) { return sv.ToString(); };
+            return GetBlockInfoPrinter(sourcePrinter);
+        }
+
+        public BlockInfoPrinter<APC> GetBlockInfoPrinter(Converter<SymbolicValue, string> source2string)
+        {
+            return delegate (APC blockEnd, string prefix, TextWriter tw)
+            {
+                BlockInfoPrinter(blockEnd, prefix, tw, source2string);
+            };
+        }
+
+        public FlatDomain<Type> SymbolTypeAtPreState(APC pc, SymbolicValue sym)
+        {
+            Domain d;
+            if (PreStateLookup(pc, out d))
+            {
+                return d.GetType(sym.symbol).Type;
+            }
+            return FlatDomain<Type>.TopValue;
+        }
+
+        public void BlockInfoPrinter(APC blockEnd, string prefix, TextWriter tw, Converter<SymbolicValue, string> source2string)
+        {
+            foreach (APC blockTarget in renamePoints.Keys2(blockEnd))
+            {
+                Pair<APC, APC> edge = new Pair<APC, APC>(blockEnd, blockTarget);
+                IFunctionalMap<SymbolicValue, FList<SymbolicValue>>/*?*/ renaming = this.EdgeRenaming(edge, blockTarget.Block.Subroutine.IsJoinPoint(blockTarget.Block));
+                if (renaming != null)
+                {
+                    edge = PrintRenaming(prefix, tw, source2string, edge, renaming);
+                }
+            }
+        }
+
+        private Pair<APC, APC> PrintRenaming(string prefix, TextWriter tw, Converter<SymbolicValue, string> source2string, Pair<APC, APC> edge, IFunctionalMap<SymbolicValue, FList<SymbolicValue>> renaming)
+        {
+            tw.WriteLine("{0}Rebinding on {1}", prefix, edge);
+            foreach (SymbolicValue source in renaming.Keys.OrderBy(s => s))
+            {
+                FList<SymbolicValue> targets = renaming[source];
+                while (targets != null)
+                {
+                    SymbolicValue target = targets.Head;
+                    tw.WriteLine("{0}  {1} := {2} {3}", prefix, target, source2string(source), SymbolTypeAtPreState(edge.One, source));
+                    Domain d;
+                    this.PreStateLookup(edge.One, out d);
+                    if (d != null)
+                    {
+                        string path = d.GetAccessPath(source.symbol);
+                        if (path != null)
+                        {
+                            tw.WriteLine("{0}     Access path to {1} = {2}", prefix, source2string(source), path);
+                        }
+                    }
+                    targets = targets.Tail;
+                }
+            }
+            return edge;
+        }
+
+        public IEnumerable<APC> RenamingTargets(APC from)
+        {
+            return renamePoints.Keys2(from);
+        }
+
+        /// <summary>
+        /// null result means identity, thus no renaming needed
+        /// </summary>
+        internal IFunctionalMap<SymbolicValue, SymbolicValue> BackwardEdgeRenaming(APC from, APC to)
+        {
+            // We only need to do the renaming if next is a join point since we cached all 
+            // original program states.
+            IFunctionalMap<SymbolicValue, SymbolicValue> result;
+            Pair<APC, APC> edge = new Pair<APC, APC>(from, to);
+
+            if (backwardRenamings.TryGetValue(edge, out result))
+            {
+                return result;
+            }
+
+            if (!renamePoints.ContainsKey(to, from))
+            {
+                if (from.SubroutineContext != to.SubroutineContext) return null;
+                if (!to.Block.Last.Equals(to)) return null;
+                if (!from.Block.First.Equals(from)) return null;
+
+                APC pred;
+                if (!this.context.MethodContext.CFG.HasSinglePredecessor(from, out pred, skipContracts: false)) return null;
+                if (pred.Equals(to)) return null;
+                // looks like we skipped over contracts. 
+
+                result = null;
+                // compute renaming.
+                Domain start;
+                this.PostStateLookup(to, out start);
+                Domain end;
+                this.PreStateLookup(from, out end);
+                IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
+                IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
+                if (start != null && end != null)
+                {
+                    if (!end.LessEqual(start, out forward, out backward))
+                    {
+                        // failed to compute a renaming
+                        return null;
+                    }
+                    if (forward != null)
+                    {
+                        result = FunctionalIntKeyMap<SymbolicValue, SymbolicValue>.Empty(SymbolicValue.GetUniqueKey);
+                        foreach (ESymValue source in forward.Keys)
+                        {
+                            var candidates = forward[source];
+                            if (candidates != null)
+                            {
+                                result = result.Add(new SymbolicValue(source), new SymbolicValue(candidates.Head));
+                            }
+                        }
+                    }
+                }
+                backwardRenamings.Add(edge, result);
+                return result;
             }
             else
             {
-              return delegatee.Binary(pc, BinaryOperator.Cobjeq, ConvertDest(pc, dest), TryConvertUnbox(pc, args[0]), TryConvertUnbox(pc, args[1]), data);
+                result = null;
+                // compute renaming.
+                Domain start;
+                this.PostStateLookup(to, out start);
+                Domain end;
+                this.PreStateLookup(from, out end);
+                IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
+                IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
+                if (start != null && end != null)
+                {
+                    if (!start.LessEqual(end, out forward, out backward))
+                    {
+                        Contract.Assume(false, "egraphs don't correspond at joins"); // means egraphs don't correspond
+                        throw new Exception("Should never happen");
+                    }
+                    if (backward != null)
+                    {
+                        result = FunctionalIntKeyMap<SymbolicValue, SymbolicValue>.Empty(SymbolicValue.GetUniqueKey);
+                        foreach (ESymValue source in backward.Keys)
+                        {
+                            result = result.Add(new SymbolicValue(source), new SymbolicValue(backward[source]));
+                        }
+                    }
+                }
+                backwardRenamings.Add(edge, result);
+                return result;
             }
-          }
-          else if (parent.mdDecoder.IsReferenceType(parent.mdDecoder.DeclaringType(method)) || parent.mdDecoder.IsNativePointerType(parent.mdDecoder.DeclaringType(method)))
-          {
-            if (methodName == "op_Inequality")
-            {
-              return delegatee.Binary(pc, BinaryOperator.Cne_Un, ConvertDest(pc, dest), ConvertSource(pc, args[0]), ConvertSource(pc, args[1]), data);
-            }
-            else if (methodName == "op_Equality")
-            {
-              if (parent.mdDecoder.IsNativePointerType(parent.mdDecoder.DeclaringType(method)))
-              {
-                return delegatee.Binary(pc, BinaryOperator.Ceq, ConvertDest(pc, dest), ConvertSource(pc, args[0]), ConvertSource(pc, args[1]), data);
-              }
-              else
-              {
-                return delegatee.Binary(pc, BinaryOperator.Cobjeq, ConvertDest(pc, dest), ConvertSource(pc, args[0]), ConvertSource(pc, args[1]), data);
-              }
-            }
-          }
         }
-        return delegatee.Call(pc, method, tail, virt, extraVarargs, ConvertDest(pc, dest), ConvertSources(pc, args), data);
-      }
-
-      public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        if (!parent.mdDecoder.IsVoid(returnType) && InsideOld(pc))
-        {
-          // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
-          return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
-        }
-
-        return delegatee.Calli(pc, returnType, argTypes, tail, isInstance, ConvertDest(pc, dest), ConvertSource(pc, fp), ConvertSources(pc, args), data);
-      }
-
-      public Result Ckfinite(APC pc, Dest dest, Source source, Data data)
-      {
-        return delegatee.Ckfinite(pc, ConvertDest(pc, dest), ConvertSource(pc, source), data);
-      }
-
-      public Result Cpblk(APC pc, bool @volatile, Source destaddr, Source srcaddr, Source len, Data data)
-      {
-        return delegatee.Cpblk(pc, @volatile, ConvertSource(pc, destaddr), ConvertSource(pc, srcaddr), ConvertSource(pc, len), data);
-      }
-
-      public Result Endfilter(APC pc, Source decision, Data data)
-      {
-        return delegatee.Endfilter(pc, ConvertSource(pc, decision), data);
-      }
-
-      public Result Endfinally(APC pc, Data data)
-      {
-        return delegatee.Endfinally(pc, data);
-      }
-
-      public Result Entry(APC pc, Method method, Data data)
-      {
-        return delegatee.Entry(pc, method, data);
-      }
-
-      public Result Initblk(APC pc, bool @volatile, Source destaddr, Source value, Source len, Data data)
-      {
-        return delegatee.Initblk(pc, @volatile, ConvertSource(pc, destaddr), ConvertSource(pc, value), ConvertSource(pc, len), data);
-      }
-
-      public Result Jmp(APC pc, Method method, Data data)
-      {
-        return delegatee.Jmp(pc, method, data);
-      }
-
-      public Result Ldarg(APC pc, Parameter argument, bool isOld, Dest dest, Data data)
-      {
-        return delegatee.Ldarg(pc, argument, isOld, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldarga(APC pc, Parameter argument, bool isOld, Dest dest, Data data)
-      {
-        return delegatee.Ldarga(pc, argument, isOld, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldconst(APC pc, object constant, Type type, Dest dest, Data data)
-      {
-        return delegatee.Ldconst(pc, constant, type, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldnull(APC pc, Dest dest, Data data)
-      {
-        return delegatee.Ldnull(pc, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldftn(APC pc, Method method, Dest dest, Data data)
-      {
-        return delegatee.Ldftn(pc, method, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldind(APC pc, Type type, bool @volatile, Dest dest, Source ptr, Data data)
-      {
-        if (InsideOld(pc))
-        {
-          // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
-          return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
-        }
-
-        return delegatee.Ldind(pc, type, @volatile, ConvertDest(pc, dest), ConvertSource(pc, ptr), data);
-      }
-
-      public Result Ldloc(APC pc, Local local, Dest dest, Data data)
-      {
-        return delegatee.Ldloc(pc, local, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldloca(APC pc, Local local, Dest dest, Data data)
-      {
-        return delegatee.Ldloca(pc, local, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldresult(APC pc, Type type, int dest, int source, Data data)
-      {
-        return delegatee.Ldresult(pc, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
-      }
-
-      public Result Ldstack(APC pc, int offset, Dest dest, Source source, bool isOld, Data data)
-      {
-        if (isOld)
-        {
-          return delegatee.Ldstack(pc, offset, ConvertDest(pc, dest), ConvertOldSource(pc, source), isOld, data);
-        }
-        else
-        {
-          return delegatee.Ldstack(pc, offset, ConvertDest(pc, dest), ConvertSource(pc, source), isOld, data);
-        }
-      }
-
-      public Result Ldstacka(APC pc, int offset, Dest dest, Source source, Type type, bool old, Data data)
-      {
-        return delegatee.Ldstacka(pc, offset, ConvertDest(pc, dest), ConvertSource(pc, source), type, old, data);
-      }
-
-      public Result Localloc(APC pc, Dest dest, Source size, Data data)
-      {
-        return delegatee.Localloc(pc, ConvertDest(pc, dest), ConvertSource(pc, size), data);
-      }
-
-      public Result Nop(APC pc, Data data)
-      {
-        return delegatee.Nop(pc, data);
-      }
-
-      public Result Pop(APC pc, Source source, Data data)
-      {
-        return delegatee.Pop(pc, ConvertSource(pc, source), data);
-      }
-
-      public Result Return(APC pc, Source source, Data data)
-      {
-        return delegatee.Return(pc, ConvertSource(pc, source), data);
-      }
-
-      public Result Starg(APC pc, Parameter argument, Source source, Data data)
-      {
-        return delegatee.Starg(pc, argument, ConvertSource(pc, source), data);
-      }
-
-      public Result Stind(APC pc, Type type, bool @volatile, Source ptr, Source value, Data data)
-      {
-        return delegatee.Stind(pc, type, @volatile, ConvertSource(pc, ptr), ConvertSource(pc, value), data);
-      }
-
-      public Result Stloc(APC pc, Local local, Source source, Data data)
-      {
-        return delegatee.Stloc(pc, local, ConvertSource(pc, source), data);
-      }
-
-      public Result Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, Source value, Data data)
-      {
-        return delegatee.Switch(pc, type, cases, ConvertSource(pc, value), data);
-      }
-
-      public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Source source, Data data)
-      {
-        return delegatee.Unary(pc, op, overflow, unsigned, ConvertDest(pc, dest), ConvertSource(pc, source), data);
-      }
-
-      public Result Box(APC pc, Type type, Dest dest, Source source, Data data)
-      {
-        return delegatee.Box(pc, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
-      }
-
-      public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        if (!parent.mdDecoder.IsVoidMethod(method) && InsideOld(pc))
-        {
-          // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
-          return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
-        }
-
-        return delegatee.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, ConvertDest(pc, dest), ConvertSources(pc, args), data);
-      }
-
-      public Result Castclass(APC pc, Type type, Dest dest, Source obj, Data data)
-      {
-        return delegatee.Castclass(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      public Result Cpobj(APC pc, Type type, Source destptr, Source srcptr, Data data)
-      {
-        return delegatee.Cpobj(pc, type, ConvertSource(pc, destptr), ConvertSource(pc, srcptr), data);
-      }
-
-      public Result Initobj(APC pc, Type type, Source ptr, Data data)
-      {
-        return delegatee.Initobj(pc, type, ConvertSource(pc, ptr), data);
-      }
-
-      public Result Isinst(APC pc, Type type, Dest dest, Source obj, Data data)
-      {
-        return delegatee.Isinst(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      Type ArrayElementType(APC pc, Type type, Source array)
-      {
-        if (parent.mdDecoder.IsStruct(type)) return type;
-        Domain domain;
-        if (!this.parent.PreStateLookup(pc, out domain))
-        {
-          return type;
-        }
-        return domain.GetArrayElementType(type, array);
-      }
-
-      public Result Ldelem(APC pc, Type type, Dest dest, Source array, Source index, Data data)
-      {
-        if (InsideOld(pc))
-        {
-          // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
-          return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
-        }
-        type = ArrayElementType(pc, type, array);
-        return delegatee.Ldelem(pc, type, ConvertDest(pc, dest), ConvertSource(pc, array), ConvertSource(pc, index), data);
-      }
-
-      public Result Ldelema(APC pc, Type type, bool @readonly, Dest dest, Source array, Source index, Data data)
-      {
-        type = ArrayElementType(pc, type, array);
-        return delegatee.Ldelema(pc, type, @readonly, ConvertDest(pc, dest), ConvertSource(pc, array), ConvertSource(pc, index), data);
-      }
-
-      public Result Ldfld(APC pc, Field field, bool @volatile, Dest dest, Source obj, Data data)
-      {
-        if (InsideOld(pc))
-        {
-          // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
-          return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
-        }
-
-        return delegatee.Ldfld(pc, field, @volatile, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      public Result Ldflda(APC pc, Field field, Dest dest, Source obj, Data data)
-      {
-        return delegatee.Ldflda(pc, field, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      public Result Ldlen(APC pc, Dest dest, Source array, Data data)
-      {
-        return delegatee.Ldlen(pc, ConvertDest(pc, dest), ConvertSource(pc, array), data);
-      }
-
-      public Result Ldsfld(APC pc, Field field, bool @volatile, Dest dest, Data data)
-      {
-        if (InsideOld(pc))
-        {
-          // we mapped back result from old state, so use old.ldstack here so abstract domain gets a chance as well.
-          return delegatee.Ldstack(pc, 0, ConvertDest(pc, dest), ConvertOldDest(pc, dest), true, data);
-        }
-
-        return delegatee.Ldsfld(pc, field, @volatile, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldsflda(APC pc, Field field, Dest dest, Data data)
-      {
-        return delegatee.Ldsflda(pc, field, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldtypetoken(APC pc, Type type, Dest dest, Data data)
-      {
-        return delegatee.Ldtypetoken(pc, type, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldfieldtoken(APC pc, Field field, Dest dest, Data data)
-      {
-        return delegatee.Ldfieldtoken(pc, field, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldmethodtoken(APC pc, Method method, Dest dest, Data data)
-      {
-        return delegatee.Ldmethodtoken(pc, method, ConvertDest(pc, dest), data);
-      }
-
-      public Result Ldvirtftn(APC pc, Method method, Dest dest, Source obj, Data data)
-      {
-        return delegatee.Ldvirtftn(pc, method, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      public Result Mkrefany(APC pc, Type type, Dest dest, Source obj, Data data)
-      {
-        return delegatee.Mkrefany(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      public Result Newarray<ArgList>(APC pc, Type type, Dest dest, ArgList lengths, Data data)
-        where ArgList : IIndexable<Source>
-      {
-        return delegatee.Newarray(pc, type, ConvertDest(pc, dest), ConvertSources(pc, lengths), data);
-      }
-
-      public Result Newobj<ArgList>(APC pc, Method ctor, Dest dest, ArgList args, Data data)
-        where ArgList : IIndexable<Source>
-      {
-        return delegatee.Newobj(pc, ctor, ConvertDest(pc, dest), ConvertSources(pc, args), data);
-      }
-
-      public Result Refanytype(APC pc, Dest dest, Source source, Data data)
-      {
-        return delegatee.Refanytype(pc, ConvertDest(pc, dest), ConvertSource(pc, source), data);
-      }
-
-      public Result Refanyval(APC pc, Type type, Dest dest, Source source, Data data)
-      {
-        return delegatee.Refanyval(pc, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
-      }
-
-      public Result Rethrow(APC pc, Data data)
-      {
-        return delegatee.Rethrow(pc, data);
-      }
-
-      public Result Sizeof(APC pc, Type type, Dest dest, Data data)
-      {
-        return delegatee.Sizeof(pc, type, ConvertDest(pc, dest), data);
-      }
-
-      public Result Stelem(APC pc, Type type, Source array, Source index, Source value, Data data)
-      {
-        type = ArrayElementType(pc, type, array);
-        return delegatee.Stelem(pc, type, ConvertSource(pc, array), ConvertSource(pc, index), ConvertSource(pc, value), data);
-      }
-
-      public Result Stfld(APC pc, Field field, bool @volatile, Source obj, Source value, Data data)
-      {
-        return delegatee.Stfld(pc, field, @volatile, ConvertSource(pc, obj), ConvertSource(pc, value), data);
-      }
-
-      public Result Stsfld(APC pc, Field field, bool @volatile, Source value, Data data)
-      {
-        return delegatee.Stsfld(pc, field, @volatile, ConvertSource(pc, value), data);
-      }
-
-      public Result Throw(APC pc, Source exn, Data data)
-      {
-        if (this.parent.TurnArgumentExceptionThrowsIntoAssertFalse)
-        {
-          Type argExcType;
-          if (this.parent.ArgumentExceptionTypeCache.TryGet(this.parent.mdDecoder, out argExcType))
-          {
-            Type type;
-            SymbolicValue falseSymValue;
-            if (HasSourceType(pc, exn, out type, out falseSymValue))
-            {
-              if (this.parent.mdDecoder.DerivesFrom(type, argExcType))
-              {
-                // turn into assert false.
-                //return delegatee.Assert(pc, "assert", falseSymValue, null, data);
-                return delegatee.Assert(pc, "assert", falseSymValue, "throw instruction", data);
-
-              }
-            }
-          }
-        }
-        return delegatee.Throw(pc, ConvertSource(pc, exn), data);
-      }
-
-      public Result Unbox(APC pc, Type type, Dest dest, Source obj, Data data)
-      {
-        return delegatee.Unbox(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      public Result Unboxany(APC pc, Type type, Dest dest, Source obj, Data data)
-      {
-        return delegatee.Unboxany(pc, type, ConvertDest(pc, dest), ConvertSource(pc, obj), data);
-      }
-
-      #region IVisitSynthIL<APC,Method,int,int,Data,Result> Members
-
-
-      public Result BeginOld(APC pc, APC matchingEnd, Data data)
-      {
-        return delegatee.BeginOld(pc, matchingEnd, data);
-      }
-
-      public Result EndOld(APC pc, APC matchingBegin, Type type, int dest, int source, Data data)
-      {
-        return delegatee.Nop(pc, data);
-        //        return delegatee.EndOld(pc, matchingBegin, type, ConvertDest(pc, dest), ConvertSource(pc, source), data);
-      }
-
-      #endregion
-      #endregion
+        private Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, SymbolicValue>> backwardRenamings = new Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, SymbolicValue>>();
     }
-
-    class ValueContext<Context>
-      : IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>
-      , IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue>
-      where Context : IStackContext<Field, Method>
-    {
-      #region Privates
-      OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
-      Context underlying;
-      #endregion
-
-      public ValueContext(
-        OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent,
-        Context underlying
-      )
-      {
-        this.parent = parent;
-        this.underlying = underlying;
-      }
-
-      #region IValueContext<APC,Method,Type,SymbolicValue> Members
-
-      IValueContextData<Local, Parameter, Method, Field, Type, SymbolicValue> IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>.ValueContext { get { return this; } }
-
-      public bool TryZero(APC at, out SymbolicValue value)
-      {
-        Domain d;
-        if (!this.parent.PreStateLookup(at, out d) || d.IsBottom)
-        {
-          value = default(SymbolicValue);
-          return false;
-        }
-        value = new SymbolicValue(d.Zero);
-        return true;
-      }
-
-      public bool TryNull(APC at, out SymbolicValue value)
-      {
-        Domain d;
-        if (!this.parent.PreStateLookup(at, out d) || d.IsBottom)
-        {
-          value = default(SymbolicValue);
-          return false;
-        }
-        value = new SymbolicValue(d.Null);
-        return true;
-      }
-
-      public FlatDomain<Type> GetType(APC at, SymbolicValue v)
-      {
-        try
-        {
-          Domain d;
-          if (!this.parent.PreStateLookup(at, out d) || d.IsBottom)
-          {
-            return FlatDomain<Type>.TopValue;
-          }
-          return d.GetType(v.symbol).Type;
-        }
-        catch(NullReferenceException)
-        {
-#if DEBUG
-          Console.WriteLine("[OptimisticHeapAnalysis]: Found a Null pointer exception in GetType for {0} @ PC = {1}. Returning Top type", v, at);
-#endif
-          return FlatDomain<Type>.TopValue; // Should we return Bottom?
-        }
-      }
-
-      public bool TryGetArrayLength(APC at, SymbolicValue array, out SymbolicValue length)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          length = default(SymbolicValue);
-          return false;
-        }
-        ESymValue len;
-        bool success = d.TryGetArrayLength(array.symbol, out len);
-        length = new SymbolicValue(len);
-        return success;
-      }
-
-      public bool TryGetModelArray(APC at, SymbolicValue enumerable, out SymbolicValue modelArray)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          modelArray = default(SymbolicValue);
-          return false;
-        }
-        ESymValue model = d.TryGetModelMethod(enumerable.symbol, "Model");
-        if (model == null)
-        {
-          model = d.TryGetModelMethod(enumerable.symbol, "System.Collections.IEnumerable.Model");
-        }
-        modelArray = new SymbolicValue(model);
-        return model != null;
-      }
-
-      public bool TryGetObjectFromObjectVersion(APC at, SymbolicValue objectVersion, out SymbolicValue objectValue)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          objectValue = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetObjectFromObjectVersion(objectVersion, out objectValue);
-      }
-
-      public bool TryGetArrayFromElementAddress(APC at, SymbolicValue elementAddress, out SymbolicValue array, out SymbolicValue index)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          array = default(SymbolicValue);
-          index = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetArrayFromArrayElementAddress(elementAddress, out array, out index);
-      }
-
-      public bool TryUnbox(APC pc, SymbolicValue box, out SymbolicValue contents)
-      {
-        // lookup the given source in the egraph for this program point
-        Domain d;
-        if (!this.parent.PreStateLookup(pc, out d))
-        {
-          contents = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetUnboxedValue(box.symbol, out contents);
-      }
-
-      public bool TryGetWritableBytes(APC at, SymbolicValue pointer, out SymbolicValue length)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          length = default(SymbolicValue);
-          return false;
-        }
-        ESymValue len;
-        bool success = d.TryGetWritableBytes(pointer.symbol, out len);
-        length = new SymbolicValue(len);
-        return success;
-      }
-
-      public bool IsZero(APC at, SymbolicValue value)
-      {
-        Domain entry = this.parent.GetPreState(at);
-        if (entry == null) return true; // unreached
-        return entry.IsZero(value.symbol);
-      }
-
-      public bool TryStackValue(APC at, Temp stackIndex, out SymbolicValue sv)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          sv = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetCorrespondingValueAbstraction(stackIndex, out sv);
-      }
-
-      public bool TryLocalValue(APC at, Local local, out SymbolicValue sv)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          sv = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetCorrespondingValueAbstraction(local, out sv);
-      }
-
-      public bool TryLocalAddress(APC at, Local local, out SymbolicValue sv)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          sv = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetCorrespondingAddressAbstraction(local, out sv);
-      }
-
-      public bool TryParameterAddress(APC at, Parameter parameter, out SymbolicValue sv)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          sv = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetCorrespondingAddressAbstraction(parameter, out sv);
-      }
-
-      public bool TryParameterValue(APC at, Parameter parameter, out SymbolicValue sv)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          sv = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetCorrespondingValueAbstraction(parameter, out sv);
-      }
-
-      public bool TryFieldAddress(APC at, SymbolicValue obj, Field field, out SymbolicValue address)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          address = default(SymbolicValue);
-          return false;
-        }
-        return d.TryGetFieldAddress(obj, field, out address);
-      }
-
-      public bool TryLoadIndirect(APC at, SymbolicValue addr, out SymbolicValue value)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          value = default(SymbolicValue);
-          return false;
-        }
-        return d.TryLoadIndirect(addr, out value);
-      }
-
-      public bool TryResultValue(APC at, out SymbolicValue resultValue)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          resultValue = default(SymbolicValue);
-          return false;
-        }
-
-        return d.TryGetCorrespondingValueAbstraction(0, out resultValue); // top of stack
-      }
-
-      public bool IsPureFunctionCall(APC at, SymbolicValue value, out Method method, out SymbolicValue[] args)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          method = default(Method);
-          args = null;
-          return false;
-        }
-        return d.IsPureFunctionCall(value, out method, out args);
-      }
-
-      public bool IsDelegateValue(APC at, SymbolicValue value, out SymbolicValue targetObject, out Method targetMethod)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          targetMethod = default(Method);
-          targetObject = default(SymbolicValue);
-          return false;
-        }
-        return d.IsDelegateValue(value, out targetObject, out targetMethod);
-      }
-
-      public bool IsValid(SymbolicValue sv)
-      {
-        return sv.symbol != null;
-      }
-
-      public string AccessPath(APC at, SymbolicValue value)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-        return d.GetAccessPath(value.symbol);
-      }
-
-      public FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall = default(Type))
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-
-        return AccessPathList(at, value, allowLocal, preferLocal, allowReturnValueFromCall, d);
-      }
-
-      private FList<PathElement> AccessPathList(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, Type allowReturnValueFromCall, Domain d)
-      {
-        AccessPathFilter<Method, Type> opt;
-        if (allowReturnValueFromCall != null && !allowReturnValueFromCall.Equals(default(Type)))
-        {
-          var stackDepth = this.parent.context.StackContext.LocalStackDepth(at);
-          // use the stackDepth in the filter to determine if the value is the top-of-the-stack
-
-
-          opt = AccessPathFilter<Method, Type>.IsVisibleFromMethodOrCalledPost(this.MethodContext.CurrentMethod, allowReturnValueFromCall, stackDepth);
-        }
-        else
-        {
-          opt = AccessPathFilter<Method, Type>.IsVisibleFrom(this.MethodContext.CurrentMethod);
-        }
-        return d.GetAccessPathList(value.symbol, opt, allowLocal, preferLocal);
-      }
-
-      public FList<PathElement> AccessPathListAndWitness(APC at, SymbolicValue value, bool allowLocal, bool preferLocal, out FList<SymbolicValue> witness, Type allowReturnValueFromCall = default(Type))
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-
-        var ap = AccessPathList(at, value, allowLocal, preferLocal, allowReturnValueFromCall, d);
-        if (ap == null) { witness = null; return null; }
-
-        var rev = d.AccessPathWitnessReversed(d, ap);
-        if (rev == null)
-        {
-          // something is wrong
-          witness = null;
-          return null;
-        }
-        witness = rev.Reverse(sv => new SymbolicValue(sv));
-        return ap;
-      }
-
-      public IEnumerable<FList<PathElement>> AccessPaths(APC at, SymbolicValue value, AccessPathFilter<Method, Type> filter)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-        foreach (var path in d.GetAccessPathsFiltered(value.symbol, filter, true))
-        {
-          yield return path.Coerce<Domain.PathElementBase, PathElement>();
-        }
-      }
-
-      public FList<PathElement> VisibleAccessPathListFromPre(APC at, SymbolicValue value)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          return null;
-        }
-        var opt = AccessPathFilter<Method, Type>.FromPrecondition(this.MethodContext.CurrentMethod);
-        return d.GetBestAccessPath(value.symbol, opt, true, false, false, path => PathSuitableInRequires(at, path));
-      }
-
-      public FList<PathElement> VisibleAccessPathListFromPost(APC at, SymbolicValue value, bool allowReturnValue = true)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          return null;
-        }
-        var opt = AccessPathFilter<Method, Type>.FromPostcondition(this.MethodContext.CurrentMethod, this.parent.mdDecoder.ReturnType(this.MethodContext.CurrentMethod));
-        return d.GetBestAccessPath(value.symbol, opt, true, false, false, path => PathSuitableInEnsures(at, path, allowReturnValue));
-      }
-
-
-      public bool PathUnmodifiedSinceEntry(APC at, FList<PathElement> path)
-      {
-        if (path == null) return false;
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-        ESymValue sym;
-        if (d.IsTopLevelVisibleAtMethodEntry(path.Head, out sym))
-        {
-          return d.CheckIfPathUnmodified(sym, path.Tail);
-        }
-        return false;
-      }
-
-      public bool PathSuitableInRequires(APC at, FList<PathElement> path)
-      {
-        if (path == null) return false;
-        var pe = path.Head as Domain.MethodCallPathElement;
-        if (pe != null)
-        {
-          // must be a static property. Ignore it.
-          return false;
-        }
-        return PathUnmodifiedSinceEntry(at, path);
-      }
-
-      public bool PathSuitableInEnsures(APC at, FList<PathElement> path, bool allowReturnValue)
-      {
-        if (path == null) return false;
-        var pe = path.Head as Domain.MethodCallPathElement;
-        if (pe != null)
-        {
-          // must be a static property. Ignore it.
-          return false;
-        }
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-        ESymValue sym;
-        if (d.IsTopLevelVisibleAtMethodEntry(path.Head, out sym))
-        {
-          return true;
-        }
-        if (allowReturnValue && path.Head.IsReturnValue) return true;
-        return false;
-      }
-
-
-      public bool IsConstant(APC at, SymbolicValue sv, out Type type, out object value)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-        return d.IsConstant(sv.symbol, out type, out value);
-      }
-
-      public bool IsRuntimeType(APC at, SymbolicValue sv, out Type type)
-      {
-        SymbolicValue[] args;
-        Method method;
-
-        type = default(Type);
-        if (!IsPureFunctionCall(at, sv, out method, out args)) return false;
-        if (this.parent.mdDecoder.Name(method) != "GetTypeFromHandle") return false;
-        Type dummy;
-        object value;
-        if (args.Length != 1) return false;
-        if (!IsConstant(at, args[0], out dummy, out value)) return false;
-        if (!(value is Type)) return false;
-
-        type = (Type)value;
-        return true;
-      }
-
-      public bool IsRootedInParameter(FList<PathElement> path)
-      {
-        return Domain.IsRootedInParameter(path);
-      }
-
-      public bool IsRootedInReturnValue(FList<PathElement> path)
-      {
-        return Domain.IsRootedInReturnValue(path);
-      }
-
-      public PathContextFlags PathContexts(APC at, SymbolicValue sv)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(at, out d))
-        {
-          throw new ArgumentException("pc was not visited");
-        }
-        return d.PathContexts(sv.symbol);
-      }
-
-      #endregion
-
-      #region IMethodContext<Method> Members
-      public IStackContextData<Field, Method> StackContext { get { return this.underlying.StackContext; } }
-      public IMethodContextData<Field, Method> MethodContext { get { return this.underlying.MethodContext; } }
-
-      #endregion
-    }
-
-    class Decoder<ContextData> :
-      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
-      where ContextData : IStackContext<Field, Method>
-    {
-      #region Privates
-      OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
-      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, ContextData, Unit> underlying;
-      #endregion
-
-      public Decoder(
-        OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent,
-        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, ContextData, Unit> underlying
-        )
-      {
-        this.parent = parent;
-        this.underlying = underlying;
-      }
-
-      #region IMSILDecoder<APC,Local,Parameter,Method,Field,Type,SymbolicValue,SymbolicValue> Members
-
-      public Result ForwardDecode<Data, Result, Visitor>(APC lab, Visitor visitor, Data data) where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, Data, Result>
-      {
-        return this.underlying.ForwardDecode<Data, Result, SymbolicAdapter<Data, Result, Visitor>>(lab, new SymbolicAdapter<Data, Result, Visitor>(this.parent, visitor), data);
-      }
-
-      ValueContext<ContextData> context;
-      public IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue> Context
-      {
-        get
-        {
-          if (context == null)
-          {
-            context = new ValueContext<ContextData>(this.parent, this.underlying.Context);
-          }
-          return context;
-        }
-      }
-
-      public EdgeData EdgeData(APC from, APC to)
-      {
-        // avoid renaming when not necessary
-        if (!parent.renamePoints.ContainsKey(from, to)) return null;
-
-        // optizmize identity renaming
-        if (this.parent.mergeInfoCache.ContainsKey(to) && this.parent.mergeInfoCache[to] == null)
-        {
-          return null;
-        }
-
-        // revisit the issue of the fact that EdgeRenaming may provide different info based on whether it is a join point or not.
-        return this.parent.EdgeRenaming(new Pair<APC, APC>(from, to), this.context.MethodContext.CFG.IsJoinPoint(to));
-      }
-
-      public void Display(TextWriter tw, string prefix, EdgeData edgeData)
-      {
-        if (edgeData == null) return;
-        edgeData.Visit(delegate(SymbolicValue key, FList<SymbolicValue> targets)
-        {
-          tw.Write("  {0} -> ", key);
-          foreach (var target in targets.GetEnumerable())
-          {
-            tw.Write("{0} ", target);
-          }
-          tw.WriteLine();
-          return VisitStatus.ContinueVisit;
-        });
-      }
-
-      public bool IsUnreachable(APC pc)
-      {
-        return this.parent.IsUnreachable(pc);
-      }
-      #endregion
-
-    }
-
-    #endregion
-
-    public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>, EdgeData>
-      GetDecoder<Context>(
-        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, Context, Unit> underlying
-      )
-      where Context : IStackContext<Field, Method>
-    {
-      return new Decoder<Context>(this, underlying);
-    }
-
-    #region Value adapter
-#if false
-    class ValueDriver<AState> :
-      IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, AState, AState>, Unit>
-    {
-      IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>> valuedriver;
-      OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent;
-      IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState> delegatee;
-
-      public ValueDriver(
-        IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>> valuedriver,
-        OptimisticHeapAnalyzer<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> parent
-      )
-      {
-        this.valuedriver = valuedriver;
-        this.parent = parent;
-      }
-
-    #region IAnalysis<APC,AState,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,AState,AState>> Members
-
-
-      /// <summary>
-      /// This is the trickiest part of the whole abstraction. Along the given edge, the heap state was possibly renamed, and
-      /// a single symbolic name might correspond to multiple names in the target state. We have to perform the same renaming
-      /// and constraining of the abstract state here.
-      /// </summary>
-      /// <param name="edge">Edge along there might be renaming of the egraph symbolic values</param>
-      /// <param name="state">Abstract client state</param>
-      /// <returns>New abstract client state renamed to target vocabulary</returns>
-      public AState EdgeConversion(APC from, APC next, bool joinPoint, Unit edgeData, AState state)
-      {
-        // We only need to do the renaming if next is a join point since we cached all 
-        // original program states.
-        if (!this.parent.renamePoints.ContainsKey(from, next)) return state;
-        
-        // optimize Identity renaming case
-        if (this.parent.mergeInfoCache.ContainsKey(next) && this.parent.mergeInfoCache[next] == null)
-        {
-          return state;
-        }
-
-        Pair<APC, APC> edge = new Pair<APC, APC>(from, next);
-        IFunctionalMap<SymbolicValue, FList<SymbolicValue>>/*?*/ renaming = this.parent.EdgeRenaming(edge, joinPoint);
-
-        if (renaming != null) {
-          state = this.valuedriver.ParallelAssign(edge, renaming, state);
-        }
-        else {
-          // identity renaming
-        }
-
-        return state;
-      }
-
-      /// <summary>
-      /// The states joined already use the same variable vocabulary, as th Edge renaming has already happened.
-      /// Thus, we can just use the original joiner, no need to interpose.
-      /// </summary>
-      public AState Join(Pair<APC, APC> edge, AState newState, AState prevState, out bool weaker, bool widen)
-      {
-        return valuedriver.Join(edge, newState, prevState, out weaker, widen);
-      }
-
-      public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, AState, AState> Visitor()
-      {
-        this.delegatee = valuedriver.Visitor();
-
-        return new SymbolicAdapter<AState, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>>(this.parent, this.delegatee);
-      }
-
-      public Predicate<APC> CacheStates(IFixpointInfo<APC, AState> fixpointInfo)
-      {
-        return this.valuedriver.CacheStates(fixpointInfo);
-      }
-
-      public void Dump(Pair<AState, TextWriter> stateAndWriter)
-      {
-        this.valuedriver.Dump(stateAndWriter);
-      }
-
-      public AState ImmutableVersion(AState state)
-      {
-        return this.valuedriver.ImmutableVersion(state);
-      }
-
-      public AState MutableVersion(AState state)
-      {
-        return this.valuedriver.MutableVersion(state);
-      }
-
-      public bool IsBottom(APC pc, AState state)
-      {
-        Domain d;
-        if (!parent.PreStateLookup(pc, out d))
-        {
-          return true;
-        }
-        if (d.IsBottom) return true;
-        return this.valuedriver.IsBottom(pc, state);
-      }
-
-      #endregion
-
-
-
-    }
-#endif
-    #endregion
-
-#if false
-    public IAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Temp, Temp, AState, AState>, Unit>
-      GetValueDriver<AState>(
-        IValueAnalysis<APC, AState, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, SymbolicValue, SymbolicValue, AState, AState>, SymbolicValue, IValueContext<Local, Parameter, Method, Field, Type, SymbolicValue>> valuedriver)
-    {
-      return new ValueDriver<AState>(valuedriver, this);
-    }
-#endif
-
-    public BlockInfoPrinter<APC> GetEdgePrinter()
-    {
-      Converter<SymbolicValue, string> sourcePrinter = delegate(SymbolicValue sv) { return sv.ToString(); };
-      return GetBlockInfoPrinter(sourcePrinter);
-    }
-
-    public BlockInfoPrinter<APC> GetBlockInfoPrinter(Converter<SymbolicValue, string> source2string)
-    {
-      return delegate(APC blockEnd, string prefix, TextWriter tw)
-      {
-        BlockInfoPrinter(blockEnd, prefix, tw, source2string);
-      };
-    }
-
-    public FlatDomain<Type> SymbolTypeAtPreState(APC pc, SymbolicValue sym)
-    {
-      Domain d;
-      if (PreStateLookup(pc, out d))
-      {
-        return d.GetType(sym.symbol).Type;
-      }
-      return FlatDomain<Type>.TopValue;
-    }
-
-    public void BlockInfoPrinter(APC blockEnd, string prefix, TextWriter tw, Converter<SymbolicValue, string> source2string)
-    {
-      foreach (APC blockTarget in this.renamePoints.Keys2(blockEnd))
-      {
-        Pair<APC, APC> edge = new Pair<APC, APC>(blockEnd, blockTarget);
-        IFunctionalMap<SymbolicValue, FList<SymbolicValue>>/*?*/ renaming = this.EdgeRenaming(edge, blockTarget.Block.Subroutine.IsJoinPoint(blockTarget.Block));
-        if (renaming != null)
-        {
-          edge = PrintRenaming(prefix, tw, source2string, edge, renaming);
-        }
-      }
-    }
-
-    private Pair<APC, APC> PrintRenaming(string prefix, TextWriter tw, Converter<SymbolicValue, string> source2string, Pair<APC, APC> edge, IFunctionalMap<SymbolicValue, FList<SymbolicValue>> renaming)
-    {
-      tw.WriteLine("{0}Rebinding on {1}", prefix, edge);
-      foreach (SymbolicValue source in renaming.Keys.OrderBy(s => s))
-      {
-        FList<SymbolicValue> targets = renaming[source];
-        while (targets != null)
-        {
-          SymbolicValue target = targets.Head;
-          tw.WriteLine("{0}  {1} := {2} {3}", prefix, target, source2string(source), SymbolTypeAtPreState(edge.One, source));
-          Domain d;
-          this.PreStateLookup(edge.One, out d);
-          if (d != null)
-          {
-            string path = d.GetAccessPath(source.symbol);
-            if (path != null)
-            {
-              tw.WriteLine("{0}     Access path to {1} = {2}", prefix, source2string(source), path);
-            }
-          }
-          targets = targets.Tail;
-        }
-      }
-      return edge;
-    }
-
-    public IEnumerable<APC> RenamingTargets(APC from)
-    {
-      return this.renamePoints.Keys2(from);
-    }
-
-    /// <summary>
-    /// null result means identity, thus no renaming needed
-    /// </summary>
-    internal IFunctionalMap<SymbolicValue, SymbolicValue> BackwardEdgeRenaming(APC from, APC to)
-    {
-      // We only need to do the renaming if next is a join point since we cached all 
-      // original program states.
-      IFunctionalMap<SymbolicValue, SymbolicValue> result;
-      Pair<APC, APC> edge = new Pair<APC, APC>(from, to);
-
-      if (this.backwardRenamings.TryGetValue(edge, out result))
-      {
-        return result;
-      }
-
-      if (!this.renamePoints.ContainsKey(to, from))
-      {
-        if (from.SubroutineContext != to.SubroutineContext) return null;
-        if (!to.Block.Last.Equals(to)) return null;
-        if (!from.Block.First.Equals(from)) return null;
-
-        APC pred;
-        if (!this.context.MethodContext.CFG.HasSinglePredecessor(from, out pred, skipContracts: false)) return null;
-        if (pred.Equals(to)) return null;
-        // looks like we skipped over contracts. 
-
-        result = null;
-        // compute renaming.
-        Domain start;
-        this.PostStateLookup(to, out start);
-        Domain end;
-        this.PreStateLookup(from, out end);
-        IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
-        IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
-        if (start != null && end != null)
-        {
-          if (!end.LessEqual(start, out forward, out backward))
-          {
-            // failed to compute a renaming
-            return null;
-          }
-          if (forward != null)
-          {
-            result = FunctionalIntKeyMap<SymbolicValue, SymbolicValue>.Empty(SymbolicValue.GetUniqueKey);
-            foreach (ESymValue source in forward.Keys)
-            {
-              var candidates = forward[source];
-              if (candidates != null)
-              {
-                result = result.Add(new SymbolicValue(source), new SymbolicValue(candidates.Head));
-              }
-            }
-          }
-        }
-        this.backwardRenamings.Add(edge, result);
-        return result;
-      }
-      else
-      {
-        result = null;
-        // compute renaming.
-        Domain start;
-        this.PostStateLookup(to, out start);
-        Domain end;
-        this.PreStateLookup(from, out end);
-        IFunctionalMap<ESymValue, FList<ESymValue>>/*?*/ forward;
-        IFunctionalMap<ESymValue, ESymValue>/*?*/ backward;
-        if (start != null && end != null)
-        {
-          if (!start.LessEqual(end, out forward, out backward))
-          {
-            Contract.Assume(false, "egraphs don't correspond at joins"); // means egraphs don't correspond
-            throw new Exception("Should never happen");
-          }
-          if (backward != null)
-          {
-            result = FunctionalIntKeyMap<SymbolicValue, SymbolicValue>.Empty(SymbolicValue.GetUniqueKey);
-            foreach (ESymValue source in backward.Keys)
-            {
-              result = result.Add(new SymbolicValue(source), new SymbolicValue(backward[source]));
-            }
-          }
-        }
-        this.backwardRenamings.Add(edge, result);
-        return result;
-      }
-    }
-    Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, SymbolicValue>> backwardRenamings = new Dictionary<Pair<APC, APC>, IFunctionalMap<SymbolicValue, SymbolicValue>>();
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Output.cs
+++ b/Microsoft.Research/CodeAnalysis/Output.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,85 +10,84 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public class TextWriterOutput : SimpleLineWriter.FromTextWriter, IOutput
-  {
-    private readonly IFrameworkLogOptions options;
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    public class TextWriterOutput : SimpleLineWriter.FromTextWriter, IOutput
     {
-      Contract.Invariant(this.options != null);
+        private readonly IFrameworkLogOptions options;
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(options != null);
+        }
+
+        public TextWriterOutput(TextWriter tw, IFrameworkLogOptions options)
+          : base(tw)
+        {
+            Contract.Requires(tw != null);
+            Contract.Requires(options != null);
+
+            this.options = options;
+        }
+
+        #region IOutput Members
+
+        public void Suggestion(ClousotSuggestion.Kind type, string kind, APC pc, string suggestion, List<uint> causes, ClousotSuggestion.ExtraSuggestionInfo extraInfo)
+        {
+            this.WriteLine("{0}: message : Suggested {1}: {2}", pc.PrimarySourceContext(), kind, suggestion);
+        }
+
+        public void Statistic(string format, params object[] args)
+        {
+            Contract.Requires(format != null);
+            Contract.Requires(args != null);
+
+            this.WriteLine(format, args);
+        }
+
+        public void FinalStatistic(string assembly, string msg)
+        {
+            this.WriteLine("{0} : {1}", assembly, msg);
+        }
+
+        public void EmitError(System.CodeDom.Compiler.CompilerError error)
+        {
+            this.WriteLine("{0}({1},{2}): {3}", error.FileName, error.Line, error.Column, error.ErrorText);
+        }
+
+        public IFrameworkLogOptions LogOptions
+        {
+            get { return options; }
+        }
+
+        public void Close()
+        {
+            if (this.textWriter != Console.Out)
+            {
+                this.textWriter.Flush();
+                this.textWriter.Close();
+            }
+        }
+
+        #endregion
     }
 
-    public TextWriterOutput(TextWriter tw, IFrameworkLogOptions options)
-      : base(tw)
+    public class TextWriterOutputWithPrefix : TextWriterOutput
     {
-      Contract.Requires(tw != null);
-      Contract.Requires(options != null);
+        private readonly string prefix;
 
-      this.options = options;
+        public TextWriterOutputWithPrefix(TextWriter tw, IFrameworkLogOptions options, string prefix)
+          : base(tw, options)
+        {
+            Contract.Requires(tw != null);
+            Contract.Requires(options != null);
+            Contract.Requires(prefix == null || !prefix.Contains("{"));
+
+            this.prefix = prefix ?? "";
+        }
+
+        public override void WriteLine(string value, params object[] arg)
+        {
+            base.WriteLine(prefix + value, arg);
+        }
     }
-
-    #region IOutput Members
-
-    public void Suggestion(ClousotSuggestion.Kind type, string kind, APC pc, string suggestion, List<uint> causes, ClousotSuggestion.ExtraSuggestionInfo extraInfo)
-    {
-      this.WriteLine("{0}: message : Suggested {1}: {2}", pc.PrimarySourceContext(), kind, suggestion);
-    }
-
-    public void Statistic(string format, params object[] args)
-    {
-      Contract.Requires(format != null);
-      Contract.Requires(args != null);
-
-      this.WriteLine(format, args);
-    }
-
-    public void FinalStatistic(string assembly, string msg)
-    {
-      this.WriteLine("{0} : {1}", assembly, msg);
-    }
-
-    public void EmitError(System.CodeDom.Compiler.CompilerError error)
-    {
-      this.WriteLine("{0}({1},{2}): {3}", error.FileName, error.Line, error.Column, error.ErrorText);
-    }
-
-    public IFrameworkLogOptions LogOptions
-    {
-      get { return options; }
-    }
-
-    public void Close()
-    {
-      if (this.textWriter != Console.Out)
-      {
-        this.textWriter.Flush();
-        this.textWriter.Close();
-      }
-    }
-
-    #endregion
-
-  }
-
-  public class TextWriterOutputWithPrefix : TextWriterOutput
-  {
-    private readonly string prefix;
-
-    public TextWriterOutputWithPrefix(TextWriter tw, IFrameworkLogOptions options, string prefix)
-      : base(tw, options)
-    {
-      Contract.Requires(tw != null);
-      Contract.Requires(options != null);
-      Contract.Requires(prefix == null || !prefix.Contains("{"));
-
-      this.prefix = prefix ?? "";
-    }
-
-    public override void WriteLine(string value, params object[] arg)
-    {
-      base.WriteLine(prefix + value, arg);
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/OutputPrettyCS.cs
+++ b/Microsoft.Research/CodeAnalysis/OutputPrettyCS.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -32,5426 +21,5428 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.CodeAnalysis.OutputPrettyCS
 {
-  /// <summary>
-  /// Accessibility information for fields, methods, class, ...
-  /// </summary>
-  public enum Access
-  {
-    NONE,
-    PUBLIC,
-    PROTECTED,
-    PRIVATE,
-    INTERNAL,
-    INTERNAL_AND_OR_PROTECTED,
-  }
-
-  /// <summary>
-  /// All the indentation and newline stuff is handled here in the OutputHelper
-  /// object associated to the current context.
-  /// So, just use oh.OutputEOL when End Of Line is needed, and Output when
-  /// regular text must be output. All the indentation is automatically taken
-  /// care of.
-  /// </summary>
-  public class OutputHelper
-  {
-    public enum OutputStrategy
+    /// <summary>
+    /// Accessibility information for fields, methods, class, ...
+    /// </summary>
+    public enum Access
     {
-      ONE_FILE_PER_NAMESPACE,
-      ONE_FILE_PER_TOPLEVEL_CLASS,
-      ONE_FILE_PER_CLASS
+        NONE,
+        PUBLIC,
+        PROTECTED,
+        PRIVATE,
+        INTERNAL,
+        INTERNAL_AND_OR_PROTECTED,
     }
 
     /// <summary>
-    /// Symbol for tabulations and EOL. Change it here only.
+    /// All the indentation and newline stuff is handled here in the OutputHelper
+    /// object associated to the current context.
+    /// So, just use oh.OutputEOL when End Of Line is needed, and Output when
+    /// regular text must be output. All the indentation is automatically taken
+    /// care of.
     /// </summary>
-    private const string mTabSymbol = "  "; // 2 spaces
-    private const string mEOLSymbol = "\r\n";
-
-    /// <param name="output">The stream where the IndentHelper will output its commands</param>
-    public OutputHelper(OutputStrategy Strategy, string ProjectFolder, string RelativeFilesPath, List<string> mUsings, IOutput mDebugOutput, bool verbose)
+    public class OutputHelper
     {
-      Contract.Requires(ProjectFolder != null);
-      Contract.Requires(RelativeFilesPath != null);
-      Contract.Requires(mDebugOutput != null);
-
-      this.mStrategy = Strategy;
-      this.mCurIndent = 0;
-      this.mOutput    = null;
-      this.mbEOL      = false;
-      this.mDebugOutput = mDebugOutput;
-      this.mProjectFolder = ProjectFolder;
-      this.mRelativeFilesPath = RelativeFilesPath;
-      this.mCurrentFileName = "";
-      this.mWrittenFiles = new List<string>();
-      this.mWrittenFileSet = new Dictionary<string,string>();
-      this.mVerbose = verbose;
-
-      this.mUsings = mUsings;
-    }
-
-    public List<string> WrittenFiles { get { return mWrittenFiles; } }
-    public OutputStrategy Strategy { get { return mStrategy; } }
-    public List<string> Usings { get { return mUsings; } }
-
-    #region Indentation control
-    /// <summary>
-    /// Adds one indentation level
-    /// </summary>
-    public void IncrIndent ()
-    {
-      ++mCurIndent;
-    }
-
-    /// <summary>
-    /// Removes one indentation level
-    /// </summary>
-    public void DecrIndent()
-    {
-      if (mCurIndent > 0)
-        --mCurIndent;
-      else
-        throw new InvalidOperationException("Cannot DecrIndent, already decremented.");
-    }
-    #endregion
-
-    #region Output control
-    /// <summary>
-    /// Outputs only an End Of Line character
-    /// </summary>
-    public void OutputEOL()
-    {
-      mOutput.Write(mEOLSymbol);
-      mbEOL = true;
-    }
-
-    public void BeginRegion(string name)
-    {
-      Output("#region " + name, true);
-    }
-
-    public void EndRegion()
-    {
-      Output("#endregion", true);
-    }
-
-    /// <summary>
-    /// Output only the leading indentation in the current context (only for manual handling, otherwise use Output)
-    /// </summary>
-    public void OutputIndent()
-    {
-      StringBuilder sb = new StringBuilder();
-      sb.EnsureCapacity(mTabSymbol.Length * mCurIndent);
-      for (int i = 0; i < mCurIndent; ++i)
-        sb.Append(mTabSymbol);
-
-      mOutput.Write(sb.ToString());
-      mbEOL = false;
-    }
-
-    public void OutputEOLAndIndent()
-    {
-      OutputEOL();
-      OutputIndent();
-    }
-
-    public void Output (string str, bool eol_after)
-    {
-      if (mbEOL)
-        OutputIndent();
-
-      mOutput.Write (str);
-      mbEOL = false;
-
-      if (eol_after)
-        OutputEOL();
-    }
-
-    public void DebugOutput(string str)
-    {
-      Contract.Requires(str != null);
-
-      mDebugOutput.WriteLine(str);
-    }
-    #endregion
-
-    public void ForceNewFile(string file)
-    {
-      Contract.Requires(file != null);
-
-      StartNewFile(file);
-    }
-
-    private void StartNewFile(string file)
-    {
-      Contract.Requires(file != null);
-      EndFile();
-      var path = Path.Combine(mRelativeFilesPath, file);
-
-      var existingFile = false;
-      if (mWrittenFileSet.ContainsKey(path.ToLower()))
-      {
-        //Console.WriteLine("Appending the file \"{0}\"!", path);
-        existingFile = true;
-      }
-
-      this.mCurrentFileName = path;
-
-      string fullpath = Path.Combine(mProjectFolder, path);
-      try
-      {
-        mOutput = new StreamWriter(fullpath, existingFile);
-
-        if (!existingFile)
+        public enum OutputStrategy
         {
-          Output("// File " + file, true);
-          Output("// Automatically generated contract file.", true);
-          // Using: depending on what we simplify in SimplifyType
-          foreach (var use in mUsings)
-            Output("using " + use + ";", true);
-
-          OutputEOL();
-          Output("// Disable the \"this variable is not used\" warning as every field would imply it.", true);
-          Output("#pragma warning disable 0414", true);
-          Output("// Disable the \"this variable is never assigned to\".", true);
-          Output("#pragma warning disable 0067", true);
-          Output("// Disable the \"this event is never assigned to\".", true);
-          Output("#pragma warning disable 0649", true);
-          Output("// Disable the \"this variable is never used\".", true);
-          Output("#pragma warning disable 0169", true);
-          Output("// Disable the \"new keyword not required\" warning.", true);
-          Output("#pragma warning disable 0109", true);
-          Output("// Disable the \"extern without DllImport\" warning.", true);
-          Output("#pragma warning disable 0626", true);
-          Output("// Disable the \"could hide other member\" warning, can happen on certain properties.", true);
-          Output("#pragma warning disable 0108", true);
-          OutputEOL();
-          OutputEOL();
+            ONE_FILE_PER_NAMESPACE,
+            ONE_FILE_PER_TOPLEVEL_CLASS,
+            ONE_FILE_PER_CLASS
         }
-      }
-      catch (PathTooLongException)
-      {
-        mDebugOutput.WriteLine("OutputPretty C#: Unable to write file " + fullpath + ": Path is too long.");
-        throw;
-      }
-      catch (IOException)
-      {
-        mDebugOutput.WriteLine("OutputPretty C#: Unable to write file " + fullpath + ": file may be readonly or disk may be full.");
-        throw;
-      }
-      catch (ArgumentException)
-      {
-        mDebugOutput.WriteLine("OutputPretty C#: Unable to write file " + fullpath + ": character in the path is not allowed.");
-        throw;
-      }
-    }
 
-    public void EndFile()
-    {
-      if (mOutput != null)
-      {
-        if (mVerbose)
+        /// <summary>
+        /// Symbol for tabulations and EOL. Change it here only.
+        /// </summary>
+        private const string mTabSymbol = "  "; // 2 spaces
+        private const string mEOLSymbol = "\r\n";
+
+        /// <param name="output">The stream where the IndentHelper will output its commands</param>
+        public OutputHelper(OutputStrategy Strategy, string ProjectFolder, string RelativeFilesPath, List<string> mUsings, IOutput mDebugOutput, bool verbose)
         {
-          mDebugOutput.WriteLine("OutputPretty C#: Inferred contracts successfully output in file: " + mCurrentFileName);
+            Contract.Requires(ProjectFolder != null);
+            Contract.Requires(RelativeFilesPath != null);
+            Contract.Requires(mDebugOutput != null);
+
+            mStrategy = Strategy;
+            mCurIndent = 0;
+            mOutput = null;
+            mbEOL = false;
+            this.mDebugOutput = mDebugOutput;
+            mProjectFolder = ProjectFolder;
+            mRelativeFilesPath = RelativeFilesPath;
+            mCurrentFileName = "";
+            mWrittenFiles = new List<string>();
+            mWrittenFileSet = new Dictionary<string, string>();
+            mVerbose = verbose;
+
+            this.mUsings = mUsings;
         }
-        mOutput.Close();
-        mOutput = null;
-        var key = mCurrentFileName.ToLower();
-        if (!mWrittenFileSet.ContainsKey(key)) 
+
+        public List<string> WrittenFiles { get { return mWrittenFiles; } }
+        public OutputStrategy Strategy { get { return mStrategy; } }
+        public List<string> Usings { get { return mUsings; } }
+
+        #region Indentation control
+        /// <summary>
+        /// Adds one indentation level
+        /// </summary>
+        public void IncrIndent()
         {
-          mWrittenFileSet.Add(key, mCurrentFileName);
-          mWrittenFiles.Add(mCurrentFileName);
+            ++mCurIndent;
         }
-        
-      }
 
-      mCurIndent = 0;
-      mbEOL = false;
-      mCurrentFileName = "";
-    }
-
-    public void BeginNamespace(Namespace ns)
-    {
-      if (mStrategy == OutputStrategy.ONE_FILE_PER_NAMESPACE)
-      {
-        string name = ns.Name;
-        if (name == "<toplevel>")
-          name = "toplevel";
-        StartNewFile(name + ".cs");
-      }
-    }
-
-    public void EndNamespace()
-    {
-      if (mStrategy == OutputStrategy.ONE_FILE_PER_NAMESPACE)
-        EndFile();
-    }
-
-    public void BeginClass(Class cl)
-    {
-      if (mStrategy == OutputStrategy.ONE_FILE_PER_CLASS
-        || (mStrategy == OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS && cl.Parent == null))
-      {
-        string filename = cl.FullName;
-
-        // postfix the filename with the number of formal parameters to allow for types
-        // with the same name but different formal parameters
-        int nb_formal_param = cl.ILFormalTypeParameterCount;
-        if (nb_formal_param > 0)
-          filename += "_" + nb_formal_param;
-
-        filename += ".cs";
-
-        StartNewFile(filename);
-      }
-    }
-
-    public void EndClass (Class cl)
-    {
-      if (mStrategy == OutputStrategy.ONE_FILE_PER_CLASS
-        || (mStrategy == OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS && cl.Parent == null))
-        EndFile();
-    }
-
-    #region Privates
-    readonly private bool mVerbose = false;
-    readonly private OutputStrategy mStrategy;
-    private int mCurIndent;
-    private StreamWriter  mOutput; /// Current destination
-    readonly private string mProjectFolder;
-    readonly private string mRelativeFilesPath;
-    private bool  mbEOL; /// Last thing output was a EOL
-    readonly private IOutput mDebugOutput;
-    readonly private List<string> mWrittenFiles;
-    readonly private Dictionary<string, string> mWrittenFileSet;
-    private string mCurrentFileName;
-    readonly private List<string> mUsings; /// Using assemblies at the beginning of the output files (set in constructor)
-                                  /// 
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(mCurIndent >= 0);
-      Contract.Invariant(mRelativeFilesPath != null);
-      Contract.Invariant(mProjectFolder != null);
-    }
-
-    #endregion Privates
-  }
-
-  [ContractVerification(false)]
-  public class Namespace
-  {
-    public Namespace(string name)
-    {
-      this.mName = name;
-      this.mChildren = new List<ElementBase>();
-    }
-
-    public void OpenNamespace(OutputHelper oh)
-    {
-      Contract.Requires(oh != null);
-
-      oh.BeginNamespace(this);
-      if (mName != "<toplevel>")
-      {
-        oh.Output("namespace " + mName, true);
-        oh.Output("{", true);
-
-        oh.IncrIndent();
-      }
-    }
-
-    public void CloseNamespace(OutputHelper oh)
-    {
-      Contract.Requires(oh != null);
-
-      if (mName != "<toplevel>")
-      {
-        oh.DecrIndent();
-
-        oh.Output("}", true);
-      }
-      oh.EndNamespace();
-    }
-
-    public void Output(OutputHelper oh)
-    {
-      Contract.Requires(oh != null);
-
-      if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
-        OpenNamespace(oh);
-
-      // Sort the children alphabetically
-      mChildren.Sort(new ElementBaseComparer());
-
-      bool first = true;
-      bool bOutputOtherChildren = false;
-      foreach (var child in mChildren)
-      {
-        if (child.IsClass)
+        /// <summary>
+        /// Removes one indentation level
+        /// </summary>
+        public void DecrIndent()
         {
-          Class cl = child as Class;
+            if (mCurIndent > 0)
+                --mCurIndent;
+            else
+                throw new InvalidOperationException("Cannot DecrIndent, already decremented.");
+        }
+        #endregion
 
-          Contract.Assume(cl != null);
+        #region Output control
+        /// <summary>
+        /// Outputs only an End Of Line character
+        /// </summary>
+        public void OutputEOL()
+        {
+            mOutput.Write(mEOLSymbol);
+            mbEOL = true;
+        }
 
-          if (cl.Parent == null
-            || (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS))
-          {
-            if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
+        public void BeginRegion(string name)
+        {
+            Output("#region " + name, true);
+        }
+
+        public void EndRegion()
+        {
+            Output("#endregion", true);
+        }
+
+        /// <summary>
+        /// Output only the leading indentation in the current context (only for manual handling, otherwise use Output)
+        /// </summary>
+        public void OutputIndent()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.EnsureCapacity(mTabSymbol.Length * mCurIndent);
+            for (int i = 0; i < mCurIndent; ++i)
+                sb.Append(mTabSymbol);
+
+            mOutput.Write(sb.ToString());
+            mbEOL = false;
+        }
+
+        public void OutputEOLAndIndent()
+        {
+            OutputEOL();
+            OutputIndent();
+        }
+
+        public void Output(string str, bool eol_after)
+        {
+            if (mbEOL)
+                OutputIndent();
+
+            mOutput.Write(str);
+            mbEOL = false;
+
+            if (eol_after)
+                OutputEOL();
+        }
+
+        public void DebugOutput(string str)
+        {
+            Contract.Requires(str != null);
+
+            mDebugOutput.WriteLine(str);
+        }
+        #endregion
+
+        public void ForceNewFile(string file)
+        {
+            Contract.Requires(file != null);
+
+            StartNewFile(file);
+        }
+
+        private void StartNewFile(string file)
+        {
+            Contract.Requires(file != null);
+            EndFile();
+            var path = Path.Combine(mRelativeFilesPath, file);
+
+            var existingFile = false;
+            if (mWrittenFileSet.ContainsKey(path.ToLower()))
             {
-              if (first)
-                first = false;
-              else
-                oh.OutputEOL();
+                //Console.WriteLine("Appending the file \"{0}\"!", path);
+                existingFile = true;
             }
-            cl.Output(oh);
-          }
-        }
-        else
-        {
-          if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
-          {
-            if (first)
-              first = false;
-            else
-              oh.OutputEOL();
-            child.Output(oh);
-          }
-          else
-            bOutputOtherChildren = true;
-        }
-      }
 
-      if (oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE && bOutputOtherChildren)
-      {
-        string name = mName;
-        if (name == "<toplevel>")
-          name = "toplevel";
-        oh.ForceNewFile(name + ".cs");
-        OpenNamespace(oh);
-        first = true;
-        foreach (var child in mChildren)
-        {
-          if (!child.IsClass)
-          {
-            if (first)
-              first = false;
-            else
-              oh.OutputEOL();
-            child.Output(oh);
-          }
-        }
-        CloseNamespace(oh);
-        oh.EndFile();
-      }
+            mCurrentFileName = path;
 
-      if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
-        CloseNamespace(oh);
-    }
+            string fullpath = Path.Combine(mProjectFolder, path);
+            try
+            {
+                mOutput = new StreamWriter(fullpath, existingFile);
 
-    public void AddChild(ElementBase child)
-    {
-      if (!mChildren.Contains (child))
-        mChildren.Add(child);
-    }
+                if (!existingFile)
+                {
+                    Output("// File " + file, true);
+                    Output("// Automatically generated contract file.", true);
+                    // Using: depending on what we simplify in SimplifyType
+                    foreach (var use in mUsings)
+                        Output("using " + use + ";", true);
 
-    public bool Empty()
-    {
-      return mChildren.Count == 0;
-    }
-
-    public bool HasUnsafeCode()
-    {
-      foreach (var ch in mChildren)
-      {
-        if (ch.HasUnsafeCode())
-          return true;
-      }
-      return false;
-    }
-
-    public virtual string Name { get { return mName; } }
-
-    #region Privates
-    /// <summary>
-    /// Namespace name. Can be empty for toplevel
-    /// </summary>
-    private string mName;
-
-    /// <summary>
-    /// Objects in the namespace
-    /// </summary>
-    private List<ElementBase>  mChildren;
-    #endregion
-  }
-
-  public class ElementBaseComparer : IComparer<ElementBase>
-  {
-    public int Compare(ElementBase e1, ElementBase e2)
-    {
-      return e1.Name.CompareTo(e2.Name);
-    }
-  }
-
-  public abstract class ElementBase
-  {
-    public abstract void Output(OutputHelper oh);
-
-    public virtual string Name { get { throw new NotImplementedException(); } }
-
-    public virtual bool IsClass { get { return false; } }
-    public virtual bool IsMethod { get { return false; } }
-    public virtual bool IsProperty { get { return false; } }
-    public virtual bool IsEvent { get { return false; } }
-    public virtual bool IsField { get { return false; } }
-    public virtual bool IsEnum { get { return false; } }
-    public virtual bool IsDelegate { get { return false; } }
-
-    public virtual bool IsUnsafe { get { return false; } }
-    // Classes may have unsafe code but not declared as unsafe
-    public virtual bool HasUnsafeCode() { return IsUnsafe; }
-  }
-
-  [ContractVerification(false)]
-  public class Class : ElementBase
-  {
-    public enum ClassType
-    {
-      CLASS,
-      STRUCT,
-      INTERFACE,
-    }
-
-    public Class(Access mAccess, bool mbIsAbstract, bool mbIsSealed, bool mbIsStatic, bool mbIsUnsafe, ClassType mType, string mName, Class mParent, string mBaseClass, Namespace mParentNS)
-    {
-      this.mAccess = mAccess;
-      this.mbIsAbstract = mbIsAbstract;
-      this.mbIsSealed = mbIsSealed;
-      this.mbIsStatic = mbIsStatic;
-      this.mbIsUnsafe = mbIsUnsafe;
-      this.mType = mType;
-      this.mName = mName;
-      this.mParent = mParent;
-      this.mBaseClass = mBaseClass;
-      this.mParentNS = mParentNS;
-
-      this.mFormals = new List<FormalTypeParameter>();
-      this.mInterfaces = new List<string>();
-      this.mChildren = new List<ElementBase>();
-      this.mInvariants = new List<string>();
-      this.mAttributes = new List<string>();
-    }
-
-    public override bool IsClass { get { return true; } }
-    public override bool IsUnsafe { get { return mbIsUnsafe; } }
-
-    public int ILFormalTypeParameterCount
-    {
-      get
-      {
-        var result = (this.FormalTypeParameters == null)?0:this.FormalTypeParameters.Count;
-        if (this.Parent != null) result += this.Parent.ILFormalTypeParameterCount;
-        return result;
-      }
-    }
-    public ClassType Type { get { return mType; } }
-    public List<FormalTypeParameter> FormalTypeParameters { get { return mFormals; } }
-
-    public override string Name { get { return mName; } }
-    public string FullName
-    {
-      get
-      {
-        string fname = "";
-        if (mParent == null)
-        {
-          if (mParentNS.Name != "<toplevel>")
-            fname += mParentNS.Name + ".";
-        }
-        else
-          fname += mParent.FullName + ".";
-        fname += mName;
-        return fname;
-      }
-    }
-    public Class Parent { get { return mParent; } set { mParent = value; } }
-    public string BaseClass { get { return mBaseClass; } set { mBaseClass = value; } }
-    public Namespace Namespace { get { return mParentNS; } }
-
-    #region Output
-    private void OutputName(OutputHelper oh)
-    {
-      oh.Output(mName, false);
-    }
-
-    private void OutputHeader(OutputHelper oh, bool bOutputPartial, bool bOutputInterfaces, bool bOutputAttributes)
-    {
-      if (bOutputAttributes && mAttributes.Count > 0)
-      {
-        foreach (var att in mAttributes)
-          oh.Output("[" + att + "]", true);
-      }
-
-      if (mbIsUnsafe)
-        oh.Output("unsafe ", false);
-
-      if (mbIsStatic)
-        oh.Output("static ", false);
-      if (mbIsAbstract)
-        oh.Output("abstract ", false);
-      if (mbIsSealed)
-        oh.Output("sealed ", false);
-
-      switch (mAccess)
-      {
-        case Access.PUBLIC:
-          oh.Output("public ", false);
-          break;
-        case Access.PROTECTED:
-          oh.Output("protected ", false);
-          break;
-        case Access.PRIVATE:
-          oh.Output("private ", false);
-          break;
-        case Access.INTERNAL:
-          oh.Output("internal ", false);
-          break;
-        case Access.INTERNAL_AND_OR_PROTECTED:
-          oh.Output("internal protected ", false);
-          break;
-      }
-
-      if (bOutputPartial)
-        oh.Output("partial ", false);
-
-      switch (mType)
-      {
-        case ClassType.CLASS:
-          oh.Output ("class ", false);
-          break;
-        case ClassType.STRUCT:
-          oh.Output ("struct ", false);
-          break;
-        case ClassType.INTERFACE:
-          oh.Output("interface ", false);
-          break;
-      }
-
-      OutputName(oh);
-
-      //** Formal type parameters
-      if (mFormals.Count > 0)
-      {
-        oh.Output("<", false);
-        bool first = true;
-        foreach (var f in mFormals)
-        {
-          if (first)
-            first = false;
-          else
-            oh.Output(", ", false);
-          f.OutputName(oh);
-        }
-        oh.Output(">", false);
-      }
-
-      //** Base class, interfaces
-      bool semicol = false;
-      if (mBaseClass.Length > 0)
-      {
-        oh.Output(" : ", false);
-        semicol = true;
-        oh.Output(mBaseClass, false);
-      }
-
-      if (mInterfaces.Count > 0 && bOutputInterfaces)
-      {
-        if (!semicol)
-          oh.Output(" : ", false);
-
-        bool first = true;
-        foreach (var i in mInterfaces)
-        {
-          if (!first || semicol)
-            oh.Output(", ", false);
-          first = false;
-          
-          oh.Output(i, false);
-        }
-      }
-
-      oh.OutputEOL();
-    }
-
-    private void OutputFormalTypeParameterConstraints (OutputHelper oh)
-    {
-      oh.IncrIndent();
-      foreach (var formal in mFormals)
-        formal.OutputConstraint(oh);
-      oh.DecrIndent();
-    }
-
-    public int OutputOpening(OutputHelper oh, bool bNestingClasses, bool bOutputPartial, bool bFull)
-    {
-      Contract.Requires(oh != null);
-
-      if (oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE
-        && mParent == null)
-        mParentNS.OpenNamespace(oh);
-
-      // only output full information for the last class, not the nesting ones
-      int indents = 1;
-      if (bNestingClasses && mParent != null)
-        indents += mParent.OutputOpening(oh, bNestingClasses, bOutputPartial, false);
-
-      OutputHeader(oh, bOutputPartial, bFull, bFull);
-      if (bFull)
-        OutputFormalTypeParameterConstraints(oh);
-
-      oh.Output("{", true);
-      oh.IncrIndent();
-
-      return indents;
-    }
-
-    public void OutputClosing(OutputHelper oh, int indents)
-    {
-      Contract.Requires(oh != null);
-
-      for (int i = 0; i < indents; ++i)
-      {
-        oh.DecrIndent();
-        oh.Output("}", true);
-      }
-    }
-
-    public override void Output(OutputHelper oh)
-    {
-      oh.BeginClass(this);
-
-      OutputIntern(oh,
-        oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS,
-        oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS);
-
-      oh.EndClass(this);
-    }
-
-    private void OutputIntern(OutputHelper oh, bool bNestingClasses, bool bOutputNestedTypes)
-    {
-      int indents = OutputOpening(oh, bNestingClasses, bNestingClasses, true);
-
-      // Sort the children alphabetically
-      mChildren.Sort(new ElementBaseComparer());
-
-      // Mic: Mmmhh... Each type is a separate case. It quites destroys the
-      // idea to handle ElementBase elements without needing their actual
-      // type but it's much more handy for output with regions (although it would be cleaner
-      // by tuning up ElementBaseComparer perhaps).
-      // So whatever...
-
-      bool first = true;
-
-      //** Object invariants
-      bool firstinv = true;
-      foreach (var inv in mInvariants)
-      {
-        if (firstinv)
-        {
-          // open the invariants declaration
-          oh.BeginRegion("Object Invariants");
-          oh.Output("[ContractInvariantMethod]", true);
-          oh.Output("protected void ", false);
-
-          // make sure the method name is not already in use
-          string method_name = "InferredObjectInvariant";
-          int count = 0;
-          while (HasSymbol(method_name))
-            method_name = string.Format("{0}{1}", "InferredObjectInvariant", ++count);
-
-          oh.Output(method_name + "()", true);
-          oh.Output("{", true);
-          oh.IncrIndent();
+                    OutputEOL();
+                    Output("// Disable the \"this variable is not used\" warning as every field would imply it.", true);
+                    Output("#pragma warning disable 0414", true);
+                    Output("// Disable the \"this variable is never assigned to\".", true);
+                    Output("#pragma warning disable 0067", true);
+                    Output("// Disable the \"this event is never assigned to\".", true);
+                    Output("#pragma warning disable 0649", true);
+                    Output("// Disable the \"this variable is never used\".", true);
+                    Output("#pragma warning disable 0169", true);
+                    Output("// Disable the \"new keyword not required\" warning.", true);
+                    Output("#pragma warning disable 0109", true);
+                    Output("// Disable the \"extern without DllImport\" warning.", true);
+                    Output("#pragma warning disable 0626", true);
+                    Output("// Disable the \"could hide other member\" warning, can happen on certain properties.", true);
+                    Output("#pragma warning disable 0108", true);
+                    OutputEOL();
+                    OutputEOL();
+                }
+            }
+            catch (PathTooLongException)
+            {
+                mDebugOutput.WriteLine("OutputPretty C#: Unable to write file " + fullpath + ": Path is too long.");
+                throw;
+            }
+            catch (IOException)
+            {
+                mDebugOutput.WriteLine("OutputPretty C#: Unable to write file " + fullpath + ": file may be readonly or disk may be full.");
+                throw;
+            }
+            catch (ArgumentException)
+            {
+                mDebugOutput.WriteLine("OutputPretty C#: Unable to write file " + fullpath + ": character in the path is not allowed.");
+                throw;
+            }
         }
 
-        oh.Output(string.Format("Contract.Invariant({0});", inv), true);
-        first = false;
-        firstinv = false;
-      }
-
-      if (!firstinv)
-      {
-        // close the invariants declaration
-        oh.DecrIndent();
-        oh.Output("}", true);
-        oh.EndRegion();
-      }
-
-      //** Delegates
-      bool firstdel = true;
-      foreach (var child in mChildren)
-      {
-        if (child.IsDelegate)
+        public void EndFile()
         {
-          if (!first)
+            if (mOutput != null)
+            {
+                if (mVerbose)
+                {
+                    mDebugOutput.WriteLine("OutputPretty C#: Inferred contracts successfully output in file: " + mCurrentFileName);
+                }
+                mOutput.Close();
+                mOutput = null;
+                var key = mCurrentFileName.ToLower();
+                if (!mWrittenFileSet.ContainsKey(key))
+                {
+                    mWrittenFileSet.Add(key, mCurrentFileName);
+                    mWrittenFiles.Add(mCurrentFileName);
+                }
+            }
+
+            mCurIndent = 0;
+            mbEOL = false;
+            mCurrentFileName = "";
+        }
+
+        public void BeginNamespace(Namespace ns)
+        {
+            if (mStrategy == OutputStrategy.ONE_FILE_PER_NAMESPACE)
+            {
+                string name = ns.Name;
+                if (name == "<toplevel>")
+                    name = "toplevel";
+                StartNewFile(name + ".cs");
+            }
+        }
+
+        public void EndNamespace()
+        {
+            if (mStrategy == OutputStrategy.ONE_FILE_PER_NAMESPACE)
+                EndFile();
+        }
+
+        public void BeginClass(Class cl)
+        {
+            if (mStrategy == OutputStrategy.ONE_FILE_PER_CLASS
+              || (mStrategy == OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS && cl.Parent == null))
+            {
+                string filename = cl.FullName;
+
+                // postfix the filename with the number of formal parameters to allow for types
+                // with the same name but different formal parameters
+                int nb_formal_param = cl.ILFormalTypeParameterCount;
+                if (nb_formal_param > 0)
+                    filename += "_" + nb_formal_param;
+
+                filename += ".cs";
+
+                StartNewFile(filename);
+            }
+        }
+
+        public void EndClass(Class cl)
+        {
+            if (mStrategy == OutputStrategy.ONE_FILE_PER_CLASS
+              || (mStrategy == OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS && cl.Parent == null))
+                EndFile();
+        }
+
+        #region Privates
+        readonly private bool mVerbose = false;
+        readonly private OutputStrategy mStrategy;
+        private int mCurIndent;
+        private StreamWriter mOutput; /// Current destination
+        readonly private string mProjectFolder;
+        readonly private string mRelativeFilesPath;
+        private bool mbEOL; /// Last thing output was a EOL
+        readonly private IOutput mDebugOutput;
+        readonly private List<string> mWrittenFiles;
+        readonly private Dictionary<string, string> mWrittenFileSet;
+        private string mCurrentFileName;
+        readonly private List<string> mUsings; /// Using assemblies at the beginning of the output files (set in constructor)
+                                               /// 
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(mCurIndent >= 0);
+            Contract.Invariant(mRelativeFilesPath != null);
+            Contract.Invariant(mProjectFolder != null);
+        }
+
+        #endregion Privates
+    }
+
+    [ContractVerification(false)]
+    public class Namespace
+    {
+        public Namespace(string name)
+        {
+            mName = name;
+            mChildren = new List<ElementBase>();
+        }
+
+        public void OpenNamespace(OutputHelper oh)
+        {
+            Contract.Requires(oh != null);
+
+            oh.BeginNamespace(this);
+            if (mName != "<toplevel>")
+            {
+                oh.Output("namespace " + mName, true);
+                oh.Output("{", true);
+
+                oh.IncrIndent();
+            }
+        }
+
+        public void CloseNamespace(OutputHelper oh)
+        {
+            Contract.Requires(oh != null);
+
+            if (mName != "<toplevel>")
+            {
+                oh.DecrIndent();
+
+                oh.Output("}", true);
+            }
+            oh.EndNamespace();
+        }
+
+        public void Output(OutputHelper oh)
+        {
+            Contract.Requires(oh != null);
+
+            if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
+                OpenNamespace(oh);
+
+            // Sort the children alphabetically
+            mChildren.Sort(new ElementBaseComparer());
+
+            bool first = true;
+            bool bOutputOtherChildren = false;
+            foreach (var child in mChildren)
+            {
+                if (child.IsClass)
+                {
+                    Class cl = child as Class;
+
+                    Contract.Assume(cl != null);
+
+                    if (cl.Parent == null
+                      || (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS))
+                    {
+                        if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
+                        {
+                            if (first)
+                                first = false;
+                            else
+                                oh.OutputEOL();
+                        }
+                        cl.Output(oh);
+                    }
+                }
+                else
+                {
+                    if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
+                    {
+                        if (first)
+                            first = false;
+                        else
+                            oh.OutputEOL();
+                        child.Output(oh);
+                    }
+                    else
+                        bOutputOtherChildren = true;
+                }
+            }
+
+            if (oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE && bOutputOtherChildren)
+            {
+                string name = mName;
+                if (name == "<toplevel>")
+                    name = "toplevel";
+                oh.ForceNewFile(name + ".cs");
+                OpenNamespace(oh);
+                first = true;
+                foreach (var child in mChildren)
+                {
+                    if (!child.IsClass)
+                    {
+                        if (first)
+                            first = false;
+                        else
+                            oh.OutputEOL();
+                        child.Output(oh);
+                    }
+                }
+                CloseNamespace(oh);
+                oh.EndFile();
+            }
+
+            if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
+                CloseNamespace(oh);
+        }
+
+        public void AddChild(ElementBase child)
+        {
+            if (!mChildren.Contains(child))
+                mChildren.Add(child);
+        }
+
+        public bool Empty()
+        {
+            return mChildren.Count == 0;
+        }
+
+        public bool HasUnsafeCode()
+        {
+            foreach (var ch in mChildren)
+            {
+                if (ch.HasUnsafeCode())
+                    return true;
+            }
+            return false;
+        }
+
+        public virtual string Name { get { return mName; } }
+
+        #region Privates
+        /// <summary>
+        /// Namespace name. Can be empty for toplevel
+        /// </summary>
+        private string mName;
+
+        /// <summary>
+        /// Objects in the namespace
+        /// </summary>
+        private List<ElementBase> mChildren;
+        #endregion
+    }
+
+    public class ElementBaseComparer : IComparer<ElementBase>
+    {
+        public int Compare(ElementBase e1, ElementBase e2)
+        {
+            return e1.Name.CompareTo(e2.Name);
+        }
+    }
+
+    public abstract class ElementBase
+    {
+        public abstract void Output(OutputHelper oh);
+
+        public virtual string Name { get { throw new NotImplementedException(); } }
+
+        public virtual bool IsClass { get { return false; } }
+        public virtual bool IsMethod { get { return false; } }
+        public virtual bool IsProperty { get { return false; } }
+        public virtual bool IsEvent { get { return false; } }
+        public virtual bool IsField { get { return false; } }
+        public virtual bool IsEnum { get { return false; } }
+        public virtual bool IsDelegate { get { return false; } }
+
+        public virtual bool IsUnsafe { get { return false; } }
+        // Classes may have unsafe code but not declared as unsafe
+        public virtual bool HasUnsafeCode() { return IsUnsafe; }
+    }
+
+    [ContractVerification(false)]
+    public class Class : ElementBase
+    {
+        public enum ClassType
+        {
+            CLASS,
+            STRUCT,
+            INTERFACE,
+        }
+
+        public Class(Access mAccess, bool mbIsAbstract, bool mbIsSealed, bool mbIsStatic, bool mbIsUnsafe, ClassType mType, string mName, Class mParent, string mBaseClass, Namespace mParentNS)
+        {
+            this.mAccess = mAccess;
+            this.mbIsAbstract = mbIsAbstract;
+            this.mbIsSealed = mbIsSealed;
+            this.mbIsStatic = mbIsStatic;
+            this.mbIsUnsafe = mbIsUnsafe;
+            this.mType = mType;
+            this.mName = mName;
+            this.mParent = mParent;
+            this.mBaseClass = mBaseClass;
+            this.mParentNS = mParentNS;
+
+            mFormals = new List<FormalTypeParameter>();
+            mInterfaces = new List<string>();
+            mChildren = new List<ElementBase>();
+            mInvariants = new List<string>();
+            mAttributes = new List<string>();
+        }
+
+        public override bool IsClass { get { return true; } }
+        public override bool IsUnsafe { get { return mbIsUnsafe; } }
+
+        public int ILFormalTypeParameterCount
+        {
+            get
+            {
+                var result = (this.FormalTypeParameters == null) ? 0 : this.FormalTypeParameters.Count;
+                if (this.Parent != null) result += this.Parent.ILFormalTypeParameterCount;
+                return result;
+            }
+        }
+        public ClassType Type { get { return mType; } }
+        public List<FormalTypeParameter> FormalTypeParameters { get { return mFormals; } }
+
+        public override string Name { get { return mName; } }
+        public string FullName
+        {
+            get
+            {
+                string fname = "";
+                if (mParent == null)
+                {
+                    if (mParentNS.Name != "<toplevel>")
+                        fname += mParentNS.Name + ".";
+                }
+                else
+                    fname += mParent.FullName + ".";
+                fname += mName;
+                return fname;
+            }
+        }
+        public Class Parent { get { return mParent; } set { mParent = value; } }
+        public string BaseClass { get { return mBaseClass; } set { mBaseClass = value; } }
+        public Namespace Namespace { get { return mParentNS; } }
+
+        #region Output
+        private void OutputName(OutputHelper oh)
+        {
+            oh.Output(mName, false);
+        }
+
+        private void OutputHeader(OutputHelper oh, bool bOutputPartial, bool bOutputInterfaces, bool bOutputAttributes)
+        {
+            if (bOutputAttributes && mAttributes.Count > 0)
+            {
+                foreach (var att in mAttributes)
+                    oh.Output("[" + att + "]", true);
+            }
+
+            if (mbIsUnsafe)
+                oh.Output("unsafe ", false);
+
+            if (mbIsStatic)
+                oh.Output("static ", false);
+            if (mbIsAbstract)
+                oh.Output("abstract ", false);
+            if (mbIsSealed)
+                oh.Output("sealed ", false);
+
+            switch (mAccess)
+            {
+                case Access.PUBLIC:
+                    oh.Output("public ", false);
+                    break;
+                case Access.PROTECTED:
+                    oh.Output("protected ", false);
+                    break;
+                case Access.PRIVATE:
+                    oh.Output("private ", false);
+                    break;
+                case Access.INTERNAL:
+                    oh.Output("internal ", false);
+                    break;
+                case Access.INTERNAL_AND_OR_PROTECTED:
+                    oh.Output("internal protected ", false);
+                    break;
+            }
+
+            if (bOutputPartial)
+                oh.Output("partial ", false);
+
+            switch (mType)
+            {
+                case ClassType.CLASS:
+                    oh.Output("class ", false);
+                    break;
+                case ClassType.STRUCT:
+                    oh.Output("struct ", false);
+                    break;
+                case ClassType.INTERFACE:
+                    oh.Output("interface ", false);
+                    break;
+            }
+
+            OutputName(oh);
+
+            //** Formal type parameters
+            if (mFormals.Count > 0)
+            {
+                oh.Output("<", false);
+                bool first = true;
+                foreach (var f in mFormals)
+                {
+                    if (first)
+                        first = false;
+                    else
+                        oh.Output(", ", false);
+                    f.OutputName(oh);
+                }
+                oh.Output(">", false);
+            }
+
+            //** Base class, interfaces
+            bool semicol = false;
+            if (mBaseClass.Length > 0)
+            {
+                oh.Output(" : ", false);
+                semicol = true;
+                oh.Output(mBaseClass, false);
+            }
+
+            if (mInterfaces.Count > 0 && bOutputInterfaces)
+            {
+                if (!semicol)
+                    oh.Output(" : ", false);
+
+                bool first = true;
+                foreach (var i in mInterfaces)
+                {
+                    if (!first || semicol)
+                        oh.Output(", ", false);
+                    first = false;
+
+                    oh.Output(i, false);
+                }
+            }
+
             oh.OutputEOL();
-          // Don't output EOL between delegates
-          if (firstdel)
-            oh.BeginRegion("Delegates");
-          child.Output(oh);
-          first = false;
-          firstdel = false;
-        }
-      }
-      if (!firstdel)
-        oh.EndRegion();
-
-      //** Enum
-      bool firstenum = true;
-      foreach (var child in mChildren)
-      {
-        if (child.IsEnum)
-        {
-          if (!first)
-            oh.OutputEOL();
-          if (firstenum)
-            oh.BeginRegion("Enums");
-          child.Output(oh);
-          first = false;
-          firstenum = false;
-        }
-      }
-      if (!firstenum)
-        oh.EndRegion();
-
-      //** Classes
-      bool firstclass = true;
-      foreach (var child in mChildren)
-      {
-        if (child.IsClass && bOutputNestedTypes)
-        {
-          if (!first)
-            oh.OutputEOL();
-          if (firstclass)
-            oh.BeginRegion("Nested classes (from " + mName + ")");
-          child.Output(oh);
-          first = false;
-          firstclass = false;
-        }
-      }
-      if (!firstclass)
-        oh.EndRegion();
-
-      #region Methods
-
-      bool firstmeth = true;
-      foreach (var child in mChildren)
-      {
-        if (child.IsMethod)
-        {
-          if (!first)
-            oh.OutputEOL();
-          if (firstmeth)
-            oh.BeginRegion("Methods and constructors");
-          child.Output(oh);
-          first = false;
-          firstmeth = false;
-        }
-      }
-      if (!firstmeth)
-        oh.EndRegion();
-      #endregion
-      
-      #region Properties
-
-      bool firstprop = true;
-      foreach (var child in mChildren)
-      {
-        if (child.IsProperty)
-        {
-          if (!first)
-            oh.OutputEOL();
-          if (firstprop)
-            oh.BeginRegion("Properties and indexers");
-          child.Output(oh);
-          first = false;
-          firstprop = false;
-        }
-      }
-      if (!firstprop)
-        oh.EndRegion();
-      #endregion
-
-      #region Events
-      
-      bool firstEvent= true;
-      foreach (var child in mChildren)
-      {
-        if (child.IsEvent)
-        {
-          if (!first)
-            oh.OutputEOL();
-          if (firstEvent)
-            oh.BeginRegion("Events");
-          child.Output(oh);
-          first = false;
-          firstEvent = false;
-        }
-      }
-      if (!firstEvent)
-        oh.EndRegion();
-      #endregion
-
-      #region Fields
-
-      bool firstfield = true;
-      foreach (var child in mChildren)
-      {
-        if (child.IsField)
-        {
-          // Don't output EOL between fields
-          if (firstfield && !first)
-            oh.OutputEOL();
-          if (firstfield)
-            oh.BeginRegion("Fields");
-          child.Output(oh);
-          firstfield = false;
-          first = false;
-        }
-      }
-      if (!firstfield)
-        oh.EndRegion();
-      #endregion
-
-      OutputClosing(oh, indents);
-
-      if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS
-        || (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS && mParent == null))
-        mParentNS.CloseNamespace(oh);
-    }
-    #endregion
-
-    public void ForceUnsafe(bool uns)
-    {
-      this.mbIsUnsafe = uns;
-    }
-
-    #region Registering functions
-    public void AddChild(ElementBase child)
-    {
-      Contract.Requires(child != null);
-
-      mChildren.Add(child);
-      if (child.IsField && child.IsUnsafe)
-        ForceUnsafe(true);
-    }
-
-    public void AddChildren(IEnumerable<ElementBase> children)
-    {
-      Contract.Requires(children != null);
-
-      foreach (var ch in children)
-        AddChild(ch);
-    }
-
-    public void AddInterface(string interf)
-    {
-      mInterfaces.Add(interf);
-    }
-
-    public void AddFormalTypeParameter(FormalTypeParameter ftp)
-    {
-      mFormals.Add(ftp);
-    }
-
-    public void AddFormalTypeParameters(List<FormalTypeParameter> ftpl)
-    {
-      Contract.Requires(ftpl != null);
-
-      mFormals.AddRange(ftpl);
-    }
-
-    public void AddInvariant(string invariant)
-    {
-      Contract.Requires(invariant != null);
-
-      if (invariant.Length > 0 && !mInvariants.Contains(invariant)) // sanity check
-        mInvariants.Add(invariant);
-    }
-
-    public void AddAttribute(string att)
-    {
-      mAttributes.Add(att);
-    }
-    #endregion
-
-    public override bool HasUnsafeCode()
-    {
-      foreach (var ch in mChildren)
-      {
-        if (ch.HasUnsafeCode())
-          return true;
-      }
-      return false;
-    }
-
-    public bool HasSymbol(string name)
-    {
-      foreach (var c in mChildren)
-      {
-        if (c.Name == name)
-          return true;
-      }
-
-      if (mParent != null)
-        return mParent.HasSymbol(name);
-
-      return false;
-    }
-
-    #region Privates
-    private Namespace mParentNS;
-    private Access mAccess;
-    private bool mbIsAbstract;
-    private bool mbIsSealed;
-    private bool mbIsStatic;
-    private bool mbIsUnsafe;
-    private ClassType mType; // struct, class, interface
-    private string mName;
-    private Class mParent; // for nested classes
-    private List<FormalTypeParameter> mFormals;
-    // Strings for base class and interface because they might come
-    // from references so we don't necessarily want to build objects for them
-    private string mBaseClass; // for inheritance
-    private List<string> mInterfaces;
-    private List<string> mInvariants;
-    private List<string> mAttributes; /// These are output before the class declaration
-
-    private List<ElementBase> mChildren;
-    #endregion
-  }
-
-  [ContractVerification(false)]
-  public class Enum : ElementBase
-  {
-    public Enum(Access mAccess, Class mParent, Namespace mParentNS, string mName, string mUnderlyingType)
-    {
-      this.mAccess = mAccess;
-      this.mParent = mParent;
-      this.mParentNS = mParentNS;
-      this.mName = mName;
-      this.mUnderlyingType = mUnderlyingType;
-
-      this.mFields = new List<EnumField>();
-    }
-
-    public override bool IsEnum { get { return true; } }
-    public override string Name { get { return mName; } }
-
-    public Class Parent { get { return mParent; } }
-    public Namespace Namespace { get { return mParentNS; } }
-
-    public override void Output(OutputHelper oh)
-    {
-      int indents = 0;
-      if (mParent != null && false) // TODO: switch entre options
-        indents = mParent.OutputOpening(oh, false, false, false);
-
-      switch (mAccess)
-      {
-        case Access.PUBLIC:
-          oh.Output("public ", false);
-          break;
-        case Access.PROTECTED:
-          oh.Output("protected ", false);
-          break;
-        case Access.PRIVATE:
-          oh.Output("private ", false);
-          break;
-        case Access.INTERNAL:
-          oh.Output("internal ", false);
-          break;
-        case Access.INTERNAL_AND_OR_PROTECTED:
-          oh.Output("internal protected ", false);
-          break;
-      }
-
-      oh.Output("enum ", false);
-      oh.Output(mName, false);
-
-      if (mUnderlyingType.Length > 0 && mUnderlyingType != "int") // int is the default value so don't output it
-        oh.Output(" : " + mUnderlyingType, false);
-
-      oh.OutputEOL();
-      oh.Output("{", true);
-      oh.IncrIndent();
-
-      foreach (var f in mFields)
-        f.Output(oh);
-
-      oh.DecrIndent();
-      oh.Output("}", true);
-
-      if (mParent != null && false)
-        mParent.OutputClosing(oh, indents);
-    }
-
-    public void AddField(EnumField ef)
-    {
-      mFields.Add(ef);
-    }
-
-    #region Privates
-    private Access mAccess;
-    private Class mParent;
-    private Namespace mParentNS;
-    private string mName;
-    private string mUnderlyingType;
-    private List<EnumField> mFields;
-    #endregion
-
-    public class EnumField
-    {
-      public EnumField(string mName, string mInitialValue)
-      {
-        this.mName = mName;
-        this.mInitialValue = mInitialValue;
-      }
-
-      public void Output(OutputHelper oh)
-      {
-        Contract.Requires(oh != null);
-
-        oh.Output(mName, false);
-        if (mInitialValue.Length > 0)
-          oh.Output(" = " + mInitialValue, false);
-        oh.Output(", ", true);
-      }
-
-      private string mName;
-      private string mInitialValue;
-    }
-  }
-
-  public class FormalTypeParameter
-  {
-    public FormalTypeParameter(string mName, FormalTypeParamConstraint mConstraint)
-    {
-      this.mName = mName;
-      setConstraint(mConstraint);
-    }
-
-    public FormalTypeParameter(string mName)
-    {
-      this.mName = mName;
-      setConstraint(default(FormalTypeParamConstraint));
-      this.mbHasContraint = false;
-    }
-
-    public void setConstraint(FormalTypeParamConstraint mConstraint)
-    {
-      this.mConstraint = mConstraint;
-    }
-
-    public void OutputName (OutputHelper oh)
-    {
-      Contract.Requires(oh != null);
-
-      oh.Output (mName, false);
-    }
-
-    public void OutputConstraint (OutputHelper oh)
-    {
-      if (mbHasContraint)
-        mConstraint.Output(oh);
-    }
-
-    #region Privates
-    readonly private string mName;
-    readonly private bool mbHasContraint;
-    private FormalTypeParamConstraint mConstraint;
-    #endregion
-  }
-
-  public class FormalTypeParamConstraint
-  {
-    public enum TypeConstraint
-    {
-      NONE,
-      CLASS,
-      STRUCT,
-      BASECLASS,
-    }
-
-    public FormalTypeParamConstraint(FormalTypeParameter mParent, TypeConstraint mTypeConstraint, string mClassConstraint, bool mbIsNew)
-    {
-      setInfos(mParent, mTypeConstraint, mClassConstraint, mbIsNew);
-    }
-
-    public void setInfos(FormalTypeParameter mParent, TypeConstraint mTypeConstraint, string mClassConstraint, bool mbIsNew)
-    {
-      this.mParent = mParent;
-      this.mTypeConstraint = mTypeConstraint;
-      this.mClassConstraint = mClassConstraint;
-      mInterfaces = new List<string>();
-      this.mbIsNew = mbIsNew;
-    }
-
-    public void AddInterfaceConstraint(string name)
-    {
-      mInterfaces.Add(name);
-    }
-
-    public void Output(OutputHelper oh)
-    {
-      Contract.Requires(oh != null);
-
-      oh.Output("where ", false);
-      mParent.OutputName(oh);
-      oh.Output (" : ", false);
-      //** base class
-      bool comma = false;
-      if (mTypeConstraint == TypeConstraint.CLASS)
-      {
-        oh.Output("class", false);
-        comma = true;
-      }
-      else if (mTypeConstraint == TypeConstraint.STRUCT)
-      {
-        oh.Output("struct", false);
-        comma = true;
-      }
-      else if (mTypeConstraint == TypeConstraint.CLASS)
-      {
-        oh.Output(mClassConstraint, false);
-        comma = true;
-      }
-
-      //** Interfaces
-      foreach (var inter in mInterfaces)
-      {
-        if (comma)
-          oh.Output (", ", false);
-        else
-          comma = true;
-
-        oh.Output (inter, false);
-      }
-
-      //** The new() thing
-      if (mbIsNew)
-        oh.Output ((comma ? ", " : "") + "new()", false);
-
-      oh.OutputEOL();
-    }
-
-    #region Privates
-    private FormalTypeParameter mParent;
-    private TypeConstraint mTypeConstraint;
-    private string mClassConstraint;
-    private List<string> mInterfaces;
-    private bool mbIsNew;
-    #endregion
-  }
-  [ContractVerification(false)]
-  public class Method : ElementBase
-  {
-    public Method(Access mAccess, Class mParent, string mReturnType, string mName, bool mbUnsafe, bool mbIsExtern, bool mbIsStatic, bool mbIsVirtual, bool mbIsNewSlot, bool mbIsSealed, bool mbIsAbstract, bool mbIsConstructor, bool mbIsFinalizer, bool mbIsOverride, string mCustomInitList)
-    {
-      Contract.Requires(mParent != null);
-
-      this.mAccess = mAccess;
-      this.mbIsInInterface = mParent.Type == Class.ClassType.INTERFACE;
-      this.mParent = mParent;
-      this.mParentNS = mParent.Namespace;
-      this.mReturnType = mReturnType;
-      this.mName = mName;
-      this.mParams = new ParametersList();
-      this.mLines = new List<string>();
-      this.mPrecond = new List<string>();
-      this.mPostcond = new List<string>();
-      this.mFormalParams = new List<FormalTypeParameter>();
-      this.mVarsToInitialize = new List<string>();
-      this.mAttributes = new List<string>();
-
-      this.Implicit = false;
-      this.Explicit = false;
-      this.Operator = false;
-
-      this.mbUnsafe = mbUnsafe;
-      this.mbIsExtern = mbIsExtern;
-      this.mbIsStatic = mbIsStatic;
-      this.mbIsVirtual = mbIsVirtual;
-      this.mbIsNewSlot = mbIsNewSlot;
-      this.mbIsSealed = mbIsSealed;
-      this.mbIsAbstract = mbIsAbstract;
-      this.mbIsConstructor = mbIsConstructor;
-      this.mbIsFinalizer = mbIsFinalizer;
-      this.mbIsOverride = mbIsOverride;
-      this.mCustomInitList = mCustomInitList;
-    }
-
-    public override bool IsMethod { get { return true; } }
-    public override bool IsUnsafe { get { return mbUnsafe; } }
-    public override string Name { get { return mName; } }
-
-    public bool Implicit { get; set; } /// useful for operators
-    public bool Explicit { get; set; } /// useful for operators
-    public string ReturnType { get { return mReturnType; } set { mReturnType = value; } } /// useful for operators
-    public void SetName(string name) { mName = name; }
-    public bool Operator { get; set; }
-
-    public override void Output(OutputHelper oh)
-    {
-      if (mAttributes.Count > 0)
-      {
-        foreach (var att in mAttributes)
-          oh.Output("[" + att + "]", true);
-      }
-
-      if (mbUnsafe)
-        oh.Output("unsafe ", false);
-
-      if (Operator || (!mbIsFinalizer && !mName.Contains(".")))
-      {
-        //** Accessibility
-        switch (mAccess)
-        {
-          case Access.INTERNAL_AND_OR_PROTECTED:
-            oh.Output("protected internal ", false);
-            break;
-          case Access.INTERNAL:
-            oh.Output("internal ", false);
-            break;
-          case Access.PRIVATE:
-            oh.Output("private ", false);
-            break;
-          case Access.PROTECTED:
-            oh.Output("protected ", false);
-            break;
-          case Access.PUBLIC:
-            oh.Output("public ", false);
-            break;
         }
 
-        //** Modifiers
-        if (mbIsExtern)
-          oh.Output("extern ", false);
-        if (mbIsStatic)
-          oh.Output("static ", false);
-        if (mbIsVirtual)
-          oh.Output("virtual ", false);
-        if (mbIsNewSlot)
-          oh.Output("new ", false);
-        if (mbIsSealed)
-          oh.Output("sealed ", false);
-        if (mbIsAbstract)
-          oh.Output("abstract ", false);
-        if (mbIsOverride)
-          oh.Output("override ", false);
-        if (Implicit)
-          oh.Output("implicit ", false);
-        if (Explicit)
-          oh.Output("explicit ", false);
-      }
-
-      if (!mbIsConstructor && !mbIsFinalizer)
-        oh.Output(mReturnType + (mReturnType.Length > 0 ? " " : ""), false);
-
-      if (Operator)
-        oh.Output("operator ", false);
-
-      if (mbIsFinalizer)
-        oh.Output("~", false);
-
-      oh.Output(mName, false);
-
-      //** Formal parameters
-      if (mFormalParams.Count > 0)
-      {
-        oh.Output("<", false);
-        bool first = true;
-        foreach (var t in mFormalParams)
+        private void OutputFormalTypeParameterConstraints(OutputHelper oh)
         {
-          if (first)
-            first = false;
-          else
-            oh.Output(", ", false);
-
-          t.OutputName(oh);
-        }
-        oh.Output(">", false);
-      }
-
-      oh.Output ("(", false);
-      mParams.OutputList(oh);
-      oh.Output(")", false);
-
-      // In these cases, stop there
-      if (mbIsAbstract || mbIsExtern || mbIsInInterface)
-      {
-        oh.Output(";", true);
-        return;
-      }
-
-      if (mCustomInitList.Length > 0)
-        oh.Output(mCustomInitList, false);
-
-      oh.OutputEOL();
-
-      //** Formal type parameters constraints
-      if (mFormalParams.Count > 0)
-      {
-        oh.IncrIndent();
-        foreach (var cst in mFormalParams)
-          cst.OutputConstraint(oh);
-        oh.DecrIndent();
-      }
-
-      //** Body
-      oh.Output("{", true);
-      oh.IncrIndent();
-
-      // Determine if there is already a symbol named "Contract" accessible from the body of the method
-      string contract_name = "Contract";
-      if (mParent.HasSymbol("Contract"))
-        contract_name = "System.Diagnostics.Contracts.Contract";
-
-      foreach (var cond in mPrecond)
-        oh.Output(contract_name + ".Requires(" + cond + ");", true);
-      foreach (var cond in mPostcond)
-        oh.Output(contract_name + ".Ensures(" + cond + ");", true);
-
-      bool firstl = true;
-      foreach (var l in mLines)
-      {
-        if ((mPrecond.Count > 0 || mPostcond.Count > 0) && firstl)
-          oh.OutputEOL();
-        oh.Output(l, true);
-        firstl = false;
-      }
-
-      bool firstv = true;
-      foreach (var v in mVarsToInitialize)
-      {
-        if ((firstv && !firstl) || (firstv && firstl && (mPrecond.Count > 0 || mPostcond.Count > 0)))
-          oh.OutputEOL();
-        oh.Output(v, true);
-        firstv = false;
-      }
-
-      if (mReturnType != "void" && mReturnType != "System.Void"
-        && !mbIsConstructor && !mbIsFinalizer)
-      {
-        if (mPrecond.Count > 0 || mPostcond.Count > 0
-          || mLines.Count > 0 || mVarsToInitialize.Count > 0)
-          oh.OutputEOL();
-        if (Operator && mReturnType.Length == 0) // Particular case for conversion operators
-          oh.Output("return default(" + mName + ");", true);
-        else
-          oh.Output("return default(" + mReturnType + ");", true);
-      }
-
-      oh.DecrIndent();
-      oh.Output("}", true);
-    }
-
-    public void AddParameter (Parameter newparam)
-    {
-      Contract.Requires(newparam != null);
-
-      mParams.AddParameter (newparam);
-      if (newparam.GetModifier() == Parameter.Modifier.OUT)
-        AddVarToInitialize(newparam.Type, newparam.Name);
-      if (newparam.IsUnsafe)
-        ForceUnsafe(true);
-    }
-
-    public void ForceUnsafe (bool uns)
-    {
-      this.mbUnsafe = uns;
-    }
-
-    public void AddFormalTypeParameter(FormalTypeParameter ftp)
-    {
-      mFormalParams.Add(ftp);
-    }
-
-    public void AddFormalTypeParameters(List<FormalTypeParameter> ftpl)
-    {
-      Contract.Requires(ftpl != null);
-
-      mFormalParams.AddRange(ftpl);
-    }
-
-    public void AddVarToInitialize(string type, string name)
-    {
-      mVarsToInitialize.Add(name + " = default(" + type + ");");
-    }
-
-    public void AddLine(string line)
-    {
-      mLines.Add(line);
-    }
-
-    public void AddPrecond(string cond)
-    {
-      mPrecond.Add(cond);
-    }
-
-    public void AddPostcond(string cond)
-    {
-      mPostcond.Add(cond);
-    }
-
-    public void AddAttribute(string att)
-    {
-      mAttributes.Add(att);
-    }
-
-    #region Privates
-    private Access mAccess;
-    private bool mbIsInInterface;
-    private Class mParent;
-    private Namespace mParentNS;
-    private string mReturnType;
-    private string mName;
-    private ParametersList mParams; /// In the form "modifier type name"
-    private List<FormalTypeParameter> mFormalParams;
-    private List<string> mLines;
-    private List<string> mPrecond, mPostcond;
-    private List<string> mVarsToInitialize;
-    private List<string> mAttributes; /// Each string here is output as an attribute before the method body
-
-    private bool mbUnsafe;
-    private bool mbIsExtern;
-    private bool mbIsStatic;
-    private bool mbIsVirtual;
-    private bool mbIsNewSlot;
-    private bool mbIsSealed;
-    private bool mbIsAbstract;
-    private bool mbIsConstructor;
-    private bool mbIsFinalizer;
-    private bool mbIsOverride;
-    private string mCustomInitList;
-    #endregion
-  }
-
-  [ContractVerification(false)]
-  public class Delegate : ElementBase
-  {
-    public Delegate(Access mAccess, bool mbUnsafe, string mName, Class mParent, Namespace mParentNS, string mReturnType)
-    {
-      this.mAccess = mAccess;
-      this.mbUnsafe = mbUnsafe;
-      this.mName = mName;
-      this.mParent = mParent;
-      this.mParentNS = mParentNS;
-      this.mReturnType = mReturnType;
-
-      this.mParams = new ParametersList();
-      this.mFormalParams = new List<FormalTypeParameter>();
-    }
-
-    public override bool IsDelegate { get {return true;} }
-    public override string Name { get { return mName; } }
-
-    public Class Parent { get { return mParent; } }
-    public Namespace Namespace { get { return mParentNS; } }
-
-    public override void Output(OutputHelper oh)
-    {
-      //if (mParent == null && oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
-      //  mParentNS.OpenNamespace(oh);
-      
-      if (mbUnsafe)
-        oh.Output("unsafe ", false);
-
-      switch (mAccess)
-      {
-        case Access.INTERNAL:
-          oh.Output("internal ", false);
-          break;
-        case Access.PRIVATE:
-          oh.Output("private ", false);
-          break;
-        case Access.PROTECTED:
-          oh.Output("protected ", false);
-          break;
-        case Access.PUBLIC:
-          oh.Output("public ", false);
-          break;
-        case Access.INTERNAL_AND_OR_PROTECTED:
-          oh.Output("internal protected ", false);
-          break;
-      }
-
-      oh.Output("delegate " + mReturnType + " " + mName, false);
-
-      //** Formal parameters
-      if (mFormalParams.Count > 0)
-      {
-        oh.Output("<", false);
-        bool first = true;
-        foreach (var t in mFormalParams)
-        {
-          if (first)
-            first = false;
-          else
-            oh.Output(", ", false);
-
-          t.OutputName(oh);
-        }
-        oh.Output(">", false);
-      }
-      
-      oh.Output ("(", false);
-      mParams.OutputList(oh);
-      oh.Output(")", false);
-
-      //** Formal type parameters constraints
-      if (mFormalParams.Count > 0)
-      {
-        oh.IncrIndent();
-        foreach (var cst in mFormalParams)
-          cst.OutputConstraint(oh);
-        oh.DecrIndent();
-      }
-
-      oh.Output(";", true);
-
-      //if (mParent == null && oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
-      //  mParentNS.CloseNamespace(oh);
-    }
-
-    public void ForceUnsafe(bool uns)
-    {
-      this.mbUnsafe = uns;
-    }
-
-    public void AddParameter(Parameter param)
-    {
-      Contract.Requires(param != null);
-      mParams.AddParameter(param);
-      if (param.IsUnsafe)
-        ForceUnsafe(true);
-    }
-
-    public void AddFormalTypeParameter(FormalTypeParameter ftp)
-    {
-      mFormalParams.Add(ftp);
-    }
-
-    public void AddFormalTypeParameters(List<FormalTypeParameter> ftpl)
-    {
-      Contract.Requires(ftpl != null);
-
-      mFormalParams.AddRange(ftpl);
-    }
-
-    #region Privates.
-    private Access mAccess;
-    private bool mbUnsafe;
-    private string mName;
-    private Class mParent;
-    private Namespace mParentNS;
-    private ParametersList mParams;
-    private string mReturnType;
-    private List<FormalTypeParameter> mFormalParams;
-    #endregion
-  }
-
-  [ContractVerification(false)]
-  public class Parameter
-  {
-    public Parameter (string type, string name, Modifier mModifier)
-    {
-      this.mType = type;
-      this.mName = name;
-      this.mModifier = mModifier;
-    }
-
-    public string Name {get {return mName;}}
-    public string Type {get {return mType;}}
-    public Modifier GetModifier (){ return mModifier; }
-    public bool IsUnsafe { get { return this.mType.Contains("*"); } }
-
-    public void Output (OutputHelper oh)
-    {
-      Contract.Requires(oh != null);
-
-      if (mModifier == Modifier.OUT)
-        oh.Output ("out ", false);
-      else if (mModifier == Modifier.REF)
-        oh.Output ("ref ", false);
-
-      oh.Output (mType + " " + mName, false);
-    }
-
-    public enum Modifier
-    {
-      NONE,
-      REF,
-      OUT,
-    }
-
-    private string mType;
-    private string mName;
-    private Modifier mModifier;
-  }
-
-  public class ParametersList
-  {
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.mParams != null);
-    }
-
-
-    public ParametersList()
-    {
-      mParams = new List<Parameter>();
-    }
-
-    public void AddParameter(Parameter newparam)
-    {
-      mParams.Add(newparam);
-    }
-
-    public void OutputList(OutputHelper oh)
-    {
-      bool first = true;
-      foreach (var p in mParams)
-      {
-        if (first)
-          first = false;
-        else
-          oh.Output(", ", false);
-
-        p.Output(oh);
-      }
-    }
-
-    public bool IsEmpty()
-    {
-      return mParams.Count > 0;
-    }
-
-    readonly private List<Parameter> mParams;
-  }
-
-  [ContractVerification(false)]
-  public class Property : ElementBase
-  {
-    public Property(Class mParent, bool mbHasGetter, bool mbHasSetter, string mName, bool mbIsUnsafe, bool mbIsInInterface, bool mbIsIndexer, string mReturnType, Access mAccess, Access mAccessGet, Access mAccessSet, bool mbIsStatic, bool mbIsNewSlot, bool mbIsOverride, bool mbIsSealed, bool mbIsVirtual, bool mbIsExtern, bool mbIsAbstract)
-    {
-      Contract.Requires(mParent != null);
-
-      this.mParent = mParent;
-      this.mParentNS = mParent.Namespace;
-      this.mbHasGetter = mbHasGetter;
-      this.mbHasSetter = mbHasSetter;
-      this.mName = mName;
-      this.mbIsUnsafe = mbIsUnsafe;
-      this.mbIsInInterface = mbIsInInterface;
-      this.mbIsIndexer = mbIsIndexer;
-      this.mReturnType = mReturnType;
-      this.mbIsNewSlot = mbIsNewSlot;
-      this.mbIsOverride = mbIsOverride;
-      this.mbIsSealed = mbIsSealed;
-      this.mbIsStatic = mbIsStatic;
-      this.mbIsVirtual = mbIsVirtual;
-      this.mbIsExtern = mbIsExtern;
-      this.mbIsAbstract = mbIsAbstract;
-
-      this.mParameters = new ParametersList();
-      this.mBodyGet = new List<string>();
-      this.mBodySet = new List<string>();
-      this.mGetPrecond = new List<string>();
-      this.mGetPostcond = new List<string>();
-      this.mSetPrecond = new List<string>();
-      this.mSetPostcond = new List<string>();
-      this.mAccess = mAccess;
-      this.mAccessGet = mAccessGet;
-      this.mAccessSet = mAccessSet;
-    }
-
-    public override bool IsProperty { get { return true; } }
-    public override bool IsUnsafe { get { return mbIsUnsafe; } }
-    public override string Name { get { return mName; } }
-
-    public void AddLineToGetBody(string line)
-    {
-      mBodyGet.Add(line);
-    }
-    public void AddLineToSetBody(string line)
-    {
-      mBodySet.Add(line);
-    }
-    public void AddPrecondToGet(string precond)
-    {
-      mGetPrecond.Add(precond);
-    }
-    public void AddPostcondToGet(string postcond)
-    {
-      mGetPostcond.Add(postcond);
-    }
-    public void AddPrecondToSet(string precond)
-    {
-      mSetPrecond.Add(precond);
-    }
-    public void AddPostcondToSet(string postcond)
-    {
-      mSetPostcond.Add(postcond);
-    }
-
-    public void AddParameter(Parameter param) // No modifier for indexers
-    {
-      Contract.Requires(param != null);
-
-      mParameters.AddParameter(param);
-      if (param.IsUnsafe)
-        ForceUnsafe(true);
-    }
-
-    public void ForceUnsafe (bool uns)
-    {
-      this.mbIsUnsafe = uns;
-    }
-
-    public override void Output(OutputHelper oh)
-    {
-      if (mbIsUnsafe)
-        oh.Output("unsafe ", false);
-
-      if (!mbHasGetter && !mbHasSetter)
-      {
-        string err = "Error, property \"" + mName + "\" must have either a getter or a setter."; // Empty property, should never happen
-        oh.DebugOutput("Pretty C# Output error: " + err);
-        oh.Output("/* " + err + " */", true);
-      }
-
-      if (mbIsIndexer && mName != "Item" && !mName.EndsWith(".Item"))
-      {
-        string alt = mName;
-        if (alt.Contains("."))
-          alt = alt.Substring(alt.LastIndexOf('.') + 1);
-        oh.Output("[System.Runtime.CompilerServices.IndexerName(\"" + alt + "\")]", true);
-      }
-
-      if (!mName.Contains("."))
-      {
-        OutputAccessibility(oh, mAccess);
-
-        if (mbIsAbstract)
-          oh.Output("abstract ", false);
-        if (mbIsVirtual)
-          oh.Output("virtual ", false);
-        if (mbIsExtern)
-          oh.Output("extern ", false);
-        if (mbIsStatic)
-          oh.Output("static ", false);
-        if (mbIsNewSlot)
-          oh.Output("new ", false);
-        if (mbIsOverride)
-          oh.Output("override ", false);
-        if (mbIsSealed)
-          oh.Output("sealed ", false);
-      }
-
-      oh.Output(mReturnType + " ", false);
-
-      if (!mbIsIndexer)
-        oh.Output(mName, true);
-      else
-      {
-        int lastdot = mName.LastIndexOf('.');
-        if (lastdot < 0)
-        {
-          oh.Output("this", false);
-        }
-        else // explicit implementation, such as NS.Interface.this
-        {
-          string name = mName.Substring(0, lastdot) + ".this";
-
-          oh.Output(name, false);
+            oh.IncrIndent();
+            foreach (var formal in mFormals)
+                formal.OutputConstraint(oh);
+            oh.DecrIndent();
         }
 
-        oh.Output(" [", false);
-        mParameters.OutputList(oh);
-        oh.Output("]", true);
-      }
-
-      oh.Output("{", true);
-      oh.IncrIndent();
-
-      #region Getter
-      if (mbHasGetter)
-      {
-        OutputAccessibility(oh, mAccessGet);
-        oh.Output("get", false);
-        if (mbIsInInterface || mbIsAbstract)
-          oh.Output(";", true);
-        else
+        public int OutputOpening(OutputHelper oh, bool bNestingClasses, bool bOutputPartial, bool bFull)
         {
-          oh.OutputEOL();
-          oh.Output("{", true);
-          oh.IncrIndent();
+            Contract.Requires(oh != null);
 
-          foreach (var cond in mGetPrecond)
-            oh.Output("Contract.Requires(" + cond + ");", true);
-          foreach (var cond in mGetPostcond)
-            oh.Output("Contract.Ensures(" + cond + ");", true);
+            if (oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE
+              && mParent == null)
+                mParentNS.OpenNamespace(oh);
 
-          if (mGetPrecond.Count > 0 || mGetPostcond.Count > 0)
-            oh.OutputEOL();
+            // only output full information for the last class, not the nesting ones
+            int indents = 1;
+            if (bNestingClasses && mParent != null)
+                indents += mParent.OutputOpening(oh, bNestingClasses, bOutputPartial, false);
 
-          foreach (var line in mBodyGet)
-            oh.Output(line, true);
+            OutputHeader(oh, bOutputPartial, bFull, bFull);
+            if (bFull)
+                OutputFormalTypeParameterConstraints(oh);
 
-          if (mBodyGet.Count > 0)
-            oh.OutputEOL();
+            oh.Output("{", true);
+            oh.IncrIndent();
 
-          oh.Output("return default(" + mReturnType + ");", true);
-
-          oh.DecrIndent();
-          oh.Output("}", true);
+            return indents;
         }
-      }
-      #endregion
 
-      #region Setter
-      if (mbHasSetter)
-      {
-        OutputAccessibility(oh, mAccessSet);
-        oh.Output("set", false);
-        if (mbIsInInterface || mbIsAbstract)
-          oh.Output(";", true);
-        else
+        public void OutputClosing(OutputHelper oh, int indents)
         {
-          oh.OutputEOL();
-          oh.Output("{", true);
-          oh.IncrIndent();
+            Contract.Requires(oh != null);
 
-          // Determine if there is already a symbol named "Contract" accessible from the body of the method
-          string contract_name = "Contract";
-          if (mParent.HasSymbol("Contract"))
-            contract_name = "System.Diagnostics.Contracts.Contract";
-
-          foreach (var cond in mSetPrecond)
-            oh.Output(contract_name + ".Requires(" + cond + ");", true);
-          foreach (var cond in mSetPostcond)
-            oh.Output(contract_name + ".Ensures(" + cond + ");", true);
-
-          if (mBodySet.Count > 0
-            && (mSetPrecond.Count > 0 || mSetPostcond.Count > 0))
-            oh.OutputEOL();
-
-          foreach (var line in mBodySet)
-            oh.Output(line, true);
-
-          oh.DecrIndent();
-          oh.Output("}", true);
+            for (int i = 0; i < indents; ++i)
+            {
+                oh.DecrIndent();
+                oh.Output("}", true);
+            }
         }
-      }
-      #endregion
 
-      oh.DecrIndent();
-      oh.Output("}", true);
-    }
-
-    private void OutputAccessibility(OutputHelper oh, Access access)
-    {
-      if (mbIsInInterface || access == Access.NONE)
-        return;
-
-      switch (access)
-      {
-        case Access.INTERNAL:
-          oh.Output("internal ", false);
-          break;
-        case Access.PRIVATE:
-          oh.Output("private ", false);
-          break;
-        case Access.PROTECTED:
-          oh.Output("protected ", false);
-          break;
-        case Access.PUBLIC:
-          oh.Output("public ", false);
-          break;
-        case Access.INTERNAL_AND_OR_PROTECTED:
-          oh.Output("internal protected ", false);
-          break;
-      }
-    }
-
-    private Class mParent;
-    private Namespace mParentNS;
-    private bool mbHasGetter, mbHasSetter;
-    private string mName; /// Even if it's an indexer
-    private bool mbIsUnsafe;
-    private bool mbIsInInterface;
-    private bool mbIsIndexer;
-    private string mReturnType;
-
-    Access mAccess, mAccessGet, mAccessSet;
-
-    private bool mbIsStatic;
-    private bool mbIsNewSlot;
-    private bool mbIsOverride;
-    private bool mbIsSealed;
-    private bool mbIsVirtual;
-    private bool mbIsExtern;
-    private bool mbIsAbstract;
-    private ParametersList mParameters;
-
-    private List<string> mBodyGet, mBodySet;
-    private List<string> mGetPrecond, mGetPostcond;
-    private List<string> mSetPrecond, mSetPostcond;
-  }
-
-  [ContractVerification(false)]
-  public class Event : ElementBase
-  {
-    public Event(Class mParent, bool mbHasAdd, bool mbHasRemove, string mName, bool mbIsUnsafe, bool mbIsInInterface, string mReturnType, Access mAccess, Access mAccessGet, Access mAccessSet, bool mbIsStatic, bool mbIsNewSlot, bool mbIsOverride, bool mbIsSealed, bool mbIsVirtual, bool mbIsExtern, bool mbIsAbstract)
-    {
-      Contract.Requires(mParent != null);
-
-      this.mParent = mParent;
-      this.mParentNS = mParent.Namespace;
-      this.mbHasAdd = mbHasAdd;
-      this.mbHasRemove = mbHasRemove;
-      this.mName = mName;
-      this.mbIsUnsafe = mbIsUnsafe;
-      this.mbIsInInterface = mbIsInInterface;
-      this.mReturnType = mReturnType;
-      this.mbIsNewSlot = mbIsNewSlot;
-      this.mbIsOverride = mbIsOverride;
-      this.mbIsSealed = mbIsSealed;
-      this.mbIsStatic = mbIsStatic;
-      this.mbIsVirtual = mbIsVirtual;
-      this.mbIsExtern = mbIsExtern;
-      this.mbIsAbstract = mbIsAbstract;
-
-      this.mParameters = new ParametersList();
-      this.mBodyAdd = new List<string>();
-      this.mBodyRemove = new List<string>();
-      this.mAddPrecond = new List<string>();
-      this.mAddPostcond = new List<string>();
-      this.mRemovePrecond = new List<string>();
-      this.mRemovePostcond = new List<string>();
-      this.mAccess = mAccess;
-      this.mAccessGet = mAccessGet;
-      this.mAccessSet = mAccessSet;
-    }
-
-    public override bool IsEvent { get { return true; } }
-    public override bool IsUnsafe { get { return mbIsUnsafe; } }
-    public override string Name { get { return mName; } }
-
-    public void AddLineToGetBody(string line)
-    {
-      mBodyAdd.Add(line);
-    }
-    public void AddLineToSetBody(string line)
-    {
-      mBodyRemove.Add(line);
-    }
-    public void AddPrecondToGet(string precond)
-    {
-      mAddPrecond.Add(precond);
-    }
-    public void AddPostcondToGet(string postcond)
-    {
-      mAddPostcond.Add(postcond);
-    }
-    public void AddPrecondToSet(string precond)
-    {
-      mRemovePrecond.Add(precond);
-    }
-    public void AddPostcondToSet(string postcond)
-    {
-      mRemovePostcond.Add(postcond);
-    }
-
-    public void AddParameter(Parameter param) // No modifier for indexers
-    {
-      Contract.Requires(param != null);
-      mParameters.AddParameter(param);
-      if (param.IsUnsafe)
-        ForceUnsafe(true);
-    }
-
-    public void ForceUnsafe(bool uns)
-    {
-      this.mbIsUnsafe = uns;
-    }
-
-    public override void Output(OutputHelper oh)
-    {
-      bool inInterface = (this.mParent.Type == Class.ClassType.INTERFACE);
-
-      if (mbIsUnsafe)
-        oh.Output("unsafe ", false);
-
-      if (!mbHasAdd && !mbHasRemove)
-      {
-        string err = "Error, event \"" + mName + "\" must have either an add or a remove."; // Empty property, should never happen
-        oh.DebugOutput("Pretty C# Output error: " + err);
-        oh.Output("/* " + err + " */", true);
-      }
-
-      if (!mName.Contains("."))
-      {
-        OutputAccessibility(oh, mAccess);
-
-        if (mbIsAbstract)
-          oh.Output("abstract ", false);
-        if (mbIsVirtual)
-          oh.Output("virtual ", false);
-        if (mbIsExtern)
-          oh.Output("extern ", false);
-        if (mbIsStatic)
-          oh.Output("static ", false);
-        if (mbIsNewSlot)
-          oh.Output("new ", false);
-        if (mbIsOverride)
-          oh.Output("override ", false);
-        if (mbIsSealed)
-          oh.Output("sealed ", false);
-      }
-
-      oh.Output("event ", false);
-
-      oh.Output(mReturnType + " ", false);
-
-      oh.Output(mName, true);
-
-      if (inInterface)
-      {
-        oh.Output(";", true);
-      }
-      else
-      {
-        oh.Output("{", true);
-        oh.IncrIndent();
-
-        #region Add
-        if (mbHasAdd)
+        public override void Output(OutputHelper oh)
         {
-          OutputAccessibility(oh, mAccessGet);
-          oh.Output("add", false);
-          if (mbIsInInterface || mbIsAbstract)
-            oh.Output(";", true);
-          else
-          {
+            oh.BeginClass(this);
+
+            OutputIntern(oh,
+              oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS,
+              oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS);
+
+            oh.EndClass(this);
+        }
+
+        private void OutputIntern(OutputHelper oh, bool bNestingClasses, bool bOutputNestedTypes)
+        {
+            int indents = OutputOpening(oh, bNestingClasses, bNestingClasses, true);
+
+            // Sort the children alphabetically
+            mChildren.Sort(new ElementBaseComparer());
+
+            // Mic: Mmmhh... Each type is a separate case. It quites destroys the
+            // idea to handle ElementBase elements without needing their actual
+            // type but it's much more handy for output with regions (although it would be cleaner
+            // by tuning up ElementBaseComparer perhaps).
+            // So whatever...
+
+            bool first = true;
+
+            //** Object invariants
+            bool firstinv = true;
+            foreach (var inv in mInvariants)
+            {
+                if (firstinv)
+                {
+                    // open the invariants declaration
+                    oh.BeginRegion("Object Invariants");
+                    oh.Output("[ContractInvariantMethod]", true);
+                    oh.Output("protected void ", false);
+
+                    // make sure the method name is not already in use
+                    string method_name = "InferredObjectInvariant";
+                    int count = 0;
+                    while (HasSymbol(method_name))
+                        method_name = string.Format("{0}{1}", "InferredObjectInvariant", ++count);
+
+                    oh.Output(method_name + "()", true);
+                    oh.Output("{", true);
+                    oh.IncrIndent();
+                }
+
+                oh.Output(string.Format("Contract.Invariant({0});", inv), true);
+                first = false;
+                firstinv = false;
+            }
+
+            if (!firstinv)
+            {
+                // close the invariants declaration
+                oh.DecrIndent();
+                oh.Output("}", true);
+                oh.EndRegion();
+            }
+
+            //** Delegates
+            bool firstdel = true;
+            foreach (var child in mChildren)
+            {
+                if (child.IsDelegate)
+                {
+                    if (!first)
+                        oh.OutputEOL();
+                    // Don't output EOL between delegates
+                    if (firstdel)
+                        oh.BeginRegion("Delegates");
+                    child.Output(oh);
+                    first = false;
+                    firstdel = false;
+                }
+            }
+            if (!firstdel)
+                oh.EndRegion();
+
+            //** Enum
+            bool firstenum = true;
+            foreach (var child in mChildren)
+            {
+                if (child.IsEnum)
+                {
+                    if (!first)
+                        oh.OutputEOL();
+                    if (firstenum)
+                        oh.BeginRegion("Enums");
+                    child.Output(oh);
+                    first = false;
+                    firstenum = false;
+                }
+            }
+            if (!firstenum)
+                oh.EndRegion();
+
+            //** Classes
+            bool firstclass = true;
+            foreach (var child in mChildren)
+            {
+                if (child.IsClass && bOutputNestedTypes)
+                {
+                    if (!first)
+                        oh.OutputEOL();
+                    if (firstclass)
+                        oh.BeginRegion("Nested classes (from " + mName + ")");
+                    child.Output(oh);
+                    first = false;
+                    firstclass = false;
+                }
+            }
+            if (!firstclass)
+                oh.EndRegion();
+
+            #region Methods
+
+            bool firstmeth = true;
+            foreach (var child in mChildren)
+            {
+                if (child.IsMethod)
+                {
+                    if (!first)
+                        oh.OutputEOL();
+                    if (firstmeth)
+                        oh.BeginRegion("Methods and constructors");
+                    child.Output(oh);
+                    first = false;
+                    firstmeth = false;
+                }
+            }
+            if (!firstmeth)
+                oh.EndRegion();
+            #endregion
+
+            #region Properties
+
+            bool firstprop = true;
+            foreach (var child in mChildren)
+            {
+                if (child.IsProperty)
+                {
+                    if (!first)
+                        oh.OutputEOL();
+                    if (firstprop)
+                        oh.BeginRegion("Properties and indexers");
+                    child.Output(oh);
+                    first = false;
+                    firstprop = false;
+                }
+            }
+            if (!firstprop)
+                oh.EndRegion();
+            #endregion
+
+            #region Events
+
+            bool firstEvent = true;
+            foreach (var child in mChildren)
+            {
+                if (child.IsEvent)
+                {
+                    if (!first)
+                        oh.OutputEOL();
+                    if (firstEvent)
+                        oh.BeginRegion("Events");
+                    child.Output(oh);
+                    first = false;
+                    firstEvent = false;
+                }
+            }
+            if (!firstEvent)
+                oh.EndRegion();
+            #endregion
+
+            #region Fields
+
+            bool firstfield = true;
+            foreach (var child in mChildren)
+            {
+                if (child.IsField)
+                {
+                    // Don't output EOL between fields
+                    if (firstfield && !first)
+                        oh.OutputEOL();
+                    if (firstfield)
+                        oh.BeginRegion("Fields");
+                    child.Output(oh);
+                    firstfield = false;
+                    first = false;
+                }
+            }
+            if (!firstfield)
+                oh.EndRegion();
+            #endregion
+
+            OutputClosing(oh, indents);
+
+            if (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS
+              || (oh.Strategy == OutputHelper.OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS && mParent == null))
+                mParentNS.CloseNamespace(oh);
+        }
+        #endregion
+
+        public void ForceUnsafe(bool uns)
+        {
+            mbIsUnsafe = uns;
+        }
+
+        #region Registering functions
+        public void AddChild(ElementBase child)
+        {
+            Contract.Requires(child != null);
+
+            mChildren.Add(child);
+            if (child.IsField && child.IsUnsafe)
+                ForceUnsafe(true);
+        }
+
+        public void AddChildren(IEnumerable<ElementBase> children)
+        {
+            Contract.Requires(children != null);
+
+            foreach (var ch in children)
+                AddChild(ch);
+        }
+
+        public void AddInterface(string interf)
+        {
+            mInterfaces.Add(interf);
+        }
+
+        public void AddFormalTypeParameter(FormalTypeParameter ftp)
+        {
+            mFormals.Add(ftp);
+        }
+
+        public void AddFormalTypeParameters(List<FormalTypeParameter> ftpl)
+        {
+            Contract.Requires(ftpl != null);
+
+            mFormals.AddRange(ftpl);
+        }
+
+        public void AddInvariant(string invariant)
+        {
+            Contract.Requires(invariant != null);
+
+            if (invariant.Length > 0 && !mInvariants.Contains(invariant)) // sanity check
+                mInvariants.Add(invariant);
+        }
+
+        public void AddAttribute(string att)
+        {
+            mAttributes.Add(att);
+        }
+        #endregion
+
+        public override bool HasUnsafeCode()
+        {
+            foreach (var ch in mChildren)
+            {
+                if (ch.HasUnsafeCode())
+                    return true;
+            }
+            return false;
+        }
+
+        public bool HasSymbol(string name)
+        {
+            foreach (var c in mChildren)
+            {
+                if (c.Name == name)
+                    return true;
+            }
+
+            if (mParent != null)
+                return mParent.HasSymbol(name);
+
+            return false;
+        }
+
+        #region Privates
+        private Namespace mParentNS;
+        private Access mAccess;
+        private bool mbIsAbstract;
+        private bool mbIsSealed;
+        private bool mbIsStatic;
+        private bool mbIsUnsafe;
+        private ClassType mType; // struct, class, interface
+        private string mName;
+        private Class mParent; // for nested classes
+        private List<FormalTypeParameter> mFormals;
+        // Strings for base class and interface because they might come
+        // from references so we don't necessarily want to build objects for them
+        private string mBaseClass; // for inheritance
+        private List<string> mInterfaces;
+        private List<string> mInvariants;
+        private List<string> mAttributes; /// These are output before the class declaration
+
+        private List<ElementBase> mChildren;
+        #endregion
+    }
+
+    [ContractVerification(false)]
+    public class Enum : ElementBase
+    {
+        public Enum(Access mAccess, Class mParent, Namespace mParentNS, string mName, string mUnderlyingType)
+        {
+            this.mAccess = mAccess;
+            this.mParent = mParent;
+            this.mParentNS = mParentNS;
+            this.mName = mName;
+            this.mUnderlyingType = mUnderlyingType;
+
+            mFields = new List<EnumField>();
+        }
+
+        public override bool IsEnum { get { return true; } }
+        public override string Name { get { return mName; } }
+
+        public Class Parent { get { return mParent; } }
+        public Namespace Namespace { get { return mParentNS; } }
+
+        public override void Output(OutputHelper oh)
+        {
+            int indents = 0;
+            if (mParent != null && false) // TODO: switch entre options
+                indents = mParent.OutputOpening(oh, false, false, false);
+
+            switch (mAccess)
+            {
+                case Access.PUBLIC:
+                    oh.Output("public ", false);
+                    break;
+                case Access.PROTECTED:
+                    oh.Output("protected ", false);
+                    break;
+                case Access.PRIVATE:
+                    oh.Output("private ", false);
+                    break;
+                case Access.INTERNAL:
+                    oh.Output("internal ", false);
+                    break;
+                case Access.INTERNAL_AND_OR_PROTECTED:
+                    oh.Output("internal protected ", false);
+                    break;
+            }
+
+            oh.Output("enum ", false);
+            oh.Output(mName, false);
+
+            if (mUnderlyingType.Length > 0 && mUnderlyingType != "int") // int is the default value so don't output it
+                oh.Output(" : " + mUnderlyingType, false);
+
             oh.OutputEOL();
             oh.Output("{", true);
             oh.IncrIndent();
 
-            foreach (var cond in mAddPrecond)
-              oh.Output("Contract.Requires(" + cond + ");", true);
-            foreach (var cond in mAddPostcond)
-              oh.Output("Contract.Ensures(" + cond + ");", true);
-
-            if (mAddPrecond.Count > 0 || mAddPostcond.Count > 0)
-              oh.OutputEOL();
-
-            foreach (var line in mBodyAdd)
-              oh.Output(line, true);
-
-            if (mBodyAdd.Count > 0)
-              oh.OutputEOL();
-
-            //oh.Output("return default(" + mReturnType + ");", true);
+            foreach (var f in mFields)
+                f.Output(oh);
 
             oh.DecrIndent();
             oh.Output("}", true);
-          }
+
+            if (mParent != null && false)
+                mParent.OutputClosing(oh, indents);
         }
+
+        public void AddField(EnumField ef)
+        {
+            mFields.Add(ef);
+        }
+
+        #region Privates
+        private Access mAccess;
+        private Class mParent;
+        private Namespace mParentNS;
+        private string mName;
+        private string mUnderlyingType;
+        private List<EnumField> mFields;
         #endregion
 
-        #region Remove
-        if (mbHasRemove)
+        public class EnumField
         {
-          OutputAccessibility(oh, mAccessSet);
-          oh.Output("remove", false);
-          if (mbIsInInterface || mbIsAbstract)
-            oh.Output(";", true);
-          else
-          {
+            public EnumField(string mName, string mInitialValue)
+            {
+                this.mName = mName;
+                this.mInitialValue = mInitialValue;
+            }
+
+            public void Output(OutputHelper oh)
+            {
+                Contract.Requires(oh != null);
+
+                oh.Output(mName, false);
+                if (mInitialValue.Length > 0)
+                    oh.Output(" = " + mInitialValue, false);
+                oh.Output(", ", true);
+            }
+
+            private string mName;
+            private string mInitialValue;
+        }
+    }
+
+    public class FormalTypeParameter
+    {
+        public FormalTypeParameter(string mName, FormalTypeParamConstraint mConstraint)
+        {
+            this.mName = mName;
+            setConstraint(mConstraint);
+        }
+
+        public FormalTypeParameter(string mName)
+        {
+            this.mName = mName;
+            setConstraint(default(FormalTypeParamConstraint));
+            mbHasContraint = false;
+        }
+
+        public void setConstraint(FormalTypeParamConstraint mConstraint)
+        {
+            this.mConstraint = mConstraint;
+        }
+
+        public void OutputName(OutputHelper oh)
+        {
+            Contract.Requires(oh != null);
+
+            oh.Output(mName, false);
+        }
+
+        public void OutputConstraint(OutputHelper oh)
+        {
+            if (mbHasContraint)
+                mConstraint.Output(oh);
+        }
+
+        #region Privates
+        readonly private string mName;
+        readonly private bool mbHasContraint;
+        private FormalTypeParamConstraint mConstraint;
+        #endregion
+    }
+
+    public class FormalTypeParamConstraint
+    {
+        public enum TypeConstraint
+        {
+            NONE,
+            CLASS,
+            STRUCT,
+            BASECLASS,
+        }
+
+        public FormalTypeParamConstraint(FormalTypeParameter mParent, TypeConstraint mTypeConstraint, string mClassConstraint, bool mbIsNew)
+        {
+            setInfos(mParent, mTypeConstraint, mClassConstraint, mbIsNew);
+        }
+
+        public void setInfos(FormalTypeParameter mParent, TypeConstraint mTypeConstraint, string mClassConstraint, bool mbIsNew)
+        {
+            this.mParent = mParent;
+            this.mTypeConstraint = mTypeConstraint;
+            this.mClassConstraint = mClassConstraint;
+            mInterfaces = new List<string>();
+            this.mbIsNew = mbIsNew;
+        }
+
+        public void AddInterfaceConstraint(string name)
+        {
+            mInterfaces.Add(name);
+        }
+
+        public void Output(OutputHelper oh)
+        {
+            Contract.Requires(oh != null);
+
+            oh.Output("where ", false);
+            mParent.OutputName(oh);
+            oh.Output(" : ", false);
+            //** base class
+            bool comma = false;
+            if (mTypeConstraint == TypeConstraint.CLASS)
+            {
+                oh.Output("class", false);
+                comma = true;
+            }
+            else if (mTypeConstraint == TypeConstraint.STRUCT)
+            {
+                oh.Output("struct", false);
+                comma = true;
+            }
+            else if (mTypeConstraint == TypeConstraint.CLASS)
+            {
+                oh.Output(mClassConstraint, false);
+                comma = true;
+            }
+
+            //** Interfaces
+            foreach (var inter in mInterfaces)
+            {
+                if (comma)
+                    oh.Output(", ", false);
+                else
+                    comma = true;
+
+                oh.Output(inter, false);
+            }
+
+            //** The new() thing
+            if (mbIsNew)
+                oh.Output((comma ? ", " : "") + "new()", false);
+
             oh.OutputEOL();
+        }
+
+        #region Privates
+        private FormalTypeParameter mParent;
+        private TypeConstraint mTypeConstraint;
+        private string mClassConstraint;
+        private List<string> mInterfaces;
+        private bool mbIsNew;
+        #endregion
+    }
+    [ContractVerification(false)]
+    public class Method : ElementBase
+    {
+        public Method(Access mAccess, Class mParent, string mReturnType, string mName, bool mbUnsafe, bool mbIsExtern, bool mbIsStatic, bool mbIsVirtual, bool mbIsNewSlot, bool mbIsSealed, bool mbIsAbstract, bool mbIsConstructor, bool mbIsFinalizer, bool mbIsOverride, string mCustomInitList)
+        {
+            Contract.Requires(mParent != null);
+
+            this.mAccess = mAccess;
+            mbIsInInterface = mParent.Type == Class.ClassType.INTERFACE;
+            this.mParent = mParent;
+            mParentNS = mParent.Namespace;
+            this.mReturnType = mReturnType;
+            this.mName = mName;
+            mParams = new ParametersList();
+            mLines = new List<string>();
+            mPrecond = new List<string>();
+            mPostcond = new List<string>();
+            mFormalParams = new List<FormalTypeParameter>();
+            mVarsToInitialize = new List<string>();
+            mAttributes = new List<string>();
+
+            this.Implicit = false;
+            this.Explicit = false;
+            this.Operator = false;
+
+            this.mbUnsafe = mbUnsafe;
+            this.mbIsExtern = mbIsExtern;
+            this.mbIsStatic = mbIsStatic;
+            this.mbIsVirtual = mbIsVirtual;
+            this.mbIsNewSlot = mbIsNewSlot;
+            this.mbIsSealed = mbIsSealed;
+            this.mbIsAbstract = mbIsAbstract;
+            this.mbIsConstructor = mbIsConstructor;
+            this.mbIsFinalizer = mbIsFinalizer;
+            this.mbIsOverride = mbIsOverride;
+            this.mCustomInitList = mCustomInitList;
+        }
+
+        public override bool IsMethod { get { return true; } }
+        public override bool IsUnsafe { get { return mbUnsafe; } }
+        public override string Name { get { return mName; } }
+
+        public bool Implicit { get; set; } /// useful for operators
+        public bool Explicit { get; set; } /// useful for operators
+        public string ReturnType { get { return mReturnType; } set { mReturnType = value; } } /// useful for operators
+        public void SetName(string name) { mName = name; }
+        public bool Operator { get; set; }
+
+        public override void Output(OutputHelper oh)
+        {
+            if (mAttributes.Count > 0)
+            {
+                foreach (var att in mAttributes)
+                    oh.Output("[" + att + "]", true);
+            }
+
+            if (mbUnsafe)
+                oh.Output("unsafe ", false);
+
+            if (Operator || (!mbIsFinalizer && !mName.Contains(".")))
+            {
+                //** Accessibility
+                switch (mAccess)
+                {
+                    case Access.INTERNAL_AND_OR_PROTECTED:
+                        oh.Output("protected internal ", false);
+                        break;
+                    case Access.INTERNAL:
+                        oh.Output("internal ", false);
+                        break;
+                    case Access.PRIVATE:
+                        oh.Output("private ", false);
+                        break;
+                    case Access.PROTECTED:
+                        oh.Output("protected ", false);
+                        break;
+                    case Access.PUBLIC:
+                        oh.Output("public ", false);
+                        break;
+                }
+
+                //** Modifiers
+                if (mbIsExtern)
+                    oh.Output("extern ", false);
+                if (mbIsStatic)
+                    oh.Output("static ", false);
+                if (mbIsVirtual)
+                    oh.Output("virtual ", false);
+                if (mbIsNewSlot)
+                    oh.Output("new ", false);
+                if (mbIsSealed)
+                    oh.Output("sealed ", false);
+                if (mbIsAbstract)
+                    oh.Output("abstract ", false);
+                if (mbIsOverride)
+                    oh.Output("override ", false);
+                if (Implicit)
+                    oh.Output("implicit ", false);
+                if (Explicit)
+                    oh.Output("explicit ", false);
+            }
+
+            if (!mbIsConstructor && !mbIsFinalizer)
+                oh.Output(mReturnType + (mReturnType.Length > 0 ? " " : ""), false);
+
+            if (Operator)
+                oh.Output("operator ", false);
+
+            if (mbIsFinalizer)
+                oh.Output("~", false);
+
+            oh.Output(mName, false);
+
+            //** Formal parameters
+            if (mFormalParams.Count > 0)
+            {
+                oh.Output("<", false);
+                bool first = true;
+                foreach (var t in mFormalParams)
+                {
+                    if (first)
+                        first = false;
+                    else
+                        oh.Output(", ", false);
+
+                    t.OutputName(oh);
+                }
+                oh.Output(">", false);
+            }
+
+            oh.Output("(", false);
+            mParams.OutputList(oh);
+            oh.Output(")", false);
+
+            // In these cases, stop there
+            if (mbIsAbstract || mbIsExtern || mbIsInInterface)
+            {
+                oh.Output(";", true);
+                return;
+            }
+
+            if (mCustomInitList.Length > 0)
+                oh.Output(mCustomInitList, false);
+
+            oh.OutputEOL();
+
+            //** Formal type parameters constraints
+            if (mFormalParams.Count > 0)
+            {
+                oh.IncrIndent();
+                foreach (var cst in mFormalParams)
+                    cst.OutputConstraint(oh);
+                oh.DecrIndent();
+            }
+
+            //** Body
             oh.Output("{", true);
             oh.IncrIndent();
 
             // Determine if there is already a symbol named "Contract" accessible from the body of the method
             string contract_name = "Contract";
             if (mParent.HasSymbol("Contract"))
-              contract_name = "System.Diagnostics.Contracts.Contract";
+                contract_name = "System.Diagnostics.Contracts.Contract";
 
-            foreach (var cond in mRemovePrecond)
-              oh.Output(contract_name + ".Requires(" + cond + ");", true);
-            foreach (var cond in mRemovePostcond)
-              oh.Output(contract_name + ".Ensures(" + cond + ");", true);
+            foreach (var cond in mPrecond)
+                oh.Output(contract_name + ".Requires(" + cond + ");", true);
+            foreach (var cond in mPostcond)
+                oh.Output(contract_name + ".Ensures(" + cond + ");", true);
 
-            if (mBodyRemove.Count > 0
-              && (mRemovePrecond.Count > 0 || mRemovePostcond.Count > 0))
-              oh.OutputEOL();
+            bool firstl = true;
+            foreach (var l in mLines)
+            {
+                if ((mPrecond.Count > 0 || mPostcond.Count > 0) && firstl)
+                    oh.OutputEOL();
+                oh.Output(l, true);
+                firstl = false;
+            }
 
-            foreach (var line in mBodyRemove)
-              oh.Output(line, true);
+            bool firstv = true;
+            foreach (var v in mVarsToInitialize)
+            {
+                if ((firstv && !firstl) || (firstv && firstl && (mPrecond.Count > 0 || mPostcond.Count > 0)))
+                    oh.OutputEOL();
+                oh.Output(v, true);
+                firstv = false;
+            }
+
+            if (mReturnType != "void" && mReturnType != "System.Void"
+              && !mbIsConstructor && !mbIsFinalizer)
+            {
+                if (mPrecond.Count > 0 || mPostcond.Count > 0
+                  || mLines.Count > 0 || mVarsToInitialize.Count > 0)
+                    oh.OutputEOL();
+                if (Operator && mReturnType.Length == 0) // Particular case for conversion operators
+                    oh.Output("return default(" + mName + ");", true);
+                else
+                    oh.Output("return default(" + mReturnType + ");", true);
+            }
 
             oh.DecrIndent();
             oh.Output("}", true);
-          }
+        }
+
+        public void AddParameter(Parameter newparam)
+        {
+            Contract.Requires(newparam != null);
+
+            mParams.AddParameter(newparam);
+            if (newparam.GetModifier() == Parameter.Modifier.OUT)
+                AddVarToInitialize(newparam.Type, newparam.Name);
+            if (newparam.IsUnsafe)
+                ForceUnsafe(true);
+        }
+
+        public void ForceUnsafe(bool uns)
+        {
+            mbUnsafe = uns;
+        }
+
+        public void AddFormalTypeParameter(FormalTypeParameter ftp)
+        {
+            mFormalParams.Add(ftp);
+        }
+
+        public void AddFormalTypeParameters(List<FormalTypeParameter> ftpl)
+        {
+            Contract.Requires(ftpl != null);
+
+            mFormalParams.AddRange(ftpl);
+        }
+
+        public void AddVarToInitialize(string type, string name)
+        {
+            mVarsToInitialize.Add(name + " = default(" + type + ");");
+        }
+
+        public void AddLine(string line)
+        {
+            mLines.Add(line);
+        }
+
+        public void AddPrecond(string cond)
+        {
+            mPrecond.Add(cond);
+        }
+
+        public void AddPostcond(string cond)
+        {
+            mPostcond.Add(cond);
+        }
+
+        public void AddAttribute(string att)
+        {
+            mAttributes.Add(att);
+        }
+
+        #region Privates
+        private Access mAccess;
+        private bool mbIsInInterface;
+        private Class mParent;
+        private Namespace mParentNS;
+        private string mReturnType;
+        private string mName;
+        private ParametersList mParams; /// In the form "modifier type name"
+        private List<FormalTypeParameter> mFormalParams;
+        private List<string> mLines;
+        private List<string> mPrecond, mPostcond;
+        private List<string> mVarsToInitialize;
+        private List<string> mAttributes; /// Each string here is output as an attribute before the method body
+
+        private bool mbUnsafe;
+        private bool mbIsExtern;
+        private bool mbIsStatic;
+        private bool mbIsVirtual;
+        private bool mbIsNewSlot;
+        private bool mbIsSealed;
+        private bool mbIsAbstract;
+        private bool mbIsConstructor;
+        private bool mbIsFinalizer;
+        private bool mbIsOverride;
+        private string mCustomInitList;
+        #endregion
+    }
+
+    [ContractVerification(false)]
+    public class Delegate : ElementBase
+    {
+        public Delegate(Access mAccess, bool mbUnsafe, string mName, Class mParent, Namespace mParentNS, string mReturnType)
+        {
+            this.mAccess = mAccess;
+            this.mbUnsafe = mbUnsafe;
+            this.mName = mName;
+            this.mParent = mParent;
+            this.mParentNS = mParentNS;
+            this.mReturnType = mReturnType;
+
+            mParams = new ParametersList();
+            mFormalParams = new List<FormalTypeParameter>();
+        }
+
+        public override bool IsDelegate { get { return true; } }
+        public override string Name { get { return mName; } }
+
+        public Class Parent { get { return mParent; } }
+        public Namespace Namespace { get { return mParentNS; } }
+
+        public override void Output(OutputHelper oh)
+        {
+            //if (mParent == null && oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
+            //  mParentNS.OpenNamespace(oh);
+
+            if (mbUnsafe)
+                oh.Output("unsafe ", false);
+
+            switch (mAccess)
+            {
+                case Access.INTERNAL:
+                    oh.Output("internal ", false);
+                    break;
+                case Access.PRIVATE:
+                    oh.Output("private ", false);
+                    break;
+                case Access.PROTECTED:
+                    oh.Output("protected ", false);
+                    break;
+                case Access.PUBLIC:
+                    oh.Output("public ", false);
+                    break;
+                case Access.INTERNAL_AND_OR_PROTECTED:
+                    oh.Output("internal protected ", false);
+                    break;
+            }
+
+            oh.Output("delegate " + mReturnType + " " + mName, false);
+
+            //** Formal parameters
+            if (mFormalParams.Count > 0)
+            {
+                oh.Output("<", false);
+                bool first = true;
+                foreach (var t in mFormalParams)
+                {
+                    if (first)
+                        first = false;
+                    else
+                        oh.Output(", ", false);
+
+                    t.OutputName(oh);
+                }
+                oh.Output(">", false);
+            }
+
+            oh.Output("(", false);
+            mParams.OutputList(oh);
+            oh.Output(")", false);
+
+            //** Formal type parameters constraints
+            if (mFormalParams.Count > 0)
+            {
+                oh.IncrIndent();
+                foreach (var cst in mFormalParams)
+                    cst.OutputConstraint(oh);
+                oh.DecrIndent();
+            }
+
+            oh.Output(";", true);
+
+            //if (mParent == null && oh.Strategy != OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE)
+            //  mParentNS.CloseNamespace(oh);
+        }
+
+        public void ForceUnsafe(bool uns)
+        {
+            mbUnsafe = uns;
+        }
+
+        public void AddParameter(Parameter param)
+        {
+            Contract.Requires(param != null);
+            mParams.AddParameter(param);
+            if (param.IsUnsafe)
+                ForceUnsafe(true);
+        }
+
+        public void AddFormalTypeParameter(FormalTypeParameter ftp)
+        {
+            mFormalParams.Add(ftp);
+        }
+
+        public void AddFormalTypeParameters(List<FormalTypeParameter> ftpl)
+        {
+            Contract.Requires(ftpl != null);
+
+            mFormalParams.AddRange(ftpl);
+        }
+
+        #region Privates.
+        private Access mAccess;
+        private bool mbUnsafe;
+        private string mName;
+        private Class mParent;
+        private Namespace mParentNS;
+        private ParametersList mParams;
+        private string mReturnType;
+        private List<FormalTypeParameter> mFormalParams;
+        #endregion
+    }
+
+    [ContractVerification(false)]
+    public class Parameter
+    {
+        public Parameter(string type, string name, Modifier mModifier)
+        {
+            mType = type;
+            mName = name;
+            this.mModifier = mModifier;
+        }
+
+        public string Name { get { return mName; } }
+        public string Type { get { return mType; } }
+        public Modifier GetModifier() { return mModifier; }
+        public bool IsUnsafe { get { return mType.Contains("*"); } }
+
+        public void Output(OutputHelper oh)
+        {
+            Contract.Requires(oh != null);
+
+            if (mModifier == Modifier.OUT)
+                oh.Output("out ", false);
+            else if (mModifier == Modifier.REF)
+                oh.Output("ref ", false);
+
+            oh.Output(mType + " " + mName, false);
+        }
+
+        public enum Modifier
+        {
+            NONE,
+            REF,
+            OUT,
+        }
+
+        private string mType;
+        private string mName;
+        private Modifier mModifier;
+    }
+
+    public class ParametersList
+    {
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(mParams != null);
+        }
+
+
+        public ParametersList()
+        {
+            mParams = new List<Parameter>();
+        }
+
+        public void AddParameter(Parameter newparam)
+        {
+            mParams.Add(newparam);
+        }
+
+        public void OutputList(OutputHelper oh)
+        {
+            bool first = true;
+            foreach (var p in mParams)
+            {
+                if (first)
+                    first = false;
+                else
+                    oh.Output(", ", false);
+
+                p.Output(oh);
+            }
+        }
+
+        public bool IsEmpty()
+        {
+            return mParams.Count > 0;
+        }
+
+        readonly private List<Parameter> mParams;
+    }
+
+    [ContractVerification(false)]
+    public class Property : ElementBase
+    {
+        public Property(Class mParent, bool mbHasGetter, bool mbHasSetter, string mName, bool mbIsUnsafe, bool mbIsInInterface, bool mbIsIndexer, string mReturnType, Access mAccess, Access mAccessGet, Access mAccessSet, bool mbIsStatic, bool mbIsNewSlot, bool mbIsOverride, bool mbIsSealed, bool mbIsVirtual, bool mbIsExtern, bool mbIsAbstract)
+        {
+            Contract.Requires(mParent != null);
+
+            this.mParent = mParent;
+            mParentNS = mParent.Namespace;
+            this.mbHasGetter = mbHasGetter;
+            this.mbHasSetter = mbHasSetter;
+            this.mName = mName;
+            this.mbIsUnsafe = mbIsUnsafe;
+            this.mbIsInInterface = mbIsInInterface;
+            this.mbIsIndexer = mbIsIndexer;
+            this.mReturnType = mReturnType;
+            this.mbIsNewSlot = mbIsNewSlot;
+            this.mbIsOverride = mbIsOverride;
+            this.mbIsSealed = mbIsSealed;
+            this.mbIsStatic = mbIsStatic;
+            this.mbIsVirtual = mbIsVirtual;
+            this.mbIsExtern = mbIsExtern;
+            this.mbIsAbstract = mbIsAbstract;
+
+            mParameters = new ParametersList();
+            mBodyGet = new List<string>();
+            mBodySet = new List<string>();
+            mGetPrecond = new List<string>();
+            mGetPostcond = new List<string>();
+            mSetPrecond = new List<string>();
+            mSetPostcond = new List<string>();
+            this.mAccess = mAccess;
+            this.mAccessGet = mAccessGet;
+            this.mAccessSet = mAccessSet;
+        }
+
+        public override bool IsProperty { get { return true; } }
+        public override bool IsUnsafe { get { return mbIsUnsafe; } }
+        public override string Name { get { return mName; } }
+
+        public void AddLineToGetBody(string line)
+        {
+            mBodyGet.Add(line);
+        }
+        public void AddLineToSetBody(string line)
+        {
+            mBodySet.Add(line);
+        }
+        public void AddPrecondToGet(string precond)
+        {
+            mGetPrecond.Add(precond);
+        }
+        public void AddPostcondToGet(string postcond)
+        {
+            mGetPostcond.Add(postcond);
+        }
+        public void AddPrecondToSet(string precond)
+        {
+            mSetPrecond.Add(precond);
+        }
+        public void AddPostcondToSet(string postcond)
+        {
+            mSetPostcond.Add(postcond);
+        }
+
+        public void AddParameter(Parameter param) // No modifier for indexers
+        {
+            Contract.Requires(param != null);
+
+            mParameters.AddParameter(param);
+            if (param.IsUnsafe)
+                ForceUnsafe(true);
+        }
+
+        public void ForceUnsafe(bool uns)
+        {
+            mbIsUnsafe = uns;
+        }
+
+        public override void Output(OutputHelper oh)
+        {
+            if (mbIsUnsafe)
+                oh.Output("unsafe ", false);
+
+            if (!mbHasGetter && !mbHasSetter)
+            {
+                string err = "Error, property \"" + mName + "\" must have either a getter or a setter."; // Empty property, should never happen
+                oh.DebugOutput("Pretty C# Output error: " + err);
+                oh.Output("/* " + err + " */", true);
+            }
+
+            if (mbIsIndexer && mName != "Item" && !mName.EndsWith(".Item"))
+            {
+                string alt = mName;
+                if (alt.Contains("."))
+                    alt = alt.Substring(alt.LastIndexOf('.') + 1);
+                oh.Output("[System.Runtime.CompilerServices.IndexerName(\"" + alt + "\")]", true);
+            }
+
+            if (!mName.Contains("."))
+            {
+                OutputAccessibility(oh, mAccess);
+
+                if (mbIsAbstract)
+                    oh.Output("abstract ", false);
+                if (mbIsVirtual)
+                    oh.Output("virtual ", false);
+                if (mbIsExtern)
+                    oh.Output("extern ", false);
+                if (mbIsStatic)
+                    oh.Output("static ", false);
+                if (mbIsNewSlot)
+                    oh.Output("new ", false);
+                if (mbIsOverride)
+                    oh.Output("override ", false);
+                if (mbIsSealed)
+                    oh.Output("sealed ", false);
+            }
+
+            oh.Output(mReturnType + " ", false);
+
+            if (!mbIsIndexer)
+                oh.Output(mName, true);
+            else
+            {
+                int lastdot = mName.LastIndexOf('.');
+                if (lastdot < 0)
+                {
+                    oh.Output("this", false);
+                }
+                else // explicit implementation, such as NS.Interface.this
+                {
+                    string name = mName.Substring(0, lastdot) + ".this";
+
+                    oh.Output(name, false);
+                }
+
+                oh.Output(" [", false);
+                mParameters.OutputList(oh);
+                oh.Output("]", true);
+            }
+
+            oh.Output("{", true);
+            oh.IncrIndent();
+
+            #region Getter
+            if (mbHasGetter)
+            {
+                OutputAccessibility(oh, mAccessGet);
+                oh.Output("get", false);
+                if (mbIsInInterface || mbIsAbstract)
+                    oh.Output(";", true);
+                else
+                {
+                    oh.OutputEOL();
+                    oh.Output("{", true);
+                    oh.IncrIndent();
+
+                    foreach (var cond in mGetPrecond)
+                        oh.Output("Contract.Requires(" + cond + ");", true);
+                    foreach (var cond in mGetPostcond)
+                        oh.Output("Contract.Ensures(" + cond + ");", true);
+
+                    if (mGetPrecond.Count > 0 || mGetPostcond.Count > 0)
+                        oh.OutputEOL();
+
+                    foreach (var line in mBodyGet)
+                        oh.Output(line, true);
+
+                    if (mBodyGet.Count > 0)
+                        oh.OutputEOL();
+
+                    oh.Output("return default(" + mReturnType + ");", true);
+
+                    oh.DecrIndent();
+                    oh.Output("}", true);
+                }
+            }
+            #endregion
+
+            #region Setter
+            if (mbHasSetter)
+            {
+                OutputAccessibility(oh, mAccessSet);
+                oh.Output("set", false);
+                if (mbIsInInterface || mbIsAbstract)
+                    oh.Output(";", true);
+                else
+                {
+                    oh.OutputEOL();
+                    oh.Output("{", true);
+                    oh.IncrIndent();
+
+                    // Determine if there is already a symbol named "Contract" accessible from the body of the method
+                    string contract_name = "Contract";
+                    if (mParent.HasSymbol("Contract"))
+                        contract_name = "System.Diagnostics.Contracts.Contract";
+
+                    foreach (var cond in mSetPrecond)
+                        oh.Output(contract_name + ".Requires(" + cond + ");", true);
+                    foreach (var cond in mSetPostcond)
+                        oh.Output(contract_name + ".Ensures(" + cond + ");", true);
+
+                    if (mBodySet.Count > 0
+                      && (mSetPrecond.Count > 0 || mSetPostcond.Count > 0))
+                        oh.OutputEOL();
+
+                    foreach (var line in mBodySet)
+                        oh.Output(line, true);
+
+                    oh.DecrIndent();
+                    oh.Output("}", true);
+                }
+            }
+            #endregion
+
+            oh.DecrIndent();
+            oh.Output("}", true);
+        }
+
+        private void OutputAccessibility(OutputHelper oh, Access access)
+        {
+            if (mbIsInInterface || access == Access.NONE)
+                return;
+
+            switch (access)
+            {
+                case Access.INTERNAL:
+                    oh.Output("internal ", false);
+                    break;
+                case Access.PRIVATE:
+                    oh.Output("private ", false);
+                    break;
+                case Access.PROTECTED:
+                    oh.Output("protected ", false);
+                    break;
+                case Access.PUBLIC:
+                    oh.Output("public ", false);
+                    break;
+                case Access.INTERNAL_AND_OR_PROTECTED:
+                    oh.Output("internal protected ", false);
+                    break;
+            }
+        }
+
+        private Class mParent;
+        private Namespace mParentNS;
+        private bool mbHasGetter, mbHasSetter;
+        private string mName; /// Even if it's an indexer
+        private bool mbIsUnsafe;
+        private bool mbIsInInterface;
+        private bool mbIsIndexer;
+        private string mReturnType;
+
+        private Access mAccess, mAccessGet, mAccessSet;
+
+        private bool mbIsStatic;
+        private bool mbIsNewSlot;
+        private bool mbIsOverride;
+        private bool mbIsSealed;
+        private bool mbIsVirtual;
+        private bool mbIsExtern;
+        private bool mbIsAbstract;
+        private ParametersList mParameters;
+
+        private List<string> mBodyGet, mBodySet;
+        private List<string> mGetPrecond, mGetPostcond;
+        private List<string> mSetPrecond, mSetPostcond;
+    }
+
+    [ContractVerification(false)]
+    public class Event : ElementBase
+    {
+        public Event(Class mParent, bool mbHasAdd, bool mbHasRemove, string mName, bool mbIsUnsafe, bool mbIsInInterface, string mReturnType, Access mAccess, Access mAccessGet, Access mAccessSet, bool mbIsStatic, bool mbIsNewSlot, bool mbIsOverride, bool mbIsSealed, bool mbIsVirtual, bool mbIsExtern, bool mbIsAbstract)
+        {
+            Contract.Requires(mParent != null);
+
+            this.mParent = mParent;
+            mParentNS = mParent.Namespace;
+            this.mbHasAdd = mbHasAdd;
+            this.mbHasRemove = mbHasRemove;
+            this.mName = mName;
+            this.mbIsUnsafe = mbIsUnsafe;
+            this.mbIsInInterface = mbIsInInterface;
+            this.mReturnType = mReturnType;
+            this.mbIsNewSlot = mbIsNewSlot;
+            this.mbIsOverride = mbIsOverride;
+            this.mbIsSealed = mbIsSealed;
+            this.mbIsStatic = mbIsStatic;
+            this.mbIsVirtual = mbIsVirtual;
+            this.mbIsExtern = mbIsExtern;
+            this.mbIsAbstract = mbIsAbstract;
+
+            mParameters = new ParametersList();
+            mBodyAdd = new List<string>();
+            mBodyRemove = new List<string>();
+            mAddPrecond = new List<string>();
+            mAddPostcond = new List<string>();
+            mRemovePrecond = new List<string>();
+            mRemovePostcond = new List<string>();
+            this.mAccess = mAccess;
+            this.mAccessGet = mAccessGet;
+            this.mAccessSet = mAccessSet;
+        }
+
+        public override bool IsEvent { get { return true; } }
+        public override bool IsUnsafe { get { return mbIsUnsafe; } }
+        public override string Name { get { return mName; } }
+
+        public void AddLineToGetBody(string line)
+        {
+            mBodyAdd.Add(line);
+        }
+        public void AddLineToSetBody(string line)
+        {
+            mBodyRemove.Add(line);
+        }
+        public void AddPrecondToGet(string precond)
+        {
+            mAddPrecond.Add(precond);
+        }
+        public void AddPostcondToGet(string postcond)
+        {
+            mAddPostcond.Add(postcond);
+        }
+        public void AddPrecondToSet(string precond)
+        {
+            mRemovePrecond.Add(precond);
+        }
+        public void AddPostcondToSet(string postcond)
+        {
+            mRemovePostcond.Add(postcond);
+        }
+
+        public void AddParameter(Parameter param) // No modifier for indexers
+        {
+            Contract.Requires(param != null);
+            mParameters.AddParameter(param);
+            if (param.IsUnsafe)
+                ForceUnsafe(true);
+        }
+
+        public void ForceUnsafe(bool uns)
+        {
+            mbIsUnsafe = uns;
+        }
+
+        public override void Output(OutputHelper oh)
+        {
+            bool inInterface = (mParent.Type == Class.ClassType.INTERFACE);
+
+            if (mbIsUnsafe)
+                oh.Output("unsafe ", false);
+
+            if (!mbHasAdd && !mbHasRemove)
+            {
+                string err = "Error, event \"" + mName + "\" must have either an add or a remove."; // Empty property, should never happen
+                oh.DebugOutput("Pretty C# Output error: " + err);
+                oh.Output("/* " + err + " */", true);
+            }
+
+            if (!mName.Contains("."))
+            {
+                OutputAccessibility(oh, mAccess);
+
+                if (mbIsAbstract)
+                    oh.Output("abstract ", false);
+                if (mbIsVirtual)
+                    oh.Output("virtual ", false);
+                if (mbIsExtern)
+                    oh.Output("extern ", false);
+                if (mbIsStatic)
+                    oh.Output("static ", false);
+                if (mbIsNewSlot)
+                    oh.Output("new ", false);
+                if (mbIsOverride)
+                    oh.Output("override ", false);
+                if (mbIsSealed)
+                    oh.Output("sealed ", false);
+            }
+
+            oh.Output("event ", false);
+
+            oh.Output(mReturnType + " ", false);
+
+            oh.Output(mName, true);
+
+            if (inInterface)
+            {
+                oh.Output(";", true);
+            }
+            else
+            {
+                oh.Output("{", true);
+                oh.IncrIndent();
+
+                #region Add
+                if (mbHasAdd)
+                {
+                    OutputAccessibility(oh, mAccessGet);
+                    oh.Output("add", false);
+                    if (mbIsInInterface || mbIsAbstract)
+                        oh.Output(";", true);
+                    else
+                    {
+                        oh.OutputEOL();
+                        oh.Output("{", true);
+                        oh.IncrIndent();
+
+                        foreach (var cond in mAddPrecond)
+                            oh.Output("Contract.Requires(" + cond + ");", true);
+                        foreach (var cond in mAddPostcond)
+                            oh.Output("Contract.Ensures(" + cond + ");", true);
+
+                        if (mAddPrecond.Count > 0 || mAddPostcond.Count > 0)
+                            oh.OutputEOL();
+
+                        foreach (var line in mBodyAdd)
+                            oh.Output(line, true);
+
+                        if (mBodyAdd.Count > 0)
+                            oh.OutputEOL();
+
+                        //oh.Output("return default(" + mReturnType + ");", true);
+
+                        oh.DecrIndent();
+                        oh.Output("}", true);
+                    }
+                }
+                #endregion
+
+                #region Remove
+                if (mbHasRemove)
+                {
+                    OutputAccessibility(oh, mAccessSet);
+                    oh.Output("remove", false);
+                    if (mbIsInInterface || mbIsAbstract)
+                        oh.Output(";", true);
+                    else
+                    {
+                        oh.OutputEOL();
+                        oh.Output("{", true);
+                        oh.IncrIndent();
+
+                        // Determine if there is already a symbol named "Contract" accessible from the body of the method
+                        string contract_name = "Contract";
+                        if (mParent.HasSymbol("Contract"))
+                            contract_name = "System.Diagnostics.Contracts.Contract";
+
+                        foreach (var cond in mRemovePrecond)
+                            oh.Output(contract_name + ".Requires(" + cond + ");", true);
+                        foreach (var cond in mRemovePostcond)
+                            oh.Output(contract_name + ".Ensures(" + cond + ");", true);
+
+                        if (mBodyRemove.Count > 0
+                          && (mRemovePrecond.Count > 0 || mRemovePostcond.Count > 0))
+                            oh.OutputEOL();
+
+                        foreach (var line in mBodyRemove)
+                            oh.Output(line, true);
+
+                        oh.DecrIndent();
+                        oh.Output("}", true);
+                    }
+                }
+                #endregion
+
+                oh.DecrIndent();
+                oh.Output("}", true);
+            }
+        }
+
+        private void OutputAccessibility(OutputHelper oh, Access access)
+        {
+            if (mbIsInInterface || access == Access.NONE)
+                return;
+
+            switch (access)
+            {
+                case Access.INTERNAL:
+                    oh.Output("internal ", false);
+                    break;
+                case Access.PRIVATE:
+                    oh.Output("private ", false);
+                    break;
+                case Access.PROTECTED:
+                    oh.Output("protected ", false);
+                    break;
+                case Access.PUBLIC:
+                    oh.Output("public ", false);
+                    break;
+                case Access.INTERNAL_AND_OR_PROTECTED:
+                    oh.Output("internal protected ", false);
+                    break;
+            }
+        }
+
+        private Class mParent;
+        private Namespace mParentNS;
+        private bool mbHasAdd, mbHasRemove;
+        private string mName; /// Even if it's an indexer
+        private bool mbIsUnsafe;
+        private bool mbIsInInterface;
+        private string mReturnType;
+
+        private Access mAccess, mAccessGet, mAccessSet;
+
+        private bool mbIsStatic;
+        private bool mbIsNewSlot;
+        private bool mbIsOverride;
+        private bool mbIsSealed;
+        private bool mbIsVirtual;
+        private bool mbIsExtern;
+        private bool mbIsAbstract;
+        private ParametersList mParameters;
+
+        private List<string> mBodyAdd, mBodyRemove;
+        private List<string> mAddPrecond, mAddPostcond;
+        private List<string> mRemovePrecond, mRemovePostcond;
+    }
+
+    [ContractVerification(false)]
+    public class Field : ElementBase
+    {
+        public Field(string mType, string mName, Class mParent, string mOutputDefault, ParentType mParentType, Access mAccess, bool mbIsUnsafe, bool mbIsReadOnly, bool mbIsStatic, bool mbIsNewSlot, bool mbIsVolatile)
+        {
+            this.mType = mType;
+            this.mName = mName;
+            this.mParent = mParent;
+
+            this.mOutputDefault = mOutputDefault;
+            this.mParentType = mParentType;
+            this.mAccess = mAccess;
+            this.mbIsUnsafe = mbIsUnsafe;
+            this.mbIsReadOnly = mbIsReadOnly;
+            this.mbIsStatic = mbIsStatic;
+            this.mbIsNewSlot = mbIsNewSlot;
+            this.mbIsVolatile = mbIsVolatile;
+        }
+
+        public override bool IsField { get { return true; } }
+        public override bool IsUnsafe { get { return mbIsUnsafe; } }
+        public override string Name { get { return mName; } }
+
+        public override void Output(OutputHelper oh)
+        {
+            // No accessibility nor modifiers on interface members
+            if (mParentType != ParentType.INTERFACE)
+            {
+                switch (mAccess)
+                {
+                    case Access.PUBLIC:
+                        oh.Output("public ", false);
+                        break;
+                    case Access.PROTECTED:
+                        oh.Output("protected ", false);
+                        break;
+                    case Access.PRIVATE:
+                        oh.Output("private ", false);
+                        break;
+                    case Access.INTERNAL:
+                        oh.Output("internal ", false);
+                        break;
+                    case Access.INTERNAL_AND_OR_PROTECTED:
+                        oh.Output("internal protected ", false);
+                        break;
+                }
+
+                if (mbIsReadOnly)
+                    oh.Output("readonly ", false);
+                if (mbIsStatic)
+                    oh.Output("static ", false);
+                if (mbIsNewSlot)
+                    oh.Output("new ", false);
+                if (mbIsVolatile)
+                    oh.Output("volatile ", false);
+            }
+
+            oh.Output(mType + " " + mName, false);
+            if (mOutputDefault.Length > 0 && mParentType == ParentType.CLASS)
+                oh.Output(" = " + mOutputDefault, false);
+
+            oh.Output(";", true);
+        }
+
+        #region Enums
+        public enum ParentType
+        {
+            CLASS,
+            STRUCT,
+            INTERFACE,
         }
         #endregion
 
-        oh.DecrIndent();
-        oh.Output("}", true);
-      }
-    }
+        #region Privates
+        private string mType;
+        private string mName;
 
-    private void OutputAccessibility(OutputHelper oh, Access access)
-    {
-      if (mbIsInInterface || access == Access.NONE)
-        return;
+        private string mOutputDefault; /// Output "... = mOutputDefault" (nothing if empty string)
+        private ParentType mParentType;
+        private Class mParent;
+        private Access mAccess;
+        private bool mbIsUnsafe;
 
-      switch (access)
-      {
-        case Access.INTERNAL:
-          oh.Output("internal ", false);
-          break;
-        case Access.PRIVATE:
-          oh.Output("private ", false);
-          break;
-        case Access.PROTECTED:
-          oh.Output("protected ", false);
-          break;
-        case Access.PUBLIC:
-          oh.Output("public ", false);
-          break;
-        case Access.INTERNAL_AND_OR_PROTECTED:
-          oh.Output("internal protected ", false);
-          break;
-      }
-    }
-
-    private Class mParent;
-    private Namespace mParentNS;
-    private bool mbHasAdd, mbHasRemove;
-    private string mName; /// Even if it's an indexer
-    private bool mbIsUnsafe;
-    private bool mbIsInInterface;
-    private string mReturnType;
-
-    Access mAccess, mAccessGet, mAccessSet;
-
-    private bool mbIsStatic;
-    private bool mbIsNewSlot;
-    private bool mbIsOverride;
-    private bool mbIsSealed;
-    private bool mbIsVirtual;
-    private bool mbIsExtern;
-    private bool mbIsAbstract;
-    private ParametersList mParameters;
-
-    private List<string> mBodyAdd, mBodyRemove;
-    private List<string> mAddPrecond, mAddPostcond;
-    private List<string> mRemovePrecond, mRemovePostcond;
-  }
-
-  [ContractVerification(false)]
-  public class Field : ElementBase
-  {
-    public Field(string mType, string mName, Class mParent, string mOutputDefault, ParentType mParentType, Access mAccess, bool mbIsUnsafe, bool mbIsReadOnly, bool mbIsStatic, bool mbIsNewSlot, bool mbIsVolatile)
-    {
-      this.mType = mType;
-      this.mName = mName;
-      this.mParent = mParent;
-
-      this.mOutputDefault = mOutputDefault;
-      this.mParentType = mParentType;
-      this.mAccess = mAccess;
-      this.mbIsUnsafe = mbIsUnsafe;
-      this.mbIsReadOnly = mbIsReadOnly;
-      this.mbIsStatic = mbIsStatic;
-      this.mbIsNewSlot = mbIsNewSlot;
-      this.mbIsVolatile = mbIsVolatile;
-    }
-
-    public override bool IsField { get { return true; } }
-    public override bool IsUnsafe { get { return mbIsUnsafe; } }
-    public override string Name { get { return mName; } }
-
-    public override void Output(OutputHelper oh)
-    {
-      // No accessibility nor modifiers on interface members
-      if (mParentType != ParentType.INTERFACE)
-      {
-        switch (mAccess)
-        {
-          case Access.PUBLIC:
-            oh.Output("public ", false);
-            break;
-          case Access.PROTECTED:
-            oh.Output("protected ", false);
-            break;
-          case Access.PRIVATE:
-            oh.Output("private ", false);
-            break;
-          case Access.INTERNAL:
-            oh.Output("internal ", false);
-            break;
-          case Access.INTERNAL_AND_OR_PROTECTED:
-            oh.Output("internal protected ", false);
-            break;
-        }
-
-        if (mbIsReadOnly)
-          oh.Output("readonly ", false);
-        if (mbIsStatic)
-          oh.Output("static ", false);
-        if (mbIsNewSlot)
-          oh.Output("new ", false);
-        if (mbIsVolatile)
-          oh.Output("volatile ", false);
-      }
-
-      oh.Output(mType + " " + mName, false);
-      if (mOutputDefault.Length > 0 && mParentType == ParentType.CLASS)
-        oh.Output(" = " + mOutputDefault, false);
-
-      oh.Output(";", true);
-    }
-
-    #region Enums
-    public enum ParentType
-    {
-      CLASS,
-      STRUCT,
-      INTERFACE,
-    }
-    #endregion
-
-    #region Privates
-    string mType;
-    string mName;
-
-    private string mOutputDefault; /// Output "... = mOutputDefault" (nothing if empty string)
-    private ParentType mParentType;
-    private Class mParent;
-    private Access mAccess;
-    private bool mbIsUnsafe;
-
-    private bool mbIsReadOnly;
-    private bool mbIsStatic;
-    private bool mbIsNewSlot;
-    private bool mbIsVolatile;
-    #endregion
-  }
-
-  /// <summary>
-  /// This class is a container for outputing C# code
-  /// </summary>
-  public class CodeManager
-  {
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.mNamespaces != null);
-    }
-
-
-    public CodeManager()
-    {
-      this.mNamespaces = new List<Namespace>();
-      this.mNamespaces.Add(new Namespace("<toplevel>"));
-    }
-
-    public void OutputCode (string ProjectFolder, string RelativeFilesPath, IOutput mOutput, out List<string> WrittenFiles, OutputHelper.OutputStrategy Strategy, List<string> Usings, bool verbose)
-    {
-      Contract.Requires(ProjectFolder != null);
-      Contract.Requires(RelativeFilesPath != null);
-      Contract.Requires(mOutput != null);
-
-      var oh =
-        new OutputHelper (
-          //OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE,
-          //OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS,
-          //OutputHelper.OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS,
-          Strategy,
-          ProjectFolder,
-          RelativeFilesPath,
-          Usings,
-          mOutput,
-          verbose);
-
-      foreach (var ns in mNamespaces)
-      {
-        if (!ns.Empty())
-          ns.Output(oh);
-      }
-
-      WrittenFiles = oh.WrittenFiles;
-    }
-
-    public void OutputProperties(string folder, string assemblyName, List<string> writtenFiles)
-    {
-      Contract.Requires(folder != null);
-      Contract.Requires(writtenFiles != null);
-
-      try
-      {
-        var properties = Path.Combine(folder, "Properties");
-        Directory.CreateDirectory(properties);
-
-        StreamWriter assemblyInfoFile = null;
-        var assemblyInfoFileName = Path.Combine(properties, "AssemblyInfo.cs");
-        try
-        {
-          assemblyInfoFile = File.CreateText(assemblyInfoFileName);
-          var assemblyInfoTemplate = Resources.AssemblyInfoTemplate;
-
-          assemblyInfoTemplate = assemblyInfoTemplate.Replace("$(ContractAssemblyName)", assemblyName + ".Contracts");
-          assemblyInfoFile.Write(assemblyInfoTemplate);
-        }
-        finally
-        {
-          if (assemblyInfoFile != null)
-          {
-            assemblyInfoFile.Close();
-            writtenFiles.Add(@"Properties\AssemblyInfo.cs");
-          }
-        }
-      }
-      finally
-      {
-      }
+        private bool mbIsReadOnly;
+        private bool mbIsStatic;
+        private bool mbIsNewSlot;
+        private bool mbIsVolatile;
+        #endregion
     }
 
     /// <summary>
-    /// Outputs a MSBuild makefile for the newly created file contracts
+    /// This class is a container for outputing C# code
     /// </summary>
-    public void OutputProjectFile(string filename, List<string> WrittenFiles, List<Pair<string,Version>> References, IOutput mOutput, string AssemblyName, bool bUnsafe, bool verbose)
+    public class CodeManager
     {
-      Contract.Requires(WrittenFiles != null);
-      Contract.Requires(References != null);
-
-      if (WrittenFiles.Count == 0)
-      {
-        if (mOutput != null)
-          mOutput.WriteLine("No source file written, no project output.");
-        return;
-      }
-
-      System.IO.StreamWriter outfile = null;
-      try
-      {
-        // first figure out some properties of the project file based on the references:
-        bool usesXaml = false;
-        bool noStdLib = true;
-        int majorFrameworkVersion = 3;
-        if (References.Count > 0)
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
         {
-          foreach (var ra in References)
-          {
-            var refname = ra.One;
+            Contract.Invariant(mNamespaces != null);
+        }
 
-            Contract.Assume(refname != null);
 
-            if (refname.Contains("mscorlib"))
+        public CodeManager()
+        {
+            mNamespaces = new List<Namespace>();
+            mNamespaces.Add(new Namespace("<toplevel>"));
+        }
+
+        public void OutputCode(string ProjectFolder, string RelativeFilesPath, IOutput mOutput, out List<string> WrittenFiles, OutputHelper.OutputStrategy Strategy, List<string> Usings, bool verbose)
+        {
+            Contract.Requires(ProjectFolder != null);
+            Contract.Requires(RelativeFilesPath != null);
+            Contract.Requires(mOutput != null);
+
+            var oh =
+              new OutputHelper(
+                //OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE,
+                //OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS,
+                //OutputHelper.OutputStrategy.ONE_FILE_PER_TOPLEVEL_CLASS,
+                Strategy,
+                ProjectFolder,
+                RelativeFilesPath,
+                Usings,
+                mOutput,
+                verbose);
+
+            foreach (var ns in mNamespaces)
             {
-              noStdLib = false;
-              if (ra.Two.Major == 4)
-              {
-                majorFrameworkVersion = 4;
-              }
+                if (!ns.Empty())
+                    ns.Output(oh);
             }
-            if (refname.Contains("System.Xaml"))
+
+            WrittenFiles = oh.WrittenFiles;
+        }
+
+        public void OutputProperties(string folder, string assemblyName, List<string> writtenFiles)
+        {
+            Contract.Requires(folder != null);
+            Contract.Requires(writtenFiles != null);
+
+            try
             {
-              usesXaml = true;
+                var properties = Path.Combine(folder, "Properties");
+                Directory.CreateDirectory(properties);
+
+                StreamWriter assemblyInfoFile = null;
+                var assemblyInfoFileName = Path.Combine(properties, "AssemblyInfo.cs");
+                try
+                {
+                    assemblyInfoFile = File.CreateText(assemblyInfoFileName);
+                    var assemblyInfoTemplate = Resources.AssemblyInfoTemplate;
+
+                    assemblyInfoTemplate = assemblyInfoTemplate.Replace("$(ContractAssemblyName)", assemblyName + ".Contracts");
+                    assemblyInfoFile.Write(assemblyInfoTemplate);
+                }
+                finally
+                {
+                    if (assemblyInfoFile != null)
+                    {
+                        assemblyInfoFile.Close();
+                        writtenFiles.Add(@"Properties\AssemblyInfo.cs");
+                    }
+                }
             }
-          }
+            finally
+            {
+            }
         }
-        string frameworkVersion = (majorFrameworkVersion == 4) ? "4.0" : "3.5";
 
-        outfile = new System.IO.StreamWriter(filename);
-        outfile.WriteLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-        outfile.WriteLine("<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">");
-        
-        outfile.WriteLine("<PropertyGroup>");
-        outfile.WriteLine("<OutputType>Library</OutputType>");
-        outfile.WriteLine("<AssemblyName>" + AssemblyName + "</AssemblyName>");
-        outfile.WriteLine("<Optimize>true</Optimize>");
-        outfile.WriteLine("<DefineConstants>CONTRACTS_FULL</DefineConstants>");
-        outfile.WriteLine("<TargetFrameworkVersion>v{0}</TargetFrameworkVersion>", frameworkVersion);
-        if (bUnsafe)
-          outfile.WriteLine("<AllowUnsafeBlocks>true</AllowUnsafeBlocks>");
-        outfile.WriteLine(@"<OutputPath>bin\Debug\</OutputPath>");
-        if (noStdLib)
+        /// <summary>
+        /// Outputs a MSBuild makefile for the newly created file contracts
+        /// </summary>
+        public void OutputProjectFile(string filename, List<string> WrittenFiles, List<Pair<string, Version>> References, IOutput mOutput, string AssemblyName, bool bUnsafe, bool verbose)
         {
-          outfile.WriteLine("<NoStdLib>true</NoStdLib>");
-        }
-        if (usesXaml)
-        {
-          outfile.WriteLine("<ProjectGuid>7521af18-5797-4511-aa3e-636c64b36dfc</ProjectGuid>");
-          outfile.WriteLine("<ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>");
-        }
-        outfile.WriteLine("<TargetFrameworkVersion>v{0}</TargetFrameworkVersion>", frameworkVersion);
-        outfile.WriteLine("<AppDesignerFolder>Properties</AppDesignerFolder>");
-        outfile.WriteLine("<SignAssembly>true</SignAssembly>");
-        outfile.WriteLine("<DelaySign>true</DelaySign>");
-        outfile.WriteLine(@"<AssemblyOriginatorKeyFile>..\..\common\Contracts.snk</AssemblyOriginatorKeyFile>");
-        outfile.WriteLine(@"<CodeContractsReferenceAssembly>Build</CodeContractsReferenceAssembly>");
+            Contract.Requires(WrittenFiles != null);
+            Contract.Requires(References != null);
 
-        outfile.WriteLine("</PropertyGroup>");
+            if (WrittenFiles.Count == 0)
+            {
+                if (mOutput != null)
+                    mOutput.WriteLine("No source file written, no project output.");
+                return;
+            }
 
-        outfile.WriteLine("<PropertyGroup Condition=\" '$(Configuration)' == 'Debug' \">");
-        outfile.WriteLine("  <CodeContractsCheckReferenceAssembly>true</CodeContractsCheckReferenceAssembly>");
-        outfile.WriteLine("</PropertyGroup>");
+            System.IO.StreamWriter outfile = null;
+            try
+            {
+                // first figure out some properties of the project file based on the references:
+                bool usesXaml = false;
+                bool noStdLib = true;
+                int majorFrameworkVersion = 3;
+                if (References.Count > 0)
+                {
+                    foreach (var ra in References)
+                    {
+                        var refname = ra.One;
 
-        var targets = "";
-        try
-        {
-          targets = GetTargets(AssemblyName);
-        }
-        catch { }
+                        Contract.Assume(refname != null);
 
-        outfile.WriteLine(@"  <ItemGroup>");
-        outfile.WriteLine(@"    <BuildTargetList Include=""{0}""/>", targets);
-        outfile.WriteLine(@"
+                        if (refname.Contains("mscorlib"))
+                        {
+                            noStdLib = false;
+                            if (ra.Two.Major == 4)
+                            {
+                                majorFrameworkVersion = 4;
+                            }
+                        }
+                        if (refname.Contains("System.Xaml"))
+                        {
+                            usesXaml = true;
+                        }
+                    }
+                }
+                string frameworkVersion = (majorFrameworkVersion == 4) ? "4.0" : "3.5";
+
+                outfile = new System.IO.StreamWriter(filename);
+                outfile.WriteLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                outfile.WriteLine("<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">");
+
+                outfile.WriteLine("<PropertyGroup>");
+                outfile.WriteLine("<OutputType>Library</OutputType>");
+                outfile.WriteLine("<AssemblyName>" + AssemblyName + "</AssemblyName>");
+                outfile.WriteLine("<Optimize>true</Optimize>");
+                outfile.WriteLine("<DefineConstants>CONTRACTS_FULL</DefineConstants>");
+                outfile.WriteLine("<TargetFrameworkVersion>v{0}</TargetFrameworkVersion>", frameworkVersion);
+                if (bUnsafe)
+                    outfile.WriteLine("<AllowUnsafeBlocks>true</AllowUnsafeBlocks>");
+                outfile.WriteLine(@"<OutputPath>bin\Debug\</OutputPath>");
+                if (noStdLib)
+                {
+                    outfile.WriteLine("<NoStdLib>true</NoStdLib>");
+                }
+                if (usesXaml)
+                {
+                    outfile.WriteLine("<ProjectGuid>7521af18-5797-4511-aa3e-636c64b36dfc</ProjectGuid>");
+                    outfile.WriteLine("<ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>");
+                }
+                outfile.WriteLine("<TargetFrameworkVersion>v{0}</TargetFrameworkVersion>", frameworkVersion);
+                outfile.WriteLine("<AppDesignerFolder>Properties</AppDesignerFolder>");
+                outfile.WriteLine("<SignAssembly>true</SignAssembly>");
+                outfile.WriteLine("<DelaySign>true</DelaySign>");
+                outfile.WriteLine(@"<AssemblyOriginatorKeyFile>..\..\common\Contracts.snk</AssemblyOriginatorKeyFile>");
+                outfile.WriteLine(@"<CodeContractsReferenceAssembly>Build</CodeContractsReferenceAssembly>");
+
+                outfile.WriteLine("</PropertyGroup>");
+
+                outfile.WriteLine("<PropertyGroup Condition=\" '$(Configuration)' == 'Debug' \">");
+                outfile.WriteLine("  <CodeContractsCheckReferenceAssembly>true</CodeContractsCheckReferenceAssembly>");
+                outfile.WriteLine("</PropertyGroup>");
+
+                var targets = "";
+                try
+                {
+                    targets = GetTargets(AssemblyName);
+                }
+                catch { }
+
+                outfile.WriteLine(@"  <ItemGroup>");
+                outfile.WriteLine(@"    <BuildTargetList Include=""{0}""/>", targets);
+                outfile.WriteLine(@"
     <MultiTargetReferencePaths Include=""..\..\Imported\ReferenceAssemblies\;..\$(OutputPath)"" />
   </ItemGroup>"
-          );
+                  );
 
-        outfile.WriteLine("<ItemGroup>");
-        foreach (var wf in WrittenFiles)
-          outfile.WriteLine("\t<Compile Include = \"" + wf + "\" />");
-        outfile.WriteLine("</ItemGroup>");
+                outfile.WriteLine("<ItemGroup>");
+                foreach (var wf in WrittenFiles)
+                    outfile.WriteLine("\t<Compile Include = \"" + wf + "\" />");
+                outfile.WriteLine("</ItemGroup>");
 
-        if (References.Count > 0)
-        {
-          outfile.WriteLine("<ItemGroup>");
-          foreach (var ra in References)
-          {
-            var refname = ra.One;
-            outfile.WriteLine("\t<Reference Include = \"" + refname + "\" />");
-          }
-          outfile.WriteLine("</ItemGroup>");
-        }
+                if (References.Count > 0)
+                {
+                    outfile.WriteLine("<ItemGroup>");
+                    foreach (var ra in References)
+                    {
+                        var refname = ra.One;
+                        outfile.WriteLine("\t<Reference Include = \"" + refname + "\" />");
+                    }
+                    outfile.WriteLine("</ItemGroup>");
+                }
 
-        if (majorFrameworkVersion < 4)
-        {
-          var progFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-          var contractHintPath = Path.Combine(progFiles, @"\Microsoft\Contracts\PublicAssemblies\v3.5\Microsoft.Contracts.dll");
-          outfile.WriteLine("<ItemGroup>");
-          outfile.WriteLine("\t<Reference Include = \"Microsoft.Contracts\">");
-          outfile.WriteLine("\t\t<HintPath>{0}</HintPath>", contractHintPath);
-          outfile.WriteLine("\t</Reference>");
-          outfile.WriteLine("</ItemGroup>");
-        }
-        //outfile.WriteLine("<Target Name=\"Build\">");
-        //outfile.WriteLine("\t<Csc Sources=\"@(Compile)\" References=\"@(Reference)\" OutputAssembly = \"Output\\" + mAssemblyName + ".Contracts.Inferred.dll\"/>");
-        outfile.WriteLine("<Import Project=\"$(MSBuildToolsPath)\\Microsoft.CSharp.targets\" />");
-        outfile.WriteLine(@"
+                if (majorFrameworkVersion < 4)
+                {
+                    var progFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                    var contractHintPath = Path.Combine(progFiles, @"\Microsoft\Contracts\PublicAssemblies\v3.5\Microsoft.Contracts.dll");
+                    outfile.WriteLine("<ItemGroup>");
+                    outfile.WriteLine("\t<Reference Include = \"Microsoft.Contracts\">");
+                    outfile.WriteLine("\t\t<HintPath>{0}</HintPath>", contractHintPath);
+                    outfile.WriteLine("\t</Reference>");
+                    outfile.WriteLine("</ItemGroup>");
+                }
+                //outfile.WriteLine("<Target Name=\"Build\">");
+                //outfile.WriteLine("\t<Csc Sources=\"@(Compile)\" References=\"@(Reference)\" OutputAssembly = \"Output\\" + mAssemblyName + ".Contracts.Inferred.dll\"/>");
+                outfile.WriteLine("<Import Project=\"$(MSBuildToolsPath)\\Microsoft.CSharp.targets\" />");
+                outfile.WriteLine(@"
   <PropertyGroup>
     <ContractReferenceOutputPathRoot>..\$(OutputPath)</ContractReferenceOutputPathRoot>
   </PropertyGroup>
   <Import Project=""..\Multitarget.targets"" />"
-          );
-        //outfile.WriteLine("</Target>");
-        outfile.WriteLine("</Project>");
+                  );
+                //outfile.WriteLine("</Target>");
+                outfile.WriteLine("</Project>");
 
-        if (mOutput != null && verbose)
-          mOutput.WriteLine("OutputPretty C#: Project file successfully output in " + filename + ".");
-      }
-      finally
-      {
-        if (outfile != null)
-          outfile.Close();
-      }
-    }
-
-    private static string GetTargets(string name)
-    {
-      var sb = new StringBuilder();
-      foreach (var dir in PathsToDll(name))
-      {
-        var suffix = RemovePrefix(dir);
-        if (suffix == null) continue;
-
-        sb.Append(@"Microsoft\Framework\");
-        sb.Append(suffix);
-        sb.Append(@"\Target;");
-      }
-
-      // trim last
-      var result = sb.ToString();
-      return result.TrimEnd(';');
-    }
-
-    private static string RemovePrefix(string dir)
-    {
-      var ri = dir.IndexOf("ReferenceAssemblies");
-      if (ri >= 0)
-      {
-        return dir.Substring(ri + "ReferenceAssemblies".Length + 1);
-      }
-      return null;
-    }
-
-    private static IEnumerable<string> PathsToDll(string name)
-    {
-      var dirs = Directory.EnumerateDirectories(@"..\Imported\ReferenceAssemblies");
-      return FindWithin(dirs, name + ".dll");
-    }
-
-    private static IEnumerable<string> FindWithin(IEnumerable<string> dirs, string file)
-    {
-      foreach (var dir in dirs)
-      {
-        if (File.Exists(Path.Combine(dir, file)))
-        {
-          yield return dir;
-        }
-        foreach (var result in FindWithin(Directory.EnumerateDirectories(dir), file))
-        {
-          yield return result;
-        }
-      }
-    }
-
-    public bool HasUnsafeCode()
-    {
-      foreach (var ns in mNamespaces)
-      {
-        if (ns.HasUnsafeCode())
-          return true;
-      }
-      return false;
-    }
-
-    public void AddNamespace(Namespace newNS)
-    {
-      mNamespaces.Add(newNS);
-    }
-
-    public Namespace LookupNamespaceByName (string name)
-    {
-      foreach (var ns in mNamespaces)
-      {
-        if (ns.Name == name)
-          return ns;
-      }
-
-      Namespace newns = new Namespace(name);
-      AddNamespace(newns);
-      return newns;
-    }
-
-    #region Privates
-    readonly private List<Namespace> mNamespaces;
-    #endregion
-  }
-
-  static public class TypeHelper
-  {
-    /// <summary>
-    /// Simplifies class types
-    /// </summary>
-    /// <param name="type">Text representation of the type to reduce</param>
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    public static string SimplifyType(string type)
-    {
-      Contract.Requires(type != null);
-
-      type = type.Trim();
-
-      switch (type)
-      {
-        case "System.Boolean":
-        case "Boolean":
-          return "bool";
-        case "System.Char":
-        case "Char":
-          return "char";
-        case "System.String":
-        case "String":
-          return "string";
-        case "System.Single":
-        case "Single":
-          return "float";
-        case "System.Double":
-        case "Double":
-          return "double";
-        case "System.SByte":
-        case "SByte":
-          return "sbyte";
-        case "System.Int16":
-        case "Int16":
-          return "short";
-        case "System.Int32":
-        case "Int32":
-          return "int";
-        case "System.Int64":
-        case "Int64":
-          return "long";
-        case "System.Byte":
-        case "Byte":
-          return "byte";
-        case "System.UInt16":
-        case "UInt16":
-          return "ushort";
-        case "System.UInt32":
-        case "UInt32":
-          return "uint";
-        case "System.UInt64":
-        case "UInt64":
-          return "ulong";
-        case "System.Void":
-        case "Void":
-          return "void";
-      }
-
-      return type;
-    }
-
-    public static string GetNamespaceFromClass<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
-      (IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder,
-      Type type)
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      Type parent;
-      if (mdDecoder.IsNested(type, out parent))
-        return GetNamespaceFromClass(mdDecoder, parent); // In CCI1, only toplevel classes have a namespace
-
-      string nsname = mdDecoder.Namespace(type);
-      if (nsname == null) // System.Int, ...
-        return "";
-
-      return nsname;
-    }
-
-    public static string TypeFullName<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
-      (IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder,
-      Type type)
-        where Type : IEquatable<Type>
-    {
-      Contract.Requires(mdDecoder != null);
-
-      return TypeFullName(mdDecoder, type, null);
-    }
-
-    public enum StripContext
-    {
-      Namespace,
-      ParentType
-    }
-
-    public static string TypeFullName<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
-      (IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder,
-      Type type,
-      Func<string, string, StripContext, bool> can_strip_prefix)
-        where Type : IEquatable<Type>
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      // Don't use FullName from meta data decoder because Clousot1
-      // has some strange name mangling habits
-      //string basecl = SimplifyType(mdDecoder.FullName(type));
-
-      if (mdDecoder.IsArray(type))
-      {
-        var elementType = TypeFullName(mdDecoder, mdDecoder.ElementType(type), can_strip_prefix);
-        var rank = mdDecoder.Rank(type);
-        if (rank == 1)
-        {
-          return elementType + "[]";
-        }
-        else
-        {
-          return String.Format("{0}[{1}]", elementType, new String(',', rank - 1));
-        }
-      }
-
-      if (mdDecoder.IsUnmanagedPointer(type))
-        return TypeFullName(mdDecoder, mdDecoder.ElementType(type), can_strip_prefix) + "*";
-
-      Type modified;
-      Microsoft.Research.DataStructures.IIndexable<Microsoft.Research.DataStructures.Pair<bool, Type>> modifiers;
-      if (mdDecoder.IsModified(type, out modified, out modifiers))
-        type = modified;
-
-      Microsoft.Research.DataStructures.IIndexable<Type> args;
-      var bSpecialized = mdDecoder.IsSpecialized(type, out args);
-      Type type_unspec = default(Type);
-      if (bSpecialized)
-        type_unspec = mdDecoder.Unspecialized(type); // take the unspecialized type, then we'll add the formal parameters later
-
-      var typeName = mdDecoder.Name(bSpecialized ? type_unspec : type);
-      string basecl;
-      Type parentt;
-      if (mdDecoder.IsNested(type, out parentt)) // crucial that we took the unspecialized version of the type to have the formal hierarchy
-      {
-        basecl = TypeFullName(mdDecoder, parentt, can_strip_prefix);
-        Contract.Assume(basecl.Length > 0);
-        if (CanStripPrefix(can_strip_prefix, basecl, typeName, StripContext.ParentType)) {
-          basecl = typeName;
-        }
-        else
-        {
-          basecl += "." + typeName;
-        }
-      }
-      else
-      {
-        string ns = GetNamespaceFromClass(mdDecoder, bSpecialized ? type_unspec : type);
-        if (ns == "<toplevel>" || ns == "type parameter" /* made-up naming in Clousot1 */) {
-          basecl = typeName;
-        }
-        else
-        {
-          if (CanStripPrefix(can_strip_prefix, typeName, ns, StripContext.Namespace))
-          {
-            basecl = typeName;
-          }
-          else
-          {
-            if (ns.Length > 0)
-            {
-              basecl = ns + "." + typeName;
+                if (mOutput != null && verbose)
+                    mOutput.WriteLine("OutputPretty C#: Project file successfully output in " + filename + ".");
             }
-            else
+            finally
             {
-              basecl = typeName;
+                if (outfile != null)
+                    outfile.Close();
             }
-          }
         }
-      }
 
-      if (bSpecialized)
-      {
-        // output generic type parameters
-        if (args.Count > 0)
+        private static string GetTargets(string name)
         {
-          basecl += "<";
-          for (int i = 0; i < args.Count; ++i)
-          {
-            if (i > 0)
-              basecl += ", ";
-            basecl += TypeFullName(mdDecoder, args[i], can_strip_prefix);
-          }
-          basecl += ">";
-        }
-      }
-
-      return SimplifyType(basecl);
-    }
-
-    private static bool CanStripPrefix(Func<string, string, StripContext, bool> can_strip_prefix, string typeName, string ns, StripContext context)
-    {
-      return can_strip_prefix != null && can_strip_prefix(ns, typeName, context);
-    }
-  }
-
-  public class ConstructionHelper<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
-    where Type : IEquatable<Type>
-  {
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.mCm != null);
-      Contract.Invariant(this.mdDecoder != null);
-    }
-
-    public ConstructionHelper(IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder, bool visibleMembersOnly)
-    {
-      Contract.Requires(mdDecoder != null);
-
-      this.mdDecoder = mdDecoder;
-      this.visibleMembersOnly = visibleMembersOnly;
-      this.mCm = new CodeManager();
-      this.mClassesLookup = new Dictionary<Type, Class>();
-      this.mMethodsLookup = new Dictionary<MethodExt, Method>();
-      this.mPropertiesLookup = new Dictionary<PropertyExt, Property>();
-
-      this.mUsings = new List<string>();
-      // order is important !! you don't want "System" to be in first place,
-      // otherwise the other won't ever match
-      this.mUsings.Add("System.Collections.Generic");
-      this.mUsings.Add("System.IO");
-      this.mUsings.Add("System.Text");
-      this.mUsings.Add("System.Diagnostics.Contracts");
-      this.mUsings.Add("System");
-    }
-
-    public List<string> Usings { get { return mUsings; } }
-
-    /// <summary>
-    /// Returns the type full name as it should be output anywhere in the code (parameter, return type ...)
-    /// </summary>
-    /// <param name="type">The type to output</param>
-    /// <param name="contextClass">If non-null, tells in which class the output will take place, so that the parent name can be stripped off</param>
-    /// <param name="ParentNS">If non-null, tells in which namespace the output will take place so that the parent namespace can be stripped off</param>
-    public string TypeFullName (Type type, Class contextClass, Namespace ParentNS)
-    {
-      List<string> prefixes = new List<string>();
-      if (ParentNS != null)
-        prefixes.Add(ParentNS.Name + ".");
-      if (contextClass != null)
-        prefixes.Add(contextClass.Name + ".");
-      
-      // finally, check if the base namespace is in the "using" namespaces, so we could skip it
-      //foreach (var use in mUsings)
-      //  prefixes.Add(use + ".");
-
-      return TypeHelper.TypeFullName(mdDecoder, type,
-        (prefix, typeName, context) =>
-        {
-          switch (context)
-          {
-            case TypeHelper.StripContext.Namespace:
-
-              // don't want to capture name in parent context
-              if (contextClass != null && contextClass.HasSymbol(typeName))
-                return false;
-              if (ParentNS != null && prefix == ParentNS.Name)
-                return true;
-              if (mUsings.Contains(prefix))
-                return true;
-              break;
-
-            case TypeHelper.StripContext.ParentType:
-
-              if (contextClass != null && prefix == contextClass.Name)
-                return true;
-              break;
-
-          }
-
-          return false;
-        }
-      );
-    }
-
-    /// <summary>
-    /// Returns whether there is a constructor for this type. Puts the one with the smaller number
-    /// of arguments in the out parameter "constructor".
-    /// If not a class, or if no constructor is found, just return false with nothing in "constructor".
-    /// The returned constructor will be visible from the "calling_type" constructor (as given by metadatadecoder.DeclaringModuleName),
-    /// and public or protected (ie. usable in a class derived from type).
-    /// The possible base class is not visited.
-    /// </summary>
-    public bool GetAConstructor (Type type, Type calling_type, out MethodExt constructor)
-    {
-      constructor = default(MethodExt);
-      if (!mdDecoder.IsClass(type))
-        return false;
-
-      int nb_min = 9999999; // should be enough
-      bool bReturn = false;
-      foreach (var m in mdDecoder.Methods(type))
-      {
-        if (mdDecoder.IsConstructor(m) && !mdDecoder.IsPrivate(m))
-        {
-          var pars = mdDecoder.Parameters(m);
-          if (pars.Count < nb_min)
-          {
-            // Check that the constructor and the arguments types are visible to the current assembly
-            Microsoft.Research.DataStructures.IIndexable<Type> dummy;
-            string base_assembly = mdDecoder.DeclaringModuleName(mdDecoder.IsSpecialized(type, out dummy) ? mdDecoder.Unspecialized(type) : type);
-            string calling_assembly = mdDecoder.DeclaringModuleName(mdDecoder.IsSpecialized(calling_type, out dummy) ? mdDecoder.Unspecialized(calling_type) : calling_type);
-
-            bool bVisible = true;
-            if (calling_assembly == base_assembly || mdDecoder.IsVisibleOutsideAssembly(m))
+            var sb = new StringBuilder();
+            foreach (var dir in PathsToDll(name))
             {
-              // Then check every parameter type
-              for (int i = 0; i < pars.Count && bVisible; ++i)
-              {
-                Type ptype = mdDecoder.ParameterType(pars[i]);
-                if (mdDecoder.IsSpecialized(ptype, out dummy))
-                  ptype = mdDecoder.Unspecialized(ptype);
-                string asst = mdDecoder.DeclaringModuleName(ptype);
-                if (asst != calling_assembly)
+                var suffix = RemovePrefix(dir);
+                if (suffix == null) continue;
+
+                sb.Append(@"Microsoft\Framework\");
+                sb.Append(suffix);
+                sb.Append(@"\Target;");
+            }
+
+            // trim last
+            var result = sb.ToString();
+            return result.TrimEnd(';');
+        }
+
+        private static string RemovePrefix(string dir)
+        {
+            var ri = dir.IndexOf("ReferenceAssemblies");
+            if (ri >= 0)
+            {
+                return dir.Substring(ri + "ReferenceAssemblies".Length + 1);
+            }
+            return null;
+        }
+
+        private static IEnumerable<string> PathsToDll(string name)
+        {
+            var dirs = Directory.EnumerateDirectories(@"..\Imported\ReferenceAssemblies");
+            return FindWithin(dirs, name + ".dll");
+        }
+
+        private static IEnumerable<string> FindWithin(IEnumerable<string> dirs, string file)
+        {
+            foreach (var dir in dirs)
+            {
+                if (File.Exists(Path.Combine(dir, file)))
                 {
-                  //if (mdDecoder.IsPrivate(ptype) || mdDecoder.IsInternal(ptype))
-                  if (!mdDecoder.IsPublic(ptype) && !mdDecoder.IsProtected(ptype))
-                  {
-                    bVisible = false;
-                    break; // reject
-                  }
+                    yield return dir;
+                }
+                foreach (var result in FindWithin(Directory.EnumerateDirectories(dir), file))
+                {
+                    yield return result;
+                }
+            }
+        }
+
+        public bool HasUnsafeCode()
+        {
+            foreach (var ns in mNamespaces)
+            {
+                if (ns.HasUnsafeCode())
+                    return true;
+            }
+            return false;
+        }
+
+        public void AddNamespace(Namespace newNS)
+        {
+            mNamespaces.Add(newNS);
+        }
+
+        public Namespace LookupNamespaceByName(string name)
+        {
+            foreach (var ns in mNamespaces)
+            {
+                if (ns.Name == name)
+                    return ns;
+            }
+
+            Namespace newns = new Namespace(name);
+            AddNamespace(newns);
+            return newns;
+        }
+
+        #region Privates
+        readonly private List<Namespace> mNamespaces;
+        #endregion
+    }
+
+    static public class TypeHelper
+    {
+        /// <summary>
+        /// Simplifies class types
+        /// </summary>
+        /// <param name="type">Text representation of the type to reduce</param>
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        public static string SimplifyType(string type)
+        {
+            Contract.Requires(type != null);
+
+            type = type.Trim();
+
+            switch (type)
+            {
+                case "System.Boolean":
+                case "Boolean":
+                    return "bool";
+                case "System.Char":
+                case "Char":
+                    return "char";
+                case "System.String":
+                case "String":
+                    return "string";
+                case "System.Single":
+                case "Single":
+                    return "float";
+                case "System.Double":
+                case "Double":
+                    return "double";
+                case "System.SByte":
+                case "SByte":
+                    return "sbyte";
+                case "System.Int16":
+                case "Int16":
+                    return "short";
+                case "System.Int32":
+                case "Int32":
+                    return "int";
+                case "System.Int64":
+                case "Int64":
+                    return "long";
+                case "System.Byte":
+                case "Byte":
+                    return "byte";
+                case "System.UInt16":
+                case "UInt16":
+                    return "ushort";
+                case "System.UInt32":
+                case "UInt32":
+                    return "uint";
+                case "System.UInt64":
+                case "UInt64":
+                    return "ulong";
+                case "System.Void":
+                case "Void":
+                    return "void";
+            }
+
+            return type;
+        }
+
+        public static string GetNamespaceFromClass<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
+          (IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder,
+          Type type)
+        {
+            Contract.Requires(mdDecoder != null);
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            Type parent;
+            if (mdDecoder.IsNested(type, out parent))
+                return GetNamespaceFromClass(mdDecoder, parent); // In CCI1, only toplevel classes have a namespace
+
+            string nsname = mdDecoder.Namespace(type);
+            if (nsname == null) // System.Int, ...
+                return "";
+
+            return nsname;
+        }
+
+        public static string TypeFullName<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
+          (IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder,
+          Type type)
+            where Type : IEquatable<Type>
+        {
+            Contract.Requires(mdDecoder != null);
+
+            return TypeFullName(mdDecoder, type, null);
+        }
+
+        public enum StripContext
+        {
+            Namespace,
+            ParentType
+        }
+
+        public static string TypeFullName<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
+          (IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder,
+          Type type,
+          Func<string, string, StripContext, bool> can_strip_prefix)
+            where Type : IEquatable<Type>
+        {
+            Contract.Requires(mdDecoder != null);
+            Contract.Ensures(Contract.Result<string>() != null);
+
+            // Don't use FullName from meta data decoder because Clousot1
+            // has some strange name mangling habits
+            //string basecl = SimplifyType(mdDecoder.FullName(type));
+
+            if (mdDecoder.IsArray(type))
+            {
+                var elementType = TypeFullName(mdDecoder, mdDecoder.ElementType(type), can_strip_prefix);
+                var rank = mdDecoder.Rank(type);
+                if (rank == 1)
+                {
+                    return elementType + "[]";
                 }
                 else
-                  bVisible = mdDecoder.IsVisibleFrom(ptype, calling_type);
-              }
+                {
+                    return String.Format("{0}[{1}]", elementType, new String(',', rank - 1));
+                }
+            }
+
+            if (mdDecoder.IsUnmanagedPointer(type))
+                return TypeFullName(mdDecoder, mdDecoder.ElementType(type), can_strip_prefix) + "*";
+
+            Type modified;
+            Microsoft.Research.DataStructures.IIndexable<Microsoft.Research.DataStructures.Pair<bool, Type>> modifiers;
+            if (mdDecoder.IsModified(type, out modified, out modifiers))
+                type = modified;
+
+            Microsoft.Research.DataStructures.IIndexable<Type> args;
+            var bSpecialized = mdDecoder.IsSpecialized(type, out args);
+            Type type_unspec = default(Type);
+            if (bSpecialized)
+                type_unspec = mdDecoder.Unspecialized(type); // take the unspecialized type, then we'll add the formal parameters later
+
+            var typeName = mdDecoder.Name(bSpecialized ? type_unspec : type);
+            string basecl;
+            Type parentt;
+            if (mdDecoder.IsNested(type, out parentt)) // crucial that we took the unspecialized version of the type to have the formal hierarchy
+            {
+                basecl = TypeFullName(mdDecoder, parentt, can_strip_prefix);
+                Contract.Assume(basecl.Length > 0);
+                if (CanStripPrefix(can_strip_prefix, basecl, typeName, StripContext.ParentType))
+                {
+                    basecl = typeName;
+                }
+                else
+                {
+                    basecl += "." + typeName;
+                }
             }
             else
-              bVisible = false;
-
-            if (bVisible)
             {
-              constructor = m;
-              nb_min = pars.Count;
-              bReturn = true;
+                string ns = GetNamespaceFromClass(mdDecoder, bSpecialized ? type_unspec : type);
+                if (ns == "<toplevel>" || ns == "type parameter" /* made-up naming in Clousot1 */)
+                {
+                    basecl = typeName;
+                }
+                else
+                {
+                    if (CanStripPrefix(can_strip_prefix, typeName, ns, StripContext.Namespace))
+                    {
+                        basecl = typeName;
+                    }
+                    else
+                    {
+                        if (ns.Length > 0)
+                        {
+                            basecl = ns + "." + typeName;
+                        }
+                        else
+                        {
+                            basecl = typeName;
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
-      return bReturn;
-    }
 
-    private List<FormalTypeParameter> GetFormalTypeParameters (Microsoft.Research.DataStructures.IIndexable<Type> formals)
-    {
-      List<FormalTypeParameter> res = new List<FormalTypeParameter>();
-
-      for (int i = 0; i < formals.Count; ++i)
-      {
-        var constraints = mdDecoder.TypeParameterConstraints(formals[i]);
-        Contract.Assume(constraints != null);
-        string name = mdDecoder.Name(formals[i]);
-        var ftp = new FormalTypeParameter(name);
-
-        var tc = FormalTypeParamConstraint.TypeConstraint.NONE;
-        string classConstraint = "";
-        if (mdDecoder.IsReferenceConstrained(formals[i]))
-          tc = FormalTypeParamConstraint.TypeConstraint.CLASS;
-        else if (mdDecoder.IsValueConstrained(formals[i]))
-          tc = FormalTypeParamConstraint.TypeConstraint.STRUCT;
-        else
-        {
-          foreach (var cont in constraints)
-          {
-            if (!mdDecoder.IsInterface(cont))
+            if (bSpecialized)
             {
-              classConstraint = TypeFullName(cont, null, LookupNamespaceFromClass(cont));
-              tc = FormalTypeParamConstraint.TypeConstraint.BASECLASS;
-              break;
+                // output generic type parameters
+                if (args.Count > 0)
+                {
+                    basecl += "<";
+                    for (int i = 0; i < args.Count; ++i)
+                    {
+                        if (i > 0)
+                            basecl += ", ";
+                        basecl += TypeFullName(mdDecoder, args[i], can_strip_prefix);
+                    }
+                    basecl += ">";
+                }
             }
-          }
+
+            return SimplifyType(basecl);
         }
 
-        bool bIsNew = mdDecoder.IsConstructorConstrained(formals[i]) && !mdDecoder.IsValueConstrained(formals[i]);
-
-        var ftpc = new FormalTypeParamConstraint(ftp, tc, classConstraint, bIsNew);
-        ftp.setConstraint(ftpc);
-
-        // Interfaces
-        foreach (var cont in constraints)
+        private static bool CanStripPrefix(Func<string, string, StripContext, bool> can_strip_prefix, string typeName, string ns, StripContext context)
         {
-          if (mdDecoder.IsInterface(cont))
-            ftpc.AddInterfaceConstraint(TypeFullName(cont, null, LookupNamespaceFromClass(cont)));
+            return can_strip_prefix != null && can_strip_prefix(ns, typeName, context);
         }
-
-        res.Add(ftp);
-      }
-
-      return res;
     }
 
-    private string GetNamespaceFromClass(Type type)
+    public class ConstructionHelper<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>
+      where Type : IEquatable<Type>
     {
-      var nsname = TypeHelper.GetNamespaceFromClass(mdDecoder, type);
-
-      if (nsname.Length == 0)
-        nsname = "<toplevel>";
-
-      return nsname;
-    }
-
-    public Namespace LookupNamespaceFromClass(Type type)
-    {
-      return mCm.LookupNamespaceByName(GetNamespaceFromClass(type));
-    }
-
-    public Class ConstructClassFromMetaDataDecoder (Type type)
-    {
-      string name = mdDecoder.Name(type);
-      Access access = Access.PUBLIC;
-      Type dummy;
-      if (mdDecoder.IsNested(type, out dummy))
-      {
-        if (mdDecoder.IsProtected(type) && mdDecoder.IsInternal(type))
-          access = Access.INTERNAL_AND_OR_PROTECTED;
-        else if (mdDecoder.IsInternal(type))
-          access = Access.INTERNAL;
-        else if (mdDecoder.IsPublic(type))
-          access = Access.PUBLIC;
-        else if (mdDecoder.IsProtected(type))
-          access = Access.PROTECTED;
-        else if (mdDecoder.IsPrivate(type))
-          access = Access.PRIVATE;
-      }
-      else
-      {
-        if (mdDecoder.IsPublic(type))
-          access = Access.PUBLIC;
-        else
-          access = Access.INTERNAL;
-      }
-
-      Class.ClassType clt = Class.ClassType.CLASS;
-      if (mdDecoder.IsClass(type))
-        clt = Class.ClassType.CLASS;
-      else if (mdDecoder.IsStruct(type))
-        clt = Class.ClassType.STRUCT;
-      else if (mdDecoder.IsInterface(type))
-        clt = Class.ClassType.INTERFACE;
-
-      Namespace ParentNS = mCm.LookupNamespaceByName(GetNamespaceFromClass(type));
-
-      Class parent = null;
-      Type parentt;
-      if (mdDecoder.IsNested(type, out parentt))
-        parent = LookupClass(parentt, false);
-
-      string basecl = "";
-      if (mdDecoder.HasBaseClass(type))
-      {
-        Type bt = mdDecoder.BaseClass(type);
-        if (mdDecoder.FullName(bt) != "System.Object")
-          basecl = TypeFullName(bt, parent, ParentNS);
-      }
-
-      bool bIsAbstract = mdDecoder.IsAbstract(type) && !mdDecoder.IsInterface(type);
-      bool bIsSealed = mdDecoder.IsSealed(type) && !mdDecoder.IsStruct(type);
-      bool bIsStatic = false;//mdDecoder.IsStatic(type); types can be static only if abstract & sealed
-      if (bIsAbstract && bIsSealed)
-      {
-        bIsAbstract = false;
-        bIsSealed = false;
-        bIsStatic = true;
-      }
-
-      Class cl = new Class(
-        access,
-        bIsAbstract,
-        bIsSealed,
-        bIsStatic,
-        false, /* Updated when children are added */
-        clt,
-        name,
-        parent,
-        basecl,
-        ParentNS);
-
-      //** Attributes ?
-      // Check if this class derives from System.Attribute, in which case we want to
-      // assign it the attribute "AttributeUsage(AttributeTargets.All)"
-      if (mdDecoder.HasBaseClass(type))
-      {
-        Type bt = mdDecoder.BaseClass(type);
-        while (true)
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          if (mdDecoder.FullName(bt) == "System.Attribute")
-            cl.AddAttribute("AttributeUsage(AttributeTargets.All)");
-
-          if (!mdDecoder.HasBaseClass(bt))
-            break;
-          else
-            bt = mdDecoder.BaseClass(bt);
-        }
-      }
-
-      //** Formal type parameters
-      Microsoft.Research.DataStructures.IIndexable<Type> formals;
-      if (mdDecoder.IsGeneric(type, out formals, false))
-        cl.AddFormalTypeParameters(GetFormalTypeParameters(formals));
-
-      //** Interfaces
-      var interfaces = mdDecoder.Interfaces(type);
-      foreach (var it in interfaces)
-      {
-        if (this.SkipType(it)) continue;
-        if (mdDecoder.FullName(it) != "System.Object")
-          cl.AddInterface(TypeFullName(it, cl, ParentNS));
-      }
-
-      Dictionary<EventExt, MethodExt> additionalEvents = new Dictionary<EventExt, MethodExt>();
-
-      #region Methods
-      bool hasRetainedConstructors = false;
-      foreach (var m in mdDecoder.Methods(type))
-      {
-        if (mdDecoder.IsPropertyGetter(m) || mdDecoder.IsPropertySetter(m))
-          continue; // skip property accessors
-
-        if (mdDecoder.IsFinalizer(m))
-          continue; // skip destructors
-
-        if (SkipMethod(m))
-          continue; // compiler generated
-
-        EventExt dev;
-        if (mdDecoder.IsEventAdder(m, out dev) || mdDecoder.IsEventRemover(m, out dev))
-        {
-          continue; // skip events adder/remover
+            Contract.Invariant(mCm != null);
+            Contract.Invariant(mdDecoder != null);
         }
 
-        bool foundEvt = false;
-        foreach (var im in mdDecoder.ImplementedMethods(m))
+        public ConstructionHelper(IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder, bool visibleMembersOnly)
         {
-          EventExt evt;
-          if (mdDecoder.IsEventAdder(im, out evt) || mdDecoder.IsEventRemover(im, out evt))
-          {
-            // looks like an event that is implemented with just add/remove but no explicit event decl
-            // create a dummy one
-            additionalEvents[evt] = m;
-            foundEvt = true;
-            break;
-          }
-        }
-        if (foundEvt)
-        {
-          // skip the method
-          continue;
-        }
-        
-        Method newm;
-        var tmpName = mdDecoder.Name(m);
-        if (tmpName.StartsWith("op_"))
-        {
-          // user defined-conversion
-          Contract.Assert(tmpName.Length >= 3);
-          newm = ConstructUserOpFromMetaDataDecoder(m, cl);
-        }
-        else
-          newm = ConstructMethodFromMetaDataDecoder(m, cl);
+            Contract.Requires(mdDecoder != null);
 
-        cl.AddChild(newm);
-        hasRetainedConstructors |= mdDecoder.IsConstructor(m);
+            this.mdDecoder = mdDecoder;
+            this.visibleMembersOnly = visibleMembersOnly;
+            mCm = new CodeManager();
+            mClassesLookup = new Dictionary<Type, Class>();
+            mMethodsLookup = new Dictionary<MethodExt, Method>();
+            mPropertiesLookup = new Dictionary<PropertyExt, Property>();
 
-        // Keep track internally of the method
-        mMethodsLookup.Add(m, newm);
-      }
-
-      // if there were no retained constructors, we might have to add an explicit one in order for base 
-      // constructor call to work
-      if (!hasRetainedConstructors && !bIsStatic && clt == Class.ClassType.CLASS)
-      {
-        var ctor = ConstructDefaultConstructor(type, cl);
-        cl.AddChild(ctor);
-      }
-      #endregion
-
-      #region Properties
-
-      foreach (var prop in mdDecoder.Properties(type))
-      {
-        if (SkipProperty(prop)) { continue; }
-        Property newprop = ConstructPropertyFromMetaDataDecoder(prop, cl);
-        //Property newprop = LookupProperty(prop);
-        cl.AddChild(newprop);
-
-        // Keep track internally of the property
-        mPropertiesLookup.Add(prop, newprop);
-      }
-      #endregion
-
-      #region Events
-
-      foreach (var evt in mdDecoder.Events(type))
-      {
-        if (SkipEvent(evt)) { continue; }
-
-        Event newEvt = ConstructEventFromMetaDataDecoder(evt, cl);
-        //Property newprop = LookupProperty(prop);
-        cl.AddChild(newEvt);
-
-        // Keep track internally of the event
-        //mPropertiesLookup.Add(evt, newEvt);
-      }
-
-      foreach (var pair in additionalEvents)
-      {
-        var implEvent = pair.Key;
-        var implMethod = pair.Value;
-
-        var newEvt = ConstructEventFromProxy(implEvent, implMethod, cl);
-        cl.AddChild(newEvt);
-      }
-      #endregion
-
-      #region Fields
-      //** Fields
-      foreach (var f in mdDecoder.Fields(type))
-      {
-        if (!SkipField(f))
-        {
-          Field newf = ConstructFieldFromMetaDataDecoder(f, cl);
-          cl.AddChild(newf);
-        }
-      }
-      #endregion
-
-      return cl;
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    private Event ConstructEventFromProxy(EventExt evt, MethodExt implMethod, Class clparent)
-    {
-      MethodExt Adder, Remover;
-      bool bHasAdder = mdDecoder.HasAdder(evt, out Adder);
-      bool bHasRemover = mdDecoder.HasRemover(evt, out Remover);
-      string name = mdDecoder.Name(evt);
-      bool bIsInInterface = false;
-
-      MethodExt any = implMethod;
-      Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(any));
-
-      Type handlerType = mdDecoder.HandlerType(evt);
-      string returntype = TypeFullName(handlerType, clparent, ns);
-
-      // Accessibility should be the less restrictive for the main property
-      // And then if an accessor is more restrictive, it should be output just for it
-      Access access = Access.NONE;
-      Access accessget = Access.NONE;
-      Access accessset = Access.NONE;
-      if (!name.Contains(".") && !bIsInInterface)
-        access = GetMostAccessible(bHasAdder, bHasRemover, Adder, Remover);
-
-      bool bExtern = mdDecoder.IsExtern(any);
-      bool bVirtual = mdDecoder.IsVirtual(any);
-      bool bSealed = mdDecoder.IsSealed(any);
-      bool bNewSlot = mdDecoder.IsNewSlot(any);
-      bool bOverride = mdDecoder.IsOverride(any);
-      bool bImplicitImpl = mdDecoder.IsImplicitImplementation(any);
-      bool bAbstract = mdDecoder.IsAbstract(any);
-      bool bStatic = mdDecoder.IsStatic(evt);
-
-      bool bActualExtern = false;
-      bool bActualStatic = false;
-      bool bActualVirtual = false;
-      bool bActualSealed = false;
-      bool bActualNewSlot = false;
-      bool bActualOverride = false;
-      bool bActualAbstract = false;
-
-      if (!bIsInInterface)
-      {
-        if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(evt))
-            && !mdDecoder.IsSealed(mdDecoder.DeclaringType(evt)))
-        {
-          if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
-            access = Access.PUBLIC;
-          else if (bVirtual && bSealed)
-          {
-            bActualSealed = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bNewSlot && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bNewSlot)
-          {
-            bActualNewSlot = true;
-            bActualVirtual = true;
-          }
-          else if (bVirtual && access == Access.PRIVATE /* explicit interface */ && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bOverride)
-          {
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bExtern)
-            bActualAbstract = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
-          else if (bVirtual)
-            bActualVirtual = true;
-        }
-        else
-        {
-          if (bVirtual && bOverride)
-            bActualOverride = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
+            mUsings = new List<string>();
+            // order is important !! you don't want "System" to be in first place,
+            // otherwise the other won't ever match
+            mUsings.Add("System.Collections.Generic");
+            mUsings.Add("System.IO");
+            mUsings.Add("System.Text");
+            mUsings.Add("System.Diagnostics.Contracts");
+            mUsings.Add("System");
         }
 
-        bActualStatic = bStatic;
-      }
+        public List<string> Usings { get { return mUsings; } }
 
-      // get accessibility on getter and setter only when the main access has been discovered
-      if (!name.Contains(".") && !bIsInInterface)
-      {
-        if (bHasAdder)
+        /// <summary>
+        /// Returns the type full name as it should be output anywhere in the code (parameter, return type ...)
+        /// </summary>
+        /// <param name="type">The type to output</param>
+        /// <param name="contextClass">If non-null, tells in which class the output will take place, so that the parent name can be stripped off</param>
+        /// <param name="ParentNS">If non-null, tells in which namespace the output will take place so that the parent namespace can be stripped off</param>
+        public string TypeFullName(Type type, Class contextClass, Namespace ParentNS)
         {
-          accessget = GetAccessForMethod(Adder);
-          if (accessget == access) // not more restrictive than the property
-            accessget = Access.NONE;
-        }
+            List<string> prefixes = new List<string>();
+            if (ParentNS != null)
+                prefixes.Add(ParentNS.Name + ".");
+            if (contextClass != null)
+                prefixes.Add(contextClass.Name + ".");
 
-        if (bHasRemover)
-        {
-          accessset = GetAccessForMethod(Remover);
-          if (accessset == access) // not more restrictive than the property
-            accessset = Access.NONE;
-        }
-      }
+            // finally, check if the base namespace is in the "using" namespaces, so we could skip it
+            //foreach (var use in mUsings)
+            //  prefixes.Add(use + ".");
 
-      Event newEvent = new Event(
-        clparent,
-        bHasAdder,
-        bHasRemover,
-        name,
-        mdDecoder.IsUnmanagedPointer(handlerType), /* Parameters are handled when added */
-        bIsInInterface,
-        returntype,
-        access,
-        accessget,
-        accessset,
-        bActualStatic,
-        bActualNewSlot,
-        bActualOverride,
-        bActualSealed,
-        bActualVirtual,
-        bActualExtern,
-        bActualAbstract);
-
-      return newEvent;
-    }
-
-    private bool MustKeepProperty(PropertyExt prop)
-    {
-      if (MustKeepType(mdDecoder.DeclaringType(prop)))
-      {
-        if (SkipType(mdDecoder.PropertyType(prop))) return false;
-        return true;
-      }
-      return false;
-    }
-
-    private bool MustKeepEvent(EventExt evt)
-    {
-      if (MustKeepType(mdDecoder.DeclaringType(evt)))
-      {
-        if (SkipType(mdDecoder.HandlerType(evt))) return false;
-        return true;
-      }
-      return false;
-    }
-
-    private bool MustKeepMethod(MethodExt method)
-    {
-      if (MustKeepType(mdDecoder.DeclaringType(method)))
-      {
-        if (SkipType(mdDecoder.ReturnType(method))) return false;
-        foreach (var par in mdDecoder.Parameters(method).Enumerate()) {
-          if (SkipType(mdDecoder.ParameterType(par))) return false;
-        }
-        return true;
-      }
-      return false;
-    }
-
-    private bool MustKeepType(Type type)
-    {
-      return MustKeepType(type, new Set<Type>());
-    }
-
-    private bool MustKeepType(Type type, Set<Type> seen) {
-      if (seen.Contains(type)) return true;
-      seen.Add(type);
-      if (mdDecoder.IsInterface(type))
-      {
-        foreach (var intf in mdDecoder.Interfaces(type))
-        {
-          IIndexable<Type> args;
-          if (mdDecoder.IsSpecialized(intf, out args))
-          {
-            foreach (var arg in args.Enumerate())
-            {
-              if (SkipType(arg, seen))
+            return TypeHelper.TypeFullName(mdDecoder, type,
+              (prefix, typeName, context) =>
               {
+                  switch (context)
+                  {
+                      case TypeHelper.StripContext.Namespace:
+
+                          // don't want to capture name in parent context
+                          if (contextClass != null && contextClass.HasSymbol(typeName))
+                              return false;
+                          if (ParentNS != null && prefix == ParentNS.Name)
+                              return true;
+                          if (mUsings.Contains(prefix))
+                              return true;
+                          break;
+
+                      case TypeHelper.StripContext.ParentType:
+
+                          if (contextClass != null && prefix == contextClass.Name)
+                              return true;
+                          break;
+                  }
+
+                  return false;
+              }
+            );
+        }
+
+        /// <summary>
+        /// Returns whether there is a constructor for this type. Puts the one with the smaller number
+        /// of arguments in the out parameter "constructor".
+        /// If not a class, or if no constructor is found, just return false with nothing in "constructor".
+        /// The returned constructor will be visible from the "calling_type" constructor (as given by metadatadecoder.DeclaringModuleName),
+        /// and public or protected (ie. usable in a class derived from type).
+        /// The possible base class is not visited.
+        /// </summary>
+        public bool GetAConstructor(Type type, Type calling_type, out MethodExt constructor)
+        {
+            constructor = default(MethodExt);
+            if (!mdDecoder.IsClass(type))
                 return false;
-              }
-            }
-          }
-        }
-        return true;
-      }
-      return false;
-    }
 
-    private bool IsVirtual(PropertyExt prop, out MethodExt rep)
-    {
-      MethodExt getter, setter;
-      bool isVirtual = false;
-      rep = default(MethodExt);
-
-      if (mdDecoder.HasGetter(prop, out getter))
-      {
-        rep = getter;
-        isVirtual = mdDecoder.IsVirtual(getter);
-      }
-      if (mdDecoder.HasSetter(prop, out setter))
-      {
-        if (mdDecoder.IsVirtual(setter))
-        {
-          rep = setter;
-          isVirtual = true;
-        }
-      }
-      return isVirtual; ;
-    }
-
-    private bool SkipProperty(PropertyExt prop)
-    {
-      if (MustKeepProperty(prop)) return false;
-
-      if (this.visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(prop))
-      {
-        // check that it is not a visible interface implementation or required by abstract base class
-        MethodExt rep;
-        if (IsVirtual(prop, out rep))
-        {
-          if (!SkipMethod(rep)) return false;
-        }
-
-        return true;
-      }
-
-      return ContainsNonCSharpType(mdDecoder.PropertyType(prop));
-    }
-
-    private bool IsVirtual(EventExt prop, out MethodExt rep)
-    {
-      MethodExt adder, remover;
-      bool isVirtual = false;
-      rep = default(MethodExt);
-
-      if (mdDecoder.HasAdder(prop, out adder))
-      {
-        rep = adder;
-        isVirtual = mdDecoder.IsVirtual(adder);
-      }
-      if (mdDecoder.HasRemover(prop, out remover))
-      {
-        if (mdDecoder.IsVirtual(remover))
-        {
-          rep = remover;
-          isVirtual = true;
-        }
-      }
-      return isVirtual; ;
-    }
-
-    private bool SkipEvent(EventExt evt)
-    {
-      if (MustKeepEvent(evt)) return false;
-
-      if (this.visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(evt))
-      {
-        MethodExt rep;
-        if (IsVirtual(evt, out rep))
-        {
-          if (!SkipMethod(rep)) return false;
-        }
-        return true;
-      }
-      return ContainsNonCSharpType(mdDecoder.HandlerType(evt));
-    }
-
-
-    private bool SkipField(FieldExt f)
-    {
-      if (this.visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(f)) return true;
-
-      return mdDecoder.IsCompilerGenerated(f) || IsNonCSharpType(mdDecoder.FieldType(f));
-    }
-
-    internal bool SkipMethod(MethodExt m)
-    {
-      if (MustKeepMethod(m)) return false;
-
-      if (this.visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(m))
-      {
-        // check that it is not a visible interface implementation or required by abstract base class
-        if (this.mdDecoder.IsVirtual(m))
-        {
-          foreach (var baseMethod in this.mdDecoder.OverriddenAndImplementedMethods(m))
-          {
-            if (!SkipMethod(baseMethod)) return false;
-          }
-        }
-        return true;
-#if false
-        bool isConstructor = mdDecoder.IsConstructor(m);
-        // if it is a constructor of a publicly visible type, keep it unless its parameter types are not visible
-        if (!isConstructor || AnyInternalParameterTypes(mdDecoder.Parameters(m)))
-        {
-          return true;
-        }
-        if (!mdDecoder.IsVisibleOutsideAssembly(mdDecoder.DeclaringType(m)))
-        {
-          return true;
-        }
-#endif
-      }
-      bool skip = mdDecoder.IsCompilerGenerated(m) || mdDecoder.Name(m) == ".cctor";
-      if (skip) return true;
-
-      if (ContainsNonCSharpType(mdDecoder.ReturnType(m))) return true;
-
-      // check parameter types
-      foreach (var p in mdDecoder.Parameters(m).Enumerate())
-      {
-        if (ContainsNonCSharpType(mdDecoder.ParameterType(p))) { return true; } // skip method
-      }
-      return false;
-    }
-
-    private bool AnyInternalParameterTypes(IIndexable<ParameterExt> iIndexable)
-    {
-      foreach (var p in iIndexable.Enumerate())
-      {
-        if (!mdDecoder.IsVisibleOutsideAssembly(mdDecoder.ParameterType(p)))
-        {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    public Enum ConstructEnumFromMetaDataDecoder(Type type)
-    {
-      Access access = Access.PUBLIC;
-      if (mdDecoder.IsPublic(type))
-        access = Access.PUBLIC;
-      else if (mdDecoder.IsProtected(type) && mdDecoder.IsInternal(type))
-        access = Access.INTERNAL_AND_OR_PROTECTED;
-      else if (mdDecoder.IsProtected(type))
-        access = Access.PROTECTED;
-      else if (mdDecoder.IsPrivate(type))
-        access = Access.PRIVATE;
-      else if (mdDecoder.IsInternal(type))
-        access = Access.INTERNAL;
-
-      Type parentt;
-      Class clparent = null;
-      if (mdDecoder.IsNested(type, out parentt))
-        clparent = LookupClass(parentt, false);
-
-      Namespace ns;
-      if (clparent == null)
-        ns = LookupNamespaceFromClass(type);
-      else
-        ns = clparent.Namespace;
-
-      Type enumtype = mdDecoder.TypeEnum(type);
-
-      Enum newenum = new Enum(access, clparent, ns, mdDecoder.Name(type), TypeFullName(enumtype, clparent, ns));
-
-      foreach (var f in mdDecoder.Fields(type))
-      {
-        Contract.Assume(f != null, "missing contract");
-
-        string name = mdDecoder.Name(f);
-        object value;
-        if (name != "value__" && mdDecoder.TryInitialValue(f, out value))
-        {
-          newenum.AddField(new Enum.EnumField(name, value.ToString()));
-        }
-      }
-
-      return newenum;
-    }
-
-    public Parameter ConstructParameterFromMetaDataDecoder(int index, ParameterExt param, Class clparent)
-    {
-      Type ptype = mdDecoder.ParameterType(param);
-      MethodExt parentm = mdDecoder.DeclaringMethod(param);
-      Type parent = mdDecoder.DeclaringType(parentm);
-      Namespace ns = LookupNamespaceFromClass(parent);
-
-      string typename = TypeFullName(ptype, clparent, ns);
-
-      Parameter.Modifier modif = Parameter.Modifier.NONE;
-      // Order is important because an out parameter is also a ref
-      if (mdDecoder.IsOut(param) && mdDecoder.IsManagedPointer(ptype))
-        modif = Parameter.Modifier.OUT;
-      else if (mdDecoder.IsManagedPointer(ptype))
-        modif = Parameter.Modifier.REF;
-
-      if (modif != Parameter.Modifier.NONE)
-        typename = TypeFullName (mdDecoder.ElementType(ptype), clparent, ns);
-
-      var name = mdDecoder.Name(param);
-      return new Parameter(typename, name, modif);
-    }
-
-    public Delegate ConstructDelegateFromMetaDataDecoder(Type type, Class clparent)
-    {
-      bool bIsInInterface = false;
-      Type parentt;
-      if (mdDecoder.IsNested(type, out parentt))
-        bIsInInterface = mdDecoder.IsInterface(parentt);
-
-      Access access;
-      if (bIsInInterface)
-        access = Access.NONE;
-      else if (mdDecoder.IsPublic(type))
-        access = Access.PUBLIC;
-      else if (mdDecoder.IsProtected(type) && mdDecoder.IsInternal(type))
-        access = Access.INTERNAL_AND_OR_PROTECTED;
-      else if (mdDecoder.IsProtected(type))
-        access = Access.PROTECTED;
-      else if (mdDecoder.IsPrivate(type))
-        access = Access.PRIVATE;
-      else if (mdDecoder.IsInternal(type))
-        access = Access.INTERNAL;
-      else
-        access = Access.NONE;
-
-      Namespace ns = LookupNamespaceFromClass(type);
-
-      // Look for the Invoke method to get the return type
-      var methods = mdDecoder.Methods(type);
-      Type rettypet= default(Type);
-      string rettype = "";
-      Microsoft.Research.DataStructures.IIndexable<ParameterExt> pars = null;
-      foreach (var m in methods)
-      {
-        if (mdDecoder.Name(m) == "Invoke")
-        {
-          rettypet = mdDecoder.ReturnType(m);
-          rettype = TypeFullName(rettypet, clparent, ns);
-          pars = mdDecoder.Parameters(m);
-          break;
-        }
-      }
-
-      if (pars != null)
-      {
-        string name = mdDecoder.Name(type);
-        Delegate newdel = new Delegate(
-          access,
-          mdDecoder.IsUnmanagedPointer(rettypet), /* Parameters are handled when added */
-          name,
-          clparent,
-          ns,
-          rettype);
-
-        //** Formal type parameters
-        Microsoft.Research.DataStructures.IIndexable<Type> formals;
-        if (mdDecoder.IsGeneric(type, out formals, false))
-          newdel.AddFormalTypeParameters(GetFormalTypeParameters(formals));
-
-        //** Add parameters
-        int n = pars.Count;
-        for (int i = 0; i < n; ++i)
-        {
-          Parameter newparam = ConstructParameterFromMetaDataDecoder(i, pars[i], clparent);
-          newdel.AddParameter(newparam);
-        }
-
-        return newdel;
-      }
-
-      return null;
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    private Method ConstructUserOpFromMetaDataDecoder(MethodExt mMethod, Class clparent)
-    {
-      Contract.Requires(mdDecoder.Name(mMethod).Length >= 3);
-      // here we assume the name of the method is op_xxx
-      // The full list is taken from ECMA standard
-      // (http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-335.pdf) chapter 10.3.1 and following
-
-      Method newm = ConstructMethodFromMetaDataDecoder(mMethod, clparent);
-      newm.Operator = true;
-
-      string keyword = mdDecoder.Name(mMethod).Substring(3);
-      string name = keyword;
-      bool bImplicit = false;
-      bool bExplicit = false;
-
-      switch (keyword)
-      {
-        case "Implicit":
-          name = newm.ReturnType;
-          newm.ReturnType = "";
-          bImplicit = true;
-          break;
-        case "Explicit":
-          name = newm.ReturnType;
-          newm.ReturnType = "";
-          bExplicit = true;
-          break;
-        case "Decrement": name = "-- "; break;
-        case "Increment": name = "++ "; break;
-        case "UnaryNegation": name = "- "; break;
-        case "UnaryPlus": name = "+ "; break;
-        case "LogicalNot": name = "! "; break;
-        case "AddressOf": name = "& "; break;
-        case "OnesComplement": name = "~ "; break;
-        case "PointerDereference": name = "* "; break;
-        case "Addition": name = "+ "; break;
-        case "Subtraction": name = "- "; break;
-        case "Multiply": name = "* "; break;
-        case "Division": name = "/ "; break;
-        case "Modulus": name = "% "; break;
-        case "ExclusiveOr": name = "^ "; break;
-        case "BitwiseAnd": name = "& "; break;
-        case "BitwiseOr": name = "| "; break;
-        case "LogicalAnd": name = "&& "; break;
-        case "LogicalOr": name = "|| "; break;
-        case "LeftShift": name = "<< "; break;
-        case "RightShift": name = ">> "; break;
-        case "Equality": name = "== "; break;
-        case "GreaterThan": name = "> "; break;
-        case "LessThan": name = "< "; break;
-        case "Inequality": name = "!= "; break;
-        case "GreaterThanOrEqual": name = ">= "; break;
-        case "LessThanOrEqual": name = "<="; break;
-        case "MemberSelection": name = "->"; break;
-        case "RightShiftAssignment": name = "<<= "; break;
-        case "MultiplicationAssignment": name = "*= "; break;
-        case "PointerToMemberSelection": name = "->* "; break;
-        case "SubtractionAssignment": name = "-= "; break;
-        case "ExclusiveOrAssignment": name = "^= "; break;
-        case "LeftShiftAssignment": name = "<<="; break;
-        case "ModulusAssignment": name = "%= "; break;
-        case "AdditionAssignment": name = "+= "; break;
-        case "BitwiseAndAssignment": name = "&= "; break;
-        case "BitwiseOrAssignment": name = "|= "; break;
-        case "Comma": name = ", "; break;
-        case "DivisionAssignment": name = "/= "; break;
-      }
-
-      newm.Implicit = bImplicit;
-      newm.Explicit = bExplicit;
-      newm.SetName (name);
-
-      return newm;
-    }
-
-    private Access GetAccessForMethod(MethodExt mMethod)
-    {
-      if (mdDecoder.IsProtected(mMethod) && mdDecoder.IsInternal(mMethod))
-        return Access.INTERNAL_AND_OR_PROTECTED;
-      else if (mdDecoder.IsProtected(mMethod))
-        return Access.PROTECTED;
-      else if (mdDecoder.IsPrivate(mMethod))
-        return Access.PRIVATE;
-      else if (mdDecoder.IsInternal(mMethod))
-        return Access.INTERNAL;
-      else if (mdDecoder.IsPublic(mMethod))
-        return Access.PUBLIC;
-      else
-        return Access.NONE;
-    }
-
-    public Method ConstructDefaultConstructor(Type parentType, Class clparent)
-    {
-      Contract.Requires(clparent != null);
-      Namespace ns = LookupNamespaceFromClass(parentType);
-
-      string CustomInitList = "";
-      bool bBaseConstructor = false;
-      MethodExt baseConstructor = default(MethodExt);
-      if (mdDecoder.HasBaseClass(parentType))
-      {
-        Type baseclass = mdDecoder.BaseClass(parentType);
-        if (mdDecoder.FullName(baseclass) != "System.Object")
-          bBaseConstructor = GetAConstructor(baseclass, parentType, out baseConstructor);
-      }
-
-      if (bBaseConstructor)
-      {
-        var pars = mdDecoder.Parameters(baseConstructor);
-        if (pars.Count > 0)
-        {
-          // only output if not the default constructor
-          CustomInitList += " : base (";
-          for (int i = 0; i < pars.Count; ++i)
-          {
-            if (i > 0)
-              CustomInitList += ", ";
-            CustomInitList += "default(" + TypeFullName(mdDecoder.ParameterType(pars[i]), clparent, ns) + ")";
-          }
-          CustomInitList += ")";
-        }
-      }
-
-      Method newmeth = new Method(
-        Access.INTERNAL,
-        clparent,
-        "void",
-        mdDecoder.Name(parentType),
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        CustomInitList);
-
-      //** Parameters
-
-      // Initialize fields in a struct constructor
-      if (mdDecoder.IsStruct(parentType))
-      {
-        foreach (var f in mdDecoder.Fields(parentType))
-        {
-          if (SkipField(f)) continue;
-          if (!mdDecoder.IsStatic(f))
-            newmeth.AddVarToInitialize(TypeFullName(mdDecoder.FieldType(f), clparent, ns), "this." + mdDecoder.Name(f));
-        }
-      }
-
-      return newmeth;
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification="Probably Clousot is right to report bExtern")]
-    public Method ConstructMethodFromMetaDataDecoder (MethodExt mMethod, Class clparent)
-    {
-      bool bExtern    = mdDecoder.IsExtern(mMethod);
-      bool bStatic    = mdDecoder.IsStatic(mMethod);
-      bool bVirtual   = mdDecoder.IsVirtual(mMethod);
-      bool bSealed    = mdDecoder.IsSealed(mMethod);
-      bool bNewSlot   = mdDecoder.IsNewSlot(mMethod);
-      bool bAbstract  = mdDecoder.IsAbstract(mMethod);
-      bool bPrivate   = mdDecoder.IsPrivate(mMethod);
-      bool bOverride  = mdDecoder.IsOverride(mMethod);
-      bool bImplicitImpl = mdDecoder.IsImplicitImplementation(mMethod);
-
-      bool bIsInInterface = mdDecoder.IsInterface(mdDecoder.DeclaringType(mMethod));
-      Access access;
-      if (bIsInInterface)
-        access = Access.NONE;
-      else if (mdDecoder.IsPublic(mMethod)
-        || (bVirtual && bSealed && bNewSlot && bImplicitImpl))
-        access = Access.PUBLIC;
-      else
-        access = GetAccessForMethod(mMethod);
-
-      bool bIsConstructor = mdDecoder.IsConstructor(mMethod);
-      bool bIsFinalizer = mdDecoder.IsFinalizer(mMethod);
-      string rettype = "";
-      Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(mMethod));
-      if (!bIsConstructor && !bIsFinalizer)
-        rettype += TypeFullName(mdDecoder.ReturnType(mMethod), clparent, ns);
-
-      //** Get actual modifiers from the metadata decoders values
-      // and the correspondance table (cf. the .xlsx file)
-      bool bActualExtern = false;
-      bool bActualStatic = false;
-      bool bActualVirtual = false;
-      bool bActualSealed = false;
-      bool bActualNewSlot = false;
-      bool bActualAbstract = false;
-      bool bActualOverride = false;
-
-      if (!bIsInInterface)
-      {
-        if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(mMethod))
-            && !mdDecoder.IsSealed(mdDecoder.DeclaringType(mMethod)))
-        {
-          if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
-            access = Access.PUBLIC;
-          else if (bVirtual && bSealed)
-          {
-            bActualSealed = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bNewSlot && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bNewSlot)
-          {
-            bActualNewSlot = true;
-            bActualVirtual = true;
-          }
-          else if (bVirtual && bPrivate /* explicit interface */ && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bOverride)
-          {
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bExtern)
-            bActualAbstract = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
-          else if (bVirtual)
-            bActualVirtual = true;
-        }
-        else
-        {
-          if (bVirtual && bOverride)
-            bActualOverride = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
-        }
-
-        bActualStatic = bStatic;
-      }
-
-      Type parentType = mdDecoder.DeclaringType(mMethod);
-      string name;
-      if (bIsConstructor || bIsFinalizer)
-        name = mdDecoder.Name(parentType);
-      else
-        name = mdDecoder.Name(mMethod);
-
-      string CustomInitList = "";
-      if (bIsConstructor)
-      {
-        bool bBaseConstructor = false;
-        MethodExt baseConstructor = default(MethodExt);
-        if (mdDecoder.HasBaseClass(parentType))
-        {
-          Type baseclass = mdDecoder.BaseClass(parentType);
-          if (mdDecoder.FullName(baseclass) != "System.Object")
-            bBaseConstructor = GetAConstructor(baseclass, parentType, out baseConstructor);
-        }
-
-        if (bBaseConstructor)
-        {
-          var pars = mdDecoder.Parameters(baseConstructor);
-          if (pars.Count > 0)
-          {
-            // only output if not the default constructor
-            CustomInitList += " : base (";
-            for (int i = 0; i < pars.Count; ++i)
+            int nb_min = 9999999; // should be enough
+            bool bReturn = false;
+            foreach (var m in mdDecoder.Methods(type))
             {
-              if (i > 0)
-                CustomInitList += ", ";
-              CustomInitList += "default(" + TypeFullName(mdDecoder.ParameterType(pars[i]), clparent, ns) + ")";
+                if (mdDecoder.IsConstructor(m) && !mdDecoder.IsPrivate(m))
+                {
+                    var pars = mdDecoder.Parameters(m);
+                    if (pars.Count < nb_min)
+                    {
+                        // Check that the constructor and the arguments types are visible to the current assembly
+                        Microsoft.Research.DataStructures.IIndexable<Type> dummy;
+                        string base_assembly = mdDecoder.DeclaringModuleName(mdDecoder.IsSpecialized(type, out dummy) ? mdDecoder.Unspecialized(type) : type);
+                        string calling_assembly = mdDecoder.DeclaringModuleName(mdDecoder.IsSpecialized(calling_type, out dummy) ? mdDecoder.Unspecialized(calling_type) : calling_type);
+
+                        bool bVisible = true;
+                        if (calling_assembly == base_assembly || mdDecoder.IsVisibleOutsideAssembly(m))
+                        {
+                            // Then check every parameter type
+                            for (int i = 0; i < pars.Count && bVisible; ++i)
+                            {
+                                Type ptype = mdDecoder.ParameterType(pars[i]);
+                                if (mdDecoder.IsSpecialized(ptype, out dummy))
+                                    ptype = mdDecoder.Unspecialized(ptype);
+                                string asst = mdDecoder.DeclaringModuleName(ptype);
+                                if (asst != calling_assembly)
+                                {
+                                    //if (mdDecoder.IsPrivate(ptype) || mdDecoder.IsInternal(ptype))
+                                    if (!mdDecoder.IsPublic(ptype) && !mdDecoder.IsProtected(ptype))
+                                    {
+                                        bVisible = false;
+                                        break; // reject
+                                    }
+                                }
+                                else
+                                    bVisible = mdDecoder.IsVisibleFrom(ptype, calling_type);
+                            }
+                        }
+                        else
+                            bVisible = false;
+
+                        if (bVisible)
+                        {
+                            constructor = m;
+                            nb_min = pars.Count;
+                            bReturn = true;
+                        }
+                    }
+                }
             }
-            CustomInitList += ")";
-          }
+            return bReturn;
         }
-      }
 
-      Method newmeth = new Method(
-        access,
-        clparent,
-        rettype,
-        name,
-        mdDecoder.IsUnmanagedPointer(mdDecoder.ReturnType(mMethod)), /* Parameters are taken into account below */
-        bActualExtern,
-        bActualStatic,
-        bActualVirtual,
-        bActualNewSlot,
-        bActualSealed,
-        bActualAbstract,
-        bIsConstructor,
-        bIsFinalizer,
-        bActualOverride,
-        CustomInitList);
-
-      //** Formal type parameters
-      Microsoft.Research.DataStructures.IIndexable<Type> formals;
-      if (mdDecoder.IsGeneric(mMethod, out formals))
-        newmeth.AddFormalTypeParameters(GetFormalTypeParameters(formals));
-
-      //** Parameters
-      var mpars = mdDecoder.Parameters(mMethod);
-      int n = mpars.Count;
-      for (int i = 0; i < n; ++i)
-      {
-        Parameter newparam = ConstructParameterFromMetaDataDecoder(i, mpars[i], clparent);
-        newmeth.AddParameter(newparam);
-      }
-
-      // Initialize fields in a struct constructor
-      if (mdDecoder.IsConstructor(mMethod) && mdDecoder.IsStruct(mdDecoder.DeclaringType(mMethod)))
-      {
-        foreach (var f in mdDecoder.Fields(parentType))
+        private List<FormalTypeParameter> GetFormalTypeParameters(Microsoft.Research.DataStructures.IIndexable<Type> formals)
         {
-          if (SkipField(f)) continue;
-          if (!mdDecoder.IsStatic(f))
-            newmeth.AddVarToInitialize(TypeFullName(mdDecoder.FieldType(f), clparent, ns), "this." + mdDecoder.Name(f));
-          else if (!mdDecoder.IsReadonly(f) || mdDecoder.IsStatic(mMethod)) // if readonly, can only be assigned in a static constructor
-            newmeth.AddVarToInitialize(TypeFullName(mdDecoder.FieldType(f), clparent, ns), clparent.Name + "." + mdDecoder.Name(f));
-        }
-      }
+            List<FormalTypeParameter> res = new List<FormalTypeParameter>();
 
-      return newmeth;
-    }
-
-    private Access GetMostAccessible(bool bIsm1Valid, bool bIsm2Valid, MethodExt m1, MethodExt m2)
-    {
-      Access access1 = Access.NONE;
-      Access access2 = Access.NONE;
-
-      if (bIsm1Valid)
-        access1 = GetAccessForMethod(m1);
-      if (bIsm2Valid)
-        access2 = GetAccessForMethod(m2);
-
-      if (!bIsm1Valid)
-        return access2;
-      if (!bIsm2Valid)
-        return access1;
-
-      if (access1 == Access.PRIVATE)
-        return access2;
-      if (access2 == Access.PRIVATE)
-        return access1;
-
-      if (access1 == Access.INTERNAL)
-        return access2;
-      if (access2 == Access.INTERNAL)
-        return access1;
-
-      if (access1 == Access.PROTECTED)
-        return access2;
-      if (access2 == Access.PROTECTED)
-        return access1;
-
-      if (access1 == Access.INTERNAL_AND_OR_PROTECTED)
-        return access2;
-      if (access2 == Access.INTERNAL_AND_OR_PROTECTED)
-        return access1;
-
-      return Access.PUBLIC;
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    public Property ConstructPropertyFromMetaDataDecoder(PropertyExt prop, Class clparent)
-    {
-      var md = mdDecoder;
-      MethodExt Getter, Setter;
-      bool bHasGetter = md.HasGetter(prop, out Getter);
-      bool bHasSetter = md.HasSetter(prop, out Setter);
-      string name = md.Name(prop);
-      bool bIsInInterface = mdDecoder.IsInterface(mdDecoder.DeclaringType(prop));
-
-      bool bIsIndexer = (name == "Item" || name.EndsWith(".Item")); // could be an explicit implementation
-      // An indexer property can have an other name than "Item"
-      // cf. http://msdn.microsoft.com/en-us/library/2549tw02(VS.71).aspx
-      MethodExt getorset = bHasGetter ? Getter : Setter;
-      Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(getorset));
-
-      var atts = md.GetAttributes(mdDecoder.DeclaringType(getorset));
-      foreach (var att in atts)
-      {
-        string attname = md.Name(mdDecoder.AttributeType(att));
-        if (attname == "DefaultMemberAttribute")
-        {
-          var inds = md.PositionalArguments(att);
-          if (inds.Count > 0)
-          {
-            // The first (and only !) argument is the name of the indexer
-            string indexname = inds[0] as string;
-            if (indexname != null)
+            for (int i = 0; i < formals.Count; ++i)
             {
-              var propName = md.Name(prop);
-              Contract.Assume(propName != null);
-              if (propName == indexname || propName.EndsWith(indexname)) // could be an explicit implementation
-              {
-                bIsIndexer = true;
-                break;
-              }
+                var constraints = mdDecoder.TypeParameterConstraints(formals[i]);
+                Contract.Assume(constraints != null);
+                string name = mdDecoder.Name(formals[i]);
+                var ftp = new FormalTypeParameter(name);
+
+                var tc = FormalTypeParamConstraint.TypeConstraint.NONE;
+                string classConstraint = "";
+                if (mdDecoder.IsReferenceConstrained(formals[i]))
+                    tc = FormalTypeParamConstraint.TypeConstraint.CLASS;
+                else if (mdDecoder.IsValueConstrained(formals[i]))
+                    tc = FormalTypeParamConstraint.TypeConstraint.STRUCT;
+                else
+                {
+                    foreach (var cont in constraints)
+                    {
+                        if (!mdDecoder.IsInterface(cont))
+                        {
+                            classConstraint = TypeFullName(cont, null, LookupNamespaceFromClass(cont));
+                            tc = FormalTypeParamConstraint.TypeConstraint.BASECLASS;
+                            break;
+                        }
+                    }
+                }
+
+                bool bIsNew = mdDecoder.IsConstructorConstrained(formals[i]) && !mdDecoder.IsValueConstrained(formals[i]);
+
+                var ftpc = new FormalTypeParamConstraint(ftp, tc, classConstraint, bIsNew);
+                ftp.setConstraint(ftpc);
+
+                // Interfaces
+                foreach (var cont in constraints)
+                {
+                    if (mdDecoder.IsInterface(cont))
+                        ftpc.AddInterfaceConstraint(TypeFullName(cont, null, LookupNamespaceFromClass(cont)));
+                }
+
+                res.Add(ftp);
             }
-          }
-        }
-      }
 
-      Type returnt;
-      // There is a special case here.
-      // If the property only has a setter, then the return type
-      // is the type of the last parameter
-      if (bHasGetter)
-        returnt = mdDecoder.ReturnType(Getter);
-      else
-      {
-        var pars = mdDecoder.Parameters(Setter);
-        Contract.Assume(pars.Count > 0, "Setters have at least one parameter");
-        var lastpar = pars[pars.Count - 1];
-        returnt = mdDecoder.ParameterType(lastpar);
-      }
-      string returntype = TypeFullName(returnt, clparent, ns);
-
-      // Accessibility should be the less restrictive for the main property
-      // And then if an accessor is more restrictive, it should be output just for it
-      Access access = Access.NONE;
-      Access accessget = Access.NONE;
-      Access accessset = Access.NONE;
-      if (!name.Contains(".") && !bIsInInterface)
-        access = GetMostAccessible(bHasGetter, bHasSetter, Getter, Setter);
-
-      bool bExtern = mdDecoder.IsExtern(getorset);
-      bool bVirtual = mdDecoder.IsVirtual(getorset);
-      bool bSealed = mdDecoder.IsSealed(getorset);
-      bool bNewSlot = mdDecoder.IsNewSlot(getorset);
-      bool bOverride = mdDecoder.IsOverride(getorset);
-      bool bImplicitImpl = mdDecoder.IsImplicitImplementation(getorset);
-      bool bAbstract = mdDecoder.IsAbstract(getorset);
-      bool bStatic = mdDecoder.IsStatic(prop);
-
-      bool bActualExtern = false;
-      bool bActualStatic = false;
-      bool bActualVirtual = false;
-      bool bActualSealed = false;
-      bool bActualNewSlot = false;
-      bool bActualOverride = false;
-      bool bActualAbstract = false;
-
-      if (!bIsInInterface)
-      {
-        if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(prop))
-            && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)))
-        {
-          if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
-          {
-            access = Access.PUBLIC;
-          }
-          else if (bVirtual && bSealed)
-          {
-            bActualSealed = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bNewSlot && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bNewSlot)
-          {
-            bActualNewSlot = true;
-            bActualVirtual = true;
-          }
-          else if (bVirtual && access == Access.PRIVATE /* explicit interface */ && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bOverride)
-          {
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bExtern)
-            bActualAbstract = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
-          else if (bVirtual)
-            bActualVirtual = true;
-        }
-        else
-        {
-          if (bVirtual && bOverride)
-            bActualOverride = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
+            return res;
         }
 
-        bActualStatic = bStatic;
-      }
-
-      // get accessibility on getter and setter only when the main access has been discovered
-      if (!name.Contains(".") && !bIsInInterface)
-      {
-        if (bHasGetter)
+        private string GetNamespaceFromClass(Type type)
         {
-          accessget = GetAccessForMethod(Getter);
-          if (accessget == access) // not more restrictive than the property
-            accessget = Access.NONE;
+            var nsname = TypeHelper.GetNamespaceFromClass(mdDecoder, type);
+
+            if (nsname.Length == 0)
+                nsname = "<toplevel>";
+
+            return nsname;
         }
 
-        if (bHasSetter)
+        public Namespace LookupNamespaceFromClass(Type type)
         {
-          accessset = GetAccessForMethod(Setter);
-          if (accessset == access) // not more restrictive than the property
-            accessset = Access.NONE;
-        }
-      }
-
-
-
-      //bool bIsStatic = mdDecoder.IsStatic (prop);
-      //bool bIsNewSlot = mdDecoder.IsNewSlot(prop) && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)) && !mdDecoder.IsStruct(mdDecoder.DeclaringType(prop));
-      //bool bIsOverride = !bIsNewSlot && mdDecoder.IsOverride(prop) && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)) && !mdDecoder.IsStruct(mdDecoder.DeclaringType(prop));
-      //bool bIsSealed = !bIsNewSlot && mdDecoder.IsSealed(prop) && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)) && !mdDecoder.IsStruct(mdDecoder.DeclaringType(prop));
-
-      bIsIndexer = bIsIndexer && mdDecoder.Parameters(getorset).Count > 0; // double-check, you can have a property called Item
-
-      Property newprop = new Property(
-        clparent,
-        bHasGetter,
-        bHasSetter,
-        name,
-        mdDecoder.IsUnmanagedPointer(returnt), /* Parameters are handled when added */
-        bIsInInterface,
-        bIsIndexer,
-        returntype,
-        access,
-        accessget,
-        accessset,
-        bActualStatic,
-        bActualNewSlot,
-        bActualOverride,
-        bActualSealed,
-        bActualVirtual,
-        bActualExtern,
-        bActualAbstract);
-
-      // Add parameters for indexers
-      if (bIsIndexer)
-      {
-        var pars = mdDecoder.Parameters(getorset);
-        int nb_par = pars.Count;
-        if (!bHasGetter)
-          --nb_par; // Skip last parameter, it's "value"
-        for (int i = 0; i < nb_par; ++i)
-          newprop.AddParameter(ConstructParameterFromMetaDataDecoder(i, pars[i], clparent));
-      }
-
-      return newprop;
-    }
-
-    [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-    public Event ConstructEventFromMetaDataDecoder(EventExt evt, Class clparent)
-    {
-      Contract.Requires(clparent != null);
-
-      MethodExt Adder, Remover;
-      bool bHasAdder = mdDecoder.HasAdder(evt, out Adder);
-      bool bHasRemover = mdDecoder.HasRemover(evt, out Remover);
-      string name = mdDecoder.Name(evt);
-      bool bIsInInterface = mdDecoder.IsInterface(mdDecoder.DeclaringType(evt));
-
-      MethodExt any = bHasAdder ? Adder : Remover;
-      Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(any));
-
-      Type handlerType = mdDecoder.HandlerType(evt);
-      string returntype = TypeFullName(handlerType, clparent, ns);
-
-      // Accessibility should be the less restrictive for the main property
-      // And then if an accessor is more restrictive, it should be output just for it
-      Access access = Access.NONE;
-      Access accessget = Access.NONE;
-      Access accessset = Access.NONE;
-      if (!name.Contains(".") && !bIsInInterface)
-        access = GetMostAccessible(bHasAdder, bHasRemover, Adder, Remover);
-
-      bool bExtern = mdDecoder.IsExtern(any);
-      bool bVirtual = mdDecoder.IsVirtual(any);
-      bool bSealed = mdDecoder.IsSealed(any);
-      bool bNewSlot = mdDecoder.IsNewSlot(any);
-      bool bOverride = mdDecoder.IsOverride(any);
-      bool bImplicitImpl = mdDecoder.IsImplicitImplementation(any);
-      bool bAbstract = mdDecoder.IsAbstract(any);
-      bool bStatic = mdDecoder.IsStatic(evt);
-
-      bool bActualExtern = false;
-      bool bActualStatic = false;
-      bool bActualVirtual = false;
-      bool bActualSealed = false;
-      bool bActualNewSlot = false;
-      bool bActualOverride = false;
-      bool bActualAbstract = false;
-
-      if (!bIsInInterface)
-      {
-        if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(evt))
-            && !mdDecoder.IsSealed(mdDecoder.DeclaringType(evt)))
-        {
-          if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
-            access = Access.PUBLIC;
-          else if (bVirtual && bSealed)
-          {
-            bActualSealed = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bNewSlot && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bAbstract)
-            bActualAbstract = true;
-          else if (bVirtual && bNewSlot)
-          {
-            bActualNewSlot = true;
-            bActualVirtual = true;
-          }
-          else if (bVirtual && access == Access.PRIVATE /* explicit interface */ && bOverride)
-          {
-            bActualAbstract = true;
-            bActualOverride = true;
-          }
-          else if (bVirtual && bOverride)
-          {
-            bActualOverride = true;
-          }
-          else if (bVirtual && bAbstract && bExtern)
-            bActualAbstract = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
-          else if (bVirtual)
-            bActualVirtual = true;
-        }
-        else
-        {
-          if (bVirtual && bOverride)
-            bActualOverride = true;
-          else if (bVirtual && bExtern)
-            bActualExtern = true;
+            return mCm.LookupNamespaceByName(GetNamespaceFromClass(type));
         }
 
-        bActualStatic = bStatic;
-      }
-
-      // get accessibility on getter and setter only when the main access has been discovered
-      if (!name.Contains(".") && !bIsInInterface)
-      {
-        if (bHasAdder)
+        public Class ConstructClassFromMetaDataDecoder(Type type)
         {
-          accessget = GetAccessForMethod(Adder);
-          if (accessget == access) // not more restrictive than the property
-            accessget = Access.NONE;
-        }
-
-        if (bHasRemover)
-        {
-          accessset = GetAccessForMethod(Remover);
-          if (accessset == access) // not more restrictive than the property
-            accessset = Access.NONE;
-        }
-      }
-
-      Event newEvent = new Event(
-        clparent,
-        bHasAdder,
-        bHasRemover,
-        name,
-        mdDecoder.IsUnmanagedPointer(handlerType), /* Parameters are handled when added */
-        bIsInInterface,
-        returntype,
-        access,
-        accessget,
-        accessset,
-        bActualStatic,
-        bActualNewSlot,
-        bActualOverride,
-        bActualSealed,
-        bActualVirtual,
-        bActualExtern,
-        bActualAbstract);
-
-      return newEvent;
-    }
-
-    public Field ConstructFieldFromMetaDataDecoder(FieldExt f, Class clparent)
-    {
-      Contract.Requires(clparent != null);
-
-      Field.ParentType pt;
-      Type parent = mdDecoder.DeclaringType(f);
-      if (mdDecoder.IsStruct(parent))
-        pt = Field.ParentType.STRUCT;
-      else if (mdDecoder.IsClass(parent))
-        pt = Field.ParentType.CLASS;
-      else
-        pt = Field.ParentType.INTERFACE;
-
-      Access acc;
-      if (mdDecoder.IsProtected(f) && mdDecoder.IsInternal(f))
-        acc = Access.INTERNAL_AND_OR_PROTECTED;
-      else if (mdDecoder.IsInternal(f))
-        acc = Access.INTERNAL;
-      else if (mdDecoder.IsPublic(f))
-        acc = Access.PUBLIC;
-      else if (mdDecoder.IsProtected(f))
-        acc = Access.PROTECTED;
-      else
-        acc = Access.PRIVATE;
-
-      Type fieldt = mdDecoder.FieldType(f);
-      string typename = TypeFullName(fieldt, clparent, clparent.Namespace);
-      string defaut = "";
-      // For readability, don't even output this, but disable the corresponding warning instead
-      //if (pt != Field.ParentType.STRUCT)
-      //  defaut = "default(" + typename + ")";
-
-      return new Field(
-        typename,
-        mdDecoder.Name(f),
-        clparent,
-        defaut,
-        pt,
-        acc,
-        mdDecoder.IsUnmanagedPointer(fieldt),
-        mdDecoder.IsReadonly(f),
-        mdDecoder.IsStatic(f),
-        mdDecoder.IsNewSlot(f),
-        mdDecoder.IsVolatile(f)
-        );
-    }
-
-    public Class LookupClass(Type type, bool bVisitNested)
-    {
-      if (!mClassesLookup.ContainsKey(type))
-        AddClass(type, bVisitNested);
-      else if (bVisitNested)
-      {
-        // Here, it is requested that nested types are well registered
-        // they could be still pending because the class could have been
-        // added before without the bVisitNested flag
-        foreach (var nested in mdDecoder.NestedTypes(type))
-          RegisterType(nested);
-      }
-
-      return mClassesLookup[type];
-    }
-
-    public Method LookupMethod(MethodExt mMethod)
-    {
-      // Ensures the declaring type has been registered
-      // so that the method has been registered
-      LookupClass(mdDecoder.DeclaringType(mMethod), false);
-
-      if (mMethodsLookup.ContainsKey(mMethod))
-        return mMethodsLookup[mMethod];
-      else
-        return null;
-    }
-
-    public Property LookupProperty(PropertyExt prop)
-    {
-      // Ensures the declaring type has been registered
-      // so that the propery has been registered
-      LookupClass(mdDecoder.DeclaringType(prop), false);
-
-      if (mPropertiesLookup.ContainsKey(prop))
-        return mPropertiesLookup[prop];
-      else
-        return null;
-    }
-
-    public Class AddClass(Type type, bool bVisitNested)
-    {
-      Class newcl = ConstructClassFromMetaDataDecoder(type);
-      mClassesLookup.Add(type, newcl);
-
-      // Register the class to its containers
-      newcl.Namespace.AddChild(newcl);
-      if (newcl.Parent != null) // only register toplevel classes to the namespace
-        newcl.Parent.AddChild(newcl);
-
-      if (bVisitNested)
-      {
-        // Also register all nested types
-        foreach (var nested in mdDecoder.NestedTypes(type))
-          RegisterType(nested);
-      }
-
-      return newcl;
-    }
-
-    bool SkipType(Type type)
-    {
-      if (MustKeepType(type)) return false;
-
-      // if type contains nested type we must keep, then we keep it too
-      foreach (var nested in mdDecoder.NestedTypes(type))
-      {
-        if (!SkipType(nested)) return false;
-      }
-
-      return (this.visibleMembersOnly && !this.mdDecoder.IsVisibleOutsideAssembly(type));
-    }
-
-    bool SkipType(Type type, Set<Type> seen)
-    {
-      if (MustKeepType(type, seen)) return false;
-
-      return (this.visibleMembersOnly && !this.mdDecoder.IsVisibleOutsideAssembly(type));
-    }
-
-    public void RegisterType(Type type)
-    {
-      if (SkipType(type)) return;
-
-      if (IsNonCSharpType(type))
-        return;
-
-      // Order is important because an enum is also said to be a struct!
-      if (mdDecoder.IsEnum(type))
-        RegisterEnum(type);
-      else if (mdDecoder.IsDelegate(type))
-        RegisterDelegate(type);
-      else if (mdDecoder.IsClass(type)
-        || mdDecoder.IsStruct(type)
-        || mdDecoder.IsInterface(type))
-        LookupClass(type, true);
-    }
-
-    private bool IsNonCSharpType(Type type)
-    {
-      return mdDecoder.IsCompilerGenerated(type) ||
-             mdDecoder.IsNativeCpp(type) ||
-             mdDecoder.Namespace(type) == "<CrtImplementationDetails>";
-    }
-
-    private bool ContainsNonCSharpType(Type type)
-    {
-      if (IsNonCSharpType(type)) return true;
-
-      if (mdDecoder.IsUnmanagedPointer(type))
-      {
-        return ContainsNonCSharpType(mdDecoder.ElementType(type));
-      }
-      if (mdDecoder.IsManagedPointer(type))
-      {
-        return ContainsNonCSharpType(mdDecoder.ElementType(type));
-      }
-      if (mdDecoder.IsArray(type))
-      {
-        return ContainsNonCSharpType(mdDecoder.ElementType(type));
-      }
-      return false;
-    }
-
-    public void RegisterEnum(Type type)
-    {
-      if (mdDecoder.IsEnum(type))
-      {
-        Enum newenum = ConstructEnumFromMetaDataDecoder(type);
-        if (newenum.Parent == null)
-          newenum.Namespace.AddChild(newenum);
-        else
-          newenum.Parent.AddChild(newenum);
-      }
-    }
-
-    public void RegisterDelegate(Type type)
-    {
-      // Ensures the declaring type has been registered
-      // so that we can have access to the parent
-      Class parent = null;
-      Type parentt;
-      if (mdDecoder.IsNested(type, out parentt))
-        parent = LookupClass(parentt, false);
-
-      if (mdDecoder.IsDelegate(type))
-      {
-        Delegate newdel = ConstructDelegateFromMetaDataDecoder(type, parent);
-        if (newdel == null)
-          return;
-
-        if (newdel.Parent == null)
-          newdel.Namespace.AddChild(newdel);
-        else
-          newdel.Parent.AddChild(newdel);
-      }
-    }
-
-    public Namespace AddNamespace(string name)
-    {
-      return mCm.LookupNamespaceByName(name);
-      /*Namespace newNS = mCm.LookupNamespaceByName (name);
-      if (newNS == null)
-      {
-        newNS = new Namespace(name);
-        mCm.AddNamespace(newNS);
-      }
-      return newNS;*/
-    }
-
-    public void Reset()
-    {
-      mClassesLookup.Clear();
-      mMethodsLookup.Clear();
-      mPropertiesLookup.Clear();
-    }
-
-    #region Assembly managing
-    private void AddRefRef(Assembly assemb, Microsoft.Research.DataStructures.IMutableSet<string> added, List<Pair<string,Version>> refnames, string mAssemblyName)
-    {
-      string assname = mdDecoder.Name(assemb);
-      if (assname != mAssemblyName && added.Add(assname)) // don't reference itself, useful for analysing system dlls
-      {
-        refnames.Add(new Pair<string, Version>(assname, mdDecoder.Version(assemb)));
-        foreach (var r in mdDecoder.AssemblyReferences(assemb))
-          AddRefRef(r, added, refnames, mAssemblyName);
-      }
-    }
-
-    public List<Pair<string,Version>> GetReferenceAssemblies(Assembly assemb)
-    {
-      var assemblies = new List<Pair<string,Version>>();
-      var added = new Set<string>();
-      //string str = System.IO.Path.GetFullPath("Microsoft.Contracts.dll");
-      //System.Reflection.Assembly ass = System.Reflection.Assembly.LoadFile(str);
-      //var asss = ass.GetReferencedAssemblies();
-
-      var asss = mdDecoder.AssemblyReferences(assemb);
-      foreach (var r in asss)
-        AddRefRef(r, added, assemblies, mdDecoder.Name(assemb));
-
-      return assemblies;
-    }
-    #endregion
-
-    public CodeManager CodeManager { get { return mCm; } }
-
-    private readonly IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder;
-
-    private Dictionary<Type, Class> mClassesLookup;
-    private Dictionary<MethodExt, Method> mMethodsLookup;
-    private Dictionary<PropertyExt, Property> mPropertiesLookup;
-    private CodeManager mCm;
-    private List<string> mUsings;
-    private bool visibleMembersOnly;
-  }
-
-  public class ContractsHandlerMgr<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
-    where LogOptions : IFrameworkLogOptions
-    where Type : IEquatable<Type>
-  {
-    #region Object invariant
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.mdDecoder != null);
-      Contract.Invariant(this.mAnalyzer != null);
-    }
-    
-    #endregion
-
-
-    #region Constructor
-    public ContractsHandlerMgr(
-        AnalysisDriver<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mAnalyzer,
-        IOutput mOutput
-        )
-    {
-      Contract.Requires(mAnalyzer != null);
-
-      this.mAnalyzer = mAnalyzer;
-      mdDecoder = mAnalyzer.MetaDataDecoder;
-      this.mOutput = mOutput;
-      this.mAssembly = default(Assembly);
-      this.mAssemblyName = "";
-      this.mWrittenFiles = new List<string>();
-      this.mCH = new ConstructionHelper<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>(mdDecoder, mAnalyzer.Options.OutputOnlyExternallyVisibleMembers);
-      this.mStrategy = OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS; // should be set later by "SetStrategy"
-    }
-    #endregion
-
-    #region Privates
-    private readonly AnalysisDriver<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mAnalyzer;
-    private readonly IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder;
-    IOutput mOutput;
-
-    ConstructionHelper<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mCH;
-
-    private string mAssemblyName;
-    private Assembly mAssembly;
-
-    private List<string> mWrittenFiles;
-    // Statistics
-    private int mNbPreMethods; /// number of registered preconditions in methods
-    private int mNbPostMethods; /// number of registered postconditions in methods
-    private int mNbPreProperties; /// number of registered preconditions in properties
-    private int mNbPostProperties; /// number of registered postconditions in properties
-    private int mNbClassInvariants; /// number of registered class invariants
-
-    OutputHelper.OutputStrategy mStrategy;
-    #endregion
-
-    public void SetStrategy(OutputHelper.OutputStrategy strat)
-    {
-      this.mStrategy = strat;
-    }
-
-    private bool UnmanagedExpression(BoxedExpression expr)
-    {
-      if (expr.IsBinary)
-        return UnmanagedExpression(expr.BinaryLeft) || UnmanagedExpression(expr.BinaryRight);
-      else if (expr.IsUnary)
-        return UnmanagedExpression(expr.UnaryArgument);
-      else if (expr.IsVariable)
-      {
-        var expAccessPath = expr.AccessPath;
-        if (expAccessPath != null)
-        {
-          Contract.Assert(Contract.ForAll(expAccessPath, p => p != null));
-          for (int i = 0; i < expAccessPath.Length; ++i)
-          {
-            if (expAccessPath[i].IsUnmanagedPointer)
-              return true; // There is an unmanaged pointer in the way
-          }
-        }
-      }
-      else if (expr.IsResult)
-      {
-        object rettype;
-        if (expr.TryGetType(out rettype))
-          return mdDecoder.IsUnmanagedPointer((Type)rettype);
-      }
-
-      return false;
-    }
-
-    private string BoxedExpressionConverter (Type type)
-    {
-      return OutputPrettyCS.TypeHelper.TypeFullName(this.mdDecoder, type);
-    }
-
-    #region Register Methods
-    public void RegisterClassInvariant(Type type, BoxedExpression invariant)
-    {
-      Contract.Requires(invariant != null);
-
-      if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
-        return;
-
-      if (this.mAnalyzer.Options.OutputOnlyExternallyVisibleMembers && !mdDecoder.IsVisibleOutsideAssembly(type)) return;
-
-      if (mdDecoder.IsCompilerGenerated(type)) // no compiler generated types
-        return;
-      if (!mdDecoder.IsClass(type) && !mdDecoder.IsStruct(type)) // only for classes and struct
-        return;
-
-      Class cl = mCH.LookupClass(type, false);
-
-      if (cl != null)
-      {
-        cl.AddInvariant(invariant.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)));
-        mNbClassInvariants++;
-      }
-    }
-
-    /// <summary>
-    /// Replace out parameters occurences in contracts by "ValueAtReturn(out x)" in fixed_exp to trick the compiler.
-    /// Return true if a change has been made, false if not.
-    /// </summary>
-    private bool FixOutParameter(MethodExt parent, BoxedExpression exp, out BoxedExpression fixed_exp)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out fixed_exp) != null);
-
-      fixed_exp = exp;
-
-      if (exp.IsVariable)
-      {
-        Microsoft.Research.DataStructures.FList<PathElement> path = Microsoft.Research.DataStructures.FList<PathElement>.Empty;
-        for (int i = 0; i < exp.AccessPath.Length; ++i)
-        {
-          var elem = exp.AccessPath[exp.AccessPath.Length - i - 1];
-          Contract.Assume(elem != null);
-          if (elem.IsModel) return false;
-          path = Microsoft.Research.DataStructures.FList<PathElement>.Cons(elem, path);
-        }
-
-        if (path != null && path.Head != null && path.Head.IsParameterRef)
-        {
-          var pars = mdDecoder.Parameters(parent);
-
-          for (int i = 0; i < pars.Count; ++i)
-          {
-            var par = pars[i];
-            //SymbolicValue vpar, vpar2, vpar3, vpar4, vpar5;
-            //context.TryParameterAddress(context.EntryAfterRequires, par, out vpar);
-            //context.TryParameterValue(context.EntryAfterRequires, par, out vpar2);
-            //context.TryLoadIndirect(context.EntryAfterRequires, vpar, out vpar3);
-            //context.TryLoadIndirect(context.EntryAfterRequires, vpar2, out vpar4);
-            //context.TryLoadIndirect(context.EntryAfterRequires, var, out vpar5);
-            //if (var.Equals(vpar))
-            if (exp.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)).StartsWith(mdDecoder.Name(par)) && mdDecoder.IsOut(par)) // allow to have something after, will be fixed by FixOutContracts
+            string name = mdDecoder.Name(type);
+            Access access = Access.PUBLIC;
+            Type dummy;
+            if (mdDecoder.IsNested(type, out dummy))
             {
-              fixed_exp = BoxedExpression.ValueAtReturn(exp, mdDecoder.ParameterType(par));
-              return true;
-            }
-          }
-        }
-        return true;
-      }
-      else if (exp.IsUnary)
-      {
-        BoxedExpression fixd;
-        if (FixOutParameter(parent, exp.UnaryArgument, out fixd))
-        {
-          fixed_exp = BoxedExpression.Unary(exp.UnaryOp, fixd);
-          return true;
-        }
-      }
-      else if (exp.IsBinary)
-      {
-        BoxedExpression fl, fr;
-        var bl = FixOutParameter(parent, exp.BinaryLeft, out fl);
-        var br = FixOutParameter(parent, exp.BinaryRight, out fr);
-
-        if (bl && br) 
-        {
-          BoxedExpression.BinaryExpressionMethodCall bemc = exp as BoxedExpression.BinaryExpressionMethodCall;
-          if (bemc != null)
-          {
-            fixed_exp = BoxedExpression.BinaryMethodToCall(exp.BinaryOp, fl, fr, bemc.MethodToCall);
-          }
-          else
-          {
-            // Mic: kind of a hack. Would be nicer to have some kind of visitor on BoxedExpression
-            if (exp.IsCast)
-            {
-              var castExpression = exp as ClousotExpression<Type>.CastExpression;
-              Contract.Assume(castExpression != null);
-              fixed_exp = BoxedExpression.BinaryCast(exp.BinaryOp, fl, fr, castExpression.mTypeCasting);
+                if (mdDecoder.IsProtected(type) && mdDecoder.IsInternal(type))
+                    access = Access.INTERNAL_AND_OR_PROTECTED;
+                else if (mdDecoder.IsInternal(type))
+                    access = Access.INTERNAL;
+                else if (mdDecoder.IsPublic(type))
+                    access = Access.PUBLIC;
+                else if (mdDecoder.IsProtected(type))
+                    access = Access.PROTECTED;
+                else if (mdDecoder.IsPrivate(type))
+                    access = Access.PRIVATE;
             }
             else
             {
-              fixed_exp = BoxedExpression.Binary(exp.BinaryOp, fl, fr);
+                if (mdDecoder.IsPublic(type))
+                    access = Access.PUBLIC;
+                else
+                    access = Access.INTERNAL;
             }
-          }
 
-          return true;
-        }
-      }
-      else if (exp.IsResult || exp.IsConstant)
-      {
-        return true;
-      }
-      // FIXME: recursively apply this transformation
-      return false;
-    }
+            Class.ClassType clt = Class.ClassType.CLASS;
+            if (mdDecoder.IsClass(type))
+                clt = Class.ClassType.CLASS;
+            else if (mdDecoder.IsStruct(type))
+                clt = Class.ClassType.STRUCT;
+            else if (mdDecoder.IsInterface(type))
+                clt = Class.ClassType.INTERFACE;
 
-    /// <summary>
-    /// Replace field parameters occurences in struct constructors contracts by "ValueAtReturn(out x)" to trick the compiler
-    /// </summary>
-    /// <param name="parent">Assumed to be a constructor</param>
-    private BoxedExpression FixFieldInConstructor(MethodExt parent, BoxedExpression exp)
-    {
-      Contract.Requires(exp != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+            Namespace ParentNS = mCm.LookupNamespaceByName(GetNamespaceFromClass(type));
 
-      if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(parent)))
-        return exp;
+            Class parent = null;
+            Type parentt;
+            if (mdDecoder.IsNested(type, out parentt))
+                parent = LookupClass(parentt, false);
 
-      if (exp.IsVariable)
-      {
-        SymbolicValue var;
-        if (exp.TryGetFrameworkVariable(out var))
-        {
-          var fields = mdDecoder.Fields(mdDecoder.DeclaringType(parent));
-          foreach (var f in fields)
-          {
-            if (exp.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)).StartsWith("this." + mdDecoder.Name(f))) // allow to have something after, will be fixed by FixOutContracts
+            string basecl = "";
+            if (mdDecoder.HasBaseClass(type))
             {
-              object t;
-              if (exp.TryGetType(out t))
-                return BoxedExpression.ValueAtReturn(exp,(Type)t);
-              else
-                return BoxedExpression.ValueAtReturn(exp, default(Type));
+                Type bt = mdDecoder.BaseClass(type);
+                if (mdDecoder.FullName(bt) != "System.Object")
+                    basecl = TypeFullName(bt, parent, ParentNS);
             }
-          }
-        }
-        else if (exp.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)).StartsWith("this.")) // sometimes TryGetFrameworkVariable fails, cf. explication elsewhere
-        {
-          object t;
-          if (exp.TryGetType(out t))
-            return BoxedExpression.ValueAtReturn(exp, (Type)t);
-          else
-            return BoxedExpression.ValueAtReturn(exp, default(Type));
-        }
-      }
-      else if (exp.IsUnary)
-        return BoxedExpression.Unary(exp.UnaryOp, FixFieldInConstructor(parent, exp.UnaryArgument));
-      else if (exp.IsBinary)
-        return BoxedExpression.Binary(exp.BinaryOp, FixFieldInConstructor(parent, exp.BinaryLeft), FixFieldInConstructor(parent, exp.BinaryRight));
 
-      return exp;
+            bool bIsAbstract = mdDecoder.IsAbstract(type) && !mdDecoder.IsInterface(type);
+            bool bIsSealed = mdDecoder.IsSealed(type) && !mdDecoder.IsStruct(type);
+            bool bIsStatic = false;//mdDecoder.IsStatic(type); types can be static only if abstract & sealed
+            if (bIsAbstract && bIsSealed)
+            {
+                bIsAbstract = false;
+                bIsSealed = false;
+                bIsStatic = true;
+            }
+
+            Class cl = new Class(
+              access,
+              bIsAbstract,
+              bIsSealed,
+              bIsStatic,
+              false, /* Updated when children are added */
+              clt,
+              name,
+              parent,
+              basecl,
+              ParentNS);
+
+            //** Attributes ?
+            // Check if this class derives from System.Attribute, in which case we want to
+            // assign it the attribute "AttributeUsage(AttributeTargets.All)"
+            if (mdDecoder.HasBaseClass(type))
+            {
+                Type bt = mdDecoder.BaseClass(type);
+                while (true)
+                {
+                    if (mdDecoder.FullName(bt) == "System.Attribute")
+                        cl.AddAttribute("AttributeUsage(AttributeTargets.All)");
+
+                    if (!mdDecoder.HasBaseClass(bt))
+                        break;
+                    else
+                        bt = mdDecoder.BaseClass(bt);
+                }
+            }
+
+            //** Formal type parameters
+            Microsoft.Research.DataStructures.IIndexable<Type> formals;
+            if (mdDecoder.IsGeneric(type, out formals, false))
+                cl.AddFormalTypeParameters(GetFormalTypeParameters(formals));
+
+            //** Interfaces
+            var interfaces = mdDecoder.Interfaces(type);
+            foreach (var it in interfaces)
+            {
+                if (this.SkipType(it)) continue;
+                if (mdDecoder.FullName(it) != "System.Object")
+                    cl.AddInterface(TypeFullName(it, cl, ParentNS));
+            }
+
+            Dictionary<EventExt, MethodExt> additionalEvents = new Dictionary<EventExt, MethodExt>();
+
+            #region Methods
+            bool hasRetainedConstructors = false;
+            foreach (var m in mdDecoder.Methods(type))
+            {
+                if (mdDecoder.IsPropertyGetter(m) || mdDecoder.IsPropertySetter(m))
+                    continue; // skip property accessors
+
+                if (mdDecoder.IsFinalizer(m))
+                    continue; // skip destructors
+
+                if (SkipMethod(m))
+                    continue; // compiler generated
+
+                EventExt dev;
+                if (mdDecoder.IsEventAdder(m, out dev) || mdDecoder.IsEventRemover(m, out dev))
+                {
+                    continue; // skip events adder/remover
+                }
+
+                bool foundEvt = false;
+                foreach (var im in mdDecoder.ImplementedMethods(m))
+                {
+                    EventExt evt;
+                    if (mdDecoder.IsEventAdder(im, out evt) || mdDecoder.IsEventRemover(im, out evt))
+                    {
+                        // looks like an event that is implemented with just add/remove but no explicit event decl
+                        // create a dummy one
+                        additionalEvents[evt] = m;
+                        foundEvt = true;
+                        break;
+                    }
+                }
+                if (foundEvt)
+                {
+                    // skip the method
+                    continue;
+                }
+
+                Method newm;
+                var tmpName = mdDecoder.Name(m);
+                if (tmpName.StartsWith("op_"))
+                {
+                    // user defined-conversion
+                    Contract.Assert(tmpName.Length >= 3);
+                    newm = ConstructUserOpFromMetaDataDecoder(m, cl);
+                }
+                else
+                    newm = ConstructMethodFromMetaDataDecoder(m, cl);
+
+                cl.AddChild(newm);
+                hasRetainedConstructors |= mdDecoder.IsConstructor(m);
+
+                // Keep track internally of the method
+                mMethodsLookup.Add(m, newm);
+            }
+
+            // if there were no retained constructors, we might have to add an explicit one in order for base 
+            // constructor call to work
+            if (!hasRetainedConstructors && !bIsStatic && clt == Class.ClassType.CLASS)
+            {
+                var ctor = ConstructDefaultConstructor(type, cl);
+                cl.AddChild(ctor);
+            }
+            #endregion
+
+            #region Properties
+
+            foreach (var prop in mdDecoder.Properties(type))
+            {
+                if (SkipProperty(prop)) { continue; }
+                Property newprop = ConstructPropertyFromMetaDataDecoder(prop, cl);
+                //Property newprop = LookupProperty(prop);
+                cl.AddChild(newprop);
+
+                // Keep track internally of the property
+                mPropertiesLookup.Add(prop, newprop);
+            }
+            #endregion
+
+            #region Events
+
+            foreach (var evt in mdDecoder.Events(type))
+            {
+                if (SkipEvent(evt)) { continue; }
+
+                Event newEvt = ConstructEventFromMetaDataDecoder(evt, cl);
+                //Property newprop = LookupProperty(prop);
+                cl.AddChild(newEvt);
+
+                // Keep track internally of the event
+                //mPropertiesLookup.Add(evt, newEvt);
+            }
+
+            foreach (var pair in additionalEvents)
+            {
+                var implEvent = pair.Key;
+                var implMethod = pair.Value;
+
+                var newEvt = ConstructEventFromProxy(implEvent, implMethod, cl);
+                cl.AddChild(newEvt);
+            }
+            #endregion
+
+            #region Fields
+            //** Fields
+            foreach (var f in mdDecoder.Fields(type))
+            {
+                if (!SkipField(f))
+                {
+                    Field newf = ConstructFieldFromMetaDataDecoder(f, cl);
+                    cl.AddChild(newf);
+                }
+            }
+            #endregion
+
+            return cl;
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        private Event ConstructEventFromProxy(EventExt evt, MethodExt implMethod, Class clparent)
+        {
+            MethodExt Adder, Remover;
+            bool bHasAdder = mdDecoder.HasAdder(evt, out Adder);
+            bool bHasRemover = mdDecoder.HasRemover(evt, out Remover);
+            string name = mdDecoder.Name(evt);
+            bool bIsInInterface = false;
+
+            MethodExt any = implMethod;
+            Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(any));
+
+            Type handlerType = mdDecoder.HandlerType(evt);
+            string returntype = TypeFullName(handlerType, clparent, ns);
+
+            // Accessibility should be the less restrictive for the main property
+            // And then if an accessor is more restrictive, it should be output just for it
+            Access access = Access.NONE;
+            Access accessget = Access.NONE;
+            Access accessset = Access.NONE;
+            if (!name.Contains(".") && !bIsInInterface)
+                access = GetMostAccessible(bHasAdder, bHasRemover, Adder, Remover);
+
+            bool bExtern = mdDecoder.IsExtern(any);
+            bool bVirtual = mdDecoder.IsVirtual(any);
+            bool bSealed = mdDecoder.IsSealed(any);
+            bool bNewSlot = mdDecoder.IsNewSlot(any);
+            bool bOverride = mdDecoder.IsOverride(any);
+            bool bImplicitImpl = mdDecoder.IsImplicitImplementation(any);
+            bool bAbstract = mdDecoder.IsAbstract(any);
+            bool bStatic = mdDecoder.IsStatic(evt);
+
+            bool bActualExtern = false;
+            bool bActualStatic = false;
+            bool bActualVirtual = false;
+            bool bActualSealed = false;
+            bool bActualNewSlot = false;
+            bool bActualOverride = false;
+            bool bActualAbstract = false;
+
+            if (!bIsInInterface)
+            {
+                if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(evt))
+                    && !mdDecoder.IsSealed(mdDecoder.DeclaringType(evt)))
+                {
+                    if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
+                        access = Access.PUBLIC;
+                    else if (bVirtual && bSealed)
+                    {
+                        bActualSealed = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bNewSlot && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bNewSlot)
+                    {
+                        bActualNewSlot = true;
+                        bActualVirtual = true;
+                    }
+                    else if (bVirtual && access == Access.PRIVATE /* explicit interface */ && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bOverride)
+                    {
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bExtern)
+                        bActualAbstract = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                    else if (bVirtual)
+                        bActualVirtual = true;
+                }
+                else
+                {
+                    if (bVirtual && bOverride)
+                        bActualOverride = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                }
+
+                bActualStatic = bStatic;
+            }
+
+            // get accessibility on getter and setter only when the main access has been discovered
+            if (!name.Contains(".") && !bIsInInterface)
+            {
+                if (bHasAdder)
+                {
+                    accessget = GetAccessForMethod(Adder);
+                    if (accessget == access) // not more restrictive than the property
+                        accessget = Access.NONE;
+                }
+
+                if (bHasRemover)
+                {
+                    accessset = GetAccessForMethod(Remover);
+                    if (accessset == access) // not more restrictive than the property
+                        accessset = Access.NONE;
+                }
+            }
+
+            Event newEvent = new Event(
+              clparent,
+              bHasAdder,
+              bHasRemover,
+              name,
+              mdDecoder.IsUnmanagedPointer(handlerType), /* Parameters are handled when added */
+              bIsInInterface,
+              returntype,
+              access,
+              accessget,
+              accessset,
+              bActualStatic,
+              bActualNewSlot,
+              bActualOverride,
+              bActualSealed,
+              bActualVirtual,
+              bActualExtern,
+              bActualAbstract);
+
+            return newEvent;
+        }
+
+        private bool MustKeepProperty(PropertyExt prop)
+        {
+            if (MustKeepType(mdDecoder.DeclaringType(prop)))
+            {
+                if (SkipType(mdDecoder.PropertyType(prop))) return false;
+                return true;
+            }
+            return false;
+        }
+
+        private bool MustKeepEvent(EventExt evt)
+        {
+            if (MustKeepType(mdDecoder.DeclaringType(evt)))
+            {
+                if (SkipType(mdDecoder.HandlerType(evt))) return false;
+                return true;
+            }
+            return false;
+        }
+
+        private bool MustKeepMethod(MethodExt method)
+        {
+            if (MustKeepType(mdDecoder.DeclaringType(method)))
+            {
+                if (SkipType(mdDecoder.ReturnType(method))) return false;
+                foreach (var par in mdDecoder.Parameters(method).Enumerate())
+                {
+                    if (SkipType(mdDecoder.ParameterType(par))) return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private bool MustKeepType(Type type)
+        {
+            return MustKeepType(type, new Set<Type>());
+        }
+
+        private bool MustKeepType(Type type, Set<Type> seen)
+        {
+            if (seen.Contains(type)) return true;
+            seen.Add(type);
+            if (mdDecoder.IsInterface(type))
+            {
+                foreach (var intf in mdDecoder.Interfaces(type))
+                {
+                    IIndexable<Type> args;
+                    if (mdDecoder.IsSpecialized(intf, out args))
+                    {
+                        foreach (var arg in args.Enumerate())
+                        {
+                            if (SkipType(arg, seen))
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private bool IsVirtual(PropertyExt prop, out MethodExt rep)
+        {
+            MethodExt getter, setter;
+            bool isVirtual = false;
+            rep = default(MethodExt);
+
+            if (mdDecoder.HasGetter(prop, out getter))
+            {
+                rep = getter;
+                isVirtual = mdDecoder.IsVirtual(getter);
+            }
+            if (mdDecoder.HasSetter(prop, out setter))
+            {
+                if (mdDecoder.IsVirtual(setter))
+                {
+                    rep = setter;
+                    isVirtual = true;
+                }
+            }
+            return isVirtual; ;
+        }
+
+        private bool SkipProperty(PropertyExt prop)
+        {
+            if (MustKeepProperty(prop)) return false;
+
+            if (visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(prop))
+            {
+                // check that it is not a visible interface implementation or required by abstract base class
+                MethodExt rep;
+                if (IsVirtual(prop, out rep))
+                {
+                    if (!SkipMethod(rep)) return false;
+                }
+
+                return true;
+            }
+
+            return ContainsNonCSharpType(mdDecoder.PropertyType(prop));
+        }
+
+        private bool IsVirtual(EventExt prop, out MethodExt rep)
+        {
+            MethodExt adder, remover;
+            bool isVirtual = false;
+            rep = default(MethodExt);
+
+            if (mdDecoder.HasAdder(prop, out adder))
+            {
+                rep = adder;
+                isVirtual = mdDecoder.IsVirtual(adder);
+            }
+            if (mdDecoder.HasRemover(prop, out remover))
+            {
+                if (mdDecoder.IsVirtual(remover))
+                {
+                    rep = remover;
+                    isVirtual = true;
+                }
+            }
+            return isVirtual; ;
+        }
+
+        private bool SkipEvent(EventExt evt)
+        {
+            if (MustKeepEvent(evt)) return false;
+
+            if (visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(evt))
+            {
+                MethodExt rep;
+                if (IsVirtual(evt, out rep))
+                {
+                    if (!SkipMethod(rep)) return false;
+                }
+                return true;
+            }
+            return ContainsNonCSharpType(mdDecoder.HandlerType(evt));
+        }
+
+
+        private bool SkipField(FieldExt f)
+        {
+            if (visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(f)) return true;
+
+            return mdDecoder.IsCompilerGenerated(f) || IsNonCSharpType(mdDecoder.FieldType(f));
+        }
+
+        internal bool SkipMethod(MethodExt m)
+        {
+            if (MustKeepMethod(m)) return false;
+
+            if (visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(m))
+            {
+                // check that it is not a visible interface implementation or required by abstract base class
+                if (mdDecoder.IsVirtual(m))
+                {
+                    foreach (var baseMethod in mdDecoder.OverriddenAndImplementedMethods(m))
+                    {
+                        if (!SkipMethod(baseMethod)) return false;
+                    }
+                }
+                return true;
+#if false
+                bool isConstructor = mdDecoder.IsConstructor(m);
+                // if it is a constructor of a publicly visible type, keep it unless its parameter types are not visible
+                if (!isConstructor || AnyInternalParameterTypes(mdDecoder.Parameters(m)))
+                {
+                    return true;
+                }
+                if (!mdDecoder.IsVisibleOutsideAssembly(mdDecoder.DeclaringType(m)))
+                {
+                    return true;
+                }
+#endif
+            }
+            bool skip = mdDecoder.IsCompilerGenerated(m) || mdDecoder.Name(m) == ".cctor";
+            if (skip) return true;
+
+            if (ContainsNonCSharpType(mdDecoder.ReturnType(m))) return true;
+
+            // check parameter types
+            foreach (var p in mdDecoder.Parameters(m).Enumerate())
+            {
+                if (ContainsNonCSharpType(mdDecoder.ParameterType(p))) { return true; } // skip method
+            }
+            return false;
+        }
+
+        private bool AnyInternalParameterTypes(IIndexable<ParameterExt> iIndexable)
+        {
+            foreach (var p in iIndexable.Enumerate())
+            {
+                if (!mdDecoder.IsVisibleOutsideAssembly(mdDecoder.ParameterType(p)))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public Enum ConstructEnumFromMetaDataDecoder(Type type)
+        {
+            Access access = Access.PUBLIC;
+            if (mdDecoder.IsPublic(type))
+                access = Access.PUBLIC;
+            else if (mdDecoder.IsProtected(type) && mdDecoder.IsInternal(type))
+                access = Access.INTERNAL_AND_OR_PROTECTED;
+            else if (mdDecoder.IsProtected(type))
+                access = Access.PROTECTED;
+            else if (mdDecoder.IsPrivate(type))
+                access = Access.PRIVATE;
+            else if (mdDecoder.IsInternal(type))
+                access = Access.INTERNAL;
+
+            Type parentt;
+            Class clparent = null;
+            if (mdDecoder.IsNested(type, out parentt))
+                clparent = LookupClass(parentt, false);
+
+            Namespace ns;
+            if (clparent == null)
+                ns = LookupNamespaceFromClass(type);
+            else
+                ns = clparent.Namespace;
+
+            Type enumtype = mdDecoder.TypeEnum(type);
+
+            Enum newenum = new Enum(access, clparent, ns, mdDecoder.Name(type), TypeFullName(enumtype, clparent, ns));
+
+            foreach (var f in mdDecoder.Fields(type))
+            {
+                Contract.Assume(f != null, "missing contract");
+
+                string name = mdDecoder.Name(f);
+                object value;
+                if (name != "value__" && mdDecoder.TryInitialValue(f, out value))
+                {
+                    newenum.AddField(new Enum.EnumField(name, value.ToString()));
+                }
+            }
+
+            return newenum;
+        }
+
+        public Parameter ConstructParameterFromMetaDataDecoder(int index, ParameterExt param, Class clparent)
+        {
+            Type ptype = mdDecoder.ParameterType(param);
+            MethodExt parentm = mdDecoder.DeclaringMethod(param);
+            Type parent = mdDecoder.DeclaringType(parentm);
+            Namespace ns = LookupNamespaceFromClass(parent);
+
+            string typename = TypeFullName(ptype, clparent, ns);
+
+            Parameter.Modifier modif = Parameter.Modifier.NONE;
+            // Order is important because an out parameter is also a ref
+            if (mdDecoder.IsOut(param) && mdDecoder.IsManagedPointer(ptype))
+                modif = Parameter.Modifier.OUT;
+            else if (mdDecoder.IsManagedPointer(ptype))
+                modif = Parameter.Modifier.REF;
+
+            if (modif != Parameter.Modifier.NONE)
+                typename = TypeFullName(mdDecoder.ElementType(ptype), clparent, ns);
+
+            var name = mdDecoder.Name(param);
+            return new Parameter(typename, name, modif);
+        }
+
+        public Delegate ConstructDelegateFromMetaDataDecoder(Type type, Class clparent)
+        {
+            bool bIsInInterface = false;
+            Type parentt;
+            if (mdDecoder.IsNested(type, out parentt))
+                bIsInInterface = mdDecoder.IsInterface(parentt);
+
+            Access access;
+            if (bIsInInterface)
+                access = Access.NONE;
+            else if (mdDecoder.IsPublic(type))
+                access = Access.PUBLIC;
+            else if (mdDecoder.IsProtected(type) && mdDecoder.IsInternal(type))
+                access = Access.INTERNAL_AND_OR_PROTECTED;
+            else if (mdDecoder.IsProtected(type))
+                access = Access.PROTECTED;
+            else if (mdDecoder.IsPrivate(type))
+                access = Access.PRIVATE;
+            else if (mdDecoder.IsInternal(type))
+                access = Access.INTERNAL;
+            else
+                access = Access.NONE;
+
+            Namespace ns = LookupNamespaceFromClass(type);
+
+            // Look for the Invoke method to get the return type
+            var methods = mdDecoder.Methods(type);
+            Type rettypet = default(Type);
+            string rettype = "";
+            Microsoft.Research.DataStructures.IIndexable<ParameterExt> pars = null;
+            foreach (var m in methods)
+            {
+                if (mdDecoder.Name(m) == "Invoke")
+                {
+                    rettypet = mdDecoder.ReturnType(m);
+                    rettype = TypeFullName(rettypet, clparent, ns);
+                    pars = mdDecoder.Parameters(m);
+                    break;
+                }
+            }
+
+            if (pars != null)
+            {
+                string name = mdDecoder.Name(type);
+                Delegate newdel = new Delegate(
+                  access,
+                  mdDecoder.IsUnmanagedPointer(rettypet), /* Parameters are handled when added */
+                  name,
+                  clparent,
+                  ns,
+                  rettype);
+
+                //** Formal type parameters
+                Microsoft.Research.DataStructures.IIndexable<Type> formals;
+                if (mdDecoder.IsGeneric(type, out formals, false))
+                    newdel.AddFormalTypeParameters(GetFormalTypeParameters(formals));
+
+                //** Add parameters
+                int n = pars.Count;
+                for (int i = 0; i < n; ++i)
+                {
+                    Parameter newparam = ConstructParameterFromMetaDataDecoder(i, pars[i], clparent);
+                    newdel.AddParameter(newparam);
+                }
+
+                return newdel;
+            }
+
+            return null;
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        private Method ConstructUserOpFromMetaDataDecoder(MethodExt mMethod, Class clparent)
+        {
+            Contract.Requires(mdDecoder.Name(mMethod).Length >= 3);
+            // here we assume the name of the method is op_xxx
+            // The full list is taken from ECMA standard
+            // (http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-335.pdf) chapter 10.3.1 and following
+
+            Method newm = ConstructMethodFromMetaDataDecoder(mMethod, clparent);
+            newm.Operator = true;
+
+            string keyword = mdDecoder.Name(mMethod).Substring(3);
+            string name = keyword;
+            bool bImplicit = false;
+            bool bExplicit = false;
+
+            switch (keyword)
+            {
+                case "Implicit":
+                    name = newm.ReturnType;
+                    newm.ReturnType = "";
+                    bImplicit = true;
+                    break;
+                case "Explicit":
+                    name = newm.ReturnType;
+                    newm.ReturnType = "";
+                    bExplicit = true;
+                    break;
+                case "Decrement": name = "-- "; break;
+                case "Increment": name = "++ "; break;
+                case "UnaryNegation": name = "- "; break;
+                case "UnaryPlus": name = "+ "; break;
+                case "LogicalNot": name = "! "; break;
+                case "AddressOf": name = "& "; break;
+                case "OnesComplement": name = "~ "; break;
+                case "PointerDereference": name = "* "; break;
+                case "Addition": name = "+ "; break;
+                case "Subtraction": name = "- "; break;
+                case "Multiply": name = "* "; break;
+                case "Division": name = "/ "; break;
+                case "Modulus": name = "% "; break;
+                case "ExclusiveOr": name = "^ "; break;
+                case "BitwiseAnd": name = "& "; break;
+                case "BitwiseOr": name = "| "; break;
+                case "LogicalAnd": name = "&& "; break;
+                case "LogicalOr": name = "|| "; break;
+                case "LeftShift": name = "<< "; break;
+                case "RightShift": name = ">> "; break;
+                case "Equality": name = "== "; break;
+                case "GreaterThan": name = "> "; break;
+                case "LessThan": name = "< "; break;
+                case "Inequality": name = "!= "; break;
+                case "GreaterThanOrEqual": name = ">= "; break;
+                case "LessThanOrEqual": name = "<="; break;
+                case "MemberSelection": name = "->"; break;
+                case "RightShiftAssignment": name = "<<= "; break;
+                case "MultiplicationAssignment": name = "*= "; break;
+                case "PointerToMemberSelection": name = "->* "; break;
+                case "SubtractionAssignment": name = "-= "; break;
+                case "ExclusiveOrAssignment": name = "^= "; break;
+                case "LeftShiftAssignment": name = "<<="; break;
+                case "ModulusAssignment": name = "%= "; break;
+                case "AdditionAssignment": name = "+= "; break;
+                case "BitwiseAndAssignment": name = "&= "; break;
+                case "BitwiseOrAssignment": name = "|= "; break;
+                case "Comma": name = ", "; break;
+                case "DivisionAssignment": name = "/= "; break;
+            }
+
+            newm.Implicit = bImplicit;
+            newm.Explicit = bExplicit;
+            newm.SetName(name);
+
+            return newm;
+        }
+
+        private Access GetAccessForMethod(MethodExt mMethod)
+        {
+            if (mdDecoder.IsProtected(mMethod) && mdDecoder.IsInternal(mMethod))
+                return Access.INTERNAL_AND_OR_PROTECTED;
+            else if (mdDecoder.IsProtected(mMethod))
+                return Access.PROTECTED;
+            else if (mdDecoder.IsPrivate(mMethod))
+                return Access.PRIVATE;
+            else if (mdDecoder.IsInternal(mMethod))
+                return Access.INTERNAL;
+            else if (mdDecoder.IsPublic(mMethod))
+                return Access.PUBLIC;
+            else
+                return Access.NONE;
+        }
+
+        public Method ConstructDefaultConstructor(Type parentType, Class clparent)
+        {
+            Contract.Requires(clparent != null);
+            Namespace ns = LookupNamespaceFromClass(parentType);
+
+            string CustomInitList = "";
+            bool bBaseConstructor = false;
+            MethodExt baseConstructor = default(MethodExt);
+            if (mdDecoder.HasBaseClass(parentType))
+            {
+                Type baseclass = mdDecoder.BaseClass(parentType);
+                if (mdDecoder.FullName(baseclass) != "System.Object")
+                    bBaseConstructor = GetAConstructor(baseclass, parentType, out baseConstructor);
+            }
+
+            if (bBaseConstructor)
+            {
+                var pars = mdDecoder.Parameters(baseConstructor);
+                if (pars.Count > 0)
+                {
+                    // only output if not the default constructor
+                    CustomInitList += " : base (";
+                    for (int i = 0; i < pars.Count; ++i)
+                    {
+                        if (i > 0)
+                            CustomInitList += ", ";
+                        CustomInitList += "default(" + TypeFullName(mdDecoder.ParameterType(pars[i]), clparent, ns) + ")";
+                    }
+                    CustomInitList += ")";
+                }
+            }
+
+            Method newmeth = new Method(
+              Access.INTERNAL,
+              clparent,
+              "void",
+              mdDecoder.Name(parentType),
+              false,
+              false,
+              false,
+              false,
+              false,
+              false,
+              false,
+              true,
+              false,
+              false,
+              CustomInitList);
+
+            //** Parameters
+
+            // Initialize fields in a struct constructor
+            if (mdDecoder.IsStruct(parentType))
+            {
+                foreach (var f in mdDecoder.Fields(parentType))
+                {
+                    if (SkipField(f)) continue;
+                    if (!mdDecoder.IsStatic(f))
+                        newmeth.AddVarToInitialize(TypeFullName(mdDecoder.FieldType(f), clparent, ns), "this." + mdDecoder.Name(f));
+                }
+            }
+
+            return newmeth;
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification = "Probably Clousot is right to report bExtern")]
+        public Method ConstructMethodFromMetaDataDecoder(MethodExt mMethod, Class clparent)
+        {
+            bool bExtern = mdDecoder.IsExtern(mMethod);
+            bool bStatic = mdDecoder.IsStatic(mMethod);
+            bool bVirtual = mdDecoder.IsVirtual(mMethod);
+            bool bSealed = mdDecoder.IsSealed(mMethod);
+            bool bNewSlot = mdDecoder.IsNewSlot(mMethod);
+            bool bAbstract = mdDecoder.IsAbstract(mMethod);
+            bool bPrivate = mdDecoder.IsPrivate(mMethod);
+            bool bOverride = mdDecoder.IsOverride(mMethod);
+            bool bImplicitImpl = mdDecoder.IsImplicitImplementation(mMethod);
+
+            bool bIsInInterface = mdDecoder.IsInterface(mdDecoder.DeclaringType(mMethod));
+            Access access;
+            if (bIsInInterface)
+                access = Access.NONE;
+            else if (mdDecoder.IsPublic(mMethod)
+              || (bVirtual && bSealed && bNewSlot && bImplicitImpl))
+                access = Access.PUBLIC;
+            else
+                access = GetAccessForMethod(mMethod);
+
+            bool bIsConstructor = mdDecoder.IsConstructor(mMethod);
+            bool bIsFinalizer = mdDecoder.IsFinalizer(mMethod);
+            string rettype = "";
+            Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(mMethod));
+            if (!bIsConstructor && !bIsFinalizer)
+                rettype += TypeFullName(mdDecoder.ReturnType(mMethod), clparent, ns);
+
+            //** Get actual modifiers from the metadata decoders values
+            // and the correspondance table (cf. the .xlsx file)
+            bool bActualExtern = false;
+            bool bActualStatic = false;
+            bool bActualVirtual = false;
+            bool bActualSealed = false;
+            bool bActualNewSlot = false;
+            bool bActualAbstract = false;
+            bool bActualOverride = false;
+
+            if (!bIsInInterface)
+            {
+                if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(mMethod))
+                    && !mdDecoder.IsSealed(mdDecoder.DeclaringType(mMethod)))
+                {
+                    if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
+                        access = Access.PUBLIC;
+                    else if (bVirtual && bSealed)
+                    {
+                        bActualSealed = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bNewSlot && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bNewSlot)
+                    {
+                        bActualNewSlot = true;
+                        bActualVirtual = true;
+                    }
+                    else if (bVirtual && bPrivate /* explicit interface */ && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bOverride)
+                    {
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bExtern)
+                        bActualAbstract = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                    else if (bVirtual)
+                        bActualVirtual = true;
+                }
+                else
+                {
+                    if (bVirtual && bOverride)
+                        bActualOverride = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                }
+
+                bActualStatic = bStatic;
+            }
+
+            Type parentType = mdDecoder.DeclaringType(mMethod);
+            string name;
+            if (bIsConstructor || bIsFinalizer)
+                name = mdDecoder.Name(parentType);
+            else
+                name = mdDecoder.Name(mMethod);
+
+            string CustomInitList = "";
+            if (bIsConstructor)
+            {
+                bool bBaseConstructor = false;
+                MethodExt baseConstructor = default(MethodExt);
+                if (mdDecoder.HasBaseClass(parentType))
+                {
+                    Type baseclass = mdDecoder.BaseClass(parentType);
+                    if (mdDecoder.FullName(baseclass) != "System.Object")
+                        bBaseConstructor = GetAConstructor(baseclass, parentType, out baseConstructor);
+                }
+
+                if (bBaseConstructor)
+                {
+                    var pars = mdDecoder.Parameters(baseConstructor);
+                    if (pars.Count > 0)
+                    {
+                        // only output if not the default constructor
+                        CustomInitList += " : base (";
+                        for (int i = 0; i < pars.Count; ++i)
+                        {
+                            if (i > 0)
+                                CustomInitList += ", ";
+                            CustomInitList += "default(" + TypeFullName(mdDecoder.ParameterType(pars[i]), clparent, ns) + ")";
+                        }
+                        CustomInitList += ")";
+                    }
+                }
+            }
+
+            Method newmeth = new Method(
+              access,
+              clparent,
+              rettype,
+              name,
+              mdDecoder.IsUnmanagedPointer(mdDecoder.ReturnType(mMethod)), /* Parameters are taken into account below */
+              bActualExtern,
+              bActualStatic,
+              bActualVirtual,
+              bActualNewSlot,
+              bActualSealed,
+              bActualAbstract,
+              bIsConstructor,
+              bIsFinalizer,
+              bActualOverride,
+              CustomInitList);
+
+            //** Formal type parameters
+            Microsoft.Research.DataStructures.IIndexable<Type> formals;
+            if (mdDecoder.IsGeneric(mMethod, out formals))
+                newmeth.AddFormalTypeParameters(GetFormalTypeParameters(formals));
+
+            //** Parameters
+            var mpars = mdDecoder.Parameters(mMethod);
+            int n = mpars.Count;
+            for (int i = 0; i < n; ++i)
+            {
+                Parameter newparam = ConstructParameterFromMetaDataDecoder(i, mpars[i], clparent);
+                newmeth.AddParameter(newparam);
+            }
+
+            // Initialize fields in a struct constructor
+            if (mdDecoder.IsConstructor(mMethod) && mdDecoder.IsStruct(mdDecoder.DeclaringType(mMethod)))
+            {
+                foreach (var f in mdDecoder.Fields(parentType))
+                {
+                    if (SkipField(f)) continue;
+                    if (!mdDecoder.IsStatic(f))
+                        newmeth.AddVarToInitialize(TypeFullName(mdDecoder.FieldType(f), clparent, ns), "this." + mdDecoder.Name(f));
+                    else if (!mdDecoder.IsReadonly(f) || mdDecoder.IsStatic(mMethod)) // if readonly, can only be assigned in a static constructor
+                        newmeth.AddVarToInitialize(TypeFullName(mdDecoder.FieldType(f), clparent, ns), clparent.Name + "." + mdDecoder.Name(f));
+                }
+            }
+
+            return newmeth;
+        }
+
+        private Access GetMostAccessible(bool bIsm1Valid, bool bIsm2Valid, MethodExt m1, MethodExt m2)
+        {
+            Access access1 = Access.NONE;
+            Access access2 = Access.NONE;
+
+            if (bIsm1Valid)
+                access1 = GetAccessForMethod(m1);
+            if (bIsm2Valid)
+                access2 = GetAccessForMethod(m2);
+
+            if (!bIsm1Valid)
+                return access2;
+            if (!bIsm2Valid)
+                return access1;
+
+            if (access1 == Access.PRIVATE)
+                return access2;
+            if (access2 == Access.PRIVATE)
+                return access1;
+
+            if (access1 == Access.INTERNAL)
+                return access2;
+            if (access2 == Access.INTERNAL)
+                return access1;
+
+            if (access1 == Access.PROTECTED)
+                return access2;
+            if (access2 == Access.PROTECTED)
+                return access1;
+
+            if (access1 == Access.INTERNAL_AND_OR_PROTECTED)
+                return access2;
+            if (access2 == Access.INTERNAL_AND_OR_PROTECTED)
+                return access1;
+
+            return Access.PUBLIC;
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        public Property ConstructPropertyFromMetaDataDecoder(PropertyExt prop, Class clparent)
+        {
+            var md = mdDecoder;
+            MethodExt Getter, Setter;
+            bool bHasGetter = md.HasGetter(prop, out Getter);
+            bool bHasSetter = md.HasSetter(prop, out Setter);
+            string name = md.Name(prop);
+            bool bIsInInterface = mdDecoder.IsInterface(mdDecoder.DeclaringType(prop));
+
+            bool bIsIndexer = (name == "Item" || name.EndsWith(".Item")); // could be an explicit implementation
+                                                                          // An indexer property can have an other name than "Item"
+                                                                          // cf. http://msdn.microsoft.com/en-us/library/2549tw02(VS.71).aspx
+            MethodExt getorset = bHasGetter ? Getter : Setter;
+            Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(getorset));
+
+            var atts = md.GetAttributes(mdDecoder.DeclaringType(getorset));
+            foreach (var att in atts)
+            {
+                string attname = md.Name(mdDecoder.AttributeType(att));
+                if (attname == "DefaultMemberAttribute")
+                {
+                    var inds = md.PositionalArguments(att);
+                    if (inds.Count > 0)
+                    {
+                        // The first (and only !) argument is the name of the indexer
+                        string indexname = inds[0] as string;
+                        if (indexname != null)
+                        {
+                            var propName = md.Name(prop);
+                            Contract.Assume(propName != null);
+                            if (propName == indexname || propName.EndsWith(indexname)) // could be an explicit implementation
+                            {
+                                bIsIndexer = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            Type returnt;
+            // There is a special case here.
+            // If the property only has a setter, then the return type
+            // is the type of the last parameter
+            if (bHasGetter)
+                returnt = mdDecoder.ReturnType(Getter);
+            else
+            {
+                var pars = mdDecoder.Parameters(Setter);
+                Contract.Assume(pars.Count > 0, "Setters have at least one parameter");
+                var lastpar = pars[pars.Count - 1];
+                returnt = mdDecoder.ParameterType(lastpar);
+            }
+            string returntype = TypeFullName(returnt, clparent, ns);
+
+            // Accessibility should be the less restrictive for the main property
+            // And then if an accessor is more restrictive, it should be output just for it
+            Access access = Access.NONE;
+            Access accessget = Access.NONE;
+            Access accessset = Access.NONE;
+            if (!name.Contains(".") && !bIsInInterface)
+                access = GetMostAccessible(bHasGetter, bHasSetter, Getter, Setter);
+
+            bool bExtern = mdDecoder.IsExtern(getorset);
+            bool bVirtual = mdDecoder.IsVirtual(getorset);
+            bool bSealed = mdDecoder.IsSealed(getorset);
+            bool bNewSlot = mdDecoder.IsNewSlot(getorset);
+            bool bOverride = mdDecoder.IsOverride(getorset);
+            bool bImplicitImpl = mdDecoder.IsImplicitImplementation(getorset);
+            bool bAbstract = mdDecoder.IsAbstract(getorset);
+            bool bStatic = mdDecoder.IsStatic(prop);
+
+            bool bActualExtern = false;
+            bool bActualStatic = false;
+            bool bActualVirtual = false;
+            bool bActualSealed = false;
+            bool bActualNewSlot = false;
+            bool bActualOverride = false;
+            bool bActualAbstract = false;
+
+            if (!bIsInInterface)
+            {
+                if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(prop))
+                    && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)))
+                {
+                    if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
+                    {
+                        access = Access.PUBLIC;
+                    }
+                    else if (bVirtual && bSealed)
+                    {
+                        bActualSealed = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bNewSlot && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bNewSlot)
+                    {
+                        bActualNewSlot = true;
+                        bActualVirtual = true;
+                    }
+                    else if (bVirtual && access == Access.PRIVATE /* explicit interface */ && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bOverride)
+                    {
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bExtern)
+                        bActualAbstract = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                    else if (bVirtual)
+                        bActualVirtual = true;
+                }
+                else
+                {
+                    if (bVirtual && bOverride)
+                        bActualOverride = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                }
+
+                bActualStatic = bStatic;
+            }
+
+            // get accessibility on getter and setter only when the main access has been discovered
+            if (!name.Contains(".") && !bIsInInterface)
+            {
+                if (bHasGetter)
+                {
+                    accessget = GetAccessForMethod(Getter);
+                    if (accessget == access) // not more restrictive than the property
+                        accessget = Access.NONE;
+                }
+
+                if (bHasSetter)
+                {
+                    accessset = GetAccessForMethod(Setter);
+                    if (accessset == access) // not more restrictive than the property
+                        accessset = Access.NONE;
+                }
+            }
+
+
+
+            //bool bIsStatic = mdDecoder.IsStatic (prop);
+            //bool bIsNewSlot = mdDecoder.IsNewSlot(prop) && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)) && !mdDecoder.IsStruct(mdDecoder.DeclaringType(prop));
+            //bool bIsOverride = !bIsNewSlot && mdDecoder.IsOverride(prop) && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)) && !mdDecoder.IsStruct(mdDecoder.DeclaringType(prop));
+            //bool bIsSealed = !bIsNewSlot && mdDecoder.IsSealed(prop) && !mdDecoder.IsSealed(mdDecoder.DeclaringType(prop)) && !mdDecoder.IsStruct(mdDecoder.DeclaringType(prop));
+
+            bIsIndexer = bIsIndexer && mdDecoder.Parameters(getorset).Count > 0; // double-check, you can have a property called Item
+
+            Property newprop = new Property(
+              clparent,
+              bHasGetter,
+              bHasSetter,
+              name,
+              mdDecoder.IsUnmanagedPointer(returnt), /* Parameters are handled when added */
+              bIsInInterface,
+              bIsIndexer,
+              returntype,
+              access,
+              accessget,
+              accessset,
+              bActualStatic,
+              bActualNewSlot,
+              bActualOverride,
+              bActualSealed,
+              bActualVirtual,
+              bActualExtern,
+              bActualAbstract);
+
+            // Add parameters for indexers
+            if (bIsIndexer)
+            {
+                var pars = mdDecoder.Parameters(getorset);
+                int nb_par = pars.Count;
+                if (!bHasGetter)
+                    --nb_par; // Skip last parameter, it's "value"
+                for (int i = 0; i < nb_par; ++i)
+                    newprop.AddParameter(ConstructParameterFromMetaDataDecoder(i, pars[i], clparent));
+            }
+
+            return newprop;
+        }
+
+        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+        public Event ConstructEventFromMetaDataDecoder(EventExt evt, Class clparent)
+        {
+            Contract.Requires(clparent != null);
+
+            MethodExt Adder, Remover;
+            bool bHasAdder = mdDecoder.HasAdder(evt, out Adder);
+            bool bHasRemover = mdDecoder.HasRemover(evt, out Remover);
+            string name = mdDecoder.Name(evt);
+            bool bIsInInterface = mdDecoder.IsInterface(mdDecoder.DeclaringType(evt));
+
+            MethodExt any = bHasAdder ? Adder : Remover;
+            Namespace ns = LookupNamespaceFromClass(mdDecoder.DeclaringType(any));
+
+            Type handlerType = mdDecoder.HandlerType(evt);
+            string returntype = TypeFullName(handlerType, clparent, ns);
+
+            // Accessibility should be the less restrictive for the main property
+            // And then if an accessor is more restrictive, it should be output just for it
+            Access access = Access.NONE;
+            Access accessget = Access.NONE;
+            Access accessset = Access.NONE;
+            if (!name.Contains(".") && !bIsInInterface)
+                access = GetMostAccessible(bHasAdder, bHasRemover, Adder, Remover);
+
+            bool bExtern = mdDecoder.IsExtern(any);
+            bool bVirtual = mdDecoder.IsVirtual(any);
+            bool bSealed = mdDecoder.IsSealed(any);
+            bool bNewSlot = mdDecoder.IsNewSlot(any);
+            bool bOverride = mdDecoder.IsOverride(any);
+            bool bImplicitImpl = mdDecoder.IsImplicitImplementation(any);
+            bool bAbstract = mdDecoder.IsAbstract(any);
+            bool bStatic = mdDecoder.IsStatic(evt);
+
+            bool bActualExtern = false;
+            bool bActualStatic = false;
+            bool bActualVirtual = false;
+            bool bActualSealed = false;
+            bool bActualNewSlot = false;
+            bool bActualOverride = false;
+            bool bActualAbstract = false;
+
+            if (!bIsInInterface)
+            {
+                if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(evt))
+                    && !mdDecoder.IsSealed(mdDecoder.DeclaringType(evt)))
+                {
+                    if (bVirtual && bSealed && bNewSlot && bImplicitImpl)
+                        access = Access.PUBLIC;
+                    else if (bVirtual && bSealed)
+                    {
+                        bActualSealed = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bNewSlot && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bAbstract)
+                        bActualAbstract = true;
+                    else if (bVirtual && bNewSlot)
+                    {
+                        bActualNewSlot = true;
+                        bActualVirtual = true;
+                    }
+                    else if (bVirtual && access == Access.PRIVATE /* explicit interface */ && bOverride)
+                    {
+                        bActualAbstract = true;
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bOverride)
+                    {
+                        bActualOverride = true;
+                    }
+                    else if (bVirtual && bAbstract && bExtern)
+                        bActualAbstract = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                    else if (bVirtual)
+                        bActualVirtual = true;
+                }
+                else
+                {
+                    if (bVirtual && bOverride)
+                        bActualOverride = true;
+                    else if (bVirtual && bExtern)
+                        bActualExtern = true;
+                }
+
+                bActualStatic = bStatic;
+            }
+
+            // get accessibility on getter and setter only when the main access has been discovered
+            if (!name.Contains(".") && !bIsInInterface)
+            {
+                if (bHasAdder)
+                {
+                    accessget = GetAccessForMethod(Adder);
+                    if (accessget == access) // not more restrictive than the property
+                        accessget = Access.NONE;
+                }
+
+                if (bHasRemover)
+                {
+                    accessset = GetAccessForMethod(Remover);
+                    if (accessset == access) // not more restrictive than the property
+                        accessset = Access.NONE;
+                }
+            }
+
+            Event newEvent = new Event(
+              clparent,
+              bHasAdder,
+              bHasRemover,
+              name,
+              mdDecoder.IsUnmanagedPointer(handlerType), /* Parameters are handled when added */
+              bIsInInterface,
+              returntype,
+              access,
+              accessget,
+              accessset,
+              bActualStatic,
+              bActualNewSlot,
+              bActualOverride,
+              bActualSealed,
+              bActualVirtual,
+              bActualExtern,
+              bActualAbstract);
+
+            return newEvent;
+        }
+
+        public Field ConstructFieldFromMetaDataDecoder(FieldExt f, Class clparent)
+        {
+            Contract.Requires(clparent != null);
+
+            Field.ParentType pt;
+            Type parent = mdDecoder.DeclaringType(f);
+            if (mdDecoder.IsStruct(parent))
+                pt = Field.ParentType.STRUCT;
+            else if (mdDecoder.IsClass(parent))
+                pt = Field.ParentType.CLASS;
+            else
+                pt = Field.ParentType.INTERFACE;
+
+            Access acc;
+            if (mdDecoder.IsProtected(f) && mdDecoder.IsInternal(f))
+                acc = Access.INTERNAL_AND_OR_PROTECTED;
+            else if (mdDecoder.IsInternal(f))
+                acc = Access.INTERNAL;
+            else if (mdDecoder.IsPublic(f))
+                acc = Access.PUBLIC;
+            else if (mdDecoder.IsProtected(f))
+                acc = Access.PROTECTED;
+            else
+                acc = Access.PRIVATE;
+
+            Type fieldt = mdDecoder.FieldType(f);
+            string typename = TypeFullName(fieldt, clparent, clparent.Namespace);
+            string defaut = "";
+            // For readability, don't even output this, but disable the corresponding warning instead
+            //if (pt != Field.ParentType.STRUCT)
+            //  defaut = "default(" + typename + ")";
+
+            return new Field(
+              typename,
+              mdDecoder.Name(f),
+              clparent,
+              defaut,
+              pt,
+              acc,
+              mdDecoder.IsUnmanagedPointer(fieldt),
+              mdDecoder.IsReadonly(f),
+              mdDecoder.IsStatic(f),
+              mdDecoder.IsNewSlot(f),
+              mdDecoder.IsVolatile(f)
+              );
+        }
+
+        public Class LookupClass(Type type, bool bVisitNested)
+        {
+            if (!mClassesLookup.ContainsKey(type))
+                AddClass(type, bVisitNested);
+            else if (bVisitNested)
+            {
+                // Here, it is requested that nested types are well registered
+                // they could be still pending because the class could have been
+                // added before without the bVisitNested flag
+                foreach (var nested in mdDecoder.NestedTypes(type))
+                    RegisterType(nested);
+            }
+
+            return mClassesLookup[type];
+        }
+
+        public Method LookupMethod(MethodExt mMethod)
+        {
+            // Ensures the declaring type has been registered
+            // so that the method has been registered
+            LookupClass(mdDecoder.DeclaringType(mMethod), false);
+
+            if (mMethodsLookup.ContainsKey(mMethod))
+                return mMethodsLookup[mMethod];
+            else
+                return null;
+        }
+
+        public Property LookupProperty(PropertyExt prop)
+        {
+            // Ensures the declaring type has been registered
+            // so that the propery has been registered
+            LookupClass(mdDecoder.DeclaringType(prop), false);
+
+            if (mPropertiesLookup.ContainsKey(prop))
+                return mPropertiesLookup[prop];
+            else
+                return null;
+        }
+
+        public Class AddClass(Type type, bool bVisitNested)
+        {
+            Class newcl = ConstructClassFromMetaDataDecoder(type);
+            mClassesLookup.Add(type, newcl);
+
+            // Register the class to its containers
+            newcl.Namespace.AddChild(newcl);
+            if (newcl.Parent != null) // only register toplevel classes to the namespace
+                newcl.Parent.AddChild(newcl);
+
+            if (bVisitNested)
+            {
+                // Also register all nested types
+                foreach (var nested in mdDecoder.NestedTypes(type))
+                    RegisterType(nested);
+            }
+
+            return newcl;
+        }
+
+        private bool SkipType(Type type)
+        {
+            if (MustKeepType(type)) return false;
+
+            // if type contains nested type we must keep, then we keep it too
+            foreach (var nested in mdDecoder.NestedTypes(type))
+            {
+                if (!SkipType(nested)) return false;
+            }
+
+            return (visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(type));
+        }
+
+        private bool SkipType(Type type, Set<Type> seen)
+        {
+            if (MustKeepType(type, seen)) return false;
+
+            return (visibleMembersOnly && !mdDecoder.IsVisibleOutsideAssembly(type));
+        }
+
+        public void RegisterType(Type type)
+        {
+            if (SkipType(type)) return;
+
+            if (IsNonCSharpType(type))
+                return;
+
+            // Order is important because an enum is also said to be a struct!
+            if (mdDecoder.IsEnum(type))
+                RegisterEnum(type);
+            else if (mdDecoder.IsDelegate(type))
+                RegisterDelegate(type);
+            else if (mdDecoder.IsClass(type)
+              || mdDecoder.IsStruct(type)
+              || mdDecoder.IsInterface(type))
+                LookupClass(type, true);
+        }
+
+        private bool IsNonCSharpType(Type type)
+        {
+            return mdDecoder.IsCompilerGenerated(type) ||
+                   mdDecoder.IsNativeCpp(type) ||
+                   mdDecoder.Namespace(type) == "<CrtImplementationDetails>";
+        }
+
+        private bool ContainsNonCSharpType(Type type)
+        {
+            if (IsNonCSharpType(type)) return true;
+
+            if (mdDecoder.IsUnmanagedPointer(type))
+            {
+                return ContainsNonCSharpType(mdDecoder.ElementType(type));
+            }
+            if (mdDecoder.IsManagedPointer(type))
+            {
+                return ContainsNonCSharpType(mdDecoder.ElementType(type));
+            }
+            if (mdDecoder.IsArray(type))
+            {
+                return ContainsNonCSharpType(mdDecoder.ElementType(type));
+            }
+            return false;
+        }
+
+        public void RegisterEnum(Type type)
+        {
+            if (mdDecoder.IsEnum(type))
+            {
+                Enum newenum = ConstructEnumFromMetaDataDecoder(type);
+                if (newenum.Parent == null)
+                    newenum.Namespace.AddChild(newenum);
+                else
+                    newenum.Parent.AddChild(newenum);
+            }
+        }
+
+        public void RegisterDelegate(Type type)
+        {
+            // Ensures the declaring type has been registered
+            // so that we can have access to the parent
+            Class parent = null;
+            Type parentt;
+            if (mdDecoder.IsNested(type, out parentt))
+                parent = LookupClass(parentt, false);
+
+            if (mdDecoder.IsDelegate(type))
+            {
+                Delegate newdel = ConstructDelegateFromMetaDataDecoder(type, parent);
+                if (newdel == null)
+                    return;
+
+                if (newdel.Parent == null)
+                    newdel.Namespace.AddChild(newdel);
+                else
+                    newdel.Parent.AddChild(newdel);
+            }
+        }
+
+        public Namespace AddNamespace(string name)
+        {
+            return mCm.LookupNamespaceByName(name);
+            /*Namespace newNS = mCm.LookupNamespaceByName (name);
+            if (newNS == null)
+            {
+              newNS = new Namespace(name);
+              mCm.AddNamespace(newNS);
+            }
+            return newNS;*/
+        }
+
+        public void Reset()
+        {
+            mClassesLookup.Clear();
+            mMethodsLookup.Clear();
+            mPropertiesLookup.Clear();
+        }
+
+        #region Assembly managing
+        private void AddRefRef(Assembly assemb, Microsoft.Research.DataStructures.IMutableSet<string> added, List<Pair<string, Version>> refnames, string mAssemblyName)
+        {
+            string assname = mdDecoder.Name(assemb);
+            if (assname != mAssemblyName && added.Add(assname)) // don't reference itself, useful for analysing system dlls
+            {
+                refnames.Add(new Pair<string, Version>(assname, mdDecoder.Version(assemb)));
+                foreach (var r in mdDecoder.AssemblyReferences(assemb))
+                    AddRefRef(r, added, refnames, mAssemblyName);
+            }
+        }
+
+        public List<Pair<string, Version>> GetReferenceAssemblies(Assembly assemb)
+        {
+            var assemblies = new List<Pair<string, Version>>();
+            var added = new Set<string>();
+            //string str = System.IO.Path.GetFullPath("Microsoft.Contracts.dll");
+            //System.Reflection.Assembly ass = System.Reflection.Assembly.LoadFile(str);
+            //var asss = ass.GetReferencedAssemblies();
+
+            var asss = mdDecoder.AssemblyReferences(assemb);
+            foreach (var r in asss)
+                AddRefRef(r, added, assemblies, mdDecoder.Name(assemb));
+
+            return assemblies;
+        }
+        #endregion
+
+        public CodeManager CodeManager { get { return mCm; } }
+
+        private readonly IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder;
+
+        private Dictionary<Type, Class> mClassesLookup;
+        private Dictionary<MethodExt, Method> mMethodsLookup;
+        private Dictionary<PropertyExt, Property> mPropertiesLookup;
+        private CodeManager mCm;
+        private List<string> mUsings;
+        private bool visibleMembersOnly;
     }
 
-    /// <summary>
-    /// Add the method to the C# pretty output database. Then it will be output with all
-    /// the saved pre/post-conditions at the end of the analysis.
-    /// </summary>
-    /// <param name="method">Can be a getter or a setter.</param>
-    public void RegisterMethodPreCondition(MethodExt method, BoxedExpression precond)
+    public class ContractsHandlerMgr<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult>
+      where LogOptions : IFrameworkLogOptions
+      where Type : IEquatable<Type>
     {
-      if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
-        return;
+        #region Object invariant
 
-      if (mCH.SkipMethod(method)) return;
-
-      if (mdDecoder.Name(method) == ".cctor")
-        return;
-
-      if (mdDecoder.IsCompilerGenerated(method) || mdDecoder.IsCompilerGenerated(mdDecoder.DeclaringType(method)))
-        return;
-
-      if (!FixOutParameter(method, precond, out precond))
-        return;
-
-      if (mdDecoder.IsConstructor(method))
-        precond = FixFieldInConstructor(method, precond);
-
-      string precond_str = precond.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter));
-      // HACK: the out trick does not take into account such code:
-      // public Socket EndAccept (out byte[] buffer, System.IAsyncResult asyncResult) {
-      // Contract.Ensures (Contracts.ValueAtReturn (out buffer.Length) >= 0);
-      // so we just want to move the last parenthese
-      precond_str = FixOutContracts(precond_str);
-
-      bool getter = false;
-      if ((getter = mdDecoder.IsPropertyGetter(method)) || mdDecoder.IsPropertySetter(method))
-      {
-        PropertyExt prop = mdDecoder.GetPropertyFromAccessor(method);
-        Property p = mCH.LookupProperty(prop);
-        if (p != null)
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
         {
-          if (getter)
-            p.AddPrecondToGet(precond_str);
-          else
-            p.AddPrecondToSet(precond_str);
-
-          if (UnmanagedExpression(precond))
-            p.ForceUnsafe(true);
-
-          ++mNbPreProperties;
+            Contract.Invariant(mdDecoder != null);
+            Contract.Invariant(mAnalyzer != null);
         }
-      }
-      else
-      {
-        Method m = mCH.LookupMethod(method);
-        if (m != null)
+
+        #endregion
+
+
+        #region Constructor
+        public ContractsHandlerMgr(
+            AnalysisDriver<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mAnalyzer,
+            IOutput mOutput
+            )
         {
-          m.AddPrecond(precond_str);
+            Contract.Requires(mAnalyzer != null);
 
-          if (UnmanagedExpression(precond))
-            m.ForceUnsafe(true);
-
-          ++mNbPreMethods;
+            this.mAnalyzer = mAnalyzer;
+            mdDecoder = mAnalyzer.MetaDataDecoder;
+            this.mOutput = mOutput;
+            mAssembly = default(Assembly);
+            mAssemblyName = "";
+            mWrittenFiles = new List<string>();
+            mCH = new ConstructionHelper<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>(mdDecoder, mAnalyzer.Options.OutputOnlyExternallyVisibleMembers);
+            mStrategy = OutputHelper.OutputStrategy.ONE_FILE_PER_CLASS; // should be set later by "SetStrategy"
         }
-      }
+        #endregion
+
+        #region Privates
+        private readonly AnalysisDriver<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly, Expression, Variable, LogOptions, MethodResult> mAnalyzer;
+        private readonly IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder;
+        private IOutput mOutput;
+
+        private ConstructionHelper<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mCH;
+
+        private string mAssemblyName;
+        private Assembly mAssembly;
+
+        private List<string> mWrittenFiles;
+        // Statistics
+        private int mNbPreMethods; /// number of registered preconditions in methods
+        private int mNbPostMethods; /// number of registered postconditions in methods
+        private int mNbPreProperties; /// number of registered preconditions in properties
+        private int mNbPostProperties; /// number of registered postconditions in properties
+        private int mNbClassInvariants; /// number of registered class invariants
+
+        private OutputHelper.OutputStrategy mStrategy;
+        #endregion
+
+        public void SetStrategy(OutputHelper.OutputStrategy strat)
+        {
+            mStrategy = strat;
+        }
+
+        private bool UnmanagedExpression(BoxedExpression expr)
+        {
+            if (expr.IsBinary)
+                return UnmanagedExpression(expr.BinaryLeft) || UnmanagedExpression(expr.BinaryRight);
+            else if (expr.IsUnary)
+                return UnmanagedExpression(expr.UnaryArgument);
+            else if (expr.IsVariable)
+            {
+                var expAccessPath = expr.AccessPath;
+                if (expAccessPath != null)
+                {
+                    Contract.Assert(Contract.ForAll(expAccessPath, p => p != null));
+                    for (int i = 0; i < expAccessPath.Length; ++i)
+                    {
+                        if (expAccessPath[i].IsUnmanagedPointer)
+                            return true; // There is an unmanaged pointer in the way
+                    }
+                }
+            }
+            else if (expr.IsResult)
+            {
+                object rettype;
+                if (expr.TryGetType(out rettype))
+                    return mdDecoder.IsUnmanagedPointer((Type)rettype);
+            }
+
+            return false;
+        }
+
+        private string BoxedExpressionConverter(Type type)
+        {
+            return OutputPrettyCS.TypeHelper.TypeFullName(mdDecoder, type);
+        }
+
+        #region Register Methods
+        public void RegisterClassInvariant(Type type, BoxedExpression invariant)
+        {
+            Contract.Requires(invariant != null);
+
+            if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
+                return;
+
+            if (mAnalyzer.Options.OutputOnlyExternallyVisibleMembers && !mdDecoder.IsVisibleOutsideAssembly(type)) return;
+
+            if (mdDecoder.IsCompilerGenerated(type)) // no compiler generated types
+                return;
+            if (!mdDecoder.IsClass(type) && !mdDecoder.IsStruct(type)) // only for classes and struct
+                return;
+
+            Class cl = mCH.LookupClass(type, false);
+
+            if (cl != null)
+            {
+                cl.AddInvariant(invariant.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)));
+                mNbClassInvariants++;
+            }
+        }
+
+        /// <summary>
+        /// Replace out parameters occurences in contracts by "ValueAtReturn(out x)" in fixed_exp to trick the compiler.
+        /// Return true if a change has been made, false if not.
+        /// </summary>
+        private bool FixOutParameter(MethodExt parent, BoxedExpression exp, out BoxedExpression fixed_exp)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out fixed_exp) != null);
+
+            fixed_exp = exp;
+
+            if (exp.IsVariable)
+            {
+                Microsoft.Research.DataStructures.FList<PathElement> path = Microsoft.Research.DataStructures.FList<PathElement>.Empty;
+                for (int i = 0; i < exp.AccessPath.Length; ++i)
+                {
+                    var elem = exp.AccessPath[exp.AccessPath.Length - i - 1];
+                    Contract.Assume(elem != null);
+                    if (elem.IsModel) return false;
+                    path = Microsoft.Research.DataStructures.FList<PathElement>.Cons(elem, path);
+                }
+
+                if (path != null && path.Head != null && path.Head.IsParameterRef)
+                {
+                    var pars = mdDecoder.Parameters(parent);
+
+                    for (int i = 0; i < pars.Count; ++i)
+                    {
+                        var par = pars[i];
+                        //SymbolicValue vpar, vpar2, vpar3, vpar4, vpar5;
+                        //context.TryParameterAddress(context.EntryAfterRequires, par, out vpar);
+                        //context.TryParameterValue(context.EntryAfterRequires, par, out vpar2);
+                        //context.TryLoadIndirect(context.EntryAfterRequires, vpar, out vpar3);
+                        //context.TryLoadIndirect(context.EntryAfterRequires, vpar2, out vpar4);
+                        //context.TryLoadIndirect(context.EntryAfterRequires, var, out vpar5);
+                        //if (var.Equals(vpar))
+                        if (exp.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)).StartsWith(mdDecoder.Name(par)) && mdDecoder.IsOut(par)) // allow to have something after, will be fixed by FixOutContracts
+                        {
+                            fixed_exp = BoxedExpression.ValueAtReturn(exp, mdDecoder.ParameterType(par));
+                            return true;
+                        }
+                    }
+                }
+                return true;
+            }
+            else if (exp.IsUnary)
+            {
+                BoxedExpression fixd;
+                if (FixOutParameter(parent, exp.UnaryArgument, out fixd))
+                {
+                    fixed_exp = BoxedExpression.Unary(exp.UnaryOp, fixd);
+                    return true;
+                }
+            }
+            else if (exp.IsBinary)
+            {
+                BoxedExpression fl, fr;
+                var bl = FixOutParameter(parent, exp.BinaryLeft, out fl);
+                var br = FixOutParameter(parent, exp.BinaryRight, out fr);
+
+                if (bl && br)
+                {
+                    BoxedExpression.BinaryExpressionMethodCall bemc = exp as BoxedExpression.BinaryExpressionMethodCall;
+                    if (bemc != null)
+                    {
+                        fixed_exp = BoxedExpression.BinaryMethodToCall(exp.BinaryOp, fl, fr, bemc.MethodToCall);
+                    }
+                    else
+                    {
+                        // Mic: kind of a hack. Would be nicer to have some kind of visitor on BoxedExpression
+                        if (exp.IsCast)
+                        {
+                            var castExpression = exp as ClousotExpression<Type>.CastExpression;
+                            Contract.Assume(castExpression != null);
+                            fixed_exp = BoxedExpression.BinaryCast(exp.BinaryOp, fl, fr, castExpression.mTypeCasting);
+                        }
+                        else
+                        {
+                            fixed_exp = BoxedExpression.Binary(exp.BinaryOp, fl, fr);
+                        }
+                    }
+
+                    return true;
+                }
+            }
+            else if (exp.IsResult || exp.IsConstant)
+            {
+                return true;
+            }
+            // FIXME: recursively apply this transformation
+            return false;
+        }
+
+        /// <summary>
+        /// Replace field parameters occurences in struct constructors contracts by "ValueAtReturn(out x)" to trick the compiler
+        /// </summary>
+        /// <param name="parent">Assumed to be a constructor</param>
+        private BoxedExpression FixFieldInConstructor(MethodExt parent, BoxedExpression exp)
+        {
+            Contract.Requires(exp != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            if (!mdDecoder.IsStruct(mdDecoder.DeclaringType(parent)))
+                return exp;
+
+            if (exp.IsVariable)
+            {
+                SymbolicValue var;
+                if (exp.TryGetFrameworkVariable(out var))
+                {
+                    var fields = mdDecoder.Fields(mdDecoder.DeclaringType(parent));
+                    foreach (var f in fields)
+                    {
+                        if (exp.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)).StartsWith("this." + mdDecoder.Name(f))) // allow to have something after, will be fixed by FixOutContracts
+                        {
+                            object t;
+                            if (exp.TryGetType(out t))
+                                return BoxedExpression.ValueAtReturn(exp, (Type)t);
+                            else
+                                return BoxedExpression.ValueAtReturn(exp, default(Type));
+                        }
+                    }
+                }
+                else if (exp.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter)).StartsWith("this.")) // sometimes TryGetFrameworkVariable fails, cf. explication elsewhere
+                {
+                    object t;
+                    if (exp.TryGetType(out t))
+                        return BoxedExpression.ValueAtReturn(exp, (Type)t);
+                    else
+                        return BoxedExpression.ValueAtReturn(exp, default(Type));
+                }
+            }
+            else if (exp.IsUnary)
+                return BoxedExpression.Unary(exp.UnaryOp, FixFieldInConstructor(parent, exp.UnaryArgument));
+            else if (exp.IsBinary)
+                return BoxedExpression.Binary(exp.BinaryOp, FixFieldInConstructor(parent, exp.BinaryLeft), FixFieldInConstructor(parent, exp.BinaryRight));
+
+            return exp;
+        }
+
+        /// <summary>
+        /// Add the method to the C# pretty output database. Then it will be output with all
+        /// the saved pre/post-conditions at the end of the analysis.
+        /// </summary>
+        /// <param name="method">Can be a getter or a setter.</param>
+        public void RegisterMethodPreCondition(MethodExt method, BoxedExpression precond)
+        {
+            if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
+                return;
+
+            if (mCH.SkipMethod(method)) return;
+
+            if (mdDecoder.Name(method) == ".cctor")
+                return;
+
+            if (mdDecoder.IsCompilerGenerated(method) || mdDecoder.IsCompilerGenerated(mdDecoder.DeclaringType(method)))
+                return;
+
+            if (!FixOutParameter(method, precond, out precond))
+                return;
+
+            if (mdDecoder.IsConstructor(method))
+                precond = FixFieldInConstructor(method, precond);
+
+            string precond_str = precond.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter));
+            // HACK: the out trick does not take into account such code:
+            // public Socket EndAccept (out byte[] buffer, System.IAsyncResult asyncResult) {
+            // Contract.Ensures (Contracts.ValueAtReturn (out buffer.Length) >= 0);
+            // so we just want to move the last parenthese
+            precond_str = FixOutContracts(precond_str);
+
+            bool getter = false;
+            if ((getter = mdDecoder.IsPropertyGetter(method)) || mdDecoder.IsPropertySetter(method))
+            {
+                PropertyExt prop = mdDecoder.GetPropertyFromAccessor(method);
+                Property p = mCH.LookupProperty(prop);
+                if (p != null)
+                {
+                    if (getter)
+                        p.AddPrecondToGet(precond_str);
+                    else
+                        p.AddPrecondToSet(precond_str);
+
+                    if (UnmanagedExpression(precond))
+                        p.ForceUnsafe(true);
+
+                    ++mNbPreProperties;
+                }
+            }
+            else
+            {
+                Method m = mCH.LookupMethod(method);
+                if (m != null)
+                {
+                    m.AddPrecond(precond_str);
+
+                    if (UnmanagedExpression(precond))
+                        m.ForceUnsafe(true);
+
+                    ++mNbPreMethods;
+                }
+            }
+        }
+
+        private string FixOutContracts(string input)
+        {
+            int begin = input.IndexOf("Contract.ValueAtReturn");
+            if (begin != -1)
+            {
+                string pattern = @"((?<1>(this\.)?\w*)([^\)]*)?\))";
+                string pattern_full = @"Contract.ValueAtReturn\(out " + pattern + @"(.*)";
+
+                //string testinput = "Contract.ValueAtReturn(out this.membera.memberb.member3)";
+                //string testinput = "capacity == Contract.ValueAtReturn(out this._array.Length)";
+                //string testinput = "(Contract.ValueAtReturn(out this._tail) - Contract.ValueAtReturn(out this._array.Length)) < 0";
+                //Match m = Regex.Match(testinput, pattern_full);
+                string refined = input.Substring(begin);
+                Match m = Regex.Match(refined, pattern_full);
+                if (m.Success)
+                {
+                    string new_str = input.Substring(0, begin);
+                    new_str += @"Contract.ValueAtReturn(out " + m.Groups[1].Captures[0].Value + ")";
+                    if (m.Groups[3].Captures.Count >= 1) // remaining accessors
+                        new_str += m.Groups[3].Captures[0].Value;
+                    if (m.Groups[4].Captures.Count >= 1) // After the ValueAtReturn(...)
+                        new_str += FixOutContracts(m.Groups[4].Captures[0].Value);
+                    return new_str;
+                }
+            }
+
+
+            return input;
+        }
+
+        /// <summary>
+        /// Add the method to the C# pretty output database. Then it will be output with all
+        /// the saved pre/post-conditions at the end of the analysis.
+        /// </summary>
+        /// <param name="method">Can be a getter or a setter.</param>
+        public void RegisterMethodPostCondition(MethodExt method, BoxedExpression postcond)
+        {
+            if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
+                return;
+
+            if (mCH.SkipMethod(method)) return;
+
+            if (mdDecoder.Name(method) == ".cctor")
+                return;
+
+            if (mdDecoder.IsCompilerGenerated(method) || mdDecoder.IsCompilerGenerated(mdDecoder.DeclaringType(method)))
+                return;
+
+            if (FilterPostCondition(postcond)) return;
+
+            if (!FixOutParameter(method, postcond, out postcond))
+                return;
+
+            if (mdDecoder.IsConstructor(method))
+                postcond = FixFieldInConstructor(method, postcond);
+
+            string postcond_str = postcond.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter));
+            // HACK: the out trick does not take into account such code:
+            // public Socket EndAccept (out byte[] buffer, System.IAsyncResult asyncResult) {
+            // Contract.Ensures (Contracts.ValueAtReturn (out buffer.Length) >= 0);
+            // so we just want to move the last parenthese
+            postcond_str = FixOutContracts(postcond_str);
+
+            bool getter = false;
+            if ((getter = mdDecoder.IsPropertyGetter(method)) || mdDecoder.IsPropertySetter(method))
+            {
+                PropertyExt prop = mdDecoder.GetPropertyFromAccessor(method);
+                Property p = mCH.LookupProperty(prop);
+                if (p != null)
+                {
+                    if (getter)
+                        p.AddPostcondToGet(postcond_str);
+                    else
+                        p.AddPostcondToSet(postcond_str);
+
+                    if (UnmanagedExpression(postcond))
+                        p.ForceUnsafe(true);
+
+                    ++mNbPostProperties;
+                }
+            }
+            else
+            {
+                Method m = mCH.LookupMethod(method);
+                if (m != null)
+                {
+                    m.AddPostcond(postcond_str);
+
+                    if (UnmanagedExpression(postcond))
+                        m.ForceUnsafe(true);
+
+                    ++mNbPostMethods;
+                }
+            }
+        }
+
+        private class FilterByVisibility : IBoxedExpressionVisitor
+        {
+            public bool ignoreMe;
+            private IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder;
+
+            public FilterByVisibility(IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> iDecodeMetaData)
+            {
+                mdDecoder = iDecodeMetaData;
+            }
+
+            public void Variable(object var, PathElement[] path, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                if (path != null)
+                {
+                    for (int i = 0; i < path.Length; i++)
+                    {
+                        CheckPathElementVisibility(path[i]);
+                        if (ignoreMe) return;
+                    }
+                }
+            }
+
+            private void CheckPathElementVisibility(PathElement pathElement)
+            {
+                var asField = pathElement as OptimisticHeapAnalyzer<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>.Domain.PathElement<FieldExt>;
+                if (asField != null)
+                {
+                    if (!mdDecoder.IsVisibleOutsideAssembly(asField.Element))
+                    {
+                        ignoreMe = true;
+                    }
+                    return;
+                }
+                var asMethod = pathElement as OptimisticHeapAnalyzer<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>.Domain.PathElement<MethodExt>;
+                if (asMethod != null)
+                {
+                    if (!mdDecoder.IsVisibleOutsideAssembly(asMethod.Element))
+                    {
+                        ignoreMe = true;
+                    }
+                    return;
+                }
+            }
+
+            public void ArrayIndex<Typ>(Typ type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                CheckTypeVisibility<Typ>(type);
+                array.Dispatch(this);
+                index.Dispatch(this);
+            }
+
+            public void Constant<Typ>(Typ type, object value, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                CheckTypeVisibility<Typ>(type);
+            }
+
+            public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                left.Dispatch(this);
+                right.Dispatch(this);
+            }
+
+            public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                argument.Dispatch(this);
+            }
+
+            public void SizeOf<Typ>(Typ type, int sizeAsConstant, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                CheckTypeVisibility<Typ>(type);
+            }
+
+            public void IsInst<Typ>(Typ type, BoxedExpression argument, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                CheckTypeVisibility<Typ>(type);
+            }
+
+            private void CheckTypeVisibility<Typ>(Typ type)
+            {
+                if (type is Type)
+                {
+                    var ourtype = (Type)(object)type;
+                    if (!mdDecoder.IsVisibleOutsideAssembly(ourtype))
+                    {
+                        ignoreMe = true;
+                        return;
+                    }
+                }
+            }
+
+            public void Result<Typ>(Typ type, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                CheckTypeVisibility<Typ>(type);
+            }
+
+            public void Old<Typ>(Typ type, BoxedExpression expression, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                CheckTypeVisibility<Typ>(type);
+                expression.Dispatch(this);
+            }
+
+            public void ValueAtReturn<Typ>(Typ type, BoxedExpression expression, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                CheckTypeVisibility<Typ>(type);
+                expression.Dispatch(this);
+            }
+
+            public void Assert(BoxedExpression condition, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                condition.Dispatch(this);
+            }
+
+            public void Assume(BoxedExpression condition, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                condition.Dispatch(this);
+            }
+
+            public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
+            {
+                for (int i = 0; i < statements.Count; i++)
+                {
+                    if (ignoreMe) return;
+                    statements[i].Dispatch(this);
+                }
+            }
+
+            public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
+            {
+                if (ignoreMe) return;
+                boundVariable.Dispatch(this);
+                lower.Dispatch(this);
+                upper.Dispatch(this);
+                body.Dispatch(this);
+            }
+        }
+
+        private bool FilterPostCondition(BoxedExpression postcond)
+        {
+            if (!mAnalyzer.Options.OutputOnlyExternallyVisibleMembers) return false;
+            var filter = new FilterByVisibility(mdDecoder);
+            postcond.Dispatch(filter);
+            return filter.ignoreMe;
+        }
+        #endregion
+
+        #region Pretty Output
+
+        private const string SourceFolder = @"Sources\";
+
+        public void PrettyCSOutput(string folder, bool verbose)
+        {
+            if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
+                return;
+
+            if (verbose)
+            {
+                mOutput.WriteLine("OutputPretty C#: has started...");
+                mOutput.WriteLine("OutputPretty C#: <{0}, {1}> preconditions have been registered in <methods, properties>.", mNbPreMethods, mNbPreProperties);
+                mOutput.WriteLine("OutputPretty C#: <{0}, {1}> postconditions have been registered in <methods, properties>.", mNbPostMethods, mNbPostProperties);
+                mOutput.WriteLine("OutputPretty C#: {0} class invariants have been registered.", mNbClassInvariants);
+            }
+
+            if (folder.Length == 0)
+                return;
+
+            // Handy
+            if (folder[folder.Length - 1] != '\\')
+                folder = folder + "\\";
+            folder += mAssemblyName; // One directory per assembly
+            if (folder[folder.Length - 1] != '\\')
+                folder = folder + "\\";
+
+            if (!Directory.Exists(folder + SourceFolder))
+            {
+                try
+                {
+                    Directory.CreateDirectory(folder + SourceFolder);
+                }
+                catch
+                {
+                    mOutput.WriteLine("OutputPretty C#: Unable to create directory " + folder + SourceFolder + ": OutputPretty C# could not continue.");
+                    return;
+                }
+            }
+
+            try
+            {
+                // Ensures that each class is in the output (to compile if referenced from somewhere, even if it does not have any contract)
+                foreach (var cl in mdDecoder.GetTypes(mAssembly))
+                {
+                    if (!mdDecoder.IsCompilerGenerated(cl) && mdDecoder.Name(cl) != "<Module>")
+                        mCH.RegisterType(cl);
+                }
+
+                // Output the code
+                mCH.CodeManager.OutputCode(folder, SourceFolder, mOutput, out mWrittenFiles, mStrategy, mCH.Usings, verbose);
+
+                mCH.CodeManager.OutputProperties(folder, mAssemblyName, mWrittenFiles);
+
+                mCH.CodeManager.OutputProjectFile(
+                    folder + mAssemblyName + ".csproj",
+                    mWrittenFiles,
+                    mCH.GetReferenceAssemblies(mAssembly),
+                    mOutput,
+                    mAssemblyName,
+                    mCH.CodeManager.HasUnsafeCode(),
+                    verbose);
+            }
+            catch (OutOfMemoryException)
+            {
+                mOutput.WriteLine("OutputPretty C#: ran out of memory and stopped.");
+                return;
+            }
+            catch (Exception e)
+            {
+                mOutput.WriteLine("OutputPretty C#: encountered an error and stopped. {0}", e.Message);
+                return;
+            }
+        }
+        #endregion
+
+        #region Assembly managing
+        public void StartAssembly(Assembly assembly)
+        {
+            mAssembly = assembly;
+            if (assembly != null)
+                mAssemblyName = mdDecoder.Name(assembly);
+        }
+
+        public void EndAssembly()
+        {
+            mAssemblyName = "";
+            mAssembly = default(Assembly);
+            mCH.Reset();
+        }
+        #endregion
     }
 
-    private string FixOutContracts(string input)
-    {
-      int begin = input.IndexOf("Contract.ValueAtReturn");
-      if (begin != -1)
-      {
-        string pattern = @"((?<1>(this\.)?\w*)([^\)]*)?\))";
-        string pattern_full = @"Contract.ValueAtReturn\(out " + pattern + @"(.*)";
+    //class DemoDoc
+    //{
+    //  void f()
+    //  {
+    //    Namespace ns = new Namespace("NSDemo");
+    //    Class cl = new Class(
+    //      Access.PUBLIC,
+    //      false, /* abstract */
+    //      false, /* sealed */
+    //      false, /* static */
+    //      false, /* unsafe */
+    //      Class.ClassType.CLASS, /* type of the class (can be struct or interface) */
+    //      "ClDemo", /* name */
+    //      null, /* no nesting class */
+    //      null, /* no base class */
+    //      ns); /* enclosing namespace */
 
-        //string testinput = "Contract.ValueAtReturn(out this.membera.memberb.member3)";
-        //string testinput = "capacity == Contract.ValueAtReturn(out this._array.Length)";
-        //string testinput = "(Contract.ValueAtReturn(out this._tail) - Contract.ValueAtReturn(out this._array.Length)) < 0";
-        //Match m = Regex.Match(testinput, pattern_full);
-        string refined = input.Substring(begin);
-        Match m = Regex.Match(refined, pattern_full);
-        if (m.Success)
-        {
-          string new_str = input.Substring(0, begin);
-          new_str += @"Contract.ValueAtReturn(out " + m.Groups[1].Captures[0].Value + ")";
-          if (m.Groups[3].Captures.Count >= 1) // remaining accessors
-            new_str += m.Groups[3].Captures[0].Value;
-          if (m.Groups[4].Captures.Count >= 1) // After the ValueAtReturn(...)
-            new_str += FixOutContracts(m.Groups[4].Captures[0].Value);
-          return new_str;
-        }
-      }
+    //    Method m = new Method(
+    //      Access.PUBLIC,
+    //      cl, /* declaring class */
+    //      "bool", /* return type */
+    //      "FctDemo", /* name */
+    //      false, /* attributes (abstract, extern, static, ...) */
+    //      false, false, false, false, false, false, false, false, false,
+    //      ""); /* initialization list (for constructors, for example " : base (...)") */
 
+    //    Parameter p1 = new Parameter("int", "x", Parameter.Modifier.NONE /* ref/out/none */, false /* unsafe */);
+    //    Parameter p2 = new Parameter("float", "x", Parameter.Modifier.OUT /* ref/out/none */, false /* unsafe */);
+    //    m.AddParameter(p1);
+    //    m.AddParameter(p2);
+    //    m.AddLine("y = x;");
+    //    m.AddLine("return x == 0;");
 
-      return input;
-    }
+    //    cl.AddChild(m);
 
-    /// <summary>
-    /// Add the method to the C# pretty output database. Then it will be output with all
-    /// the saved pre/post-conditions at the end of the analysis.
-    /// </summary>
-    /// <param name="method">Can be a getter or a setter.</param>
-    public void RegisterMethodPostCondition(MethodExt method, BoxedExpression postcond)
-    {
-      if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
-        return;
+    //    CodeManager cm = new CodeManager();
+    //    cm.AddNamespace(ns);
 
-      if (mCH.SkipMethod(method)) return;
+    //    List<string> WrittenFiles;
+    //    List<string> usings = /*...*/;
+    //    cm.OutputCode(folder, "files\\", /* IOutput to console */, out WrittenFiles, OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE , usings);
 
-      if (mdDecoder.Name(method) == ".cctor")
-        return;
-
-      if (mdDecoder.IsCompilerGenerated(method) || mdDecoder.IsCompilerGenerated(mdDecoder.DeclaringType(method)))
-        return;
-
-      if (FilterPostCondition(postcond)) return;
-
-      if (!FixOutParameter(method, postcond, out postcond))
-        return;
-
-      if (mdDecoder.IsConstructor(method))
-        postcond = FixFieldInConstructor(method, postcond);
-
-      string postcond_str = postcond.ToString(new System.Converter<Type, string>(this.BoxedExpressionConverter));
-      // HACK: the out trick does not take into account such code:
-      // public Socket EndAccept (out byte[] buffer, System.IAsyncResult asyncResult) {
-      // Contract.Ensures (Contracts.ValueAtReturn (out buffer.Length) >= 0);
-      // so we just want to move the last parenthese
-      postcond_str = FixOutContracts(postcond_str);
-
-      bool getter = false;
-      if ((getter = mdDecoder.IsPropertyGetter(method)) || mdDecoder.IsPropertySetter(method))
-      {
-        PropertyExt prop = mdDecoder.GetPropertyFromAccessor(method);
-        Property p = mCH.LookupProperty(prop);
-        if (p != null)
-        {
-          if (getter)
-            p.AddPostcondToGet(postcond_str);
-          else
-            p.AddPostcondToSet(postcond_str);
-
-          if (UnmanagedExpression(postcond))
-            p.ForceUnsafe(true);
-
-          ++mNbPostProperties;
-        }
-      }
-      else
-      {
-        Method m = mCH.LookupMethod(method);
-        if (m != null)
-        {
-          m.AddPostcond(postcond_str);
-
-          if (UnmanagedExpression(postcond))
-            m.ForceUnsafe(true);
-
-          ++mNbPostMethods;
-        }
-      }
-    }
-
-    private class FilterByVisibility : IBoxedExpressionVisitor
-    {
-      public bool ignoreMe;
-      private IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> mdDecoder;
-
-      public FilterByVisibility(IDecodeMetaData<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly> iDecodeMetaData)
-      {
-        this.mdDecoder = iDecodeMetaData;
-      }
-
-      public void Variable(object var, PathElement[] path, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        if (path != null)
-        {
-          for (int i = 0; i < path.Length; i++)
-          {
-            CheckPathElementVisibility(path[i]);
-            if (ignoreMe) return;
-          }
-        }
-      }
-
-      private void CheckPathElementVisibility(PathElement pathElement)
-      {
-        var asField = pathElement as OptimisticHeapAnalyzer<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>.Domain.PathElement<FieldExt>;
-        if (asField != null)
-        {
-          if (!this.mdDecoder.IsVisibleOutsideAssembly(asField.Element))
-          {
-            ignoreMe = true;
-          }
-          return;
-        }
-        var asMethod = pathElement as OptimisticHeapAnalyzer<Local, ParameterExt, MethodExt, FieldExt, PropertyExt, EventExt, Type, Attribute, Assembly>.Domain.PathElement<MethodExt>;
-        if (asMethod != null)
-        {
-          if (!this.mdDecoder.IsVisibleOutsideAssembly(asMethod.Element))
-          {
-            ignoreMe = true;
-          }
-          return;
-        }
-      }
-
-      public void ArrayIndex<Typ>(Typ type, BoxedExpression array, BoxedExpression index, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        CheckTypeVisibility<Typ>(type);
-        array.Dispatch(this);
-        index.Dispatch(this);
-      }
-
-      public void Constant<Typ>(Typ type, object value, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        CheckTypeVisibility<Typ>(type);
-      }
-
-      public void Binary(BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        left.Dispatch(this);
-        right.Dispatch(this);
-      }
-
-      public void Unary(UnaryOperator unaryOperator, BoxedExpression argument, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        argument.Dispatch(this);
-      }
-
-      public void SizeOf<Typ>(Typ type, int sizeAsConstant, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        CheckTypeVisibility<Typ>(type);
-      }
-
-      public void IsInst<Typ>(Typ type, BoxedExpression argument, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        CheckTypeVisibility<Typ>(type);
-      }
-
-      private void CheckTypeVisibility<Typ>(Typ type)
-      {
-        if (type is Type)
-        {
-          var ourtype = (Type)(object)type;
-          if (!this.mdDecoder.IsVisibleOutsideAssembly(ourtype))
-          {
-            ignoreMe = true;
-            return;
-          }
-        }
-      }
-
-      public void Result<Typ>(Typ type, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        CheckTypeVisibility<Typ>(type);
-      }
-
-      public void Old<Typ>(Typ type, BoxedExpression expression, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        CheckTypeVisibility<Typ>(type);
-        expression.Dispatch(this);
-      }
-
-      public void ValueAtReturn<Typ>(Typ type, BoxedExpression expression, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        CheckTypeVisibility<Typ>(type);
-        expression.Dispatch(this);
-      }
-
-      public void Assert(BoxedExpression condition, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        condition.Dispatch(this);
-      }
-
-      public void Assume(BoxedExpression condition, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        condition.Dispatch(this);
-      }
-
-      public void StatementSequence(IIndexable<BoxedExpression> statements, BoxedExpression parent)
-      {
-        for (int i = 0; i < statements.Count; i++)
-        {
-          if (ignoreMe) return;
-          statements[i].Dispatch(this);
-        }
-      }
-
-      public void ForAll(BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body, BoxedExpression parent)
-      {
-        if (ignoreMe) return;
-        boundVariable.Dispatch(this);
-        lower.Dispatch(this);
-        upper.Dispatch(this);
-        body.Dispatch(this);
-      }
-    }
-
-    private bool FilterPostCondition(BoxedExpression postcond)
-    {
-      if (!this.mAnalyzer.Options.OutputOnlyExternallyVisibleMembers) return false;
-      var filter = new FilterByVisibility(this.mdDecoder);
-      postcond.Dispatch(filter);
-      return filter.ignoreMe;
-    }
-    #endregion
-
-    #region Pretty Output
-
-    const string SourceFolder = @"Sources\";
-
-    public void PrettyCSOutput(string folder, bool verbose)
-    {
-      if (mAssemblyName.Length == 0) // sanity check: output pretty C# is disabled
-        return;
-
-      if (verbose)
-      {
-        mOutput.WriteLine("OutputPretty C#: has started...");
-        mOutput.WriteLine("OutputPretty C#: <{0}, {1}> preconditions have been registered in <methods, properties>.", mNbPreMethods, mNbPreProperties);
-        mOutput.WriteLine("OutputPretty C#: <{0}, {1}> postconditions have been registered in <methods, properties>.", mNbPostMethods, mNbPostProperties);
-        mOutput.WriteLine("OutputPretty C#: {0} class invariants have been registered.", mNbClassInvariants);
-      }
-
-      if (folder.Length == 0)
-        return;
-
-      // Handy
-      if (folder[folder.Length - 1] != '\\')
-        folder = folder + "\\";
-      folder += mAssemblyName; // One directory per assembly
-      if (folder[folder.Length - 1] != '\\')
-        folder = folder + "\\";
-
-      if (!Directory.Exists(folder + SourceFolder))
-      {
-        try
-        {
-          Directory.CreateDirectory(folder + SourceFolder);
-        }
-        catch
-        {
-          mOutput.WriteLine("OutputPretty C#: Unable to create directory " + folder + SourceFolder + ": OutputPretty C# could not continue.");
-          return;
-        }
-      }
-
-      try
-      {
-        // Ensures that each class is in the output (to compile if referenced from somewhere, even if it does not have any contract)
-        foreach (var cl in mdDecoder.GetTypes(mAssembly))
-        {
-          if (!mdDecoder.IsCompilerGenerated(cl) && mdDecoder.Name(cl) != "<Module>")
-            mCH.RegisterType(cl);
-        }
-
-        // Output the code
-        mCH.CodeManager.OutputCode(folder, SourceFolder, mOutput, out mWrittenFiles, mStrategy, mCH.Usings, verbose);
-
-        mCH.CodeManager.OutputProperties(folder, mAssemblyName, mWrittenFiles);
-
-        mCH.CodeManager.OutputProjectFile(
-            folder + mAssemblyName + ".csproj",
-            mWrittenFiles,
-            mCH.GetReferenceAssemblies(mAssembly),
-            mOutput,
-            mAssemblyName,
-            mCH.CodeManager.HasUnsafeCode(),
-            verbose);
-      }
-      catch (OutOfMemoryException)
-      {
-        mOutput.WriteLine("OutputPretty C#: ran out of memory and stopped.");
-        return;
-      }
-      catch (Exception e)
-      {
-        mOutput.WriteLine("OutputPretty C#: encountered an error and stopped. {0}", e.Message);
-        return;
-      }
-    }
-    #endregion
-
-    #region Assembly managing
-    public void StartAssembly(Assembly assembly)
-    {
-      mAssembly = assembly;
-      if (assembly != null)
-        mAssemblyName = mdDecoder.Name(assembly);
-    }
-
-    public void EndAssembly()
-    {
-      mAssemblyName = "";
-      mAssembly = default(Assembly);
-      this.mCH.Reset();
-    }
-    #endregion
-  }
-
-  //class DemoDoc
-  //{
-  //  void f()
-  //  {
-  //    Namespace ns = new Namespace("NSDemo");
-  //    Class cl = new Class(
-  //      Access.PUBLIC,
-  //      false, /* abstract */
-  //      false, /* sealed */
-  //      false, /* static */
-  //      false, /* unsafe */
-  //      Class.ClassType.CLASS, /* type of the class (can be struct or interface) */
-  //      "ClDemo", /* name */
-  //      null, /* no nesting class */
-  //      null, /* no base class */
-  //      ns); /* enclosing namespace */
-
-  //    Method m = new Method(
-  //      Access.PUBLIC,
-  //      cl, /* declaring class */
-  //      "bool", /* return type */
-  //      "FctDemo", /* name */
-  //      false, /* attributes (abstract, extern, static, ...) */
-  //      false, false, false, false, false, false, false, false, false,
-  //      ""); /* initialization list (for constructors, for example " : base (...)") */
-
-  //    Parameter p1 = new Parameter("int", "x", Parameter.Modifier.NONE /* ref/out/none */, false /* unsafe */);
-  //    Parameter p2 = new Parameter("float", "x", Parameter.Modifier.OUT /* ref/out/none */, false /* unsafe */);
-  //    m.AddParameter(p1);
-  //    m.AddParameter(p2);
-  //    m.AddLine("y = x;");
-  //    m.AddLine("return x == 0;");
-
-  //    cl.AddChild(m);
-
-  //    CodeManager cm = new CodeManager();
-  //    cm.AddNamespace(ns);
-
-  //    List<string> WrittenFiles;
-  //    List<string> usings = /*...*/;
-  //    cm.OutputCode(folder, "files\\", /* IOutput to console */, out WrittenFiles, OutputHelper.OutputStrategy.ONE_FILE_PER_NAMESPACE , usings);
-
-  //    cm.OutputProjectFile(
-  //        folder + mAssemblyName + ".csproj", /* Project filename */
-  //        WrittenFiles, /* files to compile */
-  //        /* List of the reference assemblies to put in the project file */,
-  //        /* IOutput to console */,
-  //        mAssemblyName,
-  //        cm.HasUnsafeCode());
-  //  }
-  //}
+    //    cm.OutputProjectFile(
+    //        folder + mAssemblyName + ".csproj", /* Project filename */
+    //        WrittenFiles, /* files to compile */
+    //        /* List of the reference assemblies to put in the project file */,
+    //        /* IOutput to console */,
+    //        mAssemblyName,
+    //        cm.HasUnsafeCode());
+    //  }
+    //}
 }
 

--- a/Microsoft.Research/CodeAnalysis/PostconditionSuggestion.cs
+++ b/Microsoft.Research/CodeAnalysis/PostconditionSuggestion.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,289 +10,287 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public struct Details
-  {
-    public bool HasVariables;
-    public bool HasCompoundExp;
-    public bool HasOldVariable;
-    public bool HasReturnVariable;
-    public bool IsRootedInThis;
-    public bool IsThis;
-
-    public bool HasInterestingVariables
+    public struct Details
     {
-      get
-      {
-        return this.HasVariables || this.HasOldVariable || this.HasReturnVariable || this.IsThis;
-      }
-    }
+        public bool HasVariables;
+        public bool HasCompoundExp;
+        public bool HasOldVariable;
+        public bool HasReturnVariable;
+        public bool IsRootedInThis;
+        public bool IsThis;
 
-    public void AllFalse()
-    {
-      this.HasVariables = false;
-      this.HasCompoundExp = false;
-      this.HasOldVariable = false;
-      this.HasReturnVariable = false;
-      this.IsRootedInThis = false;
-      this.IsThis = false;
-    }
- 
-  }
-
-  public class BoxedExpressionReader<Local, Parameter, Method, Field, Property, Event, Typ, Variable, Expression, Attribute, Assembly>
-    where Typ : IEquatable<Typ>
-  {
-    private readonly IExpressionContext<Local, Parameter, Method, Field, Typ, Expression, Variable> context;
-    private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> metaDataDecoder;
-    private readonly Optional<Variable> returnVariable;
-    private readonly BoxedExpression returnExpression;
-    private readonly IDisjunctiveExpressionRefiner<Variable, BoxedExpression> extendedRefiner;
-
-    public BoxedExpressionReader(IExpressionContext<Local, Parameter, Method, Field, Typ, Expression, Variable> context,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> metaDataDecoder,
-      IDisjunctiveExpressionRefiner<Variable, BoxedExpression> extendedRefiner = null)
-    {
-      Contract.Requires(context != null);
-      Contract.Requires(metaDataDecoder != null);
-
-      this.context = context;
-      this.metaDataDecoder = metaDataDecoder;
-      this.extendedRefiner = extendedRefiner;
-
-      Variable retVar;
-      if (!this.metaDataDecoder.IsVoidMethod(this.context.MethodContext.CurrentMethod) 
-        && this.context.ValueContext.TryResultValue(this.context.MethodContext.CFG.NormalExit, out retVar))
-      {
-        this.returnVariable = new Optional<Variable>(retVar);
-        Typ type = this.metaDataDecoder.ReturnType(this.context.MethodContext.CurrentMethod);
-        this.returnExpression = BoxedExpression.Result(type);
-      }
-      else
-      {
-        this.returnVariable = new Optional<Variable>();
-        this.returnExpression = null;
-      }
-    }
-
-    /// <summary>
-    /// Try to read the boxed expression <code>exp</code> in the exit state. 
-    /// If it fails, it returns null
-    /// </summary>
-    /// <param name="hasVariables">true iff the return value is != null and the expression contains at least one variable</param>
-    /// <returns>The expression read in the exit state of the method. If it cannot read it, it returns null</returns>
-    public BoxedExpression ExpressionInPostState(BoxedExpression exp, bool replaceReturnValue, out Details details)
-    {
-      Contract.Requires(exp != null);
-
-      details = new Details();
-
-      return ExpressionInPostStateHelper(exp, replaceReturnValue, false, true, ref details);
-    }
-
-    public BoxedExpression ExpressionInPostState(BoxedExpression exp, bool replaceReturnValue, bool overrideAccessModifiers, bool allowReturnValue, out Details details)
-    {
-      Contract.Requires(exp != null);
-
-      details = new Details();
-
-      return ExpressionInPostStateHelper(exp, replaceReturnValue, overrideAccessModifiers, allowReturnValue,  ref details);
-    }
-
-    private BoxedExpression ExpressionInPostStateHelper(BoxedExpression exp, bool replaceReturnValue, bool overrideAccessModifiers, bool allowReturnValue, ref Details details)
-    {
-      if (exp.IsConstant || exp.IsSizeOf /*|| exp.IsNull*/)
-      { // Nothing to do
-        return exp;
-      }
-      if (exp.IsNull)
-      {
-        return BoxedExpression.Const(null, this.metaDataDecoder.System_Object, this.metaDataDecoder);
-      }
-      if (exp.IsVariable)  
-      {
-        if (exp.IsVariableBoundedInQuantifier)
+        public bool HasInterestingVariables
         {
-          return exp;
+            get
+            {
+                return this.HasVariables || this.HasOldVariable || this.HasReturnVariable || this.IsThis;
+            }
         }
 
-        // F: this check is there as there may be slack variables form subpolyhedra
-
-        Variable var;
-        if (!exp.TryGetFrameworkVariable(out var))
+        public void AllFalse()
         {
-          return null;
+            this.HasVariables = false;
+            this.HasCompoundExp = false;
+            this.HasOldVariable = false;
+            this.HasReturnVariable = false;
+            this.IsRootedInThis = false;
+            this.IsThis = false;
+        }
+    }
+
+    public class BoxedExpressionReader<Local, Parameter, Method, Field, Property, Event, Typ, Variable, Expression, Attribute, Assembly>
+      where Typ : IEquatable<Typ>
+    {
+        private readonly IExpressionContext<Local, Parameter, Method, Field, Typ, Expression, Variable> context;
+        private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> metaDataDecoder;
+        private readonly Optional<Variable> returnVariable;
+        private readonly BoxedExpression returnExpression;
+        private readonly IDisjunctiveExpressionRefiner<Variable, BoxedExpression> extendedRefiner;
+
+        public BoxedExpressionReader(IExpressionContext<Local, Parameter, Method, Field, Typ, Expression, Variable> context,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> metaDataDecoder,
+          IDisjunctiveExpressionRefiner<Variable, BoxedExpression> extendedRefiner = null)
+        {
+            Contract.Requires(context != null);
+            Contract.Requires(metaDataDecoder != null);
+
+            this.context = context;
+            this.metaDataDecoder = metaDataDecoder;
+            this.extendedRefiner = extendedRefiner;
+
+            Variable retVar;
+            if (!this.metaDataDecoder.IsVoidMethod(this.context.MethodContext.CurrentMethod)
+              && this.context.ValueContext.TryResultValue(this.context.MethodContext.CFG.NormalExit, out retVar))
+            {
+                returnVariable = new Optional<Variable>(retVar);
+                Typ type = this.metaDataDecoder.ReturnType(this.context.MethodContext.CurrentMethod);
+                returnExpression = BoxedExpression.Result(type);
+            }
+            else
+            {
+                returnVariable = new Optional<Variable>();
+                returnExpression = null;
+            }
         }
 
-        // We want to replace the return variable with the marker for the return value
-        if (replaceReturnValue && this.returnVariable.IsValid && var.Equals(this.returnVariable.Value))
+        /// <summary>
+        /// Try to read the boxed expression <code>exp</code> in the exit state. 
+        /// If it fails, it returns null
+        /// </summary>
+        /// <param name="hasVariables">true iff the return value is != null and the expression contains at least one variable</param>
+        /// <returns>The expression read in the exit state of the method. If it cannot read it, it returns null</returns>
+        public BoxedExpression ExpressionInPostState(BoxedExpression exp, bool replaceReturnValue, out Details details)
         {
-          details.HasVariables = true;
-          details.HasReturnVariable = true;
- 
-          return this.returnExpression;
+            Contract.Requires(exp != null);
+
+            details = new Details();
+
+            return ExpressionInPostStateHelper(exp, replaceReturnValue, false, true, ref details);
         }
 
-        #region First try: Read it in the post-state
-        var accessPath = 
-          context.ValueContext.VisibleAccessPathListFromPost(context.MethodContext.CFG.NormalExit, var, allowReturnValue);
+        public BoxedExpression ExpressionInPostState(BoxedExpression exp, bool replaceReturnValue, bool overrideAccessModifiers, bool allowReturnValue, out Details details)
+        {
+            Contract.Requires(exp != null);
+
+            details = new Details();
+
+            return ExpressionInPostStateHelper(exp, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
+        }
+
+        private BoxedExpression ExpressionInPostStateHelper(BoxedExpression exp, bool replaceReturnValue, bool overrideAccessModifiers, bool allowReturnValue, ref Details details)
+        {
+            if (exp.IsConstant || exp.IsSizeOf /*|| exp.IsNull*/)
+            { // Nothing to do
+                return exp;
+            }
+            if (exp.IsNull)
+            {
+                return BoxedExpression.Const(null, metaDataDecoder.System_Object, metaDataDecoder);
+            }
+            if (exp.IsVariable)
+            {
+                if (exp.IsVariableBoundedInQuantifier)
+                {
+                    return exp;
+                }
+
+                // F: this check is there as there may be slack variables form subpolyhedra
+
+                Variable var;
+                if (!exp.TryGetFrameworkVariable(out var))
+                {
+                    return null;
+                }
+
+                // We want to replace the return variable with the marker for the return value
+                if (replaceReturnValue && returnVariable.IsValid && var.Equals(returnVariable.Value))
+                {
+                    details.HasVariables = true;
+                    details.HasReturnVariable = true;
+
+                    return returnExpression;
+                }
+
+                #region First try: Read it in the post-state
+                var accessPath =
+                  context.ValueContext.VisibleAccessPathListFromPost(context.MethodContext.CFG.NormalExit, var, allowReturnValue);
 
 #if false
-        // F: change!!!!
+                // F: change!!!!
 
-        // Console.WriteLine("Access paths for sv = {0}", var);
-        foreach (var ap in context.ValueContext.AccessPaths(context.MethodContext.CFG.NormalExit, var, AccessPathFilter<Method>.FromPostcondition(this.context.MethodContext.CurrentMethod)))
-        {
-          // Console.WriteLine(ap);
-          if (context.ValueContext.PathSuitableInEnsures(context.MethodContext.CFG.NormalExit, ap))
-          {
-            // we found our accesspath
-            accessPath = ap;
-            break;
-          }
-        }
-        
+                // Console.WriteLine("Access paths for sv = {0}", var);
+                foreach (var ap in context.ValueContext.AccessPaths(context.MethodContext.CFG.NormalExit, var, AccessPathFilter<Method>.FromPostcondition(context.MethodContext.CurrentMethod)))
+                {
+                    // Console.WriteLine(ap);
+                    if (context.ValueContext.PathSuitableInEnsures(context.MethodContext.CFG.NormalExit, ap))
+                    {
+                        // we found our accesspath
+                        accessPath = ap;
+                        break;
+                    }
+                }
+
 #endif
-        if (accessPath != null)
-        {
-          details.HasVariables = true;
+                if (accessPath != null)
+                {
+                    details.HasVariables = true;
 
-          details.HasReturnVariable = accessPath.Head.IsReturnValue;
+                    details.HasReturnVariable = accessPath.Head.IsReturnValue;
 
-          if (accessPath.Length() == 1 && accessPath.ToString() == "this")
-          {
-            details.IsThis = true;
-          }
+                    if (accessPath.Length() == 1 && accessPath.ToString() == "this")
+                    {
+                        details.IsThis = true;
+                    }
 
-          if (accessPath.Head.ToString() == "this")
-          {
-            details.IsRootedInThis = true;
-          }
+                    if (accessPath.Head.ToString() == "this")
+                    {
+                        details.IsRootedInThis = true;
+                    }
 
-          // TODO: check possible bug here: this should be var not exp.UnderlyingVariable
-          return BoxedExpression.Var(var, accessPath);
-        }
-        #endregion
+                    // TODO: check possible bug here: this should be var not exp.UnderlyingVariable
+                    return BoxedExpression.Var(var, accessPath);
+                }
+                #endregion
 
-        #region Second try: Read it in the pre-state
-        accessPath =
-          // context.ValueContext.VisibleAccessPathListFromPre(context.MethodContext.CFG.EntryAfterRequires, var);
-          context.ValueContext.AccessPathList(context.MethodContext.CFG.EntryAfterRequires, var, false, false);
+                #region Second try: Read it in the pre-state
+                accessPath =
+                  // context.ValueContext.VisibleAccessPathListFromPre(context.MethodContext.CFG.EntryAfterRequires, var);
+                  context.ValueContext.AccessPathList(context.MethodContext.CFG.EntryAfterRequires, var, false, false);
 
-        if (accessPath != null)
-        {
-          details.HasVariables = true;
+                if (accessPath != null)
+                {
+                    details.HasVariables = true;
 
-          var type = this.context.ValueContext.GetType(this.context.MethodContext.CFG.NormalExit, var);
+                    var type = context.ValueContext.GetType(context.MethodContext.CFG.NormalExit, var);
 
-          if (type.IsNormal)
-          {
-            details.HasOldVariable = true;
+                    if (type.IsNormal)
+                    {
+                        details.HasOldVariable = true;
 
-            return BoxedExpression.Old(BoxedExpression.Var(var, accessPath), type.Value);
-          }
-          else
-          {
-            return null;
-          }
+                        return BoxedExpression.Old(BoxedExpression.Var(var, accessPath), type.Value);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+                #endregion
 
-        }
-        #endregion
+                #region Third try: use the extended refined, if any
 
-        #region Third try: use the extended refined, if any
+                if (extendedRefiner != null)
+                {
+                    BoxedExpression refined;
+                    if (extendedRefiner.TryRefineExpression(context.MethodContext.CFG.NormalExit, var, out refined)
+                      && refined.IsArrayIndex) // F: it seems we generate some recursive expression which causes a stack overflow. Should investigate!!!!
+                    {
+                        return ExpressionInPostStateHelper(refined, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
+                    }
+                }
 
-        if (this.extendedRefiner != null)
-        {
-          BoxedExpression refined;
-          if (this.extendedRefiner.TryRefineExpression(this.context.MethodContext.CFG.NormalExit, var, out refined) 
-            && refined.IsArrayIndex) // F: it seems we generate some recursive expression which causes a stack overflow. Should investigate!!!!
-          {
-            return ExpressionInPostStateHelper(refined, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
-          }
-        }
-        
-        #endregion
+                #endregion
 
-        // giving up
-        return null;
-      }
-      if (exp.IsUnary)
-      {
-        var rec = ExpressionInPostStateHelper(exp.UnaryArgument, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
-        if (rec == null)
-          return null;
-
-        // Avoid copying the expression (optimization?)
-        if (rec == exp.UnaryArgument)  
-          return exp;
-        else
-          return BoxedExpression.Unary(exp.UnaryOp, rec);
-      }
-      if (exp.IsBinary)
-      {
-        if (!exp.BinaryOp.IsComparisonBinaryOperator())
-        {
-          details.HasCompoundExp = true;
-        }
-        var recLeft = ExpressionInPostStateHelper(exp.BinaryLeft, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
-        if (recLeft == null)
-          return null;
-
-        var recRight = ExpressionInPostStateHelper(exp.BinaryRight, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
-        if (recRight == null)
-          return null;
-
-        // Heuristics to rule out trivial expressions arr.Length >= 0 or 0 <= arr.Length or this.Count >= 0 or 0 <= this.Count 
-        int value;
-        if ((exp.BinaryOp == BinaryOperator.Cge && recLeft.IsArrayLengthOrThisDotCount(context.MethodContext.CFG.NormalExit, this.context, this.metaDataDecoder) && recRight.IsConstantInt(out value) && value == 0)
-          ||
-        (exp.BinaryOp == BinaryOperator.Cle && recLeft.IsConstantInt(out value) && value == 0 && recRight.IsArrayLengthOrThisDotCount(context.MethodContext.CFG.NormalExit, this.context, this.metaDataDecoder)))
-        {
-          return null;
-        }
-
-        if (recLeft == exp.BinaryLeft && recRight == exp.BinaryRight)
-        {
-          return exp;
-        }
-        else
-        {
-          return BoxedExpression.Binary(exp.BinaryOp, recLeft, recRight);
-        }
-      }
-      object t;
-      BoxedExpression array, index;
-      if(exp.IsArrayIndexExpression(out array, out index, out t) && t is Typ)
-      {
-        // Sanity check. We have a case with post-inference where the array and the index get swapped by the underlying framework
-        if (array.UnderlyingVariable is Variable)
-        {
-          var type = this.context.ValueContext.GetType(context.MethodContext.CFG.NormalExit, (Variable)array.UnderlyingVariable);
-          if (type.IsNormal && this.metaDataDecoder.IsArray(type.Value))
-          {
-            var arrayRef = ExpressionInPostStateHelper(array, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
-            if (arrayRef != null)
-            {
-              var indexRef = ExpressionInPostStateHelper(index, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
-              if (indexRef != null)
-              {
-                return new BoxedExpression.ArrayIndexExpression<Typ>(arrayRef, indexRef, (Typ)t);
-              }
+                // giving up
+                return null;
             }
-          }
+            if (exp.IsUnary)
+            {
+                var rec = ExpressionInPostStateHelper(exp.UnaryArgument, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
+                if (rec == null)
+                    return null;
+
+                // Avoid copying the expression (optimization?)
+                if (rec == exp.UnaryArgument)
+                    return exp;
+                else
+                    return BoxedExpression.Unary(exp.UnaryOp, rec);
+            }
+            if (exp.IsBinary)
+            {
+                if (!exp.BinaryOp.IsComparisonBinaryOperator())
+                {
+                    details.HasCompoundExp = true;
+                }
+                var recLeft = ExpressionInPostStateHelper(exp.BinaryLeft, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
+                if (recLeft == null)
+                    return null;
+
+                var recRight = ExpressionInPostStateHelper(exp.BinaryRight, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
+                if (recRight == null)
+                    return null;
+
+                // Heuristics to rule out trivial expressions arr.Length >= 0 or 0 <= arr.Length or this.Count >= 0 or 0 <= this.Count 
+                int value;
+                if ((exp.BinaryOp == BinaryOperator.Cge && recLeft.IsArrayLengthOrThisDotCount(context.MethodContext.CFG.NormalExit, context, metaDataDecoder) && recRight.IsConstantInt(out value) && value == 0)
+                  ||
+                (exp.BinaryOp == BinaryOperator.Cle && recLeft.IsConstantInt(out value) && value == 0 && recRight.IsArrayLengthOrThisDotCount(context.MethodContext.CFG.NormalExit, context, metaDataDecoder)))
+                {
+                    return null;
+                }
+
+                if (recLeft == exp.BinaryLeft && recRight == exp.BinaryRight)
+                {
+                    return exp;
+                }
+                else
+                {
+                    return BoxedExpression.Binary(exp.BinaryOp, recLeft, recRight);
+                }
+            }
+            object t;
+            BoxedExpression array, index;
+            if (exp.IsArrayIndexExpression(out array, out index, out t) && t is Typ)
+            {
+                // Sanity check. We have a case with post-inference where the array and the index get swapped by the underlying framework
+                if (array.UnderlyingVariable is Variable)
+                {
+                    var type = context.ValueContext.GetType(context.MethodContext.CFG.NormalExit, (Variable)array.UnderlyingVariable);
+                    if (type.IsNormal && metaDataDecoder.IsArray(type.Value))
+                    {
+                        var arrayRef = ExpressionInPostStateHelper(array, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
+                        if (arrayRef != null)
+                        {
+                            var indexRef = ExpressionInPostStateHelper(index, replaceReturnValue, overrideAccessModifiers, allowReturnValue, ref details);
+                            if (indexRef != null)
+                            {
+                                return new BoxedExpression.ArrayIndexExpression<Typ>(arrayRef, indexRef, (Typ)t);
+                            }
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            // Unreachable?
+            return null;
         }
 
-        return null;
-      }
-
-      // Unreachable?
-      return null;
+        private bool IsRootedInStaticField(FList<PathElement> accessPath)
+        {
+            return accessPath != null && accessPath.Head.IsStatic;
+        }
     }
-
-    private bool IsRootedInStaticField(FList<PathElement> accessPath)
-    {
-      return accessPath != null && accessPath.Head.IsStatic;
-    }
-  }
 }
 
 

--- a/Microsoft.Research/CodeAnalysis/PreconditionSuggestion.cs
+++ b/Microsoft.Research/CodeAnalysis/PreconditionSuggestion.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,1316 +11,1313 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public enum SourceLanguage { CSharp, VB }
+    public enum SourceLanguage { CSharp, VB }
 
 
-  #region ExpressionInPreState
+    #region ExpressionInPreState
 
-  public enum ExpressionInPreStateKind { MethodPrecondition, ObjectInvariant, Assume, Any, All=Assume, Bot=Any, Top=All }
+    public enum ExpressionInPreStateKind { MethodPrecondition, ObjectInvariant, Assume, Any, All = Assume, Bot = Any, Top = All }
 
 
-  public class ExpressionInPreStateInfo
-  {
-    public readonly bool hasAccessPath;
-    public readonly bool hasVariables;
-    public readonly bool hasOnlyImmutableVariables;
-    public ExpressionInPreStateKind kind { get; private set; }
-
-    public ExpressionInPreStateInfo(bool hasAccessPath, bool hasVariables, bool hasOnlyImmutableVariables, ExpressionInPreStateKind kind)
+    public class ExpressionInPreStateInfo
     {
-      Contract.Ensures(this.kind == kind);
+        public readonly bool hasAccessPath;
+        public readonly bool hasVariables;
+        public readonly bool hasOnlyImmutableVariables;
+        public ExpressionInPreStateKind kind { get; private set; }
 
-      this.hasAccessPath = hasAccessPath;
-      this.hasVariables = hasVariables;
-      this.hasOnlyImmutableVariables = hasOnlyImmutableVariables;
-      this.kind = kind;
+        public ExpressionInPreStateInfo(bool hasAccessPath, bool hasVariables, bool hasOnlyImmutableVariables, ExpressionInPreStateKind kind)
+        {
+            Contract.Ensures(this.kind == kind);
+
+            this.hasAccessPath = hasAccessPath;
+            this.hasVariables = hasVariables;
+            this.hasOnlyImmutableVariables = hasOnlyImmutableVariables;
+            this.kind = kind;
+        }
+
+        public ExpressionInPreStateInfo(ExpressionInPreStateKind kind, bool hasOnlyImmutableVariables = false)
+          : this(false, false, hasOnlyImmutableVariables, kind)
+        { }
+
+        #region Combine
+
+        static public ExpressionInPreStateInfo Combine(ExpressionInPreStateInfo info1, ExpressionInPreStateInfo info2)
+        {
+            Contract.Requires(info1 != null);
+            Contract.Requires(info2 != null);
+            Contract.Ensures(Contract.Result<ExpressionInPreStateInfo>() != null);
+
+            ExpressionInPreStateKind kindResult = info1.kind.Join(info2.kind);
+            return new ExpressionInPreStateInfo(info1.hasAccessPath || info2.hasAccessPath, info1.hasVariables || info2.hasVariables, info1.hasOnlyImmutableVariables && info2.hasOnlyImmutableVariables, kindResult);
+        }
+
+        static public ExpressionInPreStateInfo Combine(ExpressionInPreStateInfo info1, ExpressionInPreStateInfo info2, ExpressionInPreStateInfo info3)
+        {
+            Contract.Requires(info1 != null);
+            Contract.Requires(info2 != null);
+            Contract.Requires(info3 != null);
+            Contract.Ensures(Contract.Result<ExpressionInPreStateInfo>() != null);
+
+            var tmp = Combine(info1, info2);
+            return Combine(tmp, info3);
+        }
+
+        #endregion
     }
 
-    public ExpressionInPreStateInfo(ExpressionInPreStateKind kind, bool hasOnlyImmutableVariables = false)
-      : this(false, false, hasOnlyImmutableVariables, kind)
-    { }
-
-    #region Combine
-
-    static public ExpressionInPreStateInfo Combine(ExpressionInPreStateInfo info1, ExpressionInPreStateInfo info2)
+    public enum ConditionKind
     {
-      Contract.Requires(info1 != null);
-      Contract.Requires(info2 != null);
-      Contract.Ensures(Contract.Result<ExpressionInPreStateInfo>() != null);
-
-      ExpressionInPreStateKind kindResult = info1.kind.Join(info2.kind);
-      return new ExpressionInPreStateInfo(info1.hasAccessPath || info2.hasAccessPath, info1.hasVariables || info2.hasVariables, info1.hasOnlyImmutableVariables && info2.hasOnlyImmutableVariables, kindResult);
+        Requires,
+        ObjectInvariant,
+        EntryAssume,
+        CalleeAssume
     }
 
-    static public ExpressionInPreStateInfo Combine(ExpressionInPreStateInfo info1, ExpressionInPreStateInfo info2, ExpressionInPreStateInfo info3)
+    [ContractClass(typeof(IInferredConditionContracts))]
+    public interface IInferredCondition
     {
-      Contract.Requires(info1 != null);
-      Contract.Requires(info2 != null);
-      Contract.Requires(info3 != null);
-      Contract.Ensures(Contract.Result<ExpressionInPreStateInfo>() != null);
-
-      var tmp = Combine(info1, info2);
-      return Combine(tmp, info3);
+        BoxedExpression Expr { get; }
+        ConditionKind Kind { get; }
+        bool IsSufficientForTheWarning { get; }
     }
 
+    #region Contracts
+    [ContractClassFor(typeof(IInferredCondition))]
+    internal abstract class IInferredConditionContracts : IInferredCondition
+    {
+        public BoxedExpression Expr { get; private set; }
+        public ConditionKind Kind { get; private set; }
+        public bool IsSufficientForTheWarning { get; private set; }
+
+        [ContractInvariantMethod]
+        private void ContractInvariant()
+        {
+            Contract.Invariant(this.Expr != null);
+        }
+    }
     #endregion
-  }
 
-  public enum ConditionKind
-  {
-    Requires,
-    ObjectInvariant,
-    EntryAssume,
-    CalleeAssume
-  }
-
-  [ContractClass(typeof(IInferredConditionContracts))]
-  public interface IInferredCondition
-  {
-    BoxedExpression Expr { get; }
-    ConditionKind Kind { get; }
-    bool IsSufficientForTheWarning { get; }
-  }
-
-  #region Contracts
-  [ContractClassFor(typeof(IInferredCondition))]
-  abstract class IInferredConditionContracts : IInferredCondition
-  {
-    public BoxedExpression Expr { get; private set; }
-    public ConditionKind Kind { get; private set; }
-    public bool IsSufficientForTheWarning { get; private set; }
-
-    [ContractInvariantMethod]
-    void ContractInvariant()
+    public class SimpleInferredConditionAtEntry : IInferredCondition
     {
-      Contract.Invariant(this.Expr != null);
-    }
-  }
-  #endregion
+        public BoxedExpression Expr { get; private set; }
+        public ConditionKind Kind { get; private set; }
+        public bool IsSufficientForTheWarning { get; private set; }
+        public SimpleInferredConditionAtEntry(BoxedExpression expr, ExpressionInPreStateKind kind, bool isSufficient)
+        {
+            this.Expr = expr;
+            this.Kind = kind.ToConditionKind();
+            this.IsSufficientForTheWarning = isSufficient;
+        }
 
-  public class SimpleInferredConditionAtEntry : IInferredCondition
-  {
-    public BoxedExpression Expr { get; private set; }
-    public ConditionKind Kind { get; private set; }
-    public bool IsSufficientForTheWarning { get; private set; }
-    public SimpleInferredConditionAtEntry(BoxedExpression expr, ExpressionInPreStateKind kind, bool isSufficient)
-    {
-      this.Expr = expr;
-      this.Kind = kind.ToConditionKind();
-      this.IsSufficientForTheWarning = isSufficient;
+        [Pure]
+        public override string ToString()
+        {
+            return this.Expr != null ? this.Expr.ToString() : "null";
+        }
     }
 
-    [Pure]
-    public override string ToString()
+    public class InferredCalleeCondition<Method> : IInferredCondition
     {
-      return this.Expr != null ? this.Expr.ToString() : "null";
-    }
-  }
+        public BoxedExpression Expr { get; private set; }
+        public Method Callee { get; private set; }
+        public APC CalleePC { get; private set; }
 
-  public class InferredCalleeCondition<Method> : IInferredCondition
-  {    
-    public BoxedExpression Expr { get; private set; }
-    public Method Callee { get; private set; }
-    public APC CalleePC { get; private set; }
+        public InferredCalleeCondition(BoxedExpression expr, APC callePC, Method callee)
+        {
+            this.Expr = expr;
+            this.CalleePC = callePC;
+            this.Callee = callee;
+        }
 
-    public InferredCalleeCondition(BoxedExpression expr, APC callePC, Method callee)
-    {
-      this.Expr = expr;
-      this.CalleePC = callePC;
-      this.Callee = callee;
-    }
+        public ConditionKind Kind
+        {
+            get { return ConditionKind.CalleeAssume; }
+        }
 
-    public ConditionKind Kind
-    {
-      get { return ConditionKind.CalleeAssume; }
-    }
-
-    public bool IsSufficientForTheWarning
-    {
-      get { return false; }
-    }
-  }
-
-  public class InferredCalleeNecessaryConditionCandidate<Method> : IInferredCondition
-  {
-    public BoxedExpression Expr { get; private set; }
-    public Method Callee { get; private set; }
-    public APC CalleePC { get; private set; }
-
-    public InferredCalleeNecessaryConditionCandidate(BoxedExpression expr, APC callePC, Method callee)
-    {
-      Contract.Requires(expr != null);
-
-      this.Expr = expr;
-      this.CalleePC = callePC;
-      this.Callee = callee;
+        public bool IsSufficientForTheWarning
+        {
+            get { return false; }
+        }
     }
 
-    public ConditionKind Kind
+    public class InferredCalleeNecessaryConditionCandidate<Method> : IInferredCondition
     {
-      get { return ConditionKind.CalleeAssume; }
+        public BoxedExpression Expr { get; private set; }
+        public Method Callee { get; private set; }
+        public APC CalleePC { get; private set; }
+
+        public InferredCalleeNecessaryConditionCandidate(BoxedExpression expr, APC callePC, Method callee)
+        {
+            Contract.Requires(expr != null);
+
+            this.Expr = expr;
+            this.CalleePC = callePC;
+            this.Callee = callee;
+        }
+
+        public ConditionKind Kind
+        {
+            get { return ConditionKind.CalleeAssume; }
+        }
+
+        public bool IsSufficientForTheWarning
+        {
+            get { return false; }
+        }
     }
 
-    public bool IsSufficientForTheWarning
+    public class ExpressionInPreState : ExpressionInPreStateInfo
     {
-      get { return false; }
-    }
-  }
-
-  public class ExpressionInPreState : ExpressionInPreStateInfo
-  {
-
-    [ContractInvariantMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.expr != null);
-    }
+        [ContractInvariantMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.expr != null);
+        }
 
 
-    public BoxedExpression expr { get; private set; }
+        public BoxedExpression expr { get; private set; }
 
-    public ExpressionInPreState(BoxedExpression expr, ExpressionInPreStateInfo info)
-      : base(info.hasAccessPath, info.hasVariables, info.hasOnlyImmutableVariables, info.kind)
-    {
-      Contract.Requires(expr != null);
-      Contract.Requires(info != null);
+        public ExpressionInPreState(BoxedExpression expr, ExpressionInPreStateInfo info)
+          : base(info.hasAccessPath, info.hasVariables, info.hasOnlyImmutableVariables, info.kind)
+        {
+            Contract.Requires(expr != null);
+            Contract.Requires(info != null);
 
-      Contract.Ensures(this.kind == info.kind);
+            Contract.Ensures(this.kind == info.kind);
 
-      this.expr = expr;
-    }
+            this.expr = expr;
+        }
 
-    [Pure]
-    public override string ToString()
-    {
-      return this.expr.ToString();
-    }
-  }
-
-  public class InferredConditions : List<IInferredCondition>
-  {
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(Contract.ForAll(this, pre => pre != null));
+        [Pure]
+        public override string ToString()
+        {
+            return this.expr.ToString();
+        }
     }
 
-    public InferredConditions(IEnumerable<IInferredCondition> collection)
-      : base(collection == null ? null : collection.Where(pre => pre != null))
-    { }
+    public class InferredConditions : List<IInferredCondition>
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(Contract.ForAll(this, pre => pre != null));
+        }
+
+        public InferredConditions(IEnumerable<IInferredCondition> collection)
+          : base(collection == null ? null : collection.Where(pre => pre != null))
+        { }
 
 #if false
-    public InferredPreconditions(IEnumerable<BoxedExpression> collection, ExpressionInPreStateKind kind, bool isSufficient)
+        public InferredPreconditions(IEnumerable<BoxedExpression> collection, ExpressionInPreStateKind kind, bool isSufficient)
       : this(collection == null ? null : collection.Where(be => be != null).Select(be => new SimpleInferredPrecondition(be, kind, isSufficient)))
     { }
 #endif
 
-    public bool HasASufficientCondition
-    {
-      get
-      {
-        return this.Any(c => c.IsSufficientForTheWarning);
-      }
-    }
-
-    public Set<WarningContext> PushToContractManager(ContractInferenceManager inferenceManager, bool addFalseEntryAssume, ProofObligation obl, ref ProofOutcome outcome, ILogOptions logOptions)
-    {
-      Contract.Requires(inferenceManager != null);
-      Contract.Requires(obl != null);
-      Contract.Requires(logOptions != null);
-
-      Contract.Ensures(Contract.Result<Set<WarningContext>>() != null);
-
-      IEnumerable<BoxedExpression> suggestedPreconditions, objectInvariants, entryAssumes;
-      IEnumerable<IInferredCondition> calleeAssumes;
-
-
-      this.Split(out suggestedPreconditions, out objectInvariants, out entryAssumes, out calleeAssumes);
-
-      if (addFalseEntryAssume)
-      {
-        entryAssumes = entryAssumes.Concat(new BoxedExpression[] { BoxedExpression.ConstFalse });
-      }
-
-      var entryOutcome = outcome;
-      var result = new Set<WarningContext>();
-
-      if (objectInvariants.Any())
-      {
-        outcome = inferenceManager.ObjectInvariant.AddObjectInvariants(obl, objectInvariants, logOptions.PropagateObjectInvariants
-              ? (objectInvariants.Where(exp => this.IsSufficient(exp)).Any() ? ProofOutcome.True : outcome)
-              : outcome);
-
-        result.Add(new WarningContext(WarningContext.ContextType.InferredObjectInvariant, objectInvariants.Count()));
-      }
-      if (suggestedPreconditions.Any())
-      {
-        outcome = inferenceManager.AddPreconditionOrAssume(obl, suggestedPreconditions, logOptions.PropagateInferredRequires(true)
-              ? 
-                (suggestedPreconditions
-                .Where(exp => (entryOutcome != ProofOutcome.False || !exp.IsConstantFalse()) && this.IsSufficient(exp))
-                .Any() ? ProofOutcome.True : outcome)
-              : 
-                outcome);
-        result.Add(new WarningContext(WarningContext.ContextType.InferredPrecondition, suggestedPreconditions.Count()));
-      }
-      if (entryAssumes.Any())
-      {
-        inferenceManager.Assumptions.AddEntryAssumes(obl, entryAssumes);
-
-        result.Add(new WarningContext(WarningContext.ContextType.InferredEntryAssume, entryAssumes.Count()));
-      }
-
-      if (calleeAssumes.Any())
-      {
-        var warningContexts = inferenceManager.Assumptions.AddCalleeAssumes(obl, calleeAssumes);
-
-        result.AddRange(warningContexts);
-      }
-
-      if (this.HasASufficientCondition && this.All(cond => !cond.Expr.IsConstantFalse()))
-      {
-        result.Add(new WarningContext(WarningContext.ContextType.InferredConditionIsSufficient));
-      }
-
-      if (this.Any(
-            cond =>
-              {
-                BinaryOperator bop; BoxedExpression dummy1, dummy2;
-
-                return cond.Expr.IsBinaryExpression(out bop, out dummy1, out dummy2) && bop == BinaryOperator.LogicalOr;
-              }))
-      {
-        result.Add(new WarningContext(WarningContext.ContextType.InferredConditionContainsDisjunction));
-      }
-
-      return result;
-    }
-
-
-    private void Split(
-      out IEnumerable<BoxedExpression> suggestedPreconditions, 
-      out IEnumerable<BoxedExpression> objectInvariants, 
-      out IEnumerable<BoxedExpression> entryAssumes,
-      out IEnumerable<IInferredCondition> calleeAssumes
-      )
-    {
-      Contract.Ensures(Contract.ValueAtReturn(out suggestedPreconditions) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out objectInvariants) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out entryAssumes) != null);
-      Contract.Ensures(Contract.ValueAtReturn(out calleeAssumes) != null);
-      Contract.Ensures(Contract.ForAll(Contract.ValueAtReturn(out suggestedPreconditions), be => be != null));
-      Contract.Ensures(Contract.ForAll(Contract.ValueAtReturn(out objectInvariants), be => be != null));
-
-      suggestedPreconditions = this.Where(cond => cond.Kind == ConditionKind.Requires).Select(cond => cond.Expr);
-      objectInvariants = this.Where(cond => cond.Kind == ConditionKind.ObjectInvariant).Select(cond => cond.Expr);
-      entryAssumes = this.Where(cond=> cond.Kind == ConditionKind.EntryAssume).Select(cond => cond.Expr);
-      calleeAssumes = this.Where(cond => cond.Kind == ConditionKind.CalleeAssume);
-    }
-
-    public bool IsSufficient(BoxedExpression exp)
-    {
-      return exp != null && this.Where(pre => pre.Expr.Equals(exp)).Any(pre => pre.IsSufficientForTheWarning);
-    }
-  }
-
-  public static class ExpressionInPreStateExtensions
-  {
-    [Pure]
-    public static InferredConditions AsInferredPreconditions(this IEnumerable<IInferredCondition> collection)
-    {
-      Contract.Ensures(collection == null || Contract.Result<InferredConditions>() != null);
-      if (collection == null)
-        return null;
-      return new InferredConditions(collection);
-    }
-
-    [Pure]
-    public static InferredConditions AsInferredPreconditions(this IEnumerable<ExpressionInPreState> collection, bool isSufficient)
-    {
-      Contract.Requires(collection != null);
-      Contract.Ensures(Contract.Result<InferredConditions>() != null);
-
-      return new InferredConditions(collection.Select(expr => new SimpleInferredConditionAtEntry(expr.expr, expr.kind, isSufficient)));
-    }
-
-    /// <summary>kind1 is included in kind2 (normal domain leq)</summary>
-    [Pure]
-    static public bool IsIncludedIn(this ExpressionInPreStateKind kind1, ExpressionInPreStateKind kind2)
-    {
-      return (kind1 == ExpressionInPreStateKind.Any || kind2 == ExpressionInPreStateKind.Assume) || kind1 == kind2;
-    }
-
-    [Pure]
-    public static ExpressionInPreStateKind Join(this ExpressionInPreStateKind kind1, ExpressionInPreStateKind kind2)
-    {
-      if (kind1 == ExpressionInPreStateKind.Any) return kind2;
-      if (kind2 == ExpressionInPreStateKind.Any) return kind1;
-      if (kind2 == kind1) return kind1;
-      return ExpressionInPreStateKind.Assume;
-    }
-
-    [Pure]
-    public static ConditionKind ToConditionKind(this ExpressionInPreStateKind kind)
-    {
-      switch (kind)
-      {
-        case ExpressionInPreStateKind.Any:
-        case ExpressionInPreStateKind.MethodPrecondition:
-          return ConditionKind.Requires;
-        case ExpressionInPreStateKind.Assume:
-          return ConditionKind.EntryAssume;
-        case ExpressionInPreStateKind.ObjectInvariant:
-          return ConditionKind.ObjectInvariant;
-        default:
-          throw new NotImplementedException();
-      }
-    }
-  }
-
-  #endregion
-
-
-  public class PreconditionSuggestion
-  {
-    class InvertComparison
-    {
-      private readonly bool tryInvert;
-      private bool hasBeenInverted;
-
-      public InvertComparison(bool tryInvert)
-      {
-        this.tryInvert = tryInvert;
-      }
-
-      public static InvertComparison NoInversion = new InvertComparison(false); // Thread-safe
-
-      public bool TryInvertComparison { get { return this.tryInvert; } }
-
-      public bool HasBeenInverted { get { return this.hasBeenInverted; } }
-
-      public void DischargeInversion()
-      {
-        if (this.tryInvert)
+        public bool HasASufficientCondition
         {
-          this.hasBeenInverted = true;
-        }
-        else
-        {
-          throw new InvalidOperationException("Can't invert what needs no inversion");
-        }
-      }
-
-    }
-
-    class PreconditionTransformer<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>
-        : IVisitValueExprIL<Expression, Type, Expression, Dest, InvertComparison, BoxedExpression>
-      where Type : IEquatable<Type>
-    {
-      APC conditionPC;
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context;
-      bool hasVariables;
-      public bool HasVariables { get { return this.hasVariables; } }
-
-      /// <summary>
-      /// </summary>
-      /// <param name="conditionPC">PC where condition is being asserted</param>
-      /// <param name="context"></param>
-      /// <param name="mdDecoder"></param>
-      public PreconditionTransformer(
-        APC conditionPC,
-        IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-      {
-        this.conditionPC = conditionPC;
-        this.context = context;
-        this.mdDecoder = mdDecoder;
-      }
-
-      #region IVisitValueExprIL<Label,Type,Source,Dest,StringBuilder,bool> Members
-
-      public BoxedExpression Recurse(Expression expr)
-      {
-        return Recurse(expr, InvertComparison.NoInversion);
-      }
-
-      private BoxedExpression Recurse(Expression expr, InvertComparison tryInvert)
-      {
-        return this.context.ExpressionContext.Decode<InvertComparison, BoxedExpression, PreconditionTransformer<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>>(expr, this, tryInvert);
-      }
-
-      public BoxedExpression SymbolicConstant(Expression pc, Dest symbol, InvertComparison tryInvert)
-      {
-        FList<PathElement> path = context.ValueContext.VisibleAccessPathListFromPre(context.MethodContext.CFG.EntryAfterRequires, symbol);
-        if (path != null)
-        {
-          this.hasVariables = true;
-          return BoxedExpression.Var(symbol, path);
-        }
-        path = context.ValueContext.VisibleAccessPathListFromPre(conditionPC, symbol);
-        if (path != null)
-        {
-          this.hasVariables = true;
-          return BoxedExpression.Var(symbol, path);
-        }
-        return null;
-      }
-
-      public BoxedExpression Binary(Expression pc, BinaryOperator op, Dest dest, Expression s1, Expression s2, InvertComparison tryInvert)
-      {
-        Contract.Assume(tryInvert != null);
-
-        BoxedExpression left = null;
-        var right = Recurse(s2);
-        if (right == null) return null;
-        switch (op)
-        {
-          case BinaryOperator.Ceq:
-          case BinaryOperator.Cobjeq:
-            if (context.ExpressionContext.IsZero(s2))
+            get
             {
-              InvertComparison tryInvert2 = new InvertComparison(true);
-              BoxedExpression left2 = Recurse(s1, tryInvert2);
-              if (left2 == null) return null;
-              if (tryInvert2.HasBeenInverted)
-              {
-                // We know that left is a comparison. If outer wanted us to invert too, we cancel it here
-                if (tryInvert.TryInvertComparison)
+                return this.Any(c => c.IsSufficientForTheWarning);
+            }
+        }
+
+        public Set<WarningContext> PushToContractManager(ContractInferenceManager inferenceManager, bool addFalseEntryAssume, ProofObligation obl, ref ProofOutcome outcome, ILogOptions logOptions)
+        {
+            Contract.Requires(inferenceManager != null);
+            Contract.Requires(obl != null);
+            Contract.Requires(logOptions != null);
+
+            Contract.Ensures(Contract.Result<Set<WarningContext>>() != null);
+
+            IEnumerable<BoxedExpression> suggestedPreconditions, objectInvariants, entryAssumes;
+            IEnumerable<IInferredCondition> calleeAssumes;
+
+
+            this.Split(out suggestedPreconditions, out objectInvariants, out entryAssumes, out calleeAssumes);
+
+            if (addFalseEntryAssume)
+            {
+                entryAssumes = entryAssumes.Concat(new BoxedExpression[] { BoxedExpression.ConstFalse });
+            }
+
+            var entryOutcome = outcome;
+            var result = new Set<WarningContext>();
+
+            if (objectInvariants.Any())
+            {
+                outcome = inferenceManager.ObjectInvariant.AddObjectInvariants(obl, objectInvariants, logOptions.PropagateObjectInvariants
+                      ? (objectInvariants.Where(exp => this.IsSufficient(exp)).Any() ? ProofOutcome.True : outcome)
+                      : outcome);
+
+                result.Add(new WarningContext(WarningContext.ContextType.InferredObjectInvariant, objectInvariants.Count()));
+            }
+            if (suggestedPreconditions.Any())
+            {
+                outcome = inferenceManager.AddPreconditionOrAssume(obl, suggestedPreconditions, logOptions.PropagateInferredRequires(true)
+                      ?
+                        (suggestedPreconditions
+                        .Where(exp => (entryOutcome != ProofOutcome.False || !exp.IsConstantFalse()) && this.IsSufficient(exp))
+                        .Any() ? ProofOutcome.True : outcome)
+                      :
+                        outcome);
+                result.Add(new WarningContext(WarningContext.ContextType.InferredPrecondition, suggestedPreconditions.Count()));
+            }
+            if (entryAssumes.Any())
+            {
+                inferenceManager.Assumptions.AddEntryAssumes(obl, entryAssumes);
+
+                result.Add(new WarningContext(WarningContext.ContextType.InferredEntryAssume, entryAssumes.Count()));
+            }
+
+            if (calleeAssumes.Any())
+            {
+                var warningContexts = inferenceManager.Assumptions.AddCalleeAssumes(obl, calleeAssumes);
+
+                result.AddRange(warningContexts);
+            }
+
+            if (this.HasASufficientCondition && this.All(cond => !cond.Expr.IsConstantFalse()))
+            {
+                result.Add(new WarningContext(WarningContext.ContextType.InferredConditionIsSufficient));
+            }
+
+            if (this.Any(
+                  cond =>
+                    {
+                        BinaryOperator bop; BoxedExpression dummy1, dummy2;
+
+                        return cond.Expr.IsBinaryExpression(out bop, out dummy1, out dummy2) && bop == BinaryOperator.LogicalOr;
+                    }))
+            {
+                result.Add(new WarningContext(WarningContext.ContextType.InferredConditionContainsDisjunction));
+            }
+
+            return result;
+        }
+
+
+        private void Split(
+          out IEnumerable<BoxedExpression> suggestedPreconditions,
+          out IEnumerable<BoxedExpression> objectInvariants,
+          out IEnumerable<BoxedExpression> entryAssumes,
+          out IEnumerable<IInferredCondition> calleeAssumes
+          )
+        {
+            Contract.Ensures(Contract.ValueAtReturn(out suggestedPreconditions) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out objectInvariants) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out entryAssumes) != null);
+            Contract.Ensures(Contract.ValueAtReturn(out calleeAssumes) != null);
+            Contract.Ensures(Contract.ForAll(Contract.ValueAtReturn(out suggestedPreconditions), be => be != null));
+            Contract.Ensures(Contract.ForAll(Contract.ValueAtReturn(out objectInvariants), be => be != null));
+
+            suggestedPreconditions = this.Where(cond => cond.Kind == ConditionKind.Requires).Select(cond => cond.Expr);
+            objectInvariants = this.Where(cond => cond.Kind == ConditionKind.ObjectInvariant).Select(cond => cond.Expr);
+            entryAssumes = this.Where(cond => cond.Kind == ConditionKind.EntryAssume).Select(cond => cond.Expr);
+            calleeAssumes = this.Where(cond => cond.Kind == ConditionKind.CalleeAssume);
+        }
+
+        public bool IsSufficient(BoxedExpression exp)
+        {
+            return exp != null && this.Where(pre => pre.Expr.Equals(exp)).Any(pre => pre.IsSufficientForTheWarning);
+        }
+    }
+
+    public static class ExpressionInPreStateExtensions
+    {
+        [Pure]
+        public static InferredConditions AsInferredPreconditions(this IEnumerable<IInferredCondition> collection)
+        {
+            Contract.Ensures(collection == null || Contract.Result<InferredConditions>() != null);
+            if (collection == null)
+                return null;
+            return new InferredConditions(collection);
+        }
+
+        [Pure]
+        public static InferredConditions AsInferredPreconditions(this IEnumerable<ExpressionInPreState> collection, bool isSufficient)
+        {
+            Contract.Requires(collection != null);
+            Contract.Ensures(Contract.Result<InferredConditions>() != null);
+
+            return new InferredConditions(collection.Select(expr => new SimpleInferredConditionAtEntry(expr.expr, expr.kind, isSufficient)));
+        }
+
+        /// <summary>kind1 is included in kind2 (normal domain leq)</summary>
+        [Pure]
+        static public bool IsIncludedIn(this ExpressionInPreStateKind kind1, ExpressionInPreStateKind kind2)
+        {
+            return (kind1 == ExpressionInPreStateKind.Any || kind2 == ExpressionInPreStateKind.Assume) || kind1 == kind2;
+        }
+
+        [Pure]
+        public static ExpressionInPreStateKind Join(this ExpressionInPreStateKind kind1, ExpressionInPreStateKind kind2)
+        {
+            if (kind1 == ExpressionInPreStateKind.Any) return kind2;
+            if (kind2 == ExpressionInPreStateKind.Any) return kind1;
+            if (kind2 == kind1) return kind1;
+            return ExpressionInPreStateKind.Assume;
+        }
+
+        [Pure]
+        public static ConditionKind ToConditionKind(this ExpressionInPreStateKind kind)
+        {
+            switch (kind)
+            {
+                case ExpressionInPreStateKind.Any:
+                case ExpressionInPreStateKind.MethodPrecondition:
+                    return ConditionKind.Requires;
+                case ExpressionInPreStateKind.Assume:
+                    return ConditionKind.EntryAssume;
+                case ExpressionInPreStateKind.ObjectInvariant:
+                    return ConditionKind.ObjectInvariant;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+
+    #endregion
+
+
+    public class PreconditionSuggestion
+    {
+        private class InvertComparison
+        {
+            private readonly bool tryInvert;
+            private bool hasBeenInverted;
+
+            public InvertComparison(bool tryInvert)
+            {
+                this.tryInvert = tryInvert;
+            }
+
+            public static InvertComparison NoInversion = new InvertComparison(false); // Thread-safe
+
+            public bool TryInvertComparison { get { return tryInvert; } }
+
+            public bool HasBeenInverted { get { return hasBeenInverted; } }
+
+            public void DischargeInversion()
+            {
+                if (tryInvert)
                 {
-                  left = Recurse(s1);
-                  if (left == null) return null;
-                  tryInvert.DischargeInversion();
-                  return left;
+                    hasBeenInverted = true;
                 }
-                return left2;
-              }
-            }
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              left = Recurse(s1);
-              if (left == null) return null;
-              return BoxedExpression.Binary(BinaryOperator.Cne_Un, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Cge:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Clt, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Cge_Un:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Clt_Un, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Cgt:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Cle, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Cgt_Un:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Cle_Un, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Cle:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Cgt, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Cle_Un:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Cgt_Un, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Clt:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Cge, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Clt_Un:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Cge_Un, left, right);
-            }
-            goto default;
-
-          case BinaryOperator.Cne_Un:
-            left = Recurse(s1);
-            if (left == null) return null;
-            if (tryInvert.TryInvertComparison)
-            {
-              tryInvert.DischargeInversion();
-              return BoxedExpression.Binary(BinaryOperator.Ceq, left, right);
-            }
-            goto default;
-
-          default:
-            if (left == null) left = Recurse(s1);
-            if (left == null) return null;
-            return BoxedExpression.Binary(op, left, right);
-        }
-      }
-
-      public BoxedExpression Isinst(Expression pc, Type type, Dest dest, Expression obj, InvertComparison data)
-      {
-        if (!this.mdDecoder.IsAsVisibleAs(type, context.MethodContext.CurrentMethod)) return null;
-        BoxedExpression arg = Recurse(obj);
-        if (arg == null) return null;
-        return ClousotExpression<Type>.MakeIsInst(type, arg);
-      }
-
-      public BoxedExpression Ldconst(Expression pc, object constant, Type type, Dest dest, InvertComparison data)
-      {
-        Contract.Assume(!this.mdDecoder.Equal(type, this.mdDecoder.System_Int32) || constant is Int32);
-
-        return BoxedExpression.Const(constant, type, this.mdDecoder);
-      }
-
-      public BoxedExpression Ldnull(Expression pc, Dest dest, InvertComparison data)
-      {
-        return BoxedExpression.Const(null, default(Type), this.mdDecoder);
-      }
-
-      public BoxedExpression Sizeof(Expression pc, Type type, Dest dest, InvertComparison data)
-      {
-        return ClousotExpression<Type>.MakeSizeOf(type, this.mdDecoder.TypeSize(type));
-      }
-
-      public BoxedExpression Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Expression source, InvertComparison data)
-      {
-        BoxedExpression arg = Recurse(source);
-        if (arg == null) return null;
-        return ClousotExpression<Type>.MakeUnary(op, arg);
-      }
-
-      public BoxedExpression Box(Expression pc, Type type, Dest dest, Expression source, InvertComparison data)
-      {
-        // TODO: once we have boxed expressions with Box, we can fill this in.
-        return null;
-      }
-
-      #endregion
-    }
-
-    class ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>
-        : IVisitValueExprIL<Expression, Type, Expression, Dest, InvertComparison, string>
-      where Type : IEquatable<Type>
-    {
-      #region Object invariant
-      [ContractInvariantMethod]
-      [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.mdDecoder != null);
-        Contract.Invariant(this.context != null);
-      }
-      #endregion
-
-      readonly APC AtPC;
-      readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-      readonly IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context;
-      public bool HasVariables;
-
-      public ExpressionDecoder(
-        APC atPC,
-        IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-      {
-        Contract.Requires(context != null);
-        Contract.Requires(mdDecoder != null);
-
-        this.AtPC = atPC;
-        this.context = context;
-        this.mdDecoder = mdDecoder;
-      }
-
-      #region IVisitValueExprIL<Label,Type,Source,Dest,StringBuilder,bool> Members
-
-      private string Recurse(Expression expr)
-      {
-        return Recurse(expr, InvertComparison.NoInversion);
-      }
-
-      private string Recurse(Expression expr, InvertComparison tryInvert)
-      {
-        return this.context.ExpressionContext.Decode<InvertComparison, string, ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>>(expr, this, tryInvert);
-      }
-
-      public string SymbolicConstant(Expression pc, Dest symbol, InvertComparison tryInvert)
-      {
-        HasVariables = true;
-        string path = context.ValueContext.AccessPath(AtPC, symbol);
-        return path;
-      }
-
-      public string Binary(Expression pc, BinaryOperator op, Dest dest, Expression s1, Expression s2, InvertComparison tryInvert)
-      {
-        Contract.Assume(tryInvert != null);
-
-        string left = Recurse(s1);
-        if (left == null) return null;
-        string right = Recurse(s2);
-        if (right == null) return null;
-        switch (op)
-        {
-          case BinaryOperator.Add:
-          case BinaryOperator.Add_Ovf:
-          case BinaryOperator.Add_Ovf_Un:
-            return String.Format("({0} + {1})", left, right);
-
-          case BinaryOperator.And:
-            return String.Format("({0} & {1})", left, right);
-
-          case BinaryOperator.Ceq:
-          case BinaryOperator.Cobjeq:
-            if (right == "0")
-            {
-              InvertComparison tryInvert2 = new InvertComparison(true);
-              string left2 = Recurse(s1, tryInvert2);
-              if (tryInvert2.HasBeenInverted)
-              {
-                // We know that left is a comparison. If outer wanted us to invert too, we cancel it here
-                if (tryInvert.TryInvertComparison)
+                else
                 {
-                  tryInvert.DischargeInversion();
-                  return left;
+                    throw new InvalidOperationException("Can't invert what needs no inversion");
                 }
-                return left2;
-              }
             }
-            if (tryInvert.TryInvertComparison)
+        }
+
+        private class PreconditionTransformer<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>
+            : IVisitValueExprIL<Expression, Type, Expression, Dest, InvertComparison, BoxedExpression>
+          where Type : IEquatable<Type>
+        {
+            private APC conditionPC;
+            private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+            private IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context;
+            private bool hasVariables;
+            public bool HasVariables { get { return hasVariables; } }
+
+            /// <summary>
+            /// </summary>
+            /// <param name="conditionPC">PC where condition is being asserted</param>
+            /// <param name="context"></param>
+            /// <param name="mdDecoder"></param>
+            public PreconditionTransformer(
+              APC conditionPC,
+              IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+            )
             {
-              tryInvert.DischargeInversion();
-              return String.Format("({0} != {1})", left, right);
+                this.conditionPC = conditionPC;
+                this.context = context;
+                this.mdDecoder = mdDecoder;
             }
-            return String.Format("({0} == {1})", left, right);
 
-          case BinaryOperator.Cge:
-          case BinaryOperator.Cge_Un:
-            if (tryInvert.TryInvertComparison)
+            #region IVisitValueExprIL<Label,Type,Source,Dest,StringBuilder,bool> Members
+
+            public BoxedExpression Recurse(Expression expr)
             {
-              tryInvert.DischargeInversion();
-              return String.Format("({0} < {1})", left, right);
+                return Recurse(expr, InvertComparison.NoInversion);
             }
-            return String.Format("({0} >= {1})", left, right);
 
-          case BinaryOperator.Cgt:
-          case BinaryOperator.Cgt_Un:
-            if (tryInvert.TryInvertComparison)
+            private BoxedExpression Recurse(Expression expr, InvertComparison tryInvert)
             {
-              tryInvert.DischargeInversion();
-              return String.Format("({0} <= {1})", left, right);
+                return context.ExpressionContext.Decode<InvertComparison, BoxedExpression, PreconditionTransformer<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>>(expr, this, tryInvert);
             }
-            return String.Format("({0} > {1})", left, right);
 
-          case BinaryOperator.Cle:
-          case BinaryOperator.Cle_Un:
-            if (tryInvert.TryInvertComparison)
+            public BoxedExpression SymbolicConstant(Expression pc, Dest symbol, InvertComparison tryInvert)
             {
-              tryInvert.DischargeInversion();
-              return String.Format("({0} > {1})", left, right);
+                FList<PathElement> path = context.ValueContext.VisibleAccessPathListFromPre(context.MethodContext.CFG.EntryAfterRequires, symbol);
+                if (path != null)
+                {
+                    hasVariables = true;
+                    return BoxedExpression.Var(symbol, path);
+                }
+                path = context.ValueContext.VisibleAccessPathListFromPre(conditionPC, symbol);
+                if (path != null)
+                {
+                    hasVariables = true;
+                    return BoxedExpression.Var(symbol, path);
+                }
+                return null;
             }
-            return String.Format("({0} <= {1})", left, right);
 
-          case BinaryOperator.Clt:
-          case BinaryOperator.Clt_Un:
-            if (tryInvert.TryInvertComparison)
+            public BoxedExpression Binary(Expression pc, BinaryOperator op, Dest dest, Expression s1, Expression s2, InvertComparison tryInvert)
             {
-              tryInvert.DischargeInversion();
-              return String.Format("({0} >= {1})", left, right);
-            }
-            return String.Format("({0} < {1})", left, right);
+                Contract.Assume(tryInvert != null);
 
-          case BinaryOperator.Cne_Un:
-            if (tryInvert.TryInvertComparison)
+                BoxedExpression left = null;
+                var right = Recurse(s2);
+                if (right == null) return null;
+                switch (op)
+                {
+                    case BinaryOperator.Ceq:
+                    case BinaryOperator.Cobjeq:
+                        if (context.ExpressionContext.IsZero(s2))
+                        {
+                            InvertComparison tryInvert2 = new InvertComparison(true);
+                            BoxedExpression left2 = Recurse(s1, tryInvert2);
+                            if (left2 == null) return null;
+                            if (tryInvert2.HasBeenInverted)
+                            {
+                                // We know that left is a comparison. If outer wanted us to invert too, we cancel it here
+                                if (tryInvert.TryInvertComparison)
+                                {
+                                    left = Recurse(s1);
+                                    if (left == null) return null;
+                                    tryInvert.DischargeInversion();
+                                    return left;
+                                }
+                                return left2;
+                            }
+                        }
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            left = Recurse(s1);
+                            if (left == null) return null;
+                            return BoxedExpression.Binary(BinaryOperator.Cne_Un, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Cge:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Clt, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Cge_Un:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Clt_Un, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Cgt:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Cle, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Cgt_Un:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Cle_Un, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Cle:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Cgt, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Cle_Un:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Cgt_Un, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Clt:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Cge, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Clt_Un:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Cge_Un, left, right);
+                        }
+                        goto default;
+
+                    case BinaryOperator.Cne_Un:
+                        left = Recurse(s1);
+                        if (left == null) return null;
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return BoxedExpression.Binary(BinaryOperator.Ceq, left, right);
+                        }
+                        goto default;
+
+                    default:
+                        if (left == null) left = Recurse(s1);
+                        if (left == null) return null;
+                        return BoxedExpression.Binary(op, left, right);
+                }
+            }
+
+            public BoxedExpression Isinst(Expression pc, Type type, Dest dest, Expression obj, InvertComparison data)
             {
-              tryInvert.DischargeInversion();
-              return String.Format("({0} == {1})", left, right);
+                if (!mdDecoder.IsAsVisibleAs(type, context.MethodContext.CurrentMethod)) return null;
+                BoxedExpression arg = Recurse(obj);
+                if (arg == null) return null;
+                return ClousotExpression<Type>.MakeIsInst(type, arg);
             }
-            return String.Format("({0} != {1})", left, right);
 
-          case BinaryOperator.Div:
-          case BinaryOperator.Div_Un:
-            return String.Format("({0} / {1})", left, right);
-
-          case BinaryOperator.Mul:
-          case BinaryOperator.Mul_Ovf:
-          case BinaryOperator.Mul_Ovf_Un:
-            return String.Format("({0} * {1})", left, right);
-
-          case BinaryOperator.Or:
-            return String.Format("({0} | {1})", left, right);
-
-          case BinaryOperator.Rem:
-          case BinaryOperator.Rem_Un:
-            return String.Format("({0} % {1})", left, right);
-
-          case BinaryOperator.Shl:
-            return String.Format("({0} << {1})", left, right);
-
-          case BinaryOperator.Shr:
-          case BinaryOperator.Shr_Un:
-            return String.Format("({0} >> {1})", left, right);
-
-          case BinaryOperator.Sub:
-          case BinaryOperator.Sub_Ovf:
-          case BinaryOperator.Sub_Ovf_Un:
-            return String.Format("({0} - {1})", left, right);
-
-          case BinaryOperator.Xor:
-            return String.Format("({0} ^ {1})", left, right);
-
-          default:
-            throw new NotImplementedException("new binary operator?");
-        }
-      }
-
-      public string Isinst(Expression pc, Type type, Dest dest, Expression obj, InvertComparison data)
-      {
-        string arg = Recurse(obj);
-        if (arg == null) return null;
-        return String.Format("({0} as {1})", arg, mdDecoder.Name(type));
-      }
-
-      public string Ldconst(Expression pc, object constant, Type type, Dest dest, InvertComparison data)
-      {
-        return constant.ToString();
-      }
-
-      public string Ldnull(Expression pc, Dest dest, InvertComparison data)
-      {
-        return "null";
-      }
-
-      public string Sizeof(Expression pc, Type type, Dest dest, InvertComparison data)
-      {
-        return String.Format("sizeof({0})", mdDecoder.FullName(type));
-      }
-
-      [ContractVerification(true)]
-      public string Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Expression source, InvertComparison data)
-      {
-        string arg = Recurse(source);
-        if (arg == null) return null;
-        switch (op)
-        {
-          case UnaryOperator.Conv_i:
-            return arg;
-
-          case UnaryOperator.Conv_i1:
-            return String.Format("(System.Int8){0}", arg);
-
-          case UnaryOperator.Conv_i2:
-            return String.Format("(System.Int16){0}", arg);
-
-          case UnaryOperator.Conv_i4:
-            return String.Format("(System.Int32){0}", arg);
-
-          case UnaryOperator.Conv_i8:
-            return String.Format("(System.Int64){0}", arg);
-
-          case UnaryOperator.Conv_r_un:
-            return arg;
-
-          case UnaryOperator.Conv_r4:
-            return String.Format("(System.Single){0}", arg);
-
-          case UnaryOperator.Conv_r8:
-            return String.Format("(System.Double){0}", arg);
-
-          case UnaryOperator.Conv_u:
-            return arg;
-
-          case UnaryOperator.Conv_u1:
-            return String.Format("(System.UInt8){0}", arg);
-
-          case UnaryOperator.Conv_u2:
-            return String.Format("(System.UInt16){0}", arg);
-
-          case UnaryOperator.Conv_u4:
-            return String.Format("(System.UInt32){0}", arg);
-
-          case UnaryOperator.Conv_u8:
-            return String.Format("(System.UInt64){0}", arg);
-
-          case UnaryOperator.Neg:
-            return String.Format("(-{0})", arg);
-
-          case UnaryOperator.Not:
-            return String.Format("(!{0})", arg);
-
-          case UnaryOperator.WritableBytes:
-            return String.Format("System.Diagnostics.Contracts.Contract.WritableBytes({0})", arg);
-
-          default:
-            return "<unknown unary operator?>";
-          //Contract.Assert(false); // should be unreachable
-          //throw new NotImplementedException("new unary operator?");
-        }
-      }
-
-      public string Box(Expression pc, Type type, Dest dest, Expression source, InvertComparison data)
-      {
-        string arg = Recurse(source);
-        if (arg == null) return null;
-        return String.Format("(box {0} to {1})", arg, mdDecoder.Name(type));
-      }
-
-      #endregion
-    }
-
-    public static BoxedExpression ExpressionInPreState<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>
-      (
-      APC at,
-      Expression condition,
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      out bool hasVariables
-    )
-      where Type : IEquatable<Type>
-    {
-      var preTrans = new PreconditionTransformer<Local, Parameter, Method, Field, Property, Event, Expression, Type, SymbolicValue, Attribute, Assembly>(at, context, mdDecoder);
-
-      var result = preTrans.Recurse(condition);
-      hasVariables = preTrans.HasVariables;
-
-      return result;
-    }
-
-    /// <summary>
-    /// Computes a BoxedExpression with internal accesspaths that are valid in the pre-state of the
-    /// current method and these paths are "visible" according to the visibility rules of pre-conditions.
-    /// </summary>
-    /// <param name="hasVariables">true if expression contains any variables at all</param>
-    /// <param name="conditionPC">the pc at which the condition is being tested</param>
-    /// <returns>null if not expressible in pre-state</returns>    
-    public static ExpressionInPreState ExpressionInPreState<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
-      BoxedExpression condition,
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      APC conditionPC,
-      ExpressionInPreStateKind allowedKinds
-    )
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(mdDecoder != null);
-
-      continuations = new List<Tuple<BoxedExpression, BoxedExpression, BoxedExpression>>();
-
-      ExpressionInPreStateInfo info;
-      var boundVariables = new Set<BoxedExpression>();
-
-      var allowObjectInvariants = ExpressionInPreStateKind.ObjectInvariant.IsIncludedIn(allowedKinds) && !mdDecoder.IsConstructor(context.MethodContext.CurrentMethod);
-       
-      var result = ExpressionInPreStateInternal(condition, context, mdDecoder, out info, conditionPC, allowObjectInvariants, boundVariables);
-
-      if (result != null && continuations.Count > 0)
-      {
-        result = ApplyExistential(result);
-      }
-
-      continuations = null;
-
-      if (info != null && info.kind.IsIncludedIn(allowedKinds))
-      {
-        return result == null ? null : new ExpressionInPreState(result, info);
-      }
-      return null;
-    }
-
-    private static class BoxedExpressionsUtils // taken from BoxedExpressionsUtils, TODO: solve dependencies
-    {
-      public static List<BoxedExpression> SplitConjunctions(BoxedExpression be)
-      {
-        Contract.Requires(be != null);
-        Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
-
-        var result = new List<BoxedExpression>();
-        return SplitConjunctionsHelper(be, result);
-      }
-      private static List<BoxedExpression> SplitConjunctionsHelper(BoxedExpression be, List<BoxedExpression> result)
-      {
-        Contract.Requires(be != null);
-        Contract.Requires(result != null);
-        Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
-
-        if (be.IsBinary && be.BinaryOp == BinaryOperator.LogicalAnd)
-        {
-          result = SplitConjunctionsHelper(be.BinaryRight, SplitConjunctionsHelper(be.BinaryLeft, result));
-        }
-        else
-        {
-          result.Add(be);
-        }
-
-        return result;
-      }
-    }
-
-    public static IEnumerable<ExpressionInPreState> ExpressionsInPreState<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
-      BoxedExpression condition,
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      APC conditionPC,
-      ExpressionInPreStateKind allowedKinds
-    )
-      where Type : IEquatable<Type>
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<ExpressionInPreState>>() == null || Contract.ForAll(Contract.Result<IEnumerable<ExpressionInPreState>>(), e => e != null));
-
-      foreach (var subCondition in BoxedExpressionsUtils.SplitConjunctions(condition))
-      {
-        if (subCondition == null)
-          continue;
-        var result = ExpressionInPreState(subCondition, context, mdDecoder, conditionPC, allowedKinds);
-        if (result == null)
-          continue;
-        yield return result;
-      }
-    }
-
-    private static BoxedExpression ApplyExistential(BoxedExpression result)
-    {
-      Contract.Requires(result != null);
-      Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-      foreach (var triple in continuations)
-      {
-        Contract.Assume(triple.Item1 != null);
-        Contract.Assume(triple.Item2 != null);
-        Contract.Assume(triple.Item3 != null);
-        result = new ExistsIndexedExpression(null, triple.Item1, triple.Item2, triple.Item3, result);
-      }
-
-      return result;
-    }
-
-    [ThreadStatic]
-    private static List<Tuple<BoxedExpression, BoxedExpression, BoxedExpression>> continuations;
-
-    [ContractVerification(false)]
-    private static BoxedExpression ExpressionInPreStateInternal<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
-      BoxedExpression condition,
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      out ExpressionInPreStateInfo info,
-      APC conditionPC,
-      bool allowObjectInvariant, // only false if current method is a constructor!
-      Set<BoxedExpression> boundVariables
-    )
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(boundVariables != null);
-
-      if (boundVariables.Contains(condition))
-      {
-        Contract.Assume(condition != null);
-        info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any);
-        return condition;
-      }
-
-      if (condition.IsVariable)
-      {
-        // Special case as we may have some slack variable
-        SymbolicValue var;
-        if (!condition.TryGetFrameworkVariable(out var))
-        {
-          info = null;
-          return null;
-        }
-
-        // First check if we've got a constant
-        Type type;
-        object value;
-        if (context.ValueContext.IsConstant(conditionPC, var, out type, out value))
-        {
-          info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any);
-          return BoxedExpression.Const(value, type, mdDecoder);
-        }
-
-        var isConstructor = mdDecoder.IsConstructor(context.MethodContext.CurrentMethod);
-
-        FList<PathElement> accessPath;
-        #region Try to generate a precondition
-        accessPath = context.ValueContext.VisibleAccessPathListFromPre(conditionPC, var); // ConditionPC okay here, because this also checks that the path is unmodified
-        var headIsThis = accessPath != null ? accessPath.Head.ToString() == "this" : false;
-
-        if (accessPath != null
-          && (!isConstructor || !headIsThis))
-        {
-          var resultKind = headIsThis ? ExpressionInPreStateKind.Any : ExpressionInPreStateKind.MethodPrecondition;
-          var hasOnlyImmutableVariables = accessPath.Length() == 1 || condition.IsArrayLength(conditionPC, context, mdDecoder);
-
-          info = new ExpressionInPreStateInfo(accessPath.Length() > 1, true, hasOnlyImmutableVariables, resultKind);
-          return BoxedExpression.Var(var, accessPath);
-        }
-        #endregion
-
-        #region Try to generate an Assume or an Object Invariant
-
-        accessPath = context.ValueContext.AccessPathList(conditionPC, var, false, false);
-        if (accessPath != null && !conditionPC.Equals(context.MethodContext.CFG.EntryAfterRequires))
-        {
-          // check that path is unmodified since entry
-          if (!context.ValueContext.PathUnmodifiedSinceEntry(conditionPC, accessPath))
-          {
-            accessPath = null; // can't use it
-          }
-        }
-        if (accessPath != null
-          && accessPath.Head.IsParameter
-          && accessPath.Head.ToString() == "this"
-          && context.ValueContext.PathSuitableInRequires(conditionPC, accessPath))
-        {
-          var isReadOnly = mdDecoder.IsReadOnly(accessPath);
-
-          if (!isConstructor && isReadOnly && allowObjectInvariant)
-          {
-            var kind = ExpressionInPreStateKind.ObjectInvariant;
-
-            info = new ExpressionInPreStateInfo(accessPath.Length() > 1, true, false, kind);
-            return BoxedExpression.Var(var, accessPath);
-          }
-        }
-
-        #endregion
-
-        #region Try to generate any kind of entry assumption
-        //accessPath = context.ValueContext.AccessPathList(conditionPC, var, false, false);
-
-        if (accessPath != null
-          && (!isConstructor || accessPath.Head.ToString() != "this"))
-        {
-
-          var hasOnlyImmutableVariables = accessPath.Length() == 1 || condition.IsArrayLength(conditionPC, context, mdDecoder);
-
-          info = new ExpressionInPreStateInfo(accessPath.Length() > 1, true, hasOnlyImmutableVariables, ExpressionInPreStateKind.Assume);
-          return BoxedExpression.Var(var, accessPath);
-        }
-        #endregion
-
-        info = null;
-        return null;
-      }
-      if (condition.IsConstant || condition.IsNull)
-      {
-        // no nested variables
-        Contract.Assume(!mdDecoder.Equal((Type)condition.ConstantType, mdDecoder.System_Int32) || condition.Constant is Int32);
-        info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any, true);
-        return BoxedExpression.Const(condition.Constant, (Type)condition.ConstantType, mdDecoder);
-      }
-      if (condition.IsSizeOf)
-      {
-        int size;
-        object type;
-        condition.SizeOf(out type, out size);
-        info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any);
-        return BoxedExpression.SizeOf((Type)type, size);
-      }
-      if (condition.IsUnary)
-      {
-        // Recurse
-        var arg = ExpressionInPreStateInternal(condition.UnaryArgument, context, mdDecoder, out info, conditionPC, allowObjectInvariant, boundVariables);
-        if (arg != null)
-        {
-          return BoxedExpression.Unary(condition.UnaryOp, arg);
-        }
-        return null;
-      }
-      if (condition.IsBinary)
-      {
-        ExpressionInPreStateInfo infoLeft, infoRight;
-        // Recurse
-        var left = ExpressionInPreStateInternal(condition.BinaryLeft, context, mdDecoder, out infoLeft, conditionPC, allowObjectInvariant, boundVariables);
-        if (left == null) { info = null; return null; }
-
-        var right = ExpressionInPreStateInternal(condition.BinaryRight, context, mdDecoder, out infoRight, conditionPC, allowObjectInvariant, boundVariables);
-        if (right == null) { info = null; return null; }
-
-        info = ExpressionInPreStateInfo.Combine(infoLeft, infoRight);
-        return BoxedExpression.Binary(condition.BinaryOp, left, right);
-      }
-
-      BoxedExpression arrayExp, indexExp;
-      object t;
-      if (condition.IsArrayIndexExpression(out arrayExp, out indexExp, out t) && t is Type)
-      {
-        ExpressionInPreStateInfo infoArray, infoIndex;
-
-        var newArrayExp = ExpressionInPreStateInternal(arrayExp, context, mdDecoder, out infoArray, conditionPC, allowObjectInvariant, boundVariables);
-        if (newArrayExp == null) { info = null; return null; }
-
-        var newIndexExp = ExpressionInPreStateInternal(indexExp, context, mdDecoder, out infoIndex, conditionPC, allowObjectInvariant, boundVariables);
-        if (newIndexExp == null)
-        {
-          // try to introduce the exists
-
-          SymbolicValue arrayVar, arrayLen;
-          if (newArrayExp.TryGetFrameworkVariable(out arrayVar)
-            && context.ValueContext.TryGetArrayLength(conditionPC, arrayVar, out arrayLen))
-          {
-            var type = context.ValueContext.GetType(conditionPC, arrayVar);
-
-            var boundVar = BoxedExpression.Var(string.Format("__j{0}__", continuations.Count));
-            var zero = BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder);
-
-            // TODO: the info kind computation does not seem general enough here [MAF 3/23/13]
-
-            info = new ExpressionInPreStateInfo(true, infoArray.hasVariables, false, ExpressionInPreStateKind.MethodPrecondition);
-            FList<PathElement> accessPath = null;
-            if (infoArray.kind.IsIncludedIn(ExpressionInPreStateKind.MethodPrecondition))
+            public BoxedExpression Ldconst(Expression pc, object constant, Type type, Dest dest, InvertComparison data)
             {
-              accessPath = context.ValueContext.VisibleAccessPathListFromPre(conditionPC, arrayLen);
+                Contract.Assume(!mdDecoder.Equal(type, mdDecoder.System_Int32) || constant is Int32);
+
+                return BoxedExpression.Const(constant, type, mdDecoder);
             }
-            if (accessPath == null && infoArray.kind.IsIncludedIn(ExpressionInPreStateKind.ObjectInvariant))
+
+            public BoxedExpression Ldnull(Expression pc, Dest dest, InvertComparison data)
             {
-              accessPath = context.ValueContext.AccessPathList(context.MethodContext.CFG.EntryAfterRequires, arrayLen, false, false);
-              info = new ExpressionInPreStateInfo(true, infoArray.hasVariables, false, ExpressionInPreStateKind.ObjectInvariant);
+                return BoxedExpression.Const(null, default(Type), mdDecoder);
             }
 
-            if (accessPath != null)
+            public BoxedExpression Sizeof(Expression pc, Type type, Dest dest, InvertComparison data)
             {
-              var arrayLength = BoxedExpression.Var(arrayLen, context.ValueContext.VisibleAccessPathListFromPre(conditionPC, arrayLen));
-
-              // Add the continuation
-              continuations.Add(
-                new Tuple<BoxedExpression, BoxedExpression, BoxedExpression>(boundVar, zero, arrayLength));
-
-              return new BoxedExpression.ArrayIndexExpression<Type>(newArrayExp, boundVar, type.IsNormal ? type.Value : mdDecoder.System_Object);
+                return ClousotExpression<Type>.MakeSizeOf(type, mdDecoder.TypeSize(type));
             }
-          }
 
-          info = null;
-          return null;
+            public BoxedExpression Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Expression source, InvertComparison data)
+            {
+                BoxedExpression arg = Recurse(source);
+                if (arg == null) return null;
+                return ClousotExpression<Type>.MakeUnary(op, arg);
+            }
+
+            public BoxedExpression Box(Expression pc, Type type, Dest dest, Expression source, InvertComparison data)
+            {
+                // TODO: once we have boxed expressions with Box, we can fill this in.
+                return null;
+            }
+
+            #endregion
         }
 
-        info = ExpressionInPreStateInfo.Combine(infoArray, infoIndex);
-        return new BoxedExpression.ArrayIndexExpression<Type>(newArrayExp, newIndexExp, (Type)t);
-      }
-      bool isForAll;
-      BoxedExpression boundExp, lowerBound, upperBound, body;
-      if (condition.IsQuantifiedExpression(out isForAll, out boundExp, out lowerBound, out upperBound, out body))
-      {
-        ExpressionInPreStateInfo infoLowerBound, infoUpperBound, infoBody;
-
-        boundVariables.Add(boundExp);
-
-        var newLowerBound = ExpressionInPreStateInternal(lowerBound, context, mdDecoder, out infoLowerBound, conditionPC, allowObjectInvariant, boundVariables);
-        if (newLowerBound == null) { info = null; return null; }
-
-        var newUpperBound = ExpressionInPreStateInternal(upperBound, context, mdDecoder, out infoUpperBound, conditionPC, allowObjectInvariant, boundVariables);
-        if (newUpperBound == null) { info = null; return null; }
-
-        var newBody = ExpressionInPreStateInternal(body, context, mdDecoder, out infoBody, conditionPC, allowObjectInvariant, boundVariables);
-        if (newBody == null) { info = null; return null; }
-
-        info = ExpressionInPreStateInfo.Combine(infoLowerBound, infoUpperBound, infoBody);
-        if (isForAll)
+        private class ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>
+            : IVisitValueExprIL<Expression, Type, Expression, Dest, InvertComparison, string>
+          where Type : IEquatable<Type>
         {
-          return new ForAllIndexedExpression(null, boundExp, newLowerBound, newUpperBound, newBody);
+            #region Object invariant
+            [ContractInvariantMethod]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(mdDecoder != null);
+                Contract.Invariant(context != null);
+            }
+            #endregion
+
+            private readonly APC AtPC;
+            private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+            private readonly IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context;
+            public bool HasVariables;
+
+            public ExpressionDecoder(
+              APC atPC,
+              IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Dest> context,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+            )
+            {
+                Contract.Requires(context != null);
+                Contract.Requires(mdDecoder != null);
+
+                AtPC = atPC;
+                this.context = context;
+                this.mdDecoder = mdDecoder;
+            }
+
+            #region IVisitValueExprIL<Label,Type,Source,Dest,StringBuilder,bool> Members
+
+            private string Recurse(Expression expr)
+            {
+                return Recurse(expr, InvertComparison.NoInversion);
+            }
+
+            private string Recurse(Expression expr, InvertComparison tryInvert)
+            {
+                return context.ExpressionContext.Decode<InvertComparison, string, ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, Dest, Attribute, Assembly>>(expr, this, tryInvert);
+            }
+
+            public string SymbolicConstant(Expression pc, Dest symbol, InvertComparison tryInvert)
+            {
+                HasVariables = true;
+                string path = context.ValueContext.AccessPath(AtPC, symbol);
+                return path;
+            }
+
+            public string Binary(Expression pc, BinaryOperator op, Dest dest, Expression s1, Expression s2, InvertComparison tryInvert)
+            {
+                Contract.Assume(tryInvert != null);
+
+                string left = Recurse(s1);
+                if (left == null) return null;
+                string right = Recurse(s2);
+                if (right == null) return null;
+                switch (op)
+                {
+                    case BinaryOperator.Add:
+                    case BinaryOperator.Add_Ovf:
+                    case BinaryOperator.Add_Ovf_Un:
+                        return String.Format("({0} + {1})", left, right);
+
+                    case BinaryOperator.And:
+                        return String.Format("({0} & {1})", left, right);
+
+                    case BinaryOperator.Ceq:
+                    case BinaryOperator.Cobjeq:
+                        if (right == "0")
+                        {
+                            InvertComparison tryInvert2 = new InvertComparison(true);
+                            string left2 = Recurse(s1, tryInvert2);
+                            if (tryInvert2.HasBeenInverted)
+                            {
+                                // We know that left is a comparison. If outer wanted us to invert too, we cancel it here
+                                if (tryInvert.TryInvertComparison)
+                                {
+                                    tryInvert.DischargeInversion();
+                                    return left;
+                                }
+                                return left2;
+                            }
+                        }
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return String.Format("({0} != {1})", left, right);
+                        }
+                        return String.Format("({0} == {1})", left, right);
+
+                    case BinaryOperator.Cge:
+                    case BinaryOperator.Cge_Un:
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return String.Format("({0} < {1})", left, right);
+                        }
+                        return String.Format("({0} >= {1})", left, right);
+
+                    case BinaryOperator.Cgt:
+                    case BinaryOperator.Cgt_Un:
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return String.Format("({0} <= {1})", left, right);
+                        }
+                        return String.Format("({0} > {1})", left, right);
+
+                    case BinaryOperator.Cle:
+                    case BinaryOperator.Cle_Un:
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return String.Format("({0} > {1})", left, right);
+                        }
+                        return String.Format("({0} <= {1})", left, right);
+
+                    case BinaryOperator.Clt:
+                    case BinaryOperator.Clt_Un:
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return String.Format("({0} >= {1})", left, right);
+                        }
+                        return String.Format("({0} < {1})", left, right);
+
+                    case BinaryOperator.Cne_Un:
+                        if (tryInvert.TryInvertComparison)
+                        {
+                            tryInvert.DischargeInversion();
+                            return String.Format("({0} == {1})", left, right);
+                        }
+                        return String.Format("({0} != {1})", left, right);
+
+                    case BinaryOperator.Div:
+                    case BinaryOperator.Div_Un:
+                        return String.Format("({0} / {1})", left, right);
+
+                    case BinaryOperator.Mul:
+                    case BinaryOperator.Mul_Ovf:
+                    case BinaryOperator.Mul_Ovf_Un:
+                        return String.Format("({0} * {1})", left, right);
+
+                    case BinaryOperator.Or:
+                        return String.Format("({0} | {1})", left, right);
+
+                    case BinaryOperator.Rem:
+                    case BinaryOperator.Rem_Un:
+                        return String.Format("({0} % {1})", left, right);
+
+                    case BinaryOperator.Shl:
+                        return String.Format("({0} << {1})", left, right);
+
+                    case BinaryOperator.Shr:
+                    case BinaryOperator.Shr_Un:
+                        return String.Format("({0} >> {1})", left, right);
+
+                    case BinaryOperator.Sub:
+                    case BinaryOperator.Sub_Ovf:
+                    case BinaryOperator.Sub_Ovf_Un:
+                        return String.Format("({0} - {1})", left, right);
+
+                    case BinaryOperator.Xor:
+                        return String.Format("({0} ^ {1})", left, right);
+
+                    default:
+                        throw new NotImplementedException("new binary operator?");
+                }
+            }
+
+            public string Isinst(Expression pc, Type type, Dest dest, Expression obj, InvertComparison data)
+            {
+                string arg = Recurse(obj);
+                if (arg == null) return null;
+                return String.Format("({0} as {1})", arg, mdDecoder.Name(type));
+            }
+
+            public string Ldconst(Expression pc, object constant, Type type, Dest dest, InvertComparison data)
+            {
+                return constant.ToString();
+            }
+
+            public string Ldnull(Expression pc, Dest dest, InvertComparison data)
+            {
+                return "null";
+            }
+
+            public string Sizeof(Expression pc, Type type, Dest dest, InvertComparison data)
+            {
+                return String.Format("sizeof({0})", mdDecoder.FullName(type));
+            }
+
+            [ContractVerification(true)]
+            public string Unary(Expression pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Expression source, InvertComparison data)
+            {
+                string arg = Recurse(source);
+                if (arg == null) return null;
+                switch (op)
+                {
+                    case UnaryOperator.Conv_i:
+                        return arg;
+
+                    case UnaryOperator.Conv_i1:
+                        return String.Format("(System.Int8){0}", arg);
+
+                    case UnaryOperator.Conv_i2:
+                        return String.Format("(System.Int16){0}", arg);
+
+                    case UnaryOperator.Conv_i4:
+                        return String.Format("(System.Int32){0}", arg);
+
+                    case UnaryOperator.Conv_i8:
+                        return String.Format("(System.Int64){0}", arg);
+
+                    case UnaryOperator.Conv_r_un:
+                        return arg;
+
+                    case UnaryOperator.Conv_r4:
+                        return String.Format("(System.Single){0}", arg);
+
+                    case UnaryOperator.Conv_r8:
+                        return String.Format("(System.Double){0}", arg);
+
+                    case UnaryOperator.Conv_u:
+                        return arg;
+
+                    case UnaryOperator.Conv_u1:
+                        return String.Format("(System.UInt8){0}", arg);
+
+                    case UnaryOperator.Conv_u2:
+                        return String.Format("(System.UInt16){0}", arg);
+
+                    case UnaryOperator.Conv_u4:
+                        return String.Format("(System.UInt32){0}", arg);
+
+                    case UnaryOperator.Conv_u8:
+                        return String.Format("(System.UInt64){0}", arg);
+
+                    case UnaryOperator.Neg:
+                        return String.Format("(-{0})", arg);
+
+                    case UnaryOperator.Not:
+                        return String.Format("(!{0})", arg);
+
+                    case UnaryOperator.WritableBytes:
+                        return String.Format("System.Diagnostics.Contracts.Contract.WritableBytes({0})", arg);
+
+                    default:
+                        return "<unknown unary operator?>";
+                        //Contract.Assert(false); // should be unreachable
+                        //throw new NotImplementedException("new unary operator?");
+                }
+            }
+
+            public string Box(Expression pc, Type type, Dest dest, Expression source, InvertComparison data)
+            {
+                string arg = Recurse(source);
+                if (arg == null) return null;
+                return String.Format("(box {0} to {1})", arg, mdDecoder.Name(type));
+            }
+
+            #endregion
         }
-        else
+
+        public static BoxedExpression ExpressionInPreState<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>
+          (
+          APC at,
+          Expression condition,
+          IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          out bool hasVariables
+        )
+          where Type : IEquatable<Type>
         {
-          return new ExistsIndexedExpression(null, boundExp, newLowerBound, newUpperBound, newBody);
+            var preTrans = new PreconditionTransformer<Local, Parameter, Method, Field, Property, Event, Expression, Type, SymbolicValue, Attribute, Assembly>(at, context, mdDecoder);
+
+            var result = preTrans.Recurse(condition);
+            hasVariables = preTrans.HasVariables;
+
+            return result;
         }
-      }
-      object testtype;
-      BoxedExpression test;
-      if (condition.IsIsInstExpression(out test, out testtype))
-      {
-        var rec = ExpressionInPreStateInternal(test, context, mdDecoder, out info, conditionPC, allowObjectInvariant, boundVariables);
-        if (rec == null)
+
+        /// <summary>
+        /// Computes a BoxedExpression with internal accesspaths that are valid in the pre-state of the
+        /// current method and these paths are "visible" according to the visibility rules of pre-conditions.
+        /// </summary>
+        /// <param name="hasVariables">true if expression contains any variables at all</param>
+        /// <param name="conditionPC">the pc at which the condition is being tested</param>
+        /// <returns>null if not expressible in pre-state</returns>    
+        public static ExpressionInPreState ExpressionInPreState<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
+          BoxedExpression condition,
+          IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          APC conditionPC,
+          ExpressionInPreStateKind allowedKinds
+        )
+          where Type : IEquatable<Type>
         {
-          info = null;
-          return null;
+            Contract.Requires(mdDecoder != null);
+
+            continuations = new List<Tuple<BoxedExpression, BoxedExpression, BoxedExpression>>();
+
+            ExpressionInPreStateInfo info;
+            var boundVariables = new Set<BoxedExpression>();
+
+            var allowObjectInvariants = ExpressionInPreStateKind.ObjectInvariant.IsIncludedIn(allowedKinds) && !mdDecoder.IsConstructor(context.MethodContext.CurrentMethod);
+
+            var result = ExpressionInPreStateInternal(condition, context, mdDecoder, out info, conditionPC, allowObjectInvariants, boundVariables);
+
+            if (result != null && continuations.Count > 0)
+            {
+                result = ApplyExistential(result);
+            }
+
+            continuations = null;
+
+            if (info != null && info.kind.IsIncludedIn(allowedKinds))
+            {
+                return result == null ? null : new ExpressionInPreState(result, info);
+            }
+            return null;
         }
-        return ClousotExpression<Type>.MakeIsInst((Type)testtype, rec);
-      }
 
-      info = null;
-      return null;
+        private static class BoxedExpressionsUtils // taken from BoxedExpressionsUtils, TODO: solve dependencies
+        {
+            public static List<BoxedExpression> SplitConjunctions(BoxedExpression be)
+            {
+                Contract.Requires(be != null);
+                Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
+
+                var result = new List<BoxedExpression>();
+                return SplitConjunctionsHelper(be, result);
+            }
+            private static List<BoxedExpression> SplitConjunctionsHelper(BoxedExpression be, List<BoxedExpression> result)
+            {
+                Contract.Requires(be != null);
+                Contract.Requires(result != null);
+                Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
+
+                if (be.IsBinary && be.BinaryOp == BinaryOperator.LogicalAnd)
+                {
+                    result = SplitConjunctionsHelper(be.BinaryRight, SplitConjunctionsHelper(be.BinaryLeft, result));
+                }
+                else
+                {
+                    result.Add(be);
+                }
+
+                return result;
+            }
+        }
+
+        public static IEnumerable<ExpressionInPreState> ExpressionsInPreState<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
+          BoxedExpression condition,
+          IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          APC conditionPC,
+          ExpressionInPreStateKind allowedKinds
+        )
+          where Type : IEquatable<Type>
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<ExpressionInPreState>>() == null || Contract.ForAll(Contract.Result<IEnumerable<ExpressionInPreState>>(), e => e != null));
+
+            foreach (var subCondition in BoxedExpressionsUtils.SplitConjunctions(condition))
+            {
+                if (subCondition == null)
+                    continue;
+                var result = ExpressionInPreState(subCondition, context, mdDecoder, conditionPC, allowedKinds);
+                if (result == null)
+                    continue;
+                yield return result;
+            }
+        }
+
+        private static BoxedExpression ApplyExistential(BoxedExpression result)
+        {
+            Contract.Requires(result != null);
+            Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+            foreach (var triple in continuations)
+            {
+                Contract.Assume(triple.Item1 != null);
+                Contract.Assume(triple.Item2 != null);
+                Contract.Assume(triple.Item3 != null);
+                result = new ExistsIndexedExpression(null, triple.Item1, triple.Item2, triple.Item3, result);
+            }
+
+            return result;
+        }
+
+        [ThreadStatic]
+        private static List<Tuple<BoxedExpression, BoxedExpression, BoxedExpression>> continuations;
+
+        [ContractVerification(false)]
+        private static BoxedExpression ExpressionInPreStateInternal<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
+          BoxedExpression condition,
+          IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          out ExpressionInPreStateInfo info,
+          APC conditionPC,
+          bool allowObjectInvariant, // only false if current method is a constructor!
+          Set<BoxedExpression> boundVariables
+        )
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(boundVariables != null);
+
+            if (boundVariables.Contains(condition))
+            {
+                Contract.Assume(condition != null);
+                info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any);
+                return condition;
+            }
+
+            if (condition.IsVariable)
+            {
+                // Special case as we may have some slack variable
+                SymbolicValue var;
+                if (!condition.TryGetFrameworkVariable(out var))
+                {
+                    info = null;
+                    return null;
+                }
+
+                // First check if we've got a constant
+                Type type;
+                object value;
+                if (context.ValueContext.IsConstant(conditionPC, var, out type, out value))
+                {
+                    info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any);
+                    return BoxedExpression.Const(value, type, mdDecoder);
+                }
+
+                var isConstructor = mdDecoder.IsConstructor(context.MethodContext.CurrentMethod);
+
+                FList<PathElement> accessPath;
+                #region Try to generate a precondition
+                accessPath = context.ValueContext.VisibleAccessPathListFromPre(conditionPC, var); // ConditionPC okay here, because this also checks that the path is unmodified
+                var headIsThis = accessPath != null ? accessPath.Head.ToString() == "this" : false;
+
+                if (accessPath != null
+                  && (!isConstructor || !headIsThis))
+                {
+                    var resultKind = headIsThis ? ExpressionInPreStateKind.Any : ExpressionInPreStateKind.MethodPrecondition;
+                    var hasOnlyImmutableVariables = accessPath.Length() == 1 || condition.IsArrayLength(conditionPC, context, mdDecoder);
+
+                    info = new ExpressionInPreStateInfo(accessPath.Length() > 1, true, hasOnlyImmutableVariables, resultKind);
+                    return BoxedExpression.Var(var, accessPath);
+                }
+                #endregion
+
+                #region Try to generate an Assume or an Object Invariant
+
+                accessPath = context.ValueContext.AccessPathList(conditionPC, var, false, false);
+                if (accessPath != null && !conditionPC.Equals(context.MethodContext.CFG.EntryAfterRequires))
+                {
+                    // check that path is unmodified since entry
+                    if (!context.ValueContext.PathUnmodifiedSinceEntry(conditionPC, accessPath))
+                    {
+                        accessPath = null; // can't use it
+                    }
+                }
+                if (accessPath != null
+                  && accessPath.Head.IsParameter
+                  && accessPath.Head.ToString() == "this"
+                  && context.ValueContext.PathSuitableInRequires(conditionPC, accessPath))
+                {
+                    var isReadOnly = mdDecoder.IsReadOnly(accessPath);
+
+                    if (!isConstructor && isReadOnly && allowObjectInvariant)
+                    {
+                        var kind = ExpressionInPreStateKind.ObjectInvariant;
+
+                        info = new ExpressionInPreStateInfo(accessPath.Length() > 1, true, false, kind);
+                        return BoxedExpression.Var(var, accessPath);
+                    }
+                }
+
+                #endregion
+
+                #region Try to generate any kind of entry assumption
+                //accessPath = context.ValueContext.AccessPathList(conditionPC, var, false, false);
+
+                if (accessPath != null
+                  && (!isConstructor || accessPath.Head.ToString() != "this"))
+                {
+                    var hasOnlyImmutableVariables = accessPath.Length() == 1 || condition.IsArrayLength(conditionPC, context, mdDecoder);
+
+                    info = new ExpressionInPreStateInfo(accessPath.Length() > 1, true, hasOnlyImmutableVariables, ExpressionInPreStateKind.Assume);
+                    return BoxedExpression.Var(var, accessPath);
+                }
+                #endregion
+
+                info = null;
+                return null;
+            }
+            if (condition.IsConstant || condition.IsNull)
+            {
+                // no nested variables
+                Contract.Assume(!mdDecoder.Equal((Type)condition.ConstantType, mdDecoder.System_Int32) || condition.Constant is Int32);
+                info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any, true);
+                return BoxedExpression.Const(condition.Constant, (Type)condition.ConstantType, mdDecoder);
+            }
+            if (condition.IsSizeOf)
+            {
+                int size;
+                object type;
+                condition.SizeOf(out type, out size);
+                info = new ExpressionInPreStateInfo(ExpressionInPreStateKind.Any);
+                return BoxedExpression.SizeOf((Type)type, size);
+            }
+            if (condition.IsUnary)
+            {
+                // Recurse
+                var arg = ExpressionInPreStateInternal(condition.UnaryArgument, context, mdDecoder, out info, conditionPC, allowObjectInvariant, boundVariables);
+                if (arg != null)
+                {
+                    return BoxedExpression.Unary(condition.UnaryOp, arg);
+                }
+                return null;
+            }
+            if (condition.IsBinary)
+            {
+                ExpressionInPreStateInfo infoLeft, infoRight;
+                // Recurse
+                var left = ExpressionInPreStateInternal(condition.BinaryLeft, context, mdDecoder, out infoLeft, conditionPC, allowObjectInvariant, boundVariables);
+                if (left == null) { info = null; return null; }
+
+                var right = ExpressionInPreStateInternal(condition.BinaryRight, context, mdDecoder, out infoRight, conditionPC, allowObjectInvariant, boundVariables);
+                if (right == null) { info = null; return null; }
+
+                info = ExpressionInPreStateInfo.Combine(infoLeft, infoRight);
+                return BoxedExpression.Binary(condition.BinaryOp, left, right);
+            }
+
+            BoxedExpression arrayExp, indexExp;
+            object t;
+            if (condition.IsArrayIndexExpression(out arrayExp, out indexExp, out t) && t is Type)
+            {
+                ExpressionInPreStateInfo infoArray, infoIndex;
+
+                var newArrayExp = ExpressionInPreStateInternal(arrayExp, context, mdDecoder, out infoArray, conditionPC, allowObjectInvariant, boundVariables);
+                if (newArrayExp == null) { info = null; return null; }
+
+                var newIndexExp = ExpressionInPreStateInternal(indexExp, context, mdDecoder, out infoIndex, conditionPC, allowObjectInvariant, boundVariables);
+                if (newIndexExp == null)
+                {
+                    // try to introduce the exists
+
+                    SymbolicValue arrayVar, arrayLen;
+                    if (newArrayExp.TryGetFrameworkVariable(out arrayVar)
+                      && context.ValueContext.TryGetArrayLength(conditionPC, arrayVar, out arrayLen))
+                    {
+                        var type = context.ValueContext.GetType(conditionPC, arrayVar);
+
+                        var boundVar = BoxedExpression.Var(string.Format("__j{0}__", continuations.Count));
+                        var zero = BoxedExpression.Const(0, mdDecoder.System_Int32, mdDecoder);
+
+                        // TODO: the info kind computation does not seem general enough here [MAF 3/23/13]
+
+                        info = new ExpressionInPreStateInfo(true, infoArray.hasVariables, false, ExpressionInPreStateKind.MethodPrecondition);
+                        FList<PathElement> accessPath = null;
+                        if (infoArray.kind.IsIncludedIn(ExpressionInPreStateKind.MethodPrecondition))
+                        {
+                            accessPath = context.ValueContext.VisibleAccessPathListFromPre(conditionPC, arrayLen);
+                        }
+                        if (accessPath == null && infoArray.kind.IsIncludedIn(ExpressionInPreStateKind.ObjectInvariant))
+                        {
+                            accessPath = context.ValueContext.AccessPathList(context.MethodContext.CFG.EntryAfterRequires, arrayLen, false, false);
+                            info = new ExpressionInPreStateInfo(true, infoArray.hasVariables, false, ExpressionInPreStateKind.ObjectInvariant);
+                        }
+
+                        if (accessPath != null)
+                        {
+                            var arrayLength = BoxedExpression.Var(arrayLen, context.ValueContext.VisibleAccessPathListFromPre(conditionPC, arrayLen));
+
+                            // Add the continuation
+                            continuations.Add(
+                              new Tuple<BoxedExpression, BoxedExpression, BoxedExpression>(boundVar, zero, arrayLength));
+
+                            return new BoxedExpression.ArrayIndexExpression<Type>(newArrayExp, boundVar, type.IsNormal ? type.Value : mdDecoder.System_Object);
+                        }
+                    }
+
+                    info = null;
+                    return null;
+                }
+
+                info = ExpressionInPreStateInfo.Combine(infoArray, infoIndex);
+                return new BoxedExpression.ArrayIndexExpression<Type>(newArrayExp, newIndexExp, (Type)t);
+            }
+            bool isForAll;
+            BoxedExpression boundExp, lowerBound, upperBound, body;
+            if (condition.IsQuantifiedExpression(out isForAll, out boundExp, out lowerBound, out upperBound, out body))
+            {
+                ExpressionInPreStateInfo infoLowerBound, infoUpperBound, infoBody;
+
+                boundVariables.Add(boundExp);
+
+                var newLowerBound = ExpressionInPreStateInternal(lowerBound, context, mdDecoder, out infoLowerBound, conditionPC, allowObjectInvariant, boundVariables);
+                if (newLowerBound == null) { info = null; return null; }
+
+                var newUpperBound = ExpressionInPreStateInternal(upperBound, context, mdDecoder, out infoUpperBound, conditionPC, allowObjectInvariant, boundVariables);
+                if (newUpperBound == null) { info = null; return null; }
+
+                var newBody = ExpressionInPreStateInternal(body, context, mdDecoder, out infoBody, conditionPC, allowObjectInvariant, boundVariables);
+                if (newBody == null) { info = null; return null; }
+
+                info = ExpressionInPreStateInfo.Combine(infoLowerBound, infoUpperBound, infoBody);
+                if (isForAll)
+                {
+                    return new ForAllIndexedExpression(null, boundExp, newLowerBound, newUpperBound, newBody);
+                }
+                else
+                {
+                    return new ExistsIndexedExpression(null, boundExp, newLowerBound, newUpperBound, newBody);
+                }
+            }
+            object testtype;
+            BoxedExpression test;
+            if (condition.IsIsInstExpression(out test, out testtype))
+            {
+                var rec = ExpressionInPreStateInternal(test, context, mdDecoder, out info, conditionPC, allowObjectInvariant, boundVariables);
+                if (rec == null)
+                {
+                    info = null;
+                    return null;
+                }
+                return ClousotExpression<Type>.MakeIsInst((Type)testtype, rec);
+            }
+
+            info = null;
+            return null;
+        }
+
+
+        public static string/*?*/ ConditionAsPrecondition<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
+          Expression condition,
+          IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          out bool hasVariables,
+          SourceLanguage slang
+        )
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(context != null);
+            Contract.Requires(mdDecoder != null);
+
+            return ConditionAsStringAtPC(context.MethodContext.CFG.EntryAfterRequires, condition, context, mdDecoder, out hasVariables, slang);
+        }
+
+        public static string/*?*/ ConditionAsStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
+          APC atPC,
+          Expression condition,
+          IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          out bool hasVariables,
+          SourceLanguage slang
+        )
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(context != null);
+            Contract.Requires(mdDecoder != null);
+
+            var decoder =
+              new ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, SymbolicValue, Attribute, Assembly>(atPC, context, mdDecoder);
+
+            string result = context.ExpressionContext.Decode<InvertComparison, string, ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, SymbolicValue, Attribute, Assembly>>(condition, decoder, InvertComparison.NoInversion);
+
+            hasVariables = decoder.HasVariables;
+            return result;
+        }
     }
-
-
-    public static string/*?*/ ConditionAsPrecondition<Label, Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
-      Expression condition,
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      out bool hasVariables,
-      SourceLanguage slang
-    )
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(context != null);
-      Contract.Requires(mdDecoder != null);
-
-      return ConditionAsStringAtPC(context.MethodContext.CFG.EntryAfterRequires, condition, context, mdDecoder, out hasVariables, slang);
-    }
-
-    public static string/*?*/ ConditionAsStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, SymbolicValue, Expression, Attribute, Assembly>(
-      APC atPC,
-      Expression condition,
-      IExpressionContext<Local, Parameter, Method, Field, Type, Expression, SymbolicValue> context,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      out bool hasVariables,
-      SourceLanguage slang
-    )
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(context != null);
-      Contract.Requires(mdDecoder != null);
-
-      var decoder =
-        new ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, SymbolicValue, Attribute, Assembly>(atPC, context, mdDecoder);
-
-      string result = context.ExpressionContext.Decode<InvertComparison, string, ExpressionDecoder<Local, Parameter, Method, Field, Property, Event, Expression, Type, SymbolicValue, Attribute, Assembly>>(condition, decoder, InvertComparison.NoInversion);
-
-      hasVariables = decoder.HasVariables;
-      return result;
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/ProofObligation.cs
+++ b/Microsoft.Research/CodeAnalysis/ProofObligation.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,268 +9,266 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using Provenance = IEnumerable<ProofObligation>;
+    using Provenance = IEnumerable<ProofObligation>;
 
-  [ContractClass(typeof(ProofObligationContracts))]
-  [ContractVerification(true)]
-  public abstract class ProofObligation
-  {
-    #region Statics
+    [ContractClass(typeof(ProofObligationContracts))]
+    [ContractVerification(true)]
+    public abstract class ProofObligation
+    {
+        #region Statics
 
-    static private uint nextID = 0;
+        static private uint nextID = 0;
+
+        #endregion
+
+        #region Statistics
+
+        public static int ProofObligationsWithCodeFix { get; private set; }
+
+        #endregion
+
+        #region State & invariant
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(this.codeFixes != null);
+        }
+
+        public readonly uint ID;
+        protected readonly List<ICodeFix> codeFixes;
+        private bool hasCodeFix;
+        private bool hasSufficientAndNecessaryCondition;
+        public readonly Provenance Provenance; // can be null
+        public readonly string definingMethod; // can be null
+
+        #endregion
+
+        #region Constructor
+
+        public ProofObligation(APC pc, string definingMethod, Provenance provenance)
+        {
+            this.PC = pc;
+            this.definingMethod = definingMethod; // can be null 
+            this.codeFixes = new List<ICodeFix>();
+            hasCodeFix = false;
+            hasSufficientAndNecessaryCondition = false;
+            this.ID = nextID++;
+            this.Provenance = provenance;
+        }
+
+        #endregion
+
+        #region Public surface
+
+        public readonly APC PC;
+
+        protected IEnumerable<IInferredCondition> SufficientPreconditions { private set; get; }
+
+        public void NotifySufficientYetNotNecessaryPreconditions(IEnumerable<IInferredCondition> sufficientPreconditions)
+        {
+            if (sufficientPreconditions != null && sufficientPreconditions.Any())
+            {
+                this.SufficientPreconditions = sufficientPreconditions;
+            }
+        }
+
+        public void AddCodeFix(ICodeFix codeFix)
+        {
+            Contract.Requires(codeFix != null);
+
+            if (!hasCodeFix)
+            {
+                hasCodeFix = true;
+                ProofObligationsWithCodeFix++;
+            }
+
+            this.codeFixes.Add(codeFix);
+        }
+
+        public IEnumerable<ICodeFix> CodeFixes
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<ICodeFix>>() != null);
+
+                return this.codeFixes;
+            }
+        }
+
+        public int CodeFixCount { get { return this.codeFixes.Count; } }
+        public bool HasCodeFix { get { return this.CodeFixCount != 0; } }
+        public bool HasASufficientAndNecessaryCondition
+        {
+            get
+            {
+                return hasSufficientAndNecessaryCondition;
+            }
+            set
+            {
+                Contract.Assume(!hasSufficientAndNecessaryCondition || value == true);
+                hasSufficientAndNecessaryCondition = value;
+            }
+        }
+
+        public bool InferredConditionContainsOnlyEnumValues { get; set; } // default: false
+
+        public bool IsFromThrowInstruction { get; set; } // default: false
+
+        public MinimalProofObligation MinimalProofObligation
+        {
+            get
+            {
+                return new MinimalProofObligation(this.PC, this.definingMethod, this.ConditionForPreconditionInference, this.ObligationName, this.Provenance, this.IsFromThrowInstruction);
+            }
+        }
+
+        #endregion
+
+        #region Client contracts
+
+        /// <summary>
+        /// Returns an expression standing for the condition encoded by this proof obligation.
+        /// Can be null if the condition is not expressible as a BoxedExpression
+        /// </summary>
+        public abstract BoxedExpression Condition { get; }
+
+        /// <summary>
+        /// Sometimes we may need to know which kind of proof obligation it is 
+        /// </summary>
+        public abstract string ObligationName { get; }
+
+        /// <summary>
+        /// Returns an expression that shall be used for inferring a precondition or a code fix.
+        /// In general it is the same as this.Condition, but some proof obligations can be smarter, and ask a different condition 
+        /// Can be null if the condition is not expressible as a BoxedExpression.
+        /// </summary>
+        public virtual BoxedExpression ConditionForPreconditionInference { get { return this.Condition; } }
+
+        public virtual APC PCForValidation { get { return this.PC; } }
+
+        public virtual bool IsEmpty { get { return false; } }
+
+        #endregion
+    }
+
+    #region Contracts for ProofObligation
+
+    [ContractClassFor(typeof(ProofObligation))]
+    internal abstract class ProofObligationContracts : ProofObligation
+    {
+        // dummy
+        public ProofObligationContracts()
+          : base(default(APC), null, null)
+        {
+        }
+
+        public override BoxedExpression Condition
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override string ObligationName
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<string>() != null);
+
+                return null;
+            }
+        }
+    }
 
     #endregion
 
-    #region Statistics
-
-    public static int ProofObligationsWithCodeFix { get; private set; }
-    
-    #endregion
-
-    #region State & invariant
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
+    public class EmptyProofObligation : ProofObligation
     {
-      Contract.Invariant(this.codeFixes != null);
+        public EmptyProofObligation(APC pc)
+          : base(pc, null, null)
+        {
+        }
+
+        public override bool IsEmpty
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public override BoxedExpression Condition
+        {
+            get { return null; }
+        }
+
+        public override string ObligationName
+        {
+            get { return "Empty"; }
+        }
     }
 
-    public readonly uint ID;
-    protected readonly List<ICodeFix> codeFixes;
-    private bool hasCodeFix;
-    private bool hasSufficientAndNecessaryCondition;
-    public readonly Provenance Provenance; // can be null
-    public readonly string definingMethod; // can be null
-
-    #endregion
-
-    #region Constructor
-
-    public ProofObligation(APC pc, string definingMethod, Provenance provenance)
+    public class MinimalProofObligation : ProofObligation
     {
-      this.PC = pc;
-      this.definingMethod = definingMethod; // can be null 
-      this.codeFixes = new List<ICodeFix>();
-      this.hasCodeFix = false;
-      this.hasSufficientAndNecessaryCondition = false;
-      this.ID = nextID++;
-      this.Provenance = provenance;
+        public const string InferredForwardObjectInvariant = "inferred forward object invariant";
+
+        private readonly BoxedExpression condition;
+        private readonly string obligationName;
+
+        [ContractVerification(false)]
+        public MinimalProofObligation(APC pc, string definingMethod, BoxedExpression condition, string obligationName, Provenance provenance, bool isFromThrowInstruction)
+          : base(pc, definingMethod, provenance)
+        {
+            Contract.Requires(obligationName != null);
+            //      Contract.Requires(definingMethod != null);
+
+            this.condition = condition;
+            this.obligationName = obligationName;
+            this.IsFromThrowInstruction = isFromThrowInstruction;
+        }
+
+        public static MinimalProofObligation GetFreshObligationForBoxingForwardObjectInvariant<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(APC entry, string methodName, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(methodName != null);
+            Contract.Requires(mdDecoder != null);
+            Contract.Ensures(Contract.Result<MinimalProofObligation>() != null);
+
+            return new MinimalProofObligation(entry, methodName, BoxedExpression.ConstBool(true, mdDecoder), MinimalProofObligation.InferredForwardObjectInvariant, null, false);
+        }
+
+        public override BoxedExpression Condition
+        {
+            get { return condition; }
+        }
+
+        public override string ObligationName
+        {
+            get { return obligationName; }
+        }
     }
 
-    #endregion
-
-    #region Public surface
-
-    public readonly APC PC;
-
-    protected IEnumerable<IInferredCondition> SufficientPreconditions { private set; get; }
-
-    public void NotifySufficientYetNotNecessaryPreconditions(IEnumerable<IInferredCondition> sufficientPreconditions)
+    public class FakeProofObligationForAssertionFromTheCache : ProofObligation
     {
-      if(sufficientPreconditions != null && sufficientPreconditions.Any())
-      {
-        this.SufficientPreconditions = sufficientPreconditions;
-      }
+        private readonly BoxedExpression condition;
+        public object Method { get; private set; }
+
+        public FakeProofObligationForAssertionFromTheCache(BoxedExpression condition, string definingMethod, object method)
+          : base(APC.Dummy, definingMethod, null)
+        {
+            Contract.Requires(condition != null);
+            // method can be null
+
+            this.condition = condition;
+            this.Method = method;
+        }
+
+        public override BoxedExpression Condition
+        {
+            get { return condition; }
+        }
+
+        public override string ObligationName
+        {
+            get { return "<fake proof obligation for inferred contract read from the cache>"; }
+        }
     }
-
-    public void AddCodeFix(ICodeFix codeFix)
-    {
-      Contract.Requires(codeFix != null);
-
-      if (!this.hasCodeFix)
-      {
-        this.hasCodeFix = true;
-        ProofObligationsWithCodeFix++;
-      }
-
-      this.codeFixes.Add(codeFix);
-    }
-
-    public IEnumerable<ICodeFix> CodeFixes
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<ICodeFix>>() != null);
-
-        return this.codeFixes;
-      }
-    }
-
-    public int CodeFixCount { get { return this.codeFixes.Count; } }
-    public bool HasCodeFix { get { return this.CodeFixCount != 0; } }
-    public bool HasASufficientAndNecessaryCondition
-    {
-      get
-      {
-        return this.hasSufficientAndNecessaryCondition;
-      }
-      set
-      {
-        Contract.Assume(!this.hasSufficientAndNecessaryCondition || value == true);
-        this.hasSufficientAndNecessaryCondition = value;
-      }
-    }
-
-    public bool InferredConditionContainsOnlyEnumValues { get; set; } // default: false
-
-    public bool IsFromThrowInstruction { get; set; } // default: false
-
-    public MinimalProofObligation MinimalProofObligation 
-    { 
-      get 
-      { 
-        return new MinimalProofObligation(this.PC, this.definingMethod, this.ConditionForPreconditionInference, this.ObligationName, this.Provenance, this.IsFromThrowInstruction); 
-      } 
-    }
-
-    #endregion
-
-    #region Client contracts
-
-    /// <summary>
-    /// Returns an expression standing for the condition encoded by this proof obligation.
-    /// Can be null if the condition is not expressible as a BoxedExpression
-    /// </summary>
-    public abstract BoxedExpression Condition { get; }
-
-    /// <summary>
-    /// Sometimes we may need to know which kind of proof obligation it is 
-    /// </summary>
-    public abstract string ObligationName { get; }
-
-    /// <summary>
-    /// Returns an expression that shall be used for inferring a precondition or a code fix.
-    /// In general it is the same as this.Condition, but some proof obligations can be smarter, and ask a different condition 
-    /// Can be null if the condition is not expressible as a BoxedExpression.
-    /// </summary>
-    public virtual BoxedExpression ConditionForPreconditionInference { get { return this.Condition; } }
-
-    public virtual APC PCForValidation { get { return this.PC; } }
-
-    public virtual bool IsEmpty { get { return false;} }
- 
-    #endregion
-
-  }
-
-  #region Contracts for ProofObligation
-
-  [ContractClassFor(typeof(ProofObligation))]
-  abstract class ProofObligationContracts : ProofObligation
-  {
-    // dummy
-    public ProofObligationContracts()
-      : base(default(APC), null, null)
-    {
-    }
-
-    public override BoxedExpression Condition
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override string ObligationName
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<string>() != null);
-
-        return null;
-      }
-    }
-  }
-
-  #endregion
-
-  public class EmptyProofObligation : ProofObligation
-  {
-    public EmptyProofObligation(APC pc)
-      : base(pc, null, null)
-    {
-    }
-
-    public override bool IsEmpty
-    {
-      get
-      {
-        return true ;
-      }
-    }
-
-    public override BoxedExpression Condition
-    {
-      get { return null; }
-    }
-
-    public override string ObligationName
-    {
-      get { return "Empty"; }
-    }
-  }
-
-  public class MinimalProofObligation : ProofObligation
-  {
-    public const string InferredForwardObjectInvariant = "inferred forward object invariant";
-
-    private readonly BoxedExpression condition;
-    private readonly string obligationName;
-
-    [ContractVerification(false)]
-    public MinimalProofObligation(APC pc, string definingMethod, BoxedExpression condition, string obligationName, Provenance provenance, bool isFromThrowInstruction)
-      : base(pc, definingMethod, provenance)
-    {
-      Contract.Requires(obligationName != null);
-//      Contract.Requires(definingMethod != null);
-
-      this.condition = condition;
-      this.obligationName = obligationName;
-      this.IsFromThrowInstruction = isFromThrowInstruction;
-    }
-
-    public static MinimalProofObligation GetFreshObligationForBoxingForwardObjectInvariant<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(APC entry, string methodName, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Requires(methodName != null);
-      Contract.Requires(mdDecoder != null);
-      Contract.Ensures(Contract.Result<MinimalProofObligation>() != null);
-
-      return new MinimalProofObligation(entry, methodName, BoxedExpression.ConstBool(true, mdDecoder), MinimalProofObligation.InferredForwardObjectInvariant, null, false);
-    }
-
-    public override BoxedExpression Condition
-    {
-      get { return this.condition; }
-    }
-
-    public override string ObligationName
-    {
-      get { return this.obligationName; }
-    }
-  }
-
-  public class FakeProofObligationForAssertionFromTheCache : ProofObligation
-  {
-    private readonly BoxedExpression condition;
-    public object Method { get; private set; }
-
-    public FakeProofObligationForAssertionFromTheCache(BoxedExpression condition, string definingMethod, object method)
-      : base(APC.Dummy, definingMethod, null)
-    {
-      Contract.Requires(condition != null);
-      // method can be null
-
-      this.condition = condition;
-      this.Method = method;
-    }
-
-    public override BoxedExpression Condition
-    {
-      get { return this.condition; }
-    }
-
-    public override string ObligationName
-    {
-      get { return "<fake proof obligation for inferred contract read from the cache>"; }
-    }
-  }
-
 }

--- a/Microsoft.Research/CodeAnalysis/Quantifiers.cs
+++ b/Microsoft.Research/CodeAnalysis/Quantifiers.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using Microsoft.Research.DataStructures;
@@ -19,1156 +8,1158 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
-  using SubroutineEdge = STuple<CFGBlock, CFGBlock, string>;
+    using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
+    using SubroutineEdge = STuple<CFGBlock, CFGBlock, string>;
 
-  public static class Quantifiers
-  {
-     internal enum Quantifier { ForAll = 0, Exists = 1 }
-
-    public static ForAllIndexedExpression AsForAllIndexed<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(
-      this IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver,
-      APC pc, 
-      SymbolicValue value)
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
-      where Expression : IEquatable<Expression>
+    public static class Quantifiers
     {
-      var qd = new QuantifierDecompiler<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(driver);
-      return qd.AsQuantifiedIndexed(Quantifier.ForAll, pc, value) as ForAllIndexedExpression;
-    }
+        internal enum Quantifier { ForAll = 0, Exists = 1 }
 
-    public static ExistsIndexedExpression AsExistsIndexed<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(
-      this IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver,
-      APC pc,
-      SymbolicValue value)
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
-      where Expression : IEquatable<Expression>
-    {
-      var qd = new QuantifierDecompiler<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(driver);
-      return qd.AsQuantifiedIndexed(Quantifier.Exists, pc, value) as ExistsIndexedExpression;
-    }
+        public static ForAllIndexedExpression AsForAllIndexed<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(
+          this IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver,
+          APC pc,
+          SymbolicValue value)
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
+          where Expression : IEquatable<Expression>
+        {
+            var qd = new QuantifierDecompiler<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(driver);
+            return qd.AsQuantifiedIndexed(Quantifier.ForAll, pc, value) as ForAllIndexedExpression;
+        }
 
-    internal class QuantifierDecompiler<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>
-      : IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, BoxedExpression>
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
-      where Expression : IEquatable<Expression>
-    {
-      enum TypeName { Contract = 0, Enumerable = 1, Array = 2 }
+        public static ExistsIndexedExpression AsExistsIndexed<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(
+          this IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver,
+          APC pc,
+          SymbolicValue value)
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
+          where Expression : IEquatable<Expression>
+        {
+            var qd = new QuantifierDecompiler<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>(driver);
+            return qd.AsQuantifiedIndexed(Quantifier.Exists, pc, value) as ExistsIndexedExpression;
+        }
 
-                        // T
-      private static readonly string[,] NameTable = { 
+        internal class QuantifierDecompiler<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions>
+          : IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, BoxedExpression>
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
+          where Expression : IEquatable<Expression>
+        {
+            private enum TypeName { Contract = 0, Enumerable = 1, Array = 2 }
+
+            // T
+            private static readonly string[,] NameTable = { 
                                      // Contract  Enumerable     Array
                      /* ForAll */      {"ForAll",   "All",     "TrueForAll"},
                      /* Exist */       {"Exists",   "Any",     "Exists"}
                                     };
 
-      IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver;
-      SymbolicValue targetObject;
-      APC contractPC;
-      private BoxedExpression boundVariable;
+            private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver;
+            private SymbolicValue targetObject;
+            private APC contractPC;
+            private BoxedExpression boundVariable;
 
-      public QuantifierDecompiler(
-        IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver
-        )
-      {
-        this.driver = driver;
-      }      
-
-      [ContractVerification(true)]
-      internal QuantifiedIndexedExpression AsQuantifiedIndexed(Quantifier quantifier, APC pc, SymbolicValue value)
-      {
-        var MetaDataDecoder = driver.RawLayer.MetaDataDecoder;
-        Method method;
-        SymbolicValue[] args;
-        this.contractPC = pc;
-        if (!driver.Context.ValueContext.IsPureFunctionCall(pc, value, out method, out args)) return null;
-        var methodName = MetaDataDecoder.Name(method);
-        var typeName = MetaDataDecoder.Name(MetaDataDecoder.DeclaringType(method));
-        if (args.Length == 2) {
-
-          if (methodName == NameTable[(int)quantifier,0] && typeName == "Contract" 
-            || methodName == NameTable[(int)quantifier, 1] && typeName == "Enumerable")
-          {
-            Method forallBody;
-            if (!driver.Context.ValueContext.IsDelegateValue(pc, args[1], out this.targetObject, out forallBody)) return null;
-            var boundParameters = MetaDataDecoder.Parameters(forallBody);
-            Contract.Assume(boundParameters.Count == 1, "should be ensured by ForAll/Exists type");
-            var boundParameter = boundParameters[0];
-            var boundParameterType = MetaDataDecoder.ParameterType(boundParameter);
-            forallBody = MetaDataDecoder.Unspecialized(forallBody);
-            if (!MetaDataDecoder.HasBody(forallBody)) return null;
-            // find enumerable (arg to forall is enumerable object version)
-            SymbolicValue enumerable;
-            if (!driver.Context.ValueContext.TryGetObjectFromObjectVersion(pc, args[0], out enumerable)) return null;
-            // find model array in enumerable
-            var enumerableType = driver.Context.ValueContext.GetType(pc, enumerable);
-            SymbolicValue modelArray;
-            if (enumerableType.IsNormal && MetaDataDecoder.IsArray(enumerableType.Value))
+            public QuantifierDecompiler(
+              IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver
+              )
             {
-              modelArray = enumerable; // itself
+                this.driver = driver;
             }
-            else
+
+            [ContractVerification(true)]
+            internal QuantifiedIndexedExpression AsQuantifiedIndexed(Quantifier quantifier, APC pc, SymbolicValue value)
             {
-              if (!driver.Context.ValueContext.TryGetModelArray(pc, enumerable, out modelArray)) return null;
-            }
-            SymbolicValue arrayLen;
-            if (!driver.Context.ValueContext.TryGetArrayLength(pc, modelArray, out arrayLen)) return null;
-            // bound variable is array index
-            var index = BoxedExpression.Var("i", null, MetaDataDecoder.System_Int32);
-            var arrayBox = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, modelArray), driver.ExpressionDecoder);
-            if (arrayBox != null)
-            {
-              this.boundVariable = BoxedExpression.ArrayIndex<Type>(arrayBox, index, boundParameterType);
-              var bodyDecoded = MetaDataDecoder.AccessMethodBody(forallBody, this, Unit.Value);
-              if (bodyDecoded == null) return null;
-              var lowerBound = BoxedExpression.Const(0, MetaDataDecoder.System_Int32, MetaDataDecoder);
-              var upperBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, arrayLen), driver.ExpressionDecoder);
-
-              if (/*lowerBound != null && */ upperBound != null)
-              {
-                return MakeQuantifierExpression(value, quantifier, index, lowerBound, upperBound, bodyDecoded);
-              }
-            }
-          }
-          else if (methodName == NameTable[(int)quantifier, 2] && typeName == "Array")
-          {
-            Method forallBody;
-            if (!driver.Context.ValueContext.IsDelegateValue(pc, args[1], out this.targetObject, out forallBody)) return null;
-            var boundParameters = MetaDataDecoder.Parameters(forallBody);
-            Contract.Assume(boundParameters != null && boundParameters.Count == 1, "should be ensured by TrueForAll/Exists type");
-            var boundParameter = boundParameters[0];
-            var boundParameterType = MetaDataDecoder.ParameterType(boundParameter);
-            forallBody = MetaDataDecoder.Unspecialized(forallBody);
-            if (!MetaDataDecoder.HasBody(forallBody)) return null;
-            // find enumerable (arg to forall is enumerable object version)
-            SymbolicValue modelArray;
-            if (!driver.Context.ValueContext.TryGetObjectFromObjectVersion(pc, args[0], out modelArray)) return null;
-            // find array length
-            SymbolicValue arrayLen;
-            if (!driver.Context.ValueContext.TryGetArrayLength(pc, modelArray, out arrayLen)) return null;
-            // bound variable is array index
-            var index = BoxedExpression.Var("i", null, MetaDataDecoder.System_Int32);
-            var arrayBox = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, modelArray), driver.ExpressionDecoder);
-            if (arrayBox != null)
-            {
-              this.boundVariable = BoxedExpression.ArrayIndex<Type>(arrayBox, index, boundParameterType);
-              var bodyDecoded = MetaDataDecoder.AccessMethodBody(forallBody, this, Unit.Value);
-              if (bodyDecoded == null) return null;
-              var lowerBound = BoxedExpression.Const(0, MetaDataDecoder.System_Int32, MetaDataDecoder);
-              var upperBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, arrayLen), driver.ExpressionDecoder);
-
-              if (/*lowerBound != null && */ upperBound != null)
-              {
-                return MakeQuantifierExpression(value, quantifier, index, lowerBound, upperBound, bodyDecoded);
-              }
-            }
-          }
-          return null;
-        }
-        if (args.Length == 3) {
-          if (driver.MetaDataDecoder.Name(method) != NameTable[(int)quantifier, 0]) return null;
-          if (driver.MetaDataDecoder.Name(driver.MetaDataDecoder.DeclaringType(method)) != "Contract") return null;
-          Method forallBody;
-          if (!driver.Context.ValueContext.IsDelegateValue(pc, args[2], out this.targetObject, out forallBody)) return null;
-          forallBody = driver.MetaDataDecoder.Unspecialized(forallBody);
-          if (!driver.MetaDataDecoder.HasBody(forallBody)) return null;
-          // bound variable is index
-          this.boundVariable = BoxedExpression.Var("i", null, this.driver.MetaDataDecoder.System_Int32);
-
-          var bodyDecoded = driver.MetaDataDecoder.AccessMethodBody(forallBody, this, Unit.Value);
-          if (bodyDecoded == null) return null;
-          var lowerBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, args[0]), driver.ExpressionDecoder);
-          var upperBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, args[1]), driver.ExpressionDecoder);
-
-          if (lowerBound != null && upperBound != null)
-          {
-            return MakeQuantifierExpression(value, quantifier, this.boundVariable, lowerBound, upperBound, bodyDecoded);
-          }
-        }
-        return null;
-      }
-
-      [ContractVerification(true)]
-      private static QuantifiedIndexedExpression MakeQuantifierExpression(
-        object variable,
-        Quantifier quantifier,
-        BoxedExpression index, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression body)
-      {
-        Contract.Requires(index != null);
-        Contract.Requires(lowerBound != null);
-        Contract.Requires(upperBound != null);
-        Contract.Requires(body != null);
-
-        Contract.Ensures(Contract.Result<QuantifiedIndexedExpression>() != null);
-
-        switch (quantifier)
-        {
-          case Quantifier.Exists:
-            return new ExistsIndexedExpression(variable, index, lowerBound, upperBound, body);
-
-          case Quantifier.ForAll:
-            return new ForAllIndexedExpression(variable, index, lowerBound, upperBound, body);
-
-          default:
-            Contract.Assert(false);
-            return null;
-        }
-      }
-
-      #region IMethodCodeConsumer<Local,Parameter,Method,Field,Type,Env,BoxedExpression> Members
-
-      class Env
-      {
-        public struct Both
-        {
-          public BoxedExpression Boxed;
-          public SymbolicValue Sym;
-
-          public Both(BoxedExpression boxedExpression)
-          {
-            this.Boxed = boxedExpression;
-            this.Sym = default(SymbolicValue);
-          }
-
-          public Both(SymbolicValue sym)
-          {
-            this.Boxed = null;
-            this.Sym = sym;
-          }
-        }
-
-        readonly Stack<Both> stack = new Stack<Both>();
-        readonly private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver;
-        readonly private APC contractPC;
-
-        public Env(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> iMethodDriver,
-                   APC contractPC)
-        {
-          Contract.Requires(iMethodDriver != null);
-
-          this.contractPC = contractPC;
-          this.driver = iMethodDriver;
-        }
-
-        internal bool PopBE(out BoxedExpression boxed)
-        {
-          Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out boxed) != null);
-
-          var both = Pop();
-          if (both.Boxed != null){ boxed = both.Boxed; return true; }
-          if (!driver.Context.ValueContext.IsValid(both.Sym)) { boxed = null; return false; }
-          boxed = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(contractPC, both.Sym), driver.ExpressionDecoder);
-
-          // conversion may fail, so we check it
-
-          return boxed != null ? true : false;
-        }
-
-        internal void Push(BoxedExpression boxedExpression)
-        {
-          this.stack.Push(new Both(boxedExpression));
-        }
-
-        internal void Push(SymbolicValue sym)
-        {
-          this.stack.Push(new Both(sym));
-        }
-
-        internal bool PopSV(out SymbolicValue sym)
-        {
-          var both = Pop();
-          if (!driver.Context.ValueContext.IsValid(both.Sym)) { sym = default(SymbolicValue); return false; }
-          sym = both.Sym;
-          return true;
-        }
-
-        internal Both Pop()
-        {
-          if (stack.Count > 0) { return stack.Pop(); }
-          return default(Both);
-        }
-
-        internal bool Dup(int offset)
-        {
-          if (stack.Count > offset)
-          {
-            var array = stack.ToArray();
-            var toCopy = array[stack.Count - 1 - offset];
-            stack.Push(toCopy);
-            return true;
-          }
-          return false;
-        }
-
-        public int StackDepth { get { return this.stack.Count; } }
-      }
-
-      class Decoder<Label2, Handler> : ICodeQuery<Label2, Local, Parameter, Method, Field, Type, Env, bool> {
-
-        internal BoxedExpression resultExpression;
-        BoxedExpression boundVar;
-        private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver;
-        Method body;
-        bool isStatic;
-        private SymbolicValue closure;
-        private APC contractPC;
-        IMethodCodeProvider<Label2, Local, Parameter, Method, Field, Type, Handler> codeProvider;
-
-        public Decoder(
-          APC contractPC,
-          IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> iMethodDriver,
-          SymbolicValue closure,
-          Method body,
-          BoxedExpression boundVar,
-          IMethodCodeProvider<Label2, Local, Parameter, Method, Field, Type, Handler> codeProvider)
-        {
-          this.closure = closure;
-          this.contractPC = contractPC;
-          this.driver = iMethodDriver;
-          this.body = body;
-          this.codeProvider = codeProvider;
-          this.boundVar = boundVar;
-          this.isStatic = this.driver.MetaDataDecoder.IsStatic(body);
-        }
-
-
-        #region ICodeQuery<Label2,Local,Parameter,Method,Field,Type,Env,BoxedExpression> Members
-
-        public bool Aggregate(Label2 current, Label2 aggregateStart, bool canBeTargetOfBranch, Env data)
-        {
-          current = aggregateStart;
-          do
-          {
-            var success = codeProvider.Decode<Decoder<Label2, Handler>, Env, bool>(current, this, data);
-            if (!success) return false;
-          }
-          while (codeProvider.Next(current, out current));
-          return true;
-        }
-
-        #endregion
-
-        #region IVisitMSIL<Label2,Local,Parameter,Method,Field,Type,Unit,Unit,Env,BoxedExpression> Members
-
-        public bool Arglist(Label2 pc, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool BranchCond(Label2 pc, Label2 target, BranchOperator bop, DataStructures.Unit value1, DataStructures.Unit value2, Env data)
-        {
-          return false;
-        }
-
-        public bool BranchTrue(Label2 pc, Label2 target, DataStructures.Unit cond, Env data)
-        {
-          return false;
-        }
-
-        public bool BranchFalse(Label2 pc, Label2 target, DataStructures.Unit cond, Env data)
-        {
-          return false;
-        }
-
-        public bool Branch(Label2 pc, Label2 target, bool leave, Env data)
-        {
-          return false;
-        }
-
-        public bool Break(Label2 pc, Env data)
-        {
-          return true;
-        }
-
-        public bool Call<TypeList, ArgList>(Label2 pc, Method method, bool tail, bool virt, TypeList extraVarargs, DataStructures.Unit dest, ArgList args, Env data)
-          where TypeList : DataStructures.IIndexable<Type>
-          where ArgList : DataStructures.IIndexable<DataStructures.Unit>
-        {
-          var mdDecoder = this.driver.MetaDataDecoder;
-          var declaringType = mdDecoder.DeclaringType(method);
-          var methodName = mdDecoder.Name(method);
-
-          #region explicit == operator overloads
-          if (args.Count > 1 && (mdDecoder.IsReferenceType(declaringType) || mdDecoder.IsNativePointerType(declaringType)))
-          {
-            if (methodName.EndsWith("op_Inequality"))
-            {
-              return this.Binary(pc, BinaryOperator.Cne_Un, dest, args[0], args[1], data);
-            }
-            else if (methodName.EndsWith("op_Equality"))
-            {
-              if (mdDecoder.IsNativePointerType(declaringType))
-              {
-                return this.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
-              }
-              else
-              {
-                return this.Binary(pc, BinaryOperator.Cobjeq, dest, args[0], args[1], data);
-              }
-            }
-          }
-          #endregion
-          #region Identity functions
-          if ((mdDecoder.Equal(declaringType, mdDecoder.System_UIntPtr)
-            || mdDecoder.Equal(declaringType, mdDecoder.System_IntPtr))
-            && methodName.StartsWith("op_Explicit"))
-          {
-            Contract.Assert(0 <= args.Count);
-            return this.Ldstack(pc, 0, dest, args[0], false, data);
-          }
-          // VB's funny copy method that copies boxed objects to avoid aliasing by accident
-          if (methodName == "GetObjectValue" && mdDecoder.Name(declaringType) == "RuntimeHelpers")
-          {
-            return this.Ldstack(pc, 0, dest, args[0], false, data);
-          }
-          #endregion
-          return false;
-        }
-
-        public bool Calli<TypeList, ArgList>(Label2 pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, DataStructures.Unit dest, DataStructures.Unit fp, ArgList args, Env data)
-          where TypeList : DataStructures.IIndexable<Type>
-          where ArgList : DataStructures.IIndexable<DataStructures.Unit>
-        {
-          return false;
-        }
-
-        public bool Ckfinite(Label2 pc, DataStructures.Unit dest, DataStructures.Unit source, Env data)
-        {
-          return false;
-        }
-
-        public bool Cpblk(Label2 pc, bool @volatile, DataStructures.Unit destaddr, DataStructures.Unit srcaddr, DataStructures.Unit len, Env data)
-        {
-          return false;
-        }
-
-        public bool Endfilter(Label2 pc, DataStructures.Unit decision, Env data)
-        {
-          return false;
-        }
-
-        public bool Endfinally(Label2 pc, Env data)
-        {
-          return false;
-        }
-
-        public bool Initblk(Label2 pc, bool @volatile, DataStructures.Unit destaddr, DataStructures.Unit value, DataStructures.Unit len, Env data)
-        {
-          return false;
-        }
-
-        public bool Jmp(Label2 pc, Method method, Env data)
-        {
-          return false;
-        }
-
-        /// <summary>
-        /// Remaps a parameter referenced in a subroutine to the parameter used in the calling context
-        /// This is needed e.g. when inheriting requires/ensures/invariant subroutines, as the parameter
-        /// identities are different in each override.
-        /// </summary>
-        /// <param name="p">Parameter as appearing in the subroutine</param>
-        /// <param name="parentMethodBlock">block in the method calling the subroutine</param>
-        /// <param name="subroutineBlock">block in the subroutine</param>
-        /// <returns>The equivalent parameter in the calling method's context</returns>
-        Parameter RemapParameter(Parameter p, CFGBlock parentMethodBlock, CFGBlock subroutineBlock)
-        {
-          Contract.Requires(subroutineBlock != null);// F: added because of Clousot suggestion
-          Contract.Requires(parentMethodBlock != null);// F: added because of Clousot suggestion
-
-          var mdDecoder = this.driver.MetaDataDecoder;
-
-          IMethodInfo<Method> parentMethodInfo = (IMethodInfo<Method>)parentMethodBlock.Subroutine;
-          IMethodInfo<Method> subroutineMethodInfo = (IMethodInfo<Method>)subroutineBlock.Subroutine;
-
-          if (mdDecoder.Equal(parentMethodInfo.Method, subroutineMethodInfo.Method))
-          {
-            return p;
-          }
-
-          var argIndex = mdDecoder.ArgumentIndex(p);
-          Contract.Assume(argIndex >= 0);
-
-          if (mdDecoder.IsStatic(parentMethodInfo.Method))
-          {
-            return mdDecoder.Parameters(parentMethodInfo.Method)[argIndex];
-          }
-          else
-          {
-            if (argIndex == 0)
-            {
-              // refers to "this"
-              return mdDecoder.This(parentMethodInfo.Method);
-            }
-            var parameters = mdDecoder.Parameters(parentMethodInfo.Method).AssumeNotNull();
-            Contract.Assume(argIndex < parameters.Count);
-            return parameters[argIndex - 1];
-          }
-        }
-
-        /// <summary>
-        /// Implementes the logic outlined in Ldarg by mapping a parameter x APC context into one of
-        /// three cases:
-        ///   - ldresult         (indicated by setting isLdResult true and setting ldStackOffset)
-        ///   - ldstack offset   (indicated by returning true, and setting ldStackOffset)
-        ///   - ldarg P'         (otherwise, where the parameter ref contains p' on exit)
-        /// </summary>
-        /// <param name="isOld">set to true if the resulting instruction should execute in the pre-state of the
-        /// method.</param>
-        /// <param name="lookupPC">Set to the pc at which we need to consider the ldStackOffset. Valid on true return.</param>
-        /// <returns>true if the parameter access maps to ldresult</returns>
-        bool RemapParameterToLdStack(APC pc, ref Parameter p, out bool isLdResult, out int ldStackOffset, out bool isOld, out APC lookupPC, Env data)
-        {
-          Contract.Requires(data != null);
-
-          if (pc.SubroutineContext != null)
-          {
-            #region Requires
-            if (pc.Block.Subroutine.IsRequires)
-            {
-              // find whether calling context is entry, newObj, or call. In the first case, also remap 
-              // the parameter if necessary
-
-              isLdResult = false;
-              isOld = false;
-              lookupPC = pc;
-
-              for (var scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
-              {
-                var callTag = scontext.Head.Three;
-
-                Contract.Assume(callTag != null);
-
-                if (callTag == "entry")
+                var MetaDataDecoder = driver.RawLayer.MetaDataDecoder;
+                Method method;
+                SymbolicValue[] args;
+                contractPC = pc;
+                if (!driver.Context.ValueContext.IsPureFunctionCall(pc, value, out method, out args)) return null;
+                var methodName = MetaDataDecoder.Name(method);
+                var typeName = MetaDataDecoder.Name(MetaDataDecoder.DeclaringType(method));
+                if (args.Length == 2)
                 {
-                  // keep as ldarg, but figure out whether we need to remap
-                  Contract.Assume(scontext.Head.One != null);
-                  p = RemapParameter(p, scontext.Head.One, pc.Block);
-                  ldStackOffset = 0;
-                  return false;
+                    if (methodName == NameTable[(int)quantifier, 0] && typeName == "Contract"
+                      || methodName == NameTable[(int)quantifier, 1] && typeName == "Enumerable")
+                    {
+                        Method forallBody;
+                        if (!driver.Context.ValueContext.IsDelegateValue(pc, args[1], out targetObject, out forallBody)) return null;
+                        var boundParameters = MetaDataDecoder.Parameters(forallBody);
+                        Contract.Assume(boundParameters.Count == 1, "should be ensured by ForAll/Exists type");
+                        var boundParameter = boundParameters[0];
+                        var boundParameterType = MetaDataDecoder.ParameterType(boundParameter);
+                        forallBody = MetaDataDecoder.Unspecialized(forallBody);
+                        if (!MetaDataDecoder.HasBody(forallBody)) return null;
+                        // find enumerable (arg to forall is enumerable object version)
+                        SymbolicValue enumerable;
+                        if (!driver.Context.ValueContext.TryGetObjectFromObjectVersion(pc, args[0], out enumerable)) return null;
+                        // find model array in enumerable
+                        var enumerableType = driver.Context.ValueContext.GetType(pc, enumerable);
+                        SymbolicValue modelArray;
+                        if (enumerableType.IsNormal && MetaDataDecoder.IsArray(enumerableType.Value))
+                        {
+                            modelArray = enumerable; // itself
+                        }
+                        else
+                        {
+                            if (!driver.Context.ValueContext.TryGetModelArray(pc, enumerable, out modelArray)) return null;
+                        }
+                        SymbolicValue arrayLen;
+                        if (!driver.Context.ValueContext.TryGetArrayLength(pc, modelArray, out arrayLen)) return null;
+                        // bound variable is array index
+                        var index = BoxedExpression.Var("i", null, MetaDataDecoder.System_Int32);
+                        var arrayBox = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, modelArray), driver.ExpressionDecoder);
+                        if (arrayBox != null)
+                        {
+                            boundVariable = BoxedExpression.ArrayIndex<Type>(arrayBox, index, boundParameterType);
+                            var bodyDecoded = MetaDataDecoder.AccessMethodBody(forallBody, this, Unit.Value);
+                            if (bodyDecoded == null) return null;
+                            var lowerBound = BoxedExpression.Const(0, MetaDataDecoder.System_Int32, MetaDataDecoder);
+                            var upperBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, arrayLen), driver.ExpressionDecoder);
+
+                            if (/*lowerBound != null && */ upperBound != null)
+                            {
+                                return MakeQuantifierExpression(value, quantifier, index, lowerBound, upperBound, bodyDecoded);
+                            }
+                        }
+                    }
+                    else if (methodName == NameTable[(int)quantifier, 2] && typeName == "Array")
+                    {
+                        Method forallBody;
+                        if (!driver.Context.ValueContext.IsDelegateValue(pc, args[1], out targetObject, out forallBody)) return null;
+                        var boundParameters = MetaDataDecoder.Parameters(forallBody);
+                        Contract.Assume(boundParameters != null && boundParameters.Count == 1, "should be ensured by TrueForAll/Exists type");
+                        var boundParameter = boundParameters[0];
+                        var boundParameterType = MetaDataDecoder.ParameterType(boundParameter);
+                        forallBody = MetaDataDecoder.Unspecialized(forallBody);
+                        if (!MetaDataDecoder.HasBody(forallBody)) return null;
+                        // find enumerable (arg to forall is enumerable object version)
+                        SymbolicValue modelArray;
+                        if (!driver.Context.ValueContext.TryGetObjectFromObjectVersion(pc, args[0], out modelArray)) return null;
+                        // find array length
+                        SymbolicValue arrayLen;
+                        if (!driver.Context.ValueContext.TryGetArrayLength(pc, modelArray, out arrayLen)) return null;
+                        // bound variable is array index
+                        var index = BoxedExpression.Var("i", null, MetaDataDecoder.System_Int32);
+                        var arrayBox = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, modelArray), driver.ExpressionDecoder);
+                        if (arrayBox != null)
+                        {
+                            boundVariable = BoxedExpression.ArrayIndex<Type>(arrayBox, index, boundParameterType);
+                            var bodyDecoded = MetaDataDecoder.AccessMethodBody(forallBody, this, Unit.Value);
+                            if (bodyDecoded == null) return null;
+                            var lowerBound = BoxedExpression.Const(0, MetaDataDecoder.System_Int32, MetaDataDecoder);
+                            var upperBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, arrayLen), driver.ExpressionDecoder);
+
+                            if (/*lowerBound != null && */ upperBound != null)
+                            {
+                                return MakeQuantifierExpression(value, quantifier, index, lowerBound, upperBound, bodyDecoded);
+                            }
+                        }
+                    }
+                    return null;
                 }
-                if (callTag.StartsWith("before")) // beforeCall | beforeNewObj
+                if (args.Length == 3)
                 {
-                  int localStackDepth = this.driver.Context.StackContext.LocalStackDepth(this.contractPC) + data.StackDepth;
-                  ldStackOffset = this.driver.MetaDataDecoder.ArgumentStackIndex(p) + localStackDepth;
-                  return true;
+                    if (driver.MetaDataDecoder.Name(method) != NameTable[(int)quantifier, 0]) return null;
+                    if (driver.MetaDataDecoder.Name(driver.MetaDataDecoder.DeclaringType(method)) != "Contract") return null;
+                    Method forallBody;
+                    if (!driver.Context.ValueContext.IsDelegateValue(pc, args[2], out targetObject, out forallBody)) return null;
+                    forallBody = driver.MetaDataDecoder.Unspecialized(forallBody);
+                    if (!driver.MetaDataDecoder.HasBody(forallBody)) return null;
+                    // bound variable is index
+                    boundVariable = BoxedExpression.Var("i", null, driver.MetaDataDecoder.System_Int32);
+
+                    var bodyDecoded = driver.MetaDataDecoder.AccessMethodBody(forallBody, this, Unit.Value);
+                    if (bodyDecoded == null) return null;
+                    var lowerBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, args[0]), driver.ExpressionDecoder);
+                    var upperBound = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(pc, args[1]), driver.ExpressionDecoder);
+
+                    if (lowerBound != null && upperBound != null)
+                    {
+                        return MakeQuantifierExpression(value, quantifier, boundVariable, lowerBound, upperBound, bodyDecoded);
+                    }
                 }
-              }
-              throw new NotImplementedException();
+                return null;
             }
-            #endregion
-            #region Ensures
-            else if (pc.Block.Subroutine.IsEnsuresOrOld)
+
+            [ContractVerification(true)]
+            private static QuantifiedIndexedExpression MakeQuantifierExpression(
+              object variable,
+              Quantifier quantifier,
+              BoxedExpression index, BoxedExpression lowerBound, BoxedExpression upperBound, BoxedExpression body)
             {
-              // find whether calling context is exit, newObj, or call. In the first case, also remap 
-              // the parameter if necessary
-              isOld = true;
+                Contract.Requires(index != null);
+                Contract.Requires(lowerBound != null);
+                Contract.Requires(upperBound != null);
+                Contract.Requires(body != null);
 
-              for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
-              {
-                string callTag = scontext.Head.Three;
+                Contract.Ensures(Contract.Result<QuantifiedIndexedExpression>() != null);
 
-                if (callTag == "exit")
+                switch (quantifier)
                 {
-                  // keep as ldarg, but figure out whether we need to remap
-                  Contract.Assume(scontext.Head.One != null);
-                  p = RemapParameter(p, scontext.Head.One, pc.Block);
-                  isLdResult = false;
-                  ldStackOffset = 0;
-                  lookupPC = pc; // irrelevant
-                  return false;
+                    case Quantifier.Exists:
+                        return new ExistsIndexedExpression(variable, index, lowerBound, upperBound, body);
+
+                    case Quantifier.ForAll:
+                        return new ForAllIndexedExpression(variable, index, lowerBound, upperBound, body);
+
+                    default:
+                        Contract.Assert(false);
+                        return null;
                 }
-                if (callTag == "afterCall")
-                {
-                  // we need to compute the offset to the "parameter" on the stack. For this we must
-                  // know what method is being called.
-                  ldStackOffset = this.driver.MetaDataDecoder.ArgumentStackIndex(p);
+            }
 
-                  // no need to correct for local stack depth, as we lookup the stack in the old-state
-                  isLdResult = false;
-                  lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                  return true;
-                }
-                if (callTag == "afterNewObj")
+            #region IMethodCodeConsumer<Local,Parameter,Method,Field,Type,Env,BoxedExpression> Members
+
+            private class Env
+            {
+                public struct Both
                 {
-                  // here we have to deal with the special case of referencing argument 0, which is the result
-                  // of the construction. In that case we have to return "ldresult"
-                  int parameterIndex = this.driver.MetaDataDecoder.ArgumentIndex(p);
-                  if (parameterIndex == 0)
-                  {
-                    ldStackOffset = this.driver.Context.StackContext.LocalStackDepth(pc) + data.StackDepth;
-                    isLdResult = true;
-                    lookupPC = pc; // irrelevant
-                    isOld = false;
+                    public BoxedExpression Boxed;
+                    public SymbolicValue Sym;
+
+                    public Both(BoxedExpression boxedExpression)
+                    {
+                        this.Boxed = boxedExpression;
+                        this.Sym = default(SymbolicValue);
+                    }
+
+                    public Both(SymbolicValue sym)
+                    {
+                        this.Boxed = null;
+                        this.Sym = sym;
+                    }
+                }
+
+                private readonly Stack<Both> stack = new Stack<Both>();
+                readonly private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver;
+                readonly private APC contractPC;
+
+                public Env(IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> iMethodDriver,
+                           APC contractPC)
+                {
+                    Contract.Requires(iMethodDriver != null);
+
+                    this.contractPC = contractPC;
+                    driver = iMethodDriver;
+                }
+
+                internal bool PopBE(out BoxedExpression boxed)
+                {
+                    Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out boxed) != null);
+
+                    var both = Pop();
+                    if (both.Boxed != null) { boxed = both.Boxed; return true; }
+                    if (!driver.Context.ValueContext.IsValid(both.Sym)) { boxed = null; return false; }
+                    boxed = BoxedExpression.Convert(driver.Context.ExpressionContext.Refine(contractPC, both.Sym), driver.ExpressionDecoder);
+
+                    // conversion may fail, so we check it
+
+                    return boxed != null ? true : false;
+                }
+
+                internal void Push(BoxedExpression boxedExpression)
+                {
+                    stack.Push(new Both(boxedExpression));
+                }
+
+                internal void Push(SymbolicValue sym)
+                {
+                    stack.Push(new Both(sym));
+                }
+
+                internal bool PopSV(out SymbolicValue sym)
+                {
+                    var both = Pop();
+                    if (!driver.Context.ValueContext.IsValid(both.Sym)) { sym = default(SymbolicValue); return false; }
+                    sym = both.Sym;
+                    return true;
+                }
+
+                internal Both Pop()
+                {
+                    if (stack.Count > 0) { return stack.Pop(); }
+                    return default(Both);
+                }
+
+                internal bool Dup(int offset)
+                {
+                    if (stack.Count > offset)
+                    {
+                        var array = stack.ToArray();
+                        var toCopy = array[stack.Count - 1 - offset];
+                        stack.Push(toCopy);
+                        return true;
+                    }
                     return false;
-                  }
-
-                  // we need to compute the offset to the "parameter" on the stack. For this we must
-                  // know what method is being called.
-                  ldStackOffset = this.driver.MetaDataDecoder.ArgumentStackIndex(p);
-
-                  // no need to correct for local stack depth, as we lookup the stack in the old-state
-                  isLdResult = false;
-                  lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                  return true;
                 }
 
-                if (callTag == "oldmanifest")
-                {
-                  // used to manifest the old values on entry to a method
-                  // keep as ldarg, but figure out whether we need to remap
-                  Contract.Assume(scontext.Tail.Head.One != null);
-
-                  p = RemapParameter(p, scontext.Tail.Head.One, pc.Block);
-                  isOld = false;
-                  isLdResult = false;
-                  ldStackOffset = 0;
-                  lookupPC = pc; // irrelevant
-                  return false;
-                }
-              }
-              throw new NotImplementedException();
+                public int StackDepth { get { return stack.Count; } }
             }
-            #endregion
-            #region Invariant
-            else if (pc.Block.Subroutine.IsInvariant)
-            {
-              for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
-              {
-                string callTag = scontext.Head.Three;
-                // must be "this"
-                Contract.Assume(this.driver.MetaDataDecoder.ArgumentIndex(p) == 0);
 
-                if (callTag == "entry" || callTag == "exit")
+            private class Decoder<Label2, Handler> : ICodeQuery<Label2, Local, Parameter, Method, Field, Type, Env, bool>
+            {
+                internal BoxedExpression resultExpression;
+                private BoxedExpression boundVar;
+                private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> driver;
+                private Method body;
+                private bool isStatic;
+                private SymbolicValue closure;
+                private APC contractPC;
+                private IMethodCodeProvider<Label2, Local, Parameter, Method, Field, Type, Handler> codeProvider;
+
+                public Decoder(
+                  APC contractPC,
+                  IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, SymbolicValue, LogOptions> iMethodDriver,
+                  SymbolicValue closure,
+                  Method body,
+                  BoxedExpression boundVar,
+                  IMethodCodeProvider<Label2, Local, Parameter, Method, Field, Type, Handler> codeProvider)
                 {
-                  // keep as ldarg, but remap to this of containing method
-                  Method containingMethod;
-                  if (pc.TryGetContainingMethod(out containingMethod))
-                  {
-                    p = this.driver.MetaDataDecoder.This(containingMethod);
-                    isLdResult = false;
-                    ldStackOffset = 0;
-                    isOld = (callTag == "exit");
-                    lookupPC = pc; // irrelevant
+                    this.closure = closure;
+                    this.contractPC = contractPC;
+                    driver = iMethodDriver;
+                    this.body = body;
+                    this.codeProvider = codeProvider;
+                    this.boundVar = boundVar;
+                    isStatic = driver.MetaDataDecoder.IsStatic(body);
+                }
+
+
+                #region ICodeQuery<Label2,Local,Parameter,Method,Field,Type,Env,BoxedExpression> Members
+
+                public bool Aggregate(Label2 current, Label2 aggregateStart, bool canBeTargetOfBranch, Env data)
+                {
+                    current = aggregateStart;
+                    do
+                    {
+                        var success = codeProvider.Decode<Decoder<Label2, Handler>, Env, bool>(current, this, data);
+                        if (!success) return false;
+                    }
+                    while (codeProvider.Next(current, out current));
+                    return true;
+                }
+
+                #endregion
+
+                #region IVisitMSIL<Label2,Local,Parameter,Method,Field,Type,Unit,Unit,Env,BoxedExpression> Members
+
+                public bool Arglist(Label2 pc, DataStructures.Unit dest, Env data)
+                {
                     return false;
-                  }
-                  else
-                  {
-                    Contract.Assume(false, "Not in a method context");
-                    // dont'r remap
+                }
+
+                public bool BranchCond(Label2 pc, Label2 target, BranchOperator bop, DataStructures.Unit value1, DataStructures.Unit value2, Env data)
+                {
+                    return false;
+                }
+
+                public bool BranchTrue(Label2 pc, Label2 target, DataStructures.Unit cond, Env data)
+                {
+                    return false;
+                }
+
+                public bool BranchFalse(Label2 pc, Label2 target, DataStructures.Unit cond, Env data)
+                {
+                    return false;
+                }
+
+                public bool Branch(Label2 pc, Label2 target, bool leave, Env data)
+                {
+                    return false;
+                }
+
+                public bool Break(Label2 pc, Env data)
+                {
+                    return true;
+                }
+
+                public bool Call<TypeList, ArgList>(Label2 pc, Method method, bool tail, bool virt, TypeList extraVarargs, DataStructures.Unit dest, ArgList args, Env data)
+                  where TypeList : DataStructures.IIndexable<Type>
+                  where ArgList : DataStructures.IIndexable<DataStructures.Unit>
+                {
+                    var mdDecoder = driver.MetaDataDecoder;
+                    var declaringType = mdDecoder.DeclaringType(method);
+                    var methodName = mdDecoder.Name(method);
+
+                    #region explicit == operator overloads
+                    if (args.Count > 1 && (mdDecoder.IsReferenceType(declaringType) || mdDecoder.IsNativePointerType(declaringType)))
+                    {
+                        if (methodName.EndsWith("op_Inequality"))
+                        {
+                            return this.Binary(pc, BinaryOperator.Cne_Un, dest, args[0], args[1], data);
+                        }
+                        else if (methodName.EndsWith("op_Equality"))
+                        {
+                            if (mdDecoder.IsNativePointerType(declaringType))
+                            {
+                                return this.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
+                            }
+                            else
+                            {
+                                return this.Binary(pc, BinaryOperator.Cobjeq, dest, args[0], args[1], data);
+                            }
+                        }
+                    }
+                    #endregion
+                    #region Identity functions
+                    if ((mdDecoder.Equal(declaringType, mdDecoder.System_UIntPtr)
+                      || mdDecoder.Equal(declaringType, mdDecoder.System_IntPtr))
+                      && methodName.StartsWith("op_Explicit"))
+                    {
+                        Contract.Assert(0 <= args.Count);
+                        return this.Ldstack(pc, 0, dest, args[0], false, data);
+                    }
+                    // VB's funny copy method that copies boxed objects to avoid aliasing by accident
+                    if (methodName == "GetObjectValue" && mdDecoder.Name(declaringType) == "RuntimeHelpers")
+                    {
+                        return this.Ldstack(pc, 0, dest, args[0], false, data);
+                    }
+                    #endregion
+                    return false;
+                }
+
+                public bool Calli<TypeList, ArgList>(Label2 pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, DataStructures.Unit dest, DataStructures.Unit fp, ArgList args, Env data)
+                  where TypeList : DataStructures.IIndexable<Type>
+                  where ArgList : DataStructures.IIndexable<DataStructures.Unit>
+                {
+                    return false;
+                }
+
+                public bool Ckfinite(Label2 pc, DataStructures.Unit dest, DataStructures.Unit source, Env data)
+                {
+                    return false;
+                }
+
+                public bool Cpblk(Label2 pc, bool @volatile, DataStructures.Unit destaddr, DataStructures.Unit srcaddr, DataStructures.Unit len, Env data)
+                {
+                    return false;
+                }
+
+                public bool Endfilter(Label2 pc, DataStructures.Unit decision, Env data)
+                {
+                    return false;
+                }
+
+                public bool Endfinally(Label2 pc, Env data)
+                {
+                    return false;
+                }
+
+                public bool Initblk(Label2 pc, bool @volatile, DataStructures.Unit destaddr, DataStructures.Unit value, DataStructures.Unit len, Env data)
+                {
+                    return false;
+                }
+
+                public bool Jmp(Label2 pc, Method method, Env data)
+                {
+                    return false;
+                }
+
+                /// <summary>
+                /// Remaps a parameter referenced in a subroutine to the parameter used in the calling context
+                /// This is needed e.g. when inheriting requires/ensures/invariant subroutines, as the parameter
+                /// identities are different in each override.
+                /// </summary>
+                /// <param name="p">Parameter as appearing in the subroutine</param>
+                /// <param name="parentMethodBlock">block in the method calling the subroutine</param>
+                /// <param name="subroutineBlock">block in the subroutine</param>
+                /// <returns>The equivalent parameter in the calling method's context</returns>
+                private Parameter RemapParameter(Parameter p, CFGBlock parentMethodBlock, CFGBlock subroutineBlock)
+                {
+                    Contract.Requires(subroutineBlock != null);// F: added because of Clousot suggestion
+                    Contract.Requires(parentMethodBlock != null);// F: added because of Clousot suggestion
+
+                    var mdDecoder = driver.MetaDataDecoder;
+
+                    IMethodInfo<Method> parentMethodInfo = (IMethodInfo<Method>)parentMethodBlock.Subroutine;
+                    IMethodInfo<Method> subroutineMethodInfo = (IMethodInfo<Method>)subroutineBlock.Subroutine;
+
+                    if (mdDecoder.Equal(parentMethodInfo.Method, subroutineMethodInfo.Method))
+                    {
+                        return p;
+                    }
+
+                    var argIndex = mdDecoder.ArgumentIndex(p);
+                    Contract.Assume(argIndex >= 0);
+
+                    if (mdDecoder.IsStatic(parentMethodInfo.Method))
+                    {
+                        return mdDecoder.Parameters(parentMethodInfo.Method)[argIndex];
+                    }
+                    else
+                    {
+                        if (argIndex == 0)
+                        {
+                            // refers to "this"
+                            return mdDecoder.This(parentMethodInfo.Method);
+                        }
+                        var parameters = mdDecoder.Parameters(parentMethodInfo.Method).AssumeNotNull();
+                        Contract.Assume(argIndex < parameters.Count);
+                        return parameters[argIndex - 1];
+                    }
+                }
+
+                /// <summary>
+                /// Implementes the logic outlined in Ldarg by mapping a parameter x APC context into one of
+                /// three cases:
+                ///   - ldresult         (indicated by setting isLdResult true and setting ldStackOffset)
+                ///   - ldstack offset   (indicated by returning true, and setting ldStackOffset)
+                ///   - ldarg P'         (otherwise, where the parameter ref contains p' on exit)
+                /// </summary>
+                /// <param name="isOld">set to true if the resulting instruction should execute in the pre-state of the
+                /// method.</param>
+                /// <param name="lookupPC">Set to the pc at which we need to consider the ldStackOffset. Valid on true return.</param>
+                /// <returns>true if the parameter access maps to ldresult</returns>
+                private bool RemapParameterToLdStack(APC pc, ref Parameter p, out bool isLdResult, out int ldStackOffset, out bool isOld, out APC lookupPC, Env data)
+                {
+                    Contract.Requires(data != null);
+
+                    if (pc.SubroutineContext != null)
+                    {
+                        #region Requires
+                        if (pc.Block.Subroutine.IsRequires)
+                        {
+                            // find whether calling context is entry, newObj, or call. In the first case, also remap 
+                            // the parameter if necessary
+
+                            isLdResult = false;
+                            isOld = false;
+                            lookupPC = pc;
+
+                            for (var scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+                            {
+                                var callTag = scontext.Head.Three;
+
+                                Contract.Assume(callTag != null);
+
+                                if (callTag == "entry")
+                                {
+                                    // keep as ldarg, but figure out whether we need to remap
+                                    Contract.Assume(scontext.Head.One != null);
+                                    p = RemapParameter(p, scontext.Head.One, pc.Block);
+                                    ldStackOffset = 0;
+                                    return false;
+                                }
+                                if (callTag.StartsWith("before")) // beforeCall | beforeNewObj
+                                {
+                                    int localStackDepth = driver.Context.StackContext.LocalStackDepth(contractPC) + data.StackDepth;
+                                    ldStackOffset = driver.MetaDataDecoder.ArgumentStackIndex(p) + localStackDepth;
+                                    return true;
+                                }
+                            }
+                            throw new NotImplementedException();
+                        }
+                        #endregion
+                        #region Ensures
+                        else if (pc.Block.Subroutine.IsEnsuresOrOld)
+                        {
+                            // find whether calling context is exit, newObj, or call. In the first case, also remap 
+                            // the parameter if necessary
+                            isOld = true;
+
+                            for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+                            {
+                                string callTag = scontext.Head.Three;
+
+                                if (callTag == "exit")
+                                {
+                                    // keep as ldarg, but figure out whether we need to remap
+                                    Contract.Assume(scontext.Head.One != null);
+                                    p = RemapParameter(p, scontext.Head.One, pc.Block);
+                                    isLdResult = false;
+                                    ldStackOffset = 0;
+                                    lookupPC = pc; // irrelevant
+                                    return false;
+                                }
+                                if (callTag == "afterCall")
+                                {
+                                    // we need to compute the offset to the "parameter" on the stack. For this we must
+                                    // know what method is being called.
+                                    ldStackOffset = driver.MetaDataDecoder.ArgumentStackIndex(p);
+
+                                    // no need to correct for local stack depth, as we lookup the stack in the old-state
+                                    isLdResult = false;
+                                    lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                    return true;
+                                }
+                                if (callTag == "afterNewObj")
+                                {
+                                    // here we have to deal with the special case of referencing argument 0, which is the result
+                                    // of the construction. In that case we have to return "ldresult"
+                                    int parameterIndex = driver.MetaDataDecoder.ArgumentIndex(p);
+                                    if (parameterIndex == 0)
+                                    {
+                                        ldStackOffset = driver.Context.StackContext.LocalStackDepth(pc) + data.StackDepth;
+                                        isLdResult = true;
+                                        lookupPC = pc; // irrelevant
+                                        isOld = false;
+                                        return false;
+                                    }
+
+                                    // we need to compute the offset to the "parameter" on the stack. For this we must
+                                    // know what method is being called.
+                                    ldStackOffset = driver.MetaDataDecoder.ArgumentStackIndex(p);
+
+                                    // no need to correct for local stack depth, as we lookup the stack in the old-state
+                                    isLdResult = false;
+                                    lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                    return true;
+                                }
+
+                                if (callTag == "oldmanifest")
+                                {
+                                    // used to manifest the old values on entry to a method
+                                    // keep as ldarg, but figure out whether we need to remap
+                                    Contract.Assume(scontext.Tail.Head.One != null);
+
+                                    p = RemapParameter(p, scontext.Tail.Head.One, pc.Block);
+                                    isOld = false;
+                                    isLdResult = false;
+                                    ldStackOffset = 0;
+                                    lookupPC = pc; // irrelevant
+                                    return false;
+                                }
+                            }
+                            throw new NotImplementedException();
+                        }
+                        #endregion
+                        #region Invariant
+                        else if (pc.Block.Subroutine.IsInvariant)
+                        {
+                            for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+                            {
+                                string callTag = scontext.Head.Three;
+                                // must be "this"
+                                Contract.Assume(driver.MetaDataDecoder.ArgumentIndex(p) == 0);
+
+                                if (callTag == "entry" || callTag == "exit")
+                                {
+                                    // keep as ldarg, but remap to this of containing method
+                                    Method containingMethod;
+                                    if (pc.TryGetContainingMethod(out containingMethod))
+                                    {
+                                        p = driver.MetaDataDecoder.This(containingMethod);
+                                        isLdResult = false;
+                                        ldStackOffset = 0;
+                                        isOld = (callTag == "exit");
+                                        lookupPC = pc; // irrelevant
+                                        return false;
+                                    }
+                                    else
+                                    {
+                                        Contract.Assume(false, "Not in a method context");
+                                        // dont'r remap
+                                        isLdResult = false;
+                                        ldStackOffset = 0;
+                                        isOld = false;
+                                        lookupPC = pc;
+                                        return false;
+                                    }
+                                }
+                                if (callTag == "afterCall")
+                                {
+                                    // we need to compute the offset to the "this" receiver on the stack. For this we must
+                                    // know what method is being called.
+
+                                    Method calledMethod;
+                                    bool isNewObj;
+                                    bool isVirtualCall;
+                                    var success = scontext.Head.One.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall);
+                                    Contract.Assume(success); // must be a method call blcok
+                                    int parameterCount = driver.MetaDataDecoder.Parameters(calledMethod).Count;
+
+                                    ldStackOffset = parameterCount; // 0 is top, 1 is 1 step below top of stack, etc...
+
+                                    // no need to correct for local stack depth, as we lookup the stack in the old-state
+                                    isLdResult = false;
+                                    isOld = true;
+                                    lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                    return true;
+                                }
+                                if (callTag == "afterNewObj")
+                                {
+                                    // we need to map "this" to ldresult
+                                    isLdResult = true;
+                                    ldStackOffset = driver.Context.StackContext.LocalStackDepth(pc) + data.StackDepth;
+                                    isOld = false;
+                                    lookupPC = pc;
+                                    return false;
+                                }
+                                if (callTag == "assumeInvariant")
+                                {
+                                    // we need to map "this" to ldstack.0 just prior to call (object must be on top of stack)
+                                    isLdResult = false;
+                                    ldStackOffset = 0;
+                                    isOld = true;
+                                    lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                    return true;
+                                }
+                                if (callTag == "beforeCall")
+                                {
+                                    throw new InvalidOperationException("This should never happen");
+                                }
+                                if (callTag == "beforeNewObj")
+                                {
+                                    throw new InvalidOperationException("This should never happen");
+                                }
+                            }
+                            throw new NotImplementedException();
+                        }
+                        #endregion
+
+                    }
                     isLdResult = false;
                     ldStackOffset = 0;
                     isOld = false;
                     lookupPC = pc;
                     return false;
-                  }
                 }
-                if (callTag == "afterCall")
-                {
-                  // we need to compute the offset to the "this" receiver on the stack. For this we must
-                  // know what method is being called.
 
-                  Method calledMethod;
-                  bool isNewObj;
-                  bool isVirtualCall;
-                  var success = scontext.Head.One.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall);
-                  Contract.Assume(success); // must be a method call blcok
-                  int parameterCount = this.driver.MetaDataDecoder.Parameters(calledMethod).Count;
+                /// <summary>
+                /// We have to distinguish 3 cases:
+                /// 
+                /// 1. Access to an argument of the closure method (the index)
+                /// 2. Access to the "this" argument of the closure method (to get to the closure values under CCI1)
+                /// 3. Access to the enclosing method parameters (under CCI2)
+                ///    3a. This can be the method under analysis, if the forall is a pre/post condition
+                ///    3b. This can be a called method from the method under analysis (at new or call)
+                ///    3c. This can be called methods from within contracts of called methods
+                /// </summary>
+                public bool Ldarg(Label2 pc, Parameter argument, bool isOldIgnored, DataStructures.Unit dest, Env data)
+                {
+                    Contract.Assume(data != null);
 
-                  ldStackOffset = parameterCount; // 0 is top, 1 is 1 step below top of stack, etc...
+                    // determine if argument belongs to method on stack at contarctPC
+                    if (!OnStack(contractPC, driver.MetaDataDecoder.DeclaringMethod(argument)))
+                    {
+                        // could be closure this
+                        if (!isStatic && driver.MetaDataDecoder.ArgumentIndex(argument) == 0)
+                        {
+                            data.Push(closure);
+                            return true;
+                        }
+                        // can only be index
+                        data.Push(boundVar);
+                        return true;
+                    }
 
-                  // no need to correct for local stack depth, as we lookup the stack in the old-state
-                  isLdResult = false;
-                  isOld = true;
-                  lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                  return true;
+                    // First check to see if the parameter is a parameter of the method enclosing the
+                    // quantifier.
+                    SymbolicValue sv;
+                    if (driver.Context.ValueContext.TryParameterValue(contractPC, argument, out sv))
+                    {
+                        data.Push(sv);
+                        return true;
+                    }
+
+                    // Now try to figure out where on the evaluation stack the parameters of this inner call would be
+                    bool isLdResult;
+                    int ldStackOffset;
+                    bool isOld;
+                    APC lookupPC;
+                    var mdDecoder = driver.MetaDataDecoder;
+
+                    Parameter oldArgument = argument;
+
+                    if (RemapParameterToLdStack(contractPC, ref argument, out isLdResult, out ldStackOffset, out isOld, out lookupPC, data))
+                    {
+                        // ldstack
+                        return this.LdstackSpecial(lookupPC, ldStackOffset, dest, Unit.Value, isOld, data);
+                    }
+
+                    // F: TODOTODO Awfull fix!!!! But I do not really understand the code, I should talk with MAF about it
+                    if (argument == null)
+                    {
+                        argument = oldArgument;
+                    }
+                    // F: End
+
+                    if (isLdResult)
+                    {
+                        // ldresult
+                        // special case: if the parameter is typed address of struct, then we must be
+                        // referring to the post state of a struct constructor. In this case, map it to ldstacka
+                        if (mdDecoder.IsStruct(mdDecoder.DeclaringType(mdDecoder.DeclaringMethod(argument))))
+                        {
+                            return this.Ldstacka(pc, ldStackOffset, dest, Unit.Value, mdDecoder.ParameterType(argument), isOld, data);
+                        }
+                        return this.Ldresult(pc, mdDecoder.ParameterType(argument), dest, Unit.Value, data);
+                    }
+
+                    // if we can't find anything, it might be the index
+                    data.Push(boundVar);
+                    return true;
                 }
-                if (callTag == "afterNewObj")
+
+                private bool OnStack(APC aPC, Method method)
                 {
-                  // we need to map "this" to ldresult
-                  isLdResult = true;
-                  ldStackOffset = this.driver.Context.StackContext.LocalStackDepth(pc)  + data.StackDepth;
-                  isOld = false;
-                  lookupPC = pc;
-                  return false;
+                    var pcMethod = aPC.Block.Subroutine as IMethodInfo<Method>;
+                    if (pcMethod != null && driver.MetaDataDecoder.Equal(pcMethod.Method, method)) return true;
+                    for (var context = aPC.SubroutineContext; context != null; context = context.Tail)
+                    {
+                        pcMethod = context.Head.One.AssumeNotNull().Subroutine as IMethodInfo<Method>;
+                        if (pcMethod != null && driver.MetaDataDecoder.Equal(pcMethod.Method, method)) return true;
+                    }
+                    return false;
                 }
-                if (callTag == "assumeInvariant")
+
+                public bool Ldarga(Label2 pc, Parameter argument, bool isOld, DataStructures.Unit dest, Env data)
                 {
-                  // we need to map "this" to ldstack.0 just prior to call (object must be on top of stack)
-                  isLdResult = false;
-                  ldStackOffset = 0;
-                  isOld = true;
-                  lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                  return true;
+                    return false;
                 }
-                if (callTag == "beforeCall")
+
+                public bool Ldftn(Label2 pc, Method method, DataStructures.Unit dest, Env data)
                 {
-                  throw new InvalidOperationException("This should never happen");
+                    return false;
                 }
-                if (callTag == "beforeNewObj")
+
+                public bool Ldind(Label2 pc, Type type, bool @volatile, DataStructures.Unit dest, DataStructures.Unit ptr, Env data)
                 {
-                  throw new InvalidOperationException("This should never happen");
+                    SymbolicValue ptrValue;
+                    if (!data.PopSV(out ptrValue)) return false;
+                    SymbolicValue result;
+                    if (!driver.Context.ValueContext.TryLoadIndirect(contractPC, ptrValue, out result)) return false;
+                    data.Push(result);
+                    return true;
                 }
-              }
-              throw new NotImplementedException();
+
+                public bool Ldloc(Label2 pc, Local local, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldloca(Label2 pc, Local local, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Localloc(Label2 pc, DataStructures.Unit dest, DataStructures.Unit size, Env data)
+                {
+                    return false;
+                }
+
+                public bool Nop(Label2 pc, Env data)
+                {
+                    return true;
+                }
+
+                public bool Pop(Label2 pc, DataStructures.Unit source, Env data)
+                {
+                    data.Pop();
+                    return true;
+                }
+
+                public bool Return(Label2 pc, DataStructures.Unit source, Env data)
+                {
+                    return data.PopBE(out this.resultExpression);
+                }
+
+                public bool Starg(Label2 pc, Parameter argument, DataStructures.Unit source, Env data)
+                {
+                    return false;
+                }
+
+                public bool Stind(Label2 pc, Type type, bool @volatile, DataStructures.Unit ptr, DataStructures.Unit value, Env data)
+                {
+                    return false;
+                }
+
+                public bool Stloc(Label2 pc, Local local, DataStructures.Unit source, Env data)
+                {
+                    return false;
+                }
+
+                public bool Switch(Label2 pc, Type type, System.Collections.Generic.IEnumerable<DataStructures.Pair<object, Label2>> cases, DataStructures.Unit value, Env data)
+                {
+                    return false;
+                }
+
+                public bool Box(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
+                {
+                    // HACK: just leave the same value on the stack
+                    return true;
+                }
+
+                public bool ConstrainedCallvirt<TypeList, ArgList>(Label2 pc, Method method, bool tail, Type constraint, TypeList extraVarargs, DataStructures.Unit dest, ArgList args, Env data)
+                  where TypeList : DataStructures.IIndexable<Type>
+                  where ArgList : DataStructures.IIndexable<DataStructures.Unit>
+                {
+                    return false;
+                }
+
+                public bool Castclass(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    return true; // just leave the same value on the stack
+                }
+
+                public bool Cpobj(Label2 pc, Type type, DataStructures.Unit destptr, DataStructures.Unit srcptr, Env data)
+                {
+                    return false;
+                }
+
+                public bool Initobj(Label2 pc, Type type, DataStructures.Unit ptr, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldelem(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit array, DataStructures.Unit index, Env data)
+                {
+                    BoxedExpression indexExpr;
+                    if (!data.PopBE(out indexExpr)) return false;
+                    BoxedExpression arrayExpr;
+                    if (!data.PopBE(out arrayExpr)) return false;
+                    data.Push(BoxedExpression.ArrayIndex(arrayExpr, indexExpr, type));
+                    return true;
+                }
+
+                public bool Ldelema(Label2 pc, Type type, bool @readonly, DataStructures.Unit dest, DataStructures.Unit array, DataStructures.Unit index, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    SymbolicValue objectValue;
+                    if (!data.PopSV(out objectValue)) return false;
+                    SymbolicValue fieldAddress;
+                    if (!driver.Context.ValueContext.TryFieldAddress(contractPC, objectValue, field, out fieldAddress)) return false;
+                    SymbolicValue result;
+                    if (!driver.Context.ValueContext.TryLoadIndirect(contractPC, fieldAddress, out result)) return false;
+                    data.Push(result);
+                    return true;
+                }
+
+                public bool Ldflda(Label2 pc, Field field, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldlen(Label2 pc, DataStructures.Unit dest, DataStructures.Unit array, Env data)
+                {
+                    SymbolicValue objectValue;
+                    if (!data.PopSV(out objectValue)) return false;
+                    SymbolicValue length;
+                    if (!driver.Context.ValueContext.TryGetArrayLength(contractPC, objectValue, out length)) return false;
+                    data.Push(length);
+                    return true;
+                }
+
+                public bool Ldsfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldsflda(Label2 pc, Field field, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldtypetoken(Label2 pc, Type type, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldfieldtoken(Label2 pc, Field field, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldmethodtoken(Label2 pc, Method method, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldvirtftn(Label2 pc, Method method, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    return false;
+                }
+
+                public bool Mkrefany(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    return false;
+                }
+
+                public bool Newarray<ArgList>(Label2 pc, Type type, DataStructures.Unit dest, ArgList len, Env data) where ArgList : DataStructures.IIndexable<DataStructures.Unit>
+                {
+                    return false;
+                }
+
+                public bool Newobj<ArgList>(Label2 pc, Method ctor, DataStructures.Unit dest, ArgList args, Env data) where ArgList : DataStructures.IIndexable<DataStructures.Unit>
+                {
+                    return false;
+                }
+
+                public bool Refanytype(Label2 pc, DataStructures.Unit dest, DataStructures.Unit source, Env data)
+                {
+                    return false;
+                }
+
+                public bool Refanyval(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
+                {
+                    return false;
+                }
+
+                public bool Rethrow(Label2 pc, Env data)
+                {
+                    return false;
+                }
+
+                public bool Stelem(Label2 pc, Type type, DataStructures.Unit array, DataStructures.Unit index, DataStructures.Unit value, Env data)
+                {
+                    return false;
+                }
+
+                public bool Stfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit obj, DataStructures.Unit value, Env data)
+                {
+                    return false;
+                }
+
+                public bool Stsfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit value, Env data)
+                {
+                    return false;
+                }
+
+                public bool Throw(Label2 pc, DataStructures.Unit exn, Env data)
+                {
+                    return false;
+                }
+
+                public bool Unbox(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    return false;
+                }
+
+                public bool Unboxany(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    return false;
+                }
+
+                #endregion
+
+                #region IVisitSynthIL<Label2,Method,Type,Unit,Unit,Env,BoxedExpression> Members
+
+                public bool Entry(Label2 pc, Method method, Env data)
+                {
+                    return true;
+                }
+
+                public bool Assume(Label2 pc, string tag, DataStructures.Unit condition, object provenance, Env data)
+                {
+                    return false;
+                }
+
+                public bool Assert(Label2 pc, string tag, DataStructures.Unit condition, object provenance, Env data)
+                {
+                    return false;
+                }
+
+                private bool LdstackSpecial(APC apc, int offset, DataStructures.Unit dest, DataStructures.Unit source, bool isOld, Env data)
+                {
+                    if (offset >= data.StackDepth)
+                    {
+                        var normalizedOffset = offset - data.StackDepth;
+                        var top = driver.Context.StackContext.StackDepth(apc) - 1;
+                        var index = top - normalizedOffset;
+                        SymbolicValue result;
+                        if (driver.Context.ValueContext.TryStackValue(apc, index, out result))
+                        {
+                            data.Push(result);
+                            return true;
+                        }
+                    }
+                    return data.Dup(offset);
+                }
+
+                public bool Ldstack(Label2 pc, int offset, DataStructures.Unit dest, DataStructures.Unit source, bool isOld, Env data)
+                {
+                    return data.Dup(offset);
+                }
+
+                public bool Ldstacka(Label2 pc, int offset, DataStructures.Unit dest, DataStructures.Unit source, Type origParamType, bool isOld, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldresult(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
+                {
+                    SymbolicValue result;
+
+                    if (!driver.Context.ValueContext.TryResultValue(contractPC, out result)) return false;
+
+                    data.Push(result);
+
+                    return true;
+                }
+
+                public bool BeginOld(Label2 pc, Label2 matchingEnd, Env data)
+                {
+                    return false;
+                }
+
+                public bool EndOld(Label2 pc, Label2 matchingBegin, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
+                {
+                    return false;
+                }
+
+                #endregion
+
+                #region IVisitExprIL<Label2,Type,Unit,Unit,Env,BoxedExpression> Members
+
+                public bool Binary(Label2 pc, BinaryOperator op, DataStructures.Unit dest, DataStructures.Unit s1, DataStructures.Unit s2, Env data)
+                {
+                    BoxedExpression right;
+                    if (!data.PopBE(out right)) return false;
+                    BoxedExpression left;
+                    if (!data.PopBE(out left)) return false;
+                    data.Push(BoxedExpression.Binary(op, left, right));
+                    return true;
+                }
+
+                public bool Isinst(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
+                {
+                    return false;
+                }
+
+                public bool Ldconst(Label2 pc, object constant, Type type, DataStructures.Unit dest, Env data)
+                {
+                    data.Push(BoxedExpression.Const(constant, type, driver.MetaDataDecoder));
+                    return true;
+                }
+
+                public bool Ldnull(Label2 pc, DataStructures.Unit dest, Env data)
+                {
+                    data.Push(BoxedExpression.Const(null, default(Type), driver.MetaDataDecoder));
+                    return true;
+                }
+
+                public bool Sizeof(Label2 pc, Type type, DataStructures.Unit dest, Env data)
+                {
+                    return false;
+                }
+
+                public bool Unary(Label2 pc, UnaryOperator op, bool overflow, bool unsigned, DataStructures.Unit dest, DataStructures.Unit source, Env data)
+                {
+                    BoxedExpression arg;
+                    if (!data.PopBE(out arg)) return false;
+                    data.Push(BoxedExpression.Unary(op, arg));
+                    return true;
+                }
+
+                #endregion
             }
+
+            BoxedExpression IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, BoxedExpression>.Accept<Label2, Handler>(
+              IMethodCodeProvider<Label2, Local, Parameter, Method, Field, Type, Handler> codeProvider,
+              Label2 entryPoint, Method method, Unit unit)
+            {
+                var current = entryPoint;
+                Env env = new Env(driver, contractPC);
+                var decoder = new Decoder<Label2, Handler>(contractPC, driver, targetObject, method, boundVariable, codeProvider);
+                if (!decoder.Aggregate(entryPoint, entryPoint, false, env)) return null;
+                return decoder.resultExpression;
+            }
+
             #endregion
-
-          }
-          isLdResult = false;
-          ldStackOffset = 0;
-          isOld = false;
-          lookupPC = pc;
-          return false;
         }
-
-        /// <summary>
-        /// We have to distinguish 3 cases:
-        /// 
-        /// 1. Access to an argument of the closure method (the index)
-        /// 2. Access to the "this" argument of the closure method (to get to the closure values under CCI1)
-        /// 3. Access to the enclosing method parameters (under CCI2)
-        ///    3a. This can be the method under analysis, if the forall is a pre/post condition
-        ///    3b. This can be a called method from the method under analysis (at new or call)
-        ///    3c. This can be called methods from within contracts of called methods
-        /// </summary>
-        public bool Ldarg(Label2 pc, Parameter argument, bool isOldIgnored, DataStructures.Unit dest, Env data)
-        {
-          Contract.Assume(data != null);
-
-          // determine if argument belongs to method on stack at contarctPC
-          if (!OnStack(this.contractPC, this.driver.MetaDataDecoder.DeclaringMethod(argument)))
-          {
-            // could be closure this
-            if (!this.isStatic && driver.MetaDataDecoder.ArgumentIndex(argument) == 0)
-            {
-              data.Push(this.closure);
-              return true;
-            }
-            // can only be index
-            data.Push(this.boundVar);
-            return true;
-          }
-
-          // First check to see if the parameter is a parameter of the method enclosing the
-          // quantifier.
-          SymbolicValue sv;
-          if (driver.Context.ValueContext.TryParameterValue(this.contractPC, argument, out sv)) {
-            data.Push(sv);
-            return true;
-          }
-
-          // Now try to figure out where on the evaluation stack the parameters of this inner call would be
-          bool isLdResult;
-          int ldStackOffset;
-          bool isOld;
-          APC lookupPC;
-          var mdDecoder = this.driver.MetaDataDecoder;
-
-          Parameter oldArgument = argument;
-
-          if (RemapParameterToLdStack(this.contractPC, ref argument, out isLdResult, out ldStackOffset, out isOld, out lookupPC, data))
-          {
-            // ldstack
-            return this.LdstackSpecial(lookupPC, ldStackOffset, dest, Unit.Value, isOld, data);
-          }
-
-          // F: TODOTODO Awfull fix!!!! But I do not really understand the code, I should talk with MAF about it
-          if (argument == null)
-          {
-            argument = oldArgument;
-          }
-          // F: End
-
-          if (isLdResult)
-          {
-            // ldresult
-            // special case: if the parameter is typed address of struct, then we must be
-            // referring to the post state of a struct constructor. In this case, map it to ldstacka
-            if (mdDecoder.IsStruct(mdDecoder.DeclaringType(mdDecoder.DeclaringMethod(argument))))
-            {
-              return this.Ldstacka(pc, ldStackOffset, dest, Unit.Value, mdDecoder.ParameterType(argument), isOld, data);
-            }
-            return this.Ldresult(pc, mdDecoder.ParameterType(argument), dest, Unit.Value, data);
-          }
-
-          // if we can't find anything, it might be the index
-          data.Push(this.boundVar);
-          return true;
-        }
-
-        private bool OnStack(APC aPC, Method method)
-        {
-          var pcMethod = aPC.Block.Subroutine as IMethodInfo<Method>;
-          if (pcMethod != null && this.driver.MetaDataDecoder.Equal(pcMethod.Method, method)) return true;
-          for (var context = aPC.SubroutineContext; context != null; context = context.Tail)
-          {
-            pcMethod = context.Head.One.AssumeNotNull().Subroutine as IMethodInfo<Method>;
-            if (pcMethod != null && this.driver.MetaDataDecoder.Equal(pcMethod.Method, method)) return true;
-          }
-          return false;
-        }
-
-        public bool Ldarga(Label2 pc, Parameter argument, bool isOld, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldftn(Label2 pc, Method method, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldind(Label2 pc, Type type, bool @volatile, DataStructures.Unit dest, DataStructures.Unit ptr, Env data)
-        {
-          SymbolicValue ptrValue;
-          if (!data.PopSV(out ptrValue)) return false;
-          SymbolicValue result;
-          if (!driver.Context.ValueContext.TryLoadIndirect(contractPC, ptrValue, out result)) return false;
-          data.Push(result);
-          return true;
-        }
-
-        public bool Ldloc(Label2 pc, Local local, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldloca(Label2 pc, Local local, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Localloc(Label2 pc, DataStructures.Unit dest, DataStructures.Unit size, Env data)
-        {
-          return false;
-        }
-
-        public bool Nop(Label2 pc, Env data)
-        {
-          return true;
-        }
-
-        public bool Pop(Label2 pc, DataStructures.Unit source, Env data)
-        {
-          data.Pop();
-          return true;
-        }
-
-        public bool Return(Label2 pc, DataStructures.Unit source, Env data)
-        {
-          return data.PopBE(out this.resultExpression);
-        }
-
-        public bool Starg(Label2 pc, Parameter argument, DataStructures.Unit source, Env data)
-        {
-          return false;
-        }
-
-        public bool Stind(Label2 pc, Type type, bool @volatile, DataStructures.Unit ptr, DataStructures.Unit value, Env data)
-        {
-          return false;
-        }
-
-        public bool Stloc(Label2 pc, Local local, DataStructures.Unit source, Env data)
-        {
-          return false;
-        }
-
-        public bool Switch(Label2 pc, Type type, System.Collections.Generic.IEnumerable<DataStructures.Pair<object, Label2>> cases, DataStructures.Unit value, Env data)
-        {
-          return false;
-        }
-
-        public bool Box(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
-        {
-          // HACK: just leave the same value on the stack
-          return true;
-        }
-
-        public bool ConstrainedCallvirt<TypeList, ArgList>(Label2 pc, Method method, bool tail, Type constraint, TypeList extraVarargs, DataStructures.Unit dest, ArgList args, Env data)
-          where TypeList : DataStructures.IIndexable<Type>
-          where ArgList : DataStructures.IIndexable<DataStructures.Unit>
-        {
-          return false;
-        }
-
-        public bool Castclass(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          return true; // just leave the same value on the stack
-        }
-
-        public bool Cpobj(Label2 pc, Type type, DataStructures.Unit destptr, DataStructures.Unit srcptr, Env data)
-        {
-          return false;
-        }
-
-        public bool Initobj(Label2 pc, Type type, DataStructures.Unit ptr, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldelem(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit array, DataStructures.Unit index, Env data)
-        {
-          BoxedExpression indexExpr;
-          if (!data.PopBE(out indexExpr)) return false;
-          BoxedExpression arrayExpr;
-          if (!data.PopBE(out arrayExpr)) return false;
-          data.Push(BoxedExpression.ArrayIndex(arrayExpr, indexExpr, type));
-          return true;
-        }
-
-        public bool Ldelema(Label2 pc, Type type, bool @readonly, DataStructures.Unit dest, DataStructures.Unit array, DataStructures.Unit index, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          SymbolicValue objectValue;
-          if (!data.PopSV(out objectValue)) return false;
-          SymbolicValue fieldAddress;
-          if (!driver.Context.ValueContext.TryFieldAddress(contractPC, objectValue, field, out fieldAddress)) return false;
-          SymbolicValue result;
-          if (!driver.Context.ValueContext.TryLoadIndirect(contractPC, fieldAddress, out result)) return false;
-          data.Push(result);
-          return true;
-        }
-
-        public bool Ldflda(Label2 pc, Field field, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldlen(Label2 pc, DataStructures.Unit dest, DataStructures.Unit array, Env data)
-        {
-          SymbolicValue objectValue;
-          if (!data.PopSV(out objectValue)) return false;
-          SymbolicValue length;
-          if (!driver.Context.ValueContext.TryGetArrayLength(contractPC, objectValue, out length)) return false;
-          data.Push(length);
-          return true;
-        }
-
-        public bool Ldsfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldsflda(Label2 pc, Field field, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldtypetoken(Label2 pc, Type type, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldfieldtoken(Label2 pc, Field field, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldmethodtoken(Label2 pc, Method method, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldvirtftn(Label2 pc, Method method, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          return false;
-        }
-
-        public bool Mkrefany(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          return false;
-        }
-
-        public bool Newarray<ArgList>(Label2 pc, Type type, DataStructures.Unit dest, ArgList len, Env data) where ArgList : DataStructures.IIndexable<DataStructures.Unit>
-        {
-          return false;
-        }
-
-        public bool Newobj<ArgList>(Label2 pc, Method ctor, DataStructures.Unit dest, ArgList args, Env data) where ArgList : DataStructures.IIndexable<DataStructures.Unit>
-        {
-          return false;
-        }
-
-        public bool Refanytype(Label2 pc, DataStructures.Unit dest, DataStructures.Unit source, Env data)
-        {
-          return false;
-        }
-
-        public bool Refanyval(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
-        {
-          return false;
-        }
-
-        public bool Rethrow(Label2 pc, Env data)
-        {
-          return false;
-        }
-
-        public bool Stelem(Label2 pc, Type type, DataStructures.Unit array, DataStructures.Unit index, DataStructures.Unit value, Env data)
-        {
-          return false;
-        }
-
-        public bool Stfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit obj, DataStructures.Unit value, Env data)
-        {
-          return false;
-        }
-
-        public bool Stsfld(Label2 pc, Field field, bool @volatile, DataStructures.Unit value, Env data)
-        {
-          return false;
-        }
-
-        public bool Throw(Label2 pc, DataStructures.Unit exn, Env data)
-        {
-          return false;
-        }
-
-        public bool Unbox(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          return false;
-        }
-
-        public bool Unboxany(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          return false;
-        }
-
-        #endregion
-
-        #region IVisitSynthIL<Label2,Method,Type,Unit,Unit,Env,BoxedExpression> Members
-
-        public bool Entry(Label2 pc, Method method, Env data)
-        {
-          return true;
-        }
-
-        public bool Assume(Label2 pc, string tag, DataStructures.Unit condition, object provenance, Env data)
-        {
-          return false;
-        }
-
-        public bool Assert(Label2 pc, string tag, DataStructures.Unit condition, object provenance, Env data)
-        {
-          return false;
-        }
-
-        bool LdstackSpecial(APC apc, int offset, DataStructures.Unit dest, DataStructures.Unit source, bool isOld, Env data)
-        {
-          if (offset >= data.StackDepth)
-          {
-            var normalizedOffset = offset - data.StackDepth;
-            var top = this.driver.Context.StackContext.StackDepth(apc) - 1;
-            var index = top - normalizedOffset;
-            SymbolicValue result;
-            if (driver.Context.ValueContext.TryStackValue(apc, index, out result))
-            {
-              data.Push(result);
-              return true;
-            }
-          }
-          return data.Dup(offset);
-        }
-
-        public bool Ldstack(Label2 pc, int offset, DataStructures.Unit dest, DataStructures.Unit source, bool isOld, Env data)
-        {
-          return data.Dup(offset);
-        }
-
-        public bool Ldstacka(Label2 pc, int offset, DataStructures.Unit dest, DataStructures.Unit source, Type origParamType, bool isOld, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldresult(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
-        {
-          SymbolicValue result;
-          
-          if (!driver.Context.ValueContext.TryResultValue(contractPC, out result)) return false;
-          
-          data.Push(result);
-
-          return true;
-        }
-
-        public bool BeginOld(Label2 pc, Label2 matchingEnd, Env data)
-        {
-          return false;
-        }
-
-        public bool EndOld(Label2 pc, Label2 matchingBegin, Type type, DataStructures.Unit dest, DataStructures.Unit source, Env data)
-        {
-          return false;
-        }
-
-        #endregion
-
-        #region IVisitExprIL<Label2,Type,Unit,Unit,Env,BoxedExpression> Members
-
-        public bool Binary(Label2 pc, BinaryOperator op, DataStructures.Unit dest, DataStructures.Unit s1, DataStructures.Unit s2, Env data)
-        {
-          BoxedExpression right;
-          if (!data.PopBE(out right)) return false;
-          BoxedExpression left;
-          if (!data.PopBE(out left)) return false; 
-          data.Push(BoxedExpression.Binary(op, left, right));
-          return true;
-        }
-
-        public bool Isinst(Label2 pc, Type type, DataStructures.Unit dest, DataStructures.Unit obj, Env data)
-        {
-          return false;
-        }
-
-        public bool Ldconst(Label2 pc, object constant, Type type, DataStructures.Unit dest, Env data)
-        {
-          data.Push(BoxedExpression.Const(constant, type, this.driver.MetaDataDecoder));
-          return true;
-        }
-
-        public bool Ldnull(Label2 pc, DataStructures.Unit dest, Env data)
-        {
-          data.Push(BoxedExpression.Const(null, default(Type), this.driver.MetaDataDecoder));
-          return true;
-        }
-
-        public bool Sizeof(Label2 pc, Type type, DataStructures.Unit dest, Env data)
-        {
-          return false;
-        }
-
-        public bool Unary(Label2 pc, UnaryOperator op, bool overflow, bool unsigned, DataStructures.Unit dest, DataStructures.Unit source, Env data)
-        {
-          BoxedExpression arg;
-          if (!data.PopBE(out arg)) return false;
-          data.Push(BoxedExpression.Unary(op, arg));
-          return true;
-        }
-
-        #endregion
-      }
-
-      BoxedExpression IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, BoxedExpression>.Accept<Label2, Handler>(
-        IMethodCodeProvider<Label2, Local, Parameter, Method, Field, Type, Handler> codeProvider,
-        Label2 entryPoint, Method method, Unit unit)
-      {
-        var current = entryPoint;
-        Env env = new Env(this.driver, contractPC);
-        var decoder = new Decoder<Label2, Handler>(this.contractPC, this.driver, this.targetObject, method, this.boundVariable, codeProvider);
-        if (!decoder.Aggregate(entryPoint, entryPoint, false, env)) return null;
-        return decoder.resultExpression;
-      }
-
-      #endregion
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Serializers.cs
+++ b/Microsoft.Research/CodeAnalysis/Serializers.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -23,1040 +12,1036 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis.Caching
 {
-  /// <summary>
-  /// A specialized list to serialize so that we can skip non-deserializable elements while keeping the rest
-  /// </summary>
-  /// <typeparam name="Method"></typeparam>
-  public struct ConditionList<Method> : IEnumerable<Pair<BoxedExpression, Method>>
-  {
-    IEnumerable<Pair<BoxedExpression, Method>> data;
-
-    public ConditionList(IEnumerable<Pair<BoxedExpression, Method>> data)
+    /// <summary>
+    /// A specialized list to serialize so that we can skip non-deserializable elements while keeping the rest
+    /// </summary>
+    /// <typeparam name="Method"></typeparam>
+    public struct ConditionList<Method> : IEnumerable<Pair<BoxedExpression, Method>>
     {
-      this.data = data;
+        private IEnumerable<Pair<BoxedExpression, Method>> data;
+
+        public ConditionList(IEnumerable<Pair<BoxedExpression, Method>> data)
+        {
+            this.data = data;
+        }
+
+        public IEnumerator<Pair<BoxedExpression, Method>> GetEnumerator()
+        {
+            if (data == null) return new EmptyIndexable<Pair<BoxedExpression, Method>>().AsEnumerable().GetEnumerator();
+            return data.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
     }
 
-    public IEnumerator<Pair<BoxedExpression, Method>> GetEnumerator()
-    {
-      if (data == null) return new EmptyIndexable<Pair<BoxedExpression,Method>>().AsEnumerable().GetEnumerator();
-      return data.GetEnumerator();
-    }
-
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-    {
-      return this.GetEnumerator();
-    }
-
-
-  }
-
-
-  /// <summary>
-  /// Provides a surrogate selector and serialization surrogates for abstract types Type, Method, Parameter, Field and IDecodeMetaData
-  /// </summary>
-  /*
-   * Other types usually just need the [Serializable] attribute
-   * and a [NonSerialized] attribute on some fields
-   * 
-   * Be careful with the .net serializer and the deserialization order.
-   * 
-   * If you use a SerializationInfo structure, you can expect the objects returned by GetValue to be deserialized (i.e. they won't be null)
-   * but not their fields if the objet uses the automatic serialization (with [Serializable] attribute).
-   * The same problem happens for arrays, that's why I added an extension AddArray, GetArray
-   * 
-   * These serialization surrogates have been designed for serializing (BoxedExpression) inferred method pre/post conditions.
-   * Using them for another purpose might require (or not) small changes.
-   */
-  public static class Serializers
-  {
-    static public ISurrogateSelector SurrogateSelectorFor<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>(
-      StreamingContext context,
-      Method currentMethod,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder,
-      IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder,
-      bool trace)
-    {
-      Contract.Requires(currentMethod != null);
-      Contract.Requires(mdDecoder != null);
-
-      return Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.SurrogateSelectorFor(context, currentMethod, mdDecoder, contractDecoder, trace);
-    }
-  }
-
-  static class Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>
-  {
-    #region Surrogate selector
-    static public ISurrogateSelector SurrogateSelectorFor(
-      StreamingContext context,
-      Method currentMethod,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder,
-      IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder,
-      bool trace)
-    {
-      Contract.Requires(currentMethod != null);
-
-      // Possible optimization: instead of creating new object each time we want to serialize something,
-      // reuse them and use the Context.context to store mdDecoder and currentMethod
-
-      // Using a SimpleSubTypeSurrogateSelector is necessary for CCI2 because its type parameter Parameter is an interface
-      var selector = new SimpleSubTypeSurrogateSelector();
-
-      selector.AddSurrogate(context, TypeSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
-      selector.AddSurrogate(context, MethodSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
-      selector.AddSurrogate(context, ParameterSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
-      selector.AddSurrogate(context, FieldSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
-      selector.AddSurrogate(context, LocalSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
-      selector.AddSurrogate(context, ConditionListSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder, trace));
-
-      // We want to serialize the mdDecoder *by ourselves*, that's why we do the special case
-      // use mdDecoder.GetType() and not typeof(IDecodeMetaData), because SubTypeSurrogateSelector doesn't work with interfaces
-      selector.AddSurrogate(mdDecoder.GetType(), context, new DecodeMetaDataSerializationSurrogate(mdDecoder));
-
-      // Optimization: The serializer asks every single time if we have a surrogate. But we know that the answer will not change, so we cache the results
-      // Using a SubTypeSurrogateSelector is necessary for abstract types since we want to (de)serialize all derived types in the same way using a metadata decoder
-      ISurrogateSelector resultSelector = new CachingSurrogateSelector(selector); //new SubTypeSurrogateSelector(selector));
-#if DEBUG
-      TextWriter tw = context.Context as TextWriter;
-      if (tw != null)
-        resultSelector = new SpySurrogateSelector(tw, resultSelector);
-#endif
-      return resultSelector;
-    }
-
-    #region SurrogateSelector helpers
 
     /// <summary>
-    /// Allow to use a serialization surrogate for all *subtypes* of a class
-    /// and all classes implementing an interface.
-    /// Not context-sensitive.
+    /// Provides a surrogate selector and serialization surrogates for abstract types Type, Method, Parameter, Field and IDecodeMetaData
     /// </summary>
-    internal class SimpleSubTypeSurrogateSelector : ISurrogateSelector
+    /*
+     * Other types usually just need the [Serializable] attribute
+     * and a [NonSerialized] attribute on some fields
+     * 
+     * Be careful with the .net serializer and the deserialization order.
+     * 
+     * If you use a SerializationInfo structure, you can expect the objects returned by GetValue to be deserialized (i.e. they won't be null)
+     * but not their fields if the objet uses the automatic serialization (with [Serializable] attribute).
+     * The same problem happens for arrays, that's why I added an extension AddArray, GetArray
+     * 
+     * These serialization surrogates have been designed for serializing (BoxedExpression) inferred method pre/post conditions.
+     * Using them for another purpose might require (or not) small changes.
+     */
+    public static class Serializers
     {
-      ISurrogateSelector nextSelector;
-      List<Pair<Type, ISerializationSurrogate>> classes;      // map type -> ISerializationSurrogate
-      List<Pair<Type, ISerializationSurrogate>> interfaces;   // map type -> ISerializationSurrogate
-
-      public SimpleSubTypeSurrogateSelector()
-      {
-      }
-
-      public void ChainSelector(ISurrogateSelector selector)
-      {
-        if (this.nextSelector != null)
+        static public ISurrogateSelector SurrogateSelectorFor<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>(
+          StreamingContext context,
+          Method currentMethod,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder,
+          IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder,
+          bool trace)
         {
-          this.nextSelector.ChainSelector(selector);
+            Contract.Requires(currentMethod != null);
+            Contract.Requires(mdDecoder != null);
+
+            return Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.SurrogateSelectorFor(context, currentMethod, mdDecoder, contractDecoder, trace);
         }
-        else
-        {
-          this.nextSelector = selector;
-        }
-      }
-
-      public ISurrogateSelector GetNextSelector() { return this.nextSelector; }
-
-      public ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
-      {
-        selector = this;
-        if (classes != null)
-          foreach(var c in classes)
-            if (type == c.One || type.IsSubclassOf(c.One))
-              return c.Two;
-        if (interfaces != null)
-        {
-          var typeInterfaces = type.GetInterfaces();
-          foreach (var i in interfaces)
-            foreach (var ti in typeInterfaces)
-              if (ti == i.One)
-                return i.Two;
-        }
-        return null;
-      }
-
-      public void AddSurrogateForClass(Type type, StreamingContext context, ISerializationSurrogate surrogate)
-      {
-        if (classes == null)
-          classes = new List<Pair<Type, ISerializationSurrogate>>();
-        classes.Add(Pair.For(type, surrogate));
-      }
-
-      public void AddSurrogateForInterface(Type type, StreamingContext context, ISerializationSurrogate surrogate)
-      {
-        if (interfaces == null)
-          interfaces = new List<Pair<Type, ISerializationSurrogate>>();
-        interfaces.Add(Pair.For(type, surrogate));
-      }
-
-      public void AddSurrogate(Type type, StreamingContext context, ISerializationSurrogate surrogate)
-      {
-        if (type.IsInterface)
-          this.AddSurrogateForInterface(type, context, surrogate);
-        else
-          this.AddSurrogateForClass(type, context, surrogate);
-      }
     }
 
-    private abstract class BoxedSurrogateSelector : ISurrogateSelector
+    internal static class Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>
     {
-      protected readonly ISurrogateSelector underlyingSelector;
-
-      protected BoxedSurrogateSelector(ISurrogateSelector selector)
-      {
-        if (selector == null)
-          throw new ArgumentNullException();
-        this.underlyingSelector = selector;
-      }
-
-      public void ChainSelector(ISurrogateSelector selector)
-      {
-        this.underlyingSelector.ChainSelector(selector);
-      }
-      public ISurrogateSelector GetNextSelector()
-      {
-        return this.underlyingSelector.GetNextSelector();
-      }
-
-      public abstract ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector);
-    }
-
-    /// <summary>
-    /// A surrogate selector that falls back to the base type surrogate
-    /// </summary>
-    private class SubTypeSurrogateSelector : BoxedSurrogateSelector
-    {
-      public SubTypeSurrogateSelector(ISurrogateSelector selector) : base(selector) { }
-
-      public override ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
-      {
-        for (; type != null; type = type.BaseType)
+        #region Surrogate selector
+        static public ISurrogateSelector SurrogateSelectorFor(
+          StreamingContext context,
+          Method currentMethod,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder,
+          IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder,
+          bool trace)
         {
-          var surrogate = this.underlyingSelector.GetSurrogate(type, context, out selector);
-          if (surrogate != null)
-            return surrogate;
-        }
-        selector = null;
-        return null;
-      }
-    }
+            Contract.Requires(currentMethod != null);
 
-    private class CachingSurrogateSelector : BoxedSurrogateSelector
-    {
-      private readonly Dictionary<Pair<Type, StreamingContext>, Pair<ISerializationSurrogate, ISurrogateSelector>> selectionCache = new Dictionary<Pair<Type, StreamingContext>, Pair<ISerializationSurrogate, ISurrogateSelector>>();
+            // Possible optimization: instead of creating new object each time we want to serialize something,
+            // reuse them and use the Context.context to store mdDecoder and currentMethod
 
-      public CachingSurrogateSelector(ISurrogateSelector selector) : base(selector) { }
+            // Using a SimpleSubTypeSurrogateSelector is necessary for CCI2 because its type parameter Parameter is an interface
+            var selector = new SimpleSubTypeSurrogateSelector();
 
-      public override ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
-      {
-        var key = Pair.For(type, context);
-        Pair<ISerializationSurrogate, ISurrogateSelector> val;
-        if (selectionCache.TryGetValue(key, out val))
-        {
-          selector = val.Two;
-        }
-        else
-        {
-          var one = this.underlyingSelector.GetSurrogate(type, context, out selector);
-          val = Pair.For(one, selector);
-          selectionCache[key] = val;
-        }
-        return val.One;
-      }
-    }
+            selector.AddSurrogate(context, TypeSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
+            selector.AddSurrogate(context, MethodSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
+            selector.AddSurrogate(context, ParameterSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
+            selector.AddSurrogate(context, FieldSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
+            selector.AddSurrogate(context, LocalSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder));
+            selector.AddSurrogate(context, ConditionListSerializationSurrogate.For(currentMethod, mdDecoder, contractDecoder, trace));
 
-    private class SimpleCachingSurrogateSelector : BoxedSurrogateSelector
-    {
-      private readonly Dictionary<Type, ISerializationSurrogate> selectionCache = new Dictionary<Type, ISerializationSurrogate>();
+            // We want to serialize the mdDecoder *by ourselves*, that's why we do the special case
+            // use mdDecoder.GetType() and not typeof(IDecodeMetaData), because SubTypeSurrogateSelector doesn't work with interfaces
+            selector.AddSurrogate(mdDecoder.GetType(), context, new DecodeMetaDataSerializationSurrogate(mdDecoder));
 
-      public SimpleCachingSurrogateSelector(ISurrogateSelector selector) : base(selector) { }
-
-      public override ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
-      {
-        ISerializationSurrogate surrogate;
-        if (selectionCache.TryGetValue(type, out surrogate))
-        {
-          selector = this; // who really uses this value?
-          return surrogate;
-        }
-        return selectionCache[type] = this.underlyingSelector.GetSurrogate(type, context, out selector);
-      }
-    }
-
+            // Optimization: The serializer asks every single time if we have a surrogate. But we know that the answer will not change, so we cache the results
+            // Using a SubTypeSurrogateSelector is necessary for abstract types since we want to (de)serialize all derived types in the same way using a metadata decoder
+            ISurrogateSelector resultSelector = new CachingSurrogateSelector(selector); //new SubTypeSurrogateSelector(selector));
 #if DEBUG
-    private class SpySurrogateSelector : ISurrogateSelector
-    {
-      private readonly TextWriter writer;
-      private readonly ISurrogateSelector underlyingSelector;
-
-      public SpySurrogateSelector(TextWriter writer, ISurrogateSelector selector)
-      {
-        if (writer == null || selector == null)
-          throw new ArgumentNullException();
-        this.writer = writer;
-        this.underlyingSelector = selector;
-      }
-
-      public void ChainSelector(ISurrogateSelector selector)
-      {
-        this.underlyingSelector.ChainSelector(selector);
-      }
-      public ISurrogateSelector GetNextSelector()
-      {
-        return this.underlyingSelector.GetNextSelector();
-      }
-      public ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
-      {
-        var surrogate = this.underlyingSelector.GetSurrogate(type, context, out selector);
-        writer.WriteLine("{0} -> {1}", type, surrogate == null ? "null" : surrogate.ToString());
-        return surrogate;
-      }
-    }
+            TextWriter tw = context.Context as TextWriter;
+            if (tw != null)
+                resultSelector = new SpySurrogateSelector(tw, resultSelector);
 #endif
-
-#if DEBUG
-    private class SpySerializationSurrogate : ISerializationSurrogate
-    {
-      private readonly TextWriter writer;
-
-      public SpySerializationSurrogate(TextWriter writer)
-      {
-        if (writer == null)
-          throw new ArgumentNullException();
-        this.writer = writer;
-      }
-
-      private void WriteObject(Object obj)
-      {
-        this.writer.WriteLine("<<<{0}>>>", obj);
-      }
-      public void GetObjectData(Object obj, SerializationInfo info, StreamingContext context)
-      {
-        this.WriteObject(obj);
-      }
-      public Object SetObjectData(Object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
-      {
-        this.WriteObject(obj);
-        return default(Object);
-      }
-    }
-#endif
-
-    #endregion
-
-    #endregion
-
-    #region XSerializationSurrogate
-    /// <summary>
-    /// common abstract class for serialization surrogates.
-    /// Main reason is to be type safe, and using generics to avoid casts to/from objects
-    /// </summary>
-    [ContractVerification(true)]
-    internal abstract class XSerializationSurrogate<X, XSS> : ISerializationSurrogate
-      where XSS : XSerializationSurrogate<X, XSS>, new()
-    {
-      public bool Trace { get; set; }
-      protected XSerializationSurrogate() { }
-
-      private Method currentMethod;
-      protected Method CurrentMethod {
-        get
-        {
-          Contract.Ensures(Contract.Result<Method>() != null);
-
-          Contract.Assume(this.currentMethod != null);
-          return this.currentMethod;
-        }
-        set
-        {
-          Contract.Requires(value != null);
-          this.currentMethod = value;
-        }
-      
-      }
-      protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder { get; private set; }
-      protected IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder { get; private set; }
-      protected Assembly currentAssembly { get; private set; }
-      protected string currentAssemblyName { get; private set; }
-
-      static public XSS For(
-        Method currentMethod,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder,
-        IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder,
-        bool trace = false)
-      {
-        Contract.Requires(currentMethod != null);
-
-        var x = new XSS();
-        x.CurrentMethod = currentMethod;
-        x.mdDecoder = mdDecoder;
-        x.contractDecoder = contractDecoder;
-        x.currentAssembly = mdDecoder.DeclaringAssembly(currentMethod);
-        x.currentAssemblyName = mdDecoder.Name(x.currentAssembly);
-        x.Trace = trace;
-        return x;
-      }
-      /// <summary>
-      /// Serialization
-      /// </summary>
-      /// <param name="obj">What we serialize</param>
-      /// <param name="info">Manually specify which fields we want to serialize</param>
-      public abstract void GetObjectData(X obj, SerializationInfo info);
-
-      /// <summary>
-      /// Deserialization
-      /// </summary>
-      /// <param name="obj">empty object of the good type -- todo, remove it</param>
-      /// <param name="info">Manually specify which fields we want to deserialize</param>
-      /// <returns></returns>
-      public abstract X SetObjectData(X obj, SerializationInfo info);
-
-      public void GetObjectData(Object obj, SerializationInfo info, StreamingContext context)
-      {
-#if DEBUG
-        var writer = context.Context as TextWriter;
-        if (writer != null)
-        {
-          writer.WriteLine("<<<{0}>>>", obj);
-          writer.WriteLine();
-        }
-#endif
-        this.GetObjectData((X)obj, info);
-      }
-      public Object SetObjectData(Object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
-      {
-        return this.SetObjectData((X)obj, info);
-      }
-    }
-    #endregion
-
-    #region Serialization surrogate for Type
-    sealed class TypeSerializationSurrogate : XSerializationSurrogate<Typ, TypeSerializationSurrogate>
-    {
-      public override void GetObjectData(Typ type, SerializationInfo info)
-      {
-        Contract.Assume(type != null);
-        // we need this because CCI2 uses a struct, so this function is always called, even for "(null)" (however it is not called for null when Typ is a class)
-        // note: the Equals of CCI2 has been modified so that the test below makes sense for structs
-        if (type.Equals(null))
-        {
-          info.AddValue("Kind", TypeKind.Default);
-          return;
+            return resultSelector;
         }
 
-        Typ _t;
-        IIndexable<Pair<bool, Typ>> _ipbt;
-        IIndexable<Typ> typeArguments;
+        #region SurrogateSelector helpers
 
-        if (mdDecoder.IsModified(type, out _t, out _ipbt))
+        /// <summary>
+        /// Allow to use a serialization surrogate for all *subtypes* of a class
+        /// and all classes implementing an interface.
+        /// Not context-sensitive.
+        /// </summary>
+        internal class SimpleSubTypeSurrogateSelector : ISurrogateSelector
         {
-          throw new NotImplementedException();
-        }
-        else if (mdDecoder.IsVoid(type))
-        {
-          info.AddValue("Kind", TypeKind.SystemVoid);
-        }
-        else if (mdDecoder.IsPrimitive(type))
-        {
-          info.AddValue("Kind", TypeKind.Primitive);
-          info.AddValue("FullName", mdDecoder.FullName(type));
-        }
-        else if (mdDecoder.Equal(type, mdDecoder.System_Object))
-        {
-          info.AddValue("Kind", TypeKind.SystemObject);
-        }
-        else if (mdDecoder.IsFormalTypeParameter(type))
-        {
-          info.AddValue("Kind", TypeKind.FormalTypeParameter);
-          info.AddValue("Index", mdDecoder.NormalizedFormalTypeParameterIndex(type));
-          info.AddValue("Type", mdDecoder.FormalTypeParameterDefiningType(type));
-        }
-        else if (mdDecoder.IsMethodFormalTypeParameter(type))
-        {
-          info.AddValue("Kind", TypeKind.MethodFormalTypeParameter);
-          info.AddValue("Index", mdDecoder.MethodFormalTypeParameterIndex(type));
-          info.AddValue("Method", mdDecoder.MethodFormalTypeDefiningMethod(type));
-        }
-        else if (mdDecoder.IsManagedPointer(type))
-        {
-          info.AddValue("Kind", TypeKind.ManagedPointer);
-          info.AddValue("ElementType", mdDecoder.ElementType(type));
-        }
-        else if (mdDecoder.IsUnmanagedPointer(type))
-        {
-          info.AddValue("Kind", TypeKind.UnmanagedPointer);
-          info.AddValue("ElementType", mdDecoder.ElementType(type));
-        }
-        else if (mdDecoder.IsArray(type))
-        {
-          info.AddValue("Kind", TypeKind.Array);
-          info.AddValue("ElementType", mdDecoder.ElementType(type));
-          info.AddValue("Rank", mdDecoder.Rank(type));
-        }
-        else if (mdDecoder.NormalizedIsSpecialized(type, out typeArguments))
-        {
-          // NormalizedIsSpecialized must return false if Unspecialized would return the same type
-          // otherwise we would have cycle and an exception would occur on deserialization
-          info.AddValue("Kind", TypeKind.Specialized);
-          info.AddValue("ElementType", mdDecoder.Unspecialized(type));
-          info.AddArray("TypeArguments", typeArguments.Enumerate().ToArray());
-        }
-        else
-        {
-          // Not specialized
-          info.AddValue("Kind", TypeKind.Path);
-          Typ parentType;
-          if (mdDecoder.IsNested(type, out parentType))
-          {
-            info.AddValue("NestedIn", parentType);
-          }
-          else
-          {
-            info.AddValue("NestedIn", default(Typ)); // do not use null, won't work with CCI2
-            info.AddValue("Module", this.TranslateModuleName(mdDecoder.DeclaringModuleName(type)));
-            info.AddValue("Namespace", mdDecoder.Namespace(type));
-          }
-          info.AddValue("Name", mdDecoder.Name(type)); // since the type is not specialized, there is no generic parameter in the name
+            private ISurrogateSelector nextSelector;
+            private List<Pair<Type, ISerializationSurrogate>> classes;      // map type -> ISerializationSurrogate
+            private List<Pair<Type, ISerializationSurrogate>> interfaces;   // map type -> ISerializationSurrogate
 
-          if (mdDecoder.IsGeneric(type, out typeArguments, false))
-            info.AddValue("GenericArity", typeArguments.Count);
-          else
-            info.AddValue("GenericArity", 0);
-        }
-      }
-
-      [ContractVerification(false)] // Too hard to prove?
-      public override Typ SetObjectData(Typ type, SerializationInfo info)
-      {
-        var typeKind = info.GetValue<TypeKind>("Kind");
-
-        switch (typeKind)
-        {
-          case TypeKind.Default:
-            return default(Typ);
-
-          case TypeKind.SystemVoid:
-            return mdDecoder.System_Void;
-
-          case TypeKind.Primitive:
-            if (mdDecoder.TryGetSystemType(info.GetString("FullName"), out type))
-              return type;
-            throw new SerializationException(String.Format("Unable to construct system type \"{0}\".", info.GetString("FullName")));
-
-          case TypeKind.SystemObject:
-            return mdDecoder.System_Object;
-
-          case TypeKind.FormalTypeParameter:
+            public SimpleSubTypeSurrogateSelector()
             {
-              IIndexable<Typ> formals;
-              if (!mdDecoder.IsGeneric(info.GetValue<Typ>("Type"), out formals, true))
-              {
-                throw new SerializationException(String.Format("Trying to get a formal type parameter of \"{0}\", which is not generic", info.GetValue<Typ>("Type")));
-              }
-              return formals[info.GetInt32("Index")];
             }
 
-          case TypeKind.MethodFormalTypeParameter:
+            public void ChainSelector(ISurrogateSelector selector)
             {
-              IIndexable<Typ> formals;
-              if (!mdDecoder.IsGeneric(info.GetValue<Method>("Method"), out formals))
-              {
-                throw new SerializationException(String.Format("Trying to get a method formal type parameter of \"{0}\", which is not generic", info.GetValue<Method>("Method")));
-              }
-              return formals[info.GetInt32("Index")];
-            }
-
-          case TypeKind.ManagedPointer:
-            return mdDecoder.ManagedPointer(info.GetValue<Typ>("ElementType"));
-
-          case TypeKind.UnmanagedPointer:
-            return mdDecoder.UnmanagedPointer(info.GetValue<Typ>("ElementType"));
-
-          case TypeKind.Array:
-            return mdDecoder.ArrayType(info.GetValue<Typ>("ElementType"), info.GetInt32("Rank"));
-
-          case TypeKind.Specialized:
-            return mdDecoder.Specialize(info.GetValue<Typ>("ElementType"), info.GetArray<Typ>("TypeArguments"));
-
-          case TypeKind.Path:
-            // Essentially we loop among all the types until we found the one we need
-
-            var parentType = info.GetValue<Typ>("NestedIn");
-            var name = info.GetString("Name");
-
-            IEnumerable<Typ> types;
-            string @namespace;
-
-            if (parentType == null || parentType.Equals(null)) // Must work with CCI1 AND CCI2, one uses a class, the other one uses a struct, thank you!
-            {
-              var module = info.GetString("Module");
-              Assembly assembly;
-              if (!this.TryGetAssembly(module, out assembly))
-              {
-                throw new SerializationException(String.Format("Unable to find module \"{0}\"", module));
-              }
-              @namespace = info.GetString("Namespace");
-              types = mdDecoder.GetTypes(assembly);
-            }
-            else
-            {
-              @namespace = null;
-              types = mdDecoder.NestedTypes(parentType);
-            }
-            var genericArity = info.GetInt32("GenericArity");
-
-            if (this.TryGetType(types, @namespace, name, genericArity, out type))
-            {
-              return type;
-            }
-            throw new SerializationException(String.Format("Unable to find type {0}", name));
-
-          default:
-            throw new SerializationException("Unknown type kind: " + typeKind);
-        }
-      }
-
-      // We need to use a special name because the current assembly name may have changed
-      private const string SpecialNameForCurrentAssembly = "~#@$!";
-
-      private bool TryGetAssembly(string name, out Assembly assembly)
-      {
-        if (name == SpecialNameForCurrentAssembly || name == this.currentAssemblyName)
-        {
-          assembly = this.currentAssembly;
-          return true;
-        }
-        // TODO: optim
-        foreach (var refAssembly in mdDecoder.AssemblyReferences(this.currentAssembly))
-        {
-          if (name == mdDecoder.Name(refAssembly))
-          {
-            assembly = refAssembly;
-            return true;
-          }
-        }
-        assembly = default(Assembly);
-        return false;
-      }
-
-      private string TranslateModuleName(string name)
-      {
-        if (name == this.currentAssemblyName)
-          return SpecialNameForCurrentAssembly;
-        return name;
-      }
-
-      private bool TryGetType(IEnumerable<Typ> types, string @namespace, string name, int genericArity, out Typ foundType)
-      {
-        // TODO: optim
-        foreach (var type in types)
-        {
-          if (@namespace != null && @namespace != mdDecoder.Namespace(type))
-            continue;
-          var _name = mdDecoder.Name(type);
-          if (_name == name)
-          {
-            IIndexable<Typ> formals;
-            int arguments = 0;
-            if (mdDecoder.IsGeneric(type, out formals, false))
-            {
-              arguments = formals.Count;
-            }
-            if (genericArity != arguments)
-              continue;
-            foundType = type;
-            return true;
-          }
-        }
-        foundType = default(Typ);
-        return false;
-      }
-    }
-    #endregion
-
-    #region Serialization surrogate for Method
-    sealed class MethodSerializationSurrogate : XSerializationSurrogate<Method, MethodSerializationSurrogate>
-    {
-      public override void GetObjectData(Method method, SerializationInfo info)
-      {
-        if (mdDecoder.Equal(method, CurrentMethod))
-        {
-          info.AddValue("Kind", MethodKind.CurrentMethod);
-        }
-        else
-        {
-          IIndexable<Typ> methodTypeArguments;
-          Method genericMethod;
-          if (mdDecoder.IsSpecialized(method, out genericMethod, out methodTypeArguments))
-          {
-            // I actually haven't encounter any specialized method different from the current method
-            info.AddValue("Kind", MethodKind.Specialized);
-            info.AddValue("GenericMethod", genericMethod);
-            info.AddArray("MethodTypeArguments", methodTypeArguments.Enumerate().ToArray());
-          }
-          else
-          {
-            info.AddValue("Kind", MethodKind.Path);
-            info.AddValue("Static", mdDecoder.IsStatic(method));
-            info.AddValue("FullName", mdDecoder.FullName(method));
-            info.AddValue("DeclaringType", mdDecoder.DeclaringType(method));
-
-            IIndexable<Typ> formals;
-
-            if (mdDecoder.IsGeneric(method, out formals))
-              info.AddValue("GenericArity", formals.Count);
-            else
-              info.AddValue("GenericArity", 0);
-          }
-        }
-      }
-
-      public override Method SetObjectData(Method method, SerializationInfo info)
-      {
-        var methodKind = info.GetValue<MethodKind>("Kind");
-
-        switch (methodKind)
-        {
-          case MethodKind.CurrentMethod:
-            return CurrentMethod;
-
-          case MethodKind.Specialized:
-            return mdDecoder.Specialize(info.GetValue<Method>("GenericMethod"), info.GetArray<Typ>("MethodTypeArguments"));
-
-          case MethodKind.Path:
-            var isStatic = info.GetBoolean("Static");
-            var fullName = info.GetString("FullName");
-            var declaringType = info.GetValue<Typ>("DeclaringType");
-            var genericArity = info.GetInt32("GenericArity");
-
-            IIndexable<Typ> formals;
-            foreach (var m in mdDecoder.Methods(declaringType))
-            {
-              if (mdDecoder.IsStatic(m) != isStatic)
-                continue;
-              if (mdDecoder.FullName(m) != fullName)
-                continue;
-              if (mdDecoder.IsGeneric(m, out formals))
-              {
-                if (formals.Count != genericArity)
-                  continue;
-              }
-              else if (genericArity != 0)
-                continue;
-              return m;
-            }
-            foreach (var m in this.contractDecoder.ModelMethods(declaringType))
-            {
-              if (mdDecoder.IsStatic(m) != isStatic)
-                continue;
-              if (mdDecoder.FullName(m) != fullName)
-                continue;
-              if (mdDecoder.IsGeneric(m, out formals))
-              {
-                Contract.Assume(formals != null);
-                if (formals.Count != genericArity)
-                  continue;
-              }
-              else if (genericArity != 0)
-                continue;
-              return m;
-            }
-            throw new SerializationException(String.Format("Unable to find {0}method \"{1}\"", isStatic ? "static " : "", fullName));
-
-          default:
-            throw new SerializationException("Unknown method kind: " + methodKind);
-        }
-      }
-    }
-    #endregion
-
-    #region Serialization surrogate for Parameter
-    sealed class ParameterSerializationSurrogate : XSerializationSurrogate<Parameter, ParameterSerializationSurrogate>
-    {
-      public override void GetObjectData(Parameter parameter, SerializationInfo info)
-      {
-        if (!mdDecoder.Equal(CurrentMethod, mdDecoder.DeclaringMethod(parameter)))
-        {
-          throw new SerializationException("Trying to serialize a parameter of a method different from the current method.");
-        }
-        info.AddValue("ArgumentIndex", mdDecoder.ArgumentIndex(parameter));
-        info.AddValue("Type", mdDecoder.ParameterType(parameter));
-      }
-
-      public override Parameter SetObjectData(Parameter parameter, SerializationInfo info)
-      {
-        var parameterType = info.GetValue<Typ>("Type");
-        var argumentIndex = info.GetInt32("ArgumentIndex");
-
-        Contract.Assume(argumentIndex >= 0);
-
-        Parameter candidate;
-        if (!mdDecoder.IsStatic(CurrentMethod))
-        {
-          if (argumentIndex == 0)
-          {
-            candidate = mdDecoder.This(CurrentMethod);
-            if (mdDecoder.Equal(mdDecoder.ParameterType(candidate), parameterType))
-            {
-                return candidate;
-            }
-            throw new SerializationException(string.Format("Parameter found, but wrong type. Expected {0} but found {1}", parameterType, mdDecoder.ParameterType(candidate)));
-          }
-          argumentIndex--;
-        }
-        var pars = mdDecoder.Parameters(CurrentMethod);
-        if (pars.Count > argumentIndex)
-        {
-            candidate = pars[argumentIndex];
-            if (mdDecoder.Equal(mdDecoder.ParameterType(candidate), parameterType))
-            {
-                return candidate;
-            }
-            throw new SerializationException(string.Format("Parameter found, but wrong type. Expected {0} but found {1}", parameterType, mdDecoder.ParameterType(candidate)));
-        }
-        throw new SerializationException("Parameter not found, out of bounds");
-      }
-    }
-    #endregion
-
-    #region Serialization surrogate for Local
-    sealed class LocalSerializationSurrogate : XSerializationSurrogate<Local, LocalSerializationSurrogate>
-    {
-        public override void GetObjectData(Local local, SerializationInfo info)
-        {
-            bool found = false;
-            foreach (var l in mdDecoder.Locals(CurrentMethod).Enumerate())
-            {
-                if (l.Equals(local)) 
+                if (nextSelector != null)
                 {
-                    found = true;
-                    break;
+                    nextSelector.ChainSelector(selector);
                 }
-
-            }
-            // TODO: necessary?
-            if (!found) 
-            {
-                throw new SerializationException(
-                    String.Format("Could not find local {0}; either trying to serialize a local of a method different from the current method, or the current method no longer contains this local.",
-                                  local));
-            }
-            info.AddValue("Name", mdDecoder.Name(local));
-            info.AddValue("LocalType", mdDecoder.LocalType(local));
-        }
-
-        public override Local SetObjectData(Local local, SerializationInfo info)
-        {
-            var localType = info.GetValue<Typ>("LocalType");
-            var name = info.GetString("Name");
-
-            foreach (var l in mdDecoder.Locals(CurrentMethod).Enumerate())
-            {
-                if (mdDecoder.Name(l) == name && mdDecoder.Equal(mdDecoder.LocalType(l), localType))
-                { 
-                    return l;
+                else
+                {
+                    nextSelector = selector;
                 }
             }
-            throw new SerializationException(String.Format("Unable to find local \"{0}\" of type \"{1}\"", name, localType));
-        }
-    }
-    #endregion
 
-    #region Serialization surrogate for Field
-    sealed class FieldSerializationSurrogate : XSerializationSurrogate<Field, FieldSerializationSurrogate>
-    {
-      public override void GetObjectData(Field field, SerializationInfo info)
-      {
-        info.AddValue("Name", mdDecoder.Name(field));
-        info.AddValue("DeclaringType", mdDecoder.DeclaringType(field));
-      }
+            public ISurrogateSelector GetNextSelector() { return nextSelector; }
 
-      public override Field SetObjectData(Field field, SerializationInfo info)
-      {
-        var declaringType = info.GetValue<Typ>("DeclaringType");
-        var name = info.GetString("Name");
-
-        // optim...
-        foreach (var f in mdDecoder.Fields(declaringType))
-        {
-          if (mdDecoder.Name(f) == name)
-          {
-            return f;
-          }
-        }
-        foreach (var f in contractDecoder.ModelFields(declaringType))
-        {
-          if (mdDecoder.Name(f) == name)
-          {
-            return f;
-          }
-        }
-        throw new SerializationException(String.Format("Unable to find field \"{0}\" of type \"{1}\"", name, declaringType));
-      }
-    }
-    #endregion
-
-    #region Serialize MetaDataDecoders as singletons
-    sealed class DecodeMetaDataSerializationSurrogate : ISerializationSurrogate
-    {
-      private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder;
-
-      public DecodeMetaDataSerializationSurrogate(
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder)
-      {
-        this.mdDecoder = mdDecoder;
-      }
-
-      public void GetObjectData(Object obj, SerializationInfo info, StreamingContext context)
-      {
-        // Global invariant: there exists only one metadata decoder
-
-        if (obj != this.mdDecoder)
-        {
-          throw new SerializationException("Trying to serialize another IDecodeMetaData");
-        }
-      }
-      public Object SetObjectData(Object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
-      {
-        return this.mdDecoder;
-      }
-    }
-    #endregion
-
-    #region Serialize ConditionLists
-    sealed class ConditionListSerializationSurrogate : XSerializationSurrogate<ConditionList<Method>, ConditionListSerializationSurrogate>
-    {
-      public override void GetObjectData(ConditionList<Method> list, SerializationInfo info)
-      {
-        var values = list.ToArray();
-        info.AddValue("count", values.Length);
-        for (int i = 0; i < values.Length; i++)
-        {
-          var elem = values[i];
-          info.AddValue(i.ToString()+"E", elem.One);
-          info.AddValue(i.ToString() + "M", elem.Two);
-        }
-      }
-
-      public override ConditionList<Method> SetObjectData(ConditionList<Method> list, SerializationInfo info)
-      {
-        var count = info.GetValue<int>("count");
-        var result = new List<Pair<BoxedExpression, Method>>();
-
-        for (int i = 0; i < count; i++)
-        {
-          try
-          {
-            var be = info.GetValue<BoxedExpression>(i.ToString()+"E");
-            var m  = info.GetValue<Method>(i.ToString() + "M");
-            result.Add(new Pair<BoxedExpression,Method>(be, m));
-          }
-          catch
-          {
-            if (Trace)
+            public ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
             {
-              Console.WriteLine("[cache] skipping failed deserialization of an inferred condition list element");
+                selector = this;
+                if (classes != null)
+                    foreach (var c in classes)
+                        if (type == c.One || type.IsSubclassOf(c.One))
+                            return c.Two;
+                if (interfaces != null)
+                {
+                    var typeInterfaces = type.GetInterfaces();
+                    foreach (var i in interfaces)
+                        foreach (var ti in typeInterfaces)
+                            if (ti == i.One)
+                                return i.Two;
+                }
+                return null;
             }
-            // swallow deserialization exceptions
-          }
 
+            public void AddSurrogateForClass(Type type, StreamingContext context, ISerializationSurrogate surrogate)
+            {
+                if (classes == null)
+                    classes = new List<Pair<Type, ISerializationSurrogate>>();
+                classes.Add(Pair.For(type, surrogate));
+            }
+
+            public void AddSurrogateForInterface(Type type, StreamingContext context, ISerializationSurrogate surrogate)
+            {
+                if (interfaces == null)
+                    interfaces = new List<Pair<Type, ISerializationSurrogate>>();
+                interfaces.Add(Pair.For(type, surrogate));
+            }
+
+            public void AddSurrogate(Type type, StreamingContext context, ISerializationSurrogate surrogate)
+            {
+                if (type.IsInterface)
+                    this.AddSurrogateForInterface(type, context, surrogate);
+                else
+                    this.AddSurrogateForClass(type, context, surrogate);
+            }
         }
-        return new ConditionList<Method>(result);
-      }
+
+        private abstract class BoxedSurrogateSelector : ISurrogateSelector
+        {
+            protected readonly ISurrogateSelector underlyingSelector;
+
+            protected BoxedSurrogateSelector(ISurrogateSelector selector)
+            {
+                if (selector == null)
+                    throw new ArgumentNullException();
+                this.underlyingSelector = selector;
+            }
+
+            public void ChainSelector(ISurrogateSelector selector)
+            {
+                this.underlyingSelector.ChainSelector(selector);
+            }
+            public ISurrogateSelector GetNextSelector()
+            {
+                return this.underlyingSelector.GetNextSelector();
+            }
+
+            public abstract ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector);
+        }
+
+        /// <summary>
+        /// A surrogate selector that falls back to the base type surrogate
+        /// </summary>
+        private class SubTypeSurrogateSelector : BoxedSurrogateSelector
+        {
+            public SubTypeSurrogateSelector(ISurrogateSelector selector) : base(selector) { }
+
+            public override ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
+            {
+                for (; type != null; type = type.BaseType)
+                {
+                    var surrogate = this.underlyingSelector.GetSurrogate(type, context, out selector);
+                    if (surrogate != null)
+                        return surrogate;
+                }
+                selector = null;
+                return null;
+            }
+        }
+
+        private class CachingSurrogateSelector : BoxedSurrogateSelector
+        {
+            private readonly Dictionary<Pair<Type, StreamingContext>, Pair<ISerializationSurrogate, ISurrogateSelector>> selectionCache = new Dictionary<Pair<Type, StreamingContext>, Pair<ISerializationSurrogate, ISurrogateSelector>>();
+
+            public CachingSurrogateSelector(ISurrogateSelector selector) : base(selector) { }
+
+            public override ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
+            {
+                var key = Pair.For(type, context);
+                Pair<ISerializationSurrogate, ISurrogateSelector> val;
+                if (selectionCache.TryGetValue(key, out val))
+                {
+                    selector = val.Two;
+                }
+                else
+                {
+                    var one = this.underlyingSelector.GetSurrogate(type, context, out selector);
+                    val = Pair.For(one, selector);
+                    selectionCache[key] = val;
+                }
+                return val.One;
+            }
+        }
+
+        private class SimpleCachingSurrogateSelector : BoxedSurrogateSelector
+        {
+            private readonly Dictionary<Type, ISerializationSurrogate> selectionCache = new Dictionary<Type, ISerializationSurrogate>();
+
+            public SimpleCachingSurrogateSelector(ISurrogateSelector selector) : base(selector) { }
+
+            public override ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
+            {
+                ISerializationSurrogate surrogate;
+                if (selectionCache.TryGetValue(type, out surrogate))
+                {
+                    selector = this; // who really uses this value?
+                    return surrogate;
+                }
+                return selectionCache[type] = this.underlyingSelector.GetSurrogate(type, context, out selector);
+            }
+        }
+
+#if DEBUG
+        private class SpySurrogateSelector : ISurrogateSelector
+        {
+            private readonly TextWriter writer;
+            private readonly ISurrogateSelector underlyingSelector;
+
+            public SpySurrogateSelector(TextWriter writer, ISurrogateSelector selector)
+            {
+                if (writer == null || selector == null)
+                    throw new ArgumentNullException();
+                this.writer = writer;
+                underlyingSelector = selector;
+            }
+
+            public void ChainSelector(ISurrogateSelector selector)
+            {
+                underlyingSelector.ChainSelector(selector);
+            }
+            public ISurrogateSelector GetNextSelector()
+            {
+                return underlyingSelector.GetNextSelector();
+            }
+            public ISerializationSurrogate GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
+            {
+                var surrogate = underlyingSelector.GetSurrogate(type, context, out selector);
+                writer.WriteLine("{0} -> {1}", type, surrogate == null ? "null" : surrogate.ToString());
+                return surrogate;
+            }
+        }
+#endif
+
+#if DEBUG
+        private class SpySerializationSurrogate : ISerializationSurrogate
+        {
+            private readonly TextWriter writer;
+
+            public SpySerializationSurrogate(TextWriter writer)
+            {
+                if (writer == null)
+                    throw new ArgumentNullException();
+                this.writer = writer;
+            }
+
+            private void WriteObject(Object obj)
+            {
+                writer.WriteLine("<<<{0}>>>", obj);
+            }
+            public void GetObjectData(Object obj, SerializationInfo info, StreamingContext context)
+            {
+                this.WriteObject(obj);
+            }
+            public Object SetObjectData(Object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
+            {
+                this.WriteObject(obj);
+                return default(Object);
+            }
+        }
+#endif
+
+        #endregion
+
+        #endregion
+
+        #region XSerializationSurrogate
+        /// <summary>
+        /// common abstract class for serialization surrogates.
+        /// Main reason is to be type safe, and using generics to avoid casts to/from objects
+        /// </summary>
+        [ContractVerification(true)]
+        internal abstract class XSerializationSurrogate<X, XSS> : ISerializationSurrogate
+          where XSS : XSerializationSurrogate<X, XSS>, new()
+        {
+            public bool Trace { get; set; }
+            protected XSerializationSurrogate() { }
+
+            private Method currentMethod;
+            protected Method CurrentMethod
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<Method>() != null);
+
+                    Contract.Assume(currentMethod != null);
+                    return currentMethod;
+                }
+                set
+                {
+                    Contract.Requires(value != null);
+                    currentMethod = value;
+                }
+            }
+            protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder { get; private set; }
+            protected IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder { get; private set; }
+            protected Assembly currentAssembly { get; private set; }
+            protected string currentAssemblyName { get; private set; }
+
+            static public XSS For(
+              Method currentMethod,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder,
+              IDecodeContracts<Local, Parameter, Method, Field, Typ> contractDecoder,
+              bool trace = false)
+            {
+                Contract.Requires(currentMethod != null);
+
+                var x = new XSS();
+                x.CurrentMethod = currentMethod;
+                x.mdDecoder = mdDecoder;
+                x.contractDecoder = contractDecoder;
+                x.currentAssembly = mdDecoder.DeclaringAssembly(currentMethod);
+                x.currentAssemblyName = mdDecoder.Name(x.currentAssembly);
+                x.Trace = trace;
+                return x;
+            }
+            /// <summary>
+            /// Serialization
+            /// </summary>
+            /// <param name="obj">What we serialize</param>
+            /// <param name="info">Manually specify which fields we want to serialize</param>
+            public abstract void GetObjectData(X obj, SerializationInfo info);
+
+            /// <summary>
+            /// Deserialization
+            /// </summary>
+            /// <param name="obj">empty object of the good type -- todo, remove it</param>
+            /// <param name="info">Manually specify which fields we want to deserialize</param>
+            /// <returns></returns>
+            public abstract X SetObjectData(X obj, SerializationInfo info);
+
+            public void GetObjectData(Object obj, SerializationInfo info, StreamingContext context)
+            {
+#if DEBUG
+                var writer = context.Context as TextWriter;
+                if (writer != null)
+                {
+                    writer.WriteLine("<<<{0}>>>", obj);
+                    writer.WriteLine();
+                }
+#endif
+                this.GetObjectData((X)obj, info);
+            }
+            public Object SetObjectData(Object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
+            {
+                return this.SetObjectData((X)obj, info);
+            }
+        }
+        #endregion
+
+        #region Serialization surrogate for Type
+        private sealed class TypeSerializationSurrogate : XSerializationSurrogate<Typ, TypeSerializationSurrogate>
+        {
+            public override void GetObjectData(Typ type, SerializationInfo info)
+            {
+                Contract.Assume(type != null);
+                // we need this because CCI2 uses a struct, so this function is always called, even for "(null)" (however it is not called for null when Typ is a class)
+                // note: the Equals of CCI2 has been modified so that the test below makes sense for structs
+                if (type.Equals(null))
+                {
+                    info.AddValue("Kind", TypeKind.Default);
+                    return;
+                }
+
+                Typ _t;
+                IIndexable<Pair<bool, Typ>> _ipbt;
+                IIndexable<Typ> typeArguments;
+
+                if (mdDecoder.IsModified(type, out _t, out _ipbt))
+                {
+                    throw new NotImplementedException();
+                }
+                else if (mdDecoder.IsVoid(type))
+                {
+                    info.AddValue("Kind", TypeKind.SystemVoid);
+                }
+                else if (mdDecoder.IsPrimitive(type))
+                {
+                    info.AddValue("Kind", TypeKind.Primitive);
+                    info.AddValue("FullName", mdDecoder.FullName(type));
+                }
+                else if (mdDecoder.Equal(type, mdDecoder.System_Object))
+                {
+                    info.AddValue("Kind", TypeKind.SystemObject);
+                }
+                else if (mdDecoder.IsFormalTypeParameter(type))
+                {
+                    info.AddValue("Kind", TypeKind.FormalTypeParameter);
+                    info.AddValue("Index", mdDecoder.NormalizedFormalTypeParameterIndex(type));
+                    info.AddValue("Type", mdDecoder.FormalTypeParameterDefiningType(type));
+                }
+                else if (mdDecoder.IsMethodFormalTypeParameter(type))
+                {
+                    info.AddValue("Kind", TypeKind.MethodFormalTypeParameter);
+                    info.AddValue("Index", mdDecoder.MethodFormalTypeParameterIndex(type));
+                    info.AddValue("Method", mdDecoder.MethodFormalTypeDefiningMethod(type));
+                }
+                else if (mdDecoder.IsManagedPointer(type))
+                {
+                    info.AddValue("Kind", TypeKind.ManagedPointer);
+                    info.AddValue("ElementType", mdDecoder.ElementType(type));
+                }
+                else if (mdDecoder.IsUnmanagedPointer(type))
+                {
+                    info.AddValue("Kind", TypeKind.UnmanagedPointer);
+                    info.AddValue("ElementType", mdDecoder.ElementType(type));
+                }
+                else if (mdDecoder.IsArray(type))
+                {
+                    info.AddValue("Kind", TypeKind.Array);
+                    info.AddValue("ElementType", mdDecoder.ElementType(type));
+                    info.AddValue("Rank", mdDecoder.Rank(type));
+                }
+                else if (mdDecoder.NormalizedIsSpecialized(type, out typeArguments))
+                {
+                    // NormalizedIsSpecialized must return false if Unspecialized would return the same type
+                    // otherwise we would have cycle and an exception would occur on deserialization
+                    info.AddValue("Kind", TypeKind.Specialized);
+                    info.AddValue("ElementType", mdDecoder.Unspecialized(type));
+                    info.AddArray("TypeArguments", typeArguments.Enumerate().ToArray());
+                }
+                else
+                {
+                    // Not specialized
+                    info.AddValue("Kind", TypeKind.Path);
+                    Typ parentType;
+                    if (mdDecoder.IsNested(type, out parentType))
+                    {
+                        info.AddValue("NestedIn", parentType);
+                    }
+                    else
+                    {
+                        info.AddValue("NestedIn", default(Typ)); // do not use null, won't work with CCI2
+                        info.AddValue("Module", this.TranslateModuleName(mdDecoder.DeclaringModuleName(type)));
+                        info.AddValue("Namespace", mdDecoder.Namespace(type));
+                    }
+                    info.AddValue("Name", mdDecoder.Name(type)); // since the type is not specialized, there is no generic parameter in the name
+
+                    if (mdDecoder.IsGeneric(type, out typeArguments, false))
+                        info.AddValue("GenericArity", typeArguments.Count);
+                    else
+                        info.AddValue("GenericArity", 0);
+                }
+            }
+
+            [ContractVerification(false)] // Too hard to prove?
+            public override Typ SetObjectData(Typ type, SerializationInfo info)
+            {
+                var typeKind = info.GetValue<TypeKind>("Kind");
+
+                switch (typeKind)
+                {
+                    case TypeKind.Default:
+                        return default(Typ);
+
+                    case TypeKind.SystemVoid:
+                        return mdDecoder.System_Void;
+
+                    case TypeKind.Primitive:
+                        if (mdDecoder.TryGetSystemType(info.GetString("FullName"), out type))
+                            return type;
+                        throw new SerializationException(String.Format("Unable to construct system type \"{0}\".", info.GetString("FullName")));
+
+                    case TypeKind.SystemObject:
+                        return mdDecoder.System_Object;
+
+                    case TypeKind.FormalTypeParameter:
+                        {
+                            IIndexable<Typ> formals;
+                            if (!mdDecoder.IsGeneric(info.GetValue<Typ>("Type"), out formals, true))
+                            {
+                                throw new SerializationException(String.Format("Trying to get a formal type parameter of \"{0}\", which is not generic", info.GetValue<Typ>("Type")));
+                            }
+                            return formals[info.GetInt32("Index")];
+                        }
+
+                    case TypeKind.MethodFormalTypeParameter:
+                        {
+                            IIndexable<Typ> formals;
+                            if (!mdDecoder.IsGeneric(info.GetValue<Method>("Method"), out formals))
+                            {
+                                throw new SerializationException(String.Format("Trying to get a method formal type parameter of \"{0}\", which is not generic", info.GetValue<Method>("Method")));
+                            }
+                            return formals[info.GetInt32("Index")];
+                        }
+
+                    case TypeKind.ManagedPointer:
+                        return mdDecoder.ManagedPointer(info.GetValue<Typ>("ElementType"));
+
+                    case TypeKind.UnmanagedPointer:
+                        return mdDecoder.UnmanagedPointer(info.GetValue<Typ>("ElementType"));
+
+                    case TypeKind.Array:
+                        return mdDecoder.ArrayType(info.GetValue<Typ>("ElementType"), info.GetInt32("Rank"));
+
+                    case TypeKind.Specialized:
+                        return mdDecoder.Specialize(info.GetValue<Typ>("ElementType"), info.GetArray<Typ>("TypeArguments"));
+
+                    case TypeKind.Path:
+                        // Essentially we loop among all the types until we found the one we need
+
+                        var parentType = info.GetValue<Typ>("NestedIn");
+                        var name = info.GetString("Name");
+
+                        IEnumerable<Typ> types;
+                        string @namespace;
+
+                        if (parentType == null || parentType.Equals(null)) // Must work with CCI1 AND CCI2, one uses a class, the other one uses a struct, thank you!
+                        {
+                            var module = info.GetString("Module");
+                            Assembly assembly;
+                            if (!this.TryGetAssembly(module, out assembly))
+                            {
+                                throw new SerializationException(String.Format("Unable to find module \"{0}\"", module));
+                            }
+                            @namespace = info.GetString("Namespace");
+                            types = mdDecoder.GetTypes(assembly);
+                        }
+                        else
+                        {
+                            @namespace = null;
+                            types = mdDecoder.NestedTypes(parentType);
+                        }
+                        var genericArity = info.GetInt32("GenericArity");
+
+                        if (this.TryGetType(types, @namespace, name, genericArity, out type))
+                        {
+                            return type;
+                        }
+                        throw new SerializationException(String.Format("Unable to find type {0}", name));
+
+                    default:
+                        throw new SerializationException("Unknown type kind: " + typeKind);
+                }
+            }
+
+            // We need to use a special name because the current assembly name may have changed
+            private const string SpecialNameForCurrentAssembly = "~#@$!";
+
+            private bool TryGetAssembly(string name, out Assembly assembly)
+            {
+                if (name == SpecialNameForCurrentAssembly || name == this.currentAssemblyName)
+                {
+                    assembly = this.currentAssembly;
+                    return true;
+                }
+                // TODO: optim
+                foreach (var refAssembly in mdDecoder.AssemblyReferences(this.currentAssembly))
+                {
+                    if (name == mdDecoder.Name(refAssembly))
+                    {
+                        assembly = refAssembly;
+                        return true;
+                    }
+                }
+                assembly = default(Assembly);
+                return false;
+            }
+
+            private string TranslateModuleName(string name)
+            {
+                if (name == this.currentAssemblyName)
+                    return SpecialNameForCurrentAssembly;
+                return name;
+            }
+
+            private bool TryGetType(IEnumerable<Typ> types, string @namespace, string name, int genericArity, out Typ foundType)
+            {
+                // TODO: optim
+                foreach (var type in types)
+                {
+                    if (@namespace != null && @namespace != mdDecoder.Namespace(type))
+                        continue;
+                    var _name = mdDecoder.Name(type);
+                    if (_name == name)
+                    {
+                        IIndexable<Typ> formals;
+                        int arguments = 0;
+                        if (mdDecoder.IsGeneric(type, out formals, false))
+                        {
+                            arguments = formals.Count;
+                        }
+                        if (genericArity != arguments)
+                            continue;
+                        foundType = type;
+                        return true;
+                    }
+                }
+                foundType = default(Typ);
+                return false;
+            }
+        }
+        #endregion
+
+        #region Serialization surrogate for Method
+        private sealed class MethodSerializationSurrogate : XSerializationSurrogate<Method, MethodSerializationSurrogate>
+        {
+            public override void GetObjectData(Method method, SerializationInfo info)
+            {
+                if (mdDecoder.Equal(method, CurrentMethod))
+                {
+                    info.AddValue("Kind", MethodKind.CurrentMethod);
+                }
+                else
+                {
+                    IIndexable<Typ> methodTypeArguments;
+                    Method genericMethod;
+                    if (mdDecoder.IsSpecialized(method, out genericMethod, out methodTypeArguments))
+                    {
+                        // I actually haven't encounter any specialized method different from the current method
+                        info.AddValue("Kind", MethodKind.Specialized);
+                        info.AddValue("GenericMethod", genericMethod);
+                        info.AddArray("MethodTypeArguments", methodTypeArguments.Enumerate().ToArray());
+                    }
+                    else
+                    {
+                        info.AddValue("Kind", MethodKind.Path);
+                        info.AddValue("Static", mdDecoder.IsStatic(method));
+                        info.AddValue("FullName", mdDecoder.FullName(method));
+                        info.AddValue("DeclaringType", mdDecoder.DeclaringType(method));
+
+                        IIndexable<Typ> formals;
+
+                        if (mdDecoder.IsGeneric(method, out formals))
+                            info.AddValue("GenericArity", formals.Count);
+                        else
+                            info.AddValue("GenericArity", 0);
+                    }
+                }
+            }
+
+            public override Method SetObjectData(Method method, SerializationInfo info)
+            {
+                var methodKind = info.GetValue<MethodKind>("Kind");
+
+                switch (methodKind)
+                {
+                    case MethodKind.CurrentMethod:
+                        return CurrentMethod;
+
+                    case MethodKind.Specialized:
+                        return mdDecoder.Specialize(info.GetValue<Method>("GenericMethod"), info.GetArray<Typ>("MethodTypeArguments"));
+
+                    case MethodKind.Path:
+                        var isStatic = info.GetBoolean("Static");
+                        var fullName = info.GetString("FullName");
+                        var declaringType = info.GetValue<Typ>("DeclaringType");
+                        var genericArity = info.GetInt32("GenericArity");
+
+                        IIndexable<Typ> formals;
+                        foreach (var m in mdDecoder.Methods(declaringType))
+                        {
+                            if (mdDecoder.IsStatic(m) != isStatic)
+                                continue;
+                            if (mdDecoder.FullName(m) != fullName)
+                                continue;
+                            if (mdDecoder.IsGeneric(m, out formals))
+                            {
+                                if (formals.Count != genericArity)
+                                    continue;
+                            }
+                            else if (genericArity != 0)
+                                continue;
+                            return m;
+                        }
+                        foreach (var m in this.contractDecoder.ModelMethods(declaringType))
+                        {
+                            if (mdDecoder.IsStatic(m) != isStatic)
+                                continue;
+                            if (mdDecoder.FullName(m) != fullName)
+                                continue;
+                            if (mdDecoder.IsGeneric(m, out formals))
+                            {
+                                Contract.Assume(formals != null);
+                                if (formals.Count != genericArity)
+                                    continue;
+                            }
+                            else if (genericArity != 0)
+                                continue;
+                            return m;
+                        }
+                        throw new SerializationException(String.Format("Unable to find {0}method \"{1}\"", isStatic ? "static " : "", fullName));
+
+                    default:
+                        throw new SerializationException("Unknown method kind: " + methodKind);
+                }
+            }
+        }
+        #endregion
+
+        #region Serialization surrogate for Parameter
+        private sealed class ParameterSerializationSurrogate : XSerializationSurrogate<Parameter, ParameterSerializationSurrogate>
+        {
+            public override void GetObjectData(Parameter parameter, SerializationInfo info)
+            {
+                if (!mdDecoder.Equal(CurrentMethod, mdDecoder.DeclaringMethod(parameter)))
+                {
+                    throw new SerializationException("Trying to serialize a parameter of a method different from the current method.");
+                }
+                info.AddValue("ArgumentIndex", mdDecoder.ArgumentIndex(parameter));
+                info.AddValue("Type", mdDecoder.ParameterType(parameter));
+            }
+
+            public override Parameter SetObjectData(Parameter parameter, SerializationInfo info)
+            {
+                var parameterType = info.GetValue<Typ>("Type");
+                var argumentIndex = info.GetInt32("ArgumentIndex");
+
+                Contract.Assume(argumentIndex >= 0);
+
+                Parameter candidate;
+                if (!mdDecoder.IsStatic(CurrentMethod))
+                {
+                    if (argumentIndex == 0)
+                    {
+                        candidate = mdDecoder.This(CurrentMethod);
+                        if (mdDecoder.Equal(mdDecoder.ParameterType(candidate), parameterType))
+                        {
+                            return candidate;
+                        }
+                        throw new SerializationException(string.Format("Parameter found, but wrong type. Expected {0} but found {1}", parameterType, mdDecoder.ParameterType(candidate)));
+                    }
+                    argumentIndex--;
+                }
+                var pars = mdDecoder.Parameters(CurrentMethod);
+                if (pars.Count > argumentIndex)
+                {
+                    candidate = pars[argumentIndex];
+                    if (mdDecoder.Equal(mdDecoder.ParameterType(candidate), parameterType))
+                    {
+                        return candidate;
+                    }
+                    throw new SerializationException(string.Format("Parameter found, but wrong type. Expected {0} but found {1}", parameterType, mdDecoder.ParameterType(candidate)));
+                }
+                throw new SerializationException("Parameter not found, out of bounds");
+            }
+        }
+        #endregion
+
+        #region Serialization surrogate for Local
+        private sealed class LocalSerializationSurrogate : XSerializationSurrogate<Local, LocalSerializationSurrogate>
+        {
+            public override void GetObjectData(Local local, SerializationInfo info)
+            {
+                bool found = false;
+                foreach (var l in mdDecoder.Locals(CurrentMethod).Enumerate())
+                {
+                    if (l.Equals(local))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                // TODO: necessary?
+                if (!found)
+                {
+                    throw new SerializationException(
+                        String.Format("Could not find local {0}; either trying to serialize a local of a method different from the current method, or the current method no longer contains this local.",
+                                      local));
+                }
+                info.AddValue("Name", mdDecoder.Name(local));
+                info.AddValue("LocalType", mdDecoder.LocalType(local));
+            }
+
+            public override Local SetObjectData(Local local, SerializationInfo info)
+            {
+                var localType = info.GetValue<Typ>("LocalType");
+                var name = info.GetString("Name");
+
+                foreach (var l in mdDecoder.Locals(CurrentMethod).Enumerate())
+                {
+                    if (mdDecoder.Name(l) == name && mdDecoder.Equal(mdDecoder.LocalType(l), localType))
+                    {
+                        return l;
+                    }
+                }
+                throw new SerializationException(String.Format("Unable to find local \"{0}\" of type \"{1}\"", name, localType));
+            }
+        }
+        #endregion
+
+        #region Serialization surrogate for Field
+        private sealed class FieldSerializationSurrogate : XSerializationSurrogate<Field, FieldSerializationSurrogate>
+        {
+            public override void GetObjectData(Field field, SerializationInfo info)
+            {
+                info.AddValue("Name", mdDecoder.Name(field));
+                info.AddValue("DeclaringType", mdDecoder.DeclaringType(field));
+            }
+
+            public override Field SetObjectData(Field field, SerializationInfo info)
+            {
+                var declaringType = info.GetValue<Typ>("DeclaringType");
+                var name = info.GetString("Name");
+
+                // optim...
+                foreach (var f in mdDecoder.Fields(declaringType))
+                {
+                    if (mdDecoder.Name(f) == name)
+                    {
+                        return f;
+                    }
+                }
+                foreach (var f in contractDecoder.ModelFields(declaringType))
+                {
+                    if (mdDecoder.Name(f) == name)
+                    {
+                        return f;
+                    }
+                }
+                throw new SerializationException(String.Format("Unable to find field \"{0}\" of type \"{1}\"", name, declaringType));
+            }
+        }
+        #endregion
+
+        #region Serialize MetaDataDecoders as singletons
+        private sealed class DecodeMetaDataSerializationSurrogate : ISerializationSurrogate
+        {
+            private readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder;
+
+            public DecodeMetaDataSerializationSurrogate(
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly> mdDecoder)
+            {
+                this.mdDecoder = mdDecoder;
+            }
+
+            public void GetObjectData(Object obj, SerializationInfo info, StreamingContext context)
+            {
+                // Global invariant: there exists only one metadata decoder
+
+                if (obj != mdDecoder)
+                {
+                    throw new SerializationException("Trying to serialize another IDecodeMetaData");
+                }
+            }
+            public Object SetObjectData(Object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
+            {
+                return mdDecoder;
+            }
+        }
+        #endregion
+
+        #region Serialize ConditionLists
+        private sealed class ConditionListSerializationSurrogate : XSerializationSurrogate<ConditionList<Method>, ConditionListSerializationSurrogate>
+        {
+            public override void GetObjectData(ConditionList<Method> list, SerializationInfo info)
+            {
+                var values = list.ToArray();
+                info.AddValue("count", values.Length);
+                for (int i = 0; i < values.Length; i++)
+                {
+                    var elem = values[i];
+                    info.AddValue(i.ToString() + "E", elem.One);
+                    info.AddValue(i.ToString() + "M", elem.Two);
+                }
+            }
+
+            public override ConditionList<Method> SetObjectData(ConditionList<Method> list, SerializationInfo info)
+            {
+                var count = info.GetValue<int>("count");
+                var result = new List<Pair<BoxedExpression, Method>>();
+
+                for (int i = 0; i < count; i++)
+                {
+                    try
+                    {
+                        var be = info.GetValue<BoxedExpression>(i.ToString() + "E");
+                        var m = info.GetValue<Method>(i.ToString() + "M");
+                        result.Add(new Pair<BoxedExpression, Method>(be, m));
+                    }
+                    catch
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("[cache] skipping failed deserialization of an inferred condition list element");
+                        }
+                        // swallow deserialization exceptions
+                    }
+                }
+                return new ConditionList<Method>(result);
+            }
+        }
+        #endregion
+
+    }
+
+    /// <summary>
+    /// Type constructors for serialization/deserialization
+    /// </summary>
+    [Serializable]
+    internal enum TypeKind
+    {
+        Default,
+        SystemVoid,
+        SystemObject,
+        Primitive,
+        FormalTypeParameter,
+        MethodFormalTypeParameter,
+        ManagedPointer,
+        UnmanagedPointer,
+        Array,
+        Specialized,
+        Path  // Non-generic type with full namespace
+    }
+
+    [Serializable]
+    internal enum MethodKind
+    {
+        CurrentMethod,
+        Specialized,
+        Path
+    }
+
+    #region Extensions
+    internal static class SurrogateSelectorExtensions
+    {
+        public static void AddSurrogate<X, XSS, Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>(
+          this SurrogateSelector selector,
+          StreamingContext context,
+          Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS> serializationSurrogate)
+          where XSS : Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS>, new()
+        {
+            selector.AddSurrogate(typeof(X), context, serializationSurrogate);
+        }
+
+        public static void AddSurrogate<X, XSS, Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>(
+          this Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.SimpleSubTypeSurrogateSelector selector,
+          StreamingContext context,
+          Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS> serializationSurrogate)
+          where XSS : Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS>, new()
+        {
+            selector.AddSurrogate(typeof(X), context, serializationSurrogate);
+        }
+    }
+
+    internal static class SerializationInfoExtensions
+    {
+        static public T GetValue<T>(this SerializationInfo info, string name)
+        {
+            Contract.Requires(name != null);
+            return (T)info.GetValue(name, typeof(T));
+        }
+
+        // HACK: because arrays are not deserialized in the correct order
+
+        static public void AddArray<T>(this SerializationInfo info, string name, T[] array)
+        {
+            if (array == null)
+            {
+                info.AddValue(name + ".Length", -1);
+            }
+            else
+            {
+                info.AddValue(name + ".Length", array.Length);
+                for (var i = 0; i < array.Length; i++)
+                {
+                    info.AddValue(name + "." + i, array[i]);
+                }
+            }
+        }
+
+        static public T[] GetArray<T>(this SerializationInfo info, string name)
+        {
+            var length = info.GetInt32(name + ".Length");
+            if (length < 0)
+            {
+                return null;
+            }
+            else
+            {
+                var array = new T[length];
+                for (int i = 0; i < length; i++)
+                {
+                    array[i] = info.GetValue<T>(name + "." + i);
+                }
+                return array;
+            }
+        }
     }
     #endregion
-
-  }
-
-  /// <summary>
-  /// Type constructors for serialization/deserialization
-  /// </summary>
-  [Serializable]
-  enum TypeKind
-  {
-    Default,
-    SystemVoid,
-    SystemObject,
-    Primitive,
-    FormalTypeParameter,
-    MethodFormalTypeParameter,
-    ManagedPointer,
-    UnmanagedPointer,
-    Array,
-    Specialized,
-    Path  // Non-generic type with full namespace
-  }
-
-  [Serializable]
-  enum MethodKind
-  {
-    CurrentMethod,
-    Specialized,
-    Path
-  }
-
-  #region Extensions
-  static class SurrogateSelectorExtensions
-  {
-    public static void AddSurrogate<X, XSS, Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>(
-      this SurrogateSelector selector,
-      StreamingContext context,
-      Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS> serializationSurrogate)
-      where XSS : Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS>, new()
-    {
-      selector.AddSurrogate(typeof(X), context, serializationSurrogate);
-    }
-
-    public static void AddSurrogate<X, XSS, Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>(
-      this Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.SimpleSubTypeSurrogateSelector selector,
-      StreamingContext context,
-      Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS> serializationSurrogate)
-      where XSS : Serializers<Local, Parameter, Method, Field, Property, Event, Typ, Attribute, Assembly>.XSerializationSurrogate<X, XSS>, new()
-    {
-      selector.AddSurrogate(typeof(X), context, serializationSurrogate);
-    }
-  }
-
-  internal static class SerializationInfoExtensions
-  {
-    static public T GetValue<T>(this SerializationInfo info, string name) 
-    {
-      Contract.Requires(name != null);
-      return (T)info.GetValue(name, typeof(T)); 
-    }
-
-    // HACK: because arrays are not deserialized in the correct order
-
-    static public void AddArray<T>(this SerializationInfo info, string name, T[] array)
-    {
-      if (array == null)
-      {
-        info.AddValue(name + ".Length", -1);
-      }
-      else
-      {
-        info.AddValue(name + ".Length", array.Length);
-        for (var i = 0; i < array.Length; i++)
-        {
-          info.AddValue(name + "." + i, array[i]);
-        }
-      }
-    }
-
-    static public T[] GetArray<T>(this SerializationInfo info, string name)
-    {
-      var length = info.GetInt32(name + ".Length");
-      if (length < 0)
-      {
-        return null;
-      }
-      else
-      {
-        var array = new T[length];
-        for (int i = 0; i < length; i++)
-        {
-          array[i] = info.GetValue<T>(name + "." + i);
-        }
-        return array;
-      }
-    }
-  }
-  #endregion
 }

--- a/Microsoft.Research/CodeAnalysis/SyntacticComplexity.cs
+++ b/Microsoft.Research/CodeAnalysis/SyntacticComplexity.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,176 +8,176 @@ using System.Text;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public class SyntacticComplexity
-  {
-    #region Thresholds
-    private const uint MAXLOOPS = 100;
-    private const uint MAXJOINS = 200;
-    private const uint MAXJOINS_BACKWARDSCHECKING = 75;
-    private const uint HUGENUMBEROFJOINS = 500;
-    private const uint MAXINSTRUCTIONS = 10000000;
-    private const double MAXINSTRUCTIONSJOINRATION = 10000d;
-    #endregion
-
-    #region Statistics
-    [ThreadStatic]
-    private static uint maxLoops;
-    [ThreadStatic]
-    private static uint maxJoins;
-    [ThreadStatic]
-    private static uint maxInstructions;
-    [ThreadStatic]
-    private static uint totalLoops;
-    [ThreadStatic]
-    private static uint totalJoins;
-    [ThreadStatic]
-    private static uint totalInstructions;
-
-    static public uint MaxLoops { private set { maxLoops = value; } get { return maxLoops; } }
-    static public uint MaxJoins { private set { maxJoins = value; } get { return maxJoins; } }
-    static public uint MaxInstructions { private set { maxInstructions = value; } get { return maxInstructions; } }
-    static public uint TotalLoops { private set { totalLoops = value; } get { return totalLoops; } }
-    static public uint TotalJoins { private set { totalJoins = value; } get { return totalJoins; } }
-    static public uint TotalInstructions { private set { totalInstructions = value; } get { return totalInstructions; } }
-
-    static private void UpdateStatistics(SyntacticComplexity next)
+    public class SyntacticComplexity
     {
-      // update maxs
-      if (MaxLoops < next.Loops)
-        MaxLoops = next.Loops;
+        #region Thresholds
+        private const uint MAXLOOPS = 100;
+        private const uint MAXJOINS = 200;
+        private const uint MAXJOINS_BACKWARDSCHECKING = 75;
+        private const uint HUGENUMBEROFJOINS = 500;
+        private const uint MAXINSTRUCTIONS = 10000000;
+        private const double MAXINSTRUCTIONSJOINRATION = 10000d;
+        #endregion
 
-      if (MaxJoins < next.JoinPoints)
-        MaxJoins = next.JoinPoints;
+        #region Statistics
+        [ThreadStatic]
+        private static uint maxLoops;
+        [ThreadStatic]
+        private static uint maxJoins;
+        [ThreadStatic]
+        private static uint maxInstructions;
+        [ThreadStatic]
+        private static uint totalLoops;
+        [ThreadStatic]
+        private static uint totalJoins;
+        [ThreadStatic]
+        private static uint totalInstructions;
 
-      if (MaxInstructions < next.Instructions)
-        MaxInstructions = next.Instructions;
+        static public uint MaxLoops { private set { maxLoops = value; } get { return maxLoops; } }
+        static public uint MaxJoins { private set { maxJoins = value; } get { return maxJoins; } }
+        static public uint MaxInstructions { private set { maxInstructions = value; } get { return maxInstructions; } }
+        static public uint TotalLoops { private set { totalLoops = value; } get { return totalLoops; } }
+        static public uint TotalJoins { private set { totalJoins = value; } get { return totalJoins; } }
+        static public uint TotalInstructions { private set { totalInstructions = value; } get { return totalInstructions; } }
 
-      // update totals
-      TotalLoops += next.Loops;
-      TotalJoins += next.JoinPoints;
-      TotalInstructions += next.Instructions;
-    }
-
-    #endregion
-
-    #region State
-    public readonly bool IsValid;
-    private bool messageAlreadyPrinted;
-
-    public readonly uint JoinPoints;
-    public readonly uint Loops;
-    public readonly uint Instructions;
-    public static SyntacticComplexity Dummy = new SyntacticComplexity();
-    
-    #endregion
-
-    private SyntacticComplexity()
-    {
-      this.IsValid = false;
-      this.JoinPoints = this.Instructions = this.Loops = 0;
-    }
-
-    public SyntacticComplexity(uint joinPoints, uint instructions, uint Loops)
-    {
-      this.IsValid = true;
-
-      this.JoinPoints = joinPoints;
-      this.Instructions = instructions;
-      this.Loops = Loops;
-      this.messageAlreadyPrinted = false;
-
-      UpdateStatistics(this);
-    }
-
-    public bool TooManyLoops
-    {
-      get
-      {
-        return this.Loops > MAXLOOPS;
-      }
-    }
-
-    public bool TooManyJoins
-    {
-      get
-      {
-        return this.JoinPoints > MAXJOINS;
-      }
-    }
-
-    public bool TooManyJoinsForBackwardsChecking
-    {
-      get
-      {
-        return this.JoinPoints > MAXJOINS_BACKWARDSCHECKING;
-      }
-    }
-
-    public bool WayTooManyJoins
-    {
-      get
-      {
-        return this.TooManyJoins && this.JoinPoints > HUGENUMBEROFJOINS;
-      }
-    }
-
-    public bool TooManyInstructionsPerJoin
-    {
-      get
-      {
-        if (this.JoinPoints == 0)
+        static private void UpdateStatistics(SyntacticComplexity next)
         {
-          return this.Instructions > 10000;
+            // update maxs
+            if (MaxLoops < next.Loops)
+                MaxLoops = next.Loops;
+
+            if (MaxJoins < next.JoinPoints)
+                MaxJoins = next.JoinPoints;
+
+            if (MaxInstructions < next.Instructions)
+                MaxInstructions = next.Instructions;
+
+            // update totals
+            TotalLoops += next.Loops;
+            TotalJoins += next.JoinPoints;
+            TotalInstructions += next.Instructions;
         }
 
-        var ratio =((double) this.Instructions) / this.JoinPoints;
-        return ratio > MAXINSTRUCTIONSJOINRATION;
-      }
-    }
+        #endregion
 
-    public override string ToString()
-    {
-      if (this.IsValid)
-      {
-        string format = "#Inst: {0}, #joins: {1}, #loops: {2}";
-        return string.Format(format, Instructions, JoinPoints, Loops);
-      }
-      else
-      {
-        return "<no stats>";
-      }
-    }
+        #region State
+        public readonly bool IsValid;
+        private bool messageAlreadyPrinted;
 
-    public bool SuggestACheapAnalysis
-    {
-      get
-      {
-        return this.TooManyLoops || this.TooManyJoins || this.TooManyInstructionsPerJoin;
-      }
-    }
+        public readonly uint JoinPoints;
+        public readonly uint Loops;
+        public readonly uint Instructions;
+        public static SyntacticComplexity Dummy = new SyntacticComplexity();
 
-    public bool SuggestAVeryCheapAnalysis
-    {
-      get
-      {
-        return this.SuggestACheapAnalysis && this.WayTooManyJoins;
-      }
-    }
+        #endregion
+
+        private SyntacticComplexity()
+        {
+            this.IsValid = false;
+            this.JoinPoints = this.Instructions = this.Loops = 0;
+        }
+
+        public SyntacticComplexity(uint joinPoints, uint instructions, uint Loops)
+        {
+            this.IsValid = true;
+
+            this.JoinPoints = joinPoints;
+            this.Instructions = instructions;
+            this.Loops = Loops;
+            messageAlreadyPrinted = false;
+
+            UpdateStatistics(this);
+        }
+
+        public bool TooManyLoops
+        {
+            get
+            {
+                return this.Loops > MAXLOOPS;
+            }
+        }
+
+        public bool TooManyJoins
+        {
+            get
+            {
+                return this.JoinPoints > MAXJOINS;
+            }
+        }
+
+        public bool TooManyJoinsForBackwardsChecking
+        {
+            get
+            {
+                return this.JoinPoints > MAXJOINS_BACKWARDSCHECKING;
+            }
+        }
+
+        public bool WayTooManyJoins
+        {
+            get
+            {
+                return this.TooManyJoins && this.JoinPoints > HUGENUMBEROFJOINS;
+            }
+        }
+
+        public bool TooManyInstructionsPerJoin
+        {
+            get
+            {
+                if (this.JoinPoints == 0)
+                {
+                    return this.Instructions > 10000;
+                }
+
+                var ratio = ((double)this.Instructions) / this.JoinPoints;
+                return ratio > MAXINSTRUCTIONSJOINRATION;
+            }
+        }
+
+        public override string ToString()
+        {
+            if (this.IsValid)
+            {
+                string format = "#Inst: {0}, #joins: {1}, #loops: {2}";
+                return string.Format(format, Instructions, JoinPoints, Loops);
+            }
+            else
+            {
+                return "<no stats>";
+            }
+        }
+
+        public bool SuggestACheapAnalysis
+        {
+            get
+            {
+                return this.TooManyLoops || this.TooManyJoins || this.TooManyInstructionsPerJoin;
+            }
+        }
+
+        public bool SuggestAVeryCheapAnalysis
+        {
+            get
+            {
+                return this.SuggestACheapAnalysis && this.WayTooManyJoins;
+            }
+        }
 
 
-    public bool ShouldAvoidWPComputation(out bool messageAlreadyPrinted)
-    {
-      if(this.WayTooManyJoins)
-      {
-        messageAlreadyPrinted = this.messageAlreadyPrinted;
-        this.messageAlreadyPrinted = true;
-        return true;
-      }
-      else
-      {
-        messageAlreadyPrinted = false;
-        return false;
-      }
+        public bool ShouldAvoidWPComputation(out bool messageAlreadyPrinted)
+        {
+            if (this.WayTooManyJoins)
+            {
+                messageAlreadyPrinted = this.messageAlreadyPrinted;
+                this.messageAlreadyPrinted = true;
+                return true;
+            }
+            else
+            {
+                messageAlreadyPrinted = false;
+                return false;
+            }
+        }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/SyntacticInformationSummary.cs
+++ b/Microsoft.Research/CodeAnalysis/SyntacticInformationSummary.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,280 +10,277 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-
-  public struct SyntacticTest
-  {
-    public enum Polarity { Assert, Assume };
-
-    public readonly Polarity Kind;
-    public readonly APC PC;
-    public readonly string Tag;
-
-    private readonly LazyEval<BoxedExpression> guard;
-
-    public BoxedExpression Guard
+    public struct SyntacticTest
     {
-      get
-      {
-        return this.guard.Value;
-      }
-    }
+        public enum Polarity { Assert, Assume };
 
-    public SyntacticTest(Polarity kind, APC pc, string tag, LazyEval<BoxedExpression> guard)
-    {
-      Contract.Requires(tag != null);
-      Contract.Requires(guard != null);
+        public readonly Polarity Kind;
+        public readonly APC PC;
+        public readonly string Tag;
 
-      this.Kind = kind;
-      this.PC = pc;
-      this.Tag = tag;
-      this.guard = guard;
-    }
+        private readonly LazyEval<BoxedExpression> guard;
 
-    public override string ToString()
-    {
-      return string.Format("{0}: {3}({1}) {2}", this.PC, this.Tag, this.Guard, this.Kind);
-    }
-  }
-  public struct RightExpression
-  {
-    public readonly APC PC;
-
-    private readonly LazyEval<BoxedExpression> assignment;
-
-    public BoxedExpression RValueExpression
-    {
-      get
-      {
-        return this.assignment.Value;
-      }
-    }
-
-    public RightExpression(APC pc, LazyEval<BoxedExpression> assignment)
-    {
-      Contract.Requires(assignment != null);
-
-      this.PC = pc;
-      this.assignment = assignment;
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj is RightExpression)
-      {
-        var other = (RightExpression)obj;
-        if (this.PC.Equals(other.PC))
+        public BoxedExpression Guard
         {
-          var exp = this.RValueExpression;
-          if (exp != null)
-          {
-            return exp.Equals(other.RValueExpression);
-          }
+            get
+            {
+                return guard.Value;
+            }
         }
-      }
 
-      return false;
+        public SyntacticTest(Polarity kind, APC pc, string tag, LazyEval<BoxedExpression> guard)
+        {
+            Contract.Requires(tag != null);
+            Contract.Requires(guard != null);
+
+            this.Kind = kind;
+            this.PC = pc;
+            this.Tag = tag;
+            this.guard = guard;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0}: {3}({1}) {2}", this.PC, this.Tag, this.Guard, this.Kind);
+        }
     }
-
-    public override int GetHashCode()
+    public struct RightExpression
     {
-      return this.PC.GetHashCode();
+        public readonly APC PC;
+
+        private readonly LazyEval<BoxedExpression> assignment;
+
+        public BoxedExpression RValueExpression
+        {
+            get
+            {
+                return assignment.Value;
+            }
+        }
+
+        public RightExpression(APC pc, LazyEval<BoxedExpression> assignment)
+        {
+            Contract.Requires(assignment != null);
+
+            this.PC = pc;
+            this.assignment = assignment;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is RightExpression)
+            {
+                var other = (RightExpression)obj;
+                if (this.PC.Equals(other.PC))
+                {
+                    var exp = this.RValueExpression;
+                    if (exp != null)
+                    {
+                        return exp.Equals(other.RValueExpression);
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.PC.GetHashCode();
+        }
     }
-  }
-  public struct Renamings<Variable>
-  {
-
-    private readonly List<Tuple<Pair<APC, APC>, int>> RenamingsLength;
-    private readonly IEnumerable<Tuple<Pair<APC, APC>, Dictionary<Variable, HashSet<Variable>>>> LiveVariablesInRenamings;
-
-    public Renamings(
-      List<Tuple<Pair<APC, APC>, int>> renamingsLength,
-      List<Tuple<Pair<APC, APC>, Dictionary<Variable, HashSet<Variable>>>> liveVariablesInRenamings)
+    public struct Renamings<Variable>
     {
-      Contract.Requires(renamingsLength != null);
-      Contract.Requires(liveVariablesInRenamings != null);
+        private readonly List<Tuple<Pair<APC, APC>, int>> RenamingsLength;
+        private readonly IEnumerable<Tuple<Pair<APC, APC>, Dictionary<Variable, HashSet<Variable>>>> LiveVariablesInRenamings;
 
-      this.RenamingsLength = renamingsLength;
-      this.LiveVariablesInRenamings = liveVariablesInRenamings;
+        public Renamings(
+          List<Tuple<Pair<APC, APC>, int>> renamingsLength,
+          List<Tuple<Pair<APC, APC>, Dictionary<Variable, HashSet<Variable>>>> liveVariablesInRenamings)
+        {
+            Contract.Requires(renamingsLength != null);
+            Contract.Requires(liveVariablesInRenamings != null);
+
+            RenamingsLength = renamingsLength;
+            LiveVariablesInRenamings = liveVariablesInRenamings;
 
 #if DEBUG && false
-      Console.WriteLine("[RENAMING] #Renamings: {0}, #Max Length {1}, #Average {2}", this.RenamingsLength.Count, this.GetMaxLengthOfARenaming(), this.GetAverageLengthOfARenaming());
+            Console.WriteLine("[RENAMING] #Renamings: {0}, #Max Length {1}, #Average {2}", RenamingsLength.Count, this.GetMaxLengthOfARenaming(), this.GetAverageLengthOfARenaming());
 #endif
-    }
-
-    public int GetMaxLengthOfARenaming()
-    {
-      return this.RenamingsLength != null && this.RenamingsLength.Any() ?
-        this.RenamingsLength.Max(tuple => tuple.Item2) :
-        -1;
-    }
-
-    public double GetAverageLengthOfARenaming()
-    {
-      return this.RenamingsLength != null && this.RenamingsLength.Any()?
-        this.RenamingsLength.Average(tuple => tuple.Item2) :
-         -1.0;
-    }
-
-    /// <summary>
-    /// The Boolean skip will force the caller to think to the cmd argument
-    /// </summary>
-    public bool TooManyRenamingsForRefinedAnalysis(bool skip, out string why)
-    {
-      why = null;
-      if (skip)
-      {
-        return false;
-      }
-
-      if(this.RenamingsLength.Any())
-      {
-        /*
-        if(this.RenamingsLength.Count >= Thresholds.Renamings.TooManyRenamings)
-        {
-          why = string.Format("Too many renamings ({0})", this.RenamingsLength);
-          return true;
-        }
-         */
-        var average = this.GetAverageLengthOfARenaming();
-        if(average >= Thresholds.Renamings.TooManyVariableRenamingsonAverage)
-        {
-          why = string.Format("Average length of renaming too large ({0})", average);
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    public bool TryLiveVariablesAtJoinPoint(APC pc, out Set<Variable> liveVars, out Set<Variable> deadVars)
-    {
-      Contract.Ensures(Contract.Result<bool>() || Contract.ValueAtReturn(out liveVars) == null);
-      Contract.Ensures(Contract.Result<bool>() || Contract.ValueAtReturn(out deadVars) == null);
-
-      liveVars = null;
-      deadVars = null;
-
-      if(this.LiveVariablesInRenamings == null)
-      {
-        return false;
-      }
-
-      var renamingsAtPC = this.LiveVariablesInRenamings.Where(tuple => tuple.Item1.Two.Equals(pc));
-      if(renamingsAtPC.Any() && renamingsAtPC.All(tuple => tuple.Item2 != null))
-      {
-        var allVariables = new List<Set<Variable>>();
-        foreach(var renaming in renamingsAtPC)
-        {
-          var allVars = new Set<Variable>();
-          foreach (var pair in renaming.Item2)
-          {
-            allVars.AddRange(pair.Value);
-          }
-          allVariables.Add(allVars);
-        }
-        // At this point, we have for each renaming the variables
-        // Now we compute the intersection to see all the variables live at the join point
-
-        var intersection = new Set<Variable>();
-        var union = new Set<Variable>();
-        var isFirst = true;
-        foreach(var vs in allVariables)
-        {
-          if(isFirst)
-          {
-            intersection = new Set<Variable>(vs);
-            union = new Set<Variable>(vs);
-            isFirst = false;
-          }
-          else
-          {
-            intersection = intersection.Intersection(vs);
-            union = union.Union(vs);
-          }
         }
 
-        liveVars = intersection;
-        deadVars = union.Difference(intersection);
-        return true;
-      }
+        public int GetMaxLengthOfARenaming()
+        {
+            return RenamingsLength != null && RenamingsLength.Any() ?
+              RenamingsLength.Max(tuple => tuple.Item2) :
+              -1;
+        }
 
-      return false;
+        public double GetAverageLengthOfARenaming()
+        {
+            return RenamingsLength != null && RenamingsLength.Any() ?
+              RenamingsLength.Average(tuple => tuple.Item2) :
+               -1.0;
+        }
+
+        /// <summary>
+        /// The Boolean skip will force the caller to think to the cmd argument
+        /// </summary>
+        public bool TooManyRenamingsForRefinedAnalysis(bool skip, out string why)
+        {
+            why = null;
+            if (skip)
+            {
+                return false;
+            }
+
+            if (RenamingsLength.Any())
+            {
+                /*
+                if(this.RenamingsLength.Count >= Thresholds.Renamings.TooManyRenamings)
+                {
+                  why = string.Format("Too many renamings ({0})", this.RenamingsLength);
+                  return true;
+                }
+                 */
+                var average = this.GetAverageLengthOfARenaming();
+                if (average >= Thresholds.Renamings.TooManyVariableRenamingsonAverage)
+                {
+                    why = string.Format("Average length of renaming too large ({0})", average);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool TryLiveVariablesAtJoinPoint(APC pc, out Set<Variable> liveVars, out Set<Variable> deadVars)
+        {
+            Contract.Ensures(Contract.Result<bool>() || Contract.ValueAtReturn(out liveVars) == null);
+            Contract.Ensures(Contract.Result<bool>() || Contract.ValueAtReturn(out deadVars) == null);
+
+            liveVars = null;
+            deadVars = null;
+
+            if (LiveVariablesInRenamings == null)
+            {
+                return false;
+            }
+
+            var renamingsAtPC = LiveVariablesInRenamings.Where(tuple => tuple.Item1.Two.Equals(pc));
+            if (renamingsAtPC.Any() && renamingsAtPC.All(tuple => tuple.Item2 != null))
+            {
+                var allVariables = new List<Set<Variable>>();
+                foreach (var renaming in renamingsAtPC)
+                {
+                    var allVars = new Set<Variable>();
+                    foreach (var pair in renaming.Item2)
+                    {
+                        allVars.AddRange(pair.Value);
+                    }
+                    allVariables.Add(allVars);
+                }
+                // At this point, we have for each renaming the variables
+                // Now we compute the intersection to see all the variables live at the join point
+
+                var intersection = new Set<Variable>();
+                var union = new Set<Variable>();
+                var isFirst = true;
+                foreach (var vs in allVariables)
+                {
+                    if (isFirst)
+                    {
+                        intersection = new Set<Variable>(vs);
+                        union = new Set<Variable>(vs);
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        intersection = intersection.Intersection(vs);
+                        union = union.Union(vs);
+                    }
+                }
+
+                liveVars = intersection;
+                deadVars = union.Difference(intersection);
+                return true;
+            }
+
+            return false;
+        }
     }
 
-  }
+    #region Method Call info
 
-  #region Method Call info
-
-  public struct MethodCallInfo<Method, Variable>
-  {
-    public readonly APC PC;
-    public readonly Method Callee;
-    public readonly List<Variable> ActualParameters;
-
-    public MethodCallInfo(APC pc, Method method, List<Variable> actualParameters)
+    public struct MethodCallInfo<Method, Variable>
     {
-      this.PC = pc;
-      this.Callee = method;
-      this.ActualParameters = actualParameters;
+        public readonly APC PC;
+        public readonly Method Callee;
+        public readonly List<Variable> ActualParameters;
+
+        public MethodCallInfo(APC pc, Method method, List<Variable> actualParameters)
+        {
+            this.PC = pc;
+            this.Callee = method;
+            this.ActualParameters = actualParameters;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0} : {1}({2} parameters)", this.PC, this.Callee, this.ActualParameters.Count);
+        }
     }
 
-    public override string ToString()
+    #endregion
+
+    public struct SyntacticInformation<Method, Field, Variable>
     {
-      return string.Format("{0} : {1}({2} parameters)", this.PC, this.Callee, this.ActualParameters.Count);
+        public readonly IDisjunctiveExpressionRefiner<Variable, BoxedExpression> DisjunctionRefiner;
+        public readonly IEnumerable<SyntacticTest> TestsInTheMethod;
+        public readonly IEnumerable<RightExpression> RightExpressions;
+        public readonly Dictionary<Variable, APC> VariableDefinitions;
+        public readonly IEnumerable<Field> MayUpdatedFields;
+        public readonly IEnumerable<MethodCallInfo<Method, Variable>> MethodCalls;
+        public readonly Renamings<Variable> Renamings;
+        public readonly bool HasThrow;
+        public readonly bool HasExceptionHandlers;
+
+        public IEnumerable<BoxedExpression> AssertedPostconditions
+        {
+            get
+            {
+                Contract.Assume(this.TestsInTheMethod != null);
+
+                return this.TestsInTheMethod.Where(t => t.Kind == SyntacticTest.Polarity.Assert && t.Tag == "ensures").Select(t => t.Guard);
+            }
+        }
+
+        public SyntacticInformation(IDisjunctiveExpressionRefiner<Variable, BoxedExpression> refiner,
+          IEnumerable<SyntacticTest> codeTests, IEnumerable<RightExpression> codeExpressions, Dictionary<Variable, APC> variableDefinitions,
+          IEnumerable<Field> mayUpdateFields,
+          IEnumerable<MethodCallInfo<Method, Variable>> methodCalls,
+          List<Tuple<Pair<APC, APC>, Dictionary<Variable, HashSet<Variable>>>> renamingsInfo,
+          List<Tuple<Pair<APC, APC>, int>> renamingsLength,
+          bool HasThrow, bool HasExceptionHandlers)
+        {
+            Contract.Requires(refiner != null);
+            Contract.Requires(codeTests != null);
+            Contract.Requires(codeExpressions != null);
+            Contract.Requires(variableDefinitions != null);
+            Contract.Requires(mayUpdateFields != null);
+            Contract.Requires(methodCalls != null);
+            Contract.Requires(renamingsInfo != null);
+            Contract.Requires(renamingsLength != null);
+
+            this.DisjunctionRefiner = refiner;
+            this.TestsInTheMethod = codeTests.Where(t => t.Guard != null);
+            this.RightExpressions = codeExpressions.Where(t => t.RValueExpression != null);
+            this.VariableDefinitions = variableDefinitions;
+            this.MayUpdatedFields = mayUpdateFields;
+            this.MethodCalls = methodCalls;
+            this.HasThrow = HasThrow;
+            this.HasExceptionHandlers = HasExceptionHandlers;
+            this.Renamings = new Renamings<Variable>(renamingsLength, renamingsInfo);
+        }
     }
-  }
-
-  #endregion
-
-  public struct SyntacticInformation<Method, Field, Variable>
-  {
-    public readonly IDisjunctiveExpressionRefiner<Variable, BoxedExpression> DisjunctionRefiner;
-    public readonly IEnumerable<SyntacticTest> TestsInTheMethod;
-    public readonly IEnumerable<RightExpression> RightExpressions;
-    public readonly Dictionary<Variable, APC> VariableDefinitions;
-    public readonly IEnumerable<Field> MayUpdatedFields;
-    public readonly IEnumerable<MethodCallInfo<Method, Variable>> MethodCalls;
-    public readonly Renamings<Variable> Renamings;
-    public readonly bool HasThrow;
-    public readonly bool HasExceptionHandlers;
-
-    public IEnumerable<BoxedExpression> AssertedPostconditions
-    {
-      get
-      {
-        Contract.Assume(this.TestsInTheMethod != null);
-
-        return this.TestsInTheMethod.Where(t => t.Kind == SyntacticTest.Polarity.Assert && t.Tag == "ensures").Select(t => t.Guard);
-      }
-    }
-
-    public SyntacticInformation(IDisjunctiveExpressionRefiner<Variable, BoxedExpression> refiner,
-      IEnumerable<SyntacticTest> codeTests, IEnumerable<RightExpression> codeExpressions, Dictionary<Variable, APC> variableDefinitions,
-      IEnumerable<Field> mayUpdateFields,
-      IEnumerable<MethodCallInfo<Method, Variable>> methodCalls,
-      List<Tuple<Pair<APC, APC>, Dictionary<Variable, HashSet<Variable>>>> renamingsInfo,
-      List<Tuple<Pair<APC, APC>, int>> renamingsLength,
-      bool HasThrow, bool HasExceptionHandlers)
-    {
-      Contract.Requires(refiner != null);
-      Contract.Requires(codeTests != null);
-      Contract.Requires(codeExpressions != null);
-      Contract.Requires(variableDefinitions != null);
-      Contract.Requires(mayUpdateFields != null);
-      Contract.Requires(methodCalls != null);
-      Contract.Requires(renamingsInfo != null);
-      Contract.Requires(renamingsLength != null);
-
-      this.DisjunctionRefiner = refiner;
-      this.TestsInTheMethod = codeTests.Where(t => t.Guard != null);
-      this.RightExpressions = codeExpressions.Where(t => t.RValueExpression != null);
-      this.VariableDefinitions = variableDefinitions;
-      this.MayUpdatedFields = mayUpdateFields;
-      this.MethodCalls = methodCalls;
-      this.HasThrow = HasThrow;
-      this.HasExceptionHandlers = HasExceptionHandlers;
-      this.Renamings = new Renamings<Variable>(renamingsLength, renamingsInfo);
-    }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/Variable.cs
+++ b/Microsoft.Research/CodeAnalysis/Variable.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -19,219 +8,219 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public class BoxedVariable<Variable>
-    : IEquatable<BoxedVariable<Variable>>
-  {
-    enum VariableKind { Framework, NoFramework, Slack }
-
-    readonly Variable var;
-    readonly InnerVariable innerVar;
-    readonly VariableKind varKind;
-
-    public BoxedVariable(Variable var)
+    public class BoxedVariable<Variable>
+      : IEquatable<BoxedVariable<Variable>>
     {
-      if (var != null)
-      {
-        this.var = var;
-        this.innerVar = default(InnerVariable);
-        this.varKind = VariableKind.Framework;
-      }
-      else
-      {
-        this.var = default(Variable);
-        this.innerVar = new InnerVariable();
-        this.varKind = VariableKind.Slack;
-      }
-    }
+        private enum VariableKind { Framework, NoFramework, Slack }
 
-    public BoxedVariable(bool slack)
-    {
-      this.var = default(Variable);
-      this.innerVar = new InnerVariable();
-      this.varKind = slack ? VariableKind.Slack: VariableKind.NoFramework;
-    }
+        private readonly Variable var;
+        private readonly InnerVariable innerVar;
+        private readonly VariableKind varKind;
 
-
-    public bool IsSlackVariable
-    {
-      get
-      {
-        return this.varKind == VariableKind.Slack;
-      }
-    }
-
-    public bool IsFrameworkVariable
-    {
-      get
-      {
-        return this.varKind == VariableKind.Framework;
-      }
-    }
-
-    public bool TryUnpackVariable(out Variable v)
-    {
-      if (this.innerVar != null)
-      {
-        v = default(Variable);
-        return false;
-      }
-      else
-      {
-        v = this.var;
-        return true;
-      }
-    }
-
-    public static void ResetFreshVariableCounter()
-    {
-      InnerVariable.ResetFreshVariableCounter();
-    }
-
-    public bool Equals(BoxedVariable<Variable> other)
-    {
-      Contract.Assume(other != null);
-
-      if (this.innerVar != null)
-      {
-        if (other.innerVar != null)
+        public BoxedVariable(Variable var)
         {
-          return this.innerVar.Equals(other.innerVar);
-        }
-      }
-      else if (other.innerVar == null)
-      {
-        return this.var.Equals(other.var);
-      }
-
-      return false;
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (this == obj)
-      {
-        return true;
-      }
-
-      var that = obj as BoxedVariable<Variable>;
-
-      if (that != null)
-      {
-        if (this.innerVar != null)
-        {
-          if (that.innerVar != null)
-          {
-            return this.innerVar.Equals(that.innerVar);
-          }
-
-          return false;
+            if (var != null)
+            {
+                this.var = var;
+                innerVar = default(InnerVariable);
+                varKind = VariableKind.Framework;
+            }
+            else
+            {
+                this.var = default(Variable);
+                innerVar = new InnerVariable();
+                varKind = VariableKind.Slack;
+            }
         }
 
-        if (this.var != null)
+        public BoxedVariable(bool slack)
         {
-          return this.var.Equals(that.var);
+            var = default(Variable);
+            innerVar = new InnerVariable();
+            varKind = slack ? VariableKind.Slack : VariableKind.NoFramework;
         }
-      }
 
-      if (obj is Variable && this.innerVar == null)
-      {
-        return obj.Equals(this.var);
-      }
 
-      return false;
-    }
-
-    public override int GetHashCode()
-    {
-      if (this.innerVar != null)
-        return innerVar.GetHashCode();
-      else
-        return var.GetHashCode();
-    }
-
-    public override string ToString()
-    {
-      if (this.innerVar != null)
-      {
-        if (this.IsSlackVariable)
+        public bool IsSlackVariable
         {
-          Debug.Assert(this.varKind == VariableKind.Slack);
-          return "s" + innerVar.ToString();
+            get
+            {
+                return varKind == VariableKind.Slack;
+            }
         }
-        else
-        {
-          Contract.Assume(this.varKind == VariableKind.NoFramework);
-          return innerVar.ToString();
-        }
-      }
-      else
-      {
-        Contract.Assume(this.varKind == VariableKind.Framework);
-        return var.ToString();
-      }
-    }
 
-    class InnerVariable
-    {
+        public bool IsFrameworkVariable
+        {
+            get
+            {
+                return varKind == VariableKind.Framework;
+            }
+        }
+
+        public bool TryUnpackVariable(out Variable v)
+        {
+            if (innerVar != null)
+            {
+                v = default(Variable);
+                return false;
+            }
+            else
+            {
+                v = var;
+                return true;
+            }
+        }
+
+        public static void ResetFreshVariableCounter()
+        {
+            InnerVariable.ResetFreshVariableCounter();
+        }
+
+        public bool Equals(BoxedVariable<Variable> other)
+        {
+            Contract.Assume(other != null);
+
+            if (innerVar != null)
+            {
+                if (other.innerVar != null)
+                {
+                    return innerVar.Equals(other.innerVar);
+                }
+            }
+            else if (other.innerVar == null)
+            {
+                return var.Equals(other.var);
+            }
+
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+
+            var that = obj as BoxedVariable<Variable>;
+
+            if (that != null)
+            {
+                if (innerVar != null)
+                {
+                    if (that.innerVar != null)
+                    {
+                        return innerVar.Equals(that.innerVar);
+                    }
+
+                    return false;
+                }
+
+                if (var != null)
+                {
+                    return var.Equals(that.var);
+                }
+            }
+
+            if (obj is Variable && innerVar == null)
+            {
+                return obj.Equals(var);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            if (innerVar != null)
+                return innerVar.GetHashCode();
+            else
+                return var.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            if (innerVar != null)
+            {
+                if (this.IsSlackVariable)
+                {
+                    Debug.Assert(varKind == VariableKind.Slack);
+                    return "s" + innerVar.ToString();
+                }
+                else
+                {
+                    Contract.Assume(varKind == VariableKind.NoFramework);
+                    return innerVar.ToString();
+                }
+            }
+            else
+            {
+                Contract.Assume(varKind == VariableKind.Framework);
+                return var.ToString();
+            }
+        }
+
+        private class InnerVariable
+        {
 #if DEBUG
-      [ThreadStatic]
+            [ThreadStatic]
 #endif
-      private static int count;
+            private static int count;
 
 #if DEBUG
-      [ThreadStatic]
-      private static int startCount;
-#endif
-
-      private readonly int id;
-#if DEBUG
-      private readonly int startId;
+            [ThreadStatic]
+            private static int startCount;
 #endif
 
-      public InnerVariable()
-      {
-        this.id = count++;
+            private readonly int id;
 #if DEBUG
-        this.startId = startCount;
+            private readonly int startId;
 #endif
-      }
 
-      public override bool Equals(object obj)
-      {
-        if (this == obj)
-          return true;
-
-        var that = obj as InnerVariable;
-
-        if (that != null)
-        {
-          return this.id == that.id;
-        }
-
-        return false;
-      }
-
-      public override int GetHashCode()
-      {
-        return this.id;
-      }
-
-      public override string ToString()
-      {
+            public InnerVariable()
+            {
+                id = count++;
 #if DEBUG
-        return "iv" + (this.id - this.startId).ToString();
+                startId = startCount;
+#endif
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (this == obj)
+                    return true;
+
+                var that = obj as InnerVariable;
+
+                if (that != null)
+                {
+                    return id == that.id;
+                }
+
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return id;
+            }
+
+            public override string ToString()
+            {
+#if DEBUG
+                return "iv" + (id - startId).ToString();
 #else
-        return "iv" + this.id.ToString();
+                return "iv" + id.ToString();
 #endif
-      }
+            }
 
-      [Conditional("DEBUG")]
-      public static void ResetFreshVariableCounter()
-      {
+            [Conditional("DEBUG")]
+            public static void ResetFreshVariableCounter()
+            {
 #if DEBUG
-        startCount = count; 
+                startCount = count;
 #endif
-      }
+            }
+        }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/WeakestPreconditionProver.cs
+++ b/Microsoft.Research/CodeAnalysis/WeakestPreconditionProver.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #define TRACEPERFORMANCE
 
@@ -25,2546 +14,2541 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public static class WeakestPreconditionProver
-  {
-    public struct AdditionalInfo
+    public static class WeakestPreconditionProver
     {
-      public static AdditionalInfo None
-      {
-        get
+        public struct AdditionalInfo
         {
-          return new AdditionalInfo(true);
-        }
-      }
-
-      public readonly bool IsNone;
-      public bool ReachedMethodEntry;
-      public bool ReachedMaximumSize;
-      public readonly bool ReachedLoop;
-
-      private AdditionalInfo(bool isNone)
-      {
-        Contract.Requires(isNone == true);
-        this.IsNone = isNone;
-        this.ReachedMethodEntry = this.ReachedMaximumSize = this.ReachedLoop = false;
-      }
-
-      public override string ToString()
-      {
-        if (this.IsNone)
-          return "none";
-        else
-          return "" +
-            (ReachedMethodEntry ? "ReachedMethodEntry " : null) +
-            (ReachedLoop ? "ReachedLoop" : null) +
-            (ReachedMaximumSize ? "ReachedMaximumSize" : null);
-      }
-
-      public IEnumerable<WarningContext> GetWarningContexts()
-      {
-        if (this.IsNone)
-          yield break;
-
-        if (this.ReachedMethodEntry)
-          yield return new WarningContext(WarningContext.ContextType.WPReachedMethodEntry);
-
-        if (this.ReachedLoop)
-          yield return new WarningContext(WarningContext.ContextType.WPReachedLoop);
-
-        if (this.ReachedMaximumSize)
-          yield return new WarningContext(WarningContext.ContextType.WPReachedMaxPathSize);
-      }
-    }
-
-    [ThreadStatic]
-    public static bool Trace;
-    [ThreadStatic]
-    public static bool EmitSMT2Formula;
-
-    #region TimeOut
-
-    [ThreadStatic]
-    private static TimeOutChecker timeout;
-    public static TimeOutChecker Timeout
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<TimeOutChecker>() != null);
-
-        // We want the timeout to be always set before, but if it is not the case, we do not want to crash, and just get a dummy Timeout
-        if (timeout == null)
-        {
-          timeout = new TimeOutChecker(180, new CancellationToken());
-        }
-
-        return timeout;
-      }
-      set
-      {
-        Contract.Requires(value != null);
-
-        timeout = value;
-      }
-    }
-
-    #endregion
-
-    /// <summary>
-    /// returns null if successfully discharged obligation, otherwise a path that cannot be discharged
-    /// </summary>
-    [Pure]
-    public static Path Discharge<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
-    (
-      APC pc,
-      Variable goal,
-      int maxPathSize,
-      IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
-      IFactQuery<BoxedExpression, Variable> facts,
-      ContractInferenceManager inferenceManager,
-      out AdditionalInfo why
-    )
-      where Expression : IEquatable<Expression>
-      where Variable : IEquatable<Variable>
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(mdriver != null);
-      Contract.Requires(facts != null);
-#if TRACEPERFORMANCE
-     AdditionalInfo whyInternal = default(AdditionalInfo);
-      
-      var result = 
-        PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.WP, () =>
-          TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out whyInternal), true);
-
-      why = whyInternal;
-
-      return result;
-#else
-      return TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out why);
-#endif
-    }
-
-    [Pure]
-    public static Path Discharge<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
-   (
-     APC pc,
-    BoxedExpression goal,
-    int maxPathSize,
-    IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
-    IFactQuery<BoxedExpression, Variable> facts,
-      ContractInferenceManager inferenceManager,
-      out AdditionalInfo why
-     )
-      where Expression : IEquatable<Expression>
-      where Variable : IEquatable<Variable>
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(facts != null);
-#if TRACEPERFORMANCE
-      AdditionalInfo whyInternal = default(AdditionalInfo);
-
-      var result = PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.WP, 
-        () => TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out whyInternal), true);
-
-      why = whyInternal;
-
-      return result;
-#else
-      return TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out why);
-#endif
-    }
-
-    public class Path
-    {
-      readonly IFunctionalSet<APC> loopHeads;
-      readonly FList<APC> codePath;
-      readonly BoxedExpression goal; // maybe null, meaning false. Must prove by contradiction
-      readonly bool goalIsNegated;
-      FList<BoxedExpression> posAssumptions;
-      FList<BoxedExpression> negAssumptions;
-
-      public int Size { get { return this.posAssumptions.Length() + this.negAssumptions.Length(); } }
-
-      public Path(APC initial, BoxedExpression initialGoal)
-      {
-        this.loopHeads = FunctionalSet<APC>.Empty();
-        this.codePath = FList<APC>.Cons(initial, null);
-        this.posAssumptions = FList<BoxedExpression>.Empty;
-        this.negAssumptions = FList<BoxedExpression>.Empty;
-        this.goal = NormalizePolarity(initialGoal, false, out this.goalIsNegated, 0);
-      }
-
-      private Path(FList<APC> path, FList<BoxedExpression> posAssumptions, FList<BoxedExpression> negAssumptions, BoxedExpression goal, bool negatedGoal, IFunctionalSet<APC> loopHeads)
-      {
-        this.loopHeads = loopHeads;
-        this.codePath = path;
-        this.posAssumptions = posAssumptions;
-        this.negAssumptions = negAssumptions;
-        this.goal = goal;
-        this.goalIsNegated = negatedGoal;
-      }
-
-      public Path ExpandBy(APC pc, bool loopHead)
-      {
-        IFunctionalSet<APC> newLoopHeads = (loopHead) ? this.loopHeads.Add(pc) : this.loopHeads;
-        return new Path(this.codePath.Cons(pc), this.posAssumptions, this.negAssumptions, this.goal, this.goalIsNegated, newLoopHeads);
-      }
-
-      public Path WithGoal(BoxedExpression newGoal)
-      {
-        return new Path(this.codePath, this.posAssumptions, this.negAssumptions, newGoal, this.goalIsNegated, this.loopHeads);
-      }
-
-      public Path Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> converter)
-      {
-        bool newlyNegated = false;
-        BoxedExpression newGoal = this.goal == null ? null : NormalizePolarity(this.goal.Substitute(converter), false, out newlyNegated, 0);
-
-        bool negatedGoal = newlyNegated ? !this.goalIsNegated : this.goalIsNegated;
-
-        FList<BoxedExpression> tmpPosAssumptions = null;
-        FList<BoxedExpression> tmpNegAssumptions = null;
-        bool contradiction = false;
-
-        this.posAssumptions.Apply(delegate(BoxedExpression b)
-                                  {
-                                    bool negated;
-                                    var b2 = NormalizePolarity(b.Substitute(converter), false, out negated, 0);
-                                    if (b2 == null) return;
-                                    if (negated)
-                                    {
-                                      tmpNegAssumptions = tmpNegAssumptions.Cons(b2);
-                                      CheckForContradiction(tmpPosAssumptions, b2, ref contradiction);
-                                    }
-                                    else
-                                    {
-                                      tmpPosAssumptions = tmpPosAssumptions.Cons(b2);
-                                      CheckForContradiction(tmpNegAssumptions, b2, ref contradiction);
-                                    }
-                                  });
-
-        if (contradiction) return null; // kill this path
-
-        this.negAssumptions.Apply(delegate(BoxedExpression b)
-                                  {
-                                    bool negated;
-                                    var b2 = NormalizePolarity(b.Substitute(converter), false, out negated, 0);
-                                    if (b2 == null) return;
-                                    if (negated)
-                                    {
-                                      tmpPosAssumptions = tmpPosAssumptions.Cons(b2);
-                                      CheckForContradiction(tmpNegAssumptions, b2, ref contradiction);
-                                    }
-                                    else
-                                    {
-                                      tmpNegAssumptions = tmpNegAssumptions.Cons(b2);
-                                      CheckForContradiction(tmpPosAssumptions, b2, ref contradiction);
-                                    }
-                                  });
-
-        if (contradiction) return null; // kill this path
-
-        // Check if goal is now implied by any of the assumptions
-        if (newGoal != null)
-        {
-          if (negatedGoal)
-          {
-            for (var list = tmpNegAssumptions; list != null; list = list.Tail)
+            public static AdditionalInfo None
             {
-              if (list.Head.Equals(newGoal)) return null; // kills this path
+                get
+                {
+                    return new AdditionalInfo(true);
+                }
             }
-          }
-          else
-          {
-            for (var list = tmpPosAssumptions; list != null; list = list.Tail)
+
+            public readonly bool IsNone;
+            public bool ReachedMethodEntry;
+            public bool ReachedMaximumSize;
+            public readonly bool ReachedLoop;
+
+            private AdditionalInfo(bool isNone)
             {
-              if (list.Head.Equals(newGoal)) return null; // kills this path
-              BinaryOperator bop;
-              BoxedExpression left, right;
-              if (list.Head.IsBinaryExpression(out bop, out left, out right))
-              {
-                int rightval;
-                if (bop == BinaryOperator.Ceq && left.Equals(newGoal) && right.IsConstantInt(out rightval) && rightval != 0)
-                {
-                  // we know left != 0, and if left is our goal, then we are done.
-                  return null;
-                }
-              }
+                Contract.Requires(isNone == true);
+                this.IsNone = isNone;
+                this.ReachedMethodEntry = this.ReachedMaximumSize = this.ReachedLoop = false;
             }
-          }
-        }
-        return new Path(this.codePath, tmpPosAssumptions, tmpNegAssumptions, newGoal, negatedGoal, this.loopHeads);
-      }
 
-      private bool CheckForContradiction(FList<BoxedExpression> assumptions, BoxedExpression toFind)
-      {
-        bool contradiction = false;
-        CheckForContradiction(assumptions, toFind, ref contradiction);
-        return contradiction;
-      }
-
-      private void CheckForContradiction(FList<BoxedExpression> assumptions, BoxedExpression toFind, ref bool contradiction)
-      {
-        if (contradiction) return; // optimize already contradiction
-
-        while (assumptions != null)
-        {
-          if (assumptions.Head.Equals(toFind))
-          {
-            contradiction = true;
-            return;
-          }
-          assumptions = assumptions.Tail;
-        }
-      }
-
-      public FList<BoxedExpression> PosAssumptions { get { return this.posAssumptions; } }
-      public FList<BoxedExpression> NegAssumptions { get { return this.negAssumptions; } }
-      public FList<APC> CodePath { get { return this.codePath; } }
-      public APC PC { get { return codePath.Head; } }
-      public APC FirstUsablePC
-      {
-        get
-        {
-          var path = this.codePath;
-          for (; path != null; path = path.Tail)
-          {
-            if (path.Head.ILOffset == 0) continue;
-            if (!path.Head.Block.Subroutine.IsMethod) continue;
-            return path.Head;
-          }
-          return PC; // no good pc
-        }
-      }
-      public BoxedExpression Goal { get { return this.goal; } }
-      public bool GoalIsNegated { get { return this.goalIsNegated; } }
-
-      public void PrintPathInMethod<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>(
-        IOutput output,
-        string lastSourceContext, // already emitted
-        IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver
-      )
-        where LogOptions : IFrameworkLogOptions
-        where Type : IEquatable<Type>
-      {
-        var path = this.codePath.Reverse().Tail; //skip assert point
-        // avoid duplicates
-        var seen = new System.Collections.Generic.HashSet<string>();
-        for (; path != null; path = path.Tail)
-        {
-          APC apc = path.Head;
-          if (!apc.Block.Subroutine.IsMethod) continue;
-          if (!apc.HasRealSourceContext) continue;
-          string sourceContext = apc.PrimarySourceContext();
-          if (sourceContext == lastSourceContext) continue;
-
-          if (seen.Contains(sourceContext)) return; // reached same point twice
-
-          seen.Add(sourceContext);
-          output.WriteLine("{0}:   warning : point on path related to warning", sourceContext);
-          lastSourceContext = sourceContext;
-        }
-      }
-
-
-      /// <summary>
-      /// Puts the expression into a normal form, where comparisons
-      /// are
-      ///  lt, lte, = 
-      /// and their negations are expressed using a toplevel not.
-      /// This way, we can spot contraditions faster.
-      /// </summary>
-      /// <param name="expr"></param>
-      /// <param name="negated">returns true if returned expression should be considered negated.</param>
-      /// <returns></returns>
-      private static BoxedExpression NormalizePolarity(BoxedExpression expr, bool inNegativeContext, out bool negated, int depth)
-      {
-        Contract.Ensures(expr == null || Contract.Result<BoxedExpression>() != null);
-
-        if (expr == null) { negated = false; return null; }
-        if (Trace)
-        {
-          WriteSpaces(depth);
-          Console.WriteLine("Prior to normalize: {0}", expr);
-        }
-        expr = NormalizePolarityInternal(expr, inNegativeContext, out negated, depth+1);
-
-        if (Trace)
-        {
-          if (negated)
-          {
-            WriteSpaces(depth);
-            Console.WriteLine("After normalize: !({0})", expr);
-          }
-          else
-          {
-            WriteSpaces(depth);
-            Console.WriteLine("After normalize: {0}", expr);
-          }
-        }
-        return expr;
-      }
-
-      private static void WriteSpaces(int depth)
-      {
-        for (var i = 0; i < depth; i++)
-        {
-          Console.Write(' ');
-        }
-      }
-
-      /// <summary>
-      /// Normalize to syntactic same form:
-      ///   a geq b  becomes b leq a
-      ///   a gt b   becomes !(a leq b)
-      ///   a leq b  stays 
-      ///   a leq_un stays
-      ///   a lt b   becomes !(b leq a)
-      ///
-      /// </summary>
-      /// <param name="expr"></param>
-      /// <param name="negated"></param>
-      /// <returns></returns>
-      [Pure]
-      private static BoxedExpression NormalizePolarityInternal(BoxedExpression expr, bool inNegativeContext, out bool negated, int depth)
-      {
-        Contract.Requires(expr != null);
-        Contract.Ensures(Contract.Result<BoxedExpression>() != null);
-
-        UnaryOperator uop;
-        BinaryOperator bop;
-        BoxedExpression left, right;
-        if (expr.IsBinaryExpression(out bop, out left, out right))
-        {
-          #region All the cases
-          switch (bop)
-          {
-            case BinaryOperator.Cge:
-              negated = false;
-              return BoxedExpression.Binary(BinaryOperator.Cle, right, left);
-            case BinaryOperator.Cge_Un:
-              negated = false;
-              return BoxedExpression.Binary(BinaryOperator.Cle_Un, right, left);
-            case BinaryOperator.Cgt:
-              negated = true;
-              return BoxedExpression.Binary(BinaryOperator.Cle, left, right);
-            case BinaryOperator.Cgt_Un:
-              // Case 1: Particular case for (a is x) >_un null - The boxed expressions are already doing it in the ToString() method
-              // Case 2: Also, it seems that Roslyn is already generating some slightly different code
-              if ((left.IsIsInst && right.IsNull) /* case 1*/ 
-                || (right.IsNull && right.Constant == null) /* case 2 */)
-              {
-                negated = false;
-                return left;
-              }
-              else
-              {
-                negated = true;
-                return BoxedExpression.Binary(BinaryOperator.Cle_Un, left, right);
-              }
-            case BinaryOperator.Clt:
-              {
-                negated = true;
-                return BoxedExpression.Binary(BinaryOperator.Cle, right, left);
-              }
-            case BinaryOperator.Clt_Un:
-              {
-                negated = true;
-                return BoxedExpression.Binary(BinaryOperator.Cle_Un, right, left);
-              }
-            case BinaryOperator.Cle:
-              {
-                if (inNegativeContext)
-                {
-                  negated = true;
-                  return BoxedExpression.Binary(BinaryOperator.Clt, right, left);
-                }
+            public override string ToString()
+            {
+                if (this.IsNone)
+                    return "none";
                 else
-                {
-                  negated = false;
-                  return expr;
-                }
-              }
-            case BinaryOperator.Cle_Un:
-              {
-                if (inNegativeContext)
-                {
-                  negated = true;
-                  return BoxedExpression.Binary(BinaryOperator.Clt_Un, right, left);
-                }
-                else
-                {
-                  negated = false;
-                  return expr;
-                }
-              }
-            case BinaryOperator.Cne_Un:
-              {
-                bool nestedNegated;
-                BoxedExpression result = NormalizePolarity(BoxedExpression.Binary(BinaryOperator.Ceq, left, right), inNegativeContext, out nestedNegated, depth+1);
-                negated = !nestedNegated;
-                return result;
-              }
-            case BinaryOperator.Ceq:
-            case BinaryOperator.Cobjeq:
-              {
-                int rightVal;
-                if (right.IsConstantIntOrNull(out rightVal))
-                {
-                  if (rightVal == 0)
-                  {
-                    // negate left
-                    bool nestedNegated;
-
-                    var left2 = NormalizePolarity(left, inNegativeContext, out nestedNegated, depth +1);
-                    negated = !nestedNegated;
-                    return left2;
-                  }
-                  int leftValue;
-                  if (rightVal == 1 && left.IsConstantInt(out leftValue) && leftValue == 1)
-                  {
-                    // (true == true) == true
-                    negated = false;
-                    return left;
-                  }
-                }
-                else
-                {
-                  int leftValue;
-                  if (left.IsConstantIntOrNull(out leftValue))
-                  {
-                    if (leftValue == 1)
-                    {
-                      // N(1 == (a bop b)) ===> N((a bop b))
-                      if (right.IsBinary && right.BinaryOp.IsComparisonBinaryOperator())
-                      {
-                        return NormalizePolarity(right, inNegativeContext, out negated, depth + 1);
-                      }
-
-                      // check if right value is the same after normalization
-                      bool nestedNegated;
-                      var right2 = NormalizePolarity(right, inNegativeContext, out nestedNegated, depth + 1);
-                      int rightValue;
-                      // if (right2 != null)
-                      {
-                        if (nestedNegated)
-                        {
-                          // negate right
-                          negated = true; // remeber we should negate it
-                          return right2;
-                        }
-                        else if (right2.IsConstantInt(out rightValue) && rightValue == 1)
-                        {
-                          Contract.Assert(!nestedNegated); // just for code readibility
-                          // (true == true) == true
-                          negated = false;
-                          return left;
-                        }
-                      }
-                    }
-                    else if (leftValue == 0)
-                    {
-                      // negate right
-                      bool nestedNegated;
-                      var right2 = NormalizePolarity(right, inNegativeContext, out nestedNegated, depth + 1);
-                      negated = !nestedNegated;
-                      return right2;
-                    }
-                  }
-                }
-                if (bop == BinaryOperator.Ceq)
-                {
-                  goto default;
-                }
-                // normalize to ceq
-                expr = BoxedExpression.Binary(BinaryOperator.Ceq, left, right);
-                goto default;
-              }
-
-            case BinaryOperator.Xor:
-              {
-                // !(a ^ b) is (a==b)
-                if (inNegativeContext)
-                {
-                  negated = true; // We swallow the negation
-
-                  return BoxedExpression.Binary(BinaryOperator.Ceq, left, right);
-                }
-                else // (a ^ b) is (a != b)
-                {
-                  negated = false;
-                  return BoxedExpression.Binary(BinaryOperator.Cne_Un, left, right);
-                }
-              }
-
-            default:
-              negated = false;
-              return expr;
-          }
-          #endregion
-        }
-        if (expr.IsUnary)
-        {
-          uop = expr.UnaryOp;
-          if (uop == UnaryOperator.Not)
-          {
-            bool nestedNegated;
-            BoxedExpression result = NormalizePolarity(expr.UnaryArgument, !inNegativeContext, out nestedNegated, depth + 1);
-            negated = !nestedNegated;
-            return result;
-          }
-          negated = false;
-          return expr;
-        }
-        bool isForAll;
-        BoxedExpression boundVar, low, upp, body;
-        if (expr.IsQuantifiedExpression(out isForAll, out boundVar, out low, out upp, out body))
-        {
-          if (!inNegativeContext)
-          {
-            BoxedExpression unaryExp;
-            // !(a bop b)
-            if (body.IsUnaryExpression(out uop, out unaryExp) && uop == UnaryOperator.Not)
-            {
-              BinaryOperator negatedBop;
-              if (unaryExp.IsBinaryExpression(out bop, out left, out right) && bop.TryNegate(out negatedBop))
-              {
-                var newBody = BoxedExpression.Binary(negatedBop, left, right);
-                negated = false;
-                return isForAll ?
-                  new ForAllIndexedExpression(expr.UnderlyingVariable, boundVar, low, upp, newBody) as BoxedExpression :
-                  new ExistsIndexedExpression(expr.UnderlyingVariable, boundVar, low, upp, newBody) as BoxedExpression;
-              }
+                    return "" +
+                      (ReachedMethodEntry ? "ReachedMethodEntry " : null) +
+                      (ReachedLoop ? "ReachedLoop" : null) +
+                      (ReachedMaximumSize ? "ReachedMaximumSize" : null);
             }
-            else if (body.IsBinaryExpression(out bop, out left, out right))
-            {
-              int k;
-              if (bop == BinaryOperator.Ceq &&
-                  (left.IsBinary && left.BinaryOp == BinaryOperator.Ceq) &&
-                  (right.IsConstantIntOrNull(out k) && k == 0))
-              {
-                var newBody = BoxedExpression.Binary(BinaryOperator.Cne_Un, left.BinaryLeft, left.BinaryRight);
-                negated = false;
 
-                return isForAll ?
-                  new ForAllIndexedExpression(null, boundVar, low, upp, newBody) as BoxedExpression :
-                  new ExistsIndexedExpression(null, boundVar, low, upp, newBody) as BoxedExpression;
-              }
-            }
-          }
-        }
-        negated = false;
-        return expr;
-      }
+            public IEnumerable<WarningContext> GetWarningContexts()
+            {
+                if (this.IsNone)
+                    yield break;
 
-      [Pure]
-      static bool IsRelation(BoxedExpression b)
-      {
-        if (b.IsBinary)
-        {
-          switch (b.BinaryOp)
-          {
-            case BinaryOperator.Ceq:
-            case BinaryOperator.Cobjeq:
-            case BinaryOperator.Cge:
-            case BinaryOperator.Cge_Un:
-            case BinaryOperator.Cgt:
-            case BinaryOperator.Cgt_Un:
-            case BinaryOperator.Cle:
-            case BinaryOperator.Cle_Un:
-            case BinaryOperator.Clt:
-            case BinaryOperator.Clt_Un:
-            case BinaryOperator.Cne_Un:
-              return true;
-            default:
-              return false;
-          }
-        }
-        return false;
-      }
+                if (this.ReachedMethodEntry)
+                    yield return new WarningContext(WarningContext.ContextType.WPReachedMethodEntry);
 
-      IList<BoxedExpression> SplitOnOperator(BoxedExpression expr, BinaryOperator logicalOp)
-      {
-        var list = new List<BoxedExpression>();
-        AddParts(expr, list, logicalOp);
-        return list;
-      }
+                if (this.ReachedLoop)
+                    yield return new WarningContext(WarningContext.ContextType.WPReachedLoop);
 
-      void AddParts(BoxedExpression expr, IList<BoxedExpression> list, BinaryOperator logicalOp)
-      {
-        BoxedExpression left, right;
-        BinaryOperator bop;
-        if (expr.IsBinaryExpression(out bop, out left, out right) && bop == logicalOp)
-        {
-          AddParts(left, list, logicalOp);
-          AddParts(right, list, logicalOp);
+                if (this.ReachedMaximumSize)
+                    yield return new WarningContext(WarningContext.ContextType.WPReachedMaxPathSize);
+            }
         }
-        else
+
+        [ThreadStatic]
+        public static bool Trace;
+        [ThreadStatic]
+        public static bool EmitSMT2Formula;
+
+        #region TimeOut
+
+        [ThreadStatic]
+        private static TimeOutChecker timeout;
+        public static TimeOutChecker Timeout
         {
-          list.Add(expr);
-        }
-      }
-      /// <summary>
-      /// Both, add the substituted assumption, which is normalized to the proper truth direction
-      /// as well as the original variable. This is needed if at some point on the path, we know that sv1 == 1
-      /// and later we don't know it and we see assume(true) sv1 and later assume(false) sv1. We need to
-      /// discharge that path, but if we only use substitutions, it may look as if we assume(true) true and later
-      /// assume(false) sv1.
-      /// </summary>
-      internal Path AddAssumption<Variable>(BoxedExpression assumption, Variable original, bool originalNegated, Comparison<Variable> comparer)
-      {
-        BinaryOperator bop;
-        BoxedExpression left, right;
-        if (assumption.IsBinaryExpression(out bop, out left, out right))
-        {
-          if (bop == BinaryOperator.LogicalAnd)
-          {
-            var conjuncts = SplitOnOperator(assumption, BinaryOperator.LogicalAnd);
-            // assume a && b
-            foreach (var conjunct in conjuncts)
+            get
             {
-              Variable var;
-              if (!conjunct.TryGetFrameworkVariable(out var)) continue;
-              if (AddAssumption(conjunct, var, false, comparer) == null) return null; // contradiction
-            }
-            return this;
-          }
-          else if (bop == BinaryOperator.LogicalOr)
-          {
-            var disjuncts = SplitOnOperator(assumption, BinaryOperator.LogicalOr);
-            // (a || b) is ~(~a && ~b)
-            // look for ~a in the existing assumptions => contradiction, thus b can be assumed. Vice versa for ~b
-            for (int i = 0; i < disjuncts.Count; i++)
-            {
-              var disjunct = disjuncts[i];
-              Variable var;
-              if (!disjunct.TryGetFrameworkVariable(out var)) return this; // can't do much
-              if (DoesAtomicAssumptionContradict(disjunct, var, false, comparer))
-              {
-                disjuncts[i] = null;
-              }
-            }
-            // now see if we have any disjuncts left.
-            var remaining = disjuncts.Where(elem => elem != null);
-            if (remaining.Any())
-            {
-              var first = remaining.First();
-              if (remaining.Skip(1).Any())
-              {
-                // still have some others.
-                return this; // can't do anything with the remaining disjunction
-              }
-              // sole remainder can be added
-              Variable firstVar;
-              if (!first.TryGetFrameworkVariable(out firstVar)) return this; // can't do much
-              return AddAssumption(first, firstVar, false, comparer);
-            }
-            else
-            {
-              return null; // contradiction
-            }
-          }
-            // a != b, and we know both a and b, then we found a contraddiction
-          else if(bop == BinaryOperator.Cne_Un)
-          {
-            Variable leftVar, rightVar;
-            if(left.TryGetFrameworkVariable(out leftVar) && right.TryGetFrameworkVariable(out rightVar))
-            {
-              if(this.ContainsVariables(this.posAssumptions, leftVar, rightVar))
-              {
-                if(Trace)
+                Contract.Ensures(Contract.Result<TimeOutChecker>() != null);
+
+                // We want the timeout to be always set before, but if it is not the case, we do not want to crash, and just get a dummy Timeout
+                if (timeout == null)
                 {
-                  Console.WriteLine("   Path discharged as we encountered {0} with both arguments true...", assumption);
+                    timeout = new TimeOutChecker(180, new CancellationToken());
                 }
 
-                return null;
-              }
+                return timeout;
             }
-          }
-        }
-        return AddAtomicAssumption(assumption, original, originalNegated, comparer);
-      }
-      
-      [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-      internal Path AddAtomicAssumption<Variable>(BoxedExpression assumption, Variable original, bool originalNegated, Comparison<Variable> comparer)
-      {
-        if(assumption == null)
-        {
-          return this;
-        }
-
-        bool negated;
-
-        // check for redundant assumption
-        if (originalNegated)
-        {
-          if (ContainsVariable(this.negAssumptions, original)) return this;
-        }
-        else
-        {
-          if (ContainsVariable(this.posAssumptions, original)) return this;
-        }
-        var normalized = NormalizePolarity(assumption, false, out negated, 0);
-
-        if (normalized.IsVariable && normalized.UnderlyingVariable.Equals(original))
-        {
-          // don't add the variable again.
-        }
-        else
-        {
-          var originalExp = BoxedExpression.Var(original);
-          if (originalNegated)
-          {
-            if (CheckForContradiction(this.posAssumptions, originalExp))
+            set
             {
-              if (Trace)
-              {
-                Console.WriteLine("Discharged Path due to negated originalExp {0} appearing in posAssumptions", original);
-              }
-              return null;
-            }
-            this.negAssumptions = this.negAssumptions.Cons(originalExp);
-          }
-          else
-          {
-            if (CheckForContradiction(this.negAssumptions, originalExp))
-            {
-              if (Trace)
-              {
-                Console.WriteLine("Discharged Path due to positive originalExp {0} appearing in negAssumptions", original);
-              }
-              return null;
-            }
-            this.posAssumptions = this.posAssumptions.Cons(originalExp);
-          }
-        }
+                Contract.Requires(value != null);
 
-        if (negated)
-        {
-          if (normalized.IsConstant)
-          {
-            var c = normalized.Constant;
-            if (!(c is string))
-            {
-              if (c == null)
-              {
-                // negated null constant as assumption is trivial true, don't add it
-                return this;
-              }
-              IConvertible ic = c as IConvertible;
-              if (ic != null)
-              {
-                try
-                {
-                  int value = ic.ToInt32(null);
-                  if (value == 0)
-                  {
-                    return this; // negated 0 is trivial true, don't add it
-                  }
-                  else
-                  {
-                    if (Trace)
-                    {
-                      Console.WriteLine("Discharged Path due to normalized expression {0} = !{1} being null constant", assumption, normalized);
-                    }
-                    return null; // negated non-zero is contradiction
-                  }
-                }
-                catch
-                {
-                }
-              }
-            }
-          }
-
-          if (goal != null && this.goalIsNegated && goal.Equals(normalized))
-          {
-            if (Trace)
-            {
-              Console.WriteLine("Discharged Path due to exact match of negative assumption {0} and negative goal {1}", normalized, goal);
-            }
-            return null;
-          }
-          if (CheckForContradiction(this.posAssumptions, normalized))
-          {
-            if (Trace)
-            {
-              Console.WriteLine("Discharged Path due to negated normalized {0} appearing in posAssumptions", normalized);
-            }
-            return null;
-          }
-          this.negAssumptions = this.negAssumptions.Cons(normalized);
-        }
-        else
-        {
-          if (normalized.IsConstant)
-          {
-            var c = normalized.Constant;
-            if (!(c is string))
-            {
-              if (c == null)
-              { // null constant as assumption is contradiction
-                if (Trace)
-                {
-                  Console.WriteLine("Discharged Path due to null constant added to assumptions");
-                }
-                return null;
-              }
-              var ic = c as IConvertible;
-              if (ic != null)
-              {
-                try
-                {
-                  int value = ic.ToInt32(null);
-                  if (value == 0)
-                  {
-                    if (Trace)
-                    {
-                      Console.WriteLine("Discharged Path due to 0 constant added to assumptions");
-                    }
-                    return null; // contradiction
-                  }
-                  else
-                  {
-                    return this; // don't add trivial "true" to assumptions
-                  }
-                }
-                catch
-                {
-                }
-              }
-            }
-          }
-          if (goal != null && !this.goalIsNegated && goal.Equals(normalized))
-          {
-            if (Trace)
-            {
-              Console.WriteLine("Discharged Path due to assumption {0} matching goal {1} exactly", normalized, goal);
-            }
-            return null;
-          }
-
-          if (CheckForContradiction(this.negAssumptions, normalized))
-          {
-            if (Trace)
-            {
-              Console.WriteLine("Discharged Path due to positive normalized {0} appearing in negAssumptions", normalized);
-            }
-            return null;
-          }
-          #region if equality, substitute in existing, but keep original equality
-          BinaryOperator bop;
-          BoxedExpression left, right;
-          Variable leftVar, rightVar;
-          var result = this;
-          if (normalized.IsBinaryExpression(out bop, out left, out right) && (bop == BinaryOperator.Ceq || bop == BinaryOperator.Cobjeq) &&
-              left.TryGetFrameworkVariable(out leftVar) && right.TryGetFrameworkVariable(out rightVar))
-          {
-            var diff = comparer(leftVar, rightVar);
-            if (diff < 0)
-            {
-              // left var is older
-              result = this.Substitute(delegate(Variable var, BoxedExpression orig) { if (comparer(var, rightVar) == 0) return left; else return orig; });
-            }
-            else if (diff > 1)
-            {
-              // right var is older
-              result = this.Substitute(delegate(Variable var, BoxedExpression orig) { if (comparer(var, leftVar) == 0) return right; else return orig; });
-            }
-          }
-          #endregion
-          if (result != null)
-          {
-            result.posAssumptions = result.posAssumptions.Cons(normalized);
-            result = SaturateNewPosAssumption(result, normalized, comparer);
-          }
-          return result;
-        }
-        return this;
-      }
-
-      private static Path SaturateNewPosAssumption<Variable>(Path result, BoxedExpression pos, Comparison<Variable> comparer)
-      {
-        if (result == null) return result;
-        if (pos.IsIsInst)
-        {
-          Variable var;
-          var arg = pos.UnaryArgument;
-          if (!arg.TryGetFrameworkVariable(out var)) return result;
-
-          // if a as T is true, then a has to be nonnull (true)
-          return result.AddAtomicAssumption(pos.UnaryArgument, var, false, comparer);
-        }
-        return result;
-      }
-
-      internal bool DoesAtomicAssumptionContradict<Variable>(BoxedExpression assumption, Variable original, bool originalNegated, Comparison<Variable> comparer)
-      {
-        Contract.Requires(assumption != null);
-
-        bool negated;
-
-        // check for redundant assumption
-        if (originalNegated)
-        {
-          if (ContainsVariable(this.negAssumptions, original)) return false;
-        }
-        else
-        {
-          if (ContainsVariable(this.posAssumptions, original)) return false;
-        }
-        var normalized = NormalizePolarity(assumption, false, out negated, 0);
-
-        if (normalized.IsVariable && normalized.UnderlyingVariable.Equals(original))
-        {
-          // don't add the variable again.
-        }
-        else
-        {
-          var originalExp = BoxedExpression.Var(original);
-          if (originalNegated)
-          {
-            if (CheckForContradiction(this.posAssumptions, originalExp))
-            {
-              return true;
-            }
-          }
-          else
-          {
-            if (CheckForContradiction(this.negAssumptions, originalExp))
-            {
-              return true;
-            }
-          }
-        }
-
-        if (negated)
-        {
-          if (normalized.IsConstant)
-          {
-            var c = normalized.Constant;
-            if (!(c is string))
-            {
-              if (c == null)
-              {
-                // negated null constant as assumption is trivial true, don't add it
-                return false;
-              }
-              var ic = c as IConvertible;
-              if (ic != null)
-              {
-                try
-                {
-                  int value = ic.ToInt32(null);
-                  if (value == 0)
-                  {
-                    return false; // negated 0 is trivial true, don't add it
-                  }
-                  else
-                  {
-                    return true; // negated non-zero is contradiction
-                  }
-                }
-                catch
-                {
-                }
-              }
-            }
-          }
-
-          if (goal != null && this.goalIsNegated && goal.Equals(normalized))
-          {
-            return true;
-          }
-          if (CheckForContradiction(this.posAssumptions, normalized))
-          {
-            return true;
-          }
-        }
-        else
-        {
-          if (normalized.IsConstant)
-          {
-            var c = normalized.Constant;
-            if (!(c is string))
-            {
-              if (c == null)
-              { // null constant as assumption is contradiction
-                return true;
-              }
-              var ic = c as IConvertible;
-              if (ic != null)
-              {
-                try
-                {
-                  int value = ic.ToInt32(null);
-                  if (value == 0)
-                  {
-                    return true; // contradiction
-                  }
-                  else
-                  {
-                    return false; // don't add trivial "true" to assumptions
-                  }
-                }
-                catch
-                {
-                }
-              }
-            }
-          }
-          if (goal != null && !this.goalIsNegated && goal.Equals(normalized))
-          {
-            return true;
-          }
-
-          if (CheckForContradiction(this.negAssumptions, normalized))
-          {
-            return true;
-          }
-        }
-        return false;
-      }
-
-      private bool ContainsVariable<Variable>(FList<BoxedExpression> assumptions, Variable original)
-      {
-        while (assumptions != null)
-        {
-          var boxed = assumptions.Head;
-          if (boxed.UnderlyingVariable != null && boxed.UnderlyingVariable.Equals(original)) return true;
-          assumptions = assumptions.Tail;
-        }
-        return false;
-      }
-      private bool ContainsVariables<Variable>(FList<BoxedExpression> assumptions, Variable left, Variable right)
-      {
-        if(left.Equals(right))
-        {
-          return ContainsVariable(assumptions, left);
-        }
-
-        while (assumptions != null)
-        {
-          Variable assumptionVar;
-          if (assumptions.Head.TryGetFrameworkVariable(out assumptionVar))
-          {
-            if(assumptionVar.Equals(left))
-            {
-              // search the other
-              return ContainsVariable(assumptions, right);
-            }
-            if(assumptionVar.Equals(right))
-            {
-              return ContainsVariable(assumptions, left);
-            }
-          }
-          assumptions = assumptions.Tail;
-        }
-        return false;
-      }
-
-      internal static string ConditionStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-        APC pc,
-        BoxedExpression condition,
-        IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-        where Type : IEquatable<Type>
-      {
-        return ConditionStringAtPC(pc, condition, context, mdDecoder, false);
-      }
-
-      internal static string ConditionStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-        APC pc,
-        BoxedExpression condition,
-        IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-        bool omitPath
-      )
-        where Type : IEquatable<Type>
-      {
-        if (condition == null) return "<null>";
-        // simply substitute variable nodes with their access paths
-        condition = condition.Substitute(delegate(Variable variable, BoxedExpression original)
-        {
-          if (omitPath) return BoxedExpression.Var(variable);
-          string accessPath = context.ValueContext.AccessPath(pc, variable);
-          if (accessPath != null) return BoxedExpression.Var(accessPath);
-          return original;
-        });
-
-        if (condition == null) return "<null>";
-
-        return condition.ToString();
-      }
-
-      public string ObligationStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-        APC pc,
-        IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-        where Type : IEquatable<Type>
-      {
-        return ObligationStringAtPC(pc, context, mdDecoder, false);
-      }
-
-      public string ObligationStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
-        APC pc,
-        IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-        bool omitPath
-      )
-        where Type : IEquatable<Type>
-      {
-        StringBuilder sb = new StringBuilder();
-        if (this.Size > 0)
-        {
-          bool first = true;
-          foreach (var posAssumption in this.posAssumptions.GetEnumerable())
-          {
-            if (!first)
-            {
-              sb.Append("&& ");
-            }
-            else
-            {
-              first = false;
-            }
-            string aString = ConditionStringAtPC(pc, posAssumption, context, mdDecoder, omitPath);
-            sb.Append(aString);
-            sb.Append(' ');
-          }
-          foreach (var negAssumption in this.negAssumptions.GetEnumerable())
-          {
-            if (!first)
-            {
-              sb.Append("&& ");
-            }
-            else
-            {
-              first = false;
-            }
-            string aString = ConditionStringAtPC(pc, negAssumption, context, mdDecoder, omitPath);
-            sb.Append('!');
-            sb.Append(aString);
-            sb.Append(' ');
-          }
-          sb.Append("=> ");
-        }
-        string cond = ConditionStringAtPC(pc, this.goal, context, mdDecoder, omitPath);
-        if (this.goalIsNegated)
-        {
-          sb.AppendFormat("!({0})", cond);
-        }
-        else
-        {
-          sb.Append(cond);
-        }
-        return sb.ToString();
-      }
-
-
-      internal bool VisitedLoop(APC aPC)
-      {
-        return this.loopHeads.Contains(aPC);
-      }
-
-      internal Path RemoveTautologiesAndDuplicatedFacts()
-      {
-        var posAssumptionsWithoutTrue = FilterTrivialitiesAndDuplicatedFacts(this.posAssumptions, true);
-        var negAssumptionsWithoutFalse = FilterTrivialitiesAndDuplicatedFacts(this.negAssumptions, false);
-
-        return new Path(this.codePath, posAssumptionsWithoutTrue, negAssumptionsWithoutFalse, this.goal, this.goalIsNegated, this.loopHeads); ;
-      }
-
-      private FList<BoxedExpression> FilterTrivialitiesAndDuplicatedFacts(FList<BoxedExpression> original, bool posPolarity)
-      {
-        var constant = posPolarity ? 1 : 0;
-
-        var result = FList<BoxedExpression>.Empty;
-
-        var removed = 0;
-
-        var dict = new Set<BoxedExpression>();
-
-        foreach (var be in original.GetEnumerable())
-        {
-          // Remove true (resp. false) constants
-          int value;
-          if (be.IsConstantIntOrNull(out value) && value == constant)
-          {
-            removed++;
-            continue;
-          }
-
-          BinaryOperator bop;
-          BoxedExpression left, right;
-          int k1, k2;
-          if (be.IsBinaryExpression(out bop, out left, out right))
-          {
-            // Remove simple tautologies in the form k1 bop k2, with k1, k2 constants
-            if (left.IsConstantIntOrNull(out k1) && right.IsConstantIntOrNull(out k2))
-            {
-              switch (bop)
-              {
-                case BinaryOperator.Ceq:
-                  if (IsTriviality(posPolarity, k1 == k2))
-                  {
-                    removed++;
-                    continue;
-                  }
-                  break;
-
-                case BinaryOperator.Cge:
-                  if (IsTriviality(posPolarity, k1 >= k2))
-                  {
-                    removed++;
-                    continue;
-                  }
-                  break;
-
-                case BinaryOperator.Cgt:
-                  if (IsTriviality(posPolarity, k1 > k2))
-                  {
-                    removed++;
-                    continue;
-                  }
-                  break;
-
-                case BinaryOperator.Cle:
-                  if (IsTriviality(posPolarity, k1 <= k2))
-                  {
-                    removed++;
-                    continue;
-                  }
-                  break;
-
-                case BinaryOperator.Clt:
-                  if (IsTriviality(posPolarity, k1 < k2))
-                  {
-                    removed++;
-                    continue;
-                  }
-                  break;
-
-                case BinaryOperator.Cne_Un:
-                  if (IsTriviality(posPolarity, k1 != k2))
-                  {
-                    removed++;
-                    continue;
-                  }
-                  break;
-
-                // We do nothing
-                default:
-                  break;
-              }
-            }
-
-            // Remove duplicated binary expressions
-            if (dict.Contains(be))
-            {
-              removed++;
-              continue;
-            }
-            else
-            {
-              dict.Add(be);
-            }
-          }
-
-          result = FList<BoxedExpression>.Cons(be, result);
-        }
-
-        if (Trace && removed > 0 && result != null)
-        {
-          Console.WriteLine("Removed {0} trivialites ({1}).\nWas:\n {2},\nIs:\n {3}", removed, posPolarity, original, result);
-        }
-
-        return result;
-      }
-
-      private bool IsTriviality(bool polarity, bool condition)
-      {
-        return (polarity && condition) || (!polarity && !condition);
-      }
-
-    }
-
-    public static class TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
-      where Expression : IEquatable<Expression>
-      where Variable : IEquatable<Variable>
-      where LogOptions : IFrameworkLogOptions
-      where Type : IEquatable<Type>
-    {
-      public static Path DischargeObligation(
-        IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
-        IFactQuery<BoxedExpression, Variable> facts,
-        ContractInferenceManager inferenceManager,
-        int maxPathSize,
-        APC pc, Variable goal, out AdditionalInfo why)
-      {
-        Contract.Requires(mdriver != null);
-        Contract.Requires(facts != null);
-
-        var goalExpression = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, goal), mdriver.ExpressionDecoder);
-
-        return DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goalExpression, out why);
-      }
-
-      public static Path DischargeObligation(
-      IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
-       IFactQuery<BoxedExpression, Variable> facts,
-               ContractInferenceManager inferenceManager,
-      int maxPathSize,
-      APC pc, BoxedExpression goalExpression, out AdditionalInfo why)
-      {
-        Contract.Requires(facts != null);
-
-        if (Trace)
-        {
-          Console.WriteLine("[WP] Trying to prove the condition {0}", goalExpression);
-        }
-
-        if (facts.IsUnreachable(pc))
-        {
-          why = AdditionalInfo.None;
-          return null;
-        }
-
-        switch (facts.IsTrue(pc, goalExpression))
-        {
-          case ProofOutcome.True:
-          case ProofOutcome.Bottom:
-            {
-              why = AdditionalInfo.None;
-              return null;
-            }
-
-          default:
-            {
-              break;
+                timeout = value;
             }
         }
 
-        var paths = FList<Path>.Cons(new Path(pc, goalExpression), null);
-        var exploration = new Exploration(mdriver, facts, inferenceManager, maxPathSize);
+        #endregion
 
-        var result = exploration.DischargePaths(paths, out why);
-
-        if(Trace)
-        { 
-          Console.WriteLine("  [WP] Outcome: {0}", result == null? "true" : "top");
-        }
-
-        return result;
-      }
-
-      class Exploration : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, Path>
-      {
-        IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver;
-        IFactQuery<BoxedExpression, Variable> facts;
-
-        readonly ContractInferenceManager inferenceManager;
-        readonly int MaxPathSize;
-
-        public Exploration(
+        /// <summary>
+        /// returns null if successfully discharged obligation, otherwise a path that cannot be discharged
+        /// </summary>
+        [Pure]
+        public static Path Discharge<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+        (
+          APC pc,
+          Variable goal,
+          int maxPathSize,
           IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
           IFactQuery<BoxedExpression, Variable> facts,
-                    ContractInferenceManager inferenceManager,
-          int maxPathSize
+          ContractInferenceManager inferenceManager,
+          out AdditionalInfo why
         )
+          where Expression : IEquatable<Expression>
+          where Variable : IEquatable<Variable>
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
         {
-          this.mdriver = mdriver;
-          this.facts = facts;
-          this.inferenceManager = inferenceManager;
-          this.MaxPathSize = maxPathSize;
+            Contract.Requires(mdriver != null);
+            Contract.Requires(facts != null);
+#if TRACEPERFORMANCE
+            AdditionalInfo whyInternal = default(AdditionalInfo);
+
+            var result =
+              PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.WP, () =>
+                TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out whyInternal), true);
+
+            why = whyInternal;
+
+            return result;
+#else
+            return TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out why);
+#endif
         }
 
-        /// <summary>
-        /// Returns a path that it cannot prove or null if all paths are provable
-        /// Assumes that the paths in the list at their current program point are unprovable
-        /// (thus starts by expanding paths, rather than proving current point).
-        /// </summary>
-        public Path DischargePaths(FList<Path> paths, out AdditionalInfo why)
+        [Pure]
+        public static Path Discharge<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+       (
+         APC pc,
+        BoxedExpression goal,
+        int maxPathSize,
+        IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
+        IFactQuery<BoxedExpression, Variable> facts,
+          ContractInferenceManager inferenceManager,
+          out AdditionalInfo why
+         )
+          where Expression : IEquatable<Expression>
+          where Variable : IEquatable<Variable>
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
         {
-          why = AdditionalInfo.None;
-          while (paths != null)
-          {
-            Timeout.CheckTimeOut("wp");
+            Contract.Requires(facts != null);
+#if TRACEPERFORMANCE
+            AdditionalInfo whyInternal = default(AdditionalInfo);
 
-            // pick first path and current PC
-            var head = paths.Head;
-            paths = paths.Tail;
+            var result = PerformanceMeasure.Measure(PerformanceMeasure.ActionTags.WP,
+              () => TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out whyInternal), true);
 
-            // expand path
-            if (ExpandPath(head, ref paths, out why))
-            {
-              continue;
-            }
-            // found a path we can't prove
-            if (Trace)
-            {
-              Console.WriteLine("Can't prove the following {0}:", head.ObligationStringAtPC(head.PC, mdriver.Context, mdriver.MetaDataDecoder));
-              foreach (var pathpc in head.CodePath.GetEnumerable())
-              {
-                Console.WriteLine("   {0}", pathpc.ToString());
-              }
-            }
-            return head;
-          }
-          return null; // success
+            why = whyInternal;
+
+            return result;
+#else
+            return TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>.DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goal, out why);
+#endif
         }
 
-        private bool ExpandPath(Path head, ref FList<Path> paths, out AdditionalInfo why)
+        public class Path
         {
-          if (Trace)
-          {
-            Console.WriteLine("{0}: ExpandPath {1}", head.PC.ToString(), head.ObligationStringAtPC(head.PC, mdriver.Context, mdriver.MetaDataDecoder));
-          }
-          var CFG = mdriver.StackLayer.Decoder.Context.MethodContext.CFG;
-          var hasPred = false;
-          foreach (var pred in CFG.Predecessors(head.PC))
-          {
-            Timeout.CheckTimeOut("wp");
+            private readonly IFunctionalSet<APC> loopHeads;
+            private readonly FList<APC> codePath;
+            private readonly BoxedExpression goal; // maybe null, meaning false. Must prove by contradiction
+            private readonly bool goalIsNegated;
+            private FList<BoxedExpression> posAssumptions;
+            private FList<BoxedExpression> negAssumptions;
 
-            if (Trace)
+            public int Size { get { return posAssumptions.Length() + negAssumptions.Length(); } }
+
+            public Path(APC initial, BoxedExpression initialGoal)
             {
-              Console.WriteLine("-Visiting {0}", pred);
+                loopHeads = FunctionalSet<APC>.Empty();
+                codePath = FList<APC>.Cons(initial, null);
+                posAssumptions = FList<BoxedExpression>.Empty;
+                negAssumptions = FList<BoxedExpression>.Empty;
+                goal = NormalizePolarity(initialGoal, false, out goalIsNegated, 0);
             }
 
-            if (facts.IsUnreachable(pred))
+            private Path(FList<APC> path, FList<BoxedExpression> posAssumptions, FList<BoxedExpression> negAssumptions, BoxedExpression goal, bool negatedGoal, IFunctionalSet<APC> loopHeads)
             {
-              if (Trace)
-              {
-                Console.WriteLine("-- {0} is unreachable", pred);
-              }
-
-              hasPred = true;
+                this.loopHeads = loopHeads;
+                codePath = path;
+                this.posAssumptions = posAssumptions;
+                this.negAssumptions = negAssumptions;
+                this.goal = goal;
+                goalIsNegated = negatedGoal;
             }
-            else
+
+            public Path ExpandBy(APC pc, bool loopHead)
             {
-              var loopHead = CFG.IsForwardBackEdgeTarget(pred);
+                IFunctionalSet<APC> newLoopHeads = (loopHead) ? loopHeads.Add(pc) : loopHeads;
+                return new Path(codePath.Cons(pc), posAssumptions, negAssumptions, goal, goalIsNegated, newLoopHeads);
+            }
 
-              if (loopHead && head.VisitedLoop(pred) || head.Size > this.MaxPathSize)
-              {
-                var outcome = TryProvingTheImplication(head);
+            public Path WithGoal(BoxedExpression newGoal)
+            {
+                return new Path(codePath, posAssumptions, negAssumptions, newGoal, goalIsNegated, loopHeads);
+            }
 
-                if (outcome)
+            public Path Substitute<Variable>(Func<Variable, BoxedExpression, BoxedExpression> converter)
+            {
+                bool newlyNegated = false;
+                BoxedExpression newGoal = goal == null ? null : NormalizePolarity(goal.Substitute(converter), false, out newlyNegated, 0);
+
+                bool negatedGoal = newlyNegated ? !goalIsNegated : goalIsNegated;
+
+                FList<BoxedExpression> tmpPosAssumptions = null;
+                FList<BoxedExpression> tmpNegAssumptions = null;
+                bool contradiction = false;
+
+                posAssumptions.Apply(delegate (BoxedExpression b)
+                                          {
+                                              bool negated;
+                                              var b2 = NormalizePolarity(b.Substitute(converter), false, out negated, 0);
+                                              if (b2 == null) return;
+                                              if (negated)
+                                              {
+                                                  tmpNegAssumptions = tmpNegAssumptions.Cons(b2);
+                                                  CheckForContradiction(tmpPosAssumptions, b2, ref contradiction);
+                                              }
+                                              else
+                                              {
+                                                  tmpPosAssumptions = tmpPosAssumptions.Cons(b2);
+                                                  CheckForContradiction(tmpNegAssumptions, b2, ref contradiction);
+                                              }
+                                          });
+
+                if (contradiction) return null; // kill this path
+
+                negAssumptions.Apply(delegate (BoxedExpression b)
+                                          {
+                                              bool negated;
+                                              var b2 = NormalizePolarity(b.Substitute(converter), false, out negated, 0);
+                                              if (b2 == null) return;
+                                              if (negated)
+                                              {
+                                                  tmpPosAssumptions = tmpPosAssumptions.Cons(b2);
+                                                  CheckForContradiction(tmpNegAssumptions, b2, ref contradiction);
+                                              }
+                                              else
+                                              {
+                                                  tmpNegAssumptions = tmpNegAssumptions.Cons(b2);
+                                                  CheckForContradiction(tmpPosAssumptions, b2, ref contradiction);
+                                              }
+                                          });
+
+                if (contradiction) return null; // kill this path
+
+                // Check if goal is now implied by any of the assumptions
+                if (newGoal != null)
                 {
-                  why = AdditionalInfo.None;
+                    if (negatedGoal)
+                    {
+                        for (var list = tmpNegAssumptions; list != null; list = list.Tail)
+                        {
+                            if (list.Head.Equals(newGoal)) return null; // kills this path
+                        }
+                    }
+                    else
+                    {
+                        for (var list = tmpPosAssumptions; list != null; list = list.Tail)
+                        {
+                            if (list.Head.Equals(newGoal)) return null; // kills this path
+                            BinaryOperator bop;
+                            BoxedExpression left, right;
+                            if (list.Head.IsBinaryExpression(out bop, out left, out right))
+                            {
+                                int rightval;
+                                if (bop == BinaryOperator.Ceq && left.Equals(newGoal) && right.IsConstantInt(out rightval) && rightval != 0)
+                                {
+                                    // we know left != 0, and if left is our goal, then we are done.
+                                    return null;
+                                }
+                            }
+                        }
+                    }
+                }
+                return new Path(codePath, tmpPosAssumptions, tmpNegAssumptions, newGoal, negatedGoal, loopHeads);
+            }
+
+            private bool CheckForContradiction(FList<BoxedExpression> assumptions, BoxedExpression toFind)
+            {
+                bool contradiction = false;
+                CheckForContradiction(assumptions, toFind, ref contradiction);
+                return contradiction;
+            }
+
+            private void CheckForContradiction(FList<BoxedExpression> assumptions, BoxedExpression toFind, ref bool contradiction)
+            {
+                if (contradiction) return; // optimize already contradiction
+
+                while (assumptions != null)
+                {
+                    if (assumptions.Head.Equals(toFind))
+                    {
+                        contradiction = true;
+                        return;
+                    }
+                    assumptions = assumptions.Tail;
+                }
+            }
+
+            public FList<BoxedExpression> PosAssumptions { get { return posAssumptions; } }
+            public FList<BoxedExpression> NegAssumptions { get { return negAssumptions; } }
+            public FList<APC> CodePath { get { return codePath; } }
+            public APC PC { get { return codePath.Head; } }
+            public APC FirstUsablePC
+            {
+                get
+                {
+                    var path = codePath;
+                    for (; path != null; path = path.Tail)
+                    {
+                        if (path.Head.ILOffset == 0) continue;
+                        if (!path.Head.Block.Subroutine.IsMethod) continue;
+                        return path.Head;
+                    }
+                    return PC; // no good pc
+                }
+            }
+            public BoxedExpression Goal { get { return goal; } }
+            public bool GoalIsNegated { get { return goalIsNegated; } }
+
+            public void PrintPathInMethod<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>(
+              IOutput output,
+              string lastSourceContext, // already emitted
+              IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver
+            )
+              where LogOptions : IFrameworkLogOptions
+              where Type : IEquatable<Type>
+            {
+                var path = codePath.Reverse().Tail; //skip assert point
+                                                    // avoid duplicates
+                var seen = new System.Collections.Generic.HashSet<string>();
+                for (; path != null; path = path.Tail)
+                {
+                    APC apc = path.Head;
+                    if (!apc.Block.Subroutine.IsMethod) continue;
+                    if (!apc.HasRealSourceContext) continue;
+                    string sourceContext = apc.PrimarySourceContext();
+                    if (sourceContext == lastSourceContext) continue;
+
+                    if (seen.Contains(sourceContext)) return; // reached same point twice
+
+                    seen.Add(sourceContext);
+                    output.WriteLine("{0}:   warning : point on path related to warning", sourceContext);
+                    lastSourceContext = sourceContext;
+                }
+            }
+
+
+            /// <summary>
+            /// Puts the expression into a normal form, where comparisons
+            /// are
+            ///  lt, lte, = 
+            /// and their negations are expressed using a toplevel not.
+            /// This way, we can spot contraditions faster.
+            /// </summary>
+            /// <param name="expr"></param>
+            /// <param name="negated">returns true if returned expression should be considered negated.</param>
+            /// <returns></returns>
+            private static BoxedExpression NormalizePolarity(BoxedExpression expr, bool inNegativeContext, out bool negated, int depth)
+            {
+                Contract.Ensures(expr == null || Contract.Result<BoxedExpression>() != null);
+
+                if (expr == null) { negated = false; return null; }
+                if (Trace)
+                {
+                    WriteSpaces(depth);
+                    Console.WriteLine("Prior to normalize: {0}", expr);
+                }
+                expr = NormalizePolarityInternal(expr, inNegativeContext, out negated, depth + 1);
+
+                if (Trace)
+                {
+                    if (negated)
+                    {
+                        WriteSpaces(depth);
+                        Console.WriteLine("After normalize: !({0})", expr);
+                    }
+                    else
+                    {
+                        WriteSpaces(depth);
+                        Console.WriteLine("After normalize: {0}", expr);
+                    }
+                }
+                return expr;
+            }
+
+            private static void WriteSpaces(int depth)
+            {
+                for (var i = 0; i < depth; i++)
+                {
+                    Console.Write(' ');
+                }
+            }
+
+            /// <summary>
+            /// Normalize to syntactic same form:
+            ///   a geq b  becomes b leq a
+            ///   a gt b   becomes !(a leq b)
+            ///   a leq b  stays 
+            ///   a leq_un stays
+            ///   a lt b   becomes !(b leq a)
+            ///
+            /// </summary>
+            /// <param name="expr"></param>
+            /// <param name="negated"></param>
+            /// <returns></returns>
+            [Pure]
+            private static BoxedExpression NormalizePolarityInternal(BoxedExpression expr, bool inNegativeContext, out bool negated, int depth)
+            {
+                Contract.Requires(expr != null);
+                Contract.Ensures(Contract.Result<BoxedExpression>() != null);
+
+                UnaryOperator uop;
+                BinaryOperator bop;
+                BoxedExpression left, right;
+                if (expr.IsBinaryExpression(out bop, out left, out right))
+                {
+                    #region All the cases
+                    switch (bop)
+                    {
+                        case BinaryOperator.Cge:
+                            negated = false;
+                            return BoxedExpression.Binary(BinaryOperator.Cle, right, left);
+                        case BinaryOperator.Cge_Un:
+                            negated = false;
+                            return BoxedExpression.Binary(BinaryOperator.Cle_Un, right, left);
+                        case BinaryOperator.Cgt:
+                            negated = true;
+                            return BoxedExpression.Binary(BinaryOperator.Cle, left, right);
+                        case BinaryOperator.Cgt_Un:
+                            // Case 1: Particular case for (a is x) >_un null - The boxed expressions are already doing it in the ToString() method
+                            // Case 2: Also, it seems that Roslyn is already generating some slightly different code
+                            if ((left.IsIsInst && right.IsNull) /* case 1*/
+                              || (right.IsNull && right.Constant == null) /* case 2 */)
+                            {
+                                negated = false;
+                                return left;
+                            }
+                            else
+                            {
+                                negated = true;
+                                return BoxedExpression.Binary(BinaryOperator.Cle_Un, left, right);
+                            }
+                        case BinaryOperator.Clt:
+                            {
+                                negated = true;
+                                return BoxedExpression.Binary(BinaryOperator.Cle, right, left);
+                            }
+                        case BinaryOperator.Clt_Un:
+                            {
+                                negated = true;
+                                return BoxedExpression.Binary(BinaryOperator.Cle_Un, right, left);
+                            }
+                        case BinaryOperator.Cle:
+                            {
+                                if (inNegativeContext)
+                                {
+                                    negated = true;
+                                    return BoxedExpression.Binary(BinaryOperator.Clt, right, left);
+                                }
+                                else
+                                {
+                                    negated = false;
+                                    return expr;
+                                }
+                            }
+                        case BinaryOperator.Cle_Un:
+                            {
+                                if (inNegativeContext)
+                                {
+                                    negated = true;
+                                    return BoxedExpression.Binary(BinaryOperator.Clt_Un, right, left);
+                                }
+                                else
+                                {
+                                    negated = false;
+                                    return expr;
+                                }
+                            }
+                        case BinaryOperator.Cne_Un:
+                            {
+                                bool nestedNegated;
+                                BoxedExpression result = NormalizePolarity(BoxedExpression.Binary(BinaryOperator.Ceq, left, right), inNegativeContext, out nestedNegated, depth + 1);
+                                negated = !nestedNegated;
+                                return result;
+                            }
+                        case BinaryOperator.Ceq:
+                        case BinaryOperator.Cobjeq:
+                            {
+                                int rightVal;
+                                if (right.IsConstantIntOrNull(out rightVal))
+                                {
+                                    if (rightVal == 0)
+                                    {
+                                        // negate left
+                                        bool nestedNegated;
+
+                                        var left2 = NormalizePolarity(left, inNegativeContext, out nestedNegated, depth + 1);
+                                        negated = !nestedNegated;
+                                        return left2;
+                                    }
+                                    int leftValue;
+                                    if (rightVal == 1 && left.IsConstantInt(out leftValue) && leftValue == 1)
+                                    {
+                                        // (true == true) == true
+                                        negated = false;
+                                        return left;
+                                    }
+                                }
+                                else
+                                {
+                                    int leftValue;
+                                    if (left.IsConstantIntOrNull(out leftValue))
+                                    {
+                                        if (leftValue == 1)
+                                        {
+                                            // N(1 == (a bop b)) ===> N((a bop b))
+                                            if (right.IsBinary && right.BinaryOp.IsComparisonBinaryOperator())
+                                            {
+                                                return NormalizePolarity(right, inNegativeContext, out negated, depth + 1);
+                                            }
+
+                                            // check if right value is the same after normalization
+                                            bool nestedNegated;
+                                            var right2 = NormalizePolarity(right, inNegativeContext, out nestedNegated, depth + 1);
+                                            int rightValue;
+                                            // if (right2 != null)
+                                            {
+                                                if (nestedNegated)
+                                                {
+                                                    // negate right
+                                                    negated = true; // remeber we should negate it
+                                                    return right2;
+                                                }
+                                                else if (right2.IsConstantInt(out rightValue) && rightValue == 1)
+                                                {
+                                                    Contract.Assert(!nestedNegated); // just for code readibility
+                                                                                     // (true == true) == true
+                                                    negated = false;
+                                                    return left;
+                                                }
+                                            }
+                                        }
+                                        else if (leftValue == 0)
+                                        {
+                                            // negate right
+                                            bool nestedNegated;
+                                            var right2 = NormalizePolarity(right, inNegativeContext, out nestedNegated, depth + 1);
+                                            negated = !nestedNegated;
+                                            return right2;
+                                        }
+                                    }
+                                }
+                                if (bop == BinaryOperator.Ceq)
+                                {
+                                    goto default;
+                                }
+                                // normalize to ceq
+                                expr = BoxedExpression.Binary(BinaryOperator.Ceq, left, right);
+                                goto default;
+                            }
+
+                        case BinaryOperator.Xor:
+                            {
+                                // !(a ^ b) is (a==b)
+                                if (inNegativeContext)
+                                {
+                                    negated = true; // We swallow the negation
+
+                                    return BoxedExpression.Binary(BinaryOperator.Ceq, left, right);
+                                }
+                                else // (a ^ b) is (a != b)
+                                {
+                                    negated = false;
+                                    return BoxedExpression.Binary(BinaryOperator.Cne_Un, left, right);
+                                }
+                            }
+
+                        default:
+                            negated = false;
+                            return expr;
+                    }
+                    #endregion
+                }
+                if (expr.IsUnary)
+                {
+                    uop = expr.UnaryOp;
+                    if (uop == UnaryOperator.Not)
+                    {
+                        bool nestedNegated;
+                        BoxedExpression result = NormalizePolarity(expr.UnaryArgument, !inNegativeContext, out nestedNegated, depth + 1);
+                        negated = !nestedNegated;
+                        return result;
+                    }
+                    negated = false;
+                    return expr;
+                }
+                bool isForAll;
+                BoxedExpression boundVar, low, upp, body;
+                if (expr.IsQuantifiedExpression(out isForAll, out boundVar, out low, out upp, out body))
+                {
+                    if (!inNegativeContext)
+                    {
+                        BoxedExpression unaryExp;
+                        // !(a bop b)
+                        if (body.IsUnaryExpression(out uop, out unaryExp) && uop == UnaryOperator.Not)
+                        {
+                            BinaryOperator negatedBop;
+                            if (unaryExp.IsBinaryExpression(out bop, out left, out right) && bop.TryNegate(out negatedBop))
+                            {
+                                var newBody = BoxedExpression.Binary(negatedBop, left, right);
+                                negated = false;
+                                return isForAll ?
+                                  new ForAllIndexedExpression(expr.UnderlyingVariable, boundVar, low, upp, newBody) as BoxedExpression :
+                                  new ExistsIndexedExpression(expr.UnderlyingVariable, boundVar, low, upp, newBody) as BoxedExpression;
+                            }
+                        }
+                        else if (body.IsBinaryExpression(out bop, out left, out right))
+                        {
+                            int k;
+                            if (bop == BinaryOperator.Ceq &&
+                                (left.IsBinary && left.BinaryOp == BinaryOperator.Ceq) &&
+                                (right.IsConstantIntOrNull(out k) && k == 0))
+                            {
+                                var newBody = BoxedExpression.Binary(BinaryOperator.Cne_Un, left.BinaryLeft, left.BinaryRight);
+                                negated = false;
+
+                                return isForAll ?
+                                  new ForAllIndexedExpression(null, boundVar, low, upp, newBody) as BoxedExpression :
+                                  new ExistsIndexedExpression(null, boundVar, low, upp, newBody) as BoxedExpression;
+                            }
+                        }
+                    }
+                }
+                negated = false;
+                return expr;
+            }
+
+            [Pure]
+            private static bool IsRelation(BoxedExpression b)
+            {
+                if (b.IsBinary)
+                {
+                    switch (b.BinaryOp)
+                    {
+                        case BinaryOperator.Ceq:
+                        case BinaryOperator.Cobjeq:
+                        case BinaryOperator.Cge:
+                        case BinaryOperator.Cge_Un:
+                        case BinaryOperator.Cgt:
+                        case BinaryOperator.Cgt_Un:
+                        case BinaryOperator.Cle:
+                        case BinaryOperator.Cle_Un:
+                        case BinaryOperator.Clt:
+                        case BinaryOperator.Clt_Un:
+                        case BinaryOperator.Cne_Un:
+                            return true;
+                        default:
+                            return false;
+                    }
+                }
+                return false;
+            }
+
+            private IList<BoxedExpression> SplitOnOperator(BoxedExpression expr, BinaryOperator logicalOp)
+            {
+                var list = new List<BoxedExpression>();
+                AddParts(expr, list, logicalOp);
+                return list;
+            }
+
+            private void AddParts(BoxedExpression expr, IList<BoxedExpression> list, BinaryOperator logicalOp)
+            {
+                BoxedExpression left, right;
+                BinaryOperator bop;
+                if (expr.IsBinaryExpression(out bop, out left, out right) && bop == logicalOp)
+                {
+                    AddParts(left, list, logicalOp);
+                    AddParts(right, list, logicalOp);
                 }
                 else
                 {
-                  why = new AdditionalInfo()
+                    list.Add(expr);
+                }
+            }
+            /// <summary>
+            /// Both, add the substituted assumption, which is normalized to the proper truth direction
+            /// as well as the original variable. This is needed if at some point on the path, we know that sv1 == 1
+            /// and later we don't know it and we see assume(true) sv1 and later assume(false) sv1. We need to
+            /// discharge that path, but if we only use substitutions, it may look as if we assume(true) true and later
+            /// assume(false) sv1.
+            /// </summary>
+            internal Path AddAssumption<Variable>(BoxedExpression assumption, Variable original, bool originalNegated, Comparison<Variable> comparer)
+            {
+                BinaryOperator bop;
+                BoxedExpression left, right;
+                if (assumption.IsBinaryExpression(out bop, out left, out right))
+                {
+                    if (bop == BinaryOperator.LogicalAnd)
                     {
-                      ReachedMethodEntry = loopHead /*&& head != null*/ && head.VisitedLoop(pred),
-                      ReachedMaximumSize = /*head != null && */head.Size > this.MaxPathSize
-                    };
-                }
-
-                if (Trace)
-                {
-                  Console.WriteLine("-- Aborting the visit at {0}. Either we reached a loophead and we already visited it, or the headsize is too large", pred);
-                }
-
-                return outcome;
-              }
-
-              var nextPath = mdriver.BackwardTransfer(head.PC, pred, head.ExpandBy(pred, loopHead), this);
-
-              // only try to prove things at source of a join edge rather than each program point
-              if (nextPath != null && CFG.IsJoinPoint(head.PC))
-              {
-                if (Trace)
-                {
-                  Console.WriteLine("-- After backwards transfer, we reached a join point. We try to discharge the proof obligation", pred);
-                }
-
-                if (DischargePath(nextPath))
-                {
-                  nextPath = null; // kill this path
-
-                  if (Trace)
-                  {
-                    Console.WriteLine("--- We were able to discharge the Path condition");
-                  }
-
-                }
-              }
-
-              // transfer may kill a path
-              if (nextPath != null)
-              {
-                paths = paths.Cons(nextPath);
-                if (Trace)
-                {
-                  Console.WriteLine(" --- adding the path to the list of paths. Current path length {0}", paths.Length());
-                }
-
-              }
-              else if (Trace)
-              {
-                Console.WriteLine("Path discharged.");
-              }
-
-              hasPred = true;
-            }
-          }
-          if (hasPred)
-          {
-            // not stuck
-            why = AdditionalInfo.None;
-            return true;
-          }
-
-          var direct = TryProvingTheImplication(head);
-
-          if (!hasPred && !direct)
-          {
-            if (Trace)
-            {
-              Console.WriteLine("Hit a PC with no predecessors");
-              Console.WriteLine("-- We were not able to prove the implication");
-            }
-
-            if (EmitSMT2Formula)
-            {
-              EmitImplicationInSMTLibFormat(head);
-            }
-          }
-
-          why = new AdditionalInfo() { ReachedMethodEntry = true };
-
-          return direct;
-        }
-
-        private bool TryProvingTheImplication(Path head)
-        {
-          // If it is a too complex CFG, we save time and do not run the relatively expensive implication checking
-          if(this.mdriver.SyntacticComplexity.TooManyJoins)
-          {
-            if(Trace)
-            {
-              Console.WriteLine("Skipping TryProvingImplication as the Clousot thinks there are too many joins in this method");
-            }
-            return false;
-          }
-
-          if (head.Goal != null)
-          {  // if goal != null, we should prove that PosAssumptions ==> Goal
-
-            var goal = head.GoalIsNegated ? BoxedExpression.Unary(UnaryOperator.Not, head.Goal) : head.Goal;
-
-            var posAssumptions = head.PosAssumptions.Append(SaturatePremises(head.PosAssumptions.ToArray()).ToFList());
-
-            var outcome = facts.IsTrueImply(head.PC, posAssumptions, head.NegAssumptions, goal);
-
-            if (outcome == ProofOutcome.True)
-            {
-              if (Trace)
-              {
-                Console.WriteLine("Goal implied by assumptions and facts");
-              }
-              return true;
-            }
-
-            return false;
-          }
-          else
-          { // if the goal is null, then we should prove !(PosAssumptions)
-            if (head.PosAssumptions != null)
-            {
-              foreach (var assumption in head.PosAssumptions.GetEnumerable())
-              {
-                if (facts.IsTrue(head.PC, assumption) == ProofOutcome.False)
-                {
-                  if (Trace)
-                  {
-                    Console.WriteLine("Assumption {0} is false according to the facts", assumption);
-                  }
-                  return true;
-                }
-              }
-            }
-
-            return false;
-          }
-
-        }
-
-        /// <summary>
-        /// Only called on pos assumption
-        /// </summary>
-        private List<BoxedExpression> SaturatePremises(BoxedExpression[] assumptions)
-        {
-          Contract.Requires(assumptions != null);
-          Contract.Requires(Contract.ForAll(assumptions, assume => assume != null));
-          Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
-
-          var toAdd = new List<BoxedExpression>();
-
-          for (var i = 0; i < assumptions.Length; i++)
-          {
-            var exp = assumptions[i];
-            if (exp.IsVariable)
-            {
-              for (var j = 0; j < assumptions.Length; j++)
-              {
-                if (i != j)
-                {
-                  var otherExp = assumptions[j];
-                  BinaryOperator bop;
-                  BoxedExpression left, right;
-                  if (otherExp.IsBinaryExpression(out bop, out left, out right) && (bop == BinaryOperator.Cobjeq || bop == BinaryOperator.Ceq))
-                  {
-                    if (left.Equals(exp))
-                    {
-                      toAdd.Add(right);
+                        var conjuncts = SplitOnOperator(assumption, BinaryOperator.LogicalAnd);
+                        // assume a && b
+                        foreach (var conjunct in conjuncts)
+                        {
+                            Variable var;
+                            if (!conjunct.TryGetFrameworkVariable(out var)) continue;
+                            if (AddAssumption(conjunct, var, false, comparer) == null) return null; // contradiction
+                        }
+                        return this;
                     }
-                    else if (right.Equals(exp))
+                    else if (bop == BinaryOperator.LogicalOr)
                     {
-                      toAdd.Add(left);
+                        var disjuncts = SplitOnOperator(assumption, BinaryOperator.LogicalOr);
+                        // (a || b) is ~(~a && ~b)
+                        // look for ~a in the existing assumptions => contradiction, thus b can be assumed. Vice versa for ~b
+                        for (int i = 0; i < disjuncts.Count; i++)
+                        {
+                            var disjunct = disjuncts[i];
+                            Variable var;
+                            if (!disjunct.TryGetFrameworkVariable(out var)) return this; // can't do much
+                            if (DoesAtomicAssumptionContradict(disjunct, var, false, comparer))
+                            {
+                                disjuncts[i] = null;
+                            }
+                        }
+                        // now see if we have any disjuncts left.
+                        var remaining = disjuncts.Where(elem => elem != null);
+                        if (remaining.Any())
+                        {
+                            var first = remaining.First();
+                            if (remaining.Skip(1).Any())
+                            {
+                                // still have some others.
+                                return this; // can't do anything with the remaining disjunction
+                            }
+                            // sole remainder can be added
+                            Variable firstVar;
+                            if (!first.TryGetFrameworkVariable(out firstVar)) return this; // can't do much
+                            return AddAssumption(first, firstVar, false, comparer);
+                        }
+                        else
+                        {
+                            return null; // contradiction
+                        }
                     }
-                  }
+                    // a != b, and we know both a and b, then we found a contraddiction
+                    else if (bop == BinaryOperator.Cne_Un)
+                    {
+                        Variable leftVar, rightVar;
+                        if (left.TryGetFrameworkVariable(out leftVar) && right.TryGetFrameworkVariable(out rightVar))
+                        {
+                            if (this.ContainsVariables(posAssumptions, leftVar, rightVar))
+                            {
+                                if (Trace)
+                                {
+                                    Console.WriteLine("   Path discharged as we encountered {0} with both arguments true...", assumption);
+                                }
+
+                                return null;
+                            }
+                        }
+                    }
                 }
-              }
+                return AddAtomicAssumption(assumption, original, originalNegated, comparer);
             }
-          }
 
-          if (Trace)
-          {
-            if (toAdd.Count > 0)
+            [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+            internal Path AddAtomicAssumption<Variable>(BoxedExpression assumption, Variable original, bool originalNegated, Comparison<Variable> comparer)
             {
-              Console.WriteLine("Saturation inferred new premises to use in proving the implication: {0}", toAdd);
-            }
-            else
-            {
-              Console.WriteLine("No new premise inferred by saturation");
-            }
-          }
+                if (assumption == null)
+                {
+                    return this;
+                }
 
-          return toAdd;
+                bool negated;
+
+                // check for redundant assumption
+                if (originalNegated)
+                {
+                    if (ContainsVariable(negAssumptions, original)) return this;
+                }
+                else
+                {
+                    if (ContainsVariable(posAssumptions, original)) return this;
+                }
+                var normalized = NormalizePolarity(assumption, false, out negated, 0);
+
+                if (normalized.IsVariable && normalized.UnderlyingVariable.Equals(original))
+                {
+                    // don't add the variable again.
+                }
+                else
+                {
+                    var originalExp = BoxedExpression.Var(original);
+                    if (originalNegated)
+                    {
+                        if (CheckForContradiction(posAssumptions, originalExp))
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("Discharged Path due to negated originalExp {0} appearing in posAssumptions", original);
+                            }
+                            return null;
+                        }
+                        negAssumptions = negAssumptions.Cons(originalExp);
+                    }
+                    else
+                    {
+                        if (CheckForContradiction(negAssumptions, originalExp))
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("Discharged Path due to positive originalExp {0} appearing in negAssumptions", original);
+                            }
+                            return null;
+                        }
+                        posAssumptions = posAssumptions.Cons(originalExp);
+                    }
+                }
+
+                if (negated)
+                {
+                    if (normalized.IsConstant)
+                    {
+                        var c = normalized.Constant;
+                        if (!(c is string))
+                        {
+                            if (c == null)
+                            {
+                                // negated null constant as assumption is trivial true, don't add it
+                                return this;
+                            }
+                            IConvertible ic = c as IConvertible;
+                            if (ic != null)
+                            {
+                                try
+                                {
+                                    int value = ic.ToInt32(null);
+                                    if (value == 0)
+                                    {
+                                        return this; // negated 0 is trivial true, don't add it
+                                    }
+                                    else
+                                    {
+                                        if (Trace)
+                                        {
+                                            Console.WriteLine("Discharged Path due to normalized expression {0} = !{1} being null constant", assumption, normalized);
+                                        }
+                                        return null; // negated non-zero is contradiction
+                                    }
+                                }
+                                catch
+                                {
+                                }
+                            }
+                        }
+                    }
+
+                    if (goal != null && goalIsNegated && goal.Equals(normalized))
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("Discharged Path due to exact match of negative assumption {0} and negative goal {1}", normalized, goal);
+                        }
+                        return null;
+                    }
+                    if (CheckForContradiction(posAssumptions, normalized))
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("Discharged Path due to negated normalized {0} appearing in posAssumptions", normalized);
+                        }
+                        return null;
+                    }
+                    negAssumptions = negAssumptions.Cons(normalized);
+                }
+                else
+                {
+                    if (normalized.IsConstant)
+                    {
+                        var c = normalized.Constant;
+                        if (!(c is string))
+                        {
+                            if (c == null)
+                            { // null constant as assumption is contradiction
+                                if (Trace)
+                                {
+                                    Console.WriteLine("Discharged Path due to null constant added to assumptions");
+                                }
+                                return null;
+                            }
+                            var ic = c as IConvertible;
+                            if (ic != null)
+                            {
+                                try
+                                {
+                                    int value = ic.ToInt32(null);
+                                    if (value == 0)
+                                    {
+                                        if (Trace)
+                                        {
+                                            Console.WriteLine("Discharged Path due to 0 constant added to assumptions");
+                                        }
+                                        return null; // contradiction
+                                    }
+                                    else
+                                    {
+                                        return this; // don't add trivial "true" to assumptions
+                                    }
+                                }
+                                catch
+                                {
+                                }
+                            }
+                        }
+                    }
+                    if (goal != null && !goalIsNegated && goal.Equals(normalized))
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("Discharged Path due to assumption {0} matching goal {1} exactly", normalized, goal);
+                        }
+                        return null;
+                    }
+
+                    if (CheckForContradiction(negAssumptions, normalized))
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("Discharged Path due to positive normalized {0} appearing in negAssumptions", normalized);
+                        }
+                        return null;
+                    }
+                    #region if equality, substitute in existing, but keep original equality
+                    BinaryOperator bop;
+                    BoxedExpression left, right;
+                    Variable leftVar, rightVar;
+                    var result = this;
+                    if (normalized.IsBinaryExpression(out bop, out left, out right) && (bop == BinaryOperator.Ceq || bop == BinaryOperator.Cobjeq) &&
+                        left.TryGetFrameworkVariable(out leftVar) && right.TryGetFrameworkVariable(out rightVar))
+                    {
+                        var diff = comparer(leftVar, rightVar);
+                        if (diff < 0)
+                        {
+                            // left var is older
+                            result = this.Substitute(delegate (Variable var, BoxedExpression orig) { if (comparer(var, rightVar) == 0) return left; else return orig; });
+                        }
+                        else if (diff > 1)
+                        {
+                            // right var is older
+                            result = this.Substitute(delegate (Variable var, BoxedExpression orig) { if (comparer(var, leftVar) == 0) return right; else return orig; });
+                        }
+                    }
+                    #endregion
+                    if (result != null)
+                    {
+                        result.posAssumptions = result.posAssumptions.Cons(normalized);
+                        result = SaturateNewPosAssumption(result, normalized, comparer);
+                    }
+                    return result;
+                }
+                return this;
+            }
+
+            private static Path SaturateNewPosAssumption<Variable>(Path result, BoxedExpression pos, Comparison<Variable> comparer)
+            {
+                if (result == null) return result;
+                if (pos.IsIsInst)
+                {
+                    Variable var;
+                    var arg = pos.UnaryArgument;
+                    if (!arg.TryGetFrameworkVariable(out var)) return result;
+
+                    // if a as T is true, then a has to be nonnull (true)
+                    return result.AddAtomicAssumption(pos.UnaryArgument, var, false, comparer);
+                }
+                return result;
+            }
+
+            internal bool DoesAtomicAssumptionContradict<Variable>(BoxedExpression assumption, Variable original, bool originalNegated, Comparison<Variable> comparer)
+            {
+                Contract.Requires(assumption != null);
+
+                bool negated;
+
+                // check for redundant assumption
+                if (originalNegated)
+                {
+                    if (ContainsVariable(negAssumptions, original)) return false;
+                }
+                else
+                {
+                    if (ContainsVariable(posAssumptions, original)) return false;
+                }
+                var normalized = NormalizePolarity(assumption, false, out negated, 0);
+
+                if (normalized.IsVariable && normalized.UnderlyingVariable.Equals(original))
+                {
+                    // don't add the variable again.
+                }
+                else
+                {
+                    var originalExp = BoxedExpression.Var(original);
+                    if (originalNegated)
+                    {
+                        if (CheckForContradiction(posAssumptions, originalExp))
+                        {
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        if (CheckForContradiction(negAssumptions, originalExp))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                if (negated)
+                {
+                    if (normalized.IsConstant)
+                    {
+                        var c = normalized.Constant;
+                        if (!(c is string))
+                        {
+                            if (c == null)
+                            {
+                                // negated null constant as assumption is trivial true, don't add it
+                                return false;
+                            }
+                            var ic = c as IConvertible;
+                            if (ic != null)
+                            {
+                                try
+                                {
+                                    int value = ic.ToInt32(null);
+                                    if (value == 0)
+                                    {
+                                        return false; // negated 0 is trivial true, don't add it
+                                    }
+                                    else
+                                    {
+                                        return true; // negated non-zero is contradiction
+                                    }
+                                }
+                                catch
+                                {
+                                }
+                            }
+                        }
+                    }
+
+                    if (goal != null && goalIsNegated && goal.Equals(normalized))
+                    {
+                        return true;
+                    }
+                    if (CheckForContradiction(posAssumptions, normalized))
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (normalized.IsConstant)
+                    {
+                        var c = normalized.Constant;
+                        if (!(c is string))
+                        {
+                            if (c == null)
+                            { // null constant as assumption is contradiction
+                                return true;
+                            }
+                            var ic = c as IConvertible;
+                            if (ic != null)
+                            {
+                                try
+                                {
+                                    int value = ic.ToInt32(null);
+                                    if (value == 0)
+                                    {
+                                        return true; // contradiction
+                                    }
+                                    else
+                                    {
+                                        return false; // don't add trivial "true" to assumptions
+                                    }
+                                }
+                                catch
+                                {
+                                }
+                            }
+                        }
+                    }
+                    if (goal != null && !goalIsNegated && goal.Equals(normalized))
+                    {
+                        return true;
+                    }
+
+                    if (CheckForContradiction(negAssumptions, normalized))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            private bool ContainsVariable<Variable>(FList<BoxedExpression> assumptions, Variable original)
+            {
+                while (assumptions != null)
+                {
+                    var boxed = assumptions.Head;
+                    if (boxed.UnderlyingVariable != null && boxed.UnderlyingVariable.Equals(original)) return true;
+                    assumptions = assumptions.Tail;
+                }
+                return false;
+            }
+            private bool ContainsVariables<Variable>(FList<BoxedExpression> assumptions, Variable left, Variable right)
+            {
+                if (left.Equals(right))
+                {
+                    return ContainsVariable(assumptions, left);
+                }
+
+                while (assumptions != null)
+                {
+                    Variable assumptionVar;
+                    if (assumptions.Head.TryGetFrameworkVariable(out assumptionVar))
+                    {
+                        if (assumptionVar.Equals(left))
+                        {
+                            // search the other
+                            return ContainsVariable(assumptions, right);
+                        }
+                        if (assumptionVar.Equals(right))
+                        {
+                            return ContainsVariable(assumptions, left);
+                        }
+                    }
+                    assumptions = assumptions.Tail;
+                }
+                return false;
+            }
+
+            internal static string ConditionStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+              APC pc,
+              BoxedExpression condition,
+              IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+            )
+              where Type : IEquatable<Type>
+            {
+                return ConditionStringAtPC(pc, condition, context, mdDecoder, false);
+            }
+
+            internal static string ConditionStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+              APC pc,
+              BoxedExpression condition,
+              IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+              bool omitPath
+            )
+              where Type : IEquatable<Type>
+            {
+                if (condition == null) return "<null>";
+                // simply substitute variable nodes with their access paths
+                condition = condition.Substitute(delegate (Variable variable, BoxedExpression original)
+                {
+                    if (omitPath) return BoxedExpression.Var(variable);
+                    string accessPath = context.ValueContext.AccessPath(pc, variable);
+                    if (accessPath != null) return BoxedExpression.Var(accessPath);
+                    return original;
+                });
+
+                if (condition == null) return "<null>";
+
+                return condition.ToString();
+            }
+
+            public string ObligationStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+              APC pc,
+              IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+            )
+              where Type : IEquatable<Type>
+            {
+                return ObligationStringAtPC(pc, context, mdDecoder, false);
+            }
+
+            public string ObligationStringAtPC<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable>(
+              APC pc,
+              IExpressionContext<Local, Parameter, Method, Field, Type, Expression, Variable> context,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+              bool omitPath
+            )
+              where Type : IEquatable<Type>
+            {
+                StringBuilder sb = new StringBuilder();
+                if (this.Size > 0)
+                {
+                    bool first = true;
+                    foreach (var posAssumption in posAssumptions.GetEnumerable())
+                    {
+                        if (!first)
+                        {
+                            sb.Append("&& ");
+                        }
+                        else
+                        {
+                            first = false;
+                        }
+                        string aString = ConditionStringAtPC(pc, posAssumption, context, mdDecoder, omitPath);
+                        sb.Append(aString);
+                        sb.Append(' ');
+                    }
+                    foreach (var negAssumption in negAssumptions.GetEnumerable())
+                    {
+                        if (!first)
+                        {
+                            sb.Append("&& ");
+                        }
+                        else
+                        {
+                            first = false;
+                        }
+                        string aString = ConditionStringAtPC(pc, negAssumption, context, mdDecoder, omitPath);
+                        sb.Append('!');
+                        sb.Append(aString);
+                        sb.Append(' ');
+                    }
+                    sb.Append("=> ");
+                }
+                string cond = ConditionStringAtPC(pc, goal, context, mdDecoder, omitPath);
+                if (goalIsNegated)
+                {
+                    sb.AppendFormat("!({0})", cond);
+                }
+                else
+                {
+                    sb.Append(cond);
+                }
+                return sb.ToString();
+            }
+
+
+            internal bool VisitedLoop(APC aPC)
+            {
+                return loopHeads.Contains(aPC);
+            }
+
+            internal Path RemoveTautologiesAndDuplicatedFacts()
+            {
+                var posAssumptionsWithoutTrue = FilterTrivialitiesAndDuplicatedFacts(posAssumptions, true);
+                var negAssumptionsWithoutFalse = FilterTrivialitiesAndDuplicatedFacts(negAssumptions, false);
+
+                return new Path(codePath, posAssumptionsWithoutTrue, negAssumptionsWithoutFalse, goal, goalIsNegated, loopHeads); ;
+            }
+
+            private FList<BoxedExpression> FilterTrivialitiesAndDuplicatedFacts(FList<BoxedExpression> original, bool posPolarity)
+            {
+                var constant = posPolarity ? 1 : 0;
+
+                var result = FList<BoxedExpression>.Empty;
+
+                var removed = 0;
+
+                var dict = new Set<BoxedExpression>();
+
+                foreach (var be in original.GetEnumerable())
+                {
+                    // Remove true (resp. false) constants
+                    int value;
+                    if (be.IsConstantIntOrNull(out value) && value == constant)
+                    {
+                        removed++;
+                        continue;
+                    }
+
+                    BinaryOperator bop;
+                    BoxedExpression left, right;
+                    int k1, k2;
+                    if (be.IsBinaryExpression(out bop, out left, out right))
+                    {
+                        // Remove simple tautologies in the form k1 bop k2, with k1, k2 constants
+                        if (left.IsConstantIntOrNull(out k1) && right.IsConstantIntOrNull(out k2))
+                        {
+                            switch (bop)
+                            {
+                                case BinaryOperator.Ceq:
+                                    if (IsTriviality(posPolarity, k1 == k2))
+                                    {
+                                        removed++;
+                                        continue;
+                                    }
+                                    break;
+
+                                case BinaryOperator.Cge:
+                                    if (IsTriviality(posPolarity, k1 >= k2))
+                                    {
+                                        removed++;
+                                        continue;
+                                    }
+                                    break;
+
+                                case BinaryOperator.Cgt:
+                                    if (IsTriviality(posPolarity, k1 > k2))
+                                    {
+                                        removed++;
+                                        continue;
+                                    }
+                                    break;
+
+                                case BinaryOperator.Cle:
+                                    if (IsTriviality(posPolarity, k1 <= k2))
+                                    {
+                                        removed++;
+                                        continue;
+                                    }
+                                    break;
+
+                                case BinaryOperator.Clt:
+                                    if (IsTriviality(posPolarity, k1 < k2))
+                                    {
+                                        removed++;
+                                        continue;
+                                    }
+                                    break;
+
+                                case BinaryOperator.Cne_Un:
+                                    if (IsTriviality(posPolarity, k1 != k2))
+                                    {
+                                        removed++;
+                                        continue;
+                                    }
+                                    break;
+
+                                // We do nothing
+                                default:
+                                    break;
+                            }
+                        }
+
+                        // Remove duplicated binary expressions
+                        if (dict.Contains(be))
+                        {
+                            removed++;
+                            continue;
+                        }
+                        else
+                        {
+                            dict.Add(be);
+                        }
+                    }
+
+                    result = FList<BoxedExpression>.Cons(be, result);
+                }
+
+                if (Trace && removed > 0 && result != null)
+                {
+                    Console.WriteLine("Removed {0} trivialites ({1}).\nWas:\n {2},\nIs:\n {3}", removed, posPolarity, original, result);
+                }
+
+                return result;
+            }
+
+            private bool IsTriviality(bool polarity, bool condition)
+            {
+                return (polarity && condition) || (!polarity && !condition);
+            }
         }
 
-        private bool DischargePath(Path head)
+        public static class TypeBinder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions>
+          where Expression : IEquatable<Expression>
+          where Variable : IEquatable<Variable>
+          where LogOptions : IFrameworkLogOptions
+          where Type : IEquatable<Type>
         {
-          var decoder = this.mdriver.MetaDataDecoder;
-          if (Trace)
-          {
-            Console.WriteLine("{1}: Trying to prove goal: {0}", head.ObligationStringAtPC(head.PC, mdriver.Context, decoder), head.PC.ToString());
-            Console.WriteLine("{1}: Trying to prove goal: {0}", head.ObligationStringAtPC(head.PC, mdriver.Context, decoder, true), head.PC.ToString());
-          }
-          if (head.Goal != null)
-          {
-            var outcome = facts.IsTrue(head.PC, head.Goal);
-            if (!head.GoalIsNegated && outcome == ProofOutcome.True ||
-                head.GoalIsNegated && outcome == ProofOutcome.False)
+            public static Path DischargeObligation(
+              IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
+              IFactQuery<BoxedExpression, Variable> facts,
+              ContractInferenceManager inferenceManager,
+              int maxPathSize,
+              APC pc, Variable goal, out AdditionalInfo why)
             {
-              if (Trace)
-              {
-                Console.WriteLine("Goal implied by facts");
-              }
-              return true;
+                Contract.Requires(mdriver != null);
+                Contract.Requires(facts != null);
+
+                var goalExpression = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, goal), mdriver.ExpressionDecoder);
+
+                return DischargeObligation(mdriver, facts, inferenceManager, maxPathSize, pc, goalExpression, out why);
             }
 
-            if (TryProvingTheImplication(head))
+            public static Path DischargeObligation(
+            IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
+             IFactQuery<BoxedExpression, Variable> facts,
+                     ContractInferenceManager inferenceManager,
+            int maxPathSize,
+            APC pc, BoxedExpression goalExpression, out AdditionalInfo why)
             {
-              return true;
-            }
-          }
-          else // We look for a contraddiction
-          {
-            if (mdriver.SyntacticComplexity.TooManyJoinsForBackwardsChecking)
-            {
-              // Do nothing
+                Contract.Requires(facts != null);
 
-              if(Trace)
-              {
-                Console.WriteLine("Skipping the relative costly operation facts.TryProveImplication");
-              }
-            }
-            else
-            {
-              var ff = BoxedExpression.Const(0, decoder.System_Int32, decoder);
-              if (facts.IsTrueImply(head.PC, head.PosAssumptions, head.NegAssumptions, ff) == ProofOutcome.True)
-              {
                 if (Trace)
                 {
-                  Console.WriteLine("  Found a contraddiction at program point {0}", head.PC);
+                    Console.WriteLine("[WP] Trying to prove the condition {0}", goalExpression);
                 }
-                return true;
-              }
+
+                if (facts.IsUnreachable(pc))
+                {
+                    why = AdditionalInfo.None;
+                    return null;
+                }
+
+                switch (facts.IsTrue(pc, goalExpression))
+                {
+                    case ProofOutcome.True:
+                    case ProofOutcome.Bottom:
+                        {
+                            why = AdditionalInfo.None;
+                            return null;
+                        }
+
+                    default:
+                        {
+                            break;
+                        }
+                }
+
+                var paths = FList<Path>.Cons(new Path(pc, goalExpression), null);
+                var exploration = new Exploration(mdriver, facts, inferenceManager, maxPathSize);
+
+                var result = exploration.DischargePaths(paths, out why);
+
+                if (Trace)
+                {
+                    Console.WriteLine("  [WP] Outcome: {0}", result == null ? "true" : "top");
+                }
+
+                return result;
             }
-          }
 
-          // try to see if any of the assumptions are contradicted in current state
-          foreach (var posAssumption in head.PosAssumptions.GetEnumerable())
-          {
-            if (facts.IsTrue(head.PC, posAssumption) == ProofOutcome.False)
+            private class Exploration : IEdgeVisit<APC, Local, Parameter, Method, Field, Type, Variable, Path>
             {
-              if (Trace)
-              {
-                Console.WriteLine("   Assumption {0} is false", Path.ConditionStringAtPC(head.PC, posAssumption, mdriver.Context, decoder));
-              }
-              return true;
-            }
-          }
-          foreach (var negAssumption in head.NegAssumptions.GetEnumerable())
-          {
-            if (facts.IsTrue(head.PC, negAssumption) == ProofOutcome.True)
-            {
-              if (Trace)
-              {
-                Console.WriteLine("   Assumption !({0}) is false", Path.ConditionStringAtPC(head.PC, negAssumption, mdriver.Context, decoder));
-              }
-              return true;
-            }
-          }
+                private IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver;
+                private IFactQuery<BoxedExpression, Variable> facts;
 
-          return false;
-        }
+                private readonly ContractInferenceManager inferenceManager;
+                private readonly int MaxPathSize;
 
-        #region IEdgeVisit<APC,Local,Parameter,Method,Field,Type,Variable,Path> Members
+                public Exploration(
+                  IMethodDriver<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Expression, Variable, LogOptions> mdriver,
+                  IFactQuery<BoxedExpression, Variable> facts,
+                            ContractInferenceManager inferenceManager,
+                  int maxPathSize
+                )
+                {
+                    this.mdriver = mdriver;
+                    this.facts = facts;
+                    this.inferenceManager = inferenceManager;
+                    MaxPathSize = maxPathSize;
+                }
 
-        private BoxedExpression Rename(APC pc, Variable v, BoxedExpression original, IFunctionalMap<Variable, Variable> renaming)
-        {
-          if (renaming.Contains(v))
-          {
-            Variable v2 = renaming[v];
-            //if (v2.Equals(v)) return original;
-            var candidate = BoxedExpression.Convert(this.mdriver.Context.ExpressionContext.Refine(pc, v2), this.mdriver.ExpressionDecoder);
+                /// <summary>
+                /// Returns a path that it cannot prove or null if all paths are provable
+                /// Assumes that the paths in the list at their current program point are unprovable
+                /// (thus starts by expanding paths, rather than proving current point).
+                /// </summary>
+                public Path DischargePaths(FList<Path> paths, out AdditionalInfo why)
+                {
+                    why = AdditionalInfo.None;
+                    while (paths != null)
+                    {
+                        Timeout.CheckTimeOut("wp");
 
-            if(candidate == null)
-            {
-              return null;
-            }
-            
-            if (candidate.IsVariable && v.Equals(v2)) return original;
-            return candidate;
-          }
-          return null;
-        }
+                        // pick first path and current PC
+                        var head = paths.Head;
+                        paths = paths.Tail;
 
-        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification = "Bug in Clousot that thinks Substitute returns != null, because it does not take into account a parameter havoc")]
-        public Path Rename(APC from, APC to, Path path, IFunctionalMap<Variable, Variable> renaming)
-        {
-          if (Trace)
-          {
-            Console.WriteLine("Rename from {0} to {1}", from, to);
-            Console.WriteLine("  Path prior to substitution: {0}", path.ObligationStringAtPC(from, mdriver.Context, mdriver.MetaDataDecoder));
-            Console.WriteLine("  Path prior to substitution (as symbolic variables) : {0}", path.ObligationStringAtPC(from, mdriver.Context, mdriver.MetaDataDecoder, true));
-            Console.WriteLine(" Substitution:");
-            renaming.Visit(delegate(Variable key, Variable value) { Console.WriteLine("  {0} -> {1}", key, value); return VisitStatus.ContinueVisit; });
+                        // expand path
+                        if (ExpandPath(head, ref paths, out why))
+                        {
+                            continue;
+                        }
+                        // found a path we can't prove
+                        if (Trace)
+                        {
+                            Console.WriteLine("Can't prove the following {0}:", head.ObligationStringAtPC(head.PC, mdriver.Context, mdriver.MetaDataDecoder));
+                            foreach (var pathpc in head.CodePath.GetEnumerable())
+                            {
+                                Console.WriteLine("   {0}", pathpc.ToString());
+                            }
+                        }
+                        return head;
+                    }
+                    return null; // success
+                }
 
-            renaming.Visit(delegate(Variable key, Variable value) { Console.WriteLine("  {0} -> Expr {1}", key, BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(to, value), mdriver.ExpressionDecoder)); return VisitStatus.ContinueVisit; });
-          }
-          Func<Variable, BoxedExpression, BoxedExpression> converter =
-            (variable, original) =>
-            {
-              var newName = Rename(to, variable, original, renaming);
-              Variable newVarName;
-              if (newName != null && newName.TryGetFrameworkVariable(out newVarName))
-              {
-                var tryForAll = this.mdriver.AsForAllIndexed(to, newVarName);
-                if (tryForAll != null)
-                  newName = tryForAll;
-              }
+                private bool ExpandPath(Path head, ref FList<Path> paths, out AdditionalInfo why)
+                {
+                    if (Trace)
+                    {
+                        Console.WriteLine("{0}: ExpandPath {1}", head.PC.ToString(), head.ObligationStringAtPC(head.PC, mdriver.Context, mdriver.MetaDataDecoder));
+                    }
+                    var CFG = mdriver.StackLayer.Decoder.Context.MethodContext.CFG;
+                    var hasPred = false;
+                    foreach (var pred in CFG.Predecessors(head.PC))
+                    {
+                        Timeout.CheckTimeOut("wp");
 
-              return newName;
-            };
+                        if (Trace)
+                        {
+                            Console.WriteLine("-Visiting {0}", pred);
+                        }
 
-          var result = path.Substitute(converter);
+                        if (facts.IsUnreachable(pred))
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("-- {0} is unreachable", pred);
+                            }
 
-          result = result != null ? result.RemoveTautologiesAndDuplicatedFacts() : null;
+                            hasPred = true;
+                        }
+                        else
+                        {
+                            var loopHead = CFG.IsForwardBackEdgeTarget(pred);
 
-          if (Trace)
-          {
-            if (result != null)
-            {
-              Console.WriteLine("  Path after substitution: {0}", result.ObligationStringAtPC(to, mdriver.Context, mdriver.MetaDataDecoder));
-              Console.WriteLine("  Path after substitution: {0}", result.ObligationStringAtPC(to, mdriver.Context, mdriver.MetaDataDecoder, true));
-            }
-            else
-            {
-              Console.WriteLine("Substitution discharged path");
-            }
-          }
-          return result;
-        }
+                            if (loopHead && head.VisitedLoop(pred) || head.Size > MaxPathSize)
+                            {
+                                var outcome = TryProvingTheImplication(head);
 
-        #endregion
+                                if (outcome)
+                                {
+                                    why = AdditionalInfo.None;
+                                }
+                                else
+                                {
+                                    why = new AdditionalInfo()
+                                    {
+                                        ReachedMethodEntry = loopHead /*&& head != null*/ && head.VisitedLoop(pred),
+                                        ReachedMaximumSize = /*head != null && */head.Size > MaxPathSize
+                                    };
+                                }
 
-        #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Variable,Variable,Path,Path> Members
+                                if (Trace)
+                                {
+                                    Console.WriteLine("-- Aborting the visit at {0}. Either we reached a loophead and we already visited it, or the headsize is too large", pred);
+                                }
 
-        public Path Arglist(APC pc, Variable dest, Path data)
-        {
-          return data;
-        }
+                                return outcome;
+                            }
 
-        public Path BranchCond(APC pc, APC target, BranchOperator bop, Variable value1, Variable value2, Path data)
-        {
-          return data;
-        }
+                            var nextPath = mdriver.BackwardTransfer(head.PC, pred, head.ExpandBy(pred, loopHead), this);
 
-        public Path BranchTrue(APC pc, APC target, Variable cond, Path data)
-        {
-          return data;
-        }
+                            // only try to prove things at source of a join edge rather than each program point
+                            if (nextPath != null && CFG.IsJoinPoint(head.PC))
+                            {
+                                if (Trace)
+                                {
+                                    Console.WriteLine("-- After backwards transfer, we reached a join point. We try to discharge the proof obligation", pred);
+                                }
 
-        public Path BranchFalse(APC pc, APC target, Variable cond, Path data)
-        {
-          return data;
-        }
+                                if (DischargePath(nextPath))
+                                {
+                                    nextPath = null; // kill this path
 
-        public Path Branch(APC pc, APC target, bool leave, Path data)
-        {
-          return data;
-        }
+                                    if (Trace)
+                                    {
+                                        Console.WriteLine("--- We were able to discharge the Path condition");
+                                    }
+                                }
+                            }
 
-        public Path Break(APC pc, Path data)
-        {
-          return data;
-        }
+                            // transfer may kill a path
+                            if (nextPath != null)
+                            {
+                                paths = paths.Cons(nextPath);
+                                if (Trace)
+                                {
+                                    Console.WriteLine(" --- adding the path to the list of paths. Current path length {0}", paths.Length());
+                                }
+                            }
+                            else if (Trace)
+                            {
+                                Console.WriteLine("Path discharged.");
+                            }
 
-        [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
-        public Path Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Variable dest, ArgList args, Path data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<Variable>
-        {
-          // We'd love to have it, but then we should also take care of the changes of array elements in stelem, non-pure method calls, etc.
-          // The only point were we do the ForAll expansion is in the renaming
-          // The code is here only to help the debugging
+                            hasPred = true;
+                        }
+                    }
+                    if (hasPred)
+                    {
+                        // not stuck
+                        why = AdditionalInfo.None;
+                        return true;
+                    }
+
+                    var direct = TryProvingTheImplication(head);
+
+                    if (!hasPred && !direct)
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("Hit a PC with no predecessors");
+                            Console.WriteLine("-- We were not able to prove the implication");
+                        }
+
+                        if (EmitSMT2Formula)
+                        {
+                            EmitImplicationInSMTLibFormat(head);
+                        }
+                    }
+
+                    why = new AdditionalInfo() { ReachedMethodEntry = true };
+
+                    return direct;
+                }
+
+                private bool TryProvingTheImplication(Path head)
+                {
+                    // If it is a too complex CFG, we save time and do not run the relatively expensive implication checking
+                    if (mdriver.SyntacticComplexity.TooManyJoins)
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("Skipping TryProvingImplication as the Clousot thinks there are too many joins in this method");
+                        }
+                        return false;
+                    }
+
+                    if (head.Goal != null)
+                    {  // if goal != null, we should prove that PosAssumptions ==> Goal
+                        var goal = head.GoalIsNegated ? BoxedExpression.Unary(UnaryOperator.Not, head.Goal) : head.Goal;
+
+                        var posAssumptions = head.PosAssumptions.Append(SaturatePremises(head.PosAssumptions.ToArray()).ToFList());
+
+                        var outcome = facts.IsTrueImply(head.PC, posAssumptions, head.NegAssumptions, goal);
+
+                        if (outcome == ProofOutcome.True)
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("Goal implied by assumptions and facts");
+                            }
+                            return true;
+                        }
+
+                        return false;
+                    }
+                    else
+                    { // if the goal is null, then we should prove !(PosAssumptions)
+                        if (head.PosAssumptions != null)
+                        {
+                            foreach (var assumption in head.PosAssumptions.GetEnumerable())
+                            {
+                                if (facts.IsTrue(head.PC, assumption) == ProofOutcome.False)
+                                {
+                                    if (Trace)
+                                    {
+                                        Console.WriteLine("Assumption {0} is false according to the facts", assumption);
+                                    }
+                                    return true;
+                                }
+                            }
+                        }
+
+                        return false;
+                    }
+                }
+
+                /// <summary>
+                /// Only called on pos assumption
+                /// </summary>
+                private List<BoxedExpression> SaturatePremises(BoxedExpression[] assumptions)
+                {
+                    Contract.Requires(assumptions != null);
+                    Contract.Requires(Contract.ForAll(assumptions, assume => assume != null));
+                    Contract.Ensures(Contract.Result<List<BoxedExpression>>() != null);
+
+                    var toAdd = new List<BoxedExpression>();
+
+                    for (var i = 0; i < assumptions.Length; i++)
+                    {
+                        var exp = assumptions[i];
+                        if (exp.IsVariable)
+                        {
+                            for (var j = 0; j < assumptions.Length; j++)
+                            {
+                                if (i != j)
+                                {
+                                    var otherExp = assumptions[j];
+                                    BinaryOperator bop;
+                                    BoxedExpression left, right;
+                                    if (otherExp.IsBinaryExpression(out bop, out left, out right) && (bop == BinaryOperator.Cobjeq || bop == BinaryOperator.Ceq))
+                                    {
+                                        if (left.Equals(exp))
+                                        {
+                                            toAdd.Add(right);
+                                        }
+                                        else if (right.Equals(exp))
+                                        {
+                                            toAdd.Add(left);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (Trace)
+                    {
+                        if (toAdd.Count > 0)
+                        {
+                            Console.WriteLine("Saturation inferred new premises to use in proving the implication: {0}", toAdd);
+                        }
+                        else
+                        {
+                            Console.WriteLine("No new premise inferred by saturation");
+                        }
+                    }
+
+                    return toAdd;
+                }
+
+                private bool DischargePath(Path head)
+                {
+                    var decoder = mdriver.MetaDataDecoder;
+                    if (Trace)
+                    {
+                        Console.WriteLine("{1}: Trying to prove goal: {0}", head.ObligationStringAtPC(head.PC, mdriver.Context, decoder), head.PC.ToString());
+                        Console.WriteLine("{1}: Trying to prove goal: {0}", head.ObligationStringAtPC(head.PC, mdriver.Context, decoder, true), head.PC.ToString());
+                    }
+                    if (head.Goal != null)
+                    {
+                        var outcome = facts.IsTrue(head.PC, head.Goal);
+                        if (!head.GoalIsNegated && outcome == ProofOutcome.True ||
+                            head.GoalIsNegated && outcome == ProofOutcome.False)
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("Goal implied by facts");
+                            }
+                            return true;
+                        }
+
+                        if (TryProvingTheImplication(head))
+                        {
+                            return true;
+                        }
+                    }
+                    else // We look for a contraddiction
+                    {
+                        if (mdriver.SyntacticComplexity.TooManyJoinsForBackwardsChecking)
+                        {
+                            // Do nothing
+
+                            if (Trace)
+                            {
+                                Console.WriteLine("Skipping the relative costly operation facts.TryProveImplication");
+                            }
+                        }
+                        else
+                        {
+                            var ff = BoxedExpression.Const(0, decoder.System_Int32, decoder);
+                            if (facts.IsTrueImply(head.PC, head.PosAssumptions, head.NegAssumptions, ff) == ProofOutcome.True)
+                            {
+                                if (Trace)
+                                {
+                                    Console.WriteLine("  Found a contraddiction at program point {0}", head.PC);
+                                }
+                                return true;
+                            }
+                        }
+                    }
+
+                    // try to see if any of the assumptions are contradicted in current state
+                    foreach (var posAssumption in head.PosAssumptions.GetEnumerable())
+                    {
+                        if (facts.IsTrue(head.PC, posAssumption) == ProofOutcome.False)
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("   Assumption {0} is false", Path.ConditionStringAtPC(head.PC, posAssumption, mdriver.Context, decoder));
+                            }
+                            return true;
+                        }
+                    }
+                    foreach (var negAssumption in head.NegAssumptions.GetEnumerable())
+                    {
+                        if (facts.IsTrue(head.PC, negAssumption) == ProofOutcome.True)
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("   Assumption !({0}) is false", Path.ConditionStringAtPC(head.PC, negAssumption, mdriver.Context, decoder));
+                            }
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                #region IEdgeVisit<APC,Local,Parameter,Method,Field,Type,Variable,Path> Members
+
+                private BoxedExpression Rename(APC pc, Variable v, BoxedExpression original, IFunctionalMap<Variable, Variable> renaming)
+                {
+                    if (renaming.Contains(v))
+                    {
+                        Variable v2 = renaming[v];
+                        //if (v2.Equals(v)) return original;
+                        var candidate = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, v2), mdriver.ExpressionDecoder);
+
+                        if (candidate == null)
+                        {
+                            return null;
+                        }
+
+                        if (candidate.IsVariable && v.Equals(v2)) return original;
+                        return candidate;
+                    }
+                    return null;
+                }
+
+                [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant", Justification = "Bug in Clousot that thinks Substitute returns != null, because it does not take into account a parameter havoc")]
+                public Path Rename(APC from, APC to, Path path, IFunctionalMap<Variable, Variable> renaming)
+                {
+                    if (Trace)
+                    {
+                        Console.WriteLine("Rename from {0} to {1}", from, to);
+                        Console.WriteLine("  Path prior to substitution: {0}", path.ObligationStringAtPC(from, mdriver.Context, mdriver.MetaDataDecoder));
+                        Console.WriteLine("  Path prior to substitution (as symbolic variables) : {0}", path.ObligationStringAtPC(from, mdriver.Context, mdriver.MetaDataDecoder, true));
+                        Console.WriteLine(" Substitution:");
+                        renaming.Visit(delegate (Variable key, Variable value) { Console.WriteLine("  {0} -> {1}", key, value); return VisitStatus.ContinueVisit; });
+
+                        renaming.Visit(delegate (Variable key, Variable value) { Console.WriteLine("  {0} -> Expr {1}", key, BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(to, value), mdriver.ExpressionDecoder)); return VisitStatus.ContinueVisit; });
+                    }
+                    Func<Variable, BoxedExpression, BoxedExpression> converter =
+                      (variable, original) =>
+                      {
+                          var newName = Rename(to, variable, original, renaming);
+                          Variable newVarName;
+                          if (newName != null && newName.TryGetFrameworkVariable(out newVarName))
+                          {
+                              var tryForAll = mdriver.AsForAllIndexed(to, newVarName);
+                              if (tryForAll != null)
+                                  newName = tryForAll;
+                          }
+
+                          return newName;
+                      };
+
+                    var result = path.Substitute(converter);
+
+                    result = result != null ? result.RemoveTautologiesAndDuplicatedFacts() : null;
+
+                    if (Trace)
+                    {
+                        if (result != null)
+                        {
+                            Console.WriteLine("  Path after substitution: {0}", result.ObligationStringAtPC(to, mdriver.Context, mdriver.MetaDataDecoder));
+                            Console.WriteLine("  Path after substitution: {0}", result.ObligationStringAtPC(to, mdriver.Context, mdriver.MetaDataDecoder, true));
+                        }
+                        else
+                        {
+                            Console.WriteLine("Substitution discharged path");
+                        }
+                    }
+                    return result;
+                }
+
+                #endregion
+
+                #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Variable,Variable,Path,Path> Members
+
+                public Path Arglist(APC pc, Variable dest, Path data)
+                {
+                    return data;
+                }
+
+                public Path BranchCond(APC pc, APC target, BranchOperator bop, Variable value1, Variable value2, Path data)
+                {
+                    return data;
+                }
+
+                public Path BranchTrue(APC pc, APC target, Variable cond, Path data)
+                {
+                    return data;
+                }
+
+                public Path BranchFalse(APC pc, APC target, Variable cond, Path data)
+                {
+                    return data;
+                }
+
+                public Path Branch(APC pc, APC target, bool leave, Path data)
+                {
+                    return data;
+                }
+
+                public Path Break(APC pc, Path data)
+                {
+                    return data;
+                }
+
+                [SuppressMessage("Microsoft.Contracts", "TestAlwaysEvaluatingToAConstant")]
+                public Path Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Variable dest, ArgList args, Path data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<Variable>
+                {
+                    // We'd love to have it, but then we should also take care of the changes of array elements in stelem, non-pure method calls, etc.
+                    // The only point were we do the ForAll expansion is in the renaming
+                    // The code is here only to help the debugging
 #if false
-            var tryForAll = this.mdriver.AsForAllIndexed(pc.Post(), dest);
-            if (tryForAll != null)
-            {
-              if (Trace)
-              {
-                Console.WriteLine("Hit a call to a ForAll. Replacing {0} with {1}", dest, tryForAll);
-              }
+                    var tryForAll = mdriver.AsForAllIndexed(pc.Post(), dest);
+                    if (tryForAll != null)
+                    {
+                        if (Trace)
+                        {
+                            Console.WriteLine("Hit a call to a ForAll. Replacing {0} with {1}", dest, tryForAll);
+                        }
 
-              Func<Variable, BoxedExpression, BoxedExpression> substituition = (v, original) => v.Equals(dest) ? tryForAll : original;
+                        Func<Variable, BoxedExpression, BoxedExpression> substituition = (v, original) => v.Equals(dest) ? tryForAll : original;
 
-              return data.Substitute(substituition);
-            }
+                        return data.Substitute(substituition);
+                    }
 #endif
-          if (Trace)
-          {
-            Console.WriteLine("  Hit a method call: {0}", method);
-          }
+                    if (Trace)
+                    {
+                        Console.WriteLine("  Hit a method call: {0}", method);
+                    }
 
-          // We do some magic for Equality and Inequality, to be used for proving properties of structs
-          if (data.Goal != null && data.Goal.Variables<Variable>().Contains(dest))
-          {
-            var mdd = this.mdriver.MetaDataDecoder;
-            var methodName = mdd.Name(method);
-            var context = mdriver.Context.ExpressionContext;
+                    // We do some magic for Equality and Inequality, to be used for proving properties of structs
+                    if (data.Goal != null && data.Goal.Variables<Variable>().Contains(dest))
+                    {
+                        var mdd = mdriver.MetaDataDecoder;
+                        var methodName = mdd.Name(method);
+                        var context = mdriver.Context.ExpressionContext;
 
-            switch (methodName)
-            {
-              case "op_Equality":
-                {
-                  return BuildExpression<ArgList>(BinaryOperator.Ceq, ref pc, dest, args, data, context);
+                        switch (methodName)
+                        {
+                            case "op_Equality":
+                                {
+                                    return BuildExpression<ArgList>(BinaryOperator.Ceq, ref pc, dest, args, data, context);
+                                }
+
+                            case "op_Inequality":
+                                {
+                                    return BuildExpression<ArgList>(BinaryOperator.Cne_Un, ref pc, dest, args, data, context);
+                                }
+                        }
+                    }
+                    return data;
                 }
 
-              case "op_Inequality":
+                private Path BuildExpression<ArgList>(BinaryOperator bop, ref APC pc, Variable var, ArgList args, Path data, IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, Variable> context) where ArgList : IIndexable<Variable>
                 {
-                  return BuildExpression<ArgList>(BinaryOperator.Cne_Un, ref pc, dest, args, data, context);
+                    Contract.Requires(data.Goal != null);
+
+                    var left = BoxedExpression.Convert(context.Refine(pc, args[0]), mdriver.ExpressionDecoder); if (left == null) return data;
+                    var right = BoxedExpression.Convert(context.Refine(pc, args[1]), mdriver.ExpressionDecoder); if (right == null) return data;
+                    var exp = BoxedExpression.Binary(bop, left, right, var);
+
+                    var newGoal = data.Goal.Substitute(
+                      delegate (Variable v, BoxedExpression original)
+                      {
+                          if (var.Equals(v)) return exp;
+                          else return original;
+                      }
+                    );
+
+                    if (Trace)
+                    {
+                        Console.WriteLine("  Replace a sub-goal with the binary exp {0}", exp);
+                        Console.WriteLine("  New goal {0}", newGoal);
+                    }
+
+                    return newGoal != null ? data.WithGoal(newGoal) : data;
                 }
-            }
-          }
-          return data;
-        }
 
-        private Path BuildExpression<ArgList>(BinaryOperator bop, ref APC pc, Variable var, ArgList args, Path data, IExpressionContextData<Local, Parameter, Method, Field, Type, Expression, Variable> context) where ArgList : IIndexable<Variable>
-        {
-          Contract.Requires(data.Goal != null);
+                public Path Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Variable dest, Variable fp, ArgList args, Path data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<Variable>
+                {
+                    return data;
+                }
 
-          var left = BoxedExpression.Convert(context.Refine(pc, args[0]), mdriver.ExpressionDecoder); if (left == null) return data;
-          var right = BoxedExpression.Convert(context.Refine(pc, args[1]), mdriver.ExpressionDecoder); if (right == null) return data;
-          var exp = BoxedExpression.Binary(bop, left, right, var);
+                public Path Ckfinite(APC pc, Variable dest, Variable source, Path data)
+                {
+                    return data;
+                }
 
-          var newGoal = data.Goal.Substitute(
-            delegate(Variable v, BoxedExpression original)
-            {
-              if (var.Equals(v)) return exp;
-              else return original;
-            }
-          );
+                public Path Cpblk(APC pc, bool @volatile, Variable destaddr, Variable srcaddr, Variable len, Path data)
+                {
+                    return data;
+                }
 
-          if(Trace)
-          {
-            Console.WriteLine("  Replace a sub-goal with the binary exp {0}", exp);
-            Console.WriteLine("  New goal {0}", newGoal);
-          }
+                public Path Endfilter(APC pc, Variable decision, Path data)
+                {
+                    return data;
+                }
 
-          return newGoal != null ? data.WithGoal(newGoal) : data;
-        }
+                public Path Endfinally(APC pc, Path data)
+                {
+                    return data;
+                }
 
-        public Path Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Variable dest, Variable fp, ArgList args, Path data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<Variable>
-        {
-          return data;
-        }
+                public Path Initblk(APC pc, bool @volatile, Variable destaddr, Variable value, Variable len, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ckfinite(APC pc, Variable dest, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path Jmp(APC pc, Method method, Path data)
+                {
+                    return data;
+                }
 
-        public Path Cpblk(APC pc, bool @volatile, Variable destaddr, Variable srcaddr, Variable len, Path data)
-        {
-          return data;
-        }
+                public Path Ldarg(APC pc, Parameter argument, bool isOld, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Endfilter(APC pc, Variable decision, Path data)
-        {
-          return data;
-        }
+                public Path Ldarga(APC pc, Parameter argument, bool isOld, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Endfinally(APC pc, Path data)
-        {
-          return data;
-        }
+                public Path Ldftn(APC pc, Method method, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Initblk(APC pc, bool @volatile, Variable destaddr, Variable value, Variable len, Path data)
-        {
-          return data;
-        }
+                public Path Ldind(APC pc, Type type, bool @volatile, Variable dest, Variable ptr, Path data)
+                {
+                    return data;
+                }
 
-        public Path Jmp(APC pc, Method method, Path data)
-        {
-          return data;
-        }
+                public Path Ldloc(APC pc, Local local, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldarg(APC pc, Parameter argument, bool isOld, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Ldloca(APC pc, Local local, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldarga(APC pc, Parameter argument, bool isOld, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Localloc(APC pc, Variable dest, Variable size, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldftn(APC pc, Method method, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Nop(APC pc, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldind(APC pc, Type type, bool @volatile, Variable dest, Variable ptr, Path data)
-        {
-          return data;
-        }
+                public Path Pop(APC pc, Variable source, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldloc(APC pc, Local local, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Return(APC pc, Variable source, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldloca(APC pc, Local local, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Starg(APC pc, Parameter argument, Variable source, Path data)
+                {
+                    return data;
+                }
 
-        public Path Localloc(APC pc, Variable dest, Variable size, Path data)
-        {
-          return data;
-        }
+                public Path Stind(APC pc, Type type, bool @volatile, Variable ptr, Variable value, Path data)
+                {
+                    return data;
+                }
 
-        public Path Nop(APC pc, Path data)
-        {
-          return data;
-        }
+                public Path Stloc(APC pc, Local local, Variable source, Path data)
+                {
+                    return data;
+                }
 
-        public Path Pop(APC pc, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path Switch(APC pc, Type type, System.Collections.Generic.IEnumerable<Pair<object, APC>> cases, Variable value, Path data)
+                {
+                    return data;
+                }
 
-        public Path Return(APC pc, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path Box(APC pc, Type type, Variable dest, Variable source, Path data)
+                {
+                    return data;
+                }
 
-        public Path Starg(APC pc, Parameter argument, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Variable dest, ArgList args, Path data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<Variable>
+                {
+                    return data;
+                }
 
-        public Path Stind(APC pc, Type type, bool @volatile, Variable ptr, Variable value, Path data)
-        {
-          return data;
-        }
+                public Path Castclass(APC pc, Type type, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
 
-        public Path Stloc(APC pc, Local local, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path Cpobj(APC pc, Type type, Variable destptr, Variable srcptr, Path data)
+                {
+                    return data;
+                }
 
-        public Path Switch(APC pc, Type type, System.Collections.Generic.IEnumerable<Pair<object, APC>> cases, Variable value, Path data)
-        {
-          return data;
-        }
+                public Path Initobj(APC pc, Type type, Variable ptr, Path data)
+                {
+                    return data;
+                }
 
-        public Path Box(APC pc, Type type, Variable dest, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path Ldelem(APC pc, Type type, Variable dest, Variable array, Variable index, Path data)
+                {
+                    return data;
+                }
 
-        public Path ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Variable dest, ArgList args, Path data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<Variable>
-        {
-          return data;
-        }
+                public Path Ldelema(APC pc, Type type, bool @readonly, Variable dest, Variable array, Variable index, Path data)
+                {
+                    return data;
+                }
 
-        public Path Castclass(APC pc, Type type, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
+                public Path Ldfld(APC pc, Field field, bool @volatile, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
 
-        public Path Cpobj(APC pc, Type type, Variable destptr, Variable srcptr, Path data)
-        {
-          return data;
-        }
+                public Path Ldflda(APC pc, Field field, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
 
-        public Path Initobj(APC pc, Type type, Variable ptr, Path data)
-        {
-          return data;
-        }
+                public Path Ldlen(APC pc, Variable dest, Variable array, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldelem(APC pc, Type type, Variable dest, Variable array, Variable index, Path data)
-        {
-          return data;
-        }
+                public Path Ldsfld(APC pc, Field field, bool @volatile, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldelema(APC pc, Type type, bool @readonly, Variable dest, Variable array, Variable index, Path data)
-        {
-          return data;
-        }
+                public Path Ldsflda(APC pc, Field field, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldfld(APC pc, Field field, bool @volatile, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
+                public Path Ldtypetoken(APC pc, Type type, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldflda(APC pc, Field field, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
+                public Path Ldfieldtoken(APC pc, Field field, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldlen(APC pc, Variable dest, Variable array, Path data)
-        {
-          return data;
-        }
+                public Path Ldmethodtoken(APC pc, Method method, Variable dest, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldsfld(APC pc, Field field, bool @volatile, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Ldvirtftn(APC pc, Method method, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldsflda(APC pc, Field field, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Mkrefany(APC pc, Type type, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldtypetoken(APC pc, Type type, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Newarray<ArgList>(APC pc, Type type, Variable dest, ArgList len, Path data) where ArgList : IIndexable<Variable>
+                {
+                    return data;
+                }
 
-        public Path Ldfieldtoken(APC pc, Field field, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Newobj<ArgList>(APC pc, Method ctor, Variable dest, ArgList args, Path data) where ArgList : IIndexable<Variable>
+                {
+                    return data;
+                }
 
-        public Path Ldmethodtoken(APC pc, Method method, Variable dest, Path data)
-        {
-          return data;
-        }
+                public Path Refanytype(APC pc, Variable dest, Variable source, Path data)
+                {
+                    return data;
+                }
 
-        public Path Ldvirtftn(APC pc, Method method, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
+                public Path Refanyval(APC pc, Type type, Variable dest, Variable source, Path data)
+                {
+                    return data;
+                }
 
-        public Path Mkrefany(APC pc, Type type, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
+                public Path Rethrow(APC pc, Path data)
+                {
+                    return data;
+                }
 
-        public Path Newarray<ArgList>(APC pc, Type type, Variable dest, ArgList len, Path data) where ArgList : IIndexable<Variable>
-        {
-          return data;
-        }
+                public Path Stelem(APC pc, Type type, Variable array, Variable index, Variable value, Path data)
+                {
+                    return data;
+                }
 
-        public Path Newobj<ArgList>(APC pc, Method ctor, Variable dest, ArgList args, Path data) where ArgList : IIndexable<Variable>
-        {
-          return data;
-        }
+                public Path Stfld(APC pc, Field field, bool @volatile, Variable obj, Variable value, Path data)
+                {
+                    return data;
+                }
 
-        public Path Refanytype(APC pc, Variable dest, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path Stsfld(APC pc, Field field, bool @volatile, Variable value, Path data)
+                {
+                    return data;
+                }
 
-        public Path Refanyval(APC pc, Type type, Variable dest, Variable source, Path data)
-        {
-          return data;
-        }
+                public Path Throw(APC pc, Variable exn, Path data)
+                {
+                    return data;
+                }
 
-        public Path Rethrow(APC pc, Path data)
-        {
-          return data;
-        }
+                public Path Unbox(APC pc, Type type, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
 
-        public Path Stelem(APC pc, Type type, Variable array, Variable index, Variable value, Path data)
-        {
-          return data;
-        }
+                public Path Unboxany(APC pc, Type type, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
 
-        public Path Stfld(APC pc, Field field, bool @volatile, Variable obj, Variable value, Path data)
-        {
-          return data;
-        }
+                #endregion
 
-        public Path Stsfld(APC pc, Field field, bool @volatile, Variable value, Path data)
-        {
-          return data;
-        }
+                #region IVisitSynthIL<APC,Method,Type,Variable,Variable,Path,Path> Members
 
-        public Path Throw(APC pc, Variable exn, Path data)
-        {
-          return data;
-        }
+                public Path Entry(APC pc, Method method, Path data)
+                {
+                    return data;
+                }
 
-        public Path Unbox(APC pc, Type type, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
+                public Path Assume(APC pc, string tag, Variable condition, object provenance, Path data)
+                {
+                    var expression = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, condition), mdriver.ExpressionDecoder);
 
-        public Path Unboxany(APC pc, Type type, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
+                    if (Trace)
+                    {
+                        Console.WriteLine("  Assume({2}) reached: non-normalized {0} {1}", condition, expression, tag);
+                    }
 
-        #endregion
+                    if (expression == null)
+                    {
+                        // abstract the assumption, if too big
 
-        #region IVisitSynthIL<APC,Method,Type,Variable,Variable,Path,Path> Members
+                        if (Trace)
+                        {
+                            Console.WriteLine("       We ignore the condition, as it is too big");
+                        }
 
-        public Path Entry(APC pc, Method method, Path data)
-        {
-          return data;
-        }
+                        return data;
+                    }
 
-        public Path Assume(APC pc, string tag, Variable condition, object provenance, Path data)
-        {
-          var expression = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, condition), mdriver.ExpressionDecoder);
-                   
-          if (Trace)
-          {
-            Console.WriteLine("  Assume({2}) reached: non-normalized {0} {1}", condition, expression, tag);
-          }
+                    var originalNegated = false;
+                    if (tag == "false")
+                    {
+                        // Try to avoid double negation
+                        if (expression.IsUnary && expression.UnaryOp == UnaryOperator.Not)
+                        {
+                            expression = expression.UnaryArgument;
+                            originalNegated = true; // check check? 
+                        }
+                        else
+                        {
+                            // negate
+                            expression = BoxedExpression.Unary(UnaryOperator.Not, expression);
+                            originalNegated = true;
+                        }
+                    }
 
-          if (expression == null)
-          {
-            // abstract the assumption, if too big
-
-            if (Trace)
-            {
-              Console.WriteLine("       We ignore the condition, as it is too big");
-            }
-            
-            return data;
-          }
-
-          var originalNegated = false;
-          if (tag == "false")
-          {
-            // Try to avoid double negation
-            if (expression.IsUnary && expression.UnaryOp == UnaryOperator.Not)
-            {
-              expression = expression.UnaryArgument;
-              originalNegated = true; // check check? 
-            }
-            else
-            {
-              // negate
-              expression = BoxedExpression.Unary(UnaryOperator.Not, expression);
-              originalNegated = true;
-            }
-          }
-          
 
 #if false
-          else if (tag == "assume" && pc.InsideRequiresAtCall)
-          {
-            // special hack: ThrowOtherwise are extracted with an extra assume(false) on the
-            // bad branch so the forward analysis actually gets some state out of it.
-            // On the backward proofs at call sites, we need to ignore that assume
-            if (expression.IsConstant) {
-              object c = expression.Constant;
-              if (c is int)
-              {
-                int ic = (int)c;
-                if (ic == 0)
-                { // ignore this assume
-                  return data;
-                }
-              }
-            }
-          }
+                    else if (tag == "assume" && pc.InsideRequiresAtCall)
+                    {
+                        // special hack: ThrowOtherwise are extracted with an extra assume(false) on the
+                        // bad branch so the forward analysis actually gets some state out of it.
+                        // On the backward proofs at call sites, we need to ignore that assume
+                        if (expression.IsConstant)
+                        {
+                            object c = expression.Constant;
+                            if (c is int)
+                            {
+                                int ic = (int)c;
+                                if (ic == 0)
+                                { // ignore this assume
+                                    return data;
+                                }
+                            }
+                        }
+                    }
 #endif
-          var simplified = expression.Simplify(this.mdriver.MetaDataDecoder);
-        
-          // We try to simplify the goal -- we know that the assumption holds, so we can rewrite the goal with "true"
-          if (data.Goal != null)
-          {
+                    var simplified = expression.Simplify(mdriver.MetaDataDecoder);
 
-            if (IsSuitableForReplacing(pc.Post(), simplified))
-            {
-              var newGoal = data.Goal.Substitute(simplified, BoxedExpression.ConstBool(true, this.mdriver.MetaDataDecoder));
+                    // We try to simplify the goal -- we know that the assumption holds, so we can rewrite the goal with "true"
+                    if (data.Goal != null)
+                    {
+                        if (IsSuitableForReplacing(pc.Post(), simplified))
+                        {
+                            var newGoal = data.Goal.Substitute(simplified, BoxedExpression.ConstBool(true, mdriver.MetaDataDecoder));
 
-              // nothing changed...
-              if(data.Goal.Equals(newGoal)) 
-              {
-                // if we know !b, then we want to replace b with "false"
-                if(simplified.IsUnary && simplified.UnaryOp == UnaryOperator.Not)
-                {
-                  newGoal = newGoal.Substitute(simplified.UnaryArgument, BoxedExpression.ConstBool(false, this.mdriver.MetaDataDecoder));
+                            // nothing changed...
+                            if (data.Goal.Equals(newGoal))
+                            {
+                                // if we know !b, then we want to replace b with "false"
+                                if (simplified.IsUnary && simplified.UnaryOp == UnaryOperator.Not)
+                                {
+                                    newGoal = newGoal.Substitute(simplified.UnaryArgument, BoxedExpression.ConstBool(false, mdriver.MetaDataDecoder));
+                                }
+                            }
+
+                            data = data.WithGoal(newGoal);
+                        }
+                    }
+
+                    var newAssumptions = data.AddAssumption(simplified, condition, originalNegated, mdriver.VariableComparer);
+
+                    if (newAssumptions != null)
+                    {
+                        if (TryProvingTheImplication(newAssumptions))
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("  Path discharged thanks to new facts from the assumption");
+                            }
+                            return null;
+                        }
+                    }
+
+                    return newAssumptions;
                 }
-              }
 
-              data = data.WithGoal(newGoal);
+                private bool IsSuitableForReplacing(APC pc, BoxedExpression simplified)
+                {
+                    Contract.Ensures(!Contract.Result<bool>() || simplified != null);
+
+                    if (simplified == null)
+                    {
+                        return false;
+                    }
+
+                    Variable v;
+                    if (simplified.TryGetFrameworkVariable(out v))
+                    {
+                        var t = mdriver.Context.ValueContext.GetType(pc, v);
+                        return t.IsNormal && mdriver.MetaDataDecoder.System_Boolean.Equals(t.Value);
+                    }
+
+                    return false;
+                }
+
+                public Path Assert(APC pc, string tag, Variable condition, object provenance, Path data)
+                {
+                    var expression = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, condition), mdriver.ExpressionDecoder);
+
+                    if (expression == null)
+                    {
+                        return data; // Let's skip the assumption
+                    }
+
+                    var newAssumptions = data.AddAssumption(expression, condition, false, mdriver.VariableComparer);
+                    if (newAssumptions != null)
+                    {
+                        if (TryProvingTheImplication(newAssumptions))
+                        {
+                            if (Trace)
+                            {
+                                Console.WriteLine("  Path discharged thanks to new facts from the assertion");
+                            }
+                            return null;
+                        }
+                    }
+
+                    return newAssumptions;
+                }
+
+                public Path Ldstack(APC pc, int offset, Variable dest, Variable source, bool isOld, Path data)
+                {
+                    return data;
+                }
+
+                public Path Ldstacka(APC pc, int offset, Variable dest, Variable source, Type type, bool isOld, Path data)
+                {
+                    return data;
+                }
+
+                public Path Ldresult(APC pc, Type type, Variable dest, Variable source, Path data)
+                {
+                    return data;
+                }
+
+                public Path BeginOld(APC pc, APC matchingEnd, Path data)
+                {
+                    return data;
+                }
+
+                public Path EndOld(APC pc, APC matchingBegin, Type type, Variable dest, Variable source, Path data)
+                {
+                    return data;
+                }
+
+                #endregion
+
+                #region IVisitExprIL<APC,Type,Variable,Variable,Path,Path> Members
+
+                public Path Binary(APC pc, BinaryOperator op, Variable dest, Variable s1, Variable s2, Path data)
+                {
+                    return data;
+                }
+
+                public Path Isinst(APC pc, Type type, Variable dest, Variable obj, Path data)
+                {
+                    return data;
+                }
+
+                public Path Ldconst(APC pc, object constant, Type type, Variable dest, Path data)
+                {
+                    return data;
+                }
+
+                public Path Ldnull(APC pc, Variable dest, Path data)
+                {
+                    return data;
+                }
+
+                public Path Sizeof(APC pc, Type type, Variable dest, Path data)
+                {
+                    return data;
+                }
+
+                public Path Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Variable source, Path data)
+                {
+                    return data;
+                }
+
+                #endregion
+
+                #region SMT-LIB Related
+
+                private void EmitImplicationInSMTLibFormat(Path head)
+                {
+                    var reader = new BoxedExpressionsToSMT2(obj => TypeFor(head.PC, obj));
+
+                    var definitions = new SMTFunctionDefinitions();
+
+                    var facts = "";
+                    var not_goal = "";
+                    var first = true;
+
+                    if (head.PosAssumptions != null)
+                    {
+                        foreach (var pos in head.PosAssumptions.GetEnumerable())
+                        {
+                            if (reader.Visit(pos, definitions) != null)
+                            {
+                                facts = And(ref first, facts, reader.ResultValue);
+                            }
+                        }
+                    }
+                    if (head.NegAssumptions != null)
+                    {
+                        foreach (var neg in head.NegAssumptions.GetEnumerable())
+                        {
+                            if (reader.Visit(BoxedExpression.Unary(UnaryOperator.Not, neg), definitions) != null)
+                            {
+                                facts = And(ref first, facts, reader.ResultValue);
+                            }
+                        }
+                    }
+
+                    if (head.Goal != null)
+                    {
+                        var what = head.GoalIsNegated ? head.Goal : BoxedExpression.Unary(UnaryOperator.Not, head.Goal);
+                        if (reader.Visit(what, definitions) != null)
+                        {
+                            not_goal = reader.ResultValue;
+                        }
+                    }
+                    else
+                    {
+                        not_goal = "true";
+                    }
+
+                    Console.WriteLine("SMT-Output");
+                    Console.WriteLine("(set-logic QF_FPA)");
+                    foreach (var def in definitions.Declarations)
+                    {
+                        Console.WriteLine(def);
+                    }
+                    Console.WriteLine(string.Format("(assert (and {0} {1}))", facts, not_goal));
+                    Console.WriteLine("(check-sat)");
+                    Console.WriteLine("(get-model)");
+                }
+
+                private string And(ref bool isFirst, string facts, string fact)
+                {
+                    if (isFirst)
+                    {
+                        isFirst = false;
+                        return fact;
+                    }
+
+                    return string.Format("(and {0} {1})", facts, fact);
+                }
+
+                private System.Type TypeFor(APC where, object obj)
+                {
+                    if (obj is Variable)
+                    {
+                        var v = (Variable)obj;
+                        var t = mdriver.Context.ValueContext.GetType(where.Post(), v);
+                        if (t.IsNormal)
+                        {
+                            var md = mdriver.MetaDataDecoder;
+                            if (t.Equals(md.System_Int32))
+                            {
+                                return typeof(System.Int32);
+                            }
+                            if (t.Equals(md.System_Single))
+                            {
+                                return typeof(System.Single);
+                            }
+                            if (t.Equals(md.System_Double))
+                            {
+                                return typeof(System.Double);
+                            }
+                            // TODO
+
+                        }
+                    }
+
+                    return null;
+                }
+
+                #endregion
             }
-          }
-
-          var newAssumptions = data.AddAssumption(simplified, condition, originalNegated, this.mdriver.VariableComparer);
-
-          if (newAssumptions != null)
-          {
-            if (TryProvingTheImplication(newAssumptions))
-            {
-              if (Trace)
-              {
-                Console.WriteLine("  Path discharged thanks to new facts from the assumption");
-              }
-              return null;
-            }
-          }
-
-          return newAssumptions;
         }
-
-        private bool IsSuitableForReplacing(APC pc, BoxedExpression simplified)
-        {
-          Contract.Ensures(!Contract.Result<bool>() || simplified != null);
-
-          if (simplified == null)
-          {
-            return false;
-          }
-
-          Variable v;
-          if(simplified.TryGetFrameworkVariable(out v))
-          {
-            var t = this.mdriver.Context.ValueContext.GetType(pc, v);
-            return t.IsNormal && this.mdriver.MetaDataDecoder.System_Boolean.Equals(t.Value);
-          }
-
-          return false;
-        }
-
-        public Path Assert(APC pc, string tag, Variable condition, object provenance, Path data)
-        {
-          var expression = BoxedExpression.Convert(mdriver.Context.ExpressionContext.Refine(pc, condition), mdriver.ExpressionDecoder);
-
-          if(expression == null)
-          {
-            return data; // Let's skip the assumption
-          }
-
-          var newAssumptions = data.AddAssumption(expression, condition, false, this.mdriver.VariableComparer);
-          if (newAssumptions != null)
-          {
-            if (TryProvingTheImplication(newAssumptions))
-            {
-              if (Trace)
-              {
-                Console.WriteLine("  Path discharged thanks to new facts from the assertion");
-              }
-              return null;
-            }
-          }
-
-          return newAssumptions;
-        }
-
-        public Path Ldstack(APC pc, int offset, Variable dest, Variable source, bool isOld, Path data)
-        {
-          return data;
-        }
-
-        public Path Ldstacka(APC pc, int offset, Variable dest, Variable source, Type type, bool isOld, Path data)
-        {
-          return data;
-        }
-
-        public Path Ldresult(APC pc, Type type, Variable dest, Variable source, Path data)
-        {
-          return data;
-        }
-
-        public Path BeginOld(APC pc, APC matchingEnd, Path data)
-        {
-          return data;
-        }
-
-        public Path EndOld(APC pc, APC matchingBegin, Type type, Variable dest, Variable source, Path data)
-        {
-          return data;
-        }
-
-        #endregion
-
-        #region IVisitExprIL<APC,Type,Variable,Variable,Path,Path> Members
-
-        public Path Binary(APC pc, BinaryOperator op, Variable dest, Variable s1, Variable s2, Path data)
-        {
-          return data;
-        }
-
-        public Path Isinst(APC pc, Type type, Variable dest, Variable obj, Path data)
-        {
-          return data;
-        }
-
-        public Path Ldconst(APC pc, object constant, Type type, Variable dest, Path data)
-        {
-          return data;
-        }
-
-        public Path Ldnull(APC pc, Variable dest, Path data)
-        {
-          return data;
-        }
-
-        public Path Sizeof(APC pc, Type type, Variable dest, Path data)
-        {
-          return data;
-        }
-
-        public Path Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Variable dest, Variable source, Path data)
-        {
-          return data;
-        }
-
-        #endregion
-
-        #region SMT-LIB Related
-
-        private void EmitImplicationInSMTLibFormat(Path head)
-        {
-          var reader = new BoxedExpressionsToSMT2(obj => TypeFor(head.PC, obj));
-
-          var definitions = new SMTFunctionDefinitions();
-
-          var facts = "";
-          var not_goal = "";
-          var first = true;
-
-          if (head.PosAssumptions != null)
-          {
-            foreach (var pos in head.PosAssumptions.GetEnumerable())
-            {
-              if (reader.Visit(pos, definitions) != null)
-              {
-                facts = And(ref first, facts, reader.ResultValue);
-              }
-            }
-          }
-          if (head.NegAssumptions != null)
-          {
-            foreach (var neg in head.NegAssumptions.GetEnumerable())
-            {
-              if (reader.Visit(BoxedExpression.Unary(UnaryOperator.Not, neg), definitions) != null)
-              {
-                facts = And(ref first, facts, reader.ResultValue);
-              }
-            }
-          }
-
-          if (head.Goal != null)
-          {
-            var what = head.GoalIsNegated ? head.Goal : BoxedExpression.Unary(UnaryOperator.Not, head.Goal);
-            if (reader.Visit(what, definitions) != null)
-            {
-              not_goal = reader.ResultValue;
-            }
-          }
-          else
-          {
-            not_goal = "true";
-          }
-
-          Console.WriteLine("SMT-Output");
-          Console.WriteLine("(set-logic QF_FPA)");
-          foreach (var def in definitions.Declarations)
-          {
-            Console.WriteLine(def);
-          }
-          Console.WriteLine(string.Format("(assert (and {0} {1}))", facts, not_goal));
-          Console.WriteLine("(check-sat)");
-          Console.WriteLine("(get-model)");
-        }
-
-        private string And(ref bool isFirst, string facts, string fact)
-        {
-          if (isFirst)
-          {
-            isFirst = false;
-            return fact;
-          }
-
-          return string.Format("(and {0} {1})", facts, fact);
-        }
-
-        private System.Type TypeFor(APC where, object obj)
-        {
-          if (obj is Variable)
-          {
-            var v = (Variable)obj;
-            var t = this.mdriver.Context.ValueContext.GetType(where.Post(), v);
-            if (t.IsNormal)
-            {
-              var md = this.mdriver.MetaDataDecoder;
-              if (t.Equals(md.System_Int32))
-              {
-                return typeof(System.Int32);
-              }
-              if (t.Equals(md.System_Single))
-              {
-                return typeof(System.Single);
-              }
-              if (t.Equals(md.System_Double))
-              {
-                return typeof(System.Double);
-              }
-              // TODO
-
-            }
-          }
-
-          return null;
-        }
-
-        #endregion
-      }
     }
-  }
 }

--- a/Microsoft.Research/CodeAnalysis/WeakestPreconditionProver.csToSMT2.cs
+++ b/Microsoft.Research/CodeAnalysis/WeakestPreconditionProver.csToSMT2.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -20,506 +9,503 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  [ContractVerification(false)]
-  public class BoxedExpressionsToSMT2 : BoxedExpressionTransformer<SMTFunctionDefinitions>
-  {
-    const string FLOAT32Bits = "11 53"; // to change!!!
-    const string FLOAT64Bits = "11 53";
-
-    const string FLOAT32 = "(_ FP 11 53)"; // To change!!!
-    const string FLOAT64 = "(_ FP 11 53)";
-    
-    const string INT = "Int"; // To change !!!
-    const string DEFAULTROUNDING = "roundTowardZero"; // .NET has some default rounding
-
-    public string ResultValue { get; private set; }
-    readonly private Func<Object, Type> VariableType;
-
-    private enum FloatType { Float32, Float64, Other};
-
-    private Dictionary<BoxedExpression, FloatType> types; 
-
-    public BoxedExpressionsToSMT2(Func<object, Type> VariableType)
+    [ContractVerification(false)]
+    public class BoxedExpressionsToSMT2 : BoxedExpressionTransformer<SMTFunctionDefinitions>
     {
-      Contract.Requires(VariableType != null);
+        private const string FLOAT32Bits = "11 53"; // to change!!!
+        private const string FLOAT64Bits = "11 53";
 
-      this.ResultValue = null;
-      this.VariableType = VariableType;
-    }
+        private const string FLOAT32 = "(_ FP 11 53)"; // To change!!!
+        private const string FLOAT64 = "(_ FP 11 53)";
 
-    public override BoxedExpression Visit(BoxedExpression exp, SMTFunctionDefinitions info, Func<object, DataStructures.FList<PathElement>> PathFetcher = null)
-    {
-      this.ResultValue = null;
-      this.types = new Dictionary<BoxedExpression, FloatType>();
+        private const string INT = "Int"; // To change !!!
+        private const string DEFAULTROUNDING = "roundTowardZero"; // .NET has some default rounding
 
-      return base.Visit(exp, info, PathFetcher);
-    }
-    
-    protected override BoxedExpression Binary(BoxedExpression original, BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right)
-    {
-      var tmp = this.Visit(left);
-      if (tmp != null)
-      {
-        var l = this.ResultValue;
-        Contract.Assume(l != null);
-        tmp = this.Visit(right);
-        if (tmp != null)
+        public string ResultValue { get; private set; }
+        readonly private Func<Object, Type> VariableType;
+
+        private enum FloatType { Float32, Float64, Other };
+
+        private Dictionary<BoxedExpression, FloatType> types;
+
+        public BoxedExpressionsToSMT2(Func<object, Type> VariableType)
         {
-          var r = this.ResultValue;
-          Contract.Assume(r != null);
+            Contract.Requires(VariableType != null);
 
-          FloatType typeOp;
-          if (!(this.types.TryGetValue(left, out typeOp)  && typeOp != FloatType.Other) && !this.types.TryGetValue(right, out typeOp))
-          {
-            typeOp = FloatType.Other;
-          }
-          this.ResultValue = Combine(binaryOperator, typeOp, l, r);
+            this.ResultValue = null;
+            this.VariableType = VariableType;
+        }
 
-          if (this.ResultValue != null)
-          {
+        public override BoxedExpression Visit(BoxedExpression exp, SMTFunctionDefinitions info, Func<object, DataStructures.FList<PathElement>> PathFetcher = null)
+        {
+            this.ResultValue = null;
+            types = new Dictionary<BoxedExpression, FloatType>();
 
-            this.types[original] = typeOp;
-            
+            return base.Visit(exp, info, PathFetcher);
+        }
+
+        protected override BoxedExpression Binary(BoxedExpression original, BinaryOperator binaryOperator, BoxedExpression left, BoxedExpression right)
+        {
+            var tmp = this.Visit(left);
+            if (tmp != null)
+            {
+                var l = this.ResultValue;
+                Contract.Assume(l != null);
+                tmp = this.Visit(right);
+                if (tmp != null)
+                {
+                    var r = this.ResultValue;
+                    Contract.Assume(r != null);
+
+                    FloatType typeOp;
+                    if (!(types.TryGetValue(left, out typeOp) && typeOp != FloatType.Other) && !types.TryGetValue(right, out typeOp))
+                    {
+                        typeOp = FloatType.Other;
+                    }
+                    this.ResultValue = Combine(binaryOperator, typeOp, l, r);
+
+                    if (this.ResultValue != null)
+                    {
+                        types[original] = typeOp;
+
+                        return original;
+                    }
+                }
+            }
+
+            this.ResultValue = null;
+            return null;
+        }
+
+        protected override BoxedExpression Unary(BoxedExpression original, UnaryOperator unaryOperator, BoxedExpression argument)
+        {
+            var tmp = this.Visit(argument);
+            if (tmp != null)
+            {
+                var arg = this.ResultValue;
+                this.ResultValue = Combine(unaryOperator, arg);
+                if (this.ResultValue != null)
+                {
+                    return original;
+                }
+            }
+
+            this.ResultValue = null;
+            return null;
+        }
+
+        protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
+        {
+            bool isDouble, isPlusInfinity, isMinusInfinity;
+            var type = VariableType(var);
+            if (type != null)
+            {
+                if (type.Equals(typeof(System.Single)))
+                {
+                    return DeclareVariable(original, FLOAT32); // TODO: change it
+                }
+                if (type.Equals(typeof(System.Double)))
+                {
+                    return DeclareVariable(original, FLOAT64);
+                }
+                if (type.Equals(typeof(System.Int32)))
+                {
+                    return DeclareVariable(original, INT);
+                }
+            }
+            // IsNaN
+            else if (path.IsNaNCall(out isDouble))
+            {
+                return NaNCheck(original, path, isDouble);
+            }
+            // IsInfinity, IsPlusInfinity, IsMinusInfinity
+            else if (path.IsInfinityCall(out isDouble, out isPlusInfinity, out isMinusInfinity))
+            {
+                return InfinityCheck(original, path, isDouble, isPlusInfinity, isMinusInfinity);
+            }
+            this.ResultValue = null;
+            return null;
+        }
+
+
+        protected override BoxedExpression Constant(BoxedExpression original, object type, object value)
+        {
+            if (value is System.Single)
+            {
+                types[original] = FloatType.Float32;
+                this.ResultValue = string.Format("((_ asFloat {0}) {1} {2:0.0})", FLOAT32Bits, DEFAULTROUNDING, value);
+            }
+            else if (value is System.Double)
+            {
+                types[original] = FloatType.Float64;
+                this.ResultValue = string.Format("((_ asFloat {0}) {1} {2:0.0})", FLOAT64Bits, DEFAULTROUNDING, value);
+            }
+            else
+            {
+                this.ResultValue = value.ToString();
+            }
             return original;
-          }
         }
-      }
 
-      this.ResultValue = null;
-      return null;
-    }
-
-    protected override BoxedExpression Unary(BoxedExpression original, UnaryOperator unaryOperator, BoxedExpression argument)
-    {
-      var tmp = this.Visit(argument);
-      if (tmp != null)
-      {
-        var arg = this.ResultValue;
-        this.ResultValue = Combine(unaryOperator, arg);
-        if (this.ResultValue != null)
+        protected override BoxedExpression Null(BoxedExpression original)
         {
-          return original;
+            return this.Constant(original, original.ConstantType, original.Constant);
         }
-      }
 
-      this.ResultValue = null;
-      return null;
-    }
+        #region TODO
 
-    protected override BoxedExpression Variable(BoxedExpression original, object var, PathElement[] path)
-    {
-      bool isDouble, isPlusInfinity, isMinusInfinity;
-      var type = this.VariableType(var);
-      if (type != null)
-      {
-        if (type.Equals(typeof(System.Single)))
+        protected override BoxedExpression Exists(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
         {
-          return DeclareVariable(original, FLOAT32); // TODO: change it
-        }
-        if (type.Equals(typeof(System.Double)))
-        {
-          return DeclareVariable(original, FLOAT64);
-        }
-        if (type.Equals(typeof(System.Int32)))
-        {
-          return DeclareVariable(original, INT);
-        }
-      }
-        // IsNaN
-      else if (path.IsNaNCall(out isDouble))
-      {
-        return NaNCheck(original, path, isDouble);
-      }
-       // IsInfinity, IsPlusInfinity, IsMinusInfinity
-      else if (path.IsInfinityCall(out isDouble, out isPlusInfinity, out isMinusInfinity))
-      {
-        return InfinityCheck(original, path, isDouble, isPlusInfinity, isMinusInfinity);
-      }
-      this.ResultValue = null;
-      return null;
-    }
-
-
-    protected override BoxedExpression Constant(BoxedExpression original, object type, object value)
-    {
-      if (value is System.Single)
-      {
-        this.types[original] = FloatType.Float32;
-        this.ResultValue = string.Format("((_ asFloat {0}) {1} {2:0.0})", FLOAT32Bits, DEFAULTROUNDING, value);
-      }
-      else if (value is System.Double)
-      {
-        this.types[original] = FloatType.Float64;
-        this.ResultValue = string.Format("((_ asFloat {0}) {1} {2:0.0})", FLOAT64Bits, DEFAULTROUNDING, value);
-      }
-      else
-      {
-        this.ResultValue = value.ToString();
-      }
-      return original;
-    }
-
-    protected override BoxedExpression Null(BoxedExpression original)
-    {
-      return this.Constant(original, original.ConstantType, original.Constant);
-    }
-
-    #region TODO
-
-    protected override BoxedExpression Exists(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
-    {
-      this.ResultValue = null;
-      return null;
-    }
-
-    protected override BoxedExpression IsInst(BoxedExpression original, object type, BoxedExpression argument)
-    {
-      this.ResultValue = null;
-      return null;
-    }
-
-    protected override BoxedExpression ForAll(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
-    {
-      this.ResultValue = null;
-      return null;
-    }
-
-    protected override BoxedExpression ArrayIndex<Typ>(BoxedExpression original, Typ type, BoxedExpression array, BoxedExpression index)
-    {
-      this.ResultValue = null;
-      return null; // TODO
-    }
-
-    protected override BoxedExpression Result(BoxedExpression original)
-    {
-      this.ResultValue = null;
-      return null;
-    }
-
-    protected override BoxedExpression SizeOf(BoxedExpression original)
-    {
-      this.ResultValue = null;
-      return null;
-    }
-
-    #endregion
-
-    #region privates
-
-    private BoxedExpression DeclareVariable(BoxedExpression original, string type)
-    {
-      var tmp = original.ToString().Replace(' ', '_');
-      this.Info.AddDeclaration(string.Format("(declare-fun {0} () {1})", tmp, type));
-      this.ResultValue = tmp;
-
-      if (type == FLOAT32)
-      {
-        this.types[original] = FloatType.Float32;
-      }
-      else if (type == FLOAT64)
-      {
-        this.types[original] = FloatType.Float64;
-      }
-
-      return original;
-    }
-
-    private BoxedExpression NaNCheck(BoxedExpression original, PathElement[] path, bool isDouble)
-    {
-      Contract.Requires(path.Length == 2);
-
-      var arg = path[0].ToString();
-      this.Info.AddDeclaration(string.Format("(declare-fun {0} () {1})", arg, isDouble ? FLOAT64 : FLOAT32));
-      this.ResultValue = string.Format("(= {0} {1})", arg, GetNaN(isDouble)); // emitting real equality "=" instead of FPA equality "==" which returns false when one of the arguments is NaN
-
-      return original;
-    }
-
-    private BoxedExpression InfinityCheck(BoxedExpression original, PathElement[] path, bool isDouble, bool isPlusInfinity, bool isMinusInfinity)
-    {
-      Contract.Requires(path.Length == 2);
-      Contract.Requires(isPlusInfinity || isMinusInfinity);
-
-      var arg = path[0].ToString();
-      this.Info.AddDeclaration(string.Format("(declare-fun {0} () {1})", arg, isDouble ? FLOAT64 : FLOAT32));
-
-      string plusInfinity = null;
-      string minusInfinity = null;
-
-      if (isPlusInfinity)
-      {
-        plusInfinity = string.Format("(= {0} {1})", arg, GetInfinity(isDouble, true));
-      }
-      if (isMinusInfinity)
-      {
-        minusInfinity = string.Format("(= {0} {1})", arg, GetInfinity(isDouble, false));
-      }
-
-      if (isPlusInfinity && isMinusInfinity)
-      {
-        this.ResultValue = string.Format("(or {0} {1})", plusInfinity, minusInfinity);
-      }
-      else if (isPlusInfinity)
-      {
-        this.ResultValue = plusInfinity;
-      }
-      else
-      {
-        this.ResultValue = minusInfinity;
-      }
-
-      return original;
-    }
-
-
-    private string GetNaN(bool IsDouble)
-    {
-      return string.Format("(as NaN {0})", IsDouble ? FLOAT64 : FLOAT32);
-    }
-
-    private string GetInfinity(bool IsDouble, bool isPlusInfinity)
-    {
-      return string.Format("(as {0} {1})", 
-        isPlusInfinity ? "plusInfinity" : "minusInfinity",
-        IsDouble ? FLOAT64 : FLOAT32);
-    }
-
-    private string Combine(BinaryOperator binaryOperator, FloatType type, string left, string right)
-    {
-      Contract.Requires(left != null);
-      Contract.Requires(right != null);
-
-      var format = "({0} {1} {2} {3})";
-      
-      string bop = null;
-      string bopType = null;
-
-      switch (type)
-      {
-        case FloatType.Float32:
-        case FloatType.Float64:
-          {
-            bopType = DEFAULTROUNDING;
-          }
-          break;
-
-        default:
-          {
-            bopType = "";
-          }
-          break;
-      }
-
-      switch (binaryOperator)
-      {
-        case BinaryOperator.Add:
-        case BinaryOperator.Add_Ovf:
-        case BinaryOperator.Add_Ovf_Un:
-          {
-            bop = "+";
-          }
-          break;
-        
-        case BinaryOperator.And:
-          {
-            bopType = null;
-            bop = "&";
-          }
-          break;
-
-        case BinaryOperator.Ceq:
-        case BinaryOperator.Cobjeq:
-          {
-            bopType = null;
-            bop = "=";
-          }
-          break;
-
-        case BinaryOperator.Cge:
-        case BinaryOperator.Cge_Un:
-          {
-            bopType = null;
-
-            bop = ">=";
-          }
-          break;
-
-        case BinaryOperator.Cgt:
-        case BinaryOperator.Cgt_Un:
-          {
-            bopType = null;
-
-            bop = ">";
-          }
-          break;
-
-        case BinaryOperator.Cle:
-        case BinaryOperator.Cle_Un:
-          {
-            bopType = null;
-            bop = "<=";
-          }
-          break;
-
-        case BinaryOperator.Clt:
-        case BinaryOperator.Clt_Un:
-          {
-            bopType = null;
-            bop = "<";
-          }
-          break;
-
-        case BinaryOperator.Cne_Un:
-          {
-            bopType = null;
-            bop = "!=";
-          }
-          break;
-
-        case BinaryOperator.Div:
-        case BinaryOperator.Div_Un:
-          {
-            bop = "/";
-          }
-          break;
-
-        case BinaryOperator.LogicalAnd:
-          {
-            bopType = null;
-            bop = "and";
-          }
-          break;
-        
-        case BinaryOperator.LogicalOr:
-          {
-            bopType = null;
-            bop = "or";
-          }
-          break;
-
-        case BinaryOperator.Mul:
-        case BinaryOperator.Mul_Ovf:
-        case BinaryOperator.Mul_Ovf_Un:
-          {
-            bop = "*";
-          }
-          break;
-
-        case BinaryOperator.Or:
-          {
-            bopType = null;
-            bop = "|";
-          }
-          break;
-
-
-        case BinaryOperator.Rem:
-        case BinaryOperator.Rem_Un:
-          {
-            bop = "%";
-          }
-          break;
-
-        case BinaryOperator.Sub:
-        case BinaryOperator.Sub_Ovf:
-        case BinaryOperator.Sub_Ovf_Un:
-          {
-            bop = "-";
-          }
-          break;
-
-        case BinaryOperator.Xor:
-          {
-            bopType = null;
-            bop = "^";
-          }
-          break;
-
-        case BinaryOperator.Shl:
-        case BinaryOperator.Shr:
-        case BinaryOperator.Shr_Un:
-          // TODO!!!!
-
-        default:
-          {
-            bopType = null;
-
+            this.ResultValue = null;
             return null;
-          }
+        }
 
-      }
-
-      Contract.Assert(bop != null);
-
-
-      return string.Format(format, bop, bopType, left, right);
-
-    }
-
-
-    private string Combine(UnaryOperator unaryOperator, string arg)
-    {
-      Contract.Requires(arg != null);
-
-      var format = "({0} {1})";
-      string op = null;
-
-      switch (unaryOperator)
-      {
-        case UnaryOperator.Neg:
-        case UnaryOperator.Not:
-          {
-            op = "not";
-          }
-          break;
-
-        case UnaryOperator.WritableBytes:
-        case UnaryOperator.Conv_i:
-        case UnaryOperator.Conv_i1:
-        case UnaryOperator.Conv_i2:
-        case UnaryOperator.Conv_i4:
-        case UnaryOperator.Conv_i8:
-        case UnaryOperator.Conv_r_un:
-        case UnaryOperator.Conv_r4:
-        case UnaryOperator.Conv_r8:
-        case UnaryOperator.Conv_u:
-        case UnaryOperator.Conv_u1:
-        case UnaryOperator.Conv_u2:
-        case UnaryOperator.Conv_u4:
-        case UnaryOperator.Conv_u8:
-          {
+        protected override BoxedExpression IsInst(BoxedExpression original, object type, BoxedExpression argument)
+        {
+            this.ResultValue = null;
             return null;
-          }
-      }
+        }
 
-      return string.Format(format, op, arg);
+        protected override BoxedExpression ForAll(BoxedExpression original, BoxedExpression boundVariable, BoxedExpression lower, BoxedExpression upper, BoxedExpression body)
+        {
+            this.ResultValue = null;
+            return null;
+        }
+
+        protected override BoxedExpression ArrayIndex<Typ>(BoxedExpression original, Typ type, BoxedExpression array, BoxedExpression index)
+        {
+            this.ResultValue = null;
+            return null; // TODO
+        }
+
+        protected override BoxedExpression Result(BoxedExpression original)
+        {
+            this.ResultValue = null;
+            return null;
+        }
+
+        protected override BoxedExpression SizeOf(BoxedExpression original)
+        {
+            this.ResultValue = null;
+            return null;
+        }
+
+        #endregion
+
+        #region privates
+
+        private BoxedExpression DeclareVariable(BoxedExpression original, string type)
+        {
+            var tmp = original.ToString().Replace(' ', '_');
+            this.Info.AddDeclaration(string.Format("(declare-fun {0} () {1})", tmp, type));
+            this.ResultValue = tmp;
+
+            if (type == FLOAT32)
+            {
+                types[original] = FloatType.Float32;
+            }
+            else if (type == FLOAT64)
+            {
+                types[original] = FloatType.Float64;
+            }
+
+            return original;
+        }
+
+        private BoxedExpression NaNCheck(BoxedExpression original, PathElement[] path, bool isDouble)
+        {
+            Contract.Requires(path.Length == 2);
+
+            var arg = path[0].ToString();
+            this.Info.AddDeclaration(string.Format("(declare-fun {0} () {1})", arg, isDouble ? FLOAT64 : FLOAT32));
+            this.ResultValue = string.Format("(= {0} {1})", arg, GetNaN(isDouble)); // emitting real equality "=" instead of FPA equality "==" which returns false when one of the arguments is NaN
+
+            return original;
+        }
+
+        private BoxedExpression InfinityCheck(BoxedExpression original, PathElement[] path, bool isDouble, bool isPlusInfinity, bool isMinusInfinity)
+        {
+            Contract.Requires(path.Length == 2);
+            Contract.Requires(isPlusInfinity || isMinusInfinity);
+
+            var arg = path[0].ToString();
+            this.Info.AddDeclaration(string.Format("(declare-fun {0} () {1})", arg, isDouble ? FLOAT64 : FLOAT32));
+
+            string plusInfinity = null;
+            string minusInfinity = null;
+
+            if (isPlusInfinity)
+            {
+                plusInfinity = string.Format("(= {0} {1})", arg, GetInfinity(isDouble, true));
+            }
+            if (isMinusInfinity)
+            {
+                minusInfinity = string.Format("(= {0} {1})", arg, GetInfinity(isDouble, false));
+            }
+
+            if (isPlusInfinity && isMinusInfinity)
+            {
+                this.ResultValue = string.Format("(or {0} {1})", plusInfinity, minusInfinity);
+            }
+            else if (isPlusInfinity)
+            {
+                this.ResultValue = plusInfinity;
+            }
+            else
+            {
+                this.ResultValue = minusInfinity;
+            }
+
+            return original;
+        }
+
+
+        private string GetNaN(bool IsDouble)
+        {
+            return string.Format("(as NaN {0})", IsDouble ? FLOAT64 : FLOAT32);
+        }
+
+        private string GetInfinity(bool IsDouble, bool isPlusInfinity)
+        {
+            return string.Format("(as {0} {1})",
+              isPlusInfinity ? "plusInfinity" : "minusInfinity",
+              IsDouble ? FLOAT64 : FLOAT32);
+        }
+
+        private string Combine(BinaryOperator binaryOperator, FloatType type, string left, string right)
+        {
+            Contract.Requires(left != null);
+            Contract.Requires(right != null);
+
+            var format = "({0} {1} {2} {3})";
+
+            string bop = null;
+            string bopType = null;
+
+            switch (type)
+            {
+                case FloatType.Float32:
+                case FloatType.Float64:
+                    {
+                        bopType = DEFAULTROUNDING;
+                    }
+                    break;
+
+                default:
+                    {
+                        bopType = "";
+                    }
+                    break;
+            }
+
+            switch (binaryOperator)
+            {
+                case BinaryOperator.Add:
+                case BinaryOperator.Add_Ovf:
+                case BinaryOperator.Add_Ovf_Un:
+                    {
+                        bop = "+";
+                    }
+                    break;
+
+                case BinaryOperator.And:
+                    {
+                        bopType = null;
+                        bop = "&";
+                    }
+                    break;
+
+                case BinaryOperator.Ceq:
+                case BinaryOperator.Cobjeq:
+                    {
+                        bopType = null;
+                        bop = "=";
+                    }
+                    break;
+
+                case BinaryOperator.Cge:
+                case BinaryOperator.Cge_Un:
+                    {
+                        bopType = null;
+
+                        bop = ">=";
+                    }
+                    break;
+
+                case BinaryOperator.Cgt:
+                case BinaryOperator.Cgt_Un:
+                    {
+                        bopType = null;
+
+                        bop = ">";
+                    }
+                    break;
+
+                case BinaryOperator.Cle:
+                case BinaryOperator.Cle_Un:
+                    {
+                        bopType = null;
+                        bop = "<=";
+                    }
+                    break;
+
+                case BinaryOperator.Clt:
+                case BinaryOperator.Clt_Un:
+                    {
+                        bopType = null;
+                        bop = "<";
+                    }
+                    break;
+
+                case BinaryOperator.Cne_Un:
+                    {
+                        bopType = null;
+                        bop = "!=";
+                    }
+                    break;
+
+                case BinaryOperator.Div:
+                case BinaryOperator.Div_Un:
+                    {
+                        bop = "/";
+                    }
+                    break;
+
+                case BinaryOperator.LogicalAnd:
+                    {
+                        bopType = null;
+                        bop = "and";
+                    }
+                    break;
+
+                case BinaryOperator.LogicalOr:
+                    {
+                        bopType = null;
+                        bop = "or";
+                    }
+                    break;
+
+                case BinaryOperator.Mul:
+                case BinaryOperator.Mul_Ovf:
+                case BinaryOperator.Mul_Ovf_Un:
+                    {
+                        bop = "*";
+                    }
+                    break;
+
+                case BinaryOperator.Or:
+                    {
+                        bopType = null;
+                        bop = "|";
+                    }
+                    break;
+
+
+                case BinaryOperator.Rem:
+                case BinaryOperator.Rem_Un:
+                    {
+                        bop = "%";
+                    }
+                    break;
+
+                case BinaryOperator.Sub:
+                case BinaryOperator.Sub_Ovf:
+                case BinaryOperator.Sub_Ovf_Un:
+                    {
+                        bop = "-";
+                    }
+                    break;
+
+                case BinaryOperator.Xor:
+                    {
+                        bopType = null;
+                        bop = "^";
+                    }
+                    break;
+
+                case BinaryOperator.Shl:
+                case BinaryOperator.Shr:
+                case BinaryOperator.Shr_Un:
+                // TODO!!!!
+
+                default:
+                    {
+                        bopType = null;
+
+                        return null;
+                    }
+            }
+
+            Contract.Assert(bop != null);
+
+
+            return string.Format(format, bop, bopType, left, right);
+        }
+
+
+        private string Combine(UnaryOperator unaryOperator, string arg)
+        {
+            Contract.Requires(arg != null);
+
+            var format = "({0} {1})";
+            string op = null;
+
+            switch (unaryOperator)
+            {
+                case UnaryOperator.Neg:
+                case UnaryOperator.Not:
+                    {
+                        op = "not";
+                    }
+                    break;
+
+                case UnaryOperator.WritableBytes:
+                case UnaryOperator.Conv_i:
+                case UnaryOperator.Conv_i1:
+                case UnaryOperator.Conv_i2:
+                case UnaryOperator.Conv_i4:
+                case UnaryOperator.Conv_i8:
+                case UnaryOperator.Conv_r_un:
+                case UnaryOperator.Conv_r4:
+                case UnaryOperator.Conv_r8:
+                case UnaryOperator.Conv_u:
+                case UnaryOperator.Conv_u1:
+                case UnaryOperator.Conv_u2:
+                case UnaryOperator.Conv_u4:
+                case UnaryOperator.Conv_u8:
+                    {
+                        return null;
+                    }
+            }
+
+            return string.Format(format, op, arg);
+        }
+
+        #endregion
     }
 
-    #endregion
-  }
-
-  public class SMTFunctionDefinitions
-  {
-    readonly private List<string> declarations;
-
-    public SMTFunctionDefinitions()
+    public class SMTFunctionDefinitions
     {
-      this.declarations = new List<string>();
+        readonly private List<string> declarations;
+
+        public SMTFunctionDefinitions()
+        {
+            declarations = new List<string>();
+        }
+
+        public void AddDeclaration(string s)
+        {
+            Contract.Requires(s != null);
+
+            declarations.Add(s);
+        }
+
+        public IEnumerable<string> Declarations
+        {
+            get
+            {
+                return declarations.Distinct();
+            }
+        }
     }
-
-   public void AddDeclaration(string s)
-   {
-     Contract.Requires(s != null);
-
-     this.declarations.Add(s);
-   }
-
-    public IEnumerable<string> Declarations 
-    {
-      get
-      {
-        return declarations.Distinct();
-      }
-    }
-  }
 }


### PR DESCRIPTION
This reformat operation used dotnet/codeformatter@1d719e4e with `/rule-:FieldNames`.