### PR TITLE
Update TypeArguments behavior to match old IntelliSense services

### DIFF
--- a/Microsoft.Research/ContractAdornments/CSharp.Roslyn/ISymbolExtensions.cs
+++ b/Microsoft.Research/ContractAdornments/CSharp.Roslyn/ISymbolExtensions.cs
@@ -54,6 +54,9 @@ namespace ContractAdornments
             if (namedTypeSymbol == null)
                 return default(ImmutableArray<ITypeSymbol>);
 
+            if (namedTypeSymbol.Equals(namedTypeSymbol.OriginalDefinition))
+                return ImmutableArray<ITypeSymbol>.Empty;
+
             return namedTypeSymbol.TypeArguments;
         }
 

--- a/Microsoft.Research/ContractAdornments/CSharp.Roslyn/ISymbolExtensions.cs
+++ b/Microsoft.Research/ContractAdornments/CSharp.Roslyn/ISymbolExtensions.cs
@@ -54,6 +54,10 @@ namespace ContractAdornments
             if (namedTypeSymbol == null)
                 return default(ImmutableArray<ITypeSymbol>);
 
+            // Roslyn treats the parameters of uninstantiated generic types as the type arguments, while the old
+            // IntelliSense services treated uninstantiated generic types as not having type arguments. Since this
+            // method is meant to mimic the behavior of the old IntelliSense services, we specifically catch this case
+            // and return a default immutable array.
             if (namedTypeSymbol.Equals(namedTypeSymbol.OriginalDefinition))
                 return ImmutableArray<ITypeSymbol>.Empty;
 


### PR DESCRIPTION
ISymbolExtensions.TypeArguments needs to return null when the argument is an uninstantiated generic type, or a StackOverflowException can occur when attempting to display contracts for members of a generic type in Visual Studio 2015.

Fixes #116