### PR TITLE
Reformat code in ControlFlow

### DIFF
--- a/Microsoft.Research/ControlFlow/ContractFilteredCFG.cs
+++ b/Microsoft.Research/ControlFlow/ContractFilteredCFG.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -22,260 +11,263 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
+    using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
 
-  using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
-
-  public class ContractFilteredCFG : ICFG, IEdgeSubroutineAdaptor
-  {
-    readonly ICFG underlying;
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
+    public class ContractFilteredCFG : ICFG, IEdgeSubroutineAdaptor
     {
-      Contract.Invariant(underlying != null);
-    }
+        private readonly ICFG underlying;
 
-    public ContractFilteredCFG(ICFG underlying)
-    {
-      Contract.Requires(underlying != null);
-      this.underlying = underlying;
-    }
-
-    #region ICFG Members
-
-    public APC Entry
-    {
-      get { return underlying.Entry; }
-    }
-
-    public APC EntryAfterRequires
-    {
-      get { return underlying.EntryAfterRequires; }
-    }
-
-
-    public APC NormalExit
-    {
-      get { return underlying.NormalExit; }
-    }
-
-    public APC ExceptionExit
-    {
-      get { return underlying.ExceptionExit; }
-    }
-
-    public APC Post(APC pc)
-    {
-      return underlying.Post(pc);
-    }
-
-    public bool HasSingleSuccessor(APC ppoint, out APC singleSuccessor)
-    {
-      CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
-      try
-      {
-        return underlying.HasSingleSuccessor(ppoint, out singleSuccessor);
-      }
-      finally {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    public IEnumerable<APC> Successors(APC ppoint)
-    {
-      CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
-      try
-      {
-        return underlying.Successors(ppoint);
-      }
-      finally {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    public bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts)
-    {
-      CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
-      try
-      {
-        return underlying.HasSinglePredecessor(ppoint, out singlePredecessor, skipContracts);
-      }
-      finally {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    public IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts)
-    {
-      CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
-      try
-      {
-        return underlying.Predecessors(ppoint, skipContracts);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    public APC PredecessorPCPriorToRequires(APC ppoint)
-    {
-      CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
-      try
-      {
-        return underlying.PredecessorPCPriorToRequires(ppoint);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    public bool IsJoinPoint(APC ppoint)
-    {
-      return underlying.IsJoinPoint(ppoint);
-    }
-
-    public bool IsSplitPoint(APC ppoint)
-    {
-      return underlying.IsSplitPoint(ppoint);
-    }
-
-    public bool IsForwardBackEdgeTarget(APC ppoint)
-    {
-      return underlying.IsForwardBackEdgeTarget(ppoint);
-    }
-
-    public bool IsBackwardBackEdgeTarget(APC ppoint)
-    {
-      return underlying.IsBackwardBackEdgeTarget(ppoint);
-    }
-
-    public bool IsForwardBackEdge(APC from, APC to)
-    {
-      return underlying.IsForwardBackEdge(from, to);
-    }
-
-    public bool IsBackwardBackEdge(APC from, APC to)
-    {
-      return underlying.IsBackwardBackEdge(from, to);
-    }
-
-    public bool IsBlockStart(APC ppoint)
-    {
-      return underlying.IsBlockStart(ppoint);
-    }
-
-    public bool IsBlockEnd(APC ppoint)
-    {
-      return underlying.IsBlockEnd(ppoint);
-    }
-
-    public IEnumerable<APC> ExceptionHandlers<Type, Data>(APC ppoint, Data data, IHandlerFilter<Type, Data> handlerPredicate)
-    {
-      return underlying.ExceptionHandlers(ppoint, data, handlerPredicate);
-    }
-
-    public Graphs.IGraph<APC, DataStructures.Unit> AsForwardGraph(bool includeExceptionEdges)
-    {
-      var underlyingGraph = underlying.AsForwardGraph(includeExceptionEdges);
-      return new GraphWrapper<APC, Unit>(
-        underlyingGraph.Nodes,
-        node => SuccessorEdges(node, underlyingGraph));
-    }
-
-    IEnumerable<Pair<Unit, APC>> SuccessorEdges(APC pc, IGraph<APC,Unit> underlyingGraph)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        foreach (var succ in underlyingGraph.Successors(pc))
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          yield return succ;
+            Contract.Invariant(underlying != null);
         }
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
+
+        public ContractFilteredCFG(ICFG underlying)
+        {
+            Contract.Requires(underlying != null);
+            this.underlying = underlying;
+        }
+
+        #region ICFG Members
+
+        public APC Entry
+        {
+            get { return underlying.Entry; }
+        }
+
+        public APC EntryAfterRequires
+        {
+            get { return underlying.EntryAfterRequires; }
+        }
+
+
+        public APC NormalExit
+        {
+            get { return underlying.NormalExit; }
+        }
+
+        public APC ExceptionExit
+        {
+            get { return underlying.ExceptionExit; }
+        }
+
+        public APC Post(APC pc)
+        {
+            return underlying.Post(pc);
+        }
+
+        public bool HasSingleSuccessor(APC ppoint, out APC singleSuccessor)
+        {
+            CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
+            try
+            {
+                return underlying.HasSingleSuccessor(ppoint, out singleSuccessor);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        public IEnumerable<APC> Successors(APC ppoint)
+        {
+            CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
+            try
+            {
+                return underlying.Successors(ppoint);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        public bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts)
+        {
+            CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
+            try
+            {
+                return underlying.HasSinglePredecessor(ppoint, out singlePredecessor, skipContracts);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        public IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts)
+        {
+            CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
+            try
+            {
+                return underlying.Predecessors(ppoint, skipContracts);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        public APC PredecessorPCPriorToRequires(APC ppoint)
+        {
+            CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
+            try
+            {
+                return underlying.PredecessorPCPriorToRequires(ppoint);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        public bool IsJoinPoint(APC ppoint)
+        {
+            return underlying.IsJoinPoint(ppoint);
+        }
+
+        public bool IsSplitPoint(APC ppoint)
+        {
+            return underlying.IsSplitPoint(ppoint);
+        }
+
+        public bool IsForwardBackEdgeTarget(APC ppoint)
+        {
+            return underlying.IsForwardBackEdgeTarget(ppoint);
+        }
+
+        public bool IsBackwardBackEdgeTarget(APC ppoint)
+        {
+            return underlying.IsBackwardBackEdgeTarget(ppoint);
+        }
+
+        public bool IsForwardBackEdge(APC from, APC to)
+        {
+            return underlying.IsForwardBackEdge(from, to);
+        }
+
+        public bool IsBackwardBackEdge(APC from, APC to)
+        {
+            return underlying.IsBackwardBackEdge(from, to);
+        }
+
+        public bool IsBlockStart(APC ppoint)
+        {
+            return underlying.IsBlockStart(ppoint);
+        }
+
+        public bool IsBlockEnd(APC ppoint)
+        {
+            return underlying.IsBlockEnd(ppoint);
+        }
+
+        public IEnumerable<APC> ExceptionHandlers<Type, Data>(APC ppoint, Data data, IHandlerFilter<Type, Data> handlerPredicate)
+        {
+            return underlying.ExceptionHandlers(ppoint, data, handlerPredicate);
+        }
+
+        public Graphs.IGraph<APC, DataStructures.Unit> AsForwardGraph(bool includeExceptionEdges)
+        {
+            var underlyingGraph = underlying.AsForwardGraph(includeExceptionEdges);
+            return new GraphWrapper<APC, Unit>(
+              underlyingGraph.Nodes,
+              node => SuccessorEdges(node, underlyingGraph));
+        }
+
+        private IEnumerable<Pair<Unit, APC>> SuccessorEdges(APC pc, IGraph<APC, Unit> underlyingGraph)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                foreach (var succ in underlyingGraph.Successors(pc))
+                {
+                    yield return succ;
+                }
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        public FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
+        {
+            CallAdaption.Push(this);
+
+            try
+            {
+                return this.Subroutine.GetOrdinaryEdgeSubroutines(from, to, context);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+
+        public Graphs.IGraph<APC, DataStructures.Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
+        {
+            var underlyingGraph = underlying.AsBackwardGraph(includeExceptionEdges, skipContracts);
+            return new GraphWrapper<APC, Unit>(
+              underlyingGraph.Nodes,
+              node => SuccessorEdges(node, underlyingGraph));
+        }
+
+        public IEnumerable<CFGBlock> LoopHeads { get { return underlying.LoopHeads; } }
+
+        public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit> GetDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            return underlying.GetDecoder(mdDecoder);
+        }
+
+        /// <summary>
+        /// Does not filter edge in this subroutine!. If we want filtering, we have to wrap the subroutine itself too.
+        /// </summary>
+        public Subroutine Subroutine
+        {
+            get
+            {
+                return underlying.Subroutine;
+            }
+        }
+
+        public string ToString(APC pc)
+        {
+            CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
+            try
+            {
+                return underlying.ToString(pc);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        public void Print(System.IO.TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> edgePrinter, Func<CFGBlock, IEnumerable<DataStructures.FList<DataStructures.STuple<CFGBlock, CFGBlock, string>>>> contextLookup, DataStructures.FList<DataStructures.STuple<CFGBlock, CFGBlock, string>> context)
+        {
+            CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
+            try
+            {
+                underlying.Print(tw, ilPrinter, edgePrinter, contextLookup, context);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        #endregion
+
+        #region IEdgeSubroutineAdaptor Members
+
+        public DataStructures.FList<DataStructures.Pair<string, Subroutine>> GetOrdinaryEdgeSubroutinesInternal(CFGBlock from, CFGBlock to, DataStructures.FList<DataStructures.STuple<CFGBlock, CFGBlock, string>> context)
+        {
+            var result = CallAdaption.Inner<IEdgeSubroutineAdaptor>(this).GetOrdinaryEdgeSubroutinesInternal(from, to, context);
+            return result.Filter(pair => !(pair.Two.IsContract || pair.Two.IsOldValue));
+        }
+
+        #endregion
     }
-
-    public FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
-    {
-      CallAdaption.Push(this);
-
-      try
-      {
-        return this.Subroutine.GetOrdinaryEdgeSubroutines(from, to, context);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
-
-
-    public Graphs.IGraph<APC, DataStructures.Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
-    {
-      var underlyingGraph = underlying.AsBackwardGraph(includeExceptionEdges, skipContracts);
-      return new GraphWrapper<APC, Unit>(
-        underlyingGraph.Nodes,
-        node => SuccessorEdges(node, underlyingGraph));
-    }
-
-    public IEnumerable<CFGBlock> LoopHeads { get { return underlying.LoopHeads; } }
-
-    public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit> GetDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      return underlying.GetDecoder(mdDecoder);
-    }
-
-    /// <summary>
-    /// Does not filter edge in this subroutine!. If we want filtering, we have to wrap the subroutine itself too.
-    /// </summary>
-    public Subroutine Subroutine
-    {
-      get { 
-        return underlying.Subroutine; 
-      }
-    }
-
-    public string ToString(APC pc)
-    {
-      CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
-      try
-      {
-        return underlying.ToString(pc);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    public void Print(System.IO.TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> edgePrinter, Func<CFGBlock, IEnumerable<DataStructures.FList<DataStructures.STuple<CFGBlock, CFGBlock, string>>>> contextLookup, DataStructures.FList<DataStructures.STuple<CFGBlock, CFGBlock, string>> context)
-    {
-      CallAdaption.Push<IEdgeSubroutineAdaptor>(this);
-      try
-      {
-        underlying.Print(tw, ilPrinter, edgePrinter, contextLookup, context);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    #endregion
-
-    #region IEdgeSubroutineAdaptor Members
-
-    public DataStructures.FList<DataStructures.Pair<string, Subroutine>> GetOrdinaryEdgeSubroutinesInternal(CFGBlock from, CFGBlock to, DataStructures.FList<DataStructures.STuple<CFGBlock, CFGBlock, string>> context)
-    {
-      var result = CallAdaption.Inner<IEdgeSubroutineAdaptor>(this).GetOrdinaryEdgeSubroutinesInternal(from, to, context);
-      return result.Filter(pair => !(pair.Two.IsContract || pair.Two.IsOldValue));
-    }
-
-    #endregion
-  }
 }

--- a/Microsoft.Research/ControlFlow/ControlFlow.cs
+++ b/Microsoft.Research/ControlFlow/ControlFlow.cs
@@ -1,20 +1,9 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // #define ENABLE_ASSERTIONS
 #if DEBUG
-  #define CHECK_RECURSIVE_APCS
+#define CHECK_RECURSIVE_APCS
 #endif
 
 using System;
@@ -33,9470 +22,9675 @@ using Microsoft.Research.Graphs;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using SubroutineEdge = STuple<CFGBlock, CFGBlock, string>;
-  using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
+    using SubroutineEdge = STuple<CFGBlock, CFGBlock, string>;
+    using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
 
-  [ContextAdapter]
-  public interface IStackInfo
-  {
-    /// <summary>
-    /// Return true if the pc is a call site and the call is on the current "this" object of the method
-    /// </summary>
-    bool IsCallOnThis(APC pc);
-  }
-
-  public static class ControlFlowFactory
-  {
-    public static MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> Create<Local, Parameter, Method, Field, Type, Property, Event, Attribute, Assembly>
-       (IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-        IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder,
-        ErrorHandler output
-       )
+    [ContextAdapter]
+    public interface IStackInfo
     {
-      Contract.Requires(mdDecoder != null);// F: Added as of Clousot suggestion
-      Contract.Requires(contractDecoder != null);// F: Added as of Clousot suggestion
-      
-      return new MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(mdDecoder, contractDecoder, output);
-    }
-  }
-
-  public static class APCExtensions
-  {
-    public static string ExtractAssertionCondition(this APC pc)
-    {
-      Contract.Assume(pc.Block != null, "Assuming the object invariant");
-      return pc.Block.SourceAssertionCondition(pc);
+        /// <summary>
+        /// Return true if the pc is a call site and the call is on the current "this" object of the method
+        /// </summary>
+        bool IsCallOnThis(APC pc);
     }
 
-    public static APC PrimaryMethodLocation(this APC candidate)
+    public static class ControlFlowFactory
     {
-      if(candidate.Block == null)
-      {
-        return candidate;
-      }
-      
-      Contract.Assert(candidate.Block != null);
-      if (candidate.Block.Subroutine.IsMethod || candidate.Block.Subroutine.IsFaultFinally) return candidate;
-      bool isRequiresContext = candidate.Block.Subroutine.IsRequires;
-
-      for (var context = candidate.SubroutineContext; context != null; context = context.Tail)
-      {
-        if (context.Head.One.Subroutine.IsMethod || context.Head.One.Subroutine.IsFaultFinally)
+        public static MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> Create<Local, Parameter, Method, Field, Type, Property, Event, Attribute, Assembly>
+           (IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+            IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder,
+            ErrorHandler output
+           )
         {
-          APC methodContext;
-          if (isRequiresContext)
-          {
-            // use target of edge in case of subroutine context
-            var contextBlock = context.Head.Two;
-            methodContext = contextBlock.First;
-          }
-          else
-          {
-            var contextBlock = context.Head.One;
-            methodContext = contextBlock.PriorLast;
-          }
-          return methodContext;
+            Contract.Requires(mdDecoder != null);// F: Added as of Clousot suggestion
+            Contract.Requires(contractDecoder != null);// F: Added as of Clousot suggestion
+
+            return new MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(mdDecoder, contractDecoder, output);
         }
-      }
-      return candidate; // don't know better. There should always be a method
     }
 
-    public static IEnumerable<APC> NonPrimaryRelatedLocations(this APC candidate)
+    public static class APCExtensions
     {
-      bool skippedMethodPrimary = false;
-      if (candidate.Block.Subroutine.IsContract)
-      {
-        // that is the first related one
-        yield return candidate;
-      }
-      else
-      {
-        Debug.Assert(candidate.Block.Subroutine.IsMethod || candidate.Block.Subroutine.IsFaultFinally);
-        skippedMethodPrimary = true;
-      }
-
-      for (var subroutineContext = candidate.SubroutineContext; subroutineContext != null; subroutineContext=subroutineContext.Tail)
-      {
-        if (!skippedMethodPrimary && (subroutineContext.Head.One.Subroutine.IsMethod || subroutineContext.Head.One.Subroutine.IsFaultFinally))
+        public static string ExtractAssertionCondition(this APC pc)
         {
-          skippedMethodPrimary = true;
-          continue;
+            Contract.Assume(pc.Block != null, "Assuming the object invariant");
+            return pc.Block.SourceAssertionCondition(pc);
         }
 
-        CFGBlock contextBlock = subroutineContext.Head.One;
-        yield return contextBlock.First;
-      }
+        public static APC PrimaryMethodLocation(this APC candidate)
+        {
+            if (candidate.Block == null)
+            {
+                return candidate;
+            }
+
+            Contract.Assert(candidate.Block != null);
+            if (candidate.Block.Subroutine.IsMethod || candidate.Block.Subroutine.IsFaultFinally) return candidate;
+            bool isRequiresContext = candidate.Block.Subroutine.IsRequires;
+
+            for (var context = candidate.SubroutineContext; context != null; context = context.Tail)
+            {
+                if (context.Head.One.Subroutine.IsMethod || context.Head.One.Subroutine.IsFaultFinally)
+                {
+                    APC methodContext;
+                    if (isRequiresContext)
+                    {
+                        // use target of edge in case of subroutine context
+                        var contextBlock = context.Head.Two;
+                        methodContext = contextBlock.First;
+                    }
+                    else
+                    {
+                        var contextBlock = context.Head.One;
+                        methodContext = contextBlock.PriorLast;
+                    }
+                    return methodContext;
+                }
+            }
+            return candidate; // don't know better. There should always be a method
+        }
+
+        public static IEnumerable<APC> NonPrimaryRelatedLocations(this APC candidate)
+        {
+            bool skippedMethodPrimary = false;
+            if (candidate.Block.Subroutine.IsContract)
+            {
+                // that is the first related one
+                yield return candidate;
+            }
+            else
+            {
+                Debug.Assert(candidate.Block.Subroutine.IsMethod || candidate.Block.Subroutine.IsFaultFinally);
+                skippedMethodPrimary = true;
+            }
+
+            for (var subroutineContext = candidate.SubroutineContext; subroutineContext != null; subroutineContext = subroutineContext.Tail)
+            {
+                if (!skippedMethodPrimary && (subroutineContext.Head.One.Subroutine.IsMethod || subroutineContext.Head.One.Subroutine.IsFaultFinally))
+                {
+                    skippedMethodPrimary = true;
+                    continue;
+                }
+
+                CFGBlock contextBlock = subroutineContext.Head.One;
+                yield return contextBlock.First;
+            }
+        }
     }
 
-  }
-
-
-  /// <summary>
-  /// An abstract program point representing a particular control point including possible finally continuations
-  ///
-  /// The point is an index into a CFGBlock. If the block has a label at that index, the point represents the program
-  /// point just PRIOR to the execution of the code at that label. 
-  /// If the point is past the sequence of labels in that CFGBlock, then the program point represents the excecution
-  /// point just after the last instruction in the block (or predecessor blocks).
-  /// </summary>
-  [ContractVerification(false)] // F: turning off the verification as something should be changed in the code so to differentiate between the Dummy struct (when this.Block == null) and all the others (when this.Block != null)
-  [Serializable]
-  public struct APC : IEquatable<APC> {
-
-    public static readonly APC Dummy = new APC(null, 0, null); // Thread-safe
-    /// <summary>
-    /// The logical block containing this abstract PC
-    /// </summary>
-    public readonly CFGBlock Block;
 
     /// <summary>
-    /// The index within the block of this abstract PC
+    /// An abstract program point representing a particular control point including possible finally continuations
+    ///
+    /// The point is an index into a CFGBlock. If the block has a label at that index, the point represents the program
+    /// point just PRIOR to the execution of the code at that label. 
+    /// If the point is past the sequence of labels in that CFGBlock, then the program point represents the excecution
+    /// point just after the last instruction in the block (or predecessor blocks).
     /// </summary>
-    public readonly int Index;
-
-    /// <summary>
-    /// Fault/Finally edges. (from,to) that are currently being traversed.
-    /// The current block/index is executing on some handler of the first edge in the
-    /// finally edges. If the current handler ends(endfinally), the next handler on the
-    /// edge is retrieved and made the current program point. If no more handlers are on the
-    /// edge, the edge is popped and the target of the edge becomes the new current point.
-    /// NOTE: if the edge targets a catch/filter handler entry point, then fault handlers
-    /// are visited, otherwise only finally handlers.
-    /// </summary>
-    public readonly SubroutineContext/*?*/ SubroutineContext;
-
-    /// <summary>
-    /// Construct APC
-    /// </summary>
-    public APC(CFGBlock block, int index,
-               SubroutineContext/*?*/ subroutineContext)
+    [ContractVerification(false)] // F: turning off the verification as something should be changed in the code so to differentiate between the Dummy struct (when this.Block == null) and all the others (when this.Block != null)
+    [Serializable]
+    public struct APC : IEquatable<APC>
     {
-      this.Block = block;
-      this.Index = index;
-      this.SubroutineContext = subroutineContext;
+        public static readonly APC Dummy = new APC(null, 0, null); // Thread-safe
+                                                                   /// <summary>
+                                                                   /// The logical block containing this abstract PC
+                                                                   /// </summary>
+        public readonly CFGBlock Block;
+
+        /// <summary>
+        /// The index within the block of this abstract PC
+        /// </summary>
+        public readonly int Index;
+
+        /// <summary>
+        /// Fault/Finally edges. (from,to) that are currently being traversed.
+        /// The current block/index is executing on some handler of the first edge in the
+        /// finally edges. If the current handler ends(endfinally), the next handler on the
+        /// edge is retrieved and made the current program point. If no more handlers are on the
+        /// edge, the edge is popped and the target of the edge becomes the new current point.
+        /// NOTE: if the edge targets a catch/filter handler entry point, then fault handlers
+        /// are visited, otherwise only finally handlers.
+        /// </summary>
+        public readonly SubroutineContext/*?*/ SubroutineContext;
+
+        /// <summary>
+        /// Construct APC
+        /// </summary>
+        public APC(CFGBlock block, int index,
+                   SubroutineContext/*?*/ subroutineContext)
+        {
+            this.Block = block;
+            this.Index = index;
+            this.SubroutineContext = subroutineContext;
 #if CHECK_RECURSIVE_APCS
-      for (; subroutineContext != null; subroutineContext = subroutineContext.Tail)
-      {
-        Debug.Assert(block.Subroutine != subroutineContext.Head.One.Subroutine);
-      }
+            for (; subroutineContext != null; subroutineContext = subroutineContext.Tail)
+            {
+                Debug.Assert(block.Subroutine != subroutineContext.Head.One.Subroutine);
+            }
 #endif
-    }
+        }
 
 
-    public APC Post()
-    {
-      if (this.Index < this.Block.Count)
-      {
-        return new APC(this.Block, this.Index + 1, this.SubroutineContext);
-      }
-      return this;
-    }
-
-    public static APC ForEnd(CFGBlock block,
-                             SubroutineContext subroutineContext) {
-                               Contract.Requires(block != null);
-      return new APC(block, block.Count, subroutineContext);
-    }
-
-    public static APC ForStart(CFGBlock block,
-                             SubroutineContext subroutineContext)
-    {
-      Contract.Requires(block != null); // F: As of Clousot suggestion
-      return new APC(block, 0, subroutineContext);
-    }
-
-    public APC LastInBlock()
-    {
-      return ForEnd(this.Block, this.SubroutineContext);
-    }
-
-    public APC FirstInBlock()
-    {
-      return ForStart(this.Block, this.SubroutineContext); 
-    }
-
-    public string AlternateSourceContext()
-    {
-      return String.Format("{0}[0x{1:x}]", this.Block.Subroutine.Name, this.Block.ILOffset(this));
-    }
-
-    public bool HasRealSourceContext
-    {
-      get
-      {
-        string realSC = this.Block.SourceContext(this);
-        return realSC != null;
-      }
-    }
-    public string PrimarySourceContext()
-    {
-      if (this.Equals(APC.Dummy))
-      {
-        return "";
-      }
-
-      string realSC = this.Block.SourceContext(this);
-      if (realSC != null) return realSC;
-      return AlternateSourceContext();
-    }
-
-
-    public int ILOffset
-    {
-      get
-      {
-        return this.Block.ILOffset(this);
-      }
-    }
-    /// <summary>
-    /// Copy constructor that removes subroutine context
-    /// </summary>
-    private APC(APC from)
-    {
-      Contract.Assume(from.Block != null, "assuming object invariant");
-
-      this.Index = from.Index;
-      this.Block = from.Block;
-      this.SubroutineContext = null;
-    }
-
-    public APC WithoutContext
-    {
-      get
-      {
-        return new APC(this);
-      }
-    }
-
-    [ContractVerification(false)]
-    public static void ToString(StringBuilder sb, SubroutineContext finallyContext)
-    {
-      bool seenFirst = false;
-      while (finallyContext != null)
-      {
-        if (!seenFirst) { sb.Append(" {"); seenFirst = true; } else { sb.Append(", "); }
-        sb.AppendFormat("(SR{2} {0},{1}) [{3}]", finallyContext.Head.One.Index, finallyContext.Head.Two.Index, finallyContext.Head.One.Subroutine.Id, finallyContext.Head.Three);
-        finallyContext = finallyContext.Tail;
-      }
-      if (seenFirst)
-      {
-        sb.Append("}");
-      }
-    }
-
-    public override string ToString()
-    {
-      StringBuilder sb = new StringBuilder();
-      sb.Append("[");
-      sb.AppendFormat("SR{2} {0},{1}", this.Block.Index, this.Index, this.Block.Subroutine.Id);
-      ToString(sb, this.SubroutineContext);
-      sb.Append("]");
-      return sb.ToString();
-    }
-
-
-    #region IEquatable<APC> Members
-
-    //^ [StateIndependent]
-    public bool Equals(APC that)
-    {
-      if (this.Block != that.Block) return false;
-      if (this.Index != that.Index) return false;
-      if (this.SubroutineContext != that.SubroutineContext) return false;
-      return true;
-    }
-
-    #endregion
-
-    public bool InsideRequiresAtCallInsideContract
-    {
-      [ContractVerification(false)]
-      get
-      {
-        if (this.Block.Subroutine.IsRequires)
+        public APC Post()
         {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+            if (this.Index < this.Block.Count)
             {
-              if (context.Head.Three == "entry") { return false; }
-              if (context.Head.Three.StartsWith("before"))
-              {
-                // find if we are inside another contract
-                Subroutine sub = context.Head.One.Subroutine;
-                return sub.IsEnsuresOrOld || sub.IsRequires || sub.IsInvariant;
-              }
+                return new APC(this.Block, this.Index + 1, this.SubroutineContext);
             }
+            return this;
+        }
+
+        public static APC ForEnd(CFGBlock block,
+                                 SubroutineContext subroutineContext)
+        {
+            Contract.Requires(block != null);
+            return new APC(block, block.Count, subroutineContext);
+        }
+
+        public static APC ForStart(CFGBlock block,
+                                 SubroutineContext subroutineContext)
+        {
+            Contract.Requires(block != null); // F: As of Clousot suggestion
+            return new APC(block, 0, subroutineContext);
+        }
+
+        public APC LastInBlock()
+        {
+            return ForEnd(this.Block, this.SubroutineContext);
+        }
+
+        public APC FirstInBlock()
+        {
+            return ForStart(this.Block, this.SubroutineContext);
+        }
+
+        public string AlternateSourceContext()
+        {
+            return String.Format("{0}[0x{1:x}]", this.Block.Subroutine.Name, this.Block.ILOffset(this));
+        }
+
+        public bool HasRealSourceContext
+        {
+            get
+            {
+                string realSC = this.Block.SourceContext(this);
+                return realSC != null;
+            }
+        }
+        public string PrimarySourceContext()
+        {
+            if (this.Equals(APC.Dummy))
+            {
+                return "";
+            }
+
+            string realSC = this.Block.SourceContext(this);
+            if (realSC != null) return realSC;
+            return AlternateSourceContext();
+        }
+
+
+        public int ILOffset
+        {
+            get
+            {
+                return this.Block.ILOffset(this);
+            }
+        }
+        /// <summary>
+        /// Copy constructor that removes subroutine context
+        /// </summary>
+        private APC(APC from)
+        {
+            Contract.Assume(from.Block != null, "assuming object invariant");
+
+            this.Index = from.Index;
+            this.Block = from.Block;
+            this.SubroutineContext = null;
+        }
+
+        public APC WithoutContext
+        {
+            get
+            {
+                return new APC(this);
+            }
+        }
+
+        [ContractVerification(false)]
+        public static void ToString(StringBuilder sb, SubroutineContext finallyContext)
+        {
+            bool seenFirst = false;
+            while (finallyContext != null)
+            {
+                if (!seenFirst) { sb.Append(" {"); seenFirst = true; } else { sb.Append(", "); }
+                sb.AppendFormat("(SR{2} {0},{1}) [{3}]", finallyContext.Head.One.Index, finallyContext.Head.Two.Index, finallyContext.Head.One.Subroutine.Id, finallyContext.Head.Three);
+                finallyContext = finallyContext.Tail;
+            }
+            if (seenFirst)
+            {
+                sb.Append("}");
+            }
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[");
+            sb.AppendFormat("SR{2} {0},{1}", this.Block.Index, this.Index, this.Block.Subroutine.Id);
+            ToString(sb, this.SubroutineContext);
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+
+        #region IEquatable<APC> Members
+
+        //^ [StateIndependent]
+        public bool Equals(APC that)
+        {
+            if (this.Block != that.Block) return false;
+            if (this.Index != that.Index) return false;
+            if (this.SubroutineContext != that.SubroutineContext) return false;
+            return true;
+        }
+
+        #endregion
+
+        public bool InsideRequiresAtCallInsideContract
+        {
+            [ContractVerification(false)]
+            get
+            {
+                if (this.Block.Subroutine.IsRequires)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "entry") { return false; }
+                            if (context.Head.Three.StartsWith("before"))
+                            {
+                                // find if we are inside another contract
+                                Subroutine sub = context.Head.One.Subroutine;
+                                return sub.IsEnsuresOrOld || sub.IsRequires || sub.IsInvariant;
+                            }
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool InsideRequiresAtCall
+        {
+            get
+            {
+                if (this.Block.Subroutine.IsRequires)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "entry") { return false; }
+                            if (context.Head.Three.StartsWith("before")) { return true; }
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool InsideEnsuresAtCall
+        {
+            get
+            {
+                if (this.Block.Subroutine.IsEnsuresOrOld)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "exit") { return false; }
+                            if (context.Head.Three == "oldmanifest") { return false; }
+                            if (context.Head.Three.StartsWith("after")) { return true; }
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool IsInsideEnsuresAtCall(out bool callInsideContract)
+        {
+            if (this.Block.Subroutine.IsEnsuresOrOld)
+            {
+                if (this.SubroutineContext != null)
+                {
+                    for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                    {
+                        if (context.Head.Three == "exit") { callInsideContract = false; return false; }
+                        if (context.Head.Three == "oldmanifest") { callInsideContract = false; return false; }
+                        if (context.Head.Three.StartsWith("after")) { callInsideContract = context.Head.One.Subroutine.IsContract; return true; }
+                    }
+                    callInsideContract = false;
+                    return false;
+                }
+            }
+            callInsideContract = false;
             return false;
-          }
         }
-        return false;
-      }
-    }
 
-    public bool InsideRequiresAtCall
-    {
-      get {
-        if (this.Block.Subroutine.IsRequires)
+        public bool InsideEnsuresInMethod
         {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+            get
             {
-              if (context.Head.Three == "entry") { return false; }
-              if (context.Head.Three.StartsWith("before")) { return true; }
+                if (this.Block.Subroutine.IsEnsuresOrOld)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "exit") { return true; }
+                            if (context.Head.Three == "entry") { return true; }
+                            if (context.Head.Three.StartsWith("after")) { return true; }
+                        }
+                        return false;
+                    }
+                }
+                return false;
             }
+        }
+
+        public bool InsideInvariantAtCall
+        {
+            get
+            {
+                if (this.Block.Subroutine.IsInvariant)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "exit") { return false; }
+                            if (context.Head.Three == "entry") { return false; }
+                            if (context.Head.Three.StartsWith("after")) { return true; }
+                            if (context.Head.Three == "assumeInvariant") { return true; }
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool IsInsideInvariantAtCall(out bool callInsideContract)
+        {
+            if (this.Block.Subroutine.IsInvariant)
+            {
+                if (this.SubroutineContext != null)
+                {
+                    for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                    {
+                        if (context.Head.Three == "exit") { callInsideContract = false; return false; }
+                        if (context.Head.Three == "entry") { callInsideContract = false; return false; }
+                        if (context.Head.Three.StartsWith("after")) { callInsideContract = context.Head.One.Subroutine.IsContract; return true; }
+                        if (context.Head.Three == "assumeInvariant") { callInsideContract = false; return true; }
+                    }
+                    callInsideContract = false; return false;
+                }
+            }
+            callInsideContract = false; return false;
+        }
+        public bool InsideNecessaryAssumption
+        {
+            get
+            {
+                return this.Block.Subroutine.IsNecessaryAssumption;
+            }
+        }
+
+        public bool InsideContractAtCall
+        {
+            get
+            {
+                if (this.Block.Subroutine.IsContract || this.Block.Subroutine.IsOldValue)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "exit") { return false; }
+                            if (context.Head.Three == "entry") { return false; }
+                            if (context.Head.Three == "oldmanifest") { return false; }
+                            if (context.Head.Three.StartsWith("before")) { return true; }
+                            if (context.Head.Three.StartsWith("after")) { return true; }
+                            if (context.Head.Three == "assumeInvariant") { return true; }
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool InsideInvariantInMethod
+        {
+            get
+            {
+                if (this.Block.Subroutine.IsInvariant)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "exit") { return true; }
+                            if (context.Head.Three == "entry") { return true; }
+                            if (context.Head.Three.StartsWith("after")) { return true; }
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            }
+        }
+
+        internal bool InsideInvariantOnExit
+        {
+            get
+            {
+                if (this.Block.Subroutine.IsInvariant)
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.Three == "exit") { return true; }
+                            if (context.Head.Three == "entry") { return false; }
+                            if (context.Head.Three.StartsWith("after")) { return false; }
+                        }
+                        return false;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool InsideContract
+        {
+            get
+            {
+                Subroutine subr = this.Block.Subroutine;
+                if (subr.IsContract || subr.IsOldValue) return true;
+                return false;
+            }
+        }
+
+        public bool InsideConstructor
+        {
+            get
+            {
+                var context = this.SubroutineContext;
+                var current = this.Block;
+                while (current != null)
+                {
+                    Subroutine subr = current.Subroutine;
+                    if (subr.IsConstructor) return true;
+                    if (subr.IsMethod) return false;
+                    if (context != null)
+                    {
+                        current = context.Head.One;
+                        context = context.Tail;
+                    }
+                    else
+                    {
+                        current = null;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public bool TryGetContainingMethod<Method>(out Method method)
+        {
+            var context = this.SubroutineContext;
+            var current = this.Block;
+            while (current != null)
+            {
+                var mi = current.Subroutine as IMethodInfo<Method>;
+                if (mi != null)
+                {
+                    method = mi.Method;
+                    return true;
+                }
+                if (context != null)
+                {
+                    current = context.Head.One;
+                    context = context.Tail;
+                }
+                else
+                {
+                    current = null;
+                }
+            }
+            method = default(Method);
             return false;
-          }
         }
-        return false;
-      }
-    }
 
-    public bool InsideEnsuresAtCall
-    {
-      get {
-        if (this.Block.Subroutine.IsEnsuresOrOld)
+        public bool TryGetContainingType<Type>(out Type type)
         {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+            var context = this.SubroutineContext;
+            var current = this.Block;
+            while (current != null)
             {
-              if (context.Head.Three == "exit") { return false; }
-              if (context.Head.Three == "oldmanifest") { return false; }
-              if (context.Head.Three.StartsWith("after")) { return true; }
+                var mi = current.Subroutine as ITypeInfo<Type>;
+                if (mi != null)
+                {
+                    type = mi.AssociatedType;
+                    return true;
+                }
+                if (context != null)
+                {
+                    current = context.Head.One;
+                    context = context.Tail;
+                }
+                else
+                {
+                    current = null;
+                }
             }
+            type = default(Type);
             return false;
-          }
         }
-        return false;
-      }
-    }
 
-    public bool IsInsideEnsuresAtCall(out bool callInsideContract)
-    {
-      if (this.Block.Subroutine.IsEnsuresOrOld)
-      {
-        if (this.SubroutineContext != null)
+        public bool InsideOldManifestation
         {
-          for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
-          {
-            if (context.Head.Three == "exit") { callInsideContract = false; return false; }
-            if (context.Head.Three == "oldmanifest") { callInsideContract = false; return false; }
-            if (context.Head.Three.StartsWith("after")) { callInsideContract = context.Head.One.Subroutine.IsContract; return true; }
-          }
-          callInsideContract = false;
-          return false;
-        }
-      }
-      callInsideContract = false;
-      return false;
-    }
-
-    public bool InsideEnsuresInMethod
-    {
-      get
-      {
-        if (this.Block.Subroutine.IsEnsuresOrOld)
-        {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+            get
             {
-              if (context.Head.Three == "exit") { return true; }
-              if (context.Head.Three == "entry") { return true; }
-              if (context.Head.Three.StartsWith("after")) { return true; }
+                Subroutine subr = this.Block.Subroutine;
+                if (subr.IsOldValue)
+                {
+                    for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                    {
+                        if (context.Head.Three == "oldmanifest") return true;
+                    }
+                }
+                return false;
             }
-            return false;
-          }
         }
-        return false;
-      }
-    }
 
-    public bool InsideInvariantAtCall
-    {
-      get
-      {
-        if (this.Block.Subroutine.IsInvariant)
+        public bool IsCompilerGenerated
         {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+            [ContractVerification(false)]
+            get
             {
-              if (context.Head.Three == "exit") { return false; }
-              if (context.Head.Three == "entry") { return false; }
-              if (context.Head.Three.StartsWith("after")) { return true; }
-              if (context.Head.Three == "assumeInvariant") { return true; }
+                if (this.Block.Subroutine.IsCompilerGenerated)
+                {
+                    return true;
+                }
+                else
+                {
+                    if (this.SubroutineContext != null)
+                    {
+                        for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
+                        {
+                            if (context.Head.One.Subroutine.IsCompilerGenerated) return true;
+                        }
+                    }
+                }
+                return false;
             }
-            return false;
-          }
         }
-        return false;
-      }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null) return false;
+            if (!(obj is APC)) return false;
+            APC that = (APC)obj;
+
+            return this.Index == that.Index && this.Block == that.Block && this.SubroutineContext == that.SubroutineContext;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Index + this.Block.Index * 10 + this.SubroutineContext.Length() * 100;
+        }
     }
 
-    public bool IsInsideInvariantAtCall(out bool callInsideContract)
+    public interface IMethodInfo<M>
     {
-      if (this.Block.Subroutine.IsInvariant)
-      {
-        if (this.SubroutineContext != null)
-        {
-          for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
-          {
-            if (context.Head.Three == "exit") { callInsideContract = false; return false; }
-            if (context.Head.Three == "entry") { callInsideContract = false; return false; }
-            if (context.Head.Three.StartsWith("after")) { callInsideContract = context.Head.One.Subroutine.IsContract; return true; }
-            if (context.Head.Three == "assumeInvariant") { callInsideContract = false; return true; }
-          }
-          callInsideContract = false; return false;
-        }
-      }
-      callInsideContract = false; return false;
+        M Method { get; }
     }
-    public bool InsideNecessaryAssumption
+    public interface ITypeInfo<Type>
     {
-      get
-      {
-        return this.Block.Subroutine.IsNecessaryAssumption;
-      }
-    }
-
-    public bool InsideContractAtCall
-    {
-      get
-      {
-        if (this.Block.Subroutine.IsContract || this.Block.Subroutine.IsOldValue)
-        {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
-            {
-              if (context.Head.Three == "exit") { return false; }
-              if (context.Head.Three == "entry") { return false; }
-              if (context.Head.Three == "oldmanifest") { return false; }
-              if (context.Head.Three.StartsWith("before")) { return true; }
-              if (context.Head.Three.StartsWith("after")) { return true; }
-              if (context.Head.Three == "assumeInvariant") { return true; }
-            }
-            return false;
-          }
-        }
-        return false;
-      }
-    }
-
-    public bool InsideInvariantInMethod
-    {
-      get
-      {
-        if (this.Block.Subroutine.IsInvariant)
-        {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
-            {
-              if (context.Head.Three == "exit") { return true; }
-              if (context.Head.Three == "entry") { return true; }
-              if (context.Head.Three.StartsWith("after")) { return true; }
-            }
-            return false;
-          }
-        }
-        return false;
-      }
-    }
-
-    internal bool InsideInvariantOnExit
-    {
-      get { 
-        if (this.Block.Subroutine.IsInvariant)
-        {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
-            {
-              if (context.Head.Three == "exit") { return true; }
-              if (context.Head.Three == "entry") { return false; }
-              if (context.Head.Three.StartsWith("after")) { return false; }
-            }
-            return false;
-          }
-        }
-        return false;
-}
-    }
-
-    public bool InsideContract
-    {
-      get
-      {
-        Subroutine subr = this.Block.Subroutine;
-        if (subr.IsContract || subr.IsOldValue) return true;
-        return false;
-      }
-    }
-
-    public bool InsideConstructor
-    {
-      get
-      {
-        var context = this.SubroutineContext;
-        var current = this.Block;
-        while (current != null)
-        {
-          Subroutine subr = current.Subroutine;
-          if (subr.IsConstructor) return true;
-          if (subr.IsMethod) return false;
-          if (context != null)
-          {
-            current = context.Head.One;
-            context = context.Tail;
-          }
-          else
-          {
-            current = null;
-          }
-        }
-        return false;
-      }
-    }
-
-    public bool TryGetContainingMethod<Method>(out Method method)
-    {
-      var context = this.SubroutineContext;
-      var current = this.Block;
-      while (current != null)
-      {
-        var mi = current.Subroutine as IMethodInfo<Method>;
-        if (mi != null)
-        {
-          method = mi.Method;
-          return true;
-        }
-        if (context != null)
-        {
-          current = context.Head.One;
-          context = context.Tail;
-        }
-        else
-        {
-          current = null;
-        }
-      }
-      method = default(Method);
-      return false;
-    }
-
-    public bool TryGetContainingType<Type>(out Type type)
-    {
-      var context = this.SubroutineContext;
-      var current = this.Block;
-      while (current != null)
-      {
-        var mi = current.Subroutine as ITypeInfo<Type>;
-        if (mi != null)
-        {
-          type = mi.AssociatedType;
-          return true;
-        }
-        if (context != null)
-        {
-          current = context.Head.One;
-          context = context.Tail;
-        }
-        else
-        {
-          current = null;
-        }
-      }
-      type = default(Type);
-      return false;
-    }
-
-    public bool InsideOldManifestation
-    {
-      get
-      {
-        Subroutine subr = this.Block.Subroutine;
-        if (subr.IsOldValue)
-        {
-          for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
-          {
-            if (context.Head.Three == "oldmanifest") return true;
-          }
-        }
-        return false;
-      }
-    }
-
-    public bool IsCompilerGenerated
-    {
-      [ContractVerification(false)]
-      get
-      {
-        if (this.Block.Subroutine.IsCompilerGenerated)
-        {
-          return true;
-        }
-        else
-        {
-          if (this.SubroutineContext != null)
-          {
-            for (SubroutineContext context = this.SubroutineContext; context != null; context = context.Tail)
-            {
-              if (context.Head.One.Subroutine.IsCompilerGenerated) return true;
-            }
-          }
-        }
-        return false;
-      }
-    }
-
-    public override bool Equals(object obj)
-    {
-      if (obj == null) return false;
-      if (!(obj is APC)) return false;
-      APC that = (APC)obj;
-
-      return this.Index == that.Index && this.Block == that.Block && this.SubroutineContext == that.SubroutineContext;
-    }
-
-    public override int GetHashCode()
-    {
-      return this.Index + this.Block.Index * 10 + this.SubroutineContext.Length() * 100;
-    }
-
-  }
-
-  public interface IMethodInfo<M> {
-    M Method { get; }
-  }
-  public interface ITypeInfo<Type>
-  {
-    Type AssociatedType { get; }
-  }
-
-  /// <summary>
-  /// Represents a region of code that has a single entry and exit, and control flow enters
-  /// only at the given entry and exits only at the given exit. Exceptions can escape from any
-  /// point however.
-  /// We use subroutines to model entire methods, finally and fault regions within methods,
-  /// and injected code, such as pre-condition and post-condition evaluations around method calls.
-  ///
-  /// The ITypedProperties interface provdes a type safe property map on subroutines so that analyses
-  /// (e.g., stack depth) can store info on each subroutine
-  /// </summary>
-  [Serializable]
-  public abstract partial class Subroutine : ITypedProperties, IEquatable<Subroutine> {
-    private static int subroutineIdGen;
-    protected readonly int subroutineId = subroutineIdGen++;
-
-    public int Id { get { return this.subroutineId; } }
-    public abstract string Kind { get; }
-    public abstract CFGBlock Entry { get; }
-    public abstract CFGBlock EntryAfterRequires { get; }
-    public abstract CFGBlock Exit { get; }
-    public abstract CFGBlock ExceptionExit { get; }
-    public abstract string Name { get; }
-    public abstract bool HasReturnValue { get; }
-    /// <summary>
-    /// true for pre/post condition subroutines and methods (if they can be inlined), but not for 
-    /// fault/finally, as these always have 0 initial stack depth
-    /// </summary>
-    public abstract bool HasContextDependentStackDepth { get; }
-
-    /// <summary>
-    /// Block level normal successors
-    /// </summary>
-    [Pure]
-    public abstract IEnumerable<CFGBlock> SuccessorBlocks(CFGBlock block);
-
-    /// <summary>
-    /// Block level normal successors (tagged).
-    /// </summary>
-    [Pure]
-    public IEnumerable<Pair<Tag, CFGBlock>> SuccessorEdgesFor(CFGBlock block)
-    {
-      return this.SuccessorEdges[block];
+        Type AssociatedType { get; }
     }
 
     /// <summary>
-    /// Block level normal predecessors
+    /// Represents a region of code that has a single entry and exit, and control flow enters
+    /// only at the given entry and exits only at the given exit. Exceptions can escape from any
+    /// point however.
+    /// We use subroutines to model entire methods, finally and fault regions within methods,
+    /// and injected code, such as pre-condition and post-condition evaluations around method calls.
+    ///
+    /// The ITypedProperties interface provdes a type safe property map on subroutines so that analyses
+    /// (e.g., stack depth) can store info on each subroutine
     /// </summary>
-    [Pure]
-    public abstract IEnumerable<CFGBlock> PredecessorBlocks(CFGBlock block);
-
-    /// <summary>
-    /// Blocks are ordered from 0 - n, so arrays can be used for lookup maps
-    /// </summary>
-    public abstract int BlockCount { get; }
-
-    /// <summary>
-    /// Block level view of CFG
-    /// </summary>
-    public abstract IEnumerable<CFGBlock> Blocks { get; }
-
-    [Pure]
-    public IEnumerable<Subroutine> UsedSubroutines()
-    {
-      var alreadyFound = new Set<int>();
-      return UsedSubroutines(alreadyFound);
-    }
-
-    [Pure]
-    public IEnumerable<Subroutine> SubroutineTree()
-    {
-      var alreadyFound = new Set<int>();
-      return SubroutineTree(alreadyFound);
-    }
-
-    IEnumerable<Subroutine> SubroutineTree(Set<int> alreadyFound)
-    {
-      alreadyFound.Add(this.Id);
-      yield return this;
-
-      foreach (var immediate in this.UsedSubroutines(alreadyFound)) {
-        foreach (var sub in immediate.SubroutineTree(alreadyFound))
-        {
-          yield return sub;
-        }
-      }
-    }
-
-    internal abstract IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadySeen);
-
-    [Pure]
-    public abstract void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed);
-
-    /// <summary>
-    /// Returns true, if the block starts an exception or filter handler, false otherwise.
-    /// NOTE: blocks relating to fault or finally handlers never return true, as these are expanded out in the CFG abstraction
-    /// </summary>
-    [Pure]
-    public virtual bool IsCatchFilterHeader(CFGBlock block) { return false; }
-    public virtual bool IsRequires { get { return false; } }
-    public virtual bool IsEnsures { get { return false; } }
-    public virtual bool IsModelEnsures { get { return false; } }
-    public bool IsEnsuresOrOld { get { return IsEnsures || IsOldValue; } }
-    public virtual bool IsOldValue { get { return false; } }
-    public virtual bool IsMethod { get { return false; } }
-    public virtual bool IsConstructor { get { return false; } }
-    public virtual bool IsInvariant { get { return false; } }
-    public virtual bool IsFaultFinally { get { return false; } }
-    public virtual bool IsContract { get { return false; } }
-    public bool IsNecessaryAssumption { get; set; }
-    [Pure]
-    public abstract bool IsSubroutineStart(CFGBlock block);
-    [Pure]
-    public abstract bool IsSubroutineEnd(CFGBlock block);
-    [Pure]
-    public abstract bool IsJoinPoint(CFGBlock block);
-    [Pure]
-    public abstract bool IsSplitPoint(CFGBlock block);
-    internal virtual bool IsCompilerGenerated { get { return false; } }
-
-    /// <summary>
-    /// Returns the delta of the evaluation stack after evaluating this subroutine.
-    /// Usually 0, but subroutines such as old subroutines push 1 value onto the stack.
-    /// </summary>
-    [Pure]
-    public abstract int StackDelta { get; }
-
-    [Pure]
-    internal abstract APC ComputeTargetFinallyContext(APC ppoint, CFGBlock succ, DConsCache consCache);
-
-    internal abstract EdgeMap<Tag> SuccessorEdges { get; }
-    internal abstract EdgeMap<Tag> PredecessorEdges { get; }
-    [Pure]
-    internal abstract bool HasSingleSuccessor(APC ppoint, out APC next, DConsCache consCache);
-    [Pure]
-    internal abstract bool HasSinglePredecessor(APC ppoint, out APC next, DConsCache consCache, bool skipContracts);
-    [Pure]
-    internal abstract APC PredecessorPCPriorToRequires(APC ppoint, DConsCache consCache);
-    [Pure]
-    internal abstract IEnumerable<APC> Predecessors(APC ppoint, DConsCache consCache, bool skipContracts);
-    [Pure]
-    internal abstract IEnumerable<APC> Successors(APC ppoint, DConsCache consCache);
-    internal abstract DepthFirst.Visitor<CFGBlock, Unit>/*?*/ EdgeInfo { get; }
-    /// <summary>
-    /// Enumerates the local exception handler start blocks protecting the given ppoint and surrounding fault/finally subroutines also protecting ppoint. If the exception can escape the current subroutine
-    /// then the last enumerated block is the subroutine exception exit block.
-    /// </summary>
-    /// <typeparam name="Data">Handler predicate specific type</typeparam>
-    /// <typeparam name="Type">Type of exceptions</typeparam>
-    /// <param name="ppoint">Current point at which exception is thrown</param>
-    /// <param name="currentSubroutine">if non-null, a subroutine already executing as a transfer from ppoint. Reduces the set of
-    /// handlers to those surrounding the execution of the given subroutine from ppoint.</param>
-    /// <param name="data">Handler filter specific data</param>
-    /// <param name="handlerPredicate">Called with each potential handler. Can determine if handler is chosen and if search continues</param>
-    /// <returns>All selected handlers within the subroutine ppoint.Block.Container.</returns>
-    [Pure]
-    internal abstract IEnumerable<CFGBlock> ExceptionHandlers<Data, Type>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type, Data> handlerPredicate);
-    public abstract void AddEdgeSubroutine(CFGBlock from, CFGBlock to, Subroutine subroutine, string callTag);
-
-    /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
-    [Pure]
-    public abstract FList<Pair<string, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context);
-
-    [Pure]
-    public abstract FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context);
-
-    /// <summary>
-    /// The constructor only builds the subroutine, but does not really traverse all the code to avoid 
-    /// infinite recursions in the cache lookup.
-    /// This method is called by the cache constructor after the subroutine is entered into the cache.
-    /// </summary>
-    internal abstract void Initialize();
-
-    #region ITypedProperties Members
-
-    private readonly TypedProperties propertyMap = new TypedProperties();
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(propertyMap != null);
-    }
-
-    [Pure]
-    public bool Contains<T>(TypedKey<T> key)
-    {
-      return propertyMap.Contains(key);
-    }
-
-    public void Add<T>(TypedKey<T> key, T value)
-    {
-      propertyMap.Add(key, value);
-    }
-
-    [Pure]
-    public bool TryGetValue<T>(TypedKey<T> key, out T value)
-    {
-      return propertyMap.TryGetValue(key, out value);
-    }
-
-    #endregion
-
-    [Pure]
-    internal static int GetKey(Subroutine s) 
-    {
-      Contract.Requires(s != null);  
-      return s.Id; 
-    }
-
-
-    #region IEquatable<Subroutine> Members
-
-    public bool Equals(Subroutine that)
-    {
-      return this == that;
-    }
-
-    #endregion
-  }
-
-  #region Subroutine contract binding
-  [ContractClass(typeof(SubroutineContract))]
-  public abstract partial class Subroutine { }
-
-  [ContractClassFor(typeof(Subroutine))]
-  abstract class SubroutineContract : Subroutine
-  {
-    public override Tag Kind
-    {
-      get {
-        Contract.Ensures(Contract.Result<string>() != null);
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public override CFGBlock Entry
-    {
-      get {
-        Contract.Ensures(Contract.Result<CFGBlock>() != null);
-        throw new NotImplementedException(); 
-      }
-    }
-
-    public override CFGBlock EntryAfterRequires
-    {
-      get {
-        Contract.Ensures(Contract.Result<CFGBlock>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    public override CFGBlock Exit
-    {
-      get {
-        Contract.Ensures(Contract.Result<CFGBlock>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    public override CFGBlock ExceptionExit
-    {
-      get {
-        Contract.Ensures(Contract.Result<CFGBlock>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    public override Tag Name
-    {
-      get {
-        Contract.Ensures(Contract.Result<string>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    public override bool HasReturnValue
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override bool HasContextDependentStackDepth
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public override IEnumerable<CFGBlock> SuccessorBlocks(CFGBlock block)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public override IEnumerable<CFGBlock> PredecessorBlocks(CFGBlock block)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public override int BlockCount
-    {
-      get {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        throw new NotImplementedException(); }
-    }
-
-    public override IEnumerable<CFGBlock> Blocks
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    internal override IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadySeen)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Subroutine>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public override void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override bool IsSubroutineStart(CFGBlock block)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override bool IsSubroutineEnd(CFGBlock block)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override bool IsJoinPoint(CFGBlock block)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override bool IsSplitPoint(CFGBlock block)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int StackDelta
-    {
-      get {
-        Contract.Ensures(Contract.Result<int>() != Int32.MinValue);
-
-        throw new NotImplementedException(); }
-    }
-
-    internal override APC ComputeTargetFinallyContext(APC ppoint, CFGBlock succ, DConsCache consCache)
-    {
-      Contract.Requires(consCache != null);
-
-      return default(APC);
-    }
-
-    internal override EdgeMap<Tag> SuccessorEdges
-    {
-      get {
-        Contract.Ensures(Contract.Result<EdgeMap<Tag>>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    internal override EdgeMap<Tag> PredecessorEdges
-    {
-      get {
-        Contract.Ensures(Contract.Result<EdgeMap<Tag>>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    internal override bool HasSingleSuccessor(APC ppoint, out APC next, DConsCache consCache)
-    {
-      Contract.Requires(consCache != null);
-
-      throw new NotImplementedException();
-    }
-
-    internal override bool HasSinglePredecessor(APC ppoint, out APC next, DConsCache consCache, bool skipContracts)
-    {
-      Contract.Requires(consCache != null);
-
-      throw new NotImplementedException();
-    }
-
-    internal override APC PredecessorPCPriorToRequires(APC ppoint, DConsCache consCache)
-    {
-      Contract.Requires(consCache != null);
-
-      throw new NotImplementedException();
-    }
-
-    internal override IEnumerable<APC> Predecessors(APC ppoint, DConsCache consCache, bool skipContracts)
-    {
-      Contract.Requires(consCache != null);
-      Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    internal override IEnumerable<APC> Successors(APC ppoint, DConsCache consCache)
-    {
-      Contract.Requires(consCache != null);
-      Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
-      throw new NotImplementedException();
-    }
-
-    internal override DepthFirst.Visitor<CFGBlock, UnitDest> EdgeInfo
-    {
-      get {
-        Contract.Ensures(Contract.Result<DepthFirst.Visitor<CFGBlock, UnitDest>>() != null);
-
-        throw new NotImplementedException(); }
-    }
-
-    internal override IEnumerable<CFGBlock> ExceptionHandlers<Data, Type>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type, Data> handlerPredicate)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public override void AddEdgeSubroutine(CFGBlock from, CFGBlock to, Subroutine subroutine, Tag callTag)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override FList<Pair<Tag, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override FList<Pair<Tag, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
-    {
-      throw new NotImplementedException();
-    }
-
-    internal override void Initialize()
-    {
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
-
-  internal delegate SubroutineContext DConsCache(SubroutineEdge edge, SubroutineContext/*?*/ tail);
-
-  [ContractClass(typeof(CFGBlockContracts))]
-  [Serializable]
-  public abstract class CFGBlock : IEquatable<CFGBlock> {
-
-    #region Private/Internal
-    private int id;
-    private int reversePostOrder;
-    private readonly Subroutine subroutine;
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(subroutine != null);
-      Contract.Invariant(this.id >= 0); // F: I am guessing this invariant should hold
-    }
-
-    internal void SetReversePostOrderIndex(int index)
-    {
-      this.reversePostOrder = index;
-    }
-
-    protected CFGBlock(Subroutine container, ref int idGen)
-    {
-      Contract.Requires(container != null);
-      Contract.Requires(idGen >= 0); // Clousot suggestion
-
-      Contract.Ensures(idGen >= 0);
-      Contract.Ensures(Contract.OldValue(idGen) + 1 == idGen);
-
-      this.id = idGen++;
-      this.subroutine = container;
-    }
-
-    internal void Renumber(ref int idGen)
-    {
-      Contract.Requires(idGen >= 0); // Clousot suggestion
-
-      this.id = idGen++;
-    }
-
-
-    #endregion
-
-    public int Index
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        return this.id;
-      }
-    }
-
-    /// <summary>
-    /// Index in reverse post order. This is the preferred order for forward data flow analysis
-    /// </summary>
-    public int ReversePostOrderIndex { get { return this.reversePostOrder; } }
-
-    public abstract int Count
-    {
-      get;
-    }
-
-    /// <summary>
-    /// Returns the list of APCs represented by this block (without finally contexts)
-    /// </summary>
-    public IEnumerable<APC> APCs()
-    {
-      return APCs(null);
-    }
-
-    /// <summary>
-    /// Returns the list of APCs represented by this block (without finally contexts)
-    /// </summary>
-    public IEnumerable<APC> APCs(SubroutineContext context)
-    {
-      for (int i = 0; i < this.Count; i++)
-      {
-        yield return new APC(this, i, context);
-      }
-    }
-
-
-    public APC First
-    {
-      get { return new APC(this, 0, null); }
-    }
-
-    /// <summary>
-    /// Returns program point after last statement in this block
-    /// </summary>
-    public APC Last
-    {
-      get
-      {
-        return APC.ForEnd(this, null);
-      }
-    }
-
-    /// <summary>
-    /// Returns program point prior to last statement in this block
-    /// </summary>
-    public APC PriorLast
-    {
-      get
-      {
-        int priorToLast = this.Count - 1;
-        if (priorToLast < 0) { priorToLast = 0; }
-        return new APC(this, priorToLast, null);
-      }
-    }
-
-    public abstract int ILOffset(APC pc);
-
-    public abstract string SourceContext(APC pc);
-    public abstract string SourceDocument(APC pc);
-    public abstract int SourceStartLine(APC pc);
-    public abstract int SourceEndLine(APC pc);
-    public abstract int SourceStartColumn(APC pc);
-    public abstract int SourceEndColumn(APC pc);
-    public abstract int SourceStartIndex(APC pc);
-    public abstract int SourceLength(APC pc);
-    public abstract string SourceAssertionCondition(APC pc);
-
-    public Subroutine Subroutine
-    {
-      get
-      {
-        Contract.Ensures(Contract.Result<Subroutine>() != null);
-        return this.subroutine;
-      }
-    }
-
-    /// <summary>
-    /// Returns true if the block is a method call block or newObj call block
-    /// </summary>
-    /// <param name="parameterCount">on success holds the parameter count of the called method (not including "this")</param>
-    public virtual bool IsMethodCallBlock<Method>(out Method calledMethod, out bool isNewObj, out bool isVirtual) {
-      calledMethod = default(Method);
-      isNewObj = false;
-      isVirtual = false;
-      return false;
-    } 
-
-    #region IEquatable<CFGBlock> Members
-
-    public bool Equals(CFGBlock other)
-    {
-      return this.id == other.id;
-    }
-
-    #endregion
-
-  }
-
-  #region Contracts for CFGBlock
-
-  [ContractClassFor(typeof(CFGBlock))]
-  abstract class CFGBlockContracts : CFGBlock
-  {
-    // To please C#
-    CFGBlockContracts(int r)
-      : base(null, ref r)
-    {    }
-
-    public override int Count
-    {
-      get 
-      {
-        Contract.Ensures(Contract.Result<int>() >= 0);
-        return 0;
-      }
-    }
-
-    public override int ILOffset(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override Tag SourceContext(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override Tag SourceDocument(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SourceStartLine(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SourceEndLine(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SourceStartColumn(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SourceEndColumn(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SourceStartIndex(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override int SourceLength(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-
-    public override Tag SourceAssertionCondition(APC pc)
-    {
-      throw new NotImplementedException();
-    }
-  }
-  
-  #endregion
-  /// <summary>
-  /// Caches method CFGs, pre and post condition subroutines
-  /// </summary>
-  public class MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>
-   : IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, Subroutine>
-  {
-    #region ------------ Fields -------------
-
-    public readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder;
-    public readonly IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder;
-
-    readonly Dictionary<Method, ControlFlow<Method, Type>> methodCache = new Dictionary<Method, ControlFlow<Method, Type>>();
-    readonly Dictionary<Method, Set<Field>> methodModifies = new Dictionary<Method, Set<Field>>();
-    readonly Dictionary<Method, Set<Field>> methodReads = new Dictionary<Method, Set<Field>>();
-    readonly Dictionary<Field, Set<Method>> propertyReads = new Dictionary<Field, Set<Method>>();
-    readonly Dictionary<Method, bool> methodWitnesses; // TODO: Make it more generic
-    readonly InvariantCache invariantCache;
-    readonly RequiresCache requiresCache;
-    readonly EnsuresCache ensuresCache;
-    readonly ModelEnsuresCache modelEnsuresCache;
-    readonly AssumeCache assumeCache;
-    /// <summary>
-    /// Used to allow inserting the same invariant twice on entry around a requires. The second one has to be wrapped
-    /// so the control flow logic for edge subroutines does not get confused (can't have the same subroutine twice on an edge).
-    /// </summary>
-    readonly Dictionary<Subroutine, Subroutine> redundantInvariants = new Dictionary<Subroutine, Subroutine>();
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(methodCache != null);
-      Contract.Invariant(methodModifies != null);
-      Contract.Invariant(methodReads != null);
-      Contract.Invariant(this.methodWitnesses != null);
-      Contract.Invariant(propertyReads != null);
-      Contract.Invariant(invariantCache != null);
-      Contract.Invariant(modelEnsuresCache != null);
-      Contract.Invariant(ensuresCache != null);
-      Contract.Invariant(requiresCache != null);
-      Contract.Invariant(MetadataDecoder != null);
-      Contract.Invariant(ContractDecoder != null);
-      Contract.Invariant(redundantInvariants != null);
-      Contract.Invariant(this.assumeCache != null);
-    }
-
-    #endregion
-
-    public MethodCache(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-                       IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder,
-                       ErrorHandler output
-                      )
-    {
-      Contract.Requires(mdDecoder != null);
-      Contract.Requires(contractDecoder != null);
-
-      this.MetadataDecoder = mdDecoder;
-      this.ContractDecoder = contractDecoder;
-      this.methodWitnesses = new Dictionary<Method, bool>();
-      this.requiresCache = new RequiresCache(this, output);
-      this.ensuresCache = new EnsuresCache(this);
-      this.modelEnsuresCache = new ModelEnsuresCache(this);
-      this.invariantCache = new InvariantCache(this);
-      this.assumeCache = new AssumeCache(this);
-    }
-
-    public ICFG GetCFG(Method method)
-    {
-      Contract.Ensures(Contract.Result<ICFG>() != null);
-
-      if (methodCache.ContainsKey(method)) {
-        return methodCache[method].AssumeNotNull();
-      }
-      ControlFlow<Method, Type> result;
-      if (MetadataDecoder.HasBody(method)) {
-        Subroutine sb = MetadataDecoder.AccessMethodBody(method, this, Unit.Value);
-
-        Contract.Assume(sb != null," Axiom HasBody(method) ==> AccesMethodBody(method ,... ) != null");
-        result = new ControlFlow<Method, Type>(sb, this);
-      }
-      else {
-        throw new InvalidOperationException("Method has no body");
-      }
-      //methodCache.Add(method, result);
-      return result;
-    }
-
-    /// <summary>
-    /// Returns null if method has no requires (and no inherited requires)
-    /// </summary>
-    internal Subroutine GetRequires(Method method)
-    {
-      // Experimental
-      //   To get contracts on generic/specialized method instances, let's grab the unspecialized method
-      //   here.
-      method = this.MetadataDecoder.Unspecialized(method);
-      // End Experimental
-      return requiresCache.Get(method);
-    }
-
-
-    /// <summary>
-    /// Returns null if method has no ensures (and no inherited ensures)
-    /// </summary>
-    internal Subroutine GetEnsures(Method method)
-    {
-      // Experimental
-      //   To get contracts on generi/specialized method instances, let's grab the unspecialized method
-      //   here.
-      method = this.MetadataDecoder.Unspecialized(method);
-      // End Experimental
-      return ensuresCache.Get(method);
-    }
-
-    /// <summary>
-    /// Returns null if method has no model ensures (and no inherited model ensures)
-    /// </summary>
-    internal Subroutine GetModelEnsures(Method method) {
-      // Experimental
-      //   To get contracts on generic/specialized method instances, let's grab the unspecialized method
-      //   here.
-      method = this.MetadataDecoder.Unspecialized(method);
-      // End Experimental
-      return modelEnsuresCache.Get(method);
-    }
-
-    /// <summary>
-    /// Returns null if no invariant is specified
-    /// </summary>
-    public Subroutine GetInvariant(Type type)
-    {
-      // we have to make sure we are not confused by the particular instantiation of the type
-      type = this.MetadataDecoder.Unspecialized(type);
-      return invariantCache.Get(type);
-    }
-
-    public Subroutine GetRedundantInvariant(Subroutine existingInvariant, Type type)
-    {
-      Subroutine result;
-      if (redundantInvariants.TryGetValue(existingInvariant, out result))
-      {
-        return result;
-      }
-      result = new InvariantSubroutine<Unit>(this, existingInvariant, type);
-      redundantInvariants.Add(existingInvariant, result);
-      return result;
-    }
-
-    #region Internal Access to Forward decoding
-    internal Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-        where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
-    {
-      BlockBase block = pc.Block as BlockBase;
-      if (block != null)
-      {
-        return block.ForwardDecode<Data, Result, Visitor>(pc, visitor, data);
-      }
-      return visitor.Nop(pc, data);
-    }
-    #endregion
-
-    public Result DecodeForReturnValue<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-        where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
-    {
-        BlockBase block = pc.Block as BlockBase;
-        if (block != null)
-        {
-            return block.ForwardDecode<Data, Result, Visitor>(pc, visitor, data);
-        }
-        return visitor.Nop(pc, data);
-    }
-
-    #region IMethodCodeConsumer<Local,Parameter,Method,Field,Type,Unit,Unit> Members
-
-    Subroutine IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, Subroutine>.Accept<Label, Handler>(
-      IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> codeProvider, 
-      Label entryPoint,
-      Method method,
-      Unit data)
-    {
-      SubroutineWithHandlersBuilder<Label, Handler> sb = new SubroutineWithHandlersBuilder<Label, Handler>(codeProvider, this, method, entryPoint);
-      return new MethodSubroutine<Label, Handler>(this, method, sb, entryPoint);
-    }
-
-    #endregion
-
-    #region ----------- Nested Types -------------
-
-    abstract class SubroutineFactory<Key, Data> : ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Subroutine> {
-
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.cache != null); // F: Added as of precondition suggestions ion many places
-        Contract.Invariant(this.MethodCache != null);// F: Added as of precondition suggestions ion many places
-      }
-      
-      readonly Dictionary<Key, Subroutine> cache = new Dictionary<Key,Subroutine>();
-      protected readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache;
-      protected IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get { return this.MethodCache.ContractDecoder; } }
-      protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder { get {
-
-        Contract.Assume(this.MethodCache.MetadataDecoder != null, "Should be made a postcondition");
-        return this.MethodCache.MetadataDecoder; } }
-
-      public SubroutineFactory(
-        MethodCache<Local,Parameter,Type,Method,Field,Property,Event,Attribute,Assembly> methodCache
-      )
-      {
-        Contract.Requires(methodCache != null);
-
-        this.MethodCache = methodCache;
-      }
-
-      public Subroutine Get(Key key) {
-        if (cache.ContainsKey(key)) {
-          return cache[key];
-        }
-        Subroutine result = this.BuildNewSubroutine(key);
-        cache.Add(key, result);
-        // Perform the initialization after adding it to the cache due to recursion
-        if (result != null) result.Initialize();
-        return result;
-      }
-
-      public void Install(Key key, Subroutine sr)
-      {
-        if (cache.ContainsKey(key))
-        {
-          Contract.Assume(cache[key] == null);
-        }
-        cache[key] = sr;
-      }
-
-      public bool Remove(Key key)
-      {
-        if (cache.ContainsKey(key))
-        {
-          cache.Remove(key);
-
-          return true;
-        }
-        return false;
-      }
-
-      protected abstract Subroutine BuildNewSubroutine(Key key);
-
-      protected abstract Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Data data);
-
-      #region ICodeConsumer<Local,Parameter,Method,Field,Type,Unit,Subroutine> Members
-
-      public Subroutine Accept<Label>(ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
-                                      Label entryPoint, Data data)
-      {
-        SimpleSubroutineBuilder<Label> sb = new SimpleSubroutineBuilder<Label>(codeProvider, this.MethodCache, entryPoint);
-
-        Subroutine subr = Factory(sb, entryPoint, data);
-
-        return subr;
-      }
-
-      #endregion
-    }
-
-    class EnsuresCache : SubroutineFactory<Method, Pair<Method,IFunctionalSet<Subroutine>>> {
-      Method lastMethodWeAddedInferredEnsures;
-      Set<string> lastMethodInferredEnsures;
-      
-      public EnsuresCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null); // F: As of Clousot suggestion
-      }
-
-      public bool AlreadyInferred(Method method, string postCondition)
-      {
-        if (!MetadataDecoder.Equal(method, lastMethodWeAddedInferredEnsures))
-        {
-          this.lastMethodWeAddedInferredEnsures = method;
-          this.lastMethodInferredEnsures = new Set<string>();
-        }
-
-        return !this.lastMethodInferredEnsures.AddQ(postCondition);
-      }
-
-      protected override Subroutine BuildNewSubroutine(Method method)
-      {
-        if (this.ContractDecoder != null)
-        {
-          IFunctionalSet<Subroutine> inheritedEnsures = this.GetInheritedEnsures(method);
-          if (this.ContractDecoder.HasEnsures(method))
-          {
-            return this.ContractDecoder.AccessEnsures(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedEnsures));
-          }
-          else if (inheritedEnsures.Count > 0)
-          {
-            if (inheritedEnsures.Count > 1)
-            {
-              // make up a label
-              return new EnsuresSubroutine<Unit>(this.MethodCache, method, inheritedEnsures);
-            }
-            else
-            {
-              return inheritedEnsures.Any;
-            }
-          }
-        }
-        // make up an empty Ensures for every method.
-        return new EnsuresSubroutine<Unit>(this.MethodCache, method, null);
-      }
-
-      protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method,IFunctionalSet<Subroutine>> data)
-      {
-        return new EnsuresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
-      }
-
-      private IFunctionalSet<Subroutine> GetInheritedEnsures(Method method)
-      {
-        IFunctionalSet<Subroutine> result = FunctionalSet<Subroutine>.Empty(Subroutine.GetKey);
-        if (MetadataDecoder.IsVirtual(method) && ContractDecoder.CanInheritContracts(method)) {
-          foreach (Method baseMethod in MetadataDecoder.OverriddenAndImplementedMethods(method).AssumeNotNull()) {
-            Subroutine rs = this.Get(MetadataDecoder.Unspecialized(baseMethod));
-            if (rs != null) {
-              result = result.Add(rs);
-            }
-          }
-        }
-        return result;
-      }
-
-
-    }
-
-    class ModelEnsuresCache : SubroutineFactory<Method, Pair<Method, IFunctionalSet<Subroutine>>> {
-
-      public ModelEnsuresCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null); // F: As of Clousot suggestion
-      }
-
-
-      protected override Subroutine BuildNewSubroutine(Method method) {
-        if (this.ContractDecoder != null) {
-          IFunctionalSet<Subroutine> inheritedEnsures = this.GetInheritedEnsures(method);
-          if (this.ContractDecoder.HasModelEnsures(method)) {
-            return this.ContractDecoder.AccessModelEnsures(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedEnsures));
-          } else if (inheritedEnsures.Count > 0) {
-            if (inheritedEnsures.Count > 1) {
-              // make up a label
-              return new ModelEnsuresSubroutine<Unit>(this.MethodCache, method, inheritedEnsures);
-            } else {
-              return inheritedEnsures.Any;
-            }
-          }
-        }
-        return null;
-      }
-
-      protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method, IFunctionalSet<Subroutine>> data) {
-        return new ModelEnsuresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
-      }
-
-      private IFunctionalSet<Subroutine> GetInheritedEnsures(Method method) {
-        IFunctionalSet<Subroutine> result = FunctionalSet<Subroutine>.Empty(Subroutine.GetKey);
-        if (MetadataDecoder.IsVirtual(method) && ContractDecoder.CanInheritContracts(method)) {
-          foreach (Method baseMethod in MetadataDecoder.OverriddenAndImplementedMethods(method).AssumeNotNull()) {
-            Subroutine rs = this.Get(MetadataDecoder.Unspecialized(baseMethod));
-            if (rs != null) {
-              result = result.Add(rs);
-            }
-          }
-        }
-        return result;
-      }
-
-
-    }
-    class RequiresCache : SubroutineFactory<Method, Pair<Method, IFunctionalSet<Subroutine>>> {
-
-      // for issuing warnings about inheritance of multiple requires
-      ErrorHandler output;
-      // for inferred requires
-
-      public RequiresCache(
-        MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-        ErrorHandler output
-      )
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null); // F: As of Clousot suggestion
-        this.output = output;
-      }
-
-
-      protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method,IFunctionalSet<Subroutine>> data)
-      {
-        return new RequiresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
-      }
-
-      protected override Subroutine BuildNewSubroutine(Method method)
-      {
-        if (this.ContractDecoder != null)
-        {
-          IFunctionalSet<Subroutine> inheritedRequires = this.GetInheritedRequires(method);
-          if (this.ContractDecoder.HasRequires(method))
-          {
-            return this.ContractDecoder.AccessRequires(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedRequires));
-          }
-          else if (inheritedRequires.Count > 0)
-          {
-            if (inheritedRequires.Count == 1) {
-              return inheritedRequires.Any;
-            }
-            return new RequiresSubroutine<Unit>(this.MethodCache, method, inheritedRequires);
-          }
-        }
-        return null;
-      }
-
-      private IFunctionalSet<Subroutine> GetInheritedRequires(Method method)
-      {
-        Contract.Ensures(Contract.Result<IFunctionalSet<Subroutine>>() != null);
-
-        IFunctionalSet<Subroutine> result = FunctionalSet<Subroutine>.Empty(Subroutine.GetKey);
-        Contract.Assert(result != null, "Let's make sure we have the contract");
-        Contract.Assert(this.MetadataDecoder != null, "Should be a postcondition");
-        if (this.MetadataDecoder.IsVirtual(method) && ContractDecoder.CanInheritContracts(method)) {
-          Method rootMethod;
-          if (this.MetadataDecoder.TryGetRootMethod(method, out rootMethod))
-          {
-            Subroutine rs = this.Get(this.MetadataDecoder.Unspecialized(rootMethod));
-            if (rs != null)
-            {
-              result = result.Add(rs);
-            }
-          }
-          foreach (Method baseMethod in this.MetadataDecoder.ImplementedMethods(method).AssumeNotNull()) {
-            var unspecBaseMethod = this.MetadataDecoder.Unspecialized(baseMethod);
-            Subroutine rs = this.Get(this.MetadataDecoder.Unspecialized(baseMethod));
-            if (rs != null) {
-              result = result.Add(rs);
-            }
-          }
-        }
-        return result;
-      }
-
-    }
-
-
-    class AssumeCache : SubroutineFactory<Method, Pair<Method, IFunctionalSet<Subroutine>>>
-    {
-
-      public AssumeCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null);
-        //Contract.Assert(false, "assume cache unimplemented");
-      }
-
-      [ContractVerification(false)]
-      protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method, IFunctionalSet<Subroutine>> data)
-      {
-        Contract.Assert(false, "untested/wrong");
-
-        return new RequiresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
-      }
-
-      [ContractVerification(false)]
-      protected override Subroutine BuildNewSubroutine(Method method)
-      {
-        Contract.Assert(false, "untested/wrong");
-        if (this.ContractDecoder != null)
-        {
-          IFunctionalSet<Subroutine> inheritedRequires = null;//this.GetInheritedRequires(method);
-          if (this.ContractDecoder.HasRequires(method))
-          {
-            return this.ContractDecoder.AccessRequires(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedRequires));
-          }
-          else if (inheritedRequires.Count > 0)
-          {
-            if (inheritedRequires.Count == 1)
-            {
-              return inheritedRequires.Any;
-            }
-            return new RequiresSubroutine<Unit>(this.MethodCache, method, inheritedRequires);
-          }
-        }
-        return null;
-      }
-    }
-
-    class InvariantCache : SubroutineFactory<Type, Pair<Type, Subroutine>> {
-
-      public InvariantCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null); // F: As of Clousot suggestion
-
-      }
-
-      protected override Subroutine BuildNewSubroutine(Type type)
-      {
-        if (this.ContractDecoder != null)
-        {
-          Subroutine baseInv = GetInheritedInvariant(type);
-
-          if (this.ContractDecoder.HasInvariant(type))
-          {
-            return this.ContractDecoder.AccessInvariant(type, this, new Pair<Type,Subroutine>(type,baseInv));
-          }
-          else
-          {
-            return baseInv;
-          }
-        }
-        else
-        {
-          return null;
-        }
-      }
-
-      protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Type,Subroutine> data)
-      {
-        var baseInv = data.Two;
-        var typekey = data.One;
-        return new InvariantSubroutine<Label>(MethodCache, sb, entry, baseInv, typekey);
-      }
-
-
-      private Subroutine GetInheritedInvariant(Type type)
-      {
-        if (this.MetadataDecoder.HasBaseClass(type) && this.ContractDecoder.CanInheritContracts(type)) {
-          Type baseClass = this.MetadataDecoder.BaseClass(MetadataDecoder.Unspecialized(type));
-          Subroutine baseInv = this.MethodCache.GetInvariant(baseClass);
-          return baseInv;
-        }
-        return null;
-      }
-
-    }
-
-
-
-    /// <summary>
-    /// This data structure contains data used during the construction of a Subroutine. For methods, this structure
-    /// is used to hold handler information and is shared among multiple subroutine, namely the method subroutine and
-    /// all the fault/finally subroutine within it.
-    /// </summary>
-    internal abstract class SubroutineBuilder<Label> {
-
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.targetLabels != null);// F: added as of many Clousot precondition suggestions and code inspection
-        Contract.Invariant(this.labelsStartingBlocks != null); // F: added as of many Clousot precondition suggestions and code inspection
-        Contract.Invariant(this.MethodCache != null);// F: added as of many Clousot precondition suggestions and code inspection
-      }
-
-      #region Data
-      internal readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache;
-      private readonly Set<Label> labelsStartingBlocks = new Set<Label>();
-      private readonly Set<Label> targetLabels = new Set<Label>();
-      private OnDemandMap<Label, Pair<Method,bool>> labelsForCallSites;
-      private OnDemandMap<Label, Method> labelsForNewObjSites;
-
-      internal readonly ICodeProvider<Label, Local, Parameter, Method, Field, Type> CodeProvider;
-      internal IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder
-      {
-        get
-        {
-          Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
-       
-          return this.MethodCache.MetadataDecoder.AssumeNotNull();
-        }
-      }
-      internal IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get { return this.MethodCache.ContractDecoder; } }
-      #endregion
-
-      protected SubroutineBuilder(
-        ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
-        MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-        Label entry
-      )
-      {
-        Contract.Requires(methodCache != null);
-
-        this.CodeProvider = codeProvider;
-        this.MethodCache = methodCache;
-        this.AddTargetLabel(entry);
-      }
-
-      protected void AddTargetLabel(Label target)
-      {
-        this.AddBlockStart(target);
-        this.targetLabels.Add(target);
-      }
-
-      protected void AddBlockStart(Label target)
-      {
-        this.labelsStartingBlocks.Add(target);
-      }
-
-
-      protected void Initialize(Label entry)
-      {
-        new BlockStartGatherer(this).TraceAggregateSequentially(entry);
-      }
-
-      protected abstract SubroutineBase<Label> CurrentSubroutine { get; }
-
-      public bool IsBlockStart(Label label)
-      {
-        return labelsStartingBlocks.Contains(label);
-      }
-
-      internal virtual void RecordBlockInfoSameAsOtherBlock(BlockWithLabels<Label> ab, BlockWithLabels<Label> otherblock)
-      {
-      }
-
-      internal bool IsMethodCallSite(Label label, out Pair<Method,bool> methodVirtPair)
-      {
-        return this.labelsForCallSites.TryGetValue(label, out methodVirtPair);
-      }
-
-      internal bool IsNewObjSite(Label label, out Method constructor)
-      {
-        return this.labelsForNewObjSites.TryGetValue(label, out constructor);
-      }
-
-      /// <summary>
-      /// Returns the last block
-      /// </summary>
-      protected BlockWithLabels<Label> BuildBlocks(Label start)
-      {
-        return BlockBuilder.BuildBlocks(start, this);
-      }
-
-      protected BlockWithLabels<Label> BuildBlocksWithFixedStartBlock(Label lbl, BlockWithLabels<Label> startBlk)
-      {
-          return BlockBuilder.BuildBlocksWithFixedStartBlock(lbl, startBlk, this);
-      }
-
-      protected virtual BlockWithLabels<Label> RecordInformationForNewBlock(Label currentLabel, BlockWithLabels<Label>/*?*/ previousBlock)
-      {
-        Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
-
-        Contract.Assume(CurrentSubroutine != null, "Made an Assume, but should it be a postcondition?");
-
-        BlockWithLabels<Label> newBlock = CurrentSubroutine.GetBlock(currentLabel);
-
-        if (previousBlock != null) {
-          var postConditionTarget = newBlock;
-          var preConditionSource = previousBlock;
-          // - if we have 2 call blocks back to back, we insert a dummy block in the middle.
-          if (newBlock is MethodCallBlock<Label> && previousBlock is MethodCallBlock<Label>)
-          {
-            var intermediateBlock = this.CurrentSubroutine.NewBlock();
-            this.RecordBlockInfoSameAsOtherBlock(intermediateBlock, previousBlock);
-            postConditionTarget = intermediateBlock;
-            preConditionSource = intermediateBlock;
-            CurrentSubroutine.AddSuccessor(previousBlock, "fallthrough", intermediateBlock);
-            CurrentSubroutine.AddSuccessor(intermediateBlock, "fallthrough", newBlock);
-          }
-          else
-          {
-            CurrentSubroutine.AddSuccessor(previousBlock, "fallthrough", newBlock);
-          }
-          // insert pre/post
-
-          // make sure to insert post condition first, as there may be a post from a previous call, followed by a pre from the subsequent call.
-          //
-          InsertPostConditionEdges(previousBlock, postConditionTarget);
-          InsertPreConditionEdges(preConditionSource, newBlock);
-        }
-        return newBlock;
-      }
-
-      private void InsertPreConditionEdges(BlockWithLabels<Label> previousBlock, BlockWithLabels<Label> newBlock)
-      {
-        InsertPreConditionEdges(previousBlock, newBlock, this.CurrentSubroutine);
-      }
-
-      internal void InsertPreConditionEdges(BlockWithLabels<Label> previousBlock, BlockWithLabels<Label> newBlock, Subroutine subroutine)
-      {
-        MethodCallBlock<Label> newCallBlock = newBlock as MethodCallBlock<Label>;
-        if (newCallBlock != null && !(subroutine.IsContract || subroutine.IsOldValue))
-        {
-          if (subroutine.IsMethod)
-          {
-            IMethodInfo<Method> mi = subroutine as IMethodInfo<Method>;
-            if (mi != null && this.MetadataDecoder.IsConstructor(mi.Method))
-            {
-              if (this.MetadataDecoder.IsPropertySetter(newCallBlock.CalledMethod) && this.MetadataDecoder.IsAutoPropertyMember(newCallBlock.CalledMethod))
-              {
-                return; // don't insert preconditions of auto-prop setters within constructors
-              }
-            }
-          }
-          // insert pre-condition
-          string tag = newCallBlock.IsNewObj ? "beforeNewObj" : "beforeCall";
-          subroutine.AddEdgeSubroutine(previousBlock, newBlock, this.MethodCache.GetRequires(newCallBlock.CalledMethod), tag);
-        }
-      }
-
-      private void InsertPostConditionEdges(BlockWithLabels<Label> previousBlock, BlockWithLabels<Label> newBlock)
-      {
-        MethodCallBlock<Label> previousCallBlock = previousBlock as MethodCallBlock<Label>;
-        if (previousCallBlock != null)
-        {
-          Contract.Assume(this.CurrentSubroutine != null);
-          if (this.CurrentSubroutine.IsMethod)
-          {
-            IMethodInfo<Method> mi = this.CurrentSubroutine as IMethodInfo<Method>;
-            if (mi != null && this.MetadataDecoder.IsConstructor(mi.Method))
-            {
-              if (this.MetadataDecoder.IsPropertyGetter(previousCallBlock.CalledMethod) && this.MetadataDecoder.IsAutoPropertyMember(previousCallBlock.CalledMethod))
-              {
-                return; // don't insert postconditions of auto-prop getters within constructors
-              }
-            }
-          }
-          string tag = previousCallBlock.IsNewObj ? "afterNewObj" : "afterCall";
-          // insert post-conditions
-          Subroutine post = this.MethodCache.GetEnsures(previousCallBlock.CalledMethod);
-          Contract.Assume(this.CurrentSubroutine != null);
-          CurrentSubroutine.AddEdgeSubroutine(previousBlock, newBlock, post, tag);
-          // insert model post-conditions
-          Subroutine modelpost = this.MethodCache.GetModelEnsures(previousCallBlock.CalledMethod);
-          CurrentSubroutine.AddEdgeSubroutine(previousBlock, newBlock, modelpost, tag);
-          // NOTE: invariants are inserted on-demand when we know receiver is "this"
-        }
-      }
-
-      class BlockStartGatherer :
-         MSILVisitor<Label, Local, Parameter, Method, Field, Type, Unit, Unit, Unit, bool>,
-         ICodeQuery<Label, Local, Parameter, Method, Field, Type, Unit, bool>
-      {
-        [ContractInvariantMethod]
-        private void ObjectInvariant()
-        {
-          Contract.Invariant(this.parent != null); // F: Added as of Clousot suggestions in many places of preconditions
-        }
-
-        SubroutineBuilder<Label> parent;
-
-        public BlockStartGatherer(SubroutineBuilder<Label> parent)
-        {
-          Contract.Requires(parent != null);// F: Added as of Clousot suggestion
-
-          this.parent = parent;
-        }
-
-        /// <returns>true, if next label starts a new block</returns>
-        public bool TraceAggregateSequentially(Label current)
-        {
-          bool nextInstructionStartsNewBlock = false;
-          bool more = true;
-          do {
-            Contract.Assume(parent.CodeProvider != null);
-            nextInstructionStartsNewBlock = parent.CodeProvider.Decode<BlockStartGatherer, Unit, bool>(current, this, Unit.Value);
-
-            more = parent.CodeProvider.Next(current, out current);
-            if (more && nextInstructionStartsNewBlock) {
-              this.AddBlockStart(current);
-            }
-          }
-          while (more);
-          return nextInstructionStartsNewBlock;
-        }
-
-        void AddBlockStart(Label target) { this.parent.AddBlockStart(target); }
-        void AddTargetLabel(Label target) { this.parent.AddTargetLabel(target); }
+    [Serializable]
+    public abstract partial class Subroutine : ITypedProperties, IEquatable<Subroutine>
+    {
+        private static int subroutineIdGen;
+        protected readonly int subroutineId = subroutineIdGen++;
+
+        public int Id { get { return this.subroutineId; } }
+        public abstract string Kind { get; }
+        public abstract CFGBlock Entry { get; }
+        public abstract CFGBlock EntryAfterRequires { get; }
+        public abstract CFGBlock Exit { get; }
+        public abstract CFGBlock ExceptionExit { get; }
+        public abstract string Name { get; }
+        public abstract bool HasReturnValue { get; }
+        /// <summary>
+        /// true for pre/post condition subroutines and methods (if they can be inlined), but not for 
+        /// fault/finally, as these always have 0 initial stack depth
+        /// </summary>
+        public abstract bool HasContextDependentStackDepth { get; }
 
         /// <summary>
-        /// Next instruction does NOT start a new block
+        /// Block level normal successors
         /// </summary>
-        protected override bool Default(Label pc, Unit data)
+        [Pure]
+        public abstract IEnumerable<CFGBlock> SuccessorBlocks(CFGBlock block);
+
+        /// <summary>
+        /// Block level normal successors (tagged).
+        /// </summary>
+        [Pure]
+        public IEnumerable<Pair<Tag, CFGBlock>> SuccessorEdgesFor(CFGBlock block)
         {
-          return false;
+            return this.SuccessorEdges[block];
         }
 
-        public override bool Branch(Label pc, Label target, bool leave, Unit data)
+        /// <summary>
+        /// Block level normal predecessors
+        /// </summary>
+        [Pure]
+        public abstract IEnumerable<CFGBlock> PredecessorBlocks(CFGBlock block);
+
+        /// <summary>
+        /// Blocks are ordered from 0 - n, so arrays can be used for lookup maps
+        /// </summary>
+        public abstract int BlockCount { get; }
+
+        /// <summary>
+        /// Block level view of CFG
+        /// </summary>
+        public abstract IEnumerable<CFGBlock> Blocks { get; }
+
+        [Pure]
+        public IEnumerable<Subroutine> UsedSubroutines()
         {
-          this.AddTargetLabel(target);
-          return true; // next instruction starts a new block
+            var alreadyFound = new Set<int>();
+            return UsedSubroutines(alreadyFound);
         }
 
-        public override bool BranchCond(Label pc, Label target, BranchOperator bop, Unit value1, Unit value2, Unit data)
+        [Pure]
+        public IEnumerable<Subroutine> SubroutineTree()
         {
-          this.AddTargetLabel(target);
-          return true; // next instruction starts a new block
+            var alreadyFound = new Set<int>();
+            return SubroutineTree(alreadyFound);
         }
 
-        public override bool BranchFalse(Label pc, Label target, Unit cond, Unit data)
+        private IEnumerable<Subroutine> SubroutineTree(Set<int> alreadyFound)
         {
-          this.AddTargetLabel(target);
-          return true; // next instruction starts a new block
+            alreadyFound.Add(this.Id);
+            yield return this;
+
+            foreach (var immediate in this.UsedSubroutines(alreadyFound))
+            {
+                foreach (var sub in immediate.SubroutineTree(alreadyFound))
+                {
+                    yield return sub;
+                }
+            }
         }
 
-        public override bool BranchTrue(Label pc, Label target, Unit cond, Unit data)
-        {
-          this.AddTargetLabel(target);
-          return true; // next instruction starts a new block
-        }
+        internal abstract IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadySeen);
 
-        public override bool Switch(Label pc, Type type, IEnumerable<Pair<object,Label>> cases, Unit value, Unit data)
-        {
-          foreach (var label in cases)
-          {
-            this.AddTargetLabel(label.Two);
-          }
-          return true;
-        }
+        [Pure]
+        public abstract void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed);
 
-        public override bool Throw(Label pc, Unit exn, Unit data)
-        {
-          return true;
-        }
-        public override bool Rethrow(Label pc, Unit data)
-        {
-          return true;
-        }
-        public override bool Endfinally(Label pc, Unit data)
-        {
-          return true;
-        }
-        public override bool Return(Label pc, Unit source, Unit data)
-        {
-          return true;
-        }
-        public bool Aggregate(Label current, Label aggregateStart, bool canBeBranchTarget, Unit data)
-        {
-          // recurse
-          return TraceAggregateSequentially(aggregateStart);
-        }
-        public override bool Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, Unit data)
-        {
-          return CallHelper(pc, method, false, virt);
-        }
+        /// <summary>
+        /// Returns true, if the block starts an exception or filter handler, false otherwise.
+        /// NOTE: blocks relating to fault or finally handlers never return true, as these are expanded out in the CFG abstraction
+        /// </summary>
+        [Pure]
+        public virtual bool IsCatchFilterHeader(CFGBlock block) { return false; }
+        public virtual bool IsRequires { get { return false; } }
+        public virtual bool IsEnsures { get { return false; } }
+        public virtual bool IsModelEnsures { get { return false; } }
+        public bool IsEnsuresOrOld { get { return IsEnsures || IsOldValue; } }
+        public virtual bool IsOldValue { get { return false; } }
+        public virtual bool IsMethod { get { return false; } }
+        public virtual bool IsConstructor { get { return false; } }
+        public virtual bool IsInvariant { get { return false; } }
+        public virtual bool IsFaultFinally { get { return false; } }
+        public virtual bool IsContract { get { return false; } }
+        public bool IsNecessaryAssumption { get; set; }
+        [Pure]
+        public abstract bool IsSubroutineStart(CFGBlock block);
+        [Pure]
+        public abstract bool IsSubroutineEnd(CFGBlock block);
+        [Pure]
+        public abstract bool IsJoinPoint(CFGBlock block);
+        [Pure]
+        public abstract bool IsSplitPoint(CFGBlock block);
+        internal virtual bool IsCompilerGenerated { get { return false; } }
 
-        public override bool ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Unit dest, ArgList args, Unit data)
-        {
-          return CallHelper(pc, method, false, true);
-        }
+        /// <summary>
+        /// Returns the delta of the evaluation stack after evaluating this subroutine.
+        /// Usually 0, but subroutines such as old subroutines push 1 value onto the stack.
+        /// </summary>
+        [Pure]
+        public abstract int StackDelta { get; }
 
-        bool CallHelper(Label current, Method method, bool newObj, bool isVirtual)
-        {
-          // if we insert pre/post conditions, we want separate blocks between the call and the preceding and succeeding instructions
-          // so we can add edge subroutines.
+        [Pure]
+        internal abstract APC ComputeTargetFinallyContext(APC ppoint, CFGBlock succ, DConsCache consCache);
 
-          this.AddBlockStart(current);
-          if (newObj)
-          {
-            this.parent.labelsForNewObjSites[current] = method; // okay to double add
-          }
-          else
-          {
-            this.parent.labelsForCallSites[current] = new Pair<Method,bool>(method, isVirtual); // okay to double add
-          }
- 
+        internal abstract EdgeMap<Tag> SuccessorEdges { get; }
+        internal abstract EdgeMap<Tag> PredecessorEdges { get; }
+        [Pure]
+        internal abstract bool HasSingleSuccessor(APC ppoint, out APC next, DConsCache consCache);
+        [Pure]
+        internal abstract bool HasSinglePredecessor(APC ppoint, out APC next, DConsCache consCache, bool skipContracts);
+        [Pure]
+        internal abstract APC PredecessorPCPriorToRequires(APC ppoint, DConsCache consCache);
+        [Pure]
+        internal abstract IEnumerable<APC> Predecessors(APC ppoint, DConsCache consCache, bool skipContracts);
+        [Pure]
+        internal abstract IEnumerable<APC> Successors(APC ppoint, DConsCache consCache);
+        internal abstract DepthFirst.Visitor<CFGBlock, Unit>/*?*/ EdgeInfo { get; }
+        /// <summary>
+        /// Enumerates the local exception handler start blocks protecting the given ppoint and surrounding fault/finally subroutines also protecting ppoint. If the exception can escape the current subroutine
+        /// then the last enumerated block is the subroutine exception exit block.
+        /// </summary>
+        /// <typeparam name="Data">Handler predicate specific type</typeparam>
+        /// <typeparam name="Type">Type of exceptions</typeparam>
+        /// <param name="ppoint">Current point at which exception is thrown</param>
+        /// <param name="currentSubroutine">if non-null, a subroutine already executing as a transfer from ppoint. Reduces the set of
+        /// handlers to those surrounding the execution of the given subroutine from ppoint.</param>
+        /// <param name="data">Handler filter specific data</param>
+        /// <param name="handlerPredicate">Called with each potential handler. Can determine if handler is chosen and if search continues</param>
+        /// <returns>All selected handlers within the subroutine ppoint.Block.Container.</returns>
+        [Pure]
+        internal abstract IEnumerable<CFGBlock> ExceptionHandlers<Data, Type>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type, Data> handlerPredicate);
+        public abstract void AddEdgeSubroutine(CFGBlock from, CFGBlock to, Subroutine subroutine, string callTag);
 
-          return true; // next instruction starts a new block
-        }
+        /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
+        [Pure]
+        public abstract FList<Pair<string, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context);
 
-        public override bool Newobj<ArgList>(Label pc, Method ctor, Unit dest, ArgList args, Unit data)
-        {
-          return CallHelper(pc, ctor, true, false);
-        }
+        [Pure]
+        public abstract FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context);
 
-        public override bool BeginOld(Label pc, Label matchingEnd, Unit data)
-        {
-          // start a new block
-          this.AddTargetLabel(pc); // It's a target block as it starts a new subroutine
-          this.parent.BeginOldHook(pc);
-          return false;
-        }
+        /// <summary>
+        /// The constructor only builds the subroutine, but does not really traverse all the code to avoid 
+        /// infinite recursions in the cache lookup.
+        /// This method is called by the cache constructor after the subroutine is entered into the cache.
+        /// </summary>
+        internal abstract void Initialize();
 
-        public override bool EndOld(Label pc, Label matchingBegin, Type type, Unit dest, Unit source, Unit data)
-        {
-          this.parent.EndOldHook(pc);
-          return true; // ends a block because we insert it as a subroutine.
-        }
+        #region ITypedProperties Members
 
-
-      }
-
-      class BlockBuilder :
-         MSILVisitor<Label,Local,Parameter,Method,Field,Type,Unit,Unit,BlockWithLabels<Label>, bool>,
-         ICodeQuery<Label, Local, Parameter, Method, Field, Type, BlockWithLabels<Label>, bool>
-/*,
-        IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Unit, Unit, Unit, Unit>
-*/
-      {
+        private readonly TypedProperties propertyMap = new TypedProperties();
 
         [ContractInvariantMethod]
         private void ObjectInvariant()
         {
-          Contract.Invariant(this.parent != null); // F: Added as of Clousot suggestion as precondition in many places
+            Contract.Invariant(propertyMap != null);
         }
 
-        SubroutineBuilder<Label> parent;
-        BlockWithLabels<Label>/*?*/ currentBlock = null;
-
-        SubroutineBase<Label> CurrentSubroutine
+        [Pure]
+        public bool Contains<T>(TypedKey<T> key)
         {
-          get
-          {
-            Contract.Ensures(Contract.Result<SubroutineBase<Label>>() != null); // F: added
-
-            Contract.Assume(parent.CurrentSubroutine != null); // F: should add as postcondition to the parent, but because of the generics we have some problems in picking it
-            return parent.CurrentSubroutine;
-          }
+            return propertyMap.Contains(key);
         }
 
-        private BlockBuilder(SubroutineBuilder<Label> builder)
+        public void Add<T>(TypedKey<T> key, T value)
         {
-          Contract.Requires(builder != null);// F: As of Clousot suggestion
-          this.parent = builder;
+            propertyMap.Add(key, value);
         }
 
-        internal static BlockWithLabels<Label> BuildBlocks(Label start, SubroutineBuilder<Label> builder)
+        [Pure]
+        public bool TryGetValue<T>(TypedKey<T> key, out T value)
         {
-          Contract.Requires(builder != null); // F: As of Clousot suggestion
-
-          BlockBuilder b = new BlockBuilder(builder);
-          b.TraceAggregateSequentially(start);
-
-          // check if we are falling off the end
-          if (b.currentBlock != null) {
-            // add edge to exit
-            b.CurrentSubroutine.AddSuccessor(b.currentBlock, "fallthrough-return", b.CurrentSubroutine.Exit);
-            // Callback
-            b.CurrentSubroutine.AddReturnBlock(b.currentBlock);
-
-            return b.currentBlock;
-          }
-          return null;
-        }
-
-        internal static BlockWithLabels<Label> BuildBlocksWithFixedStartBlock(Label start, BlockWithLabels<Label> startBlk, SubroutineBuilder<Label> builder)
-        {
-            BlockBuilder b = new BlockBuilder(builder);
-            b.TraceAggregateSequentially(start);
-            Contract.Assume(b.currentBlock != null);
-            b.CurrentSubroutine.AddSuccessor(startBlk, "assumeSetup", b.currentBlock);
-            // check if we are falling off the end
-            //if (b.currentBlock != null) // F: follows from the assume
-            {
-                // add edge to exit
-                b.CurrentSubroutine.AddSuccessor(b.currentBlock, "fallthrough-return", b.CurrentSubroutine.Exit);
-                // Callback
-                b.CurrentSubroutine.AddReturnBlock(b.currentBlock);
-
-                return b.currentBlock;
-            }
-            //return null;
-        }
-
-        /// <summary>
-        /// Builds
-        ///   - Protecting handler map
-        ///   - Successor relation
-        ///   - CFG blocks
-        /// Temporary structures
-        ///   - current protecting handlers
-        ///   - currentBlock
-        /// </summary>
-        /// <param name="currentLabel"></param>
-        private void TraceAggregateSequentially(Label currentLabel)
-        {
-          bool more = true;
-          do {
-            if (this.parent.IsBlockStart(currentLabel)) {
-              // starts a block
-              this.currentBlock = this.parent.RecordInformationForNewBlock(currentLabel, this.currentBlock);
-            }
-            Contract.Assume(this.currentBlock != null); // f: made an assume
-
-            // we add the currentLabel to the block in the decoded to Methods
-            // this allows optimizing intermediate labels away
-
-            Contract.Assume(parent.CodeProvider != null, "At this point expecting the CodeProvider != null");
-
-            // NOTE: this decode can recurse and cause this.currentBlock to change.
-            bool noFallThrough = parent.CodeProvider.Decode<BlockBuilder, BlockWithLabels<Label>, bool>(currentLabel, this, this.currentBlock);
-            if (noFallThrough) {
-              this.currentBlock = null;
-            }
-
-            Contract.Assert(this.parent.CodeProvider != null, "should we make it a postcondition?");
-            more = parent.CodeProvider.Next(currentLabel, out currentLabel);
-          }
-          while (more);
-        }
-
-        protected override bool Default(Label pc, BlockWithLabels<Label> currentBlock)
-        {
-          currentBlock.Add(pc);
-          return false; // by default, we fall through
-        }
-
-        public override bool Branch(Label pc, Label target, bool leave, BlockWithLabels<Label> currentBlock)
-        {
-          currentBlock.Add(pc);
-          CurrentSubroutine.AddSuccessor(currentBlock, "branch", CurrentSubroutine.GetTargetBlock(target));
-          return true; // no fall through
-        }
-
-        public override bool BranchCond(Label pc, Label target, BranchOperator bop, Unit value1, Unit value2, BlockWithLabels<Label> currentBlock)
-        {
-          return HandleCondBranch(pc, target, true, currentBlock);
-        }
-
-        public override bool BranchFalse(Label pc, Label target, Unit cond, BlockWithLabels<Label> data)
-        {
-          return HandleCondBranch(pc, target, false, data);
-        }
-
-        public override bool BranchTrue(Label pc, Label target, Unit cond, BlockWithLabels<Label> data)
-        {
-          return HandleCondBranch(pc, target, true, data);
-        }
-
-        private bool HandleCondBranch(Label pc, Label target, bool trueBranch, BlockWithLabels<Label> currentBlock) {
-          Contract.Requires(currentBlock != null); // F: Added as of Clousot suggestion
-
-          currentBlock.Add(pc);
-
-          string takenLabel = trueBranch ? "true" : "false";
-          string notTakenLabel = trueBranch ? "false" : "true";
-
-          // insert a special assume block for taken branch
-          AssumeBlock<Label> abTaken = CurrentSubroutine.NewAssumeBlock(pc, takenLabel);
-          parent.RecordBlockInfoSameAsOtherBlock(abTaken, this.currentBlock);
-          CurrentSubroutine.AddSuccessor(currentBlock, takenLabel, abTaken);
-          CurrentSubroutine.AddSuccessor(abTaken, "fallthrough", CurrentSubroutine.GetTargetBlock(target));
-
-          // insert a special assume block for untaken branch
-          AssumeBlock<Label> abElse = CurrentSubroutine.NewAssumeBlock(pc, notTakenLabel);
-          parent.RecordBlockInfoSameAsOtherBlock(abElse, this.currentBlock);
-          CurrentSubroutine.AddSuccessor(currentBlock, notTakenLabel, abElse);
-
-          this.currentBlock = abElse;
-          return false; // has fall through
-        }
-
-        public override bool Switch(Label pc, Type type, IEnumerable<Pair<object,Label>> cases, Unit value, BlockWithLabels<Label> currentBlock)
-        {
-          List<object> patterns = new List<object>();
-          currentBlock.Add(pc);
-          foreach (Pair<object, Label> target in cases) {
-            patterns.Add(target.One);
-            // insert a special switch case assume block            
-            SwitchCaseAssumeBlock<Label> ab = CurrentSubroutine.NewSwitchCaseAssumeBlock(pc, target.One, type);
-            parent.RecordBlockInfoSameAsOtherBlock(ab, this.currentBlock);
-            CurrentSubroutine.AddSuccessor(currentBlock, "switch", ab);
-            CurrentSubroutine.AddSuccessor(ab, "fallthrough", CurrentSubroutine.GetTargetBlock(target.Two));
-          }
-
-          // we assume we fall into the default. Insert special default assume block
-          SwitchDefaultAssumeBlock<Label> dab = CurrentSubroutine.NewSwitchDefaultAssumeBlock(pc, patterns, type);
-          parent.RecordBlockInfoSameAsOtherBlock(dab, this.currentBlock);
-          CurrentSubroutine.AddSuccessor(currentBlock, "default", dab);
-
-          this.currentBlock = dab;
-          return false; // has fall through
-        }
-
-        public override bool Throw(Label pc, Unit exn, BlockWithLabels<Label> currentBlock)
-        {
-          currentBlock.Add(pc);
-          return true; // no fall through
-        }
-        public override bool Rethrow(Label pc, BlockWithLabels<Label> currentBlock)
-        {
-          currentBlock.Add(pc);
-          return true; // no fall through
-        }
-        public override bool Endfinally(Label pc, BlockWithLabels<Label> currentBlock)
-        {
-          currentBlock.Add(pc);
-          CurrentSubroutine.AddSuccessor(currentBlock, "endsub", CurrentSubroutine.Exit);
-          return true; // no fall through
-        }
-
-        public override bool Return(Label pc, Unit source, BlockWithLabels<Label> currentBlock)
-        {
-          currentBlock.Add(pc);
-          CurrentSubroutine.AddSuccessor(currentBlock, "return", CurrentSubroutine.Exit);
-          // Callback
-          CurrentSubroutine.AddReturnBlock(currentBlock);
-          return true; // no fall through
-        }
-
-        public bool Aggregate(Label pc, Label nestedAggregate, bool canBeBranchTarget, BlockWithLabels<Label> currentBlock)
-        {
-          // recurse
-          this.TraceAggregateSequentially(nestedAggregate);
-          return false; // recursion would have already set current block to null if there is no fall through.
-        }
-
-        public override bool Nop(Label pc, BlockWithLabels<Label> data)
-        {
-          // ignore this label
-          return false; // has fall through
-        }
-
-
-        /// <summary>
-        /// Give current subroutine a chance to record information about matching begin/old old labels
-        /// </summary>
-        public override bool EndOld(Label pc, Label matchingBegin, Type type, Unit dest, Unit source, BlockWithLabels<Label> data)
-        {
-          this.currentBlock.Add(pc);
-          CurrentSubroutine.AddSuccessor(currentBlock, "endold", CurrentSubroutine.Exit);
-          return false; // indicate fall-through, otherwise we don't properly record the end of the old scope.
-        }
-
-        public override bool Stfld(Label pc, Field field, bool @volatile, Unit obj, Unit value, BlockWithLabels<Label> currentBlock)
-        {
-          if (this.CurrentSubroutine.IsMethod)
-          {
-            IMethodInfo<Method> mi = (IMethodInfo<Method>)this.CurrentSubroutine;
-            if (this.parent.MetadataDecoder.IsPropertySetter(mi.Method))
-            {
-              this.parent.MethodCache.AddModifies(mi.Method, field);
-            }
-          }
-          this.currentBlock.Add(pc);
-          return false; // has fall through
-        }
-
-        public override bool Ldflda(Label pc, Field field, UnitDest dest, UnitDest obj, BlockWithLabels<Label> data)
-        {
-          // for setter modifies analysis, treat as modifies
-          if (this.CurrentSubroutine.IsMethod)
-          {
-            IMethodInfo<Method> mi = (IMethodInfo<Method>)this.CurrentSubroutine;
-            if (this.parent.MetadataDecoder.IsPropertySetter(mi.Method))
-            {
-              this.parent.MethodCache.AddModifies(mi.Method, field);
-            }
-          }
-          this.currentBlock.Add(pc);
-          return false; // has fall through
-        }
-
-        public override bool Ldfld(Label pc, Field field, bool @volatile, Unit obj, Unit value, BlockWithLabels<Label> currentBlock)
-        {
-          if (this.CurrentSubroutine.IsMethod)
-          {
-            IMethodInfo<Method> mi = (IMethodInfo<Method>)this.CurrentSubroutine;
-            if (this.parent.MetadataDecoder.IsPropertyGetter(mi.Method))
-            {
-              this.parent.MethodCache.AddReads(mi.Method, field);
-            }
-          }
-          this.currentBlock.Add(pc);
-          return false; // has fall through
-        }
-
-
-      }
-
-
-      internal virtual void BeginOldHook(Label current)
-      {
-      }
-
-      internal virtual void EndOldHook(Label current)
-      {
-      }
-
-      internal bool IsTargetLabel(Label label)
-      {
-        return this.targetLabels.Contains(label);
-      }
-    }
-
-    internal class SubroutineWithHandlersBuilder<Label, Handler> : SubroutineBuilder<Label> {
-
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.CodeProvider != null); // F: Added as of Clousot suggestions as precondition in many places
-      }
-
-
-      protected override SubroutineBase<Label> CurrentSubroutine { get { return this.subroutineStack.Head; } }
-
-      private FList<SubroutineWithHandlers<Label,Handler>> subroutineStack;
-
-      protected SubroutineWithHandlers<Label, Handler> CurrentSubroutineWithHandler { get {
-        Contract.Assume(this.subroutineStack != null, "Seems that when calling CurrentSubroutineStack we know the assumption holds");
-
-       return subroutineStack.Head; } }
-
-      private OnDemandMap<Label, Stack<Handler>> tryStartList;
-      private OnDemandMap<Label, Queue<Handler>> tryEndList;
-      private OnDemandMap<Label, Queue<Handler>> subroutineHandlerEndList;
-      private OnDemandMap<Label, Handler> handlerStartingAt;
-      protected readonly Method method;
-
-      internal new readonly IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> CodeProvider;
-
-
-      public SubroutineWithHandlersBuilder(
-        IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> codeProvider,
-        MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-        Method method,
-        Label entry
-      )
-        : base(codeProvider, methodCache, entry)
-      {
-        Contract.Requires(codeProvider != null); // F: Added as of Clousot suggestion
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-
-        this.CodeProvider = codeProvider;
-        this.method = method;
-        ComputeTryBlockStartAndEndInfo(method);
-        base.Initialize(entry);
-      }
-
-      public CFGBlock BuildBlocks(Label entry, SubroutineWithHandlers<Label, Handler> subroutine)
-      {
-        this.subroutineStack = FList<SubroutineWithHandlers<Label, Handler>>.Cons(subroutine, null);
-        return base.BuildBlocks(entry);
-      }
-
-      internal override void RecordBlockInfoSameAsOtherBlock(BlockWithLabels<Label> ab, BlockWithLabels<Label> otherblock)
-      {
-        FList<Handler>/*?*/ protHandlers;
-        if (this.CurrentSubroutineWithHandler.ProtectingHandlers.TryGetValue(otherblock, out protHandlers)) {
-          this.CurrentSubroutineWithHandler.ProtectingHandlers.Add(ab, protHandlers);
-        }
-      }
-
-      private FList<Handler> CurrentProtectingHandlers
-      {
-        get {
-          Contract.Assume(this.CurrentSubroutineWithHandler != null);
-          return this.CurrentSubroutineWithHandler.CurrentProtectingHandlers; 
-        }
-        set { 
-          Contract.Assume(this.CurrentSubroutineWithHandler != null); 
-          this.CurrentSubroutineWithHandler.CurrentProtectingHandlers = value; 
-        }
-      }
-
-      protected override BlockWithLabels<Label> RecordInformationForNewBlock(Label currentLabel, BlockWithLabels<Label>/*?*/ previousBlock)
-      {
-        BlockWithLabels<Label>/*?*/ newBlock = null;
-
-        #region Pop subroutine handlers off stack whose scope ends here (must be first)
-        Queue<Handler> handlerEnds = this.GetHandlerEnd(currentLabel);
-        if (handlerEnds != null) {
-          foreach (Handler eh in handlerEnds) {
-            // TODO: not enough info to make sure we are popping the correct subroutine
-            SubroutineBase<Label> endingSubroutine = this.subroutineStack.Head;
-            endingSubroutine.Commit();
-
-            this.subroutineStack = this.subroutineStack.Tail;
-            // can't fall from one subroutine into another
-            previousBlock = null;
-          }
-        }
-        #endregion
-
-        #region Pop protecting handlers off stack whose scope ends here
-
-        Queue<Handler> tryEnds = this.GetTryEnd(currentLabel);
-        if (tryEnds != null) {
-          foreach (Handler eh in tryEnds) {
-            if (Object.Equals(eh, CurrentProtectingHandlers.Head)) {
-              CurrentProtectingHandlers = CurrentProtectingHandlers.Tail; // Pop handler
-            }
-            else {
-              throw new ApplicationException("wrong handler");
-            }
-          }
-        }
-        #endregion
-
-        #region Check if this is a fault/finally subroutine start or an exception handler
-        Handler handlerStarting;
-        if (this.IsHandlerStart(currentLabel, out handlerStarting)) {
-          if (this.IsFaultOrFinally(handlerStarting)) {
-            SubroutineWithHandlers<Label,Handler> subroutine;
-            if (this.CodeProvider.IsFaultHandler(handlerStarting)) {
-              subroutine = new FaultSubroutine<Label, Handler>(this.MethodCache, this, currentLabel);
-            }
-            else {
-              subroutine = new FinallySubroutine<Label, Handler>(this.MethodCache, this, currentLabel);
-            }
-            this.CurrentSubroutineWithHandler.FaultFinallySubroutines.Add(handlerStarting, subroutine);
-
-            // push new current subroutine
-            this.subroutineStack = FList<SubroutineWithHandlers<Label,Handler>>.Cons(subroutine, this.subroutineStack);
-
-            previousBlock = null; // can't fall into here.
-          }
-          else {
-            // This is an exception handler start. Make sure we use a special entry block for it.
-            newBlock = CurrentSubroutineWithHandler.CreateCatchFilterHeader(handlerStarting, currentLabel);
-          }
-        }
-        #endregion
-
-
-        #region Get new block and record fall-through edge if necessary
-        if (newBlock == null) {
-          newBlock = base.RecordInformationForNewBlock(currentLabel, previousBlock);
+            return propertyMap.TryGetValue(key, out value);
         }
 
         #endregion
 
-        #region Push protecting handlers on stack whose scope starts here
-        Stack<Handler> starts = this.GetTryStart(currentLabel);
-        if (starts != null) {
-          foreach (Handler eh in starts) {
-            // push this handler on top of current block enclosing handlers
-            CurrentProtectingHandlers = FList<Handler>.Cons(eh, CurrentProtectingHandlers); // Push handler
-          }
-        }
-        #endregion
-
-
-        #region Record handlers for new block
-        CurrentSubroutineWithHandler.ProtectingHandlers.Add(newBlock, this.CurrentProtectingHandlers);
-        #endregion
-
-        return newBlock;
-      }
-
-
-      private void ComputeTryBlockStartAndEndInfo(Method method)
-      {
-
-        foreach (Handler eh in this.CodeProvider.TryBlocks(method).AssumeNotNull()) {
-
-          if (this.CodeProvider.IsFilterHandler(eh)) {
-            this.AddTargetLabel(CodeProvider.FilterDecisionStart(eh));
-          }
-          this.AddTargetLabel(CodeProvider.HandlerStart(eh));
-          this.AddTargetLabel(CodeProvider.HandlerEnd(eh));
-
-          AddTryStart(eh);
-          AddTryEnd(eh);
-          AddHandlerEnd(eh);
-          this.handlerStartingAt.Add(CodeProvider.HandlerStart(eh), eh);
-        }
-
-      }
-
-      private void AddTryStart(Handler eh)
-      {
-        Label tryStart = this.CodeProvider.TryStart(eh);
-        Stack<Handler>/*?*/ starts;
-        this.tryStartList.TryGetValue(tryStart, out starts);
-        if (starts == null) {
-          starts = new Stack<Handler>();
-          tryStartList[tryStart] = starts;
-        }
-        starts.Push(eh);
-
-        // also update block start
-        this.AddTargetLabel(tryStart);
-      }
-
-      private void AddTryEnd(Handler eh)
-      {
-        Label tryEnd = this.CodeProvider.TryEnd(eh);
-        Queue<Handler>/*?*/ ends;
-        this.tryEndList.TryGetValue(tryEnd, out ends);
-        if (ends == null) {
-          ends = new Queue<Handler>();
-          tryEndList[tryEnd] = ends;
-        }
-        ends.Enqueue(eh);
-
-        // also update block start
-        this.AddTargetLabel(tryEnd);
-      }
-
-      private void AddHandlerEnd(Handler eh)
-      {
-        if (!this.IsFaultOrFinally(eh)) return;
-        // only record subroutine handlers
-        Label ehEnd = this.CodeProvider.HandlerEnd(eh);
-        Queue<Handler>/*?*/ ends;
-        this.subroutineHandlerEndList.TryGetValue(ehEnd, out ends);
-        if (ends == null) {
-          ends = new Queue<Handler>();
-          this.subroutineHandlerEndList[ehEnd] = ends;
-        }
-        ends.Enqueue(eh);
-
-        // also update block start
-        this.AddTargetLabel(ehEnd);
-      }
-
-      public bool IsHandlerStart(Label label, out Handler handler)
-      {
-        return (this.handlerStartingAt.TryGetValue(label, out handler));
-      }
-
-      public bool IsFaultOrFinally(Handler handler)
-      {
-        return this.CodeProvider.IsFaultHandler(handler) || this.CodeProvider.IsFinallyHandler(handler);
-      }
-
-      public Queue<Handler> GetHandlerEnd(Label label)
-      {
-        Queue<Handler>/*?*/ result;
-        this.subroutineHandlerEndList.TryGetValue(label, out result);
-        return result;
-      }
-
-      public Queue<Handler> GetTryEnd(Label label)
-      {
-        Queue<Handler>/*?*/ result;
-        this.tryEndList.TryGetValue(label, out result);
-        return result;
-      }
-
-      public Stack<Handler> GetTryStart(Label label)
-      {
-        Stack<Handler>/*?*/ result;
-        this.tryStartList.TryGetValue(label, out result);
-        return result;
-      }
-
-
-    }
-
-    internal class AssumeAsPostConditionSubroutineBuilder<Label> : SubroutineBuilder<Label>
-    {
-
-        SubroutineBase<Label> currentSubroutine;
-
-         public AssumeAsPostConditionSubroutineBuilder(ICodeProvider<Label,Local,Parameter,Method,Field,Type> codeProvider,
-                                     MethodCache<Local,Parameter,Type,Method,Field,Property,Event,Attribute,Assembly> methodCache,
-                                     Label entry
-      )
-        : base(codeProvider, methodCache, entry)
-      {
-        Contract.Requires(methodCache != null); // F: As of Clousot suggestion
-        
-        base.Initialize(entry);
-      }
-
-      public BlockWithLabels<Label> BuildBlocks(Label entry, BlockWithLabels<Label> startBlk, SubroutineBase<Label> subroutine)
-      {
-        this.currentSubroutine = subroutine;
-        return base.BuildBlocksWithFixedStartBlock(entry, startBlk);
-      }
-
-      protected override SubroutineBase<Label> CurrentSubroutine
-      {
-        get
-        {
-          return this.currentSubroutine;
-        }
-      }
-    }
-
-    internal class SimpleSubroutineBuilder<Label> : SubroutineBuilder<Label> {
-
-      SubroutineBase<Label> currentSubroutine;
-
-      public SimpleSubroutineBuilder(ICodeProvider<Label,Local,Parameter,Method,Field,Type> codeProvider,
-                                     MethodCache<Local,Parameter,Type,Method,Field,Property,Event,Attribute,Assembly> methodCache,
-                                     Label entry
-      )
-        : base(codeProvider, methodCache, entry)
-      {
-        Contract.Requires(methodCache != null); // F: As of Clousot suggestion
-        base.Initialize(entry);
-      }
-
-      public BlockWithLabels<Label> BuildBlocks(Label entry, SubroutineBase<Label> subroutine)
-      {
-        this.currentSubroutine = subroutine;
-        return base.BuildBlocks(entry);
-      }
-
-      protected override SubroutineBase<Label> CurrentSubroutine
-      {
-        get
-        {
-          if (this.currentOldSubroutine != null) return this.currentOldSubroutine;
-          return this.currentSubroutine;
-        }
-      }
-
-      protected OldValueSubroutine<Label> currentOldSubroutine;
-      protected BlockWithLabels<Label> blockPriorToOld;
-
-      protected override BlockWithLabels<Label> RecordInformationForNewBlock(Label currentLabel, BlockWithLabels<Label> previousBlock)
-      {
-        Label lastLabel;
-        BlockWithLabels<Label> newBlock;
-        if (previousBlock != null && previousBlock.HasLastLabel(out lastLabel) && endOldStart.Contains(lastLabel))
-        {
-          // end the old subroutine here.
-          var endingOldSubroutine = this.currentOldSubroutine;
-          endingOldSubroutine.Commit(previousBlock);
-
-          // now change the context to previous subroutine (ensures)
-          this.currentOldSubroutine = null;
-          Contract.Assume(this.CurrentSubroutine != null);
-          Contract.Assume(this.CurrentSubroutine.IsEnsures);
-          // We need to fall into the new block from the block prior to the old subroutine
-          Contract.Assume(blockPriorToOld.Subroutine == this.CurrentSubroutine);
-          newBlock = base.RecordInformationForNewBlock(currentLabel, blockPriorToOld);
-          Contract.Assume(newBlock.Subroutine == this.CurrentSubroutine);
-          this.CurrentSubroutine.AddEdgeSubroutine(blockPriorToOld, newBlock, endingOldSubroutine, "old");
-          return newBlock;
-        }
-        if (beginOldStart.Contains(currentLabel))
-        {
-          // start of an old subroutine
-          Contract.Assume(this.currentOldSubroutine == null); // F: made an assume
-          this.currentOldSubroutine = new OldValueSubroutine<Label>(this.MethodCache, ((CallingContractSubroutine<Label>)this.currentSubroutine).Method, this, currentLabel);
-          this.blockPriorToOld = previousBlock;
-
-          // don't fall into this block
-          newBlock = base.RecordInformationForNewBlock(currentLabel, null);
-          this.currentOldSubroutine.RegisterBeginBlock(newBlock);
-          return newBlock;
-        }
-        newBlock = base.RecordInformationForNewBlock(currentLabel, previousBlock);
-
-        return newBlock;
-      }
-
-      IMutableSet<Label> beginOldStart = new Set<Label>();
-      IMutableSet<Label> endOldStart = new Set<Label>();
-
-      internal override void BeginOldHook(Label label)
-      {
-        beginOldStart.Add(label);
-      }
-
-      internal override void EndOldHook(Label label)
-      {
-        endOldStart.Add(label);
-      }
-    }
-
-    
-    internal abstract class BlockBase : CFGBlock
-    {
-      internal BlockBase(Subroutine container, ref int idGen) : base(container, ref idGen) {
-        Contract.Requires(idGen >= 0);// F: added because of Clousot suggestion
-        Contract.Requires(container != null); // F: added because of Clousot suggestion
-
-        Contract.Ensures(idGen >= 0);
-      }
-
-      internal abstract Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-        where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>;
-
-    }
-    /// <summary>
-    /// CFG blocks group consecutive instructions/code fragments to reduce the number of edges
-    /// in the graph. A Block has a single entry point, meaning all control transfers go to the head
-    /// never to an interior label. The only control transfer out of the block is at the last instruction.
-    /// </summary>
-    /// <typeparam name="Label"></typeparam>
-    internal class BlockWithLabels<Label> : BlockBase, IEquatable<BlockWithLabels<Label>> {
-
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.subroutine != null); // F: made an object invariant
-        Contract.Invariant(this.Labels != null);// F: made an object invariant
-      }
-
-
-      #region Private/Internal
-
-      private readonly List<Label> Labels;
-
-
-      internal BlockWithLabels(SubroutineBase<Label> container, ref int idGen)
-        : base(container, ref idGen)
-      {
-        Contract.Requires(container != null); // F: As of Clousot suggestion
-        Contract.Requires(idGen >= 0); // F: As of Clousot suggestion
-
-        Contract.Ensures(idGen >= 0);
-
-        Labels = new List<Label>();
-        this.subroutine = container;
-      }
-
-      internal void Add(Label label)
-      {
-        Labels.Add(label);
-      }
-
-      #endregion
-
-      internal readonly SubroutineBase<Label> subroutine;
-
-      #region public API
-      public override int Count
-      {
-        get { return this.Labels.Count; }
-      }
-
-      internal bool HasLastLabel(out Label label)
-      {
-        if (this.Labels.Count > 0)
-        {
-          label = this.Labels[this.Labels.Count - 1];
-          return true;
-        }
-        label = default(Label);
-        return false;
-      }
-
-      internal virtual bool UnderlyingLabelForward(int index, out Label/*?*/ label)
-      {
-        Contract.Requires(index >= 0);
-
-        if (index < this.Labels.Count) {
-          label = this.Labels[index];
-          return true;
-        }
-        else {
-          label = default(Label);
-          return false;
-        }
-      }
-
-      public override string SourceAssertionCondition(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label))
-        {
-          return this.subroutine.SourceAssertionCondition(label);
-        }
-        return null;
-      }
-
-      public override string SourceContext(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceContext(label);
-        }
-        return null;
-      }
-
-      public override string SourceDocument(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceDocument(label);
-        }
-        return null;
-      }
-
-      public override int SourceStartLine(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceStartLine(label);
-        }
-        return 0;
-      }
-
-      public override int SourceEndLine(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceEndLine(label);
-        }
-        return 0;
-      }
-
-      public override int SourceStartColumn(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceStartColumn(label);
-        }
-        return 0;
-      }
-
-      public override int SourceEndColumn(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceEndColumn(label);
-        }
-        return 0;
-      }
-
-      public override int SourceStartIndex(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceStartIndex(label);
-        }
-        return 0;
-      }
-
-      public override int SourceLength(APC pc) {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.SourceLength(label);
-        }
-        return 0;
-      }
-
-      public override int ILOffset(APC pc)
-      {
-        Label label;
-        if (this.UnderlyingLabelForward(pc.Index, out label)) {
-          return this.subroutine.ILOffset(label);
-        }
-        return 0;
-      }
-
-      internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      {
-        Label/*?*/ lab;
-        if (this.UnderlyingLabelForward(pc.Index, out lab)) {
-          var decoder = this.subroutine.CodeProvider;
-          return decoder.Decode<LabelAdapter<Data, Result, Visitor>, Data, Result>(lab, new LabelAdapter<Data, Result, Visitor>(visitor, pc), data);
-        }
-        else {
-          return visitor.Nop(pc, data);
-        }
-      }
-
-      #region APC -> Label adapter visitor. Also turns Aggregate into Nops, i.e., adapts ICodeQuery to IVisitMSIL
-
-      protected struct LabelAdapter<Data, Result, Visitor> :
-        ICodeQuery<Label, Local, Parameter, Method, Field, Type, Data, Result>
-        where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result> {
-        APC originalPC;
-        Visitor visitor;
-
-        public LabelAdapter(
-          Visitor visitor,
-          APC origPC
-        )
-        {
-          this.visitor = visitor;
-          this.originalPC = origPC;
-        }
-
-        APC ConvertLabel(Label pc)
-        {
-          // we return the stored pc here, as the underlying decoder only dealt with a label
-          // this works because we never translate branch target labels.
-          return this.originalPC;
-        }
-
-        /// <summary>
-        /// Map a label occurring in a begin_old/end_old to an apc.
-        /// </summary>
-        private APC ConvertMatchingBeginLabel(Label underlying)
-        {
-          Contract.Assume(this.originalPC.Block != null); // F: made it an assumption
-
-          OldValueSubroutine<Label> subroutine = (OldValueSubroutine<Label>)this.originalPC.Block.Subroutine;
-
-          return subroutine.BeginOldAPC(this.originalPC.SubroutineContext);
-        }
-        private APC ConvertMatchingEndLabel(Label underlying)
-        {
-          Contract.Assume(this.originalPC.Block != null); // F: made it an assumption
-          OldValueSubroutine<Label> subroutine = (OldValueSubroutine<Label>)this.originalPC.Block.Subroutine;
-
-          return subroutine.EndOldAPC(this.originalPC.SubroutineContext);
-        }
-
-        public Result Aggregate(Label pc, Label nested, bool branchTarget, Data data)
-        {
-          return visitor.Nop(ConvertLabel(pc), data);
-        }
-
-        public Result Assume(Label pc, string tag, UnitSource source, object provenance, Data data)
-        {
-          return visitor.Assume(ConvertLabel(pc), tag, source, provenance, data);
-        }
-
-        public Result Assert(Label pc, string tag, UnitSource source, object provenance, Data data)
-        {
-          return visitor.Assert(ConvertLabel(pc), tag, source, provenance, data);
-        }
-
-        public Result Arglist(Label pc, UnitDest dest, Data data)
-        {
-          return visitor.Arglist(ConvertLabel(pc), dest, data);
-        }
-
-        public Result Binary(Label pc, BinaryOperator op, UnitDest dest, UnitSource s1, UnitSource s2, Data data)
-        {
-          return visitor.Binary(ConvertLabel(pc), op, dest, s1, s2, data);
-        }
-
-        public Result BranchCond(Label pc, Label target, BranchOperator bop, UnitSource value1, UnitSource value2, Data data)
-        {
-          return visitor.BranchCond(ConvertLabel(pc), ConvertLabel(target), bop, value1, value2, data);
-        }
-
-        public Result BranchTrue(Label pc, Label target, UnitSource cond, Data data)
-        {
-          return visitor.BranchTrue(ConvertLabel(pc), ConvertLabel(target), cond, data);
-        }
-
-        public Result BranchFalse(Label pc, Label target, UnitSource cond, Data data)
-        {
-          return visitor.BranchFalse(ConvertLabel(pc), ConvertLabel(target), cond, data);
-        }
-
-        public Result Branch(Label pc, Label target, bool leave, Data data)
-        {
-          return visitor.Branch(ConvertLabel(pc), ConvertLabel(target), leave, data);
-        }
-
-        public Result Break(Label pc, Data data)
-        {
-          return visitor.Break(ConvertLabel(pc), data);
-        }
-
-        public Result Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.Call(ConvertLabel(pc), method, tail, virt, extraVarargs, dest, args, data);
-        }
-
-        public Result Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, UnitDest dest, UnitSource fp, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.Calli(ConvertLabel(pc), returnType, argTypes, tail, isInstance, dest, fp, args, data);
-        }
-
-        public Result Ckfinite(Label pc, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Ckfinite(ConvertLabel(pc), dest, source, data);
-        }
-
-        public Result Cpblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource srcaddr, UnitSource len, Data data)
-        {
-          return visitor.Cpblk(ConvertLabel(pc), @volatile, destaddr, srcaddr, len, data);
-        }
-
-        public Result Endfilter(Label pc, UnitSource decision, Data data)
-        {
-          return visitor.Endfilter(ConvertLabel(pc), decision, data);
-        }
-
-        public Result Endfinally(Label pc, Data data)
-        {
-          return visitor.Endfinally(ConvertLabel(pc), data);
-        }
-
-        public Result Entry(Label pc, Method method, Data data)
-        {
-          return visitor.Entry(ConvertLabel(pc), method, data);
-        }
-
-        public Result Initblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource value, UnitSource len, Data data)
-        {
-          return visitor.Initblk(ConvertLabel(pc), @volatile, destaddr, value, len, data);
-        }
-
-        public Result Jmp(Label pc, Method method, Data data)
-        {
-          return visitor.Jmp(ConvertLabel(pc), method, data);
-        }
-
-        /// <summary>
-        /// Could be access to "this" in an invariant code sequence. Map to "this" in surrounding using method.
-        /// </summary>
-        public Result Ldarg(Label pc, Parameter argument, bool isOld, UnitDest dest, Data data)
-        {
-          return visitor.Ldarg(ConvertLabel(pc), argument, isOld, dest, data);
-        }
-
-        public Result Ldarga(Label pc, Parameter argument, bool isOld, UnitDest dest, Data data)
-        {
-          return visitor.Ldarga(ConvertLabel(pc), argument, isOld, dest, data);
-        }
-
-        public Result Ldconst(Label pc, object constant, Type type, UnitDest dest, Data data)
-        {
-          return visitor.Ldconst(ConvertLabel(pc), constant, type, dest, data);
-        }
-
-        public Result Ldnull(Label pc, UnitDest dest, Data data)
-        {
-          return visitor.Ldnull(ConvertLabel(pc), dest, data);
-        }
-
-        public Result Ldftn(Label pc, Method method, UnitDest dest, Data data)
-        {
-          return visitor.Ldftn(ConvertLabel(pc), method, dest, data);
-        }
-
-        public Result Ldind(Label pc, Type type, bool @volatile, UnitDest dest, UnitSource ptr, Data data)
-        {
-          return visitor.Ldind(ConvertLabel(pc), type, @volatile, dest, ptr, data);
-        }
-
-        public Result Ldloc(Label pc, Local local, UnitDest dest, Data data)
-        {
-          return visitor.Ldloc(ConvertLabel(pc), local, dest, data);
-        }
-
-        public Result Ldloca(Label pc, Local local, UnitDest dest, Data data)
-        {
-          return visitor.Ldloca(ConvertLabel(pc), local, dest, data);
-        }
-
-        public Result Ldstack(Label pc, int offset, UnitDest dest, UnitSource source, bool isOld, Data data)
-        {
-          return visitor.Ldstack(ConvertLabel(pc), offset, dest, source, isOld, data);
-        }
-
-        public Result Ldstacka(Label pc, int offset, UnitDest dest, UnitSource source, Type type, bool isOld, Data data)
-        {
-          return visitor.Ldstacka(ConvertLabel(pc), offset, dest, source, type, isOld, data);
-        }
-
-        public Result Localloc(Label pc, UnitDest dest, UnitSource size, Data data)
-        {
-          return visitor.Localloc(ConvertLabel(pc), dest, size, data);
-        }
-
-        public Result Nop(Label pc, Data data)
-        {
-          return visitor.Nop(ConvertLabel(pc), data);
-        }
-
-        public Result Pop(Label pc, UnitSource source, Data data)
-        {
-          return visitor.Pop(ConvertLabel(pc), source, data);
-        }
-
-        public Result Return(Label pc, UnitSource source, Data data)
-        {
-          return visitor.Return(ConvertLabel(pc), source, data);
-        }
-
-        public Result Starg(Label pc, Parameter argument, UnitSource source, Data data)
-        {
-          return visitor.Starg(ConvertLabel(pc), argument, source, data);
-        }
-
-        public Result Stind(Label pc, Type type, bool @volatile, UnitSource ptr, UnitSource value, Data data)
-        {
-          return visitor.Stind(ConvertLabel(pc), type, @volatile, ptr, value, data);
-        }
-
-        public Result Stloc(Label pc, Local local, UnitSource source, Data data)
-        {
-          return visitor.Stloc(ConvertLabel(pc), local, source, data);
-        }
-
-        public Result Switch(Label pc, Type type, IEnumerable<Pair<object,Label>> cases, UnitSource value, Data data)
-        {
-          return visitor.Nop(this.originalPC, data);
-        }
-
-        public Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Unary(ConvertLabel(pc), op, overflow, unsigned, dest, source, data);
-        }
-
-        public Result Box(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Box(ConvertLabel(pc), type, dest, source, data);
-        }
-
-        public Result ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.ConstrainedCallvirt(ConvertLabel(pc), method, tail, constraint, extraVarargs, dest, args, data);
-        }
-
-        public Result Castclass(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Castclass(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Cpobj(Label pc, Type type, UnitSource destptr, UnitSource srcptr, Data data)
-        {
-          return visitor.Cpobj(ConvertLabel(pc), type, destptr, srcptr, data);
-        }
-
-        public Result Initobj(Label pc, Type type, UnitSource ptr, Data data)
-        {
-          return visitor.Initobj(ConvertLabel(pc), type, ptr, data);
-        }
-
-        public Result Isinst(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Isinst(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Ldelem(Label pc, Type type, UnitDest dest, UnitSource array, UnitSource index, Data data)
-        {
-          return visitor.Ldelem(ConvertLabel(pc), type, dest, array, index, data);
-        }
-
-        public Result Ldelema(Label pc, Type type, bool @readonly, UnitDest dest, UnitSource array, UnitSource index, Data data)
-        {
-          return visitor.Ldelema(ConvertLabel(pc), type, @readonly, dest, array, index, data);
-        }
-
-        public Result Ldfld(Label pc, Field field, bool @volatile, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Ldfld(ConvertLabel(pc), field, @volatile, dest, obj, data);
-        }
-
-        public Result Ldflda(Label pc, Field field, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Ldflda(ConvertLabel(pc), field, dest, obj, data);
-        }
-
-        public Result Ldlen(Label pc, UnitDest dest, UnitSource array, Data data)
-        {
-          return visitor.Ldlen(ConvertLabel(pc), dest, array, data);
-        }
-
-        public Result Ldsfld(Label pc, Field field, bool @volatile, UnitDest dest, Data data)
-        {
-          return visitor.Ldsfld(ConvertLabel(pc), field, @volatile, dest, data);
-        }
-
-        public Result Ldsflda(Label pc, Field field, UnitDest dest, Data data)
-        {
-          return visitor.Ldsflda(ConvertLabel(pc), field, dest, data);
-        }
-
-        public Result Ldtypetoken(Label pc, Type type, UnitDest dest, Data data)
-        {
-          return visitor.Ldtypetoken(ConvertLabel(pc), type, dest, data);
-        }
-
-        public Result Ldfieldtoken(Label pc, Field field, UnitDest dest, Data data)
-        {
-          return visitor.Ldfieldtoken(ConvertLabel(pc), field, dest, data);
-        }
-
-        public Result Ldmethodtoken(Label pc, Method method, UnitDest dest, Data data)
-        {
-          return visitor.Ldmethodtoken(ConvertLabel(pc), method, dest, data);
-        }
-
-        public Result Ldvirtftn(Label pc, Method method, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Ldvirtftn(ConvertLabel(pc), method, dest, obj, data);
-        }
-
-        public Result Mkrefany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Mkrefany(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Newarray<ArgList>(Label pc, Type type, UnitDest dest, ArgList lengths, Data data)
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.Newarray(ConvertLabel(pc), type, dest, lengths, data);
-        }
-
-        public Result Newobj<ArgList>(Label pc, Method ctor, UnitDest dest, ArgList args, Data data)
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.Newobj(ConvertLabel(pc), ctor, dest, args, data);
-        }
-
-        public Result Refanytype(Label pc, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Refanytype(ConvertLabel(pc), dest, source, data);
-        }
-
-        public Result Refanyval(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Refanyval(ConvertLabel(pc), type, dest, source, data);
-        }
-
-        public Result Rethrow(Label pc, Data data)
-        {
-          return visitor.Rethrow(ConvertLabel(pc), data);
-        }
-
-        public Result Sizeof(Label pc, Type type, UnitDest dest, Data data)
-        {
-          return visitor.Sizeof(ConvertLabel(pc), type, dest, data);
-        }
-
-        public Result Stelem(Label pc, Type type, UnitSource array, UnitSource index, UnitSource value, Data data)
-        {
-          return visitor.Stelem(ConvertLabel(pc), type, array, index, value, data);
-        }
-
-        public Result Stfld(Label pc, Field field, bool @volatile, UnitSource obj, UnitSource value, Data data)
-        {
-          return visitor.Stfld(ConvertLabel(pc), field, @volatile, obj, value, data);
-        }
-
-        public Result Stsfld(Label pc, Field field, bool @volatile, UnitSource value, Data data)
-        {
-          return visitor.Stsfld(ConvertLabel(pc), field, @volatile, value, data);
-        }
-
-        public Result Throw(Label pc, UnitSource exn, Data data)
-        {
-          return visitor.Throw(ConvertLabel(pc), exn, data);
-        }
-
-        public Result Unbox(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Unbox(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Unboxany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Unboxany(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-
-        #region IVisitSynthIL<Label,Method2,Source,Dest,Data,Result> Members
-
-
-        public Result BeginOld(Label pc, Label matchingEnd, Data data)
-        {
-          // special treatment of beginold decoding in the context of an old manifestation.
-          if (this.originalPC.InsideOldManifestation)
-          {
-            return visitor.Nop(ConvertLabel(pc), data);
-          }
-
-          return visitor.BeginOld(ConvertLabel(pc), ConvertMatchingEndLabel(matchingEnd), data);
-        }
-
-        public Result EndOld(Label pc, Label matchingBegin, Type type, UnitDest dest, UnitSource source, Data data)
-        {
-          // special treatment of beginold decoding is done in the stack decoder, as it 
-          // needs to know the specialness of endOld to generate the appropriate copy
-          return visitor.EndOld(ConvertLabel(pc), ConvertMatchingBeginLabel(matchingBegin), type, dest, source, data);
-        }
-
-        public Result Ldresult(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Ldresult(ConvertLabel(pc), type, dest, source, data);
-        }
-
-        #endregion
-      }
-
-
-      #endregion
-
-      #endregion
-
-
-      /// <summary>
-      /// For debugging
-      /// </summary>
-      //^ [Confined]
-      public override string/*!*/ ToString()
-      {
-        return this.Index.ToString();
-      }
-
-      #region IEquatable<CFGBlock<Label>> Members
-
-      //^ [StateIndependent]
-      public bool Equals(BlockWithLabels<Label> other)
-      {
-        return this == other;
-      }
-
-      #endregion
-
-    }
-
-    internal class EnsuresBlock<Label> : BlockWithLabels<Label>
-    {
-      const int BeginOldMask = unchecked((int)0x80000000);
-      const int EndOldMask = 0x40000000;
-      const int Mask = unchecked((int)0xC0000000);
-
-      /// <summary>
-      /// The integers are used as follows:
-      /// - if no Mask bits are set, then it's the index of a label in the underlying
-      ///   label list
-      /// - otherwise, the mask bits indicate if it is a begin old or an end old and
-      ///   the remaining bits provide the index of the corresponding end/begin within
-      ///   the corresponding block (which is stored on the subroutine).
-      /// </summary>
-      List<int> overridingLabels;
-
-      public EnsuresBlock(SubroutineBase<Label> container, ref int idgen)
-        : base(container, ref idgen)
-      {
-        Contract.Requires(container != null);// F: As of Clousot suggestion
-        Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
-        Contract.Ensures(idgen >= 0);
-
-      }
-
-      internal bool UsesOverriding { get { return this.overridingLabels != null; } }
-
-      new EnsuresSubroutine<Label> Subroutine { get { return (EnsuresSubroutine<Label>)base.Subroutine; } }
-
-      public override int Count
-      {
-        get
-        {
-          if (overridingLabels != null) return overridingLabels.Count;
-          return base.Count;
-        }
-      }
-
-      bool IsOriginal(int index, out int originalOffset)
-      {
-        Contract.Requires(index >= 0);
-
-        if (overridingLabels == null)
-        {
-          originalOffset = index;
-          return true;
-        }
-        if (index < this.overridingLabels.Count && (this.overridingLabels[index] & Mask) == 0)
-        {
-          originalOffset = this.overridingLabels[index] & ~Mask;
-          return true;
-        }
-        originalOffset = 0;
-        return false;
-      }
-
-      bool IsBeginOld(int index, out int endOldIndex)
-      {
-        Contract.Requires(index >= 0);
-
-        if (overridingLabels == null || index >= overridingLabels.Count)
-        {
-          endOldIndex = 0;
-          return false;
-        }
-        if ((this.overridingLabels[index] & BeginOldMask) != 0)
-        {
-          endOldIndex = this.overridingLabels[index] & ~Mask;
-          return true;
-        }
-        endOldIndex = 0;
-        return false;
-      }
-
-      bool IsEndOld(int index, out int beginOldIndex)
-      {
-        Contract.Requires(index >= 0);
-
-        if (overridingLabels == null || index >= overridingLabels.Count)
-        {
-          beginOldIndex = 0;
-          return false;
-        }
-        if ((this.overridingLabels[index] & EndOldMask) != 0)
-        {
-          beginOldIndex = this.overridingLabels[index] & ~Mask;
-          return true;
-        }
-        beginOldIndex = 0;
-        return false;
-      }
-
-      internal override bool UnderlyingLabelForward(int index, out Label label)
-      {
-        Contract.Assert(index >= 0);
-
-        int originalOffset;
-        if (IsOriginal(index, out originalOffset))
-        {
-          Contract.Assume(originalOffset >= 0); // F: suggested by Clousot
-          return base.UnderlyingLabelForward(originalOffset, out label);
-        }
-        label = default(Label);
-        return false;
-      }
-
-
-      internal Result OriginalForwardDecode<Data, Result, Visitor>(int index, Visitor visitor, Data data)
-        where Visitor : ICodeQuery<Label, Local, Parameter, Method, Field, Type, Data, Result>
-      {
-        Contract.Assume(index >= 0);
-        Label/*?*/ lab;
-        if (base.UnderlyingLabelForward(index, out lab)) {
-          Contract.Assume(this.subroutine.CodeProvider != null); // F: made it an assumption
-          return this.subroutine.CodeProvider.Decode<Visitor, Data,Result>(lab, visitor, data);
-        }
-        throw new NotImplementedException();
-      }
-
-      internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      {
-        Label/*?*/ lab;
-        if (this.UnderlyingLabelForward(pc.Index, out lab)) {
-          return base.ForwardDecode<Data, Result, Visitor>(pc, visitor, data);
-        }
-        int endOldIndex;
-        if (IsBeginOld(pc.Index, out endOldIndex))
-        {
-          var endBlock = this.Subroutine.InferredBeginEndBijection(pc);
-          return visitor.BeginOld(pc, new APC(endBlock, endOldIndex, pc.SubroutineContext), data);
-        }
-        int beginOldIndex;
-        if (IsEndOld(pc.Index, out beginOldIndex))
-        {
-          Type endOldType;
-          var beginBlock = this.Subroutine.InferredBeginEndBijection(pc, out endOldType);
-          return visitor.EndOld(pc, new APC(beginBlock, beginOldIndex, pc.SubroutineContext), endOldType, Unit.Value, Unit.Value, data);
-        }
-        return visitor.Nop(pc, data);
-      }
-
-
-      internal void StartOverridingLabels()
-      {
-        Contract.Assume(this.overridingLabels == null); // F: as of Clousot Suggestion - but it seems something is wrong, so we make it an assume
-        Debug.Assert(this.overridingLabels == null);
-        this.overridingLabels = new List<int>();
-      }
-
-      internal void BeginOld(int index)
-      {
-        if (this.overridingLabels == null)
-        {
-          StartOverridingLabels();
-          for (int i=0; i<index; i++) {
-            this.overridingLabels.Add(i); // original instructions up to but not including index
-          }
-        }
-        // temporary begin_old without corresponding end old index
-        this.overridingLabels.Add(BeginOldMask);
-      }
-
-      internal void AddInstruction(int index)
-      {
-        Contract.Assume(this.overridingLabels != null); // F: As of Clousot suggestion - It seems something is wrong with visibility check, so we made it an assume
-        // add original instruction
-        this.overridingLabels.Add(index);
-      }
-
-
-      internal void EndOld(int index, Type nextEndOldType)
-      {
-        AddInstruction(index);
-        EndOldWithoutInstruction(nextEndOldType);
-      }
-
-      internal void EndOldWithoutInstruction(Type nextEndOldType)
-      {
-        Contract.Assume(this.overridingLabels != null); // F: As of Clousot suggestion - It seems something is wrong with visibility check, so we made it an assume
-
-        int endOldIndex = this.overridingLabels.Count;
-        CFGBlock beginBlock;
-        int correspondingBeginOldIndex = PatchPriorBeginOld(this, endOldIndex, out beginBlock);
-        this.overridingLabels.Add(EndOldMask | correspondingBeginOldIndex);
-        this.Subroutine.AddInferredOldMap(this.Index, endOldIndex, beginBlock, nextEndOldType);
-      }
-
-      private int PatchPriorBeginOld(CFGBlock endBlock, int endOldIndex, out CFGBlock beginBlock)
-      {
-        var startIndex = (this == endBlock) ? endOldIndex - 2 : this.Count - 1;
-        for (int i = startIndex; i >= 0; i--)
-        {
-          int dummy;
-          if (IsBeginOld(i, out dummy))
-          {
-            Contract.Assume(dummy == 0);
-            Contract.Assume(i < overridingLabels.Count);
-            overridingLabels[i] = BeginOldMask | endOldIndex;
-            beginBlock = this;
-            this.Subroutine.AddInferredOldMap(this.Index, i, endBlock, default(Type));
-            return i;
-          }
-        }
-        // if we get here the begin/end spans multiple blocks:
-        var preds = this.subroutine.PredecessorBlocks(this).GetEnumerator();
-        if (preds.MoveNext()) {
-          var beginOldIndex = PatchPriorBeginOld(endBlock, endOldIndex, preds.Current, out beginBlock);
-          var next = preds.MoveNext();
-          Contract.Assume(!next); // F: made an assume
-          return beginOldIndex;
-        }
-        throw new InvalidOperationException("missing begin_old");
-      }
-
-      private static int PatchPriorBeginOld(CFGBlock endBlock, int endOldIndex, CFGBlock current, out CFGBlock beginBlock)
-      {
-        Contract.Requires(current != null); // F: it seems it is a precondition?
-        
-        EnsuresBlock<Label> pred = current as EnsuresBlock<Label>;
-        if (pred == null)
-        {
-          // skip this block
-          // if we get here the begin/end spans multiple blocks:
-
-          var preds = current.Subroutine.PredecessorBlocks(current).GetEnumerator();
-          if (preds.MoveNext()) {
-            var beginOldIndex = PatchPriorBeginOld(endBlock, endOldIndex, preds.Current, out beginBlock);
-            bool next = preds.MoveNext();
-            Contract.Assume(!next); // F: made an assume
-            return beginOldIndex;
-          }
-          throw new InvalidOperationException("missing begin_old");
-        }
-        return pred.PatchPriorBeginOld(endBlock, endOldIndex, out beginBlock);
-      }
-    }
-
-
-    /// <summary>
-    /// Used for separate blocks that call methods for which we have pre/post conditions
-    /// </summary>
-    internal class MethodCallBlock<Label> : BlockWithLabels<Label> {
-      public readonly Method CalledMethod;
-      public readonly bool Virtual;
-      readonly int parameterCount;
-
-      public MethodCallBlock(Method method, bool virtcall, IDecodeMetaData<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly> mdDecoder, SubroutineBase<Label> container, ref int idgen)
-        : base(container, ref idgen)
-      {
-        Contract.Requires(mdDecoder != null);// F: Added as of Clousot suggestion
-        Contract.Requires(container != null);// F: As of Clousot suggestion
-        Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
-        Contract.Ensures(idgen >= 0);
-
-        this.CalledMethod = method;
-        this.Virtual = virtcall;
-        this.parameterCount = mdDecoder.Parameters(method).AssumeNotNull().Count;
-      }
-
-      public override bool IsMethodCallBlock<Method2>(out Method2 calledMethod, out bool isNewObj, out bool isVirtual)
-      {
-        if (this.CalledMethod is Method2)
-        {
-          calledMethod = (Method2)(object)this.CalledMethod;
-          isNewObj = this.IsNewObj;
-          isVirtual = this.Virtual;
-          return true;
-        }
-        calledMethod = default(Method2);
-        isNewObj = false;
-        isVirtual = false;
-        return false;
-      }
-
-      internal virtual bool IsNewObj
-      {
-        get { return false; }
-      }
-    }
-
-
-    internal class NewObjCallBlock<Label> : MethodCallBlock<Label>
-    {
-      public NewObjCallBlock(Method method, IDecodeMetaData<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly> mdDecoder, SubroutineBase<Label> container, ref int idgen)
-        : base(method, false, mdDecoder, container, ref idgen)
-      {
-        Contract.Requires(mdDecoder != null);// F: As of Clousot suggestion
-        Contract.Requires(container != null);// F: As of Clousot suggestion
-        Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
-
-        Contract.Ensures(idgen >= 0);
-      }
-
-      internal override bool IsNewObj
-      {
-        get
-        {
-          return true;
-        }
-      }
-    }
-
-    /// <summary>
-    /// an assume block that stores the return value of a function in the appropriate local var first
-    /// </summary>
-    /// <typeparam name="Label"></typeparam>
-    internal class AssumeAsPostConditionEntryBlock<Label> : BlockWithLabels<Label>
-    {
-      public readonly Tag Tag;
-      public readonly Local LocalRetval;
-      public readonly Parameter ParamRetval;
-      public readonly Field FieldRetval;
-      private readonly AssumeAsPostConditionSubroutine<Label>.RetvalType RetvalType;
-
-      public AssumeAsPostConditionEntryBlock(SubroutineBase<Label> container, Local localRetval, Parameter paramRetval, Field fieldRetval, AssumeAsPostConditionSubroutine<Label>.RetvalType retvalType, string tag, ref int idgen)
-        : base(container, ref idgen)
-      {
-        Contract.Requires(container != null);
-        Contract.Requires(idgen >= 0);
-
-        Contract.Ensures(idgen >= 0);
-
-        this.Tag = tag;
-        this.LocalRetval = localRetval;
-        this.ParamRetval = paramRetval;
-        this.FieldRetval = fieldRetval;
-        this.RetvalType = retvalType;
-      }
-
-      public override int Count { get { return 2; } } // synthetic instruction
-
-      #region ISelfDecode<Label,Method,Type> Members
-
-      internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      {
-        if (pc.Index == 0)
+        [Pure]
+        internal static int GetKey(Subroutine s)
         {
-            return visitor.Ldstack(pc, 0, Unit.Value, Unit.Value, false, data);
-        }
-        else if (pc.Index == 1) {
-            switch (RetvalType)
-            {
-              case (AssumeAsPostConditionSubroutine<Label>.RetvalType.LocalRetval):
-                {
-                  return visitor.Stloc(pc, this.LocalRetval, Unit.Value, data);
-                }
-              case (AssumeAsPostConditionSubroutine<Label>.RetvalType.ParameterRetval):
-                {
-                  return visitor.Starg(pc, this.ParamRetval, Unit.Value, data);
-                }
-              case (AssumeAsPostConditionSubroutine<Label>.RetvalType.FieldRetval):
-                {
-                  return visitor.Stfld(pc, this.FieldRetval, false, Unit.Value, Unit.Value, data);
-                }
-              default:
-                {
-                  return visitor.Nop(pc, data);
-                }
-            }
-        }
-        else
-        {
-            return visitor.Nop(pc, data);
-        }
-      }
-      #endregion
-    }
-
-    internal class AssumeAsPostConditionExitBlock<Label> : BlockWithLabels<Label>
-    {
-        public readonly Tag Tag;
-        public readonly Local Retval;
-        public readonly Label BranchLabel;
-        public AssumeAsPostConditionExitBlock(SubroutineBase<Label> container, Local retval, Label label, string tag, ref int idgen)
-            : base(container, ref idgen)
-        {
-            Contract.Requires(container != null);// F: As of Clousot suggestion
-            Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
-            Contract.Ensures(idgen >= 0);
-
-            this.Tag = tag;
-            this.BranchLabel = label;
-            this.Retval = retval;
+            Contract.Requires(s != null);
+            return s.Id;
         }
 
-        public override int Count { get { return 1; } } // synthetic instruction
 
-        #region ISelfDecode<Label,Method,Type> Members
+        #region IEquatable<Subroutine> Members
 
-        internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+        public bool Equals(Subroutine that)
         {
-            if (pc.Index == 0)
-            {
-                return visitor.Ldloc(pc, this.Retval, Unit.Value, data);
-            }
-            else
-            {
-                return visitor.Nop(pc, data);
-            }
+            return this == that;
         }
 
         #endregion
     }
 
-    internal class AssumeBlock<Label> : BlockWithLabels<Label>
+    #region Subroutine contract binding
+    [ContractClass(typeof(SubroutineContract))]
+    public abstract partial class Subroutine { }
+
+    [ContractClassFor(typeof(Subroutine))]
+    internal abstract class SubroutineContract : Subroutine
     {
-      public readonly Tag Tag;
-      public readonly Label BranchLabel;
-      public AssumeBlock(SubroutineBase<Label> container, Label label, string tag, ref int idgen)
-        : base(container, ref idgen)
-      {
-        Contract.Requires(container != null);// F: As of Clousot suggestion
-        Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
-
-        Contract.Ensures(idgen >= 0);
-
-        this.Tag = tag;
-        this.BranchLabel = label;
-      }
-
-      public override int Count { get { return 1; } } // synthetic instruction
-
-
-
-      #region ISelfDecode<Label,Method,Type> Members
-
-      internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      {
-        if (pc.Index == 0) {
-          return visitor.Assume(pc, this.Tag, Unit.Value, null, data);
-        }
-        else {
-          return visitor.Nop(pc, data);
-        }
-      }
-
-      #endregion
-    }
-
-
-    /// <summary>
-    /// Encodes 3 synthetic instructions
-    ///
-    ///   ldc c
-    ///   ceq
-    ///   assume
-    ///
-    /// </summary>
-    internal class SwitchCaseAssumeBlock<Label> : BlockWithLabels<Label>
-    {
-      readonly Label SwitchLabel;
-      readonly object Pattern;
-      readonly Type Type;
-
-      public SwitchCaseAssumeBlock(SubroutineBase<Label> container, Label switchLabel, object pattern, Type type, ref int idgen)
-        : base(container, ref idgen)
-      {
-        Contract.Requires(container != null);
-        Contract.Requires(idgen >= 0);
-        Contract.Ensures(idgen >= 0);
-
-        this.SwitchLabel = switchLabel;
-        this.Pattern = pattern;
-        this.Type = type;
-      }
-
-      public override int Count { get { return 3; } } // synthetic instructions
-
-
-      internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      {
-        if (pc.Index == 0) {
-          return visitor.Ldconst(pc, this.Pattern, this.Type, Unit.Value, data);
-        }
-        else if (pc.Index == 1) {
-          return visitor.Binary(pc, BinaryOperator.Ceq, Unit.Value, Unit.Value, Unit.Value, data);
-        }
-        else if (pc.Index == 2) {
-          return visitor.Assume(pc, "true", Unit.Value, null, data);
-        }
-        else {
-          return visitor.Nop(pc, data);
-        }
-
-      }
-    }
-
-    /// <summary>
-    /// Compares switched value against all constants c_i suing the following structure
-    /// </summary>
-    internal class SwitchDefaultAssumeBlock<Label> : BlockWithLabels<Label>
-    {
-      #region Object invariant
-      [ContractInvariantMethod]
-      [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.Patterns != null);
-      }
-      #endregion
-
-      readonly Label SwitchLabel;
-      readonly List<object> Patterns;
-      readonly Type Type;
-
-      public SwitchDefaultAssumeBlock(SubroutineBase<Label> container, Label label, List<object> patterns, Type type, ref int idgen)
-        : base(container, ref idgen) {
-          Contract.Requires(container != null);// F: As of Clousot suggestion
-          Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
-
-          Contract.Ensures(idgen >= 0);
-
-        this.SwitchLabel = label;
-        this.Patterns = patterns;
-        this.Type = type;
-      }
-
-      public override int Count { get { return this.Patterns.Count*4 + 1; } } // synthetic instruction
-
-      internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      {
-        int caseNum = pc.Index / 4;
-        if (caseNum < this.Patterns.Count) {
-          int withinInstr = pc.Index % 4;
-          switch (withinInstr) {
-            case 0:
-              return visitor.Ldstack(pc, 0, Unit.Value, Unit.Value, false, data);
-            case 1:
-              Contract.Assume(caseNum >= 0);
-              return visitor.Ldconst(pc, this.Patterns[caseNum], this.Type, Unit.Value, data);
-            case 2:
-              return visitor.Binary(pc, BinaryOperator.Cne_Un, Unit.Value, Unit.Value, Unit.Value, data);
-            case 3:
-              return visitor.Assume(pc, "true", Unit.Value, null, data);
-          }
-        }
-        else if (caseNum == this.Patterns.Count && pc.Index % 4 == 0) {
-          // finally pop it.
-          return visitor.Pop(pc, Unit.Value, data);
-        }
-        return visitor.Nop(pc, data);
-
-      }
-
-    }
-
-    /// <summary>
-    /// Special entry and exit block that has one program point for Entry synthetic instruction or Ret
-    /// </summary>
-    internal class EntryExitBlock<Label> : BlockWithLabels<Label>
-    {
-      public EntryExitBlock(SubroutineBase<Label> container, ref int idGen) : base(container, ref idGen) 
-      {
-        Contract.Requires(container != null);// F: As of Clousot suggestion
-        Contract.Requires(idGen >= 0);// F: As of Clousot suggestion
-      }
-
-      public override int Count { get { return 1; } } /// synthetic instruction
-    }
-
-    /// <summary>
-    /// Special entry block that self decodes first instruction to Entry
-    /// </summary>
-    internal class EntryBlock<Label> : EntryExitBlock<Label>
-    {
-      public EntryBlock(SubroutineBase<Label> container, ref int idGen)
-        : base(container, ref idGen) {
-
-          Contract.Requires(container != null);
-          Contract.Requires(idGen >= 0);
-
-          Contract.Ensures(idGen >= 0);
-      }
-
-      internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      {
-        if (pc.Index == 0 && pc.SubroutineContext == null && this.Subroutine.IsMethod) {
-          IMethodInfo<Method> ms = (IMethodInfo<Method>)this.Subroutine;
-          return visitor.Entry(pc, ms.Method, data);
-        }
-        return visitor.Nop(pc, data);
-      }
-
-    }
-
-    /// <summary>
-    /// Used to mark catch filter header blocks.
-    /// </summary>
-    internal class CatchFilterEntryBlock<Label> : BlockWithLabels<Label>
-    {
-      public CatchFilterEntryBlock(SubroutineBase<Label> container, ref int idgen)
-        : base(container, ref idgen)
-      {
-        Contract.Requires(container != null);// F: As of Clousot suggestion
-        Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
-      }
-    }
-
-
-
-    internal abstract class SubroutineBase<Label> : Subroutine, IGraph<CFGBlock, Unit>, IStackInfo, IEdgeSubroutineAdaptor
-    {
-
-      #region -------------- Fields ------------------------
-
-      private BlockWithLabels<Label> entry;
-      private readonly BlockWithLabels<Label> exit;
-      private readonly CatchFilterEntryBlock<Label> exceptionExit;
-      protected readonly Label startLabel;
-      private BlockWithLabels<Label> entryAfterRequires; // possibly null
-
-      protected int blockIdGenerator = 0;
-
-      /// <summary>
-      /// Holds the map from labels that start a block to their block
-      /// </summary>
-      protected Dictionary<Label, BlockWithLabels<Label>> BlockStart = new Dictionary<Label, BlockWithLabels<Label>>();
-
-      protected readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache;
-      protected SubroutineBuilder<Label> Builder;
-
-      private readonly List<Pair<CFGBlock, Pair<string, CFGBlock>>> successors = new List<Pair<CFGBlock,Pair<string,CFGBlock>>>();
-
-      internal readonly ICodeProvider<Label, Local, Parameter, Method, Field, Type> CodeProvider; // F: it seems it may be null
-
-      protected CFGBlock[] blocks;
-
-      /// <summary>
-      /// Stored in last to first order (thus easy to append)
-      ///
-      /// The string is a tag for what kind of call-edge it is.
-      /// </summary>
-      protected OnDemandMap<Pair<CFGBlock, CFGBlock>, FList<Pair<string, Subroutine>>> edgeSubroutines;
-
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(this.successors != null);
-        Contract.Invariant(this.MethodCache != null);
-        Contract.Invariant(entry != null);
-        Contract.Invariant(exit != null);
-        Contract.Invariant(exceptionExit != null);
-        Contract.Invariant(this.blockIdGenerator >= 0);
-        Contract.Invariant(this.BlockStart != null || this.Builder == null);
-      }
-
-      #endregion // fields
-
-      #region -------------- Private helpers --------------
-
-      internal AssumeAsPostConditionEntryBlock<Label> NewAssumeAsPostConditionEntryBlock(Local localRetval, Parameter paramRetval, Field fieldRetval, AssumeAsPostConditionSubroutine<Label>.RetvalType retvalType, Tag tag)
-      {
-        return new AssumeAsPostConditionEntryBlock<Label>(this, localRetval, paramRetval, fieldRetval, retvalType, tag, ref this.blockIdGenerator);
-      }
-
-      internal AssumeAsPostConditionExitBlock<Label> NewAssumeAsPostConditionExitBlock(Local retval, Label assume, Tag tag)
-      {
-          return new AssumeAsPostConditionExitBlock<Label>(this, retval, assume, tag, ref this.blockIdGenerator);
-      }
-
-      internal AssumeBlock<Label> NewAssumeBlock(Label current, Tag tag)
-      {
-        return new AssumeBlock<Label>(this, current, tag, ref this.blockIdGenerator);
-      }
-
-      internal SwitchCaseAssumeBlock<Label> NewSwitchCaseAssumeBlock(Label current, object pattern, Type type)
-      {
-        return new SwitchCaseAssumeBlock<Label>(this, current, pattern, type, ref this.blockIdGenerator);
-      }
-
-      internal SwitchDefaultAssumeBlock<Label> NewSwitchDefaultAssumeBlock(Label current, List<object> patterns, Type type)
-      {
-        return new SwitchDefaultAssumeBlock<Label>(this, current, patterns, type, ref this.blockIdGenerator);
-      }
-
-      #endregion -------------------------------------------
-
-      #region ------------ Protected Helpers -------------
-
-      internal virtual BlockWithLabels<Label> NewBlock()
-      {
-        Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
-
-        return new BlockWithLabels<Label>(this, ref this.blockIdGenerator);
-      }
-
-      protected SubroutineBase(
-        MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache
-      )
-      {
-        Contract.Requires(methodCache != null);
-
-        this.MethodCache = methodCache;
-        this.entry = new EntryBlock<Label>(this, ref this.blockIdGenerator);
-        this.exit = new EntryExitBlock<Label>(this, ref this.blockIdGenerator);
-        this.exceptionExit = new CatchFilterEntryBlock<Label>(this, ref this.blockIdGenerator);
-      }
-      protected SubroutineBase(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                               Label startLabel,
-                               SubroutineBuilder<Label> builder)
-        : this(methodCache)
-      {
-        Contract.Requires(methodCache != null);
-        Contract.Requires(builder != null); // F: added because of Clousot suggestion
-
-        this.startLabel = startLabel;
-        this.Builder = builder;
-        this.CodeProvider = builder.CodeProvider;
-
-        // link entry block to start label
-        this.entryAfterRequires = this.GetTargetBlock(startLabel);
-        AddSuccessor(this.entry, "entry", this.entryAfterRequires);
-
-      }
-
-      internal abstract override void Initialize();
-
-      internal virtual void Commit() {
-        Contract.Assume(blocks == null); // make sure we don't double commit
-
-        if (this.Builder != null)
+        public override Tag Kind
         {
-          this.Builder.InsertPreConditionEdges(this.entry, this.entryAfterRequires, this);
-        }
-        // cleanup
-        PostProcessBlocks();
-      }
-
-      internal void AddSuccessor(CFGBlock from, Tag tag, CFGBlock target)
-      {
-        Contract.Requires(from != null);
-        Contract.Requires(target != null); 
-        Contract.Requires(from.Subroutine == target.Subroutine); 
-
-        Contract.Assume(from != this.Exit);// F: requires added because of Clousot suggestion. 
-                                           // F: updated: made an assumption as there are too many places were we should fix it. 
-                                           // TODO: think to a way of improving it
-
-        Debug.Assert(from.Subroutine == target.Subroutine);
-        this.AddNormalControlFlowEdge(this.successors, from, tag, target);
-      }
-
-      internal BlockWithLabels<Label> GetTargetBlock(Label label)
-      {
-        Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
-
-        Contract.Assume(this.Builder != null); // should not get called otherwise
-        Contract.Assume(this.Builder.IsTargetLabel(label));
-        return GetBlock(label);
-      }
-
-      internal BlockWithLabels<Label> GetBlock(Label label)
-      {
-        Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
-
-        Contract.Assume(this.Builder != null); // should not get called otherwise
-
-        BlockWithLabels<Label> newBlock;
-        if (!this.BlockStart.TryGetValue(label, out newBlock))
-        {
-#if ENABLE_ASSERTIONS
-          Debug.Assert(this.MethodInfo.IsBlockStart(label));
-#endif
-          Pair<Method, bool> calledMethodVirtPair;
-          Method calledMethod;
-          if (this.Builder.IsMethodCallSite(label, out calledMethodVirtPair))
-          {
-            newBlock = new MethodCallBlock<Label>(calledMethodVirtPair.One, calledMethodVirtPair.Two, this.MethodCache.MetadataDecoder.AssumeNotNull(), this, ref this.blockIdGenerator);
-          }
-          else if (this.Builder.IsNewObjSite(label, out calledMethod))
-          {
-            newBlock = new NewObjCallBlock<Label>(calledMethod, this.MethodCache.MetadataDecoder.AssumeNotNull(), this, ref this.blockIdGenerator);
-          }
-          else
-          {
-            newBlock = this.NewBlock();
-          }
-          // only add branch targets to this map
-          Contract.Assume(this.Builder != null); // we need history invariants
-          if (this.Builder.IsTargetLabel(label))
-          {
-            this.BlockStart.Add(label, newBlock);
-          }
-        }
-        else
-        {
-          Contract.Assume(newBlock != null);
-        }
-        return newBlock;
-      }
-
-
-      /// <summary>
-      /// Note that subroutine can be null, in which case we add nothing.
-      /// </summary>
-      sealed public override void AddEdgeSubroutine(CFGBlock from, CFGBlock to, Subroutine subroutine, string callTag)
-      {
-        if (subroutine == null) return;
-        FList<Pair<string,Subroutine>> sofar;
-        Pair<CFGBlock,CFGBlock> edge = new Pair<CFGBlock,CFGBlock>(from, to);
-        this.edgeSubroutines.TryGetValue(edge, out sofar);
-        this.edgeSubroutines[edge] = FList<Pair<string,Subroutine>>.Cons(new Pair<string,Subroutine>(callTag,subroutine), sofar);
-      }
-
-      /// <summary>
-      /// Returns registered edge subroutines in last to first order.
-      ///
-      /// The context is used to filter subroutines on this list as follows:
-      /// - Any contract subroutines returned are distinct from the current subroutine and any subroutines in the context
-      /// </summary>
-      FList<Pair<string, Subroutine>> IEdgeSubroutineAdaptor.GetOrdinaryEdgeSubroutinesInternal(CFGBlock from, CFGBlock to, SubroutineContext context)
-      {
-        FList<Pair<string,Subroutine>> sofar;
-        Pair<CFGBlock, CFGBlock> edge = new Pair<CFGBlock, CFGBlock>(from, to);
-        this.edgeSubroutines.TryGetValue(edge, out sofar);
-        if (sofar != null && context != null)
-        {
-          sofar = sofar.Filter(FilterRecursiveContracts(to, context));
-        }
-        return sofar;
-      }
-
-      /// <summary>
-      /// Used to specialize ensures subroutines based on calling context.
-      /// We are looking for a stack of contract calls (ensures/requires) where each call is on "this" except maybe 
-      /// the outermost one. Since the calls are on "this", we can use the declaring type of the called method as
-      /// a possible improvement of the dynamic type other than the final declaring type. E.g., the ensures about to be
-      /// inserted might be the ensures of ICollection.Count, called from within ICollection.CopyTo's requires.
-      /// But the call to CopyTo happens to be a call to Array.CopyTo (inheriting ICollection.CopyTo's requires). Thus,
-      /// we can determine that the Count ensures to be used is the one from Array, which specializes ICollection.Count's 
-      /// ensures to relate the Count to the array length.
-      /// </summary>
-      [ContractVerification(false)]
-      public override FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, FList<STuple<CFGBlock, CFGBlock, string>> context)
-      {
-        var toAPC = new APC(to, 0, context);
-        CallAdaption.Push(this);
-        try
-        {
-          var origContext = context;
-          var result = CallAdaption.Dispatch<IEdgeSubroutineAdaptor>(this).GetOrdinaryEdgeSubroutinesInternal(from, to, context);
-
-          if (toAPC.InsideContract)
-          {
-            if (context != null)
+            get
             {
-              if (result != null)
-              {
-                #region inside a contract
-                var mdDecoder = this.MethodCache.MetadataDecoder;
-                Method calledMethod;
-                bool isNewObj;
-                bool isVirtualCall;
-                if (from.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall) && isVirtualCall)
-                {
-                  // try to specialize any ensures based on calling context
-
-                  // find out if call is on "this" (using Stack provider information)
-                  if (CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(from, 0, null)))
-                  {
-                    Type bestType = mdDecoder.DeclaringType(calledMethod); // so far
-                    // find best declaring type on outer calls and use it to specialize ensures.
-                    do
-                    {
-                      // this is really a do loop (as we tested for context != null on the outside
-                      if (context.Head.Three.StartsWith("inherited") || context.Head.Three.StartsWith("extra") || context.Head.Three.StartsWith("old")) { context = context.Tail; continue; }
-                      Method outerCalledMethod;
-                      bool dummy;
-                      bool dummy2;
-
-                      if (context.Head.Three.StartsWith("after") && context.Head.One.IsMethodCallBlock(out outerCalledMethod, out dummy, out dummy2))
-                      {
-                        Type candidateType = mdDecoder.DeclaringType(outerCalledMethod);
-                        if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
-                        {
-                          bestType = candidateType;
-                        }
-                        // we can try for even better types if the outer call is also on this
-                        if (!CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(context.Head.One, 0, null)))
-                        {
-                          break; // get out of do loop
-                        }
-                      }
-                      else if (context.Head.Three.StartsWith("before") && context.Head.Two.IsMethodCallBlock(out outerCalledMethod, out dummy, out dummy2))
-                      {
-                        Type candidateType = mdDecoder.DeclaringType(outerCalledMethod);
-                        if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
-                        {
-                          bestType = candidateType;
-                        }
-                        // we can try for even better types if the outer call is also on this
-                        if (!CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(context.Head.Two, 0, null)))
-                        {
-                          break; // get out of do loop
-                        }
-                      }
-                      else if (context.Head.Three == "exit")
-                      {
-                        // specialize by method we are in.
-                        var im = context.Head.One.Subroutine as IMethodInfo<Method>;
-                        if (im != null)
-                        {
-                          var candidateType = mdDecoder.DeclaringType(im.Method);
-                          if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
-                          {
-                            bestType = candidateType;
-                          }
-                        }
-                        break; // get out of do loop
-                      }
-                      else if (context.Head.Three == "entry")
-                      {
-                        // specialize by method we are in.
-                        var im = context.Head.One.Subroutine as IMethodInfo<Method>;
-                        if (im != null)
-                        {
-                          var candidateType = mdDecoder.DeclaringType(im.Method);
-                          if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
-                          {
-                            bestType = candidateType;
-                          }
-                        }
-                        break; // get out of do loop
-                      }
-                      else
-                      {
-                        // no specialization possible
-                        return result;
-                      }
-                      // loop around
-                      context = context.Tail;
-                    } while (context != null);
-                    // if we get here, we may have found a better type:
-                    if (!mdDecoder.Equal(bestType, mdDecoder.DeclaringType(calledMethod)))
-                    {
-                      Method specializedMethod;
-                      if (mdDecoder.TryGetImplementingMethod(bestType, calledMethod, out specializedMethod))
-                      {
-                        result = SpecializeEnsures(result, this.MethodCache.GetEnsures(calledMethod), this.MethodCache.GetEnsures(specializedMethod), from, origContext);
-                      }
-                    }
-                  }
-                }
-                #endregion
-              }
+                Contract.Ensures(Contract.Result<string>() != null);
+                throw new NotImplementedException();
             }
-          }
-          else
-          {
-            // context could be finally
-            var mdDecoder = this.MethodCache.MetadataDecoder;
-            Method calledMethod;
-            bool isNewObj;
-            bool isVirtualCall;
-            if (from.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall))
+        }
+
+        public override CFGBlock Entry
+        {
+            get
             {
-              // try to specialize any ensures/invariant based on current method
-              // find out if call is on "this" (using Stack provider information)
-              if (CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(from, 0, null)))
-              {
-                // specialize by method we are in.
-                var im = from.Subroutine as IMethodInfo<Method>;
-                if (im != null)
-                {
-                  var bestType = mdDecoder.DeclaringType(im.Method);
-                  if (isVirtualCall)
-                  {
-                    Method specializedMethod;
-                    if (mdDecoder.TryGetImplementingMethod(bestType, calledMethod, out specializedMethod))
-                    {
-                      result = SpecializeEnsures(result, this.MethodCache.GetEnsures(calledMethod), this.MethodCache.GetEnsures(specializedMethod), from, origContext);
-                    }
-                  }
-                  // insert invariant call if there is one and we are not calling an auto setter
-                  result = InsertInvariant(from, result, mdDecoder, calledMethod, im, ref bestType, context);
-                }
-              }
-              else if (this.MethodCache.IsMonitorWaitOrExit(calledMethod))
-              {
-                // special handling of Monitor.Exit and Monitor.Wait. These methods cause havocing of the
-                // running object and we'd like to reestablish the invariant
-                Method containingMethod;
-                if (toAPC.TryGetContainingMethod<Method>(out containingMethod))
-                {
-                  var candidate = this.MethodCache.GetInvariant(mdDecoder.DeclaringType(containingMethod));
-                  if (candidate != null)
-                  {
-                    // use entry tag to use current "this" as the target object
-                    result = result.Cons(new Pair<string, Subroutine>("entry", candidate));
-                  }
-                }
-              }
-              result = TryInsertAssumeInvariant(from, result, mdDecoder, calledMethod, context);
+                Contract.Ensures(Contract.Result<CFGBlock>() != null);
+                throw new NotImplementedException();
             }
-          }
-          return result;
         }
-        finally
+
+        public override CFGBlock EntryAfterRequires
         {
-          CallAdaption.Pop(this);
-        }
-      }
-
-      private FList<Pair<string, Subroutine>> InsertInvariant(CFGBlock from, FList<Pair<string, Subroutine>> result, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Method calledMethod, IMethodInfo<Method> im, ref Type bestType, SubroutineContext context)
-      {
-        Contract.Requires(from != null);
-        Contract.Requires(mdDecoder != null);
-
-        Contract.Assume(this.MethodCache.MetadataDecoder != null); // Should add a postcondition to MethodCache instead
-
-        if (this.MethodCache.MetadataDecoder.IsPropertySetter(calledMethod) && (this.MethodCache.MetadataDecoder.IsAutoPropertyMember(calledMethod) || WithinConstructor(from, context)))
-        {
-          return result;
-        }
-        // if the call is a ctor call, then this is the base call and we should not specialize
-        if (mdDecoder.IsConstructor(calledMethod))
-        {
-          bestType = mdDecoder.DeclaringType(calledMethod);
-        }
-        var candidate = this.MethodCache.GetInvariant(bestType);
-        if (candidate != null)
-        {
-          MethodCallBlock<Label> callBlock = from as MethodCallBlock<Label>;
-          if (callBlock != null)
-          {
-            string tag = callBlock.IsNewObj ? "afterNewObj" : "afterCall";
-
-            result = result.Cons(new Pair<string, Subroutine>(tag, candidate));
-          }
-        }
-        return result;
-      }
-
-      private FList<Pair<string, Subroutine>> TryInsertAssumeInvariant(CFGBlock from, FList<Pair<string, Subroutine>> result, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Method calledMethod, SubroutineContext context)
-      {
-          Contract.Requires(from != null);
-          Contract.Requires(mdDecoder != null);
-
-          var unspecMethod = mdDecoder.Unspecialized(calledMethod);
-          if (!mdDecoder.IsVoidMethod(unspecMethod)) return result;
-          // if the call is a ctor call, then this is the base call and we should not specialize
-          if (mdDecoder.IsConstructor(unspecMethod))
-          {
-              return result;
-          }
-
-          if (mdDecoder.Name(unspecMethod) != "AssumeInvariant") return result;
-          var parameters = mdDecoder.Parameters(calledMethod);
-          Contract.Assume(parameters != null);
-          if (parameters.Count != 1) return result;
-
-          var p = parameters[0];
-          var invariantType = this.MethodCache.MetadataDecoder.ParameterType(p);
-          var candidate = this.MethodCache.GetInvariant(invariantType);
-          if (candidate != null)
-          {
-              MethodCallBlock<Label> callBlock = from as MethodCallBlock<Label>;
-              if (callBlock != null)
-              {
-                  if (callBlock.IsNewObj) return result; // no insertion here
-                  string tag = "assumeInvariant";
-
-                  result = result.Cons(new Pair<string, Subroutine>(tag, candidate));
-              }
-          }
-          return result;
-      }
-
-      private bool WithinConstructor(CFGBlock from, SubroutineContext context)
-      {
-        Contract.Requires(from != null);// F: As of Clousot suggestion
-        return new APC(from, 0, context).InsideConstructor;
-      }
-
-      /// <summary>
-      /// Make sure not to specialize to a subroutine already in the context, otherwise we create a recursive context.
-      /// </summary>
-      FList<Pair<string, Subroutine>> SpecializeEnsures(FList<Pair<string, Subroutine>> subs, Subroutine toReplace, Subroutine specializedEnsures, CFGBlock from, SubroutineContext context)
-      {
-        return subs.Map(pair => {
-          var specialized = SpecializeEnsures(pair.Two, toReplace, specializedEnsures);
-          if (from.Subroutine == specialized) return pair;
-          for (var list = context; list != null; list = list.Tail)
-          {
-            if (list.Head.One.Subroutine == specialized) return pair;
-          }
-          return new Pair<string, Subroutine>(pair.One, specialized);
-        });
-      }
-
-      /// <summary>
-      /// Ensures can only be specialized if the call is virtual. Invariants, we always do.
-      /// </summary>
-      Subroutine SpecializeEnsures(Subroutine sub, Subroutine toReplace, Subroutine specializedEnsures)
-      {
-        var mdDecoder = this.MethodCache.MetadataDecoder;
-        if (sub == toReplace)
-        {
-          return specializedEnsures;
-        }
-        return sub;
-      }
-
-      bool IStackInfo.IsCallOnThis(APC pc)
-      {
-        // default implementation does not try to refine
-        return false;
-      }
-
-      static Predicate<Pair<string, Subroutine>> FilterRecursiveContracts(CFGBlock from, SubroutineContext context)
-      {
-        return delegate(Pair<string, Subroutine> candidatePair)
-        {
-          var candidate = candidatePair.Two;
-          if (!candidate.IsContract) return true;
-          if (candidate == from.Subroutine) return false; // direct recursion
-          for (var filter = context; filter != null; filter = filter.Tail)
-          {
-            if (candidate == filter.Head.One.Subroutine) return false;
-          }
-          return true;
-        };
-      }
-
-      /// <summary>
-      /// Call back when a return statement is found. Usually ignored but MethodSubroutine wants to know about it
-      /// </summary>
-      internal virtual void AddReturnBlock(BlockWithLabels<Label> block) { }
-
-      #endregion ------------------------------------
-
-
-      public override CFGBlock Entry
-      {
-          get { return this.entry; }
-      }
-
-      public void SetEntry(CFGBlock newEntry)
-      {
-          this.entry = newEntry as BlockWithLabels<Label>;
-      }
-
-      public override CFGBlock EntryAfterRequires
-      {
-        get { if (this.entryAfterRequires != null) { return this.entryAfterRequires; } else { return this.Entry; } }
-      }
-
-      public override CFGBlock Exit
-      {
-        get { return this.exit; }
-      }
-
-      public override CFGBlock ExceptionExit
-      {
-        get { return this.exceptionExit; }
-      }
-
-      public override bool HasReturnValue
-      {
-        get { return false; } // default
-      }
-
-      public override bool HasContextDependentStackDepth
-      {
-        get { return true; } // default
-      }
-
-      public override IEnumerable<CFGBlock> SuccessorBlocks(CFGBlock block)
-      {
-        foreach (Pair<Tag, CFGBlock> edge in this.SuccessorEdges[block])
-        {
-          yield return edge.Two;
-        }
-      }
-
-      public override IEnumerable<CFGBlock> PredecessorBlocks(CFGBlock block)
-      {
-        foreach (Pair<Tag, CFGBlock> edge in this.PredecessorEdges[block])
-        {
-          yield return edge.Two;
-        }
-      }
-
-      public override bool IsCatchFilterHeader(CFGBlock block)
-      {
-        return block is CatchFilterEntryBlock<Label>;
-      }
-
-      /// <summary>
-      /// Number of distinct syntactic blocks.
-      /// </summary>
-      public override int BlockCount
-      {
-        get
-        {
-          Contract.Assume(this.blocks != null, "otherwise Commit has not been called");
-
-          return this.blocks.Length;
-        }
-      }
-
-      /// <summary>
-      /// The blocks are numbered from 0-n. For syntactic analysis (ignoring finally context)
-      /// an array can be used to map from block to information by using the block.index as key.
-      /// </summary>
-      public override IEnumerable<CFGBlock> Blocks { get { return this.blocks; } }
-
-      public override string Name
-      {
-        get { return "SR" + this.Id.ToString(); }
-      }
-
-      #region ------------ Internal overrides ------------------
-
-
-      public override bool IsSubroutineStart(CFGBlock block)
-      {
-        return block == this.entry;
-      }
-
-      public override bool IsSubroutineEnd(CFGBlock block)
-      {
-        return block == this.exit || block == this.exceptionExit;
-      }
-
-      public override bool IsJoinPoint(CFGBlock block)
-      {
-        // catch and filter handler starts are join points
-        if (this.IsCatchFilterHeader(block)) return true;
-        // prevents us from stepping in/out of straight line code across subroutines
-        if (this.IsSubroutineStart(block)) return true;
-        if (this.IsSubroutineEnd(block)) return true;
-        return (this.PredecessorEdges[block].Count > 1);
-      }
-
-      public override bool IsSplitPoint(CFGBlock block)
-      {
-        // prevents us from stepping in/out of straight line code across subroutines
-        if (this.IsSubroutineStart(block)) return true;
-        if (this.IsSubroutineEnd(block)) return true;
-        return (SuccessorEdges[block].Count > 1);
-      }
-
-      internal override DepthFirst.Visitor<CFGBlock, Unit>/*?*/ EdgeInfo
-      {
-        get {
-          Contract.Assume(this.edgeInfo != null, "otherwise PostProcess has not been called yet");
-          return this.edgeInfo; 
-        }
-      }
-
-      internal string SourceContext(Label label)
-      {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-
-        if (this.CodeProvider.HasSourceContext(label))
-        {
-          var len = this.CodeProvider.SourceLength(label);
-          if (0 < len)
-            return String.Format("{0}({1},{2}-{3},{4})",
-              this.CodeProvider.SourceDocument(label),
-              this.CodeProvider.SourceStartLine(label),
-              this.CodeProvider.SourceStartColumn(label),
-              this.CodeProvider.SourceEndLine(label),
-              this.CodeProvider.SourceEndColumn(label)
-              );
-          else
-            return String.Format("{0}({1},{2})", this.CodeProvider.SourceDocument(label), this.CodeProvider.SourceStartLine(label), this.CodeProvider.SourceStartColumn(label));
-        }
-        return null;
-      }
-      internal string SourceDocument(Label label)
-      {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-
-        if (this.CodeProvider.HasSourceContext(label))
-        {
-          return this.CodeProvider.SourceDocument(label);
-        }
-        return null;
-      }
-      internal int SourceStartLine(Label label)
-      {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-        if (this.CodeProvider.HasSourceContext(label))
-        {
-          return this.CodeProvider.SourceStartLine(label);
-        }
-        return 0;
-      }
-      internal int SourceEndLine(Label label)
-      {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-        if (this.CodeProvider.HasSourceContext(label))
-        {
-          return this.CodeProvider.SourceEndLine(label);
-        }
-        return 0;
-      }
-      internal int SourceStartColumn(Label label)
-      {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-        if (this.CodeProvider.HasSourceContext(label))
-        {
-          return this.CodeProvider.SourceStartColumn(label);
-        }
-        return 0;
-      }
-      internal int SourceEndColumn(Label label)
-      {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-        if (this.CodeProvider.HasSourceContext(label))
-        {
-          return this.CodeProvider.SourceEndColumn(label);
-        }
-        return 0;
-      }
-      internal int SourceStartIndex(Label label) {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-        if (this.CodeProvider.HasSourceContext(label)) {
-          return this.CodeProvider.SourceStartIndex(label);
-        }
-        return 0;
-      }
-      internal int SourceLength(Label label) {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-        if (this.CodeProvider.HasSourceContext(label)) {
-          return this.CodeProvider.SourceLength(label);
-        }
-        return 0;
-      }
-
-      internal int ILOffset(Label label)
-      {
-        Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
-        return this.CodeProvider.ILOffset(label);
-      }
-
-      public override int StackDelta
-      {
-        get { return 0; }
-      }
-
-      #endregion --------------------------------------
-
-      #region Code scanning and block building
-
-
-
-      private void AddNormalControlFlowEdge(List<Pair<CFGBlock, Pair<string, CFGBlock>>> succs,
-                                            CFGBlock from, string tag, CFGBlock to)
-      {
-        Contract.Requires(succs != null); // F: added because of Clousot suggestion
-        Contract.Requires(from != this.Exit); // F: added because of Clousot suggestion
-
-        Debug.Assert(from != this.Exit);
-        succs.Add(new Pair<CFGBlock, Pair<string, CFGBlock>>(from, new Pair<string, CFGBlock>(tag, to)));
-      }
-
-
-      #endregion
-
-      #region Subroutine computations
-      internal override bool HasSingleSuccessor(APC ppoint, out APC next, DConsCache consCache)
-      {
-        Contract.Assert(consCache != null);
-        //
-        // This works as follows:
-        //  1) determine if we are at the end of a block, if not, just provide the successor
-        //  2) if this point ends a finally handler, find the next handler or pop the stack
-        //  3) determine syntactic successor labels
-        //     a) for each such label, determine finally nesting difference with current finally scope
-        //     b) push executed finallies onto finally stack and make top be the new current PC
-        // If this is an endfinally, there must be at least one label
-
-        // We allow stepping past the last instruction in this block!
-        if (ppoint.Index < ppoint.Block.Count)
-        {
-          next = new APC(ppoint.Block, ppoint.Index + 1, ppoint.SubroutineContext);
-          return true;
-        }
-
-        if (IsSubroutineEnd(ppoint.Block))
-        {
-          // Could be end of entire CFG
-          if (ppoint.SubroutineContext == null)
-          {
-            next = APC.Dummy;
-            return false;
-          }
-          next = ComputeSubroutineContinuation(ppoint, consCache);
-          return true;
-        }
-
-        BlockWithLabels<Label> singleSucc = null;
-        foreach (BlockWithLabels<Label> succ in ppoint.Block.Subroutine.SuccessorBlocks(ppoint.Block))
-        {
-          if (singleSucc == null)
-          {
-            singleSucc = succ;
-          }
-          else
-          {
-            // more than one
-            next = APC.Dummy;
-            return false;
-          }
-        }
-        if (singleSucc != null)
-        {
-          next = ComputeTargetFinallyContext(ppoint, singleSucc, consCache);
-          return true;
-        }
-
-        // zero
-        next = APC.Dummy;
-        return false;
-      }
-
-      internal override bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, DConsCache consCache, bool skipContracts)
-      {
-        //
-        // This works as follows:
-        //  1) determine if we are at the beginning of a block, if not, just provide the predecessor
-        //  2) if this point starts a finally handler, find the previous handler or pop the stack
-        //     NOTE: if the popping is necessary and the target of the edge is a catch handler, then
-        //           the predecessors are all indices in the block where the exception is thrown.
-        //  3) determine syntactic predecessors
-        //     a) for each such label, determine finally nesting difference with current finally scope
-        //     b) push edge onto finally stack and make top be the new current PC
-        if (ppoint.Index > 0)
-        {
-          singlePredecessor = new APC(ppoint.Block, ppoint.Index - 1, ppoint.SubroutineContext);
-          return true;
-        }
-
-        // If this is the beginning of the subroutine, get the next one
-        if (IsSubroutineStart(ppoint.Block))
-        {
-          // could be beginning of entire CFG
-          if (ppoint.SubroutineContext == null)
-          {
-            singlePredecessor = APC.Dummy;
-            return false;
-          }
-          bool hasSinglePred;
-          singlePredecessor = this.ComputeSubroutinePreContinuation(ppoint, out hasSinglePred, consCache, skipContracts);
-          return hasSinglePred;
-        }
-
-        CFGBlock/*?*/ singlePred = null;
-        foreach (CFGBlock pred in ppoint.Block.Subroutine.PredecessorBlocks(ppoint.Block))
-        {
-          if (singlePred != null)
-          {
-            singlePredecessor = APC.Dummy;
-            return false;
-          }
-          singlePred = pred;
-        }
-        if (singlePred == null)
-        {
-          // 0
-          singlePredecessor = APC.Dummy;
-          return false;
-        }
-
-        FList<Pair<string,Subroutine>> diffs = EdgeSubroutinesOuterToInner(singlePred, ppoint.Block, ppoint.SubroutineContext);
-
-        diffs = SkipContracts(skipContracts, diffs);
-        if (diffs == null)
-        {
-          singlePredecessor = APC.ForEnd(singlePred, ppoint.SubroutineContext);
-          return true;
-        }
-
-        // now diff is in outermost to inner most order of fault/finallies we are traversing.
-        // 1) push edge onto fault/finally context stack
-        // 2) for each endfinally in innermost handler, yield a program point
-        // IMPORTANT: the Finally context must be hash consed so that APC's have Equal working properly!
-        //
-
-        Contract.Assert(consCache != null); // F: made the assumption explicit
-        SubroutineContext newFinallyContext = consCache(new SubroutineEdge(singlePred, ppoint.Block, diffs.Head.One), ppoint.SubroutineContext);
-
-        // 3) find outermost handler (Head) and its subroutine
-        // 4) transfer control to end of first (outermost) fault/finally
-        //     (NOTE: diffs only contains finallies unless ppoint.Block is a catch/filter header)
-
-        Subroutine subroutine = diffs.Head.Two;
-        Contract.Assume(subroutine != null);
-
-        singlePredecessor = APC.ForEnd(subroutine.Exit, newFinallyContext);
-        return true;
-      }
-
-      internal override APC PredecessorPCPriorToRequires(APC pc, DConsCache consCache)
-      {
-        // must be at head of block
-        if (pc.Index != 0) return pc;
-
-        var currBlock = pc.Block;
-        Method dummy;
-        bool dummyBool;
-        bool dummyIsVirtual;
-        if (currBlock.IsMethodCallBlock(out dummy, out dummyBool, out dummyIsVirtual))
-        {
-          var preds = this.PredecessorBlocks(currBlock).AsIndexable(1);
-          if (preds.Count == 1)
-          {
-            var predBlock = preds[0];
-            Contract.Assume(predBlock != null);
-            return APC.ForEnd(predBlock, pc.SubroutineContext);
-          }
-        }
-        return pc;
-#if false
-        var subs = EdgeSubroutinesOuterToInner(predBlock, currBlock, pc.SubroutineContext);
-
-        for (;  subs != null; subs = subs.Tail)
-        {
-          var sub = subs.Head.Two;
-          if (sub.IsRequires) continue;
-          // non requires sub could be ensures/invariant, etc. Need to use this as last pc
-          SubroutineContext newFinallyContext = consCache(new SubroutineEdge(predBlock, currBlock, subs.Head.One), pc.SubroutineContext);
-          return APC.ForEnd(sub.Exit, newFinallyContext);
-        }
-#endif
-      }
-
-      /// <summary>
-      /// Returns all normal control flow successors
-      /// </summary>
-      internal override IEnumerable<APC>/*!*/ Successors(APC ppoint, DConsCache consCache)
-      {
-
-        APC singleNext;
-        if (HasSingleSuccessor(ppoint, out singleNext, consCache))
-        {
-          yield return singleNext;
-          yield break;
-        }
-        //
-        //  determine syntactic successor labels
-        //     a) for each such label, determine finally nesting difference with current finally scope
-        //     b) push executed finallies onto finally stack and make top be the new current PC
-
-        int successors = 0;
-        foreach (BlockWithLabels<Label> succ in ppoint.Block.Subroutine.SuccessorBlocks(ppoint.Block))
-        {
-          successors++;
-          yield return ppoint.Block.Subroutine.ComputeTargetFinallyContext(ppoint, succ, consCache);
-        }
-
-        if (successors == 0)
-        {
-          // The following is too strong, as throw in a finally block aborts the finally continuation
-          // System.Diagnostics.Debug.Assert(ppoint.FaultFinallyContext == null);
-
-          // the following is too strong, as the current pc could also be a throw.
-          // However, we don't know how to compute this.
-          // System.Diagnostics.Debug.Assert(ppoint.Block == this.normalExit || ppoint.Block == this.exceptionExit);
-        }
-      }
-
-      internal override IEnumerable<APC> Predecessors(APC ppoint, DConsCache consCache, bool skipContracts)
-      {
-        //
-        // This works as follows:
-        //  1) determine if we are at the beginning of a block, if not, just provide the predecessor
-        //  2) if this point starts a finally handler, find the previous handler or pop the stack
-        //  3) determine syntactic predecessors
-        //     a) for each such label, determine finally nesting difference with current finally scope
-        //     b) push edge onto finally stack and make top be the new current PC
-        if (ppoint.Index > 0)
-        {
-          yield return new APC(ppoint.Block, ppoint.Index - 1, ppoint.SubroutineContext);
-          yield break;
-        }
-
-        if (IsSubroutineStart(ppoint.Block))
-        {
-          // Could be start of entire CFG
-          if (ppoint.SubroutineContext == null)
-          {
-            yield break;
-          }
-          // 
-          foreach (APC nestedpred in this.ComputeSubroutinePreContinuation(ppoint, consCache, skipContracts))
-          {
-            yield return nestedpred;
-          }
-          yield break;
-        }
-
-        foreach (CFGBlock pred in ppoint.Block.Subroutine.PredecessorBlocks(ppoint.Block))
-        {
-          FList<Pair<string,Subroutine>> diffs = EdgeSubroutinesOuterToInner(pred, ppoint.Block, ppoint.SubroutineContext);
-
-          diffs = SkipContracts(skipContracts, diffs);
-          if (diffs == null)
-          {
-            yield return APC.ForEnd(pred, ppoint.SubroutineContext);
-          }
-          else
-          {
-            // now diff is in outermost to inner most order of fault/finallies we are traversing.
-            // 1) push edge onto fault/finally context stack
-            // 2) yield exit of subroutine as program point
-            // IMPORTANT: the Finally context must be hash consed so that APC's have Equal working properly!
-            //
-            SubroutineContext newFinallyContext = consCache(new SubroutineEdge(pred, ppoint.Block, diffs.Head.One), ppoint.SubroutineContext);
-
-            // 2) find outermost handler (Head)
-            // 3) transfer control to end of first (outermost) fault/finally
-            Subroutine subroutine = diffs.Head.Two;
-            yield return APC.ForEnd(subroutine.Exit, newFinallyContext);
-          }
-        }
-      }
-
-      private static FList<Pair<Tag, Subroutine>> SkipContracts(bool skipContracts, FList<Pair<string, Subroutine>> diffs)
-      {
-        if (skipContracts)
-        {
-          while (diffs != null && (diffs.Head.Two.IsContract || diffs.Head.Two.IsOldValue))
-          {
-            diffs = diffs.Tail;
-          }
-        }
-        return diffs;
-      }
-
-      /// <summary>
-      /// Called when ppoint is beginning of a subroutine on backwards walk.
-      ///
-      /// Finds next subroutine on current edge, or pops edge
-      ///
-      /// Note: we distinguish between edges that target an exception handler and thus need
-      /// to execute fault and finally handlers and other edges that only execute finally handlers
-      /// by the target block. In the former case, the target block is a SpecialCatchFilterHeader
-      /// block. These blocks are needed, as the start of a catch handler could also be the normal
-      /// goto/leave target of some try finally within the catch handler itself. Thus, the special
-      /// block disinguishes between a throw target where faults must be traversed, and a normal
-      /// leave target to the beginning of a catch handler.
-      /// </summary>
-      private IEnumerable<APC> ComputeSubroutinePreContinuation(APC ppoint, DConsCache consCache, bool skipContracts)
-      // ^ requires ppoint.FinallyEdges != null;
-      {
-        SubroutineEdge edge = ppoint.SubroutineContext.Head;
-        bool isHandlerEdge;
-        FList<Pair<string,Subroutine>> diffs = EdgeSubroutinesOuterToInner(edge.One, edge.Two, out isHandlerEdge, ppoint.SubroutineContext.Tail);
-        Debug.Assert(diffs != null);
-        while (diffs.Head.Two != this)
-        {
-          diffs = diffs.Tail;
-        }
-
-        // skip this
-        diffs = diffs.Tail;
-
-        diffs = SkipContracts(skipContracts, diffs);
-        // diffs.Head is new handler or none
-        if (diffs == null)
-        {
-          // If isHandlerEdge, then each label in the source block of the edge is a target
-          if (isHandlerEdge)
-          {
-            for (int index = 0; index == 0 || index < edge.One.Count; index++)
+            get
             {
-              yield return new APC(edge.One, index, ppoint.SubroutineContext.Tail);
+                Contract.Ensures(Contract.Result<CFGBlock>() != null);
+                throw new NotImplementedException();
             }
-          }
-          else
-          {
-            yield return APC.ForEnd(edge.One, ppoint.SubroutineContext.Tail);
-          }
-          yield break;
-        }
-        // predecessor is end of the next inner handler
-        Subroutine nextSubroutine = diffs.Head.Two;
-        yield return APC.ForEnd(nextSubroutine.Exit, consCache(new SubroutineEdge(edge.One, edge.Two, diffs.Head.One), ppoint.SubroutineContext.Tail));
-      }
-
-      /// <summary>
-      /// Called when ppoint is beginning of a finally on backwards walk.
-      ///
-      /// Finds next handler on current edge, or pops edge
-      ///
-      /// Note: we distinguish between edges that target an exception handler and thus need
-      /// to execute fault and finally handlers and other edges that only execute finally handlers
-      /// by the target block. In the former case, the target block is a SpecialCatchFilterHeader
-      /// block. These blocks are needed, as the start of a catch handler could also be the normal
-      /// goto/leave target of some try finally within the catch handler itself. Thus, the special
-      /// block disinguishes between a throw target where faults must be traversed, and a normal
-      /// leave target to the beginning of a catch handler.
-      /// </summary>
-      [ContractVerification(false)]
-      private APC ComputeSubroutinePreContinuation(APC ppoint, out bool hasSinglePred, DConsCache consCache, bool skipContracts)
-      // ^ requires ppoint.FinallyEdges != null;
-      {
-        SubroutineEdge edge = ppoint.SubroutineContext.Head;
-        bool isHandlerEdge;
-        FList<Pair<string,Subroutine>> diffs = EdgeSubroutinesOuterToInner(edge.One, edge.Two, out isHandlerEdge, ppoint.SubroutineContext.Tail);
-        Contract.Assume(diffs != null);
-        while (diffs.Head.Two != this)
-        {
-          diffs = diffs.Tail;
-        }
-        diffs = diffs.Tail; // skip this
-
-        diffs = SkipContracts(skipContracts, diffs);
-        // diffs.Head is new handler or none
-        if (diffs == null)
-        {
-          // If isHandlerEdge, then each label in the source block of the edge is a target
-          if (isHandlerEdge && edge.One.Count > 1)
-          {
-            // no single pred
-            hasSinglePred = false;
-            return APC.Dummy;
-          }
-          hasSinglePred = true;
-          return APC.ForEnd(edge.One, ppoint.SubroutineContext.Tail);
-        }
-        // predecessor is end of the next inner handler
-        Subroutine nextSubroutine = diffs.Head.Two;
-        // only one end
-        hasSinglePred = true;
-        return APC.ForEnd(nextSubroutine.Exit, consCache(new SubroutineEdge(edge.One, edge.Two, diffs.Head.One), ppoint.SubroutineContext.Tail));
-      }
-
-      /// <summary>
-      /// Called when ppoint is an endfinally.
-      ///
-      /// Finds next handler on current edge, or pops edge
-      ///
-      /// Note: we distinguish between edges that target an exception handler and thus need
-      /// to execute fault and finally handlers and other edges that only execute finally handlers
-      /// by the target block. In the former case, the target block is a SpecialCatchFilterHeader
-      /// block. These blocks are needed, as the start of a catch handler could also be the normal
-      /// goto/leave target of some try finally within the catch handler itself. Thus, the special
-      /// block disinguishes between a throw target where faults must be traversed, and a normal
-      /// leave target to the beginning of a catch handler.
-      /// </summary>
-      [ContractVerification(false)]
-      private APC ComputeSubroutineContinuation(APC ppoint, DConsCache consCache)
-      // ^ requires ppoint.SubroutineContext != null;
-      {
-        SubroutineEdge edge = ppoint.SubroutineContext.Head;
-
-        FList<Pair<string,Subroutine>> diffs = EdgeSubroutinesOuterToInner(edge.One, edge.Two, ppoint.SubroutineContext.Tail);
-        Contract.Assume(diffs != null);
-        if (diffs.Head.Two == this)
-        {
-          // last handler executed.
-          // pop finally edge
-          return new APC(edge.Two, 0, ppoint.SubroutineContext.Tail);
-        }
-        while (diffs.Tail.Head.Two != this)
-        {
-          diffs = diffs.Tail;
-        }
-        // diffs.Head is new handler
-        Subroutine nextSubroutine = diffs.Head.Two;
-        return new APC(nextSubroutine.Entry, 0, consCache(new SubroutineEdge(edge.One,edge.Two,diffs.Head.One), ppoint.SubroutineContext.Tail));
-      }
-
-      /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
-      private FList<Pair<string, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, SubroutineContext context)
-      {
-        bool isExnHandler;
-        return EdgeSubroutinesOuterToInner(current, succ, out isExnHandler, context);
-      }
-
-      /// <summary>
-      /// Returns the difference in fault/finally handlers between the given program point and the
-      /// given successor. Normally, the list only includes finally handlers, except in the case 
-      /// where succ is a special catch/filter header block, indicating that this edge represents
-      /// the execution on a throw, and thus fault handlers are included
-      /// </summary>
-      /// <param name="isExceptionHandlerEdge">is true, if the successor is a catch/filter handler</param>
-      /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
-      public override FList<Pair<string,Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context)
-      {
-        if (current.Subroutine != this)
-        {
-          // dispatch
-          return current.Subroutine.EdgeSubroutinesOuterToInner(current, succ, out isExceptionHandlerEdge, context);
         }
 
-        bool includeFaults = IsCatchFilterHeader(succ);
-        isExceptionHandlerEdge = includeFaults;
-
-        return this.GetOrdinaryEdgeSubroutines(current, succ, context);
-      }
-
-      internal override APC ComputeTargetFinallyContext(APC ppoint, CFGBlock succ, DConsCache consCache)
-      {
-        FList<Pair<string,Subroutine>> diffs = EdgeSubroutinesOuterToInner(ppoint.Block, succ, ppoint.SubroutineContext);
-
-        if (diffs == null)
+        public override CFGBlock Exit
         {
-          return new APC(succ, 0, ppoint.SubroutineContext);
-        }
-        // now diff is in outermost to inner most order of finallies we are traversing.
-        // 1) push edge onto fault/finally context stack
-        // 2) make innermost handler start current program point
-        // IMPORTANT: the Finally context must be hash consed so that APC's have Equal working properly!
-        //
-
-        // 2) find innermost handler
-        while (diffs.Length() > 1)
-        {
-          diffs = diffs.Tail;
-        }
-
-        Subroutine innerMost = diffs.Head.Two;
-        Contract.Assume(innerMost != null);
-        SubroutineContext newFinallyContext = consCache(new SubroutineEdge(ppoint.Block, succ, diffs.Head.One), ppoint.SubroutineContext);
-
-        // 3) transfer control to last (innermost) finally
-        return new APC(innerMost.Entry, 0, newFinallyContext);
-      }
-
-      /// <summary>
-      /// Returns a set of program points that are possible execution continuations if 
-      /// an exception is raised at the given ppoint.
-      ///
-      /// The supplied predicate allows the client to determine which handlers are possible
-      /// candidates. The predicate is called from closest enclosing to outermost.
-      /// </summary>
-      /// <param name="data">Arbitrary client data passed to the handler predicate</param>
-      /// <returns>A set of continuation program points that represent how execution continues to a chosen handler.
-      /// The continuation includes Finally and Fault executions that intervene between the given ppoint and a
-      /// chosen handler.
-      ///
-      /// Hack. This only works if Type2 is Type. We do this because we don't want to expose Type in Subroutine and thus
-      /// CFGBlock.
-      /// </returns>
-      internal override IEnumerable<CFGBlock> ExceptionHandlers<Data, Type2>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type2, Data> handlerPredicateArg)
-      {
-        // This kind of subroutine has no handlers except the exceptional exit point
-        yield return this.exceptionExit;
-      }
-
-      #endregion
-
-      #region Post Cleanup
-
-      private DepthFirst.Visitor<CFGBlock, Unit>/*?*/ edgeInfo = null;
-
-      private bool IsEdgeUsed(Pair<CFGBlock, Pair<string, CFGBlock>> edge)
-      {
-        return (edge.One.Index != UnusedBlockIndex);
-      }
-
-      private EdgeMap<string> successorEdges;
-      private EdgeMap<string> predecessorEdges; // cache
-
-      internal override EdgeMap<string> SuccessorEdges
-      {
-        get { return this.successorEdges; }
-      }
-
-      internal override EdgeMap<string> PredecessorEdges
-      {
-        get
-        {
-          if (predecessorEdges == null)
-          {
-            //  compute predecessor map on demand
-            this.predecessorEdges = this.SuccessorEdges.ReversedEdges();
-          }
-          return this.predecessorEdges;
-        }
-      }
-
-      const int UnusedBlockIndex = Int16.MaxValue - 10;
-
-
-      /// <summary>
-      /// Removes unreachable blocks and reorders them in reverse post order for easier reading
-      /// and for analysis.
-      /// </summary>
-      [ContractVerification(false)] // because this is like Dispose and it violates some invariants.
-      protected void PostProcessBlocks()
-      {
-        Stack<CFGBlock> blockStack = new Stack<CFGBlock>();
-
-        this.successorEdges = new EdgeMap<string>(this.successors);
-
-        // choose only reachable blocks
-        edgeInfo = new DepthFirst.Visitor<CFGBlock, Unit>(
-           this,
-           null,
-          // we use the post visit for the post order
-           delegate(CFGBlock block)
-           {
-             // we use a stack to obtain reverse post order
-             blockStack.Push(block);
-
-             // we approximate the backwards reverse post order here as the forward pre-order
-             // block.SetBackwardReversePostOrderIndex(ref backwardIndexGen);
-           },
-           null);
-
-        // Make sure that the exception exit block appears last and the normal exit block 2nd to last
-        // This also makes sure that these nodes appear in our list.
-        edgeInfo.VisitSubGraphNonRecursive(this.exceptionExit);
-        edgeInfo.VisitSubGraphNonRecursive(this.exit);
-        edgeInfo.VisitSubGraphNonRecursive(this.entry);
-
-        //
-        //  Now, we have unreachable blocks (and unused edges)
-        //  1) unnumber all the blocks so we can recognize which ones are dead
-        foreach (Pair<CFGBlock,Pair<Tag, CFGBlock>> edge in this.successorEdges)
-        {
-          int unused = UnusedBlockIndex;
-          edge.One.Renumber(ref unused);
-        }
-        //  2) renumber the blocks in the reverse post order
-        int blockRenumber = 0;
-        foreach (BlockWithLabels<Label> block in blockStack)
-        {
-          Contract.Assume(block != null);
-          block.Renumber(ref blockRenumber);
-        }
-
-        //  3) remove edges that are of unused blocks
-        this.SuccessorEdges.Filter(IsEdgeUsed);
-
-        // 3a) compute reversed graph
-        this.predecessorEdges = this.SuccessorEdges.ReversedEdges();
-
-        int finishTime = 0;
-        // 3b) renumber according to reverse post order 
-        var predvisit = new DepthFirst.Visitor<CFGBlock, string>(
-           this.predecessorEdges, 
-           null,
-           delegate(CFGBlock block)
-           {
-             block.SetReversePostOrderIndex(finishTime++);
-           },
-           null);
-
-        predvisit.VisitSubGraphNonRecursive(this.exit);
-
-        foreach (var block in blockStack)
-        {
-          predvisit.VisitSubGraphNonRecursive(block);
-        }
-
-
-        //  4) resort the edges according to the new numbering
-        //
-        this.SuccessorEdges.ReSort();
-
-        //  5) persist blocks as array
-        this.blocks = blockStack.ToArray();
-
-        //  6) cleanup
-        this.BlockStart = null;
-        this.Builder = null;
-
-        // for testing:
-        // Dominators.Compute(this, this.entry);
-
-
-      }
-      #endregion
-
-      #region IGraph<CFGBlock<Label>,Pair<CFGBlock<Label>,CFGBlock<Label>>> Members
-
-      IEnumerable<CFGBlock>/*!*/ IGraph<CFGBlock, Unit>.Nodes
-      {
-        get { return this.blocks; }
-      }
-
-      bool IGraph<CFGBlock, Unit>.Contains(CFGBlock node)
-      {
-        for (int i = 0; i < blocks.Length; i++)
-        {
-          if (blocks[i] == node) return true;
-        }
-        return false;
-      }
-
-      /// <summary>
-      /// Provide all successors, normal and exceptional
-      /// </summary>
-      public virtual IEnumerable<Pair<Unit, CFGBlock>>/*!*/ Successors(CFGBlock node)
-      {
-
-        foreach (Pair<Tag, CFGBlock> normalSucc in this.SuccessorEdges[node])
-        {
-          yield return new Pair<Unit, CFGBlock>(Unit.Value, normalSucc.Two);
-        }
-
-        if (node != this.exceptionExit)
-        {
-          yield return new Pair<Unit, CFGBlock>(Unit.Value, this.exceptionExit);
-        }
-      }
-
-
-      #endregion
-
-      public override void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ blockInfoPrinter, Func<CFGBlock,IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine,SubroutineContext>> printed)
-      {
-        var identifier = new Pair<Subroutine, SubroutineContext>(this, context);
-        if (printed.Contains(identifier)) return; // already printed
-        printed.Add(identifier);
-        IMutableSet<Subroutine> subs = new Set<Subroutine>();
-        IMethodInfo<Method> mi = this as IMethodInfo<Method>;
-        string extraSRIdentification = (mi != null) ? String.Format("({0})", this.MethodCache.MetadataDecoder.FullName(mi.Method)) : null;
-
-        Contract.Assume(tw != null); // F: Added. Should it be a precondition?
-        
-        if (context == null)
-        {
-          tw.WriteLine("Subroutine SR{0} {1} {2}", this.Id, this.Kind, extraSRIdentification);
-        }
-        else
-        {
-          tw.WriteLine("Subroutine SR{0} {1} {2} {3}", this.Id, this.Kind, new APC(this.Entry, 0, context), extraSRIdentification);
-        }
-        tw.WriteLine("-----------------");
-        
-        foreach (BlockWithLabels<Label> block in this.Blocks.AssumeNotNull())
-        {
-          tw.Write("Block {0} ({1})", block.Index, block.ReversePostOrderIndex);
-          // revisit this. How should we print CFGs with subroutines?
-          if (this.EdgeInfo.DepthFirstInfo(block).TargetOfBackEdge)
-          {
-            tw.WriteLine(" (target of backedge)");
-            Debug.Assert(this.IsJoinPoint(block));
-          }
-          else if (this.IsJoinPoint(block))
-          {
-            tw.WriteLine(" (join point)");
-          }
-          else
-          {
-            tw.WriteLine();
-          }
-          tw.Write("  Predecessors: ");
-          foreach (Pair<string, CFGBlock> taggedPred in block.Subroutine.PredecessorEdges[block])
-          {
-            tw.Write("({0}, {1}) ", taggedPred.One, taggedPred.Two.Index);
-          }
-          tw.WriteLine();
-          PrintHandlers(tw, block);
-          tw.WriteLine("  Code:");
-          foreach (APC apc in block.APCs(context))
-          {
-            string sc = apc.PrimarySourceContext();
-            if (sc != null) tw.WriteLine(sc);
-
-            Contract.Assume(ilPrinter != null);
-            
-            ilPrinter(apc, "    ", tw);
-          }
-          tw.Write("  Successors: ");
-          foreach (Pair<Tag, CFGBlock> taggedSucc in this.SuccessorEdges[block])
-          {
-            tw.Write("({0},{1}", taggedSucc.One, taggedSucc.Two.Index);
-            if (this.EdgeInfo.IsBackEdge(block, Unit.Value, taggedSucc.Two))
+            get
             {
-              tw.Write(" BE");
+                Contract.Ensures(Contract.Result<CFGBlock>() != null);
+                throw new NotImplementedException();
             }
-            FList<Pair<string,Subroutine>> edgesubs = this.GetOrdinaryEdgeSubroutines(block, taggedSucc.Two, context);
-            while (edgesubs != null)
+        }
+
+        public override CFGBlock ExceptionExit
+        {
+            get
             {
-              subs.Add(edgesubs.Head.Two);
-              tw.Write(" SR{0}({1})", edgesubs.Head.Two.Id, edgesubs.Head.One);
-              edgesubs = edgesubs.Tail;
+                Contract.Ensures(Contract.Result<CFGBlock>() != null);
+                throw new NotImplementedException();
             }
-            tw.Write(") ");
-
-          }
-          tw.WriteLine();
-          if (blockInfoPrinter != null)
-          {
-            blockInfoPrinter(new APC(block, block.Last.Index, context), "  ", tw);
-          }
-          tw.WriteLine();
         }
 
-        PrintReferencedSubroutines(tw, subs, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
-
-      }
-
-      [ContractVerification(false)] // We cannot prove the invariant this.BlockStart == null ==> this.Builder == null
-      protected virtual void PrintReferencedSubroutines(TextWriter tw, IMutableSet<Subroutine> subs, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed)
-      {
-        Contract.Requires(subs != null); 
-
-        // print edge subroutines
-        foreach (Subroutine sb in subs)
+        public override Tag Name
         {
-          if (contextLookup == null)
-          {
-            sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, null, printed);
-          }
-          else
-          {
-            foreach (SubroutineContext newContext in contextLookup(sb.Entry))
+            get
             {
-              sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, newContext, printed);
+                Contract.Ensures(Contract.Result<string>() != null);
+                throw new NotImplementedException();
             }
-          }
         }
-      }
 
-      protected virtual void PrintHandlers(TextWriter tw, BlockWithLabels<Label> block)
-      {
-        Contract.Requires(tw != null);
-
-        tw.Write("  Handlers: ");
-        // print out method wide handler (implicitly added in the appropriate query on CFGs)
-        if (block != this.exceptionExit)
+        public override bool HasReturnValue
         {
-          tw.Write("{0} ", this.exceptionExit.Index);
+            get { throw new NotImplementedException(); }
         }
-        tw.WriteLine();
-      }
 
-      internal override IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadyFound) {
-        foreach (var sublist in this.edgeSubroutines.Values)
+        public override bool HasContextDependentStackDepth
         {
-          var list = sublist;
-          for (; list != null; list = list.Tail)
-          {
-            var sub = list.Head.Two;
-            if (alreadyFound.Contains(sub.Id)) continue;
-            alreadyFound.Add(sub.Id);
-            yield return sub;
-          }
+            get { throw new NotImplementedException(); }
         }
-      }
 
-      internal virtual string SourceAssertionCondition(Label label)
-      {
-        Contract.Assume(this.CodeProvider !=null, "At this point expecting the CodeProvider != null");
-        return this.CodeProvider.SourceAssertionCondition(label);
-      }
-    }
-
-    internal abstract class SubroutineWithHandlers<Label, Handler> : SubroutineBase<Label> {
-
-      /// <summary>
-      /// Used during scanning to compute the protecting handlers in this subroutine only
-      /// </summary>
-      internal FList<Handler> CurrentProtectingHandlers = FList<Handler>.Empty; // protecting the current block
-      /// <summary>
-      /// Holds the block starting the filter code for filter handlers.
-      /// Materialized on demand.
-      /// </summary>
-      protected OnDemandMap<Handler, BlockWithLabels<Label>> FilterCodeBlocks;
-      protected OnDemandMap<Handler, BlockWithLabels<Label>> CatchFilterHeaders;
-      internal OnDemandMap<Handler, Subroutine> FaultFinallySubroutines;
-      /// <summary>
-      /// For each block, this provides the enclosing handlers (finally,fault, and exceptions) targeted by an exception raised in this block.
-      /// </summary>
-      internal OnDemandMap<CFGBlock, FList<Handler>> ProtectingHandlers;
-
-
-      new protected IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> CodeProvider
-      {
-        get {
-          Contract.Ensures(Contract.Result<IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler>>() != null);
-
-          return (IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler>)base.CodeProvider; }
-      }
-
-      internal SubroutineWithHandlers(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
-       : base(methodCache)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-      }
-
-      internal SubroutineWithHandlers(MethodCache<Local,Parameter,Type,Method,Field,Property,Event,Attribute,Assembly> methodCache,
-                                      SubroutineWithHandlersBuilder<Label, Handler> builder,
-                                      Label entry)
-        : base(methodCache, entry, builder)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(builder != null);// F: As of Clousot suggestion
-      }
-
-
-      bool IsFault(Handler handler)
-      {
-        return this.CodeProvider.IsFaultHandler(handler);
-      }
-
-      private FList<Handler> ProtectingHandlersList(CFGBlock block)
-      {
-        FList<Handler>/*?*/ result;
-        ProtectingHandlers.TryGetValue(block, out result);
-        return result;
-      }
-
-      private IEnumerable<Handler> GetProtectingHandlers(CFGBlock block)
-      {
-        return ProtectingHandlersList(block).GetEnumerable();
-      }
-
-
-      internal BlockWithLabels<Label> CreateCatchFilterHeader(Handler handler, Label label)
-      {
-        BlockWithLabels<Label> newBlock;
-        if (!this.BlockStart.TryGetValue(label, out newBlock)) {
-#if ENABLE_ASSERTIONS
-          Debug.Assert(this.MethodInfo.IsBlockStart(label));
-#endif
-          newBlock = new CatchFilterEntryBlock<Label>(this, ref this.blockIdGenerator);
-          this.CatchFilterHeaders.Add(handler, newBlock);
-          this.BlockStart.Add(label, newBlock);
-          if (this.CodeProvider.IsFilterHandler(handler))
-          {
-            // cache the filter code block which we need to lookup during exception paths
-            var filterCodeBlock = GetTargetBlock(this.CodeProvider.FilterDecisionStart(handler));
-            this.FilterCodeBlocks.Add(handler, filterCodeBlock);
-          }
-        }
-        return newBlock;
-      }
-
-      internal override IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadySeen)
-      {
-        foreach (Subroutine ffsr in this.FaultFinallySubroutines.Values)
+        public override IEnumerable<CFGBlock> SuccessorBlocks(CFGBlock block)
         {
-          yield return ffsr;
+            Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
+            throw new NotImplementedException();
         }
-        foreach (var sub in BaseUsedSubroutines(alreadySeen))
+
+        public override IEnumerable<CFGBlock> PredecessorBlocks(CFGBlock block)
         {
-          yield return sub;
+            Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
+            throw new NotImplementedException();
         }
-      }
-      private IEnumerable<Subroutine> BaseUsedSubroutines(IMutableSet<int> alreadySeen)
-      {
-        return base.UsedSubroutines(alreadySeen);
-      }
 
-      /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
-      public override FList<Pair<string, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context)
-      {
-        if (current.Subroutine != this)
+        public override int BlockCount
         {
-          // dispatch
-          return current.Subroutine.EdgeSubroutinesOuterToInner(current, succ, out isExceptionHandlerEdge, context);
-        }
-        // determine finally nesting difference
-        FList<Handler> currentHandlers = this.ProtectingHandlersList(current);
-        FList<Handler> newHandlers = this.ProtectingHandlersList(succ);
-
-        bool includeFaults = IsCatchFilterHeader(succ);
-        isExceptionHandlerEdge = includeFaults;
-
-        // now we could pop some, push some, or both (pop then push)
-        FList<Pair<string, Subroutine>>/*?*/ subroutines = this.GetOrdinaryEdgeSubroutines(current, succ, context);
-        while (currentHandlers != newHandlers)
-        {
-          if (currentHandlers.Length() >= newHandlers.Length())
-          {
-            Contract.Assume(currentHandlers != null);
-            // definite pop
-            Handler eh = currentHandlers.Head;
-            if (this.IsFaultOrFinally(eh))
+            get
             {
-              if (!IsFault(eh) || includeFaults)
-              {
-                subroutines = FList<Pair<string, Subroutine>>.Cons(new Pair<string, Subroutine>("finally", this.FaultFinallySubroutines[eh]), subroutines);
-              }
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                throw new NotImplementedException();
             }
-            currentHandlers = currentHandlers.Tail;
-          }
-          else
-          {
-            // definite push
-            newHandlers = newHandlers.Tail;
-          }
-        }
-        return subroutines;
-      }
-
-      public bool IsFaultOrFinally(Handler handler)
-      {
-        return this.CodeProvider.IsFaultHandler(handler) || this.CodeProvider.IsFinallyHandler(handler);
-      }
-
-      internal override IEnumerable<CFGBlock> ExceptionHandlers<Data, Type2>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type2, Data> handlerPredicateArg)
-      {
-        // Hack: cast to expected Type.
-        IHandlerFilter<Type, Data> handlerPredicate = (IHandlerFilter<Type, Data>)handlerPredicateArg;
-
-        // First, find handlers that protect ppoint, while being further out than innerSubroutine
-        FList<Handler> protectingHandlers = this.ProtectingHandlersList(ppoint);
-
-        if (innerSubroutine != null && innerSubroutine.IsFaultFinally) {
-          while (protectingHandlers != null) {
-            if (this.IsFaultOrFinally(protectingHandlers.Head) && this.FaultFinallySubroutines[protectingHandlers.Head] == innerSubroutine) {
-              protectingHandlers = protectingHandlers.Tail;
-              // found remaining handlers
-              break;
-            }
-            protectingHandlers = protectingHandlers.Tail;
-          }
         }
 
-        // now we have the remaining handlers that protect the program point
-
-        while (protectingHandlers != null) {
-          Handler handler = protectingHandlers.Head;
-          if (!this.IsFaultOrFinally(handler)) {
-            if (handlerPredicate != null) {
-              bool stopPropagation = false;
-              if (this.CodeProvider.IsCatchHandler(handler)) {
-                if (handlerPredicate.Catch(data, this.CodeProvider.CatchType(handler), out stopPropagation)) {
-                  yield return this.CatchFilterHeaders[handler];
-                }
-              }
-              else {
-                Debug.Assert(this.CodeProvider.IsFilterHandler(handler));
-                if (handlerPredicate.Filter(data, new APC(this.FilterCodeBlocks[handler], 0, null), out stopPropagation)) {
-                  yield return this.CatchFilterHeaders[handler];
-                }
-              }
-              if (stopPropagation) yield break; // no further handlers
-            }
-            else {
-              // no predicate, add all handlers
-              yield return this.CatchFilterHeaders[handler];
-            }
-            if (this.CodeProvider.IsCatchAllHandler(handler)) {
-              yield break; // no further handlers
-            }
-          }
-          protectingHandlers = protectingHandlers.Tail;
-        }
-
-        // if we get here, the exception can escape the subroutine
-        yield return this.ExceptionExit;
-      }
-
-      /// <summary>
-      /// Provide all successors, normal and exceptional
-      /// </summary>
-      public override IEnumerable<Pair<Unit, CFGBlock>>/*!*/ Successors(CFGBlock node)
-      {
-        foreach (Pair<Tag, CFGBlock> normalSucc in this.SuccessorEdges[node]) {
-          yield return new Pair<Unit, CFGBlock>(Unit.Value, normalSucc.Two);
-        }
-
-        foreach (Handler handler in this.GetProtectingHandlers(node)) {
-          // Careful: for fault finally the block belongs to a different subroutine, so we ignore it here
-          //          for filter/catch, it is the special header block
-          if (this.IsFaultOrFinally(handler)) {
-            continue;
-          }
-          else {
-            yield return new Pair<Unit, CFGBlock>(Unit.Value, this.CatchFilterHeaders[handler]);
-          }
-        }
-        if (node != this.ExceptionExit) {
-          yield return new Pair<Unit, CFGBlock>(Unit.Value, this.ExceptionExit);
-        }
-      }
-
-      protected override void PrintReferencedSubroutines(TextWriter tw, IMutableSet<Subroutine> subs, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> blockInfoPrinter, Func<CFGBlock, IEnumerable<FList<STuple<CFGBlock, CFGBlock, string>>>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed)
-      {
-        foreach (Subroutine sb in this.FaultFinallySubroutines.Values)
+        public override IEnumerable<CFGBlock> Blocks
         {
-          if (contextLookup == null)
-          {
-            sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
-          }
-          else
-          {
-            foreach (SubroutineContext newContext in contextLookup(sb.Entry))
-            {
-              sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, newContext, printed);
-            }
-          }
+            get { throw new NotImplementedException(); }
         }
-        base.PrintReferencedSubroutines(tw, subs, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
-      }
 
-      protected override void PrintHandlers(TextWriter tw, BlockWithLabels<Label> block)
-      {
-        tw.Write("  Handlers: ");
-        foreach (Handler handler in this.GetProtectingHandlers(block))
+        internal override IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadySeen)
         {
-          if (this.IsFaultOrFinally(handler))
-          {
-            Subroutine sb = this.FaultFinallySubroutines[handler];
-            Contract.Assume(sb != null, "Making the assumption explicit");
-            tw.Write("SR{0} ", sb.Id);
-          }
-          else
-          {
-            BlockWithLabels<Label> handlerStart = this.CatchFilterHeaders[handler];
-            Contract.Assume(handlerStart != null);
-            tw.Write("{0} ", handlerStart.Index);
-          }
+            Contract.Ensures(Contract.Result<IEnumerable<Subroutine>>() != null);
+            throw new NotImplementedException();
         }
-        // print out method wide handler (implicitly added in the appropriate query on CFGs)
-        if (block != this.ExceptionExit)
+
+        public override void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed)
         {
-          tw.Write("{0} ", this.ExceptionExit.Index);
+            throw new NotImplementedException();
         }
-        tw.WriteLine();
-      }
 
-    }
-
-    /// <summary>
-    /// Represents an entire method
-    /// </summary>
-    internal class MethodSubroutine<Label, Handler> : SubroutineWithHandlers<Label, Handler>, IMethodInfo<Method>
-    {
-
-      #region Object invariant
-      
-      [ContractInvariantMethod]
-      [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.MethodCache.MetadataDecoder != null);
-      }
-
-      #endregion
-
-      Set<BlockWithLabels<Label>> blocksEndingInReturn;
-
-      /// <summary>
-      /// Dummy one without a body
-      /// </summary>
-      internal MethodSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, Method method)
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        this.method = method;
-      }
-
-      Method method;
-
-      [ContractVerification(false)] // We cannot prove the invariant this.BlockStart == null ==> this.Builder == null
-      public MethodSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                              Method method,
-                              SubroutineWithHandlersBuilder<Label, Handler> builder,
-                              Label startLabel)
-        : base(methodCache, builder, startLabel)
-      {
-        Contract.Requires(builder != null);// F: Added as of Clousot suggestion
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        this.method = method;
-
-        builder.BuildBlocks(startLabel, this);
-
-        BlockWithLabels<Label> startLabelBlock = this.GetTargetBlock(startLabel);
-
-        this.Commit();
-        Type declaringType = MethodCache.MetadataDecoder.DeclaringType(method);
-
-        Subroutine invariant = MethodCache.GetInvariant(declaringType);
-
-        if (invariant != null && !MethodCache.MetadataDecoder.IsConstructor(method) && !MethodCache.MetadataDecoder.IsStatic(method))
+        public override bool IsSubroutineStart(CFGBlock block)
         {
-          this.AddEdgeSubroutine(this.Entry, startLabelBlock, invariant, "entry"); // first assume invariant as that might validate some implicit obligations in requires
-          var requires = MethodCache.GetRequires(method);
-          if (requires != null)
-          {
-            this.AddEdgeSubroutine(this.Entry, startLabelBlock, requires, "entry");
-            this.AddEdgeSubroutine(this.Entry, startLabelBlock, MethodCache.GetRedundantInvariant(invariant, declaringType), "entry"); // redudant invariant assumption to handle disjunctions implied by requires better
-          }
+            throw new NotImplementedException();
         }
-        else
+
+        public override bool IsSubroutineEnd(CFGBlock block)
         {
-          this.AddEdgeSubroutine(this.Entry, startLabelBlock, MethodCache.GetRequires(method), "entry");
+            throw new NotImplementedException();
         }
-        if (blocksEndingInReturn != null)
+
+        public override bool IsJoinPoint(CFGBlock block)
         {
-          var ensuresSub = MethodCache.GetEnsures(method);
-
-          foreach (BlockWithLabels<Label> retBlock in blocksEndingInReturn)
-          {
-            if (!MethodCache.MetadataDecoder.IsStatic(method) &&
-                !MethodCache.ContractDecoder.IsPure(method) &&
-                !MethodCache.MetadataDecoder.IsFinalizer(method) && 
-                !MethodCache.MetadataDecoder.IsDispose(method))
-            {
-              this.AddEdgeSubroutine(retBlock, this.Exit, invariant, "exit");
-            }
-            this.AddEdgeSubroutine(retBlock, this.Exit, ensuresSub, "exit");
-          }
-
-          // insert dummy Old subroutine calls at beginning to materialize for Clousot
-#if !CCI2_CONTROLFLOW_DIST
-          if (ensuresSub != null)
-          {
-            foreach (var nestedEnsuresSub in ensuresSub.UsedSubroutines())
-            {
-              if (nestedEnsuresSub.IsOldValue)
-              {
-                this.AddEdgeSubroutine(this.Entry, startLabelBlock, Microsoft.Research.CodeAnalysis.ILCodeProvider.Predefined.OldEvalPopSubroutine(MethodCache, nestedEnsuresSub), "oldmanifest");
-              }
-            }
-          }
-#endif
-          // cleanup
-          blocksEndingInReturn = null;
+            throw new NotImplementedException();
         }
-      }
 
-      public override string Kind
-      {
-        get { return "method"; }
-      }
-      /// <summary>
-      /// Method subroutines are eagerly initialized
-      /// </summary>
-      internal override void Initialize()
-      {
-      }
-
-      /// <summary>
-      /// Record which blocks end in returns
-      /// </summary>
-      internal override void AddReturnBlock(BlockWithLabels<Label> block)
-      {
-        if (blocksEndingInReturn == null)
+        public override bool IsSplitPoint(CFGBlock block)
         {
-          this.blocksEndingInReturn = new Set<BlockWithLabels<Label>>();
+            throw new NotImplementedException();
         }
-        this.blocksEndingInReturn.Add(block);
-        base.AddReturnBlock(block);
-      }
-
-      public override bool HasReturnValue
-      {
-        get
-        {
-          return !this.MethodCache.MetadataDecoder.AssumeNotNull().IsVoidMethod(this.method);
-        }
-      }
-
-      public override bool IsMethod
-      {
-        get
-        {
-          return true;
-        }
-      }
-
-      public override bool IsConstructor
-      {
-        get
-        {
-          return (this.MethodCache.MetadataDecoder.IsConstructor(this.method));
-        }
-      }
-
-      internal override bool IsCompilerGenerated
-      {
-        get
-        {
-          return this.MethodCache.MetadataDecoder.IsCompilerGenerated(this.method);
-        }
-      }
-
-      public override string Name
-      {
-        get
-        {
-          return this.MethodCache.MetadataDecoder.FullName(this.method);
-        }
-      }
-
-      public Method Method { get { return this.method; } }
-    }
-
-    internal abstract class FaultFinallySubroutineBase<Label, Handler> : SubroutineWithHandlers<Label, Handler>
-    {
-      protected FaultFinallySubroutineBase(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                                           SubroutineWithHandlersBuilder<Label, Handler> builder,
-                                           Label startLabel)
-        : base(methodCache, builder, startLabel)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(builder != null);// F: As of Clousot suggestion
-      }
-
-      internal override void Initialize()
-      {
-        // nothing to do. MethodSubroutine finalizes the fault finally subroutines.
-      }
-
-      public override bool HasContextDependentStackDepth
-      {
-        get
-        {
-          return false; // always starts at 0
-        }
-      }
-
-      public override bool IsFaultFinally
-      {
-        get
-        {
-          return true;
-        }
-      }
-    }
-
-    /// <summary>
-    /// Represents a fault region within a method
-    /// </summary>
-    internal class FaultSubroutine<Label, Handler> : FaultFinallySubroutineBase<Label, Handler>
-    {
-      public FaultSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, 
-                             SubroutineWithHandlersBuilder<Label, Handler> builder,
-                             Label startLabel)
-        : base(methodCache, builder, startLabel)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(builder != null);// F: As of Clousot suggestion
-      }
-
-      public override string Kind
-      {
-        get { return "fault"; }
-      }
-
-    }
-
-
-    /// <summary>
-    /// Represents a finally region within a method
-    /// </summary>
-    internal class FinallySubroutine<Label, Handler> : FaultFinallySubroutineBase<Label, Handler>
-    {
-      public FinallySubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                               SubroutineWithHandlersBuilder<Label, Handler> builder,
-                               Label startLabel)
-        : base(methodCache, builder, startLabel)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(builder != null);// F: As of Clousot suggestion
-      }
-
-      public override string Kind
-      {
-        get { return "finally"; }
-      }
-    }
-
-    internal abstract class CallingContractSubroutine<Label> : SubroutineBase<Label>, IMethodInfo<Method>
-    {
-      Method methodWithThisContract;
-      new protected SimpleSubroutineBuilder<Label> Builder;
-
-      public CallingContractSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                                       Method method)
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
-
-
-        this.methodWithThisContract = method;
-      }
-
-      public CallingContractSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                                       Method method,
-                                       SimpleSubroutineBuilder<Label> builder,
-                                       Label startLabel)
-        : base(methodCache, startLabel, builder)
-      {
-        Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
-        Contract.Requires(builder != null);// F: As of Clousot suggestion
-
-        this.Builder = builder;
-        this.methodWithThisContract = method;
-      }
-
-      #region IMethodInfo<Method> Members
-
-      public Method Method
-      {
-        get { return this.methodWithThisContract; }
-      }
-
-      #endregion
-
-      public override bool IsContract
-      {
-        get
-        {
-          return true;
-        }
-      }
-    }
-
-    internal class RequiresSubroutine<Label> : CallingContractSubroutine<Label>, IEquatable<RequiresSubroutine<Label>>
-    {
-      public RequiresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                                Method method,
-                                SimpleSubroutineBuilder<Label> builder, Label startLabel, IFunctionalSet<Subroutine> inherited)
-        : base(methodCache, method, builder, startLabel)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(builder != null);// F: As of Clousot suggestion
-        Contract.Requires(inherited != null);// F: As of Clousot suggestion
-        this.AddBaseRequires(this.GetTargetBlock(startLabel), inherited);
-      }
-
-      public override string Kind
-      {
-        get { return "requires"; }
-      }
-
-      internal override void Initialize()
-      {
-        if (Builder == null) return;
-
-        Builder.BuildBlocks(startLabel, this);
-        this.Commit();
-        Builder = null;
-      }
-
-      public RequiresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, Method method, IFunctionalSet<Subroutine> inherited)
-        : base(methodCache, method)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(inherited != null);// F: As of Clousot suggestion
-        this.AddSuccessor(this.Entry, "entry", this.Exit);
-        this.AddBaseRequires(this.Exit, inherited);
-        this.Commit(); // do it here, since we have no builder it won't get called later
-      }
-
-      /// <summary>
-      /// Add subroutine calls to
-      ///  - non-abstract virtual methods
-      ///  - abstract methods with HasRequires
-      /// </summary>
-      private void AddBaseRequires(CFGBlock targetOfEntry, IFunctionalSet<Subroutine> inherited) {
-        Contract.Requires(inherited != null);// F: As of Clousot suggestion
-        
-        foreach (Subroutine rs in inherited.Elements)
-        {
-          this.AddEdgeSubroutine(this.Entry, targetOfEntry, rs, "inherited");
-        }
-      }
-
-      public override bool IsRequires
-      {
-        get { return true; }
-      }
-
-      public override bool IsContract
-      {
-        get { return true; }
-      }
-
-      public bool Equals(RequiresSubroutine<Label> that)
-      {
-        return this.Id == that.Id;
-      }
-    }
-
-    internal class SimpleSubroutine<Label> : SubroutineBase<Label>
-    {
-      public SimpleSubroutine(
-        int stackDelta,
-        MethodCache<Local,Parameter,Type,Method,Field,Property,Event,Attribute,Assembly> methodCache,
-        Label startLabel,
-        SimpleSubroutineBuilder<Label> builder
-      )
-        : base(methodCache, startLabel, builder)
-      {
-        Contract.Requires(builder != null);// F: Added as of Clousot suggestion
-        Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
-
-        this.stackDelta = stackDelta;
-        builder.BuildBlocks(startLabel, this);
-
-        this.Commit();
-      }
-
-      int stackDelta;
-
-      public override int StackDelta
-      {
-        get
-        {
-          return this.stackDelta;
-        }
-      }
-
-      internal override void Initialize()
-      {
-      }
-
-      public override string Kind
-      {
-        get { return "simple"; }
-      }
-    }
-
-
-    internal class AssumeAsPostConditionSubroutine<Label> : SubroutineBase<Label>
-    {
-
-        public enum RetvalType { LocalRetval, ParameterRetval, FieldRetval };
-
-        public AssumeAsPostConditionSubroutine(
-          int stackDelta,
-          MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-          Local retvalLocal,
-          Parameter retvalParameter,
-          Field retvalField,
-          Label startLabel,
-          AssumeAsPostConditionSubroutineBuilder<Label> builder, 
-          RetvalType retvalType
-        )
-            : base(methodCache, startLabel, builder)
-        {
-            Contract.Requires(builder != null);
-            Contract.Requires(methodCache != null);
-
-            this.stackDelta = stackDelta;
-            // if a local / param is assigned the return value of a function, we must put the symbolic var for return value into the appropriate local in order to compute the correct assume result
-            var assumeEntryBlk = base.NewAssumeAsPostConditionEntryBlock(retvalLocal, retvalParameter, retvalField, retvalType, "assumeAsPostEntry"); 
-            // HACK! had to change Entry to be mutable. This is probably bad, but is the only solution I could get to work. Will investigate alternatives later.
-            this.SetEntry(assumeEntryBlk);
-            var blk = builder.BuildBlocks(startLabel, assumeEntryBlk, this); // force decoding of assume
-            this.Commit();
-        }
-
-        int stackDelta;
 
         public override int StackDelta
         {
             get
             {
-                return this.stackDelta;
+                Contract.Ensures(Contract.Result<int>() != Int32.MinValue);
+
+                throw new NotImplementedException();
             }
+        }
+
+        internal override APC ComputeTargetFinallyContext(APC ppoint, CFGBlock succ, DConsCache consCache)
+        {
+            Contract.Requires(consCache != null);
+
+            return default(APC);
+        }
+
+        internal override EdgeMap<Tag> SuccessorEdges
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<EdgeMap<Tag>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        internal override EdgeMap<Tag> PredecessorEdges
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<EdgeMap<Tag>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        internal override bool HasSingleSuccessor(APC ppoint, out APC next, DConsCache consCache)
+        {
+            Contract.Requires(consCache != null);
+
+            throw new NotImplementedException();
+        }
+
+        internal override bool HasSinglePredecessor(APC ppoint, out APC next, DConsCache consCache, bool skipContracts)
+        {
+            Contract.Requires(consCache != null);
+
+            throw new NotImplementedException();
+        }
+
+        internal override APC PredecessorPCPriorToRequires(APC ppoint, DConsCache consCache)
+        {
+            Contract.Requires(consCache != null);
+
+            throw new NotImplementedException();
+        }
+
+        internal override IEnumerable<APC> Predecessors(APC ppoint, DConsCache consCache, bool skipContracts)
+        {
+            Contract.Requires(consCache != null);
+            Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        internal override IEnumerable<APC> Successors(APC ppoint, DConsCache consCache)
+        {
+            Contract.Requires(consCache != null);
+            Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
+            throw new NotImplementedException();
+        }
+
+        internal override DepthFirst.Visitor<CFGBlock, UnitDest> EdgeInfo
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<DepthFirst.Visitor<CFGBlock, UnitDest>>() != null);
+
+                throw new NotImplementedException();
+            }
+        }
+
+        internal override IEnumerable<CFGBlock> ExceptionHandlers<Data, Type>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type, Data> handlerPredicate)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public override void AddEdgeSubroutine(CFGBlock from, CFGBlock to, Subroutine subroutine, Tag callTag)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override FList<Pair<Tag, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override FList<Pair<Tag, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
+        {
+            throw new NotImplementedException();
         }
 
         internal override void Initialize()
         {
-        }
-
-        public override string Kind
-        {
-            get { return "assumeAsPost"; }
-        }
-
-        public override bool IsContract
-        {
-          get
-          {
-            return true;
-          }
+            throw new NotImplementedException();
         }
     }
+    #endregion
 
-    internal class OldValueSubroutine<Label> : CallingContractSubroutine<Label>
+    internal delegate SubroutineContext DConsCache(SubroutineEdge edge, SubroutineContext/*?*/ tail);
+
+    [ContractClass(typeof(CFGBlockContracts))]
+    [Serializable]
+    public abstract class CFGBlock : IEquatable<CFGBlock>
     {
-      BlockWithLabels<Label> beginOldBlock;
-      BlockWithLabels<Label> endOldBlock;
+        #region Private/Internal
+        private int id;
+        private int reversePostOrder;
+        private readonly Subroutine subroutine;
 
-      public OldValueSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                                Method method,
-                                SimpleSubroutineBuilder<Label> builder, Label startLabel)
-        : base(methodCache, method, builder, startLabel)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(builder!= null);// F: As of Clousot suggestion
-      }
-
-      public override string Kind
-      {
-        get { return "old"; }
-      }
-
-      public override int StackDelta
-      {
-        get
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
         {
-          return 1;
-        }
-      }
-
-      public override bool IsOldValue
-      {
-        get { return true; }
-      }
-
-      internal override void Initialize()
-      {
-        // nothing to do. EnsuresSubroutine finalizes this subroutines.
-      }
-
-
-      internal void Commit(BlockWithLabels<Label> endOldBlock)
-      {
-        this.endOldBlock = endOldBlock;
-        this.Commit();
-      }
-
-      internal void RegisterBeginBlock(BlockWithLabels<Label> newBlock)
-      {
-        this.beginOldBlock = newBlock;
-      }
-
-      internal APC BeginOldAPC(SubroutineContext context)
-      {
-        return new APC(beginOldBlock, 0, context);
-      }
-
-      internal APC EndOldAPC(SubroutineContext context)
-      {
-        Contract.Assume(this.endOldBlock != null); // F: made an assumption
-        return new APC(endOldBlock, endOldBlock.Count - 1, context);
-      }
-    }
-
-    internal class EnsuresSubroutine<Label> : CallingContractSubroutine<Label>, IEquatable<EnsuresSubroutine<Label>>
-    {
-      /// <summary>
-      /// Requires call to Initialize eventually before use
-      /// </summary>
-      public EnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                               Method method,
-                               SimpleSubroutineBuilder<Label> builder, Label startLabel, IFunctionalSet<Subroutine> inherited)
-        : base(methodCache, method, builder, startLabel)
-      {
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-        Contract.Requires(builder != null);// F: As of Clousot suggestion
-
-        CFGBlock startBlock = this.GetTargetBlock(startLabel);
-        this.AddBaseEnsures(this.Entry, startBlock, inherited);
-      }
-
-      public override string Kind
-      {
-        get { return "ensures"; }
-      }
-
-      internal override void Initialize()
-      {
-        if (Builder == null) return;
-
-        Builder.BuildBlocks(startLabel, this);
-
-        this.Commit();
-        Builder = null;
-      }
-
-      public EnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, 
-                              Method method, 
-                              IFunctionalSet<Subroutine> inherited)
-        : base(methodCache, method)
-      {
-
-        Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-
-        this.AddSuccessor(this.Entry, "entry", this.Exit);
-        this.AddBaseEnsures(this.Entry, this.Exit, inherited);
-        this.Commit();
-      }
-
-
-      internal override BlockWithLabels<Label> NewBlock()
-      {
-        return new EnsuresBlock<Label>(this, ref this.blockIdGenerator);
-      }
-
-      /// <summary>
-      /// Add subroutine calls to
-      ///  - non-abstract virtual methods
-      ///  - abstract methods with HasRequires
-      /// </summary>
-      private void AddBaseEnsures(CFGBlock fromBlock, CFGBlock toBlock, IFunctionalSet<Subroutine> inherited)
-      {
-        if (inherited == null) return;
-        foreach (Subroutine es in inherited.Elements)
-        {
-          this.AddEdgeSubroutine(fromBlock, toBlock, es, "inherited");
-        }
-      }
-
-
-      /// <summary>
-      /// This map is used by inferred old regions to map (index lsh 16) + block_id to the corresponding 
-      /// block and type (for end old)
-      /// </summary>
-      OnDemandMap<int, Pair<CFGBlock, Type>> inferredOldLabelReverseMap;
-
-      internal static int GetKey(EnsuresSubroutine<Label> rs)
-      {
-        Contract.Requires(rs!= null);// F: As of Clousot suggestion
-        return rs.Id;
-      }
-
-      public override bool IsEnsures
-      {
-        get { return true; }
-      }
-
-      public override bool IsContract
-      {
-        get { return true; }
-      }
-
-      public bool Equals(EnsuresSubroutine<Label> that)
-      {
-        return this.Id == that.Id;
-      }
-
-      #region Committing
-
-      enum ScanState { OutsideOld, InsideOld, InsertingOld, InsertingOldAfterCall }
-
-      /// <summary>
-      /// Fixes up sequences of ldarga ...  ... to wrap them with begin_old end_old
-      /// Visitor returns true if we are adding instructions to underlying block. Argument is original block index.
-      ///
-      /// We have to be very careful when the old sequence ends in a method call. If the method has arguments
-      /// other than the old address, then we can't evaluate the method call in the old scope, since we wouldn't find
-      /// all the arguments to it.
-      /// So we have to prematurely end the old scope at such method calls.
-      /// </summary>
-      private class CommitScanState : MSILVisitor<Label,Local,Parameter,Method,Field,Type, Unit, Unit, int, bool>,
-        ICodeQuery<Label, Local, Parameter, Method, Field, Type, int, bool>
-      {
-        ScanState state;
-        Type nextEndOldType;
-        EnsuresBlock<Label> currentBlock;
-        EnsuresSubroutine<Label> parent;
-
-        OnDemandMap<CFGBlock, ScanState> blockStartState;
-
-        public CommitScanState(EnsuresSubroutine<Label> parent)
-        {
-          this.parent = parent;
-          this.state = ScanState.OutsideOld;
+            Contract.Invariant(subroutine != null);
+            Contract.Invariant(id >= 0); // F: I am guessing this invariant should hold
         }
 
-        public void StartBlock(EnsuresBlock<Label> block)
+        internal void SetReversePostOrderIndex(int index)
         {
-          Contract.Requires(block != null);
-
-          if (!this.blockStartState.TryGetValue(block, out this.state))
-          {
-            this.state = ScanState.OutsideOld; // default
-            this.blockStartState.Add(block, this.state); // remember in case of bad control flow
-          }
-          if (this.state == ScanState.InsertingOld)
-          {
-            block.StartOverridingLabels();
-          }
-          if (this.state == ScanState.InsertingOldAfterCall)
-          {
-            // insert end old at head of block
-            block.StartOverridingLabels();
-            block.EndOldWithoutInstruction(this.nextEndOldType);
-            this.state = ScanState.OutsideOld;
-          }
-          this.currentBlock = block;
+            reversePostOrder = index;
         }
 
-        public void SetStartState(CFGBlock succ)
+        protected CFGBlock(Subroutine container, ref int idGen)
         {
-          // Debug.Assert(this.state != ScanState.InsertingOld); // can't insert old spanning blocks.
-          ScanState start;
-          if (!blockStartState.TryGetValue(succ, out start))
-          {
-            blockStartState.Add(succ, this.state);
-          }
-          else
-          {
-            Contract.Assume(start == this.state); // F: made an assume
-          }
+            Contract.Requires(container != null);
+            Contract.Requires(idGen >= 0); // Clousot suggestion
+
+            Contract.Ensures(idGen >= 0);
+            Contract.Ensures(Contract.OldValue(idGen) + 1 == idGen);
+
+            id = idGen++;
+            subroutine = container;
         }
 
-        #region Visitor
-        protected override bool Default(Label pc, int index)
+        internal void Renumber(ref int idGen)
         {
-          if (this.state == ScanState.InsertingOld)
-          {
-            // something's odd: need to end old scope here. Could be loading only the address of
-            // a parameter and never dereferencing it, or passing it to a method among other parameters,
-            // in which case, we can't do much (mix of old and new in a method use).
+            Contract.Requires(idGen >= 0); // Clousot suggestion
 
-            // the end old type is actually a pointer
-            this.state = ScanState.OutsideOld;
-            var oldType = this.parent.MethodCache.AssumeNotNull().MetadataDecoder.ManagedPointer(this.nextEndOldType);
-            this.currentBlock.EndOldWithoutInstruction(oldType);
-            
-            // still insert the current instruction (now after the end old)
-            return true;
-          }
-          return this.currentBlock.UsesOverriding;
+            id = idGen++;
         }
 
-        public bool Aggregate(Label pc, Label aggStart, bool branchTarget, int data)
-        {
-          return this.Nop(pc, data);
-        }
 
-        public override bool Nop(Label pc, int data)
-        {
-          return this.currentBlock.UsesOverriding;
-        }
+        #endregion
 
-        public override bool BeginOld(Label pc, Label matchingEnd, int index)
+        public int Index
         {
-          Contract.Assume(this.state == ScanState.OutsideOld);
-          this.state = ScanState.InsideOld;
-          return this.currentBlock.UsesOverriding;
-        }
-
-        public override bool EndOld(Label pc, Label matchingBegin, Type type, Unit dest, Unit source, int index)
-        {
-          Contract.Assume(this.state == ScanState.InsideOld);
-          this.state = ScanState.OutsideOld;
-          return this.currentBlock.UsesOverriding;
-        }
-
-        public override bool Ldarga(Label pc, Parameter argument, bool dummyIsOld, Unit dest, int index)
-        {
-          if (this.state == ScanState.OutsideOld)
-          {
-            this.state = ScanState.InsertingOld;
-            this.currentBlock.BeginOld(index);
-            this.nextEndOldType = parent.MethodCache.AssumeNotNull().MetadataDecoder.ParameterType(argument);
-          }
-          return this.currentBlock.UsesOverriding;
-        }
-
-        public override bool Ldind(Label pc, Type type, bool @volatile, Unit dest, Unit ptr, int index)
-        {
-          if (this.state == ScanState.InsertingOld)
-          {
-            // ends the old scope
-            this.state = ScanState.OutsideOld;
-            this.currentBlock.EndOld(index, nextEndOldType);
-            return false; // we already had to add this instruction before the end_old.
-          }
-          return this.currentBlock.UsesOverriding;
-        }
-
-        public override bool Ldfld(Label pc, Field field, bool @volatile, Unit dest, Unit obj, int index)
-        {
-          if (this.state == ScanState.InsertingOld)
-          {
-            // ends the old scope
-            this.state = ScanState.OutsideOld;
-            this.currentBlock.EndOld(index, this.parent.MethodCache.AssumeNotNull().MetadataDecoder.FieldType(field));
-            return false; // we already had to add this instruction before the end_old.
-          }
-          return this.currentBlock.UsesOverriding;
-        }
-
-        public override bool Ldflda(Label pc, Field field, Unit dest, Unit obj, int data)
-        {
-          if (this.state == ScanState.InsertingOld)
-          {
-            // keep track of eventual type in old
-            this.nextEndOldType = this.parent.MethodCache.AssumeNotNull().MetadataDecoder.FieldType(field);
-          }
-          return this.currentBlock.UsesOverriding;
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                return id;
+            }
         }
 
         /// <summary>
-        /// Ends sequence of inserted old. Call is on struct address passed by value, thus in the old state
-        /// Trickyness:
-        ///  - Because Call statements appear in their own block, and post-conditions of the call need to be
-        ///    evaluated also in the old state, we need to insert the EndOld statement in the next block
-        ///  - The CFG construction is making sure that there are no back-to-back call blocks in ensures.
+        /// Index in reverse post order. This is the preferred order for forward data flow analysis
         /// </summary>
-        public override bool Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, int index)
+        public int ReversePostOrderIndex { get { return reversePostOrder; } }
+
+        public abstract int Count
         {
-          Contract.Assume(false, "we should not be decoding method call blocks");
-          return false;
+            get;
         }
+
+        /// <summary>
+        /// Returns the list of APCs represented by this block (without finally contexts)
+        /// </summary>
+        public IEnumerable<APC> APCs()
+        {
+            return APCs(null);
+        }
+
+        /// <summary>
+        /// Returns the list of APCs represented by this block (without finally contexts)
+        /// </summary>
+        public IEnumerable<APC> APCs(SubroutineContext context)
+        {
+            for (int i = 0; i < this.Count; i++)
+            {
+                yield return new APC(this, i, context);
+            }
+        }
+
+
+        public APC First
+        {
+            get { return new APC(this, 0, null); }
+        }
+
+        /// <summary>
+        /// Returns program point after last statement in this block
+        /// </summary>
+        public APC Last
+        {
+            get
+            {
+                return APC.ForEnd(this, null);
+            }
+        }
+
+        /// <summary>
+        /// Returns program point prior to last statement in this block
+        /// </summary>
+        public APC PriorLast
+        {
+            get
+            {
+                int priorToLast = this.Count - 1;
+                if (priorToLast < 0) { priorToLast = 0; }
+                return new APC(this, priorToLast, null);
+            }
+        }
+
+        public abstract int ILOffset(APC pc);
+
+        public abstract string SourceContext(APC pc);
+        public abstract string SourceDocument(APC pc);
+        public abstract int SourceStartLine(APC pc);
+        public abstract int SourceEndLine(APC pc);
+        public abstract int SourceStartColumn(APC pc);
+        public abstract int SourceEndColumn(APC pc);
+        public abstract int SourceStartIndex(APC pc);
+        public abstract int SourceLength(APC pc);
+        public abstract string SourceAssertionCondition(APC pc);
+
+        public Subroutine Subroutine
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Subroutine>() != null);
+                return subroutine;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the block is a method call block or newObj call block
+        /// </summary>
+        /// <param name="parameterCount">on success holds the parameter count of the called method (not including "this")</param>
+        public virtual bool IsMethodCallBlock<Method>(out Method calledMethod, out bool isNewObj, out bool isVirtual)
+        {
+            calledMethod = default(Method);
+            isNewObj = false;
+            isVirtual = false;
+            return false;
+        }
+
+        #region IEquatable<CFGBlock> Members
+
+        public bool Equals(CFGBlock other)
+        {
+            return id == other.id;
+        }
+
         #endregion
+    }
+
+    #region Contracts for CFGBlock
+
+    [ContractClassFor(typeof(CFGBlock))]
+    internal abstract class CFGBlockContracts : CFGBlock
+    {
+        // To please C#
+        private CFGBlockContracts(int r)
+          : base(null, ref r)
+        { }
+
+        public override int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                return 0;
+            }
+        }
+
+        public override int ILOffset(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Tag SourceContext(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Tag SourceDocument(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SourceStartLine(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SourceEndLine(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SourceStartColumn(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SourceEndColumn(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SourceStartIndex(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int SourceLength(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Tag SourceAssertionCondition(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    #endregion
+    /// <summary>
+    /// Caches method CFGs, pre and post condition subroutines
+    /// </summary>
+    public class MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>
+     : IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, Subroutine>
+    {
+        #region ------------ Fields -------------
+
+        public readonly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder;
+        public readonly IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder;
+
+        private readonly Dictionary<Method, ControlFlow<Method, Type>> methodCache = new Dictionary<Method, ControlFlow<Method, Type>>();
+        private readonly Dictionary<Method, Set<Field>> methodModifies = new Dictionary<Method, Set<Field>>();
+        private readonly Dictionary<Method, Set<Field>> methodReads = new Dictionary<Method, Set<Field>>();
+        private readonly Dictionary<Field, Set<Method>> propertyReads = new Dictionary<Field, Set<Method>>();
+        private readonly Dictionary<Method, bool> methodWitnesses; // TODO: Make it more generic
+        private readonly InvariantCache invariantCache;
+        private readonly RequiresCache requiresCache;
+        private readonly EnsuresCache ensuresCache;
+        private readonly ModelEnsuresCache modelEnsuresCache;
+        private readonly AssumeCache assumeCache;
+        /// <summary>
+        /// Used to allow inserting the same invariant twice on entry around a requires. The second one has to be wrapped
+        /// so the control flow logic for edge subroutines does not get confused (can't have the same subroutine twice on an edge).
+        /// </summary>
+        private readonly Dictionary<Subroutine, Subroutine> redundantInvariants = new Dictionary<Subroutine, Subroutine>();
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(methodCache != null);
+            Contract.Invariant(methodModifies != null);
+            Contract.Invariant(methodReads != null);
+            Contract.Invariant(methodWitnesses != null);
+            Contract.Invariant(propertyReads != null);
+            Contract.Invariant(invariantCache != null);
+            Contract.Invariant(modelEnsuresCache != null);
+            Contract.Invariant(ensuresCache != null);
+            Contract.Invariant(requiresCache != null);
+            Contract.Invariant(MetadataDecoder != null);
+            Contract.Invariant(ContractDecoder != null);
+            Contract.Invariant(redundantInvariants != null);
+            Contract.Invariant(assumeCache != null);
+        }
+
+        #endregion
+
+        public MethodCache(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+                           IDecodeContracts<Local, Parameter, Method, Field, Type> contractDecoder,
+                           ErrorHandler output
+                          )
+        {
+            Contract.Requires(mdDecoder != null);
+            Contract.Requires(contractDecoder != null);
+
+            this.MetadataDecoder = mdDecoder;
+            this.ContractDecoder = contractDecoder;
+            methodWitnesses = new Dictionary<Method, bool>();
+            requiresCache = new RequiresCache(this, output);
+            ensuresCache = new EnsuresCache(this);
+            modelEnsuresCache = new ModelEnsuresCache(this);
+            invariantCache = new InvariantCache(this);
+            assumeCache = new AssumeCache(this);
+        }
+
+        public ICFG GetCFG(Method method)
+        {
+            Contract.Ensures(Contract.Result<ICFG>() != null);
+
+            if (methodCache.ContainsKey(method))
+            {
+                return methodCache[method].AssumeNotNull();
+            }
+            ControlFlow<Method, Type> result;
+            if (MetadataDecoder.HasBody(method))
+            {
+                Subroutine sb = MetadataDecoder.AccessMethodBody(method, this, Unit.Value);
+
+                Contract.Assume(sb != null, " Axiom HasBody(method) ==> AccesMethodBody(method ,... ) != null");
+                result = new ControlFlow<Method, Type>(sb, this);
+            }
+            else
+            {
+                throw new InvalidOperationException("Method has no body");
+            }
+            //methodCache.Add(method, result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns null if method has no requires (and no inherited requires)
+        /// </summary>
+        internal Subroutine GetRequires(Method method)
+        {
+            // Experimental
+            //   To get contracts on generic/specialized method instances, let's grab the unspecialized method
+            //   here.
+            method = this.MetadataDecoder.Unspecialized(method);
+            // End Experimental
+            return requiresCache.Get(method);
+        }
 
 
         /// <summary>
-        /// If we are inserting old, and this method has more than 1 parameter (including this), then
-        /// we are out of luck. We cannot evaluate it in the oldstate, as the other parameters were pushed in 
-        /// the new state.
+        /// Returns null if method has no ensures (and no inherited ensures)
         /// </summary>
-        /// <param name="block"></param>
-        internal void HandlePotentialCallBlock(MethodCallBlock<Label> block, EnsuresBlock<Label> priorBlock)
+        internal Subroutine GetEnsures(Method method)
         {
-          // We comment this preconditon has it always brings to a violation. We did not saw it before because runtimechecking was not enabled for the ControlFlow Project
-          // Contract.Requires(priorBlock != null); 
+            // Experimental
+            //   To get contracts on generi/specialized method instances, let's grab the unspecialized method
+            //   here.
+            method = this.MetadataDecoder.Unspecialized(method);
+            // End Experimental
+            return ensuresCache.Get(method);
+        }
 
-          if (block == null) return;
+        /// <summary>
+        /// Returns null if method has no model ensures (and no inherited model ensures)
+        /// </summary>
+        internal Subroutine GetModelEnsures(Method method)
+        {
+            // Experimental
+            //   To get contracts on generic/specialized method instances, let's grab the unspecialized method
+            //   here.
+            method = this.MetadataDecoder.Unspecialized(method);
+            // End Experimental
+            return modelEnsuresCache.Get(method);
+        }
 
-          if (this.state == ScanState.InsertingOld)
-          {
-            // ends scope. Figure out if before call, or after call.
-            var paramCount = parent.MethodCache.AssumeNotNull().MetadataDecoder.AssumeNotNull().Parameters(block.CalledMethod).AssumeNotNull().Count;
-            if (!parent.MethodCache.AssumeNotNull().MetadataDecoder.AssumeNotNull().IsStatic(block.CalledMethod))
+        /// <summary>
+        /// Returns null if no invariant is specified
+        /// </summary>
+        public Subroutine GetInvariant(Type type)
+        {
+            // we have to make sure we are not confused by the particular instantiation of the type
+            type = this.MetadataDecoder.Unspecialized(type);
+            return invariantCache.Get(type);
+        }
+
+        public Subroutine GetRedundantInvariant(Subroutine existingInvariant, Type type)
+        {
+            Subroutine result;
+            if (redundantInvariants.TryGetValue(existingInvariant, out result))
             {
-              paramCount++;
+                return result;
             }
-            Contract.Assert(parent.MethodCache != null);
-            Contract.Assume(parent.MethodCache.MetadataDecoder != null);
-            if (paramCount > 1)
+            result = new InvariantSubroutine<Unit>(this, existingInvariant, type);
+            redundantInvariants.Add(existingInvariant, result);
+            return result;
+        }
+
+        #region Internal Access to Forward decoding
+        internal Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
+        {
+            BlockBase block = pc.Block as BlockBase;
+            if (block != null)
             {
-              if(priorBlock == null)
-              {
-                return; // F: nothing to do?
-              }
-
-              // end old in prior block (block before call block).
-              this.state = ScanState.OutsideOld;
-
-              // the end old type is actually a pointer
-              var oldType = parent.MethodCache.MetadataDecoder.ManagedPointer(this.nextEndOldType);
-              priorBlock.EndOldWithoutInstruction(oldType);
+                return block.ForwardDecode<Data, Result, Visitor>(pc, visitor, data);
             }
-            else
+            return visitor.Nop(pc, data);
+        }
+        #endregion
+
+        public Result DecodeForReturnValue<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
+        {
+            BlockBase block = pc.Block as BlockBase;
+            if (block != null)
             {
-              this.state = ScanState.InsertingOldAfterCall;
-              this.nextEndOldType = parent.MethodCache.MetadataDecoder.ReturnType(block.CalledMethod);
+                return block.ForwardDecode<Data, Result, Visitor>(pc, visitor, data);
             }
-          }
+            return visitor.Nop(pc, data);
         }
-      }
 
-      [ContractVerification(false)] // We cannot prove the invariant this.BlockStart == null ==> this.Builder == null
-      internal override void Commit()
-      {
-        base.Commit();
-        var scan = new CommitScanState(this);
+        #region IMethodCodeConsumer<Local,Parameter,Method,Field,Type,Unit,Unit> Members
 
-        EnsuresBlock<Label> priorBlock = null;
-
-        foreach (var block in this.Blocks)
+        Subroutine IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Unit, Subroutine>.Accept<Label, Handler>(
+          IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> codeProvider,
+          Label entryPoint,
+          Method method,
+          Unit data)
         {
-          // skip blocks that are not our special blocks.
-          EnsuresBlock<Label> b = block as EnsuresBlock<Label>;
-          if (b != null)
-          {
-            // save block in case next block is a call block. 
-            // (we assume that block order is sequential for straight line code)
-            priorBlock = b;
-            // scan block, keeping track if we are in old, inserting old, or outside old
-            // decode each instruction
-            // if ldarg or ldarga and we are not in old, add a begin_old bubble and start inserting_old
-            //   if inserting_old and current instruction is a memory deref (ldfld, ldind), add end_old after instruction 
-            //   and state is now outside old
-            // if reaching end of block while inserting old, insert an end_old (could be passing address by ref to a method)
-            int originalCount = b.Count; // do this before scan.StartBlock
-            scan.StartBlock(b);
-
-            for (int i = 0; i < originalCount; i++)
-            {
-              bool addInstruction = b.OriginalForwardDecode<int, bool, CommitScanState>(i, scan, i);
-              if (addInstruction)
-              {
-                b.AddInstruction(i);
-              }
-            }
-          }
-          else // might be a method call block
-          {
-            // Method call blocks end the old scope if we are in one
-            scan.HandlePotentialCallBlock(block as MethodCallBlock<Label>, priorBlock);
-          }
-          foreach (var succ in this.SuccessorBlocks(block))
-          {
-            scan.SetStartState(succ);
-          }
-        }
-      }
-      #endregion
-
-
-      internal void AddInferredOldMap(int blockIndex, int instructionIndex, CFGBlock otherBlock, Type endOldType)
-      {
-        this.inferredOldLabelReverseMap.Add(OverlayInstructionKey(blockIndex, instructionIndex), new Pair<CFGBlock, Type>(otherBlock, endOldType));
-      }
-
-      private static int OverlayInstructionKey(int blockIndex, int instruction)
-      {
-        var result = (instruction << 16) + blockIndex;
-        return result;
-      }
-
-      internal CFGBlock InferredBeginEndBijection(APC pc)
-      {
-        Type dummy;
-        return InferredBeginEndBijection(pc, out dummy);
-      }
-
-      internal CFGBlock InferredBeginEndBijection(APC pc, out Type endOldType)
-      {
-        Contract.Assume(pc.Block != null, "Assuming the object invariant");
-
-        var key = OverlayInstructionKey(pc.Block.Index, pc.Index);
-        Pair<CFGBlock, Type> data;
-        if (!this.inferredOldLabelReverseMap.TryGetValue(key, out data))
-        {
-          throw new ApplicationException("Fatal bug in ensures CFG begin/end old map");
-        }
-        endOldType = data.Two;
-        return data.One;
-      }
-    }
-
-    internal class ModelEnsuresSubroutine<Label> : EnsuresSubroutine<Label> {
-      public ModelEnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                                    Method method,
-                                    SimpleSubroutineBuilder<Label> builder, Label startLabel, IFunctionalSet<Subroutine> inherited)
-        : base(methodCache, method, builder, startLabel, inherited) {
-          Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-          Contract.Requires(builder != null);// F: As of Clousot suggestion
-
-      }
-
-      public ModelEnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, Method method, IFunctionalSet<Subroutine> inherited)
-        : base(methodCache, method, inherited) {
-          Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-      }
-
-      public override bool IsModelEnsures {
-        get {
-          return true;
-        }
-      }
-
-      public override string Kind {
-        get { return "model-ensures"; }
-      }
-
-    }
-
-    internal class InvariantSubroutine<Label> : SubroutineBase<Label>, ITypeInfo<Type>
-    {
-      new SimpleSubroutineBuilder<Label> Builder;
-      Type associatedType;
-
-      public InvariantSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-                                 SimpleSubroutineBuilder<Label> builder, Label startLabel,
-                                 Subroutine baseInv, Type associatedType
-      )
-        : base(methodCache, startLabel, builder)
-      {
-        Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
-        Contract.Requires(builder!= null);// F: As of Clousot suggestion
-
-        this.Builder = builder;
-        this.associatedType = associatedType;
-        CFGBlock startBlock = this.GetTargetBlock(startLabel);
-        this.AddBaseInvariant(this.Entry, startBlock, baseInv);
-      }
-
-      public InvariantSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, 
-        Subroutine inherited, Type associatedType)
-        : base(methodCache)
-      {
-        Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
-
-        this.AddSuccessor(this.Entry, "entry", this.Exit);
-        this.AddBaseInvariant(this.Entry, this.Exit, inherited);
-        this.Commit(); // do it here, since we have no builder it won't get called later
-      }
-
-      public override string Kind
-      {
-        get { return "invariant"; }
-      }
-
-      internal override void Initialize()
-      {
-        if (Builder == null) return;
-
-        Builder.BuildBlocks(startLabel, this);
-        this.Commit();
-        Builder = null;
-      }
-
-      /// <summary>
-      /// Add subroutine calls to base invariant if non-null
-      /// </summary>
-      private void AddBaseInvariant(CFGBlock fromBlock, CFGBlock toBlock, Subroutine inherited)
-      {
-        this.AddEdgeSubroutine(fromBlock, toBlock, inherited, "inherited");
-      }
-
-      public override bool IsInvariant
-      {
-        get { return true; }
-      }
-      public override bool IsContract
-      {
-        get { return true; }
-      }
-
-      #region ITypeInfo<Type> Members
-
-      Type ITypeInfo<Type>.AssociatedType
-      {
-        get { return associatedType; }
-      }
-
-      #endregion
-    }
-
-    #endregion // ------------- Nested Types --------------------
-
-    /// <summary>
-    /// Try to add a requires to a method. If the method inherits a requires, then this is not possible.
-    /// </summary>
-    /// <param name="identifying">Identifiying string (e.g. of pre-condition). Used to eliminate dups</param>
-    /// <returns>true if added or already present</returns>
-    public bool AddPreCondition<Label>(Method method, Label precondition, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
-    {
-      // TODO: figure out whether we already analyzed a caller to this method. In that case, we can't strengthen the pre-condition.
-
-      var original = GetRequires(method);
-
-      if (original != null)
-      {
-        IMethodInfo<Method> mi = original as IMethodInfo<Method>;
-        if (mi != null && !this.MetadataDecoder.Equal(mi.Method, method))
-        {
-          // inherited, can't add
-          return false;
-        }
-      }
-
-      var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, precondition);
-
-      var newPre = new RequiresSubroutine<Label>(this, method, builder, precondition, FunctionalSet<Subroutine>.Empty());
-      newPre.Initialize(); // not going through cache and lazy initialized
-      if (original == null)
-      {
-        this.requiresCache.Install(method, newPre);
-        return true;
-      }
-      else
-      {
-        foreach (var pred in original.PredecessorBlocks(original.Exit))
-        {
-          original.AddEdgeSubroutine(pred, original.Exit, newPre, "extra");
-        }
-        return true;
-      }
-    }
-
-    public bool RemovePreCondition(Method method)
-    {
-      return this.requiresCache.Remove(method);
-    }
-
-    public bool AddPostCondition<Label>(Method method, Label postCondition, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
-    {
-      var original = GetEnsures(method);
-      var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, postCondition);
-      var newPost = new EnsuresSubroutine<Label>(this, method, builder, postCondition, FunctionalSet<Subroutine>.Empty());
-      newPost.Initialize();
-
-      if (original == null)
-      {
-        this.ensuresCache.Install(method, newPost);
-        return true;
-      }
-      else
-      {
-        foreach (var pred in original.PredecessorBlocks(original.Exit))
-        {
-          original.AddEdgeSubroutine(pred, original.Exit, newPost, "extra");
-        }
-        return true;
-      }
-    }
-
-
-
-    public bool AddWitness(Method method, bool mayReturnNull)
-    {
-      this.methodWitnesses[method] = mayReturnNull;
-
-      return true; // Always succeed in this easy case
-    }
-
-    /// <summary>
-    /// At the moment, we only say if a method may return null. TODO: expand to witnesses
-    /// </summary>
-    public bool GetWitnessForMayReturnNull(Method method)
-    {
-      bool mayReturnNull;
-      return this.methodWitnesses.TryGetValue(method, out mayReturnNull) && mayReturnNull;
-    }
-
-    public bool AddEntryAssume<Label>(ICFG cfg, Method caller, Label assume, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
-    {
-      Contract.Requires(cfg != null);
-
-      if (cfg.Subroutine.Blocks == null)
-      {
-        // Should not happen?
-        return false;
-      }
-
-      bool installed = false;
-
-      var from = cfg.Entry.Block.AssumeNotNull();
-      var next = cfg.EntryAfterRequires.Block;
-
-      var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, assume);
-      var assumeSub = new RequiresSubroutine<Label>(this, caller, builder, assume, FunctionalSet<Subroutine>.Empty());
-      assumeSub.Initialize();
-      assumeSub.IsNecessaryAssumption = true;
-      // install assume
-      from.Subroutine.AddEdgeSubroutine(from, next, assumeSub, "entry");
-      installed = true;
-      return installed;
-    }
-
-    public bool AddCalleeAssumeAsPostCondition<Label>(ICFG cfg, Method caller, Method callee, Label assume, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
-    {
-      Contract.Requires(cfg != null);
-
-      if (cfg.Subroutine.Blocks == null)
-      {
-        // Should not happen?
-        return false;
-      }
-
-      // (1) find the method that the assume is a postcondition of
-      // (2) validate that the context is ok (vars reference in assume exist, are initialized, e.t.c) TODO
-      // (3) install the assume 
-      bool installed = false;
-      // TODO: perform deeper traversal in case a subroutine contains our call of interest?
-      foreach (var from in cfg.Subroutine.Blocks)
-      {
-        Method methodCall;
-        bool constructor, virtualCall;
-        if (from.IsMethodCallBlock(out methodCall, out constructor, out virtualCall))
-        {
-          if (methodCall.Equals(callee)) // found method we were looking for
-          {
-            CFGBlock next = null;
-           // Hyp: there should be only one successor block, the ensures block
-            foreach (var cand in from.Subroutine.SuccessorBlocks(from)) // should be single successor here
-            {
-              next = cand;
-              break;
-            }
-            if (next == null) continue; // make sure we found *some* successor of the call; otherwise don't try to install
-
-            var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, assume);
-            var assumeSub = new EnsuresSubroutine<Label>(this, callee, builder, assume, null);
-            assumeSub.Initialize();
-            assumeSub.IsNecessaryAssumption = true;
-#if false
-            var builder = new AssumeAsPostConditionSubroutineBuilder<Label>(codeProvider, this, assume);
-
-            // find return value of the function (for now, we only infer assumes for method postconditions, so it should exist...)
-            // TODO: use Contract.Result when we generate the code fix. 
-            var retvalFinder = new ReturnValueFinderVisitor<Local, Parameter, Method, Field, Property, Event, Type, UnitSource, UnitDest, APC, APC, APC, Unit>();
-            this.DecodeForReturnValue<APC, Unit, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, APC, Unit>>(next.First, retvalFinder.Visitor(), next.First);
-
-
-            // By now, we case split to see which kinds of variable the result value is. In the future, with Contract.Result (as above) we will not need it
-            AssumeAsPostConditionSubroutine<Label> assumeSub;
-            Local retvalLocal = default(Local);
-            Parameter retvalParam = default(Parameter);
-            Field retvalField = default(Field);
-            if (retvalFinder.GetLocalReturnValue(out retvalLocal))
-            {
-              assumeSub = new AssumeAsPostConditionSubroutine<Label>(0, this, retvalLocal, retvalParam, retvalField, assume, builder, AssumeAsPostConditionSubroutine<Label>.RetvalType.LocalRetval);
-            }
-            else if (retvalFinder.GetParameterReturnValue(out retvalParam))
-            {
-              assumeSub = new AssumeAsPostConditionSubroutine<Label>(0, this, retvalLocal, retvalParam, retvalField, assume, builder, AssumeAsPostConditionSubroutine<Label>.RetvalType.ParameterRetval);
-            }
-              // Field case commented out, as it does not work for now
-            //else if (retvalFinder.GetFieldReturnValue(out retvalField)) assumeSub = new AssumeAsPostConditionSubroutine<Label>(0, this, retvalLocal, retvalParam, retvalField, assume, builder, AssumeAsPostConditionSubroutine<Label>.RetvalType.FieldRetval);
-            else
-            {
-              return false; // abort install if we can't find return value
-            }
-#endif
-            // install assume
-            from.Subroutine.AddEdgeSubroutine(from, next, assumeSub, "afterCallAssume");
-            installed = true;
-          }
-        }
-      }
-      return installed;
-    }
-
-    public bool AddInvariant<Label>(Type type, Label invariant, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
-    {
-      var original = GetInvariant(type);
-
-      if (original != null)
-      {
-        ITypeInfo<Type> ti = original as ITypeInfo<Type>;
-        if (ti != null && !this.MetadataDecoder.Equal(ti.AssociatedType, type))
-        {
-          // inherited, can't add
-          return false;
-        }
-      }
-
-      var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, invariant);
-
-      var newInvariant = new InvariantSubroutine<Label>(this, builder, invariant, original, type);
-      newInvariant.Initialize();
-
-      if (original == null)
-      {
-        this.invariantCache.Install(type, newInvariant);
-        return true;
-      }
-      else
-      {
-        foreach (var pred in original.PredecessorBlocks(original.Exit))
-        {
-          original.AddEdgeSubroutine(pred, original.Exit, newInvariant, "extra");
-        }
-        return true;
-      }
-    }
-
-
-    internal Subroutine BuildSubroutine<Label>(
-      int stackDelta,
-      ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
-      Label entryPoint)
-    {
-      var sb = new SimpleSubroutineBuilder<Label>(codeProvider, this, entryPoint);
-      return new SimpleSubroutine<Label>(stackDelta, this, entryPoint, sb);
-    }
-
-    private static readonly IEnumerable<Field> emptyFields = new Field[0];
-    private static readonly IEnumerable<Method> emptyMethods = new Method[0];
-    
-    /// <summary>
-    /// We assume that we only call this on methods under analysis (never on methods from other assemblies)
-    /// </summary>
-    internal IEnumerable<Field> GetModifies(Method method)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
-
-      // make sure we computed the modifies info
-      if (this.MetadataDecoder.HasBody(method))
-      {
-        this.GetCFG(method);
-
-        Set<Field> result;
-        if (methodModifies.TryGetValue(method, out result))
-        {
-          Contract.Assume(result != null);
-          return result;
-        }
-      }
-      return emptyFields;
-    }
-
-    /// <summary>
-    /// We assume that we only call this on methods under analysis (never on methods from other assemblies)
-    /// </summary>
-    internal IEnumerable<Field> GetReads(Method method)
-    {
-      // make sure we computed the modifies info
-      if (this.MetadataDecoder.HasBody(method))
-      {
-        this.GetCFG(method);
-
-        Set<Field> result;
-        if (methodReads.TryGetValue(method, out result))
-        {
-          return result;
-        }
-      }
-      return emptyFields;
-    }
-
-    /// <summary>
-    /// We assume that we only call this on fields of types under analysis (never on fields from other assemblies)
-    /// </summary>
-    internal IEnumerable<Method> GetAffectedGetters(Field field)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
-
-      // we can't really ensure that we computed this set for all methods in the type
-      Set<Method> result;
-      if (propertyReads.TryGetValue(field, out result))
-      {
-        Contract.Assume(result != null);
-        return result;
-      }
-
-      return emptyMethods;
-    }
-    private Set<Field> ModifiesSet(Method method)
-    {
-      Contract.Ensures(Contract.Result<Set<Field>>() != null);
-
-      Set<Field> result;
-      if (!methodModifies.TryGetValue(method, out result))
-      {
-        result = new Set<Field>();
-        methodModifies.Add(method, result);
-      }
-      Contract.Assume(result != null);
-      return result;
-    }
-
-    private Set<Field> ReadSet(Method method)
-    {
-      Contract.Ensures(Contract.Result<Set<Field>>() != null);
-      Set<Field> result;
-      if (!methodReads.TryGetValue(method, out result))
-      {
-        result = new Set<Field>();
-        methodReads.Add(method, result);
-      }
-      Contract.Assume(result != null);
-      return result;
-    }
-
-    private Set<Method> PropertySet(Field field)
-    {
-      Contract.Ensures(Contract.Result<Set<Method>>() != null);
-
-      Set<Method> result;
-      if (!this.propertyReads.TryGetValue(field, out result))
-      {
-        result = new Set<Method>();
-        this.propertyReads.Add(field, result);
-      }
-      Contract.Assume(result != null);
-      return result;
-    }
-
-
-    internal void AddModifies(Method method, Field field)
-    {
-      ModifiesSet(method).Add(field);
-    }
-
-    public bool IsMonitorWaitOrExit(Method method)
-    {
-      var t = this.MetadataDecoder.DeclaringType(method);
-      if (this.MetadataDecoder.Name(t) != "Monitor") return false;
-      var name = this.MetadataDecoder.Name(method);
-      if (name == "Exit" || name == "Wait") return true;
-      return false;
-    }
-
-    internal void AddReads(Method method, Field field)
-    {
-      this.ReadSet(method).Add(field);
-      this.PropertySet(field).Add(method);
-    }
-
-    public void RemoveContractsFor(Method method)
-    {
-      if (this.methodCache.ContainsKey(method))
-      {
-        this.methodCache.Remove(method);
-      }
-      if (this.methodModifies.ContainsKey(method))
-      {
-        this.methodModifies.Remove(method);
-      }
-      if (this.methodReads.ContainsKey(method))
-      {
-        this.methodReads.Remove(method);
-      }
-      requiresCache.Remove(method);
-      ensuresCache.Remove(method);
-      modelEnsuresCache.Remove(method);
-    }
-  }
-
-
-  public class ControlFlow<Method, Type> : ICFG
-  {
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.contextCache != null);
-      Contract.Invariant(this.consCache != null);
-      Contract.Invariant(this.methodSubroutine != null); // F: because of many precondition suggestions, made it an object invariant
-    }
-
-
-    #region Private
-
-    private readonly Subroutine methodSubroutine;
-    private readonly object methodCache;
-
-    private CFGBlock entry { get { return this.methodSubroutine.Entry; } }
-    private CFGBlock normalExit { get { return this.methodSubroutine.Exit; } }
-    private CFGBlock exceptionExit { get { return this.methodSubroutine.ExceptionExit; } }
-
-    
-    #endregion
-
-    /// <summary>
-    /// The control flow class provides an overlay of logical control flow over a syntactic
-    /// code structure by making control flow explicit, including block entry/exit, and 
-    /// finally block execution.
-    /// </summary>
-    /// <param name="start">Entry point for method</param>
-    //^ [NotDelayed]
-    internal ControlFlow(Subroutine subroutine, object methodCache) {
-      Contract.Requires(subroutine != null); // F: As suggested by Clousot
-      
-      this.methodSubroutine = subroutine;
-      this.consCache = this.contextCache.Cons;
-      this.methodCache = methodCache;
-    }
-
-
-    #region ICFG<Code,Label,Handler,APC> Members
-
-    public Method CFGMethod
-    {
-      get
-      {
-        IMethodInfo<Method> mi = this.methodSubroutine as IMethodInfo<Method>;
-        if (mi != null) return mi.Method;
-        throw new Exception("CFG has bad subroutine that is not a method");
-      }
-    }
-    public APC Entry {
-      get { return new APC(this.entry, 0, null); }
-    }
-
-    public APC EntryAfterRequires
-    {
-      get { return new APC(this.methodSubroutine.EntryAfterRequires, 0, null); }
-    }
-
-    public APC NormalExit
-    {
-      get { return new APC(this.normalExit, 0, null); }
-    }
-
-    public APC ExceptionExit {
-      get { return new APC(this.methodSubroutine.ExceptionExit, 0, null); }
-    }
-
-    public APC Post(APC pc)
-    {
-      APC succ;
-      if (this.HasSingleSuccessor(pc, out succ))
-      {
-        return succ;
-      }
-      return pc;
-    }
-
-    public bool HasSingleSuccessor(APC ppoint, out APC next) {
-      return ppoint.Block.Subroutine.HasSingleSuccessor(ppoint, out next, this.consCache);
-    }
-
-    public bool HasSinglePredecessor(APC ppoint, out APC next, bool skipContracts)
-    {
-      return ppoint.Block.Subroutine.HasSinglePredecessor(ppoint, out next, this.consCache, skipContracts);
-    }
-
-    public APC PredecessorPCPriorToRequires(APC ppoint)
-    {
-      return ppoint.Block.Subroutine.PredecessorPCPriorToRequires(ppoint, this.consCache);
-    }
-
-    /// <summary>
-    /// Returns all normal control flow successors
-    /// </summary>
-    public IEnumerable<APC>/*!*/ Successors(APC ppoint) {
-      return ppoint.Block.Subroutine.Successors(ppoint, this.consCache);
-    }
-
-
-    public IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts) {
-      return ppoint.Block.Subroutine.Predecessors(ppoint, this.consCache, skipContracts);
-    }
-
-    public FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
-    {
-      return from.Subroutine.GetOrdinaryEdgeSubroutines(from, to, context);
-    }
-
-
-    /// <summary>
-    /// Used to hash cons subroutine context edge lists
-    /// </summary>
-    private readonly SubroutineContextCache contextCache = new SubroutineContextCache();
-    private readonly DConsCache consCache;
-
-    private class SubroutineContextCache
-    {
-      private DoubleTable<SubroutineEdge, SubroutineContext, SubroutineContext> subroutineContextHashMap = new DoubleTable<STuple<CFGBlock, CFGBlock, string>, FList<STuple<CFGBlock, CFGBlock, string>>, FList<STuple<CFGBlock, CFGBlock, string>>>();
-      private Dictionary<SubroutineEdge, SubroutineContext> subroutineContextHashMapSingleton = new Dictionary<STuple<CFGBlock, CFGBlock, string>, FList<STuple<CFGBlock, CFGBlock, string>>>();
-
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(subroutineContextHashMap != null);
-        Contract.Invariant(subroutineContextHashMapSingleton != null);
-      }
-
-      public SubroutineContext Cons(SubroutineEdge edge, SubroutineContext tail)
-      {
-        SubroutineContext/*?*/ result;
-        if (tail != null)
-        {
-          Debug.Assert(tail.Head.One.Subroutine != edge.One.Subroutine);
-          if (!this.subroutineContextHashMap.TryGetValue(edge, tail, out result))
-          {
-            result = SubroutineContext.Cons(edge, tail);
-            this.subroutineContextHashMap.Add(edge, tail, result);
-          }
-        }
-        else
-        {
-          if (!this.subroutineContextHashMapSingleton.TryGetValue(edge, out result))
-          {
-            result = SubroutineContext.Cons(edge, null);
-            this.subroutineContextHashMapSingleton[edge] = result;
-          }
-        }
-        return result;
-      }
-    }
-
-    /// <summary>
-    /// Returns a set of program points that are possible execution continuations if 
-    /// an exception is raised at the given ppoint.
-    ///
-    /// The supplied predicate allows the client to determine which handlers are possible
-    /// candidates. The predicate is called from closest enclosing to outermost.
-    /// </summary>
-    /// <param name="data">Arbitrary client data passed to the handler predicate</param>
-    /// <returns>A set of continuation program points that represent how execution continues to a chosen handler.
-    /// The continuation includes Finally and Fault executions that intervene between the given ppoint and a
-    /// chosen handler.
-    /// </returns>
-    public IEnumerable<APC> ExceptionHandlers<Type2, Data>(APC ppoint, Data data, IHandlerFilter<Type2, Data> handlerPredicate)
-    {
-
-      // This is a cross-subroutine operation. We need to ask for the handlers guarding the current block,
-      // followed by the handlers guarding the source of each edge on the subroutine stack.
-
-      // Ask the innermost subroutine for its handler continuations
-      bool escapesFromSubroutine = false;
-      foreach (CFGBlock handlerBlock in ppoint.Block.Subroutine.ExceptionHandlers(ppoint.Block, null, data, handlerPredicate))
-      {
-        if (handlerBlock != ppoint.Block.Subroutine.ExceptionExit)
-        {
-          yield return ppoint.Block.Subroutine.ComputeTargetFinallyContext(ppoint, handlerBlock, this.consCache);
-        }
-        else
-        {
-          escapesFromSubroutine = true;
-        }
-      }
-
-      if (!escapesFromSubroutine)
-      {
-        yield break; // no more outer handlers needed
-      }
-
-
-      // Now find handlers in surrounding subroutines, from inner to outer.
-      //
-      SubroutineContext outerContext = ppoint.SubroutineContext;
-      FList<Pair<string,CFGBlock>> innerAbortingContext = null;
-      APC innermostAbortingAPC = ppoint.Block.Subroutine.ComputeTargetFinallyContext(ppoint.WithoutContext, ppoint.Block.Subroutine.ExceptionExit, this.consCache);
-      SubroutineContext innerMostReversedContext = SubroutineContext.Reverse(innermostAbortingAPC.SubroutineContext);
-      Subroutine innerSubroutine = ppoint.Block.Subroutine;
-      while (outerContext != null)
-      {
-        escapesFromSubroutine = false;
-
-        CFGBlock from = outerContext.Head.One;
-        foreach (CFGBlock handlerBlock in from.Subroutine.ExceptionHandlers(from, innerSubroutine, data, handlerPredicate))
-        {
-          if (handlerBlock == from.Subroutine.ExceptionExit)
-          {
-            escapesFromSubroutine = true;
-          }
-          else
-          {
-            yield return this.ComputeExceptionTarget(innermostAbortingAPC.Block, innermostAbortingAPC.Index, innerMostReversedContext,
-                                      innerAbortingContext,
-                                      this.consCache(new SubroutineEdge(from, handlerBlock, "exception"), outerContext.Tail),
-                                      this.consCache);
-          }
-        }
-        if (!escapesFromSubroutine)
-        {
-          yield break; // no more outer handlers needed
-        }
-        innerAbortingContext = FList<Pair<string,CFGBlock>>.Cons(new Pair<string,CFGBlock>(outerContext.Head.Three, from), innerAbortingContext);
-        outerContext = outerContext.Tail;
-      }
-      // if we get here, we are throwing out of the outermost context
-      yield return this.ComputeExceptionTarget(innermostAbortingAPC.Block, innermostAbortingAPC.Index, innerMostReversedContext,
-                                innerAbortingContext,
-                                null,
-                                this.consCache);
-    }
-
-    /// <summary>
-    /// Computes new APC corresponding to a concatenation of exectuion from the current abortPoint (and its subroutine execution, provided in reversed from as innerMostReversedContext)
-    /// with the innerAbortingContext and the outerAbortingContext.
-    /// The innerAbortingContext is a set of blocks from outer to inner surrounding the abort point.
-    /// The resulting APC starts with the abort point and the innermost context (in proper order), followed by (x,exit_x) edges for all points in the innerAbortingContext (from inner to outer)
-    /// This entire context is pre-pended to the outer subroutine context.
-    /// </summary>
-    private APC ComputeExceptionTarget(CFGBlock abortPoint, int abortIndex, 
-                                       SubroutineContext innerMostReversedContext, 
-                                       FList<Pair<string,CFGBlock>> innerAbortingContext,
-                                       SubroutineContext outerSubroutineContext,
-                                       DConsCache consCache)
-    {
-      while (innerAbortingContext != null) {
-        outerSubroutineContext = this.consCache(new SubroutineEdge(innerAbortingContext.Head.Two, innerAbortingContext.Head.Two.Subroutine.ExceptionExit, innerAbortingContext.Head.One), outerSubroutineContext);
-        innerAbortingContext = innerAbortingContext.Tail;
-      }
-      while (innerMostReversedContext != null)
-      {
-        outerSubroutineContext = this.consCache(innerMostReversedContext.Head, outerSubroutineContext);
-        innerMostReversedContext = innerMostReversedContext.Tail;
-      }
-      return new APC(abortPoint, abortIndex, outerSubroutineContext);
-    }
-
-
-
-    public void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context) {
-      var printed = new Set<Pair<Subroutine, SubroutineContext>>();
-      this.methodSubroutine.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
-    }
-
-#if false
-    public void EmitTransferEquations(TextWriter tw, InvariantQuery<APC> invariantDB, AssumptionFinder<APC> assumptionfinder, 
-      CrossBlockRenamings<APC> renamings, RenamedVariables<APC> renamed)
-    {
-      this.methodSubroutine.EmitTransferEquations(tw, invariantDB, assumptionfinder, renamings, renamed);
-    }
-#endif
-
-    private string FormatSourceContext(string doc, int line, int col) {
-      return String.Format("{0}({1},{2})", doc, line, col);
-    }
-
-
-    public Subroutine Subroutine { get { return this.methodSubroutine; } }
-
-    public bool IsJoinPoint(CFGBlock block) {
-      Contract.Requires(block != null);// F: Added as of Clousot suggestion
-
-      return block.Subroutine.IsJoinPoint(block);
-    }
-
-    public bool IsJoinPoint(APC ppoint) {
-      if (ppoint.Index != 0) return false;
-      return IsJoinPoint(ppoint.Block);
-    }
-
-    public bool IsSplitPoint(CFGBlock block) {
-      Contract.Requires(block != null);// F: Added as of Clousot suggestion
-      return block.Subroutine.IsSplitPoint(block);
-    }
-
-    public bool IsSplitPoint(APC ppoint)
-    {
-      if (ppoint.Index != ppoint.Block.Count) return false;
-
-      return IsSplitPoint(ppoint.Block);
-    }
-
-    public bool IsForwardBackEdgeTarget(APC ppoint) {
-      CFGBlock block = ppoint.Block;
-      if (ppoint.Index != 0) return false; // not at beginning.
-      return ppoint.Block.Subroutine.EdgeInfo.DepthFirstInfo(block).TargetOfBackEdge;
-    }
-
-    public bool IsForwardBackEdgeTarget(CFGBlock block)
-    {
-      Contract.Requires(block != null); // F: Added as of Clousot suggestion
-      return block.Subroutine.EdgeInfo.DepthFirstInfo(block).TargetOfBackEdge;
-    }
-
-    public bool IsBackwardBackEdgeTarget(APC ppoint) {
-      CFGBlock block = ppoint.Block;
-      if (ppoint.Index != block.Count) return false; // not at end.
-      return ppoint.Block.Subroutine.EdgeInfo.DepthFirstInfo(block).SourceOfBackEdge;
-    }
-
-    public bool IsForwardBackEdge(APC from, APC to) {
-      if (to.Index != 0) return false;
-      return IsForwardBackEdgeHelper(from, to);
-    }
-
-    public bool IsBackwardBackEdge(APC from, APC to) {
-      if (from.Index != 0) return false;
-      return IsBackwardBackEdgeHelper(from, to);
-    }
-
-    private bool IsForwardBackEdgeHelper(APC from, APC to) {
-      Contract.Assume(to.Block != null, "assuming the object invariant");
-      Contract.Assume(from.Block != null, "assuming the object invariant");
-      if (to.Block.Subroutine.EdgeInfo.IsBackEdge(from.Block, Unit.Value, to.Block)) return true;
-
-      // in case of an end finally we consult the original edge
-      // If this is an endfinally, there must be at least one label
-      if (from.SubroutineContext != null && from.SubroutineContext.Tail == to.SubroutineContext) {
-        // it was a pop
-        SubroutineEdge edge = from.SubroutineContext.Head;
-        return edge.Two.Subroutine.EdgeInfo.IsBackEdge(edge.One, Unit.Value, edge.Two);
-      }
-      return false;
-    }
-
-    private bool IsBackwardBackEdgeHelper(APC from, APC to) {
-      // use symmetry
-      Contract.Assume(from.Block != null); // F: made an assumption
-
-      if (from.Block.Subroutine.EdgeInfo.IsBackEdge(to.Block, Unit.Value, from.Block)) return true;
-
-      // in case of an end finally we consult the original edge
-      // If this is an endfinally, there must be at least one label
-      if (to.SubroutineContext != null && to.SubroutineContext.Tail == from.SubroutineContext) {
-        // it was a pop
-        SubroutineEdge reversedEdge = to.SubroutineContext.Head;
-        // ask reversed question
-        return reversedEdge.One.Subroutine.EdgeInfo.IsBackEdge(reversedEdge.Two, Unit.Value, reversedEdge.One);
-      }
-      return false;
-    }
-
-
-    public bool IsBlockStart(APC ppoint) {
-      return (ppoint.Index == 0);
-    }
-
-    public bool IsBlockEnd(APC ppoint) {
-      return (ppoint.Index == ppoint.Block.Count);
-    }
-
-    #endregion
-
-
-    #region IGraph of APCs (forward only)
-
-    public IGraph<APC, Unit> AsForwardGraph(bool includeExceptionEdges)
-    {
-      var forwardGraphCache = new GraphWrapper<APC, Unit>(
-                new APC[0], // we don't provide the set of all apcs
-                (pc) => SuccessorEdges(pc, includeExceptionEdges));
-      return forwardGraphCache;
-    }
-
-    IEnumerable<Pair<Unit, APC>> SuccessorEdges(APC pc, bool includeExceptionEdges) {
-      var normalized = pc.LastInBlock();
-      foreach (APC succ in this.Successors(normalized)) {
-        yield return new Pair<Unit, APC>(Unit.Value, succ);
-      }
-      if (!includeExceptionEdges) yield break;
-
-      foreach (APC succ in this.ExceptionHandlers<Type, int>(pc, 0, null)) {
-        yield return new Pair<Unit, APC>(Unit.Value, succ);
-      }
-    }
-
-
-    public IGraph<APC, Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
-    {
-      if (includeExceptionEdges) throw new NotSupportedException();
-
-      var backwardGraph = new GraphWrapper<APC, Unit>(
-          new APC[0], // we don't provide the set of all apcs
-          (pc) => PredecessorEdges(pc, includeExceptionEdges, skipContracts));
-      
-      return backwardGraph;
-    }
-
-    IEnumerable<Pair<Unit, APC>> PredecessorEdges(APC pc, bool includeExceptionEdges, bool skipContracts)
-    {
-      var normalized = pc.FirstInBlock();
-      foreach (APC pred in this.Predecessors(normalized, skipContracts))
-      {
-        yield return new Pair<Unit, APC>(Unit.Value, pred.FirstInBlock());
-      }
-
-      // TOOD: support backwards exception edges.
-    }
-
-    #endregion
-
-
-    #region ICFG<Label,Handler,APC> Members
-
-    public IDecodeMSIL<APC, Local, Parameter, Method2, Field, Type2, Unit, Unit, IMethodContext<Field, Method2>, Unit>
-      GetDecoder<Local, Parameter, Method2, Field, Property, Event, Type2, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method2, Field, Property, Event, Type2, Attribute, Assembly> mdDecoder)
-    {
-      var mcache = this.methodCache as MethodCache<Local, Parameter, Type2, Method2, Field, Property, Event, Attribute, Assembly>;
-      return new APCDecoder<Local, Parameter, Method2, Field, Property, Event, Type2, Attribute, Assembly>(
-                 (ControlFlow<Method2, Type2>)(object)this,
-                 mdDecoder,
-                 mcache);
-    }
-
-
-#if false
-    public IDecodeMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest> 
-    GetDecoder<Local, Parameter, Method2, Field, Type, Source, Dest>(
-      IDecodeMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying)
-    {
-      return new AssumeDecoder<Local, Parameter, Method2, Field, Type, Source, Dest>(this, underlying);
-    }
-
-    public ITransformer<APC, Local, Parameter, Method2, Field, Type, Source, Dest>
-    GetTransformer<Local, Parameter, Method2, Field, Type, Source, Dest>(
-      ITransformer<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying) {
-      return new AssumeTransformer<Local, Parameter, Method2, Field, Type, Source, Dest>(this, underlying);
-    }
-
-    private class AssumeDecoder<Local, Parameter, Method2, Field, Type, Source, Dest> : 
-      IDecodeMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest>
-    {
-      ControlFlow<Method, Label, Handler> parent;
-      IDecodeMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying;
-
-      public AssumeDecoder(
-        ControlFlow<Method, Label, Handler> parent,
-        IDecodeMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying
-      ) {
-        this.parent = parent;
-        this.underlying = underlying;
-      }
-
-
-      #region IDecodeMSIL<AbstractPC,Local,Parameter,Method,Field,Type,Source,Dest> Members
-
-      private class NoBranchDelegator<Data, Result> : 
-        MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Data,IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, APC, Source, Dest, Data> 
-      {
-
-        protected override Data Convert(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          return data.One;
-        }
-        protected override Dest ConvertDest(Label pc, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Dest dest) {
-          return dest;
-        }
-        protected override IIndexable<Source> Convert(Label pc, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IIndexable<Source> sources) {
-          return sources;
-        }
-        protected override Source ConvertSource(Label pc, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Source source) {
-          return source;
-        }
-        protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          return data.Two;
-        }
-        protected override APC ConvertLabel(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Label label) {
-          throw new Exception("Should not get here");
-        }
-        protected override IEnumerable<APC> Convert(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IEnumerable<Label> label) {
-          throw new Exception("Should not get here");
-        }
-        public NoBranchDelegator() {
-        }
-
-        public override Result Branch(Label pc, Label target, bool leave, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          // branches are no-ops in the CFG IL
-          return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
-        }
-
-        public override Result BranchCond(Label pc, Label target, Source cond, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          // branches are no-ops in the CFG IL
-          return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
-        }
-
-        public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          // branches are no-ops in the CFG IL
-          return Delegatee(data).Nop(ConvertLabel(data,pc), Convert(data));
-        }
-      }
-
-      private class AssumeDelegator<Data, Result> :
-        MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Pair<Tag, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, APC, Source, Dest, Data> {
-
-        #region Overrides
-        protected override Data Convert(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          return data.One.Two;
-        }
-
-        protected override Source ConvertSource(Label pc, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Source source) {
-          return source;
-        }
-
-        protected override Dest ConvertDest(Label pc, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Dest dest) {
-          return dest;
-        }
-
-        protected override IIndexable<Source> Convert(Label pc, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IIndexable<Source> sources) {
-          return sources;
-        }
-
-        protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          return data.Two;
-        }
-
-        protected override APC ConvertLabel(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Label label) {
-          throw new NotImplementedException("Should not be called");
-        }
-
-        protected override IEnumerable<APC> Convert(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IEnumerable<Label> label) {
-          throw new NotImplementedException("Should not be called");
-        }
-
-        public override Result Branch(Label pc, Label target, bool leave, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          // unconditional branch has no assume, thus is a nop
-          return Delegatee(data).Nop(ConvertLabel(data,pc), Convert(data));
-        }
-
-        public override Result BranchCond(Label pc, Label target, Source cond, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          return Delegatee(data).Assume(ConvertLabel(data, pc), data.One.One, cond, Convert(data));
-        }
-
-        public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data) {
-          return Delegatee(data).Assume(ConvertLabel(data,pc), data.One.One, value, Convert(data));
+            SubroutineWithHandlersBuilder<Label, Handler> sb = new SubroutineWithHandlersBuilder<Label, Handler>(codeProvider, this, method, entryPoint);
+            return new MethodSubroutine<Label, Handler>(this, method, sb, entryPoint);
         }
 
         #endregion
-      }
-        
-      public ILDecoder<APC, Data, Result, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> GetDecoder<Data, Result>() {
-        ILDecoder<Label, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, IVisitMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest,Pair<Data,IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result>> decoder1 = underlying.GetDecoder<Pair<Data,IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source,Dest, Data, Result>>, Result>();
-        ILDecoder<Label, Pair<Pair<Tag,Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, IVisitMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest,Pair<Pair<Tag,Data>,IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result>> decoder2 = underlying.GetDecoder<Pair<Pair<Tag,Data>,IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source,Dest, Data, Result>>, Result>();
 
-        NoBranchDelegator<Data, Result> delegator = new NoBranchDelegator<Data, Result>();
-        AssumeDelegator<Data, Result> assumeDelegator = new AssumeDelegator<Data, Result>();
+        #region ----------- Nested Types -------------
 
-        return delegate(APC pc, Data data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> visitor) 
+        private abstract class SubroutineFactory<Key, Data> : ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Subroutine>
         {
-          Label/*?*/ lab;
-          if (parent.UnderlyingLabel(pc, out lab)) {
-            return decoder1(lab, new Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>(data, visitor), delegator);
-          }
-          AssumeBlock/*?*/ ab = pc.Block as AssumeBlock;
-          if (ab != null) {
-            return decoder2(ab.Label, new Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>(new Pair<Tag, Data>(ab.Tag, data), visitor), assumeDelegator);
-          }
-          return visitor.Nop(pc, data);
-        };
-      }
-      
-      #endregion
-    }
-
-    class AssumeTransformer<Local, Parameter, Method2, Field, Type, Source, Dest> : ITransformer<APC, Local, Parameter, Method2, Field, Type, Source, Dest> 
-    {
-      ControlFlow<Method, Label, Handler> parent;
-      ITransformer<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying;
-
-      public AssumeTransformer(
-        ControlFlow<Method, Label, Handler> parent,
-        ITransformer<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying
-      ) {
-        this.parent = parent;
-        this.underlying = underlying;
-      }
-
-
-      #region ITransformer<APC,Local,Parameter,Method2,Field,Type,Source,Dest> Members
-
-      private class NoBranchDelegator<Data, Result> :
-        MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<APC,Data>, Result, APC, Source, Dest, Data>
-      {
-        // We need to funnel the original apc through, although the underlying decoder will call us with a label only.
-        // Thus, we pass the original APC in the data part and take it out in the label converter.
-        // We just need to check that the underlying label actually agrees.
-
-        IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee;
-
-        public NoBranchDelegator(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee)
-        {
-          this.delegatee = delegatee;
-        }
-
-        protected override Data Convert(Pair<APC,Data> data)
-        {
-          return data.Two;
-        }
-        protected override Dest ConvertDest(Label pc, Pair<APC,Data> data, Dest dest)
-        {
-          return dest;
-        }
-        protected override IIndexable<Source> Convert(Label pc, Pair<APC,Data> data, IIndexable<Source> sources)
-        {
-          return sources;
-        }
-        protected override Source ConvertSource(Label pc, Pair<APC,Data> data, Source source)
-        {
-          return source;
-        }
-        protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<APC,Data> data)
-        {
-          return this.delegatee;
-        }
-        protected override APC ConvertLabel(Pair<APC,Data> data, Label label)
-        {
-          // check that the underlying label in the data part is indeed the current label
-          Label/*?*/ underlying;
-          if (data.One.UnderlyingLabel(out underlying)) {
-            if (underlying.Equals(label)) {
-              return data.One;
-            }
-          }
-          throw new Exception("Should not get here");
-        }
-        protected override IEnumerable<APC> Convert(Pair<APC,Data> data, IEnumerable<Label> label)
-        {
-          throw new Exception("Should not get here");
-        }
-
-
-        public override Result Branch(Label pc, Label target, bool leave, Pair<APC,Data> data)
-        {
-          // branches are no-ops in the CFG IL
-          return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
-        }
-
-        public override Result BranchCond(Label pc, Label target, Source cond, Pair<APC,Data> data)
-        {
-          // branches are no-ops in the CFG IL
-          return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
-        }
-
-        public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<APC,Data> data)
-        {
-          // branches are no-ops in the CFG IL
-          return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
-        }
-      }
-
-      /// <summary>
-      /// We need to funnel the original APC through with the data as well as the assume label.
-      /// </summary>
-      private class AssumeDelegator<Data, Result> :
-        MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Pair<APC,Tag>, Data>, Result, APC, Source, Dest, Data>
-      {
-        IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee;
-
-        public AssumeDelegator(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee) {
-          this.delegatee = delegatee;
-        }
-
-        #region Overrides
-        protected override Data Convert(Pair<Pair<APC,Tag>, Data> data)
-        {
-          return data.Two;
-        }
-
-        protected override Source ConvertSource(Label pc, Pair<Pair<APC,Tag>, Data> data, Source source)
-        {
-          return source;
-        }
-
-        protected override Dest ConvertDest(Label pc, Pair<Pair<APC,Tag>, Data> data, Dest dest)
-        {
-          return dest;
-        }
-
-        protected override IIndexable<Source> Convert(Label pc, Pair<Pair<APC,Tag>, Data> data, IIndexable<Source> sources)
-        {
-          return sources;
-        }
-
-        protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<Pair<APC,Tag>, Data> data)
-        {
-          return this.delegatee;
-        }
-
-        protected override APC ConvertLabel(Pair<Pair<APC, Tag>, Data> data, Label label) 
-        {
-          // check that the underlying label in the data part is indeed the current label
-          Label/*?*/ underlying;
-          if (data.One.One.UnderlyingLabel(out underlying)) {
-            if (underlying.Equals(label)) {
-              return data.One.One;
-            }
-          }
-          throw new NotImplementedException("Should not be called");
-        }
-
-        protected override IEnumerable<APC> Convert(Pair<Pair<APC,Tag>, Data> data, IEnumerable<Label> label)
-        {
-          throw new NotImplementedException("Should not be called");
-        }
-
-        public override Result Branch(Label pc, Label target, bool leave, Pair<Pair<APC,Tag>, Data> data)
-        {
-          // unconditional branch has no assume, thus is a nop
-
-          // NOTE: pick the apc out of the data part, as we are decoding the branch that gave rise to the Assume,
-          // but the assume is at a different apc.
-          return Delegatee(data).Nop(data.One.One, Convert(data));
-        }
-
-        public override Result BranchCond(Label pc, Label target, Source cond, Pair<Pair<APC,Tag>, Data> data)
-        {
-          // NOTE: pick the apc out of the data part, as we are decoding the branch that gave rise to the Assume,
-          // but the assume is at a different apc.
-          return Delegatee(data).Assume(data.One.One, data.One.Two, cond, Convert(data));
-        }
-
-        public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<Pair<APC,Tag>, Data> data)
-        {
-          // NOTE: pick the apc out of the data part, as we are decoding the branch that gave rise to the Assume,
-          // but the assume is at a different apc.
-          return Delegatee(data).Assume(data.One.One, data.One.Two, value, Convert(data));
-        }
-
-        #endregion
-      }
-
-      public Transformer<APC, Data, Result> GetTransformer<Data, Result>(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> visitor) {
-#if SPECSHARP
-        NoBranchDelegator<Data, Result> noBranchDelegator = null; // new NoBranchDelegator<Data, Result>(visitor);
-        AssumeDelegator<Data, Result> assumeDelegator = null; // new AssumeDelegator<Data, Result>(visitor);
-
-        Transformer<Label, Pair<APC, Data>, Result> decoder1 = null; // underlying.GetTransformer(noBranchDelegator);
-        Transformer<Label, Pair<Pair<APC, Tag>, Data>, Result> decoder2 = null; // underlying.GetTransformer(assumeDelegator);
-#else
-        NoBranchDelegator<Data, Result> noBranchDelegator = new NoBranchDelegator<Data, Result>(visitor);
-        AssumeDelegator<Data, Result> assumeDelegator = new AssumeDelegator<Data, Result>(visitor);
-
-        Transformer<Label, Pair<APC, Data>, Result> decoder1 = underlying.GetTransformer(noBranchDelegator);
-        Transformer<Label, Pair<Pair<APC, Tag>, Data>, Result> decoder2 = underlying.GetTransformer(assumeDelegator);
-#endif
-
-        return delegate(APC pc, Data data)
-        {
-          Label/*?*/ lab;
-          if (parent.UnderlyingLabel(pc, out lab)) {
-            return decoder1(lab, new Pair<APC,Data>(pc, data));
-          }
-          AssumeBlock/*?*/ ab = pc.Block as AssumeBlock;
-          if (ab != null) {
-            return decoder2(ab.Label, new Pair<Pair<APC,Tag>, Data>(new Pair<APC,Tag>(pc,ab.Tag), data));
-          }
-          return visitor.Nop(pc, data);
-        };
-      }
-      
-      #endregion
-    }
-#endif
-
-    #endregion
-
-    #region ICFG<Type,APC> Members
-
-
-    public string ToString(APC pc)
-    {
-      return pc.ToString();
-    }
-
-    public IEnumerable<CFGBlock> LoopHeads
-    {
-      get
-      {
-        foreach (var sub in this.Subroutine.SubroutineTree())
-        {
-          foreach (var block in sub.Blocks)
-          {
-            if (this.IsForwardBackEdgeTarget(block)) yield return block;
-          }
-        }
-      }
-    }
-    #endregion
-  }
-
-  /// <summary>
-  /// We know that Source and Dest are Unit
-  /// </summary>
-  internal class APCDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> :
-    IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, IMethodContext<Field, Method>, Unit>,
-    IMethodContext<Field, Method>, IMethodContextData<Field, Method>
-  {
-    ControlFlow<Method, Type> parent;
-    IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-    MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache;
-
-    public APCDecoder(
-      ControlFlow<Method, Type> parent,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache
-    )
-    {
-      this.parent = parent;
-      this.mdDecoder = mdDecoder;
-      this.methodCache = methodCache;
-    }
-
-
-    #region IMSILDecoder<APC,Local,Parameter,Method,Field,Type,Source,Dest> Members
-
-    /// <summary>
-    /// * Removes unconditional branches and branch true, branch false.
-    /// * Turns binary conditional branches into their condition evaluation
-    /// * Computes proper polarity of assume/assert based on tag and context
-    /// * Turns Object.ReferenceEquals into binary Ceq
-    /// </summary>
-    struct RemoveBranchDelegator<Data, Result, Visitor> :
-      IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result>
-      where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result>
-    {
-      Visitor visitor;
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(mdDecoder != null);
-      }
-
-      public RemoveBranchDelegator(
-        Visitor visitor,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-      {
-        Contract.Requires(mdDecoder != null);
-
-        this.visitor = visitor;
-        this.mdDecoder = mdDecoder;
-      }
-
-      /// <summary>
-      /// If original block is a method contract block, then invert assume/assert
-      /// </summary>
-      public Result Assume(APC pc, string tag, UnitSource source, object provenance, Data data)
-      {
-        if ((tag == "requires" && pc.InsideRequiresAtCall) || (tag == "invariant" && pc.InsideInvariantOnExit))
-        {
-          return visitor.Assert(pc, tag, source, provenance, data);
-        }
-        if (tag == "assume" && pc.InsideRequiresAtCall)
-        {
-          // extra clousot extractor assume false in legacy requires. At call-site, need to null it out.
-          return visitor.Pop(pc, source, data);
-        }
-        return visitor.Assume(pc, tag, source, provenance, data);
-      }
-
-
-      /// <summary>
-      /// If original block is a method contract block, then invert assume/assert
-      /// </summary>
-      public Result Assert(APC pc, string tag, UnitSource source, object provenance, Data data)
-      {
-        if (pc.InsideEnsuresAtCall)
-        {
-          return visitor.Assume(pc, tag, source, provenance, data);
-        }
-        return visitor.Assert(pc, tag, source, provenance, data);
-      }
-
-      public Result Arglist(APC pc, UnitDest dest, Data data)
-      {
-        return visitor.Arglist(pc, dest, data);
-      }
-
-      public Result Binary(APC pc, BinaryOperator op, UnitDest dest, UnitSource s1, UnitSource s2, Data data)
-      {
-        return visitor.Binary(pc, op, dest, s1, s2, data);
-      }
-
-      public Result BranchCond(APC pc, APC target, BranchOperator bop, UnitSource value1, UnitSource value2, Data data)
-      {
-        UnitDest dest = UnitDest.Value;
-        switch (bop)
-        {
-          case BranchOperator.Beq:
-            // equal to Ceq followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Ceq, dest, value1, value2, data);
-
-          case BranchOperator.Bge:
-            // equal to Cge followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Cge, dest, value1, value2, data);
-
-          case BranchOperator.Bge_un:
-            // equal to Cge_un followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Cge_Un, dest, value1, value2, data);
-
-          case BranchOperator.Bgt:
-            // equal to Cgt followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Cgt, dest, value1, value2, data);
-
-          case BranchOperator.Bgt_un:
-            // equal to Cgt_un followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Cgt_Un, dest, value1, value2, data);
-
-          case BranchOperator.Ble:
-            // equal to Cle followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Cle, dest, value1, value2, data);
-
-          case BranchOperator.Ble_un:
-            // equal to Cle_un followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Cle_Un, dest, value1, value2, data);
-
-          case BranchOperator.Blt:
-            // equal to Clt followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Clt, dest, value1, value2, data);
-
-          case BranchOperator.Blt_un:
-            // equal to Clt_un followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Clt_Un, dest, value1, value2, data);
-
-          case BranchOperator.Bne_un:
-            // equal to Cne_un followed by br.true
-            return this.visitor.Binary(pc, BinaryOperator.Cne_Un, dest, value1, value2, data);
-
-
-
-        }
-        return this.visitor.Nop(pc, data);
-      }
-
-      public Result BranchTrue(APC pc, APC target, UnitSource cond, Data data)
-      {
-        return this.visitor.Nop(pc, data);
-      }
-
-      public Result BranchFalse(APC pc, APC target, UnitSource cond, Data data)
-      {
-        return this.visitor.Nop(pc, data);
-      }
-
-      public Result Branch(APC pc, APC target, bool leave, Data data)
-      {
-        return this.visitor.Nop(pc, data);
-      }
-
-      public Result Break(APC pc, Data data)
-      {
-        return visitor.Break(pc, data);
-      }
-
-      public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<UnitSource>
-      {
-        Type declaringType = mdDecoder.DeclaringType(method);
-        if (
-            mdDecoder.IsStatic(method))
-        {
-            if (args.Count == 2 && mdDecoder.Equal(declaringType, mdDecoder.System_Object) &&
-                mdDecoder.Name(method) == "ReferenceEquals"
-                )
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
             {
-                // special case equal here
-                return visitor.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
+                Contract.Invariant(cache != null); // F: Added as of precondition suggestions ion many places
+                Contract.Invariant(this.MethodCache != null);// F: Added as of precondition suggestions ion many places
             }
-            // special case Decimal methods to operators
-            if (mdDecoder.Equal(declaringType, mdDecoder.System_Decimal))
+
+            private readonly Dictionary<Key, Subroutine> cache = new Dictionary<Key, Subroutine>();
+            protected readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache;
+            protected IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get { return this.MethodCache.ContractDecoder; } }
+            protected IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder
             {
-                switch (mdDecoder.Name(method))
+                get
                 {
-                    case "op_Addition":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Add, dest, args[0], args[1], data);
+                    Contract.Assume(this.MethodCache.MetadataDecoder != null, "Should be made a postcondition");
+                    return this.MethodCache.MetadataDecoder;
+                }
+            }
 
-                    case "op_Division":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Div, dest, args[0], args[1], data);
+            public SubroutineFactory(
+              MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache
+            )
+            {
+                Contract.Requires(methodCache != null);
 
-                    case "op_Equality":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
+                this.MethodCache = methodCache;
+            }
 
-                    case "op_GreaterThan":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Cgt, dest, args[0], args[1], data);
+            public Subroutine Get(Key key)
+            {
+                if (cache.ContainsKey(key))
+                {
+                    return cache[key];
+                }
+                Subroutine result = this.BuildNewSubroutine(key);
+                cache.Add(key, result);
+                // Perform the initialization after adding it to the cache due to recursion
+                if (result != null) result.Initialize();
+                return result;
+            }
 
-                    case "op_GreaterThanOrEqual":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Cge, dest, args[0], args[1], data);
+            public void Install(Key key, Subroutine sr)
+            {
+                if (cache.ContainsKey(key))
+                {
+                    Contract.Assume(cache[key] == null);
+                }
+                cache[key] = sr;
+            }
 
-                    case "op_Inequality":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Cne_Un, dest, args[0], args[1], data);
+            public bool Remove(Key key)
+            {
+                if (cache.ContainsKey(key))
+                {
+                    cache.Remove(key);
 
-                    case "op_LessThan":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Clt, dest, args[0], args[1], data);
+                    return true;
+                }
+                return false;
+            }
 
-                    case "op_LessThanOrEqual":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Cle, dest, args[0], args[1], data);
+            protected abstract Subroutine BuildNewSubroutine(Key key);
 
-                    case "op_Modulus":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Rem, dest, args[0], args[1], data);
+            protected abstract Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Data data);
 
-                    case "op_Multiply":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Mul, dest, args[0], args[1], data);
+            #region ICodeConsumer<Local,Parameter,Method,Field,Type,Unit,Subroutine> Members
 
-                    case "op_Subtraction":
-                        Contract.Assume(args.Count >= 2);
-                        return visitor.Binary(pc, BinaryOperator.Sub, dest, args[0], args[1], data);
+            public Subroutine Accept<Label>(ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
+                                            Label entryPoint, Data data)
+            {
+                SimpleSubroutineBuilder<Label> sb = new SimpleSubroutineBuilder<Label>(codeProvider, this.MethodCache, entryPoint);
 
-                    case "op_UnaryNegation":
-                        Contract.Assume(args.Count >= 1);
-                        return visitor.Unary(pc, UnaryOperator.Neg, false, false, dest, args[0], data);
+                Subroutine subr = Factory(sb, entryPoint, data);
 
-                    default:
-                        break;
+                return subr;
+            }
+
+            #endregion
+        }
+
+        private class EnsuresCache : SubroutineFactory<Method, Pair<Method, IFunctionalSet<Subroutine>>>
+        {
+            private Method lastMethodWeAddedInferredEnsures;
+            private Set<string> lastMethodInferredEnsures;
+
+            public EnsuresCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null); // F: As of Clousot suggestion
+            }
+
+            public bool AlreadyInferred(Method method, string postCondition)
+            {
+                if (!MetadataDecoder.Equal(method, lastMethodWeAddedInferredEnsures))
+                {
+                    lastMethodWeAddedInferredEnsures = method;
+                    lastMethodInferredEnsures = new Set<string>();
+                }
+
+                return !lastMethodInferredEnsures.AddQ(postCondition);
+            }
+
+            protected override Subroutine BuildNewSubroutine(Method method)
+            {
+                if (this.ContractDecoder != null)
+                {
+                    IFunctionalSet<Subroutine> inheritedEnsures = this.GetInheritedEnsures(method);
+                    if (this.ContractDecoder.HasEnsures(method))
+                    {
+                        return this.ContractDecoder.AccessEnsures(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedEnsures));
+                    }
+                    else if (inheritedEnsures.Count > 0)
+                    {
+                        if (inheritedEnsures.Count > 1)
+                        {
+                            // make up a label
+                            return new EnsuresSubroutine<Unit>(this.MethodCache, method, inheritedEnsures);
+                        }
+                        else
+                        {
+                            return inheritedEnsures.Any;
+                        }
+                    }
+                }
+                // make up an empty Ensures for every method.
+                return new EnsuresSubroutine<Unit>(this.MethodCache, method, null);
+            }
+
+            protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method, IFunctionalSet<Subroutine>> data)
+            {
+                return new EnsuresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
+            }
+
+            private IFunctionalSet<Subroutine> GetInheritedEnsures(Method method)
+            {
+                IFunctionalSet<Subroutine> result = FunctionalSet<Subroutine>.Empty(Subroutine.GetKey);
+                if (MetadataDecoder.IsVirtual(method) && ContractDecoder.CanInheritContracts(method))
+                {
+                    foreach (Method baseMethod in MetadataDecoder.OverriddenAndImplementedMethods(method).AssumeNotNull())
+                    {
+                        Subroutine rs = this.Get(MetadataDecoder.Unspecialized(baseMethod));
+                        if (rs != null)
+                        {
+                            result = result.Add(rs);
+                        }
+                    }
+                }
+                return result;
+            }
+        }
+
+        private class ModelEnsuresCache : SubroutineFactory<Method, Pair<Method, IFunctionalSet<Subroutine>>>
+        {
+            public ModelEnsuresCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null); // F: As of Clousot suggestion
+            }
+
+
+            protected override Subroutine BuildNewSubroutine(Method method)
+            {
+                if (this.ContractDecoder != null)
+                {
+                    IFunctionalSet<Subroutine> inheritedEnsures = this.GetInheritedEnsures(method);
+                    if (this.ContractDecoder.HasModelEnsures(method))
+                    {
+                        return this.ContractDecoder.AccessModelEnsures(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedEnsures));
+                    }
+                    else if (inheritedEnsures.Count > 0)
+                    {
+                        if (inheritedEnsures.Count > 1)
+                        {
+                            // make up a label
+                            return new ModelEnsuresSubroutine<Unit>(this.MethodCache, method, inheritedEnsures);
+                        }
+                        else
+                        {
+                            return inheritedEnsures.Any;
+                        }
+                    }
+                }
+                return null;
+            }
+
+            protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method, IFunctionalSet<Subroutine>> data)
+            {
+                return new ModelEnsuresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
+            }
+
+            private IFunctionalSet<Subroutine> GetInheritedEnsures(Method method)
+            {
+                IFunctionalSet<Subroutine> result = FunctionalSet<Subroutine>.Empty(Subroutine.GetKey);
+                if (MetadataDecoder.IsVirtual(method) && ContractDecoder.CanInheritContracts(method))
+                {
+                    foreach (Method baseMethod in MetadataDecoder.OverriddenAndImplementedMethods(method).AssumeNotNull())
+                    {
+                        Subroutine rs = this.Get(MetadataDecoder.Unspecialized(baseMethod));
+                        if (rs != null)
+                        {
+                            result = result.Add(rs);
+                        }
+                    }
+                }
+                return result;
+            }
+        }
+        private class RequiresCache : SubroutineFactory<Method, Pair<Method, IFunctionalSet<Subroutine>>>
+        {
+            // for issuing warnings about inheritance of multiple requires
+            private ErrorHandler output;
+            // for inferred requires
+
+            public RequiresCache(
+              MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+              ErrorHandler output
+            )
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null); // F: As of Clousot suggestion
+                this.output = output;
+            }
+
+
+            protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method, IFunctionalSet<Subroutine>> data)
+            {
+                return new RequiresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
+            }
+
+            protected override Subroutine BuildNewSubroutine(Method method)
+            {
+                if (this.ContractDecoder != null)
+                {
+                    IFunctionalSet<Subroutine> inheritedRequires = this.GetInheritedRequires(method);
+                    if (this.ContractDecoder.HasRequires(method))
+                    {
+                        return this.ContractDecoder.AccessRequires(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedRequires));
+                    }
+                    else if (inheritedRequires.Count > 0)
+                    {
+                        if (inheritedRequires.Count == 1)
+                        {
+                            return inheritedRequires.Any;
+                        }
+                        return new RequiresSubroutine<Unit>(this.MethodCache, method, inheritedRequires);
+                    }
+                }
+                return null;
+            }
+
+            private IFunctionalSet<Subroutine> GetInheritedRequires(Method method)
+            {
+                Contract.Ensures(Contract.Result<IFunctionalSet<Subroutine>>() != null);
+
+                IFunctionalSet<Subroutine> result = FunctionalSet<Subroutine>.Empty(Subroutine.GetKey);
+                Contract.Assert(result != null, "Let's make sure we have the contract");
+                Contract.Assert(this.MetadataDecoder != null, "Should be a postcondition");
+                if (this.MetadataDecoder.IsVirtual(method) && ContractDecoder.CanInheritContracts(method))
+                {
+                    Method rootMethod;
+                    if (this.MetadataDecoder.TryGetRootMethod(method, out rootMethod))
+                    {
+                        Subroutine rs = this.Get(this.MetadataDecoder.Unspecialized(rootMethod));
+                        if (rs != null)
+                        {
+                            result = result.Add(rs);
+                        }
+                    }
+                    foreach (Method baseMethod in this.MetadataDecoder.ImplementedMethods(method).AssumeNotNull())
+                    {
+                        var unspecBaseMethod = this.MetadataDecoder.Unspecialized(baseMethod);
+                        Subroutine rs = this.Get(this.MetadataDecoder.Unspecialized(baseMethod));
+                        if (rs != null)
+                        {
+                            result = result.Add(rs);
+                        }
+                    }
+                }
+                return result;
+            }
+        }
+
+
+        private class AssumeCache : SubroutineFactory<Method, Pair<Method, IFunctionalSet<Subroutine>>>
+        {
+            public AssumeCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null);
+                //Contract.Assert(false, "assume cache unimplemented");
+            }
+
+            [ContractVerification(false)]
+            protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Method, IFunctionalSet<Subroutine>> data)
+            {
+                Contract.Assert(false, "untested/wrong");
+
+                return new RequiresSubroutine<Label>(this.MethodCache, data.One, sb, entry, data.Two);
+            }
+
+            [ContractVerification(false)]
+            protected override Subroutine BuildNewSubroutine(Method method)
+            {
+                Contract.Assert(false, "untested/wrong");
+                if (this.ContractDecoder != null)
+                {
+                    IFunctionalSet<Subroutine> inheritedRequires = null;//this.GetInheritedRequires(method);
+                    if (this.ContractDecoder.HasRequires(method))
+                    {
+                        return this.ContractDecoder.AccessRequires(method, this, new Pair<Method, IFunctionalSet<Subroutine>>(method, inheritedRequires));
+                    }
+                    else if (inheritedRequires.Count > 0)
+                    {
+                        if (inheritedRequires.Count == 1)
+                        {
+                            return inheritedRequires.Any;
+                        }
+                        return new RequiresSubroutine<Unit>(this.MethodCache, method, inheritedRequires);
+                    }
+                }
+                return null;
+            }
+        }
+
+        private class InvariantCache : SubroutineFactory<Type, Pair<Type, Subroutine>>
+        {
+            public InvariantCache(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null); // F: As of Clousot suggestion
+            }
+
+            protected override Subroutine BuildNewSubroutine(Type type)
+            {
+                if (this.ContractDecoder != null)
+                {
+                    Subroutine baseInv = GetInheritedInvariant(type);
+
+                    if (this.ContractDecoder.HasInvariant(type))
+                    {
+                        return this.ContractDecoder.AccessInvariant(type, this, new Pair<Type, Subroutine>(type, baseInv));
+                    }
+                    else
+                    {
+                        return baseInv;
+                    }
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            protected override Subroutine Factory<Label>(SimpleSubroutineBuilder<Label> sb, Label entry, Pair<Type, Subroutine> data)
+            {
+                var baseInv = data.Two;
+                var typekey = data.One;
+                return new InvariantSubroutine<Label>(MethodCache, sb, entry, baseInv, typekey);
+            }
+
+
+            private Subroutine GetInheritedInvariant(Type type)
+            {
+                if (this.MetadataDecoder.HasBaseClass(type) && this.ContractDecoder.CanInheritContracts(type))
+                {
+                    Type baseClass = this.MetadataDecoder.BaseClass(MetadataDecoder.Unspecialized(type));
+                    Subroutine baseInv = this.MethodCache.GetInvariant(baseClass);
+                    return baseInv;
+                }
+                return null;
+            }
+        }
+
+
+
+        /// <summary>
+        /// This data structure contains data used during the construction of a Subroutine. For methods, this structure
+        /// is used to hold handler information and is shared among multiple subroutine, namely the method subroutine and
+        /// all the fault/finally subroutine within it.
+        /// </summary>
+        internal abstract class SubroutineBuilder<Label>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(targetLabels != null);// F: added as of many Clousot precondition suggestions and code inspection
+                Contract.Invariant(labelsStartingBlocks != null); // F: added as of many Clousot precondition suggestions and code inspection
+                Contract.Invariant(this.MethodCache != null);// F: added as of many Clousot precondition suggestions and code inspection
+            }
+
+            #region Data
+            internal readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache;
+            private readonly Set<Label> labelsStartingBlocks = new Set<Label>();
+            private readonly Set<Label> targetLabels = new Set<Label>();
+            private OnDemandMap<Label, Pair<Method, bool>> labelsForCallSites;
+            private OnDemandMap<Label, Method> labelsForNewObjSites;
+
+            internal readonly ICodeProvider<Label, Local, Parameter, Method, Field, Type> CodeProvider;
+            internal IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> MetadataDecoder
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>>() != null);
+
+                    return this.MethodCache.MetadataDecoder.AssumeNotNull();
+                }
+            }
+            internal IDecodeContracts<Local, Parameter, Method, Field, Type> ContractDecoder { get { return this.MethodCache.ContractDecoder; } }
+            #endregion
+
+            protected SubroutineBuilder(
+              ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
+              MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+              Label entry
+            )
+            {
+                Contract.Requires(methodCache != null);
+
+                this.CodeProvider = codeProvider;
+                this.MethodCache = methodCache;
+                this.AddTargetLabel(entry);
+            }
+
+            protected void AddTargetLabel(Label target)
+            {
+                this.AddBlockStart(target);
+                targetLabels.Add(target);
+            }
+
+            protected void AddBlockStart(Label target)
+            {
+                labelsStartingBlocks.Add(target);
+            }
+
+
+            protected void Initialize(Label entry)
+            {
+                new BlockStartGatherer(this).TraceAggregateSequentially(entry);
+            }
+
+            protected abstract SubroutineBase<Label> CurrentSubroutine { get; }
+
+            public bool IsBlockStart(Label label)
+            {
+                return labelsStartingBlocks.Contains(label);
+            }
+
+            internal virtual void RecordBlockInfoSameAsOtherBlock(BlockWithLabels<Label> ab, BlockWithLabels<Label> otherblock)
+            {
+            }
+
+            internal bool IsMethodCallSite(Label label, out Pair<Method, bool> methodVirtPair)
+            {
+                return labelsForCallSites.TryGetValue(label, out methodVirtPair);
+            }
+
+            internal bool IsNewObjSite(Label label, out Method constructor)
+            {
+                return labelsForNewObjSites.TryGetValue(label, out constructor);
+            }
+
+            /// <summary>
+            /// Returns the last block
+            /// </summary>
+            protected BlockWithLabels<Label> BuildBlocks(Label start)
+            {
+                return BlockBuilder.BuildBlocks(start, this);
+            }
+
+            protected BlockWithLabels<Label> BuildBlocksWithFixedStartBlock(Label lbl, BlockWithLabels<Label> startBlk)
+            {
+                return BlockBuilder.BuildBlocksWithFixedStartBlock(lbl, startBlk, this);
+            }
+
+            protected virtual BlockWithLabels<Label> RecordInformationForNewBlock(Label currentLabel, BlockWithLabels<Label>/*?*/ previousBlock)
+            {
+                Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
+
+                Contract.Assume(CurrentSubroutine != null, "Made an Assume, but should it be a postcondition?");
+
+                BlockWithLabels<Label> newBlock = CurrentSubroutine.GetBlock(currentLabel);
+
+                if (previousBlock != null)
+                {
+                    var postConditionTarget = newBlock;
+                    var preConditionSource = previousBlock;
+                    // - if we have 2 call blocks back to back, we insert a dummy block in the middle.
+                    if (newBlock is MethodCallBlock<Label> && previousBlock is MethodCallBlock<Label>)
+                    {
+                        var intermediateBlock = this.CurrentSubroutine.NewBlock();
+                        this.RecordBlockInfoSameAsOtherBlock(intermediateBlock, previousBlock);
+                        postConditionTarget = intermediateBlock;
+                        preConditionSource = intermediateBlock;
+                        CurrentSubroutine.AddSuccessor(previousBlock, "fallthrough", intermediateBlock);
+                        CurrentSubroutine.AddSuccessor(intermediateBlock, "fallthrough", newBlock);
+                    }
+                    else
+                    {
+                        CurrentSubroutine.AddSuccessor(previousBlock, "fallthrough", newBlock);
+                    }
+                    // insert pre/post
+
+                    // make sure to insert post condition first, as there may be a post from a previous call, followed by a pre from the subsequent call.
+                    //
+                    InsertPostConditionEdges(previousBlock, postConditionTarget);
+                    InsertPreConditionEdges(preConditionSource, newBlock);
+                }
+                return newBlock;
+            }
+
+            private void InsertPreConditionEdges(BlockWithLabels<Label> previousBlock, BlockWithLabels<Label> newBlock)
+            {
+                InsertPreConditionEdges(previousBlock, newBlock, this.CurrentSubroutine);
+            }
+
+            internal void InsertPreConditionEdges(BlockWithLabels<Label> previousBlock, BlockWithLabels<Label> newBlock, Subroutine subroutine)
+            {
+                MethodCallBlock<Label> newCallBlock = newBlock as MethodCallBlock<Label>;
+                if (newCallBlock != null && !(subroutine.IsContract || subroutine.IsOldValue))
+                {
+                    if (subroutine.IsMethod)
+                    {
+                        IMethodInfo<Method> mi = subroutine as IMethodInfo<Method>;
+                        if (mi != null && this.MetadataDecoder.IsConstructor(mi.Method))
+                        {
+                            if (this.MetadataDecoder.IsPropertySetter(newCallBlock.CalledMethod) && this.MetadataDecoder.IsAutoPropertyMember(newCallBlock.CalledMethod))
+                            {
+                                return; // don't insert preconditions of auto-prop setters within constructors
+                            }
+                        }
+                    }
+                    // insert pre-condition
+                    string tag = newCallBlock.IsNewObj ? "beforeNewObj" : "beforeCall";
+                    subroutine.AddEdgeSubroutine(previousBlock, newBlock, this.MethodCache.GetRequires(newCallBlock.CalledMethod), tag);
+                }
+            }
+
+            private void InsertPostConditionEdges(BlockWithLabels<Label> previousBlock, BlockWithLabels<Label> newBlock)
+            {
+                MethodCallBlock<Label> previousCallBlock = previousBlock as MethodCallBlock<Label>;
+                if (previousCallBlock != null)
+                {
+                    Contract.Assume(this.CurrentSubroutine != null);
+                    if (this.CurrentSubroutine.IsMethod)
+                    {
+                        IMethodInfo<Method> mi = this.CurrentSubroutine as IMethodInfo<Method>;
+                        if (mi != null && this.MetadataDecoder.IsConstructor(mi.Method))
+                        {
+                            if (this.MetadataDecoder.IsPropertyGetter(previousCallBlock.CalledMethod) && this.MetadataDecoder.IsAutoPropertyMember(previousCallBlock.CalledMethod))
+                            {
+                                return; // don't insert postconditions of auto-prop getters within constructors
+                            }
+                        }
+                    }
+                    string tag = previousCallBlock.IsNewObj ? "afterNewObj" : "afterCall";
+                    // insert post-conditions
+                    Subroutine post = this.MethodCache.GetEnsures(previousCallBlock.CalledMethod);
+                    Contract.Assume(this.CurrentSubroutine != null);
+                    CurrentSubroutine.AddEdgeSubroutine(previousBlock, newBlock, post, tag);
+                    // insert model post-conditions
+                    Subroutine modelpost = this.MethodCache.GetModelEnsures(previousCallBlock.CalledMethod);
+                    CurrentSubroutine.AddEdgeSubroutine(previousBlock, newBlock, modelpost, tag);
+                    // NOTE: invariants are inserted on-demand when we know receiver is "this"
+                }
+            }
+
+            private class BlockStartGatherer :
+               MSILVisitor<Label, Local, Parameter, Method, Field, Type, Unit, Unit, Unit, bool>,
+               ICodeQuery<Label, Local, Parameter, Method, Field, Type, Unit, bool>
+            {
+                [ContractInvariantMethod]
+                private void ObjectInvariant()
+                {
+                    Contract.Invariant(parent != null); // F: Added as of Clousot suggestions in many places of preconditions
+                }
+
+                private SubroutineBuilder<Label> parent;
+
+                public BlockStartGatherer(SubroutineBuilder<Label> parent)
+                {
+                    Contract.Requires(parent != null);// F: Added as of Clousot suggestion
+
+                    this.parent = parent;
+                }
+
+                /// <returns>true, if next label starts a new block</returns>
+                public bool TraceAggregateSequentially(Label current)
+                {
+                    bool nextInstructionStartsNewBlock = false;
+                    bool more = true;
+                    do
+                    {
+                        Contract.Assume(parent.CodeProvider != null);
+                        nextInstructionStartsNewBlock = parent.CodeProvider.Decode<BlockStartGatherer, Unit, bool>(current, this, Unit.Value);
+
+                        more = parent.CodeProvider.Next(current, out current);
+                        if (more && nextInstructionStartsNewBlock)
+                        {
+                            this.AddBlockStart(current);
+                        }
+                    }
+                    while (more);
+                    return nextInstructionStartsNewBlock;
+                }
+
+                private void AddBlockStart(Label target) { parent.AddBlockStart(target); }
+                private void AddTargetLabel(Label target) { parent.AddTargetLabel(target); }
+
+                /// <summary>
+                /// Next instruction does NOT start a new block
+                /// </summary>
+                protected override bool Default(Label pc, Unit data)
+                {
+                    return false;
+                }
+
+                public override bool Branch(Label pc, Label target, bool leave, Unit data)
+                {
+                    this.AddTargetLabel(target);
+                    return true; // next instruction starts a new block
+                }
+
+                public override bool BranchCond(Label pc, Label target, BranchOperator bop, Unit value1, Unit value2, Unit data)
+                {
+                    this.AddTargetLabel(target);
+                    return true; // next instruction starts a new block
+                }
+
+                public override bool BranchFalse(Label pc, Label target, Unit cond, Unit data)
+                {
+                    this.AddTargetLabel(target);
+                    return true; // next instruction starts a new block
+                }
+
+                public override bool BranchTrue(Label pc, Label target, Unit cond, Unit data)
+                {
+                    this.AddTargetLabel(target);
+                    return true; // next instruction starts a new block
+                }
+
+                public override bool Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Unit value, Unit data)
+                {
+                    foreach (var label in cases)
+                    {
+                        this.AddTargetLabel(label.Two);
+                    }
+                    return true;
+                }
+
+                public override bool Throw(Label pc, Unit exn, Unit data)
+                {
+                    return true;
+                }
+                public override bool Rethrow(Label pc, Unit data)
+                {
+                    return true;
+                }
+                public override bool Endfinally(Label pc, Unit data)
+                {
+                    return true;
+                }
+                public override bool Return(Label pc, Unit source, Unit data)
+                {
+                    return true;
+                }
+                public bool Aggregate(Label current, Label aggregateStart, bool canBeBranchTarget, Unit data)
+                {
+                    // recurse
+                    return TraceAggregateSequentially(aggregateStart);
+                }
+                public override bool Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, Unit data)
+                {
+                    return CallHelper(pc, method, false, virt);
+                }
+
+                public override bool ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Unit dest, ArgList args, Unit data)
+                {
+                    return CallHelper(pc, method, false, true);
+                }
+
+                private bool CallHelper(Label current, Method method, bool newObj, bool isVirtual)
+                {
+                    // if we insert pre/post conditions, we want separate blocks between the call and the preceding and succeeding instructions
+                    // so we can add edge subroutines.
+
+                    this.AddBlockStart(current);
+                    if (newObj)
+                    {
+                        parent.labelsForNewObjSites[current] = method; // okay to double add
+                    }
+                    else
+                    {
+                        parent.labelsForCallSites[current] = new Pair<Method, bool>(method, isVirtual); // okay to double add
+                    }
+
+
+                    return true; // next instruction starts a new block
+                }
+
+                public override bool Newobj<ArgList>(Label pc, Method ctor, Unit dest, ArgList args, Unit data)
+                {
+                    return CallHelper(pc, ctor, true, false);
+                }
+
+                public override bool BeginOld(Label pc, Label matchingEnd, Unit data)
+                {
+                    // start a new block
+                    this.AddTargetLabel(pc); // It's a target block as it starts a new subroutine
+                    parent.BeginOldHook(pc);
+                    return false;
+                }
+
+                public override bool EndOld(Label pc, Label matchingBegin, Type type, Unit dest, Unit source, Unit data)
+                {
+                    parent.EndOldHook(pc);
+                    return true; // ends a block because we insert it as a subroutine.
+                }
+            }
+
+            private class BlockBuilder :
+               MSILVisitor<Label, Local, Parameter, Method, Field, Type, Unit, Unit, BlockWithLabels<Label>, bool>,
+               ICodeQuery<Label, Local, Parameter, Method, Field, Type, BlockWithLabels<Label>, bool>
+            /*,
+                    IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Unit, Unit, Unit, Unit>
+            */
+            {
+                [ContractInvariantMethod]
+                private void ObjectInvariant()
+                {
+                    Contract.Invariant(parent != null); // F: Added as of Clousot suggestion as precondition in many places
+                }
+
+                private SubroutineBuilder<Label> parent;
+                private BlockWithLabels<Label>/*?*/ currentBlock = null;
+
+                private SubroutineBase<Label> CurrentSubroutine
+                {
+                    get
+                    {
+                        Contract.Ensures(Contract.Result<SubroutineBase<Label>>() != null); // F: added
+
+                        Contract.Assume(parent.CurrentSubroutine != null); // F: should add as postcondition to the parent, but because of the generics we have some problems in picking it
+                        return parent.CurrentSubroutine;
+                    }
+                }
+
+                private BlockBuilder(SubroutineBuilder<Label> builder)
+                {
+                    Contract.Requires(builder != null);// F: As of Clousot suggestion
+                    parent = builder;
+                }
+
+                internal static BlockWithLabels<Label> BuildBlocks(Label start, SubroutineBuilder<Label> builder)
+                {
+                    Contract.Requires(builder != null); // F: As of Clousot suggestion
+
+                    BlockBuilder b = new BlockBuilder(builder);
+                    b.TraceAggregateSequentially(start);
+
+                    // check if we are falling off the end
+                    if (b.currentBlock != null)
+                    {
+                        // add edge to exit
+                        b.CurrentSubroutine.AddSuccessor(b.currentBlock, "fallthrough-return", b.CurrentSubroutine.Exit);
+                        // Callback
+                        b.CurrentSubroutine.AddReturnBlock(b.currentBlock);
+
+                        return b.currentBlock;
+                    }
+                    return null;
+                }
+
+                internal static BlockWithLabels<Label> BuildBlocksWithFixedStartBlock(Label start, BlockWithLabels<Label> startBlk, SubroutineBuilder<Label> builder)
+                {
+                    BlockBuilder b = new BlockBuilder(builder);
+                    b.TraceAggregateSequentially(start);
+                    Contract.Assume(b.currentBlock != null);
+                    b.CurrentSubroutine.AddSuccessor(startBlk, "assumeSetup", b.currentBlock);
+                    // check if we are falling off the end
+                    //if (b.currentBlock != null) // F: follows from the assume
+                    {
+                        // add edge to exit
+                        b.CurrentSubroutine.AddSuccessor(b.currentBlock, "fallthrough-return", b.CurrentSubroutine.Exit);
+                        // Callback
+                        b.CurrentSubroutine.AddReturnBlock(b.currentBlock);
+
+                        return b.currentBlock;
+                    }
+                    //return null;
+                }
+
+                /// <summary>
+                /// Builds
+                ///   - Protecting handler map
+                ///   - Successor relation
+                ///   - CFG blocks
+                /// Temporary structures
+                ///   - current protecting handlers
+                ///   - currentBlock
+                /// </summary>
+                /// <param name="currentLabel"></param>
+                private void TraceAggregateSequentially(Label currentLabel)
+                {
+                    bool more = true;
+                    do
+                    {
+                        if (parent.IsBlockStart(currentLabel))
+                        {
+                            // starts a block
+                            currentBlock = parent.RecordInformationForNewBlock(currentLabel, currentBlock);
+                        }
+                        Contract.Assume(currentBlock != null); // f: made an assume
+
+                        // we add the currentLabel to the block in the decoded to Methods
+                        // this allows optimizing intermediate labels away
+
+                        Contract.Assume(parent.CodeProvider != null, "At this point expecting the CodeProvider != null");
+
+                        // NOTE: this decode can recurse and cause this.currentBlock to change.
+                        bool noFallThrough = parent.CodeProvider.Decode<BlockBuilder, BlockWithLabels<Label>, bool>(currentLabel, this, currentBlock);
+                        if (noFallThrough)
+                        {
+                            currentBlock = null;
+                        }
+
+                        Contract.Assert(parent.CodeProvider != null, "should we make it a postcondition?");
+                        more = parent.CodeProvider.Next(currentLabel, out currentLabel);
+                    }
+                    while (more);
+                }
+
+                protected override bool Default(Label pc, BlockWithLabels<Label> currentBlock)
+                {
+                    currentBlock.Add(pc);
+                    return false; // by default, we fall through
+                }
+
+                public override bool Branch(Label pc, Label target, bool leave, BlockWithLabels<Label> currentBlock)
+                {
+                    currentBlock.Add(pc);
+                    CurrentSubroutine.AddSuccessor(currentBlock, "branch", CurrentSubroutine.GetTargetBlock(target));
+                    return true; // no fall through
+                }
+
+                public override bool BranchCond(Label pc, Label target, BranchOperator bop, Unit value1, Unit value2, BlockWithLabels<Label> currentBlock)
+                {
+                    return HandleCondBranch(pc, target, true, currentBlock);
+                }
+
+                public override bool BranchFalse(Label pc, Label target, Unit cond, BlockWithLabels<Label> data)
+                {
+                    return HandleCondBranch(pc, target, false, data);
+                }
+
+                public override bool BranchTrue(Label pc, Label target, Unit cond, BlockWithLabels<Label> data)
+                {
+                    return HandleCondBranch(pc, target, true, data);
+                }
+
+                private bool HandleCondBranch(Label pc, Label target, bool trueBranch, BlockWithLabels<Label> currentBlock)
+                {
+                    Contract.Requires(currentBlock != null); // F: Added as of Clousot suggestion
+
+                    currentBlock.Add(pc);
+
+                    string takenLabel = trueBranch ? "true" : "false";
+                    string notTakenLabel = trueBranch ? "false" : "true";
+
+                    // insert a special assume block for taken branch
+                    AssumeBlock<Label> abTaken = CurrentSubroutine.NewAssumeBlock(pc, takenLabel);
+                    parent.RecordBlockInfoSameAsOtherBlock(abTaken, this.currentBlock);
+                    CurrentSubroutine.AddSuccessor(currentBlock, takenLabel, abTaken);
+                    CurrentSubroutine.AddSuccessor(abTaken, "fallthrough", CurrentSubroutine.GetTargetBlock(target));
+
+                    // insert a special assume block for untaken branch
+                    AssumeBlock<Label> abElse = CurrentSubroutine.NewAssumeBlock(pc, notTakenLabel);
+                    parent.RecordBlockInfoSameAsOtherBlock(abElse, this.currentBlock);
+                    CurrentSubroutine.AddSuccessor(currentBlock, notTakenLabel, abElse);
+
+                    this.currentBlock = abElse;
+                    return false; // has fall through
+                }
+
+                public override bool Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Unit value, BlockWithLabels<Label> currentBlock)
+                {
+                    List<object> patterns = new List<object>();
+                    currentBlock.Add(pc);
+                    foreach (Pair<object, Label> target in cases)
+                    {
+                        patterns.Add(target.One);
+                        // insert a special switch case assume block            
+                        SwitchCaseAssumeBlock<Label> ab = CurrentSubroutine.NewSwitchCaseAssumeBlock(pc, target.One, type);
+                        parent.RecordBlockInfoSameAsOtherBlock(ab, this.currentBlock);
+                        CurrentSubroutine.AddSuccessor(currentBlock, "switch", ab);
+                        CurrentSubroutine.AddSuccessor(ab, "fallthrough", CurrentSubroutine.GetTargetBlock(target.Two));
+                    }
+
+                    // we assume we fall into the default. Insert special default assume block
+                    SwitchDefaultAssumeBlock<Label> dab = CurrentSubroutine.NewSwitchDefaultAssumeBlock(pc, patterns, type);
+                    parent.RecordBlockInfoSameAsOtherBlock(dab, this.currentBlock);
+                    CurrentSubroutine.AddSuccessor(currentBlock, "default", dab);
+
+                    this.currentBlock = dab;
+                    return false; // has fall through
+                }
+
+                public override bool Throw(Label pc, Unit exn, BlockWithLabels<Label> currentBlock)
+                {
+                    currentBlock.Add(pc);
+                    return true; // no fall through
+                }
+                public override bool Rethrow(Label pc, BlockWithLabels<Label> currentBlock)
+                {
+                    currentBlock.Add(pc);
+                    return true; // no fall through
+                }
+                public override bool Endfinally(Label pc, BlockWithLabels<Label> currentBlock)
+                {
+                    currentBlock.Add(pc);
+                    CurrentSubroutine.AddSuccessor(currentBlock, "endsub", CurrentSubroutine.Exit);
+                    return true; // no fall through
+                }
+
+                public override bool Return(Label pc, Unit source, BlockWithLabels<Label> currentBlock)
+                {
+                    currentBlock.Add(pc);
+                    CurrentSubroutine.AddSuccessor(currentBlock, "return", CurrentSubroutine.Exit);
+                    // Callback
+                    CurrentSubroutine.AddReturnBlock(currentBlock);
+                    return true; // no fall through
+                }
+
+                public bool Aggregate(Label pc, Label nestedAggregate, bool canBeBranchTarget, BlockWithLabels<Label> currentBlock)
+                {
+                    // recurse
+                    this.TraceAggregateSequentially(nestedAggregate);
+                    return false; // recursion would have already set current block to null if there is no fall through.
+                }
+
+                public override bool Nop(Label pc, BlockWithLabels<Label> data)
+                {
+                    // ignore this label
+                    return false; // has fall through
+                }
+
+
+                /// <summary>
+                /// Give current subroutine a chance to record information about matching begin/old old labels
+                /// </summary>
+                public override bool EndOld(Label pc, Label matchingBegin, Type type, Unit dest, Unit source, BlockWithLabels<Label> data)
+                {
+                    currentBlock.Add(pc);
+                    CurrentSubroutine.AddSuccessor(currentBlock, "endold", CurrentSubroutine.Exit);
+                    return false; // indicate fall-through, otherwise we don't properly record the end of the old scope.
+                }
+
+                public override bool Stfld(Label pc, Field field, bool @volatile, Unit obj, Unit value, BlockWithLabels<Label> currentBlock)
+                {
+                    if (this.CurrentSubroutine.IsMethod)
+                    {
+                        IMethodInfo<Method> mi = (IMethodInfo<Method>)this.CurrentSubroutine;
+                        if (parent.MetadataDecoder.IsPropertySetter(mi.Method))
+                        {
+                            parent.MethodCache.AddModifies(mi.Method, field);
+                        }
+                    }
+                    this.currentBlock.Add(pc);
+                    return false; // has fall through
+                }
+
+                public override bool Ldflda(Label pc, Field field, UnitDest dest, UnitDest obj, BlockWithLabels<Label> data)
+                {
+                    // for setter modifies analysis, treat as modifies
+                    if (this.CurrentSubroutine.IsMethod)
+                    {
+                        IMethodInfo<Method> mi = (IMethodInfo<Method>)this.CurrentSubroutine;
+                        if (parent.MetadataDecoder.IsPropertySetter(mi.Method))
+                        {
+                            parent.MethodCache.AddModifies(mi.Method, field);
+                        }
+                    }
+                    currentBlock.Add(pc);
+                    return false; // has fall through
+                }
+
+                public override bool Ldfld(Label pc, Field field, bool @volatile, Unit obj, Unit value, BlockWithLabels<Label> currentBlock)
+                {
+                    if (this.CurrentSubroutine.IsMethod)
+                    {
+                        IMethodInfo<Method> mi = (IMethodInfo<Method>)this.CurrentSubroutine;
+                        if (parent.MetadataDecoder.IsPropertyGetter(mi.Method))
+                        {
+                            parent.MethodCache.AddReads(mi.Method, field);
+                        }
+                    }
+                    this.currentBlock.Add(pc);
+                    return false; // has fall through
+                }
+            }
+
+
+            internal virtual void BeginOldHook(Label current)
+            {
+            }
+
+            internal virtual void EndOldHook(Label current)
+            {
+            }
+
+            internal bool IsTargetLabel(Label label)
+            {
+                return targetLabels.Contains(label);
+            }
+        }
+
+        internal class SubroutineWithHandlersBuilder<Label, Handler> : SubroutineBuilder<Label>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.CodeProvider != null); // F: Added as of Clousot suggestions as precondition in many places
+            }
+
+
+            protected override SubroutineBase<Label> CurrentSubroutine { get { return subroutineStack.Head; } }
+
+            private FList<SubroutineWithHandlers<Label, Handler>> subroutineStack;
+
+            protected SubroutineWithHandlers<Label, Handler> CurrentSubroutineWithHandler
+            {
+                get
+                {
+                    Contract.Assume(subroutineStack != null, "Seems that when calling CurrentSubroutineStack we know the assumption holds");
+
+                    return subroutineStack.Head;
+                }
+            }
+
+            private OnDemandMap<Label, Stack<Handler>> tryStartList;
+            private OnDemandMap<Label, Queue<Handler>> tryEndList;
+            private OnDemandMap<Label, Queue<Handler>> subroutineHandlerEndList;
+            private OnDemandMap<Label, Handler> handlerStartingAt;
+            protected readonly Method method;
+
+            internal new readonly IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> CodeProvider;
+
+
+            public SubroutineWithHandlersBuilder(
+              IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> codeProvider,
+              MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+              Method method,
+              Label entry
+            )
+              : base(codeProvider, methodCache, entry)
+            {
+                Contract.Requires(codeProvider != null); // F: Added as of Clousot suggestion
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+
+                this.CodeProvider = codeProvider;
+                this.method = method;
+                ComputeTryBlockStartAndEndInfo(method);
+                base.Initialize(entry);
+            }
+
+            public CFGBlock BuildBlocks(Label entry, SubroutineWithHandlers<Label, Handler> subroutine)
+            {
+                subroutineStack = FList<SubroutineWithHandlers<Label, Handler>>.Cons(subroutine, null);
+                return base.BuildBlocks(entry);
+            }
+
+            internal override void RecordBlockInfoSameAsOtherBlock(BlockWithLabels<Label> ab, BlockWithLabels<Label> otherblock)
+            {
+                FList<Handler>/*?*/ protHandlers;
+                if (this.CurrentSubroutineWithHandler.ProtectingHandlers.TryGetValue(otherblock, out protHandlers))
+                {
+                    this.CurrentSubroutineWithHandler.ProtectingHandlers.Add(ab, protHandlers);
+                }
+            }
+
+            private FList<Handler> CurrentProtectingHandlers
+            {
+                get
+                {
+                    Contract.Assume(this.CurrentSubroutineWithHandler != null);
+                    return this.CurrentSubroutineWithHandler.CurrentProtectingHandlers;
+                }
+                set
+                {
+                    Contract.Assume(this.CurrentSubroutineWithHandler != null);
+                    this.CurrentSubroutineWithHandler.CurrentProtectingHandlers = value;
+                }
+            }
+
+            protected override BlockWithLabels<Label> RecordInformationForNewBlock(Label currentLabel, BlockWithLabels<Label>/*?*/ previousBlock)
+            {
+                BlockWithLabels<Label>/*?*/ newBlock = null;
+
+                #region Pop subroutine handlers off stack whose scope ends here (must be first)
+                Queue<Handler> handlerEnds = this.GetHandlerEnd(currentLabel);
+                if (handlerEnds != null)
+                {
+                    foreach (Handler eh in handlerEnds)
+                    {
+                        // TODO: not enough info to make sure we are popping the correct subroutine
+                        SubroutineBase<Label> endingSubroutine = subroutineStack.Head;
+                        endingSubroutine.Commit();
+
+                        subroutineStack = subroutineStack.Tail;
+                        // can't fall from one subroutine into another
+                        previousBlock = null;
+                    }
+                }
+                #endregion
+
+                #region Pop protecting handlers off stack whose scope ends here
+
+                Queue<Handler> tryEnds = this.GetTryEnd(currentLabel);
+                if (tryEnds != null)
+                {
+                    foreach (Handler eh in tryEnds)
+                    {
+                        if (Object.Equals(eh, CurrentProtectingHandlers.Head))
+                        {
+                            CurrentProtectingHandlers = CurrentProtectingHandlers.Tail; // Pop handler
+                        }
+                        else
+                        {
+                            throw new ApplicationException("wrong handler");
+                        }
+                    }
+                }
+                #endregion
+
+                #region Check if this is a fault/finally subroutine start or an exception handler
+                Handler handlerStarting;
+                if (this.IsHandlerStart(currentLabel, out handlerStarting))
+                {
+                    if (this.IsFaultOrFinally(handlerStarting))
+                    {
+                        SubroutineWithHandlers<Label, Handler> subroutine;
+                        if (this.CodeProvider.IsFaultHandler(handlerStarting))
+                        {
+                            subroutine = new FaultSubroutine<Label, Handler>(this.MethodCache, this, currentLabel);
+                        }
+                        else
+                        {
+                            subroutine = new FinallySubroutine<Label, Handler>(this.MethodCache, this, currentLabel);
+                        }
+                        this.CurrentSubroutineWithHandler.FaultFinallySubroutines.Add(handlerStarting, subroutine);
+
+                        // push new current subroutine
+                        subroutineStack = FList<SubroutineWithHandlers<Label, Handler>>.Cons(subroutine, subroutineStack);
+
+                        previousBlock = null; // can't fall into here.
+                    }
+                    else
+                    {
+                        // This is an exception handler start. Make sure we use a special entry block for it.
+                        newBlock = CurrentSubroutineWithHandler.CreateCatchFilterHeader(handlerStarting, currentLabel);
+                    }
+                }
+                #endregion
+
+
+                #region Get new block and record fall-through edge if necessary
+                if (newBlock == null)
+                {
+                    newBlock = base.RecordInformationForNewBlock(currentLabel, previousBlock);
+                }
+
+                #endregion
+
+                #region Push protecting handlers on stack whose scope starts here
+                Stack<Handler> starts = this.GetTryStart(currentLabel);
+                if (starts != null)
+                {
+                    foreach (Handler eh in starts)
+                    {
+                        // push this handler on top of current block enclosing handlers
+                        CurrentProtectingHandlers = FList<Handler>.Cons(eh, CurrentProtectingHandlers); // Push handler
+                    }
+                }
+                #endregion
+
+
+                #region Record handlers for new block
+                CurrentSubroutineWithHandler.ProtectingHandlers.Add(newBlock, this.CurrentProtectingHandlers);
+                #endregion
+
+                return newBlock;
+            }
+
+
+            private void ComputeTryBlockStartAndEndInfo(Method method)
+            {
+                foreach (Handler eh in this.CodeProvider.TryBlocks(method).AssumeNotNull())
+                {
+                    if (this.CodeProvider.IsFilterHandler(eh))
+                    {
+                        this.AddTargetLabel(CodeProvider.FilterDecisionStart(eh));
+                    }
+                    this.AddTargetLabel(CodeProvider.HandlerStart(eh));
+                    this.AddTargetLabel(CodeProvider.HandlerEnd(eh));
+
+                    AddTryStart(eh);
+                    AddTryEnd(eh);
+                    AddHandlerEnd(eh);
+                    handlerStartingAt.Add(CodeProvider.HandlerStart(eh), eh);
+                }
+            }
+
+            private void AddTryStart(Handler eh)
+            {
+                Label tryStart = this.CodeProvider.TryStart(eh);
+                Stack<Handler>/*?*/ starts;
+                tryStartList.TryGetValue(tryStart, out starts);
+                if (starts == null)
+                {
+                    starts = new Stack<Handler>();
+                    tryStartList[tryStart] = starts;
+                }
+                starts.Push(eh);
+
+                // also update block start
+                this.AddTargetLabel(tryStart);
+            }
+
+            private void AddTryEnd(Handler eh)
+            {
+                Label tryEnd = this.CodeProvider.TryEnd(eh);
+                Queue<Handler>/*?*/ ends;
+                tryEndList.TryGetValue(tryEnd, out ends);
+                if (ends == null)
+                {
+                    ends = new Queue<Handler>();
+                    tryEndList[tryEnd] = ends;
+                }
+                ends.Enqueue(eh);
+
+                // also update block start
+                this.AddTargetLabel(tryEnd);
+            }
+
+            private void AddHandlerEnd(Handler eh)
+            {
+                if (!this.IsFaultOrFinally(eh)) return;
+                // only record subroutine handlers
+                Label ehEnd = this.CodeProvider.HandlerEnd(eh);
+                Queue<Handler>/*?*/ ends;
+                subroutineHandlerEndList.TryGetValue(ehEnd, out ends);
+                if (ends == null)
+                {
+                    ends = new Queue<Handler>();
+                    subroutineHandlerEndList[ehEnd] = ends;
+                }
+                ends.Enqueue(eh);
+
+                // also update block start
+                this.AddTargetLabel(ehEnd);
+            }
+
+            public bool IsHandlerStart(Label label, out Handler handler)
+            {
+                return (handlerStartingAt.TryGetValue(label, out handler));
+            }
+
+            public bool IsFaultOrFinally(Handler handler)
+            {
+                return this.CodeProvider.IsFaultHandler(handler) || this.CodeProvider.IsFinallyHandler(handler);
+            }
+
+            public Queue<Handler> GetHandlerEnd(Label label)
+            {
+                Queue<Handler>/*?*/ result;
+                subroutineHandlerEndList.TryGetValue(label, out result);
+                return result;
+            }
+
+            public Queue<Handler> GetTryEnd(Label label)
+            {
+                Queue<Handler>/*?*/ result;
+                tryEndList.TryGetValue(label, out result);
+                return result;
+            }
+
+            public Stack<Handler> GetTryStart(Label label)
+            {
+                Stack<Handler>/*?*/ result;
+                tryStartList.TryGetValue(label, out result);
+                return result;
+            }
+        }
+
+        internal class AssumeAsPostConditionSubroutineBuilder<Label> : SubroutineBuilder<Label>
+        {
+            private SubroutineBase<Label> currentSubroutine;
+
+            public AssumeAsPostConditionSubroutineBuilder(ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
+                                        MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                        Label entry
+         )
+           : base(codeProvider, methodCache, entry)
+            {
+                Contract.Requires(methodCache != null); // F: As of Clousot suggestion
+
+                base.Initialize(entry);
+            }
+
+            public BlockWithLabels<Label> BuildBlocks(Label entry, BlockWithLabels<Label> startBlk, SubroutineBase<Label> subroutine)
+            {
+                currentSubroutine = subroutine;
+                return base.BuildBlocksWithFixedStartBlock(entry, startBlk);
+            }
+
+            protected override SubroutineBase<Label> CurrentSubroutine
+            {
+                get
+                {
+                    return currentSubroutine;
                 }
             }
         }
-        return visitor.Call(pc, method, tail, virt, extraVarargs, dest, args, data);
-      }
 
-      public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, UnitDest dest, UnitSource fp, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<UnitSource>
-      {
-        return visitor.Calli(pc, returnType, argTypes, tail, isInstance, dest, fp, args, data);
-      }
-
-      public Result Ckfinite(APC pc, UnitDest dest, UnitSource source, Data data)
-      {
-        return visitor.Ckfinite(pc, dest, source, data);
-      }
-
-      public Result Cpblk(APC pc, bool @volatile, UnitSource destaddr, UnitSource srcaddr, UnitSource len, Data data)
-      {
-        return visitor.Cpblk(pc, @volatile, destaddr, srcaddr, len, data);
-      }
-
-      public Result Endfilter(APC pc, UnitSource decision, Data data)
-      {
-        return visitor.Endfilter(pc, decision, data);
-      }
-
-      public Result Endfinally(APC pc, Data data)
-      {
-        return visitor.Endfinally(pc, data);
-      }
-
-      public Result Entry(APC pc, Method method, Data data)
-      {
-        return visitor.Entry(pc, method, data);
-      }
-
-      public Result Initblk(APC pc, bool @volatile, UnitSource destaddr, UnitSource value, UnitSource len, Data data)
-      {
-        return visitor.Initblk(pc, @volatile, destaddr, value, len, data);
-      }
-
-      public Result Jmp(APC pc, Method method, Data data)
-      {
-        return visitor.Jmp(pc, method, data);
-      }
-
-      public Result Ldarg(APC pc, Parameter argument, bool isOld, UnitDest dest, Data data)
-      {
-        return visitor.Ldarg(pc, argument, isOld, dest, data);
-      }
-
-      public Result Ldarga(APC pc, Parameter argument, bool isOld, UnitDest dest, Data data)
-      {
-        return visitor.Ldarga(pc, argument, isOld, dest, data);
-      }
-
-      public Result Ldconst(APC pc, object constant, Type type, UnitDest dest, Data data)
-      {
-        return visitor.Ldconst(pc, constant, type, dest, data);
-      }
-
-      public Result Ldnull(APC pc, UnitDest dest, Data data)
-      {
-        return visitor.Ldnull(pc, dest, data);
-      }
-
-      public Result Ldftn(APC pc, Method method, UnitDest dest, Data data)
-      {
-        return visitor.Ldftn(pc, method, dest, data);
-      }
-
-      public Result Ldind(APC pc, Type type, bool @volatile, UnitDest dest, UnitSource ptr, Data data)
-      {
-        return visitor.Ldind(pc, type, @volatile, dest, ptr, data);
-      }
-
-      public Result Ldloc(APC pc, Local local, UnitDest dest, Data data)
-      {
-        return visitor.Ldloc(pc, local, dest, data);
-      }
-
-      public Result Ldloca(APC pc, Local local, UnitDest dest, Data data)
-      {
-        return visitor.Ldloca(pc, local, dest, data);
-      }
-
-      public Result Ldstack(APC pc, int offset, UnitDest dest, UnitSource source, bool isOld, Data data)
-      {
-        return visitor.Ldstack(pc, offset, dest, source, isOld, data);
-      }
-
-      public Result Ldstacka(APC pc, int offset, UnitDest dest, UnitSource source, Type type, bool isOld, Data data)
-      {
-        return visitor.Ldstacka(pc, offset, dest, source, type, isOld, data);
-      }
-
-      public Result Localloc(APC pc, UnitDest dest, UnitSource size, Data data)
-      {
-        return visitor.Localloc(pc, dest, size, data);
-      }
-
-      public Result Nop(APC pc, Data data)
-      {
-        return visitor.Nop(pc, data);
-      }
-
-      public Result Pop(APC pc, UnitSource source, Data data)
-      {
-        return visitor.Pop(pc, source, data);
-      }
-
-      public Result Return(APC pc, UnitSource source, Data data)
-      {
-        return visitor.Return(pc, source, data);
-      }
-
-      public Result Starg(APC pc, Parameter argument, UnitSource source, Data data)
-      {
-        return visitor.Starg(pc, argument, source, data);
-      }
-
-      public Result Stind(APC pc, Type type, bool @volatile, UnitSource ptr, UnitSource value, Data data)
-      {
-        return visitor.Stind(pc, type, @volatile, ptr, value, data);
-      }
-
-      public Result Stloc(APC pc, Local local, UnitSource source, Data data)
-      {
-        return visitor.Stloc(pc, local, source, data);
-      }
-
-      public Result Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, UnitSource value, Data data)
-      {
-        return visitor.Nop(pc, data);
-      }
-
-      public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, UnitDest dest, UnitSource source, Data data)
-      {
-        return visitor.Unary(pc, op, overflow, unsigned, dest, source, data);
-      }
-
-      public Result Box(APC pc, Type type, UnitDest dest, UnitSource source, Data data)
-      {
-        return visitor.Box(pc, type, dest, source, data);
-      }
-
-      public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<UnitSource>
-      {
-        return visitor.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, dest, args, data);
-      }
-
-      public Result Castclass(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Castclass(pc, type, dest, obj, data);
-      }
-
-      public Result Cpobj(APC pc, Type type, UnitSource destptr, UnitSource srcptr, Data data)
-      {
-        return visitor.Cpobj(pc, type, destptr, srcptr, data);
-      }
-
-      public Result Initobj(APC pc, Type type, UnitSource ptr, Data data)
-      {
-        return visitor.Initobj(pc, type, ptr, data);
-      }
-
-      public Result Isinst(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Isinst(pc, type, dest, obj, data);
-      }
-
-      public Result Ldelem(APC pc, Type type, UnitDest dest, UnitSource array, UnitSource index, Data data)
-      {
-        return visitor.Ldelem(pc, type, dest, array, index, data);
-      }
-
-      public Result Ldelema(APC pc, Type type, bool @readonly, UnitDest dest, UnitSource array, UnitSource index, Data data)
-      {
-        return visitor.Ldelema(pc, type, @readonly, dest, array, index, data);
-      }
-
-      public Result Ldfld(APC pc, Field field, bool @volatile, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Ldfld(pc, field, @volatile, dest, obj, data);
-      }
-
-      public Result Ldflda(APC pc, Field field, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Ldflda(pc, field, dest, obj, data);
-      }
-
-      public Result Ldlen(APC pc, UnitDest dest, UnitSource array, Data data)
-      {
-        return visitor.Ldlen(pc, dest, array, data);
-      }
-
-      public Result Ldsfld(APC pc, Field field, bool @volatile, UnitDest dest, Data data)
-      {
-        return visitor.Ldsfld(pc, field, @volatile, dest, data);
-      }
-
-      public Result Ldsflda(APC pc, Field field, UnitDest dest, Data data)
-      {
-        return visitor.Ldsflda(pc, field, dest, data);
-      }
-
-      public Result Ldtypetoken(APC pc, Type type, UnitDest dest, Data data)
-      {
-        return visitor.Ldtypetoken(pc, type, dest, data);
-      }
-
-      public Result Ldfieldtoken(APC pc, Field field, UnitDest dest, Data data)
-      {
-        return visitor.Ldfieldtoken(pc, field, dest, data);
-      }
-
-      public Result Ldmethodtoken(APC pc, Method method, UnitDest dest, Data data)
-      {
-        return visitor.Ldmethodtoken(pc, method, dest, data);
-      }
-
-      public Result Ldvirtftn(APC pc, Method method, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Ldvirtftn(pc, method, dest, obj, data);
-      }
-
-      public Result Mkrefany(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Mkrefany(pc, type, dest, obj, data);
-      }
-
-      public Result Newarray<ArgList>(APC pc, Type type, UnitDest dest, ArgList lengths, Data data)
-        where ArgList : IIndexable<UnitSource>
-      {
-        return visitor.Newarray(pc, type, dest, lengths, data);
-      }
-
-      public Result Newobj<ArgList>(APC pc, Method ctor, UnitDest dest, ArgList args, Data data)
-        where ArgList : IIndexable<UnitSource>
-      {
-          Type declaringType = mdDecoder.DeclaringType(ctor);
-          if (args.Count == 2 && mdDecoder.Equal(declaringType, mdDecoder.System_Decimal))
-          {
-              // note: ctor first arg is object, but not on stack during newobj.
-              // special case equal here
-              return visitor.Unary(pc, UnaryOperator.Conv_dec, false, false, dest, args[1], data);
-          }
-
-          return visitor.Newobj(pc, ctor, dest, args, data);
-      }
-
-      public Result Refanytype(APC pc, UnitDest dest, UnitSource source, Data data)
-      {
-        return visitor.Refanytype(pc, dest, source, data);
-      }
-
-      public Result Refanyval(APC pc, Type type, UnitDest dest, UnitSource source, Data data)
-      {
-        return visitor.Refanyval(pc, type, dest, source, data);
-      }
-
-      public Result Rethrow(APC pc, Data data)
-      {
-        return visitor.Rethrow(pc, data);
-      }
-
-      public Result Sizeof(APC pc, Type type, UnitDest dest, Data data)
-      {
-        return visitor.Sizeof(pc, type, dest, data);
-      }
-
-      public Result Stelem(APC pc, Type type, UnitSource array, UnitSource index, UnitSource value, Data data)
-      {
-        return visitor.Stelem(pc, type, array, index, value, data);
-      }
-
-      public Result Stfld(APC pc, Field field, bool @volatile, UnitSource obj, UnitSource value, Data data)
-      {
-        return visitor.Stfld(pc, field, @volatile, obj, value, data);
-      }
-
-      public Result Stsfld(APC pc, Field field, bool @volatile, UnitSource value, Data data)
-      {
-        return visitor.Stsfld(pc, field, @volatile, value, data);
-      }
-
-      public Result Throw(APC pc, UnitSource exn, Data data)
-      {
-        return visitor.Throw(pc, exn, data);
-      }
-
-      public Result Unbox(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Unbox(pc, type, dest, obj, data);
-      }
-
-      public Result Unboxany(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
-      {
-        return visitor.Unboxany(pc, type, dest, obj, data);
-      }
-
-
-      #region IVisitSynthIL<Label,Method2,Source,Dest,Data,Result> Members
-
-
-      public Result BeginOld(APC pc, APC matchingEnd, Data data)
-      {
-        return visitor.BeginOld(pc, matchingEnd, data);
-      }
-
-      public Result EndOld(APC pc, APC matchingBegin, Type type, UnitDest dest, UnitSource source, Data data)
-      {
-        return visitor.EndOld(pc, matchingBegin, type, dest, source, data);
-      }
-
-      public Result Ldresult(APC pc, Type type, UnitDest dest, UnitSource source, Data data)
-      {
-        return visitor.Ldresult(pc, type, dest, source, data);
-      }
-
-      #endregion
-    }
-
-#if false
-      struct AssumeDelegator<Data, Result, Visitor> :
-        IVisitMSIL<Label, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result>
-        where Visitor : IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result>
-      {
-        Visitor visitor;
-        Tag assumeLabel;
-        APC originalPC;
-
-        public AssumeDelegator(
-          Visitor visitor,
-          Tag assumeLabel,
-          APC origPC)
+        internal class SimpleSubroutineBuilder<Label> : SubroutineBuilder<Label>
         {
-          this.visitor = visitor;
-          this.assumeLabel = assumeLabel;
-          this.originalPC = origPC;
+            private SubroutineBase<Label> currentSubroutine;
+
+            public SimpleSubroutineBuilder(ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
+                                           MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                           Label entry
+            )
+              : base(codeProvider, methodCache, entry)
+            {
+                Contract.Requires(methodCache != null); // F: As of Clousot suggestion
+                base.Initialize(entry);
+            }
+
+            public BlockWithLabels<Label> BuildBlocks(Label entry, SubroutineBase<Label> subroutine)
+            {
+                currentSubroutine = subroutine;
+                return base.BuildBlocks(entry);
+            }
+
+            protected override SubroutineBase<Label> CurrentSubroutine
+            {
+                get
+                {
+                    if (this.currentOldSubroutine != null) return this.currentOldSubroutine;
+                    return currentSubroutine;
+                }
+            }
+
+            protected OldValueSubroutine<Label> currentOldSubroutine;
+            protected BlockWithLabels<Label> blockPriorToOld;
+
+            protected override BlockWithLabels<Label> RecordInformationForNewBlock(Label currentLabel, BlockWithLabels<Label> previousBlock)
+            {
+                Label lastLabel;
+                BlockWithLabels<Label> newBlock;
+                if (previousBlock != null && previousBlock.HasLastLabel(out lastLabel) && endOldStart.Contains(lastLabel))
+                {
+                    // end the old subroutine here.
+                    var endingOldSubroutine = this.currentOldSubroutine;
+                    endingOldSubroutine.Commit(previousBlock);
+
+                    // now change the context to previous subroutine (ensures)
+                    this.currentOldSubroutine = null;
+                    Contract.Assume(this.CurrentSubroutine != null);
+                    Contract.Assume(this.CurrentSubroutine.IsEnsures);
+                    // We need to fall into the new block from the block prior to the old subroutine
+                    Contract.Assume(blockPriorToOld.Subroutine == this.CurrentSubroutine);
+                    newBlock = base.RecordInformationForNewBlock(currentLabel, blockPriorToOld);
+                    Contract.Assume(newBlock.Subroutine == this.CurrentSubroutine);
+                    this.CurrentSubroutine.AddEdgeSubroutine(blockPriorToOld, newBlock, endingOldSubroutine, "old");
+                    return newBlock;
+                }
+                if (beginOldStart.Contains(currentLabel))
+                {
+                    // start of an old subroutine
+                    Contract.Assume(this.currentOldSubroutine == null); // F: made an assume
+                    this.currentOldSubroutine = new OldValueSubroutine<Label>(this.MethodCache, ((CallingContractSubroutine<Label>)currentSubroutine).Method, this, currentLabel);
+                    this.blockPriorToOld = previousBlock;
+
+                    // don't fall into this block
+                    newBlock = base.RecordInformationForNewBlock(currentLabel, null);
+                    this.currentOldSubroutine.RegisterBeginBlock(newBlock);
+                    return newBlock;
+                }
+                newBlock = base.RecordInformationForNewBlock(currentLabel, previousBlock);
+
+                return newBlock;
+            }
+
+            private IMutableSet<Label> beginOldStart = new Set<Label>();
+            private IMutableSet<Label> endOldStart = new Set<Label>();
+
+            internal override void BeginOldHook(Label label)
+            {
+                beginOldStart.Add(label);
+            }
+
+            internal override void EndOldHook(Label label)
+            {
+                endOldStart.Add(label);
+            }
         }
 
-        APC ConvertLabel(Label pc)
+
+        internal abstract class BlockBase : CFGBlock
         {
-          // we return the stored pc here, as the underlying decoder only dealt with a label
-          // this works because we never translate branch target labels.
-          return this.originalPC;
+            internal BlockBase(Subroutine container, ref int idGen) : base(container, ref idGen)
+            {
+                Contract.Requires(idGen >= 0);// F: added because of Clousot suggestion
+                Contract.Requires(container != null); // F: added because of Clousot suggestion
+
+                Contract.Ensures(idGen >= 0);
+            }
+
+            internal abstract Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+              where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>;
+        }
+        /// <summary>
+        /// CFG blocks group consecutive instructions/code fragments to reduce the number of edges
+        /// in the graph. A Block has a single entry point, meaning all control transfers go to the head
+        /// never to an interior label. The only control transfer out of the block is at the last instruction.
+        /// </summary>
+        /// <typeparam name="Label"></typeparam>
+        internal class BlockWithLabels<Label> : BlockBase, IEquatable<BlockWithLabels<Label>>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.subroutine != null); // F: made an object invariant
+                Contract.Invariant(Labels != null);// F: made an object invariant
+            }
+
+
+            #region Private/Internal
+
+            private readonly List<Label> Labels;
+
+
+            internal BlockWithLabels(SubroutineBase<Label> container, ref int idGen)
+              : base(container, ref idGen)
+            {
+                Contract.Requires(container != null); // F: As of Clousot suggestion
+                Contract.Requires(idGen >= 0); // F: As of Clousot suggestion
+
+                Contract.Ensures(idGen >= 0);
+
+                Labels = new List<Label>();
+                this.subroutine = container;
+            }
+
+            internal void Add(Label label)
+            {
+                Labels.Add(label);
+            }
+
+            #endregion
+
+            internal readonly SubroutineBase<Label> subroutine;
+
+            #region public API
+            public override int Count
+            {
+                get { return Labels.Count; }
+            }
+
+            internal bool HasLastLabel(out Label label)
+            {
+                if (Labels.Count > 0)
+                {
+                    label = Labels[Labels.Count - 1];
+                    return true;
+                }
+                label = default(Label);
+                return false;
+            }
+
+            internal virtual bool UnderlyingLabelForward(int index, out Label/*?*/ label)
+            {
+                Contract.Requires(index >= 0);
+
+                if (index < Labels.Count)
+                {
+                    label = Labels[index];
+                    return true;
+                }
+                else
+                {
+                    label = default(Label);
+                    return false;
+                }
+            }
+
+            public override string SourceAssertionCondition(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceAssertionCondition(label);
+                }
+                return null;
+            }
+
+            public override string SourceContext(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceContext(label);
+                }
+                return null;
+            }
+
+            public override string SourceDocument(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceDocument(label);
+                }
+                return null;
+            }
+
+            public override int SourceStartLine(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceStartLine(label);
+                }
+                return 0;
+            }
+
+            public override int SourceEndLine(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceEndLine(label);
+                }
+                return 0;
+            }
+
+            public override int SourceStartColumn(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceStartColumn(label);
+                }
+                return 0;
+            }
+
+            public override int SourceEndColumn(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceEndColumn(label);
+                }
+                return 0;
+            }
+
+            public override int SourceStartIndex(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceStartIndex(label);
+                }
+                return 0;
+            }
+
+            public override int SourceLength(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.SourceLength(label);
+                }
+                return 0;
+            }
+
+            public override int ILOffset(APC pc)
+            {
+                Label label;
+                if (this.UnderlyingLabelForward(pc.Index, out label))
+                {
+                    return this.subroutine.ILOffset(label);
+                }
+                return 0;
+            }
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                Label/*?*/ lab;
+                if (this.UnderlyingLabelForward(pc.Index, out lab))
+                {
+                    var decoder = this.subroutine.CodeProvider;
+                    return decoder.Decode<LabelAdapter<Data, Result, Visitor>, Data, Result>(lab, new LabelAdapter<Data, Result, Visitor>(visitor, pc), data);
+                }
+                else
+                {
+                    return visitor.Nop(pc, data);
+                }
+            }
+
+            #region APC -> Label adapter visitor. Also turns Aggregate into Nops, i.e., adapts ICodeQuery to IVisitMSIL
+
+            protected struct LabelAdapter<Data, Result, Visitor> :
+              ICodeQuery<Label, Local, Parameter, Method, Field, Type, Data, Result>
+              where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result>
+            {
+                private APC originalPC;
+                private Visitor visitor;
+
+                public LabelAdapter(
+                  Visitor visitor,
+                  APC origPC
+                )
+                {
+                    this.visitor = visitor;
+                    originalPC = origPC;
+                }
+
+                private APC ConvertLabel(Label pc)
+                {
+                    // we return the stored pc here, as the underlying decoder only dealt with a label
+                    // this works because we never translate branch target labels.
+                    return originalPC;
+                }
+
+                /// <summary>
+                /// Map a label occurring in a begin_old/end_old to an apc.
+                /// </summary>
+                private APC ConvertMatchingBeginLabel(Label underlying)
+                {
+                    Contract.Assume(originalPC.Block != null); // F: made it an assumption
+
+                    OldValueSubroutine<Label> subroutine = (OldValueSubroutine<Label>)originalPC.Block.Subroutine;
+
+                    return subroutine.BeginOldAPC(originalPC.SubroutineContext);
+                }
+                private APC ConvertMatchingEndLabel(Label underlying)
+                {
+                    Contract.Assume(originalPC.Block != null); // F: made it an assumption
+                    OldValueSubroutine<Label> subroutine = (OldValueSubroutine<Label>)originalPC.Block.Subroutine;
+
+                    return subroutine.EndOldAPC(originalPC.SubroutineContext);
+                }
+
+                public Result Aggregate(Label pc, Label nested, bool branchTarget, Data data)
+                {
+                    return visitor.Nop(ConvertLabel(pc), data);
+                }
+
+                public Result Assume(Label pc, string tag, UnitSource source, object provenance, Data data)
+                {
+                    return visitor.Assume(ConvertLabel(pc), tag, source, provenance, data);
+                }
+
+                public Result Assert(Label pc, string tag, UnitSource source, object provenance, Data data)
+                {
+                    return visitor.Assert(ConvertLabel(pc), tag, source, provenance, data);
+                }
+
+                public Result Arglist(Label pc, UnitDest dest, Data data)
+                {
+                    return visitor.Arglist(ConvertLabel(pc), dest, data);
+                }
+
+                public Result Binary(Label pc, BinaryOperator op, UnitDest dest, UnitSource s1, UnitSource s2, Data data)
+                {
+                    return visitor.Binary(ConvertLabel(pc), op, dest, s1, s2, data);
+                }
+
+                public Result BranchCond(Label pc, Label target, BranchOperator bop, UnitSource value1, UnitSource value2, Data data)
+                {
+                    return visitor.BranchCond(ConvertLabel(pc), ConvertLabel(target), bop, value1, value2, data);
+                }
+
+                public Result BranchTrue(Label pc, Label target, UnitSource cond, Data data)
+                {
+                    return visitor.BranchTrue(ConvertLabel(pc), ConvertLabel(target), cond, data);
+                }
+
+                public Result BranchFalse(Label pc, Label target, UnitSource cond, Data data)
+                {
+                    return visitor.BranchFalse(ConvertLabel(pc), ConvertLabel(target), cond, data);
+                }
+
+                public Result Branch(Label pc, Label target, bool leave, Data data)
+                {
+                    return visitor.Branch(ConvertLabel(pc), ConvertLabel(target), leave, data);
+                }
+
+                public Result Break(Label pc, Data data)
+                {
+                    return visitor.Break(ConvertLabel(pc), data);
+                }
+
+                public Result Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<UnitSource>
+                {
+                    return visitor.Call(ConvertLabel(pc), method, tail, virt, extraVarargs, dest, args, data);
+                }
+
+                public Result Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, UnitDest dest, UnitSource fp, ArgList args, Data data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<UnitSource>
+                {
+                    return visitor.Calli(ConvertLabel(pc), returnType, argTypes, tail, isInstance, dest, fp, args, data);
+                }
+
+                public Result Ckfinite(Label pc, UnitDest dest, UnitSource source, Data data)
+                {
+                    return visitor.Ckfinite(ConvertLabel(pc), dest, source, data);
+                }
+
+                public Result Cpblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource srcaddr, UnitSource len, Data data)
+                {
+                    return visitor.Cpblk(ConvertLabel(pc), @volatile, destaddr, srcaddr, len, data);
+                }
+
+                public Result Endfilter(Label pc, UnitSource decision, Data data)
+                {
+                    return visitor.Endfilter(ConvertLabel(pc), decision, data);
+                }
+
+                public Result Endfinally(Label pc, Data data)
+                {
+                    return visitor.Endfinally(ConvertLabel(pc), data);
+                }
+
+                public Result Entry(Label pc, Method method, Data data)
+                {
+                    return visitor.Entry(ConvertLabel(pc), method, data);
+                }
+
+                public Result Initblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource value, UnitSource len, Data data)
+                {
+                    return visitor.Initblk(ConvertLabel(pc), @volatile, destaddr, value, len, data);
+                }
+
+                public Result Jmp(Label pc, Method method, Data data)
+                {
+                    return visitor.Jmp(ConvertLabel(pc), method, data);
+                }
+
+                /// <summary>
+                /// Could be access to "this" in an invariant code sequence. Map to "this" in surrounding using method.
+                /// </summary>
+                public Result Ldarg(Label pc, Parameter argument, bool isOld, UnitDest dest, Data data)
+                {
+                    return visitor.Ldarg(ConvertLabel(pc), argument, isOld, dest, data);
+                }
+
+                public Result Ldarga(Label pc, Parameter argument, bool isOld, UnitDest dest, Data data)
+                {
+                    return visitor.Ldarga(ConvertLabel(pc), argument, isOld, dest, data);
+                }
+
+                public Result Ldconst(Label pc, object constant, Type type, UnitDest dest, Data data)
+                {
+                    return visitor.Ldconst(ConvertLabel(pc), constant, type, dest, data);
+                }
+
+                public Result Ldnull(Label pc, UnitDest dest, Data data)
+                {
+                    return visitor.Ldnull(ConvertLabel(pc), dest, data);
+                }
+
+                public Result Ldftn(Label pc, Method method, UnitDest dest, Data data)
+                {
+                    return visitor.Ldftn(ConvertLabel(pc), method, dest, data);
+                }
+
+                public Result Ldind(Label pc, Type type, bool @volatile, UnitDest dest, UnitSource ptr, Data data)
+                {
+                    return visitor.Ldind(ConvertLabel(pc), type, @volatile, dest, ptr, data);
+                }
+
+                public Result Ldloc(Label pc, Local local, UnitDest dest, Data data)
+                {
+                    return visitor.Ldloc(ConvertLabel(pc), local, dest, data);
+                }
+
+                public Result Ldloca(Label pc, Local local, UnitDest dest, Data data)
+                {
+                    return visitor.Ldloca(ConvertLabel(pc), local, dest, data);
+                }
+
+                public Result Ldstack(Label pc, int offset, UnitDest dest, UnitSource source, bool isOld, Data data)
+                {
+                    return visitor.Ldstack(ConvertLabel(pc), offset, dest, source, isOld, data);
+                }
+
+                public Result Ldstacka(Label pc, int offset, UnitDest dest, UnitSource source, Type type, bool isOld, Data data)
+                {
+                    return visitor.Ldstacka(ConvertLabel(pc), offset, dest, source, type, isOld, data);
+                }
+
+                public Result Localloc(Label pc, UnitDest dest, UnitSource size, Data data)
+                {
+                    return visitor.Localloc(ConvertLabel(pc), dest, size, data);
+                }
+
+                public Result Nop(Label pc, Data data)
+                {
+                    return visitor.Nop(ConvertLabel(pc), data);
+                }
+
+                public Result Pop(Label pc, UnitSource source, Data data)
+                {
+                    return visitor.Pop(ConvertLabel(pc), source, data);
+                }
+
+                public Result Return(Label pc, UnitSource source, Data data)
+                {
+                    return visitor.Return(ConvertLabel(pc), source, data);
+                }
+
+                public Result Starg(Label pc, Parameter argument, UnitSource source, Data data)
+                {
+                    return visitor.Starg(ConvertLabel(pc), argument, source, data);
+                }
+
+                public Result Stind(Label pc, Type type, bool @volatile, UnitSource ptr, UnitSource value, Data data)
+                {
+                    return visitor.Stind(ConvertLabel(pc), type, @volatile, ptr, value, data);
+                }
+
+                public Result Stloc(Label pc, Local local, UnitSource source, Data data)
+                {
+                    return visitor.Stloc(ConvertLabel(pc), local, source, data);
+                }
+
+                public Result Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, UnitSource value, Data data)
+                {
+                    return visitor.Nop(originalPC, data);
+                }
+
+                public Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, UnitDest dest, UnitSource source, Data data)
+                {
+                    return visitor.Unary(ConvertLabel(pc), op, overflow, unsigned, dest, source, data);
+                }
+
+                public Result Box(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
+                {
+                    return visitor.Box(ConvertLabel(pc), type, dest, source, data);
+                }
+
+                public Result ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
+                  where TypeList : IIndexable<Type>
+                  where ArgList : IIndexable<UnitSource>
+                {
+                    return visitor.ConstrainedCallvirt(ConvertLabel(pc), method, tail, constraint, extraVarargs, dest, args, data);
+                }
+
+                public Result Castclass(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Castclass(ConvertLabel(pc), type, dest, obj, data);
+                }
+
+                public Result Cpobj(Label pc, Type type, UnitSource destptr, UnitSource srcptr, Data data)
+                {
+                    return visitor.Cpobj(ConvertLabel(pc), type, destptr, srcptr, data);
+                }
+
+                public Result Initobj(Label pc, Type type, UnitSource ptr, Data data)
+                {
+                    return visitor.Initobj(ConvertLabel(pc), type, ptr, data);
+                }
+
+                public Result Isinst(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Isinst(ConvertLabel(pc), type, dest, obj, data);
+                }
+
+                public Result Ldelem(Label pc, Type type, UnitDest dest, UnitSource array, UnitSource index, Data data)
+                {
+                    return visitor.Ldelem(ConvertLabel(pc), type, dest, array, index, data);
+                }
+
+                public Result Ldelema(Label pc, Type type, bool @readonly, UnitDest dest, UnitSource array, UnitSource index, Data data)
+                {
+                    return visitor.Ldelema(ConvertLabel(pc), type, @readonly, dest, array, index, data);
+                }
+
+                public Result Ldfld(Label pc, Field field, bool @volatile, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Ldfld(ConvertLabel(pc), field, @volatile, dest, obj, data);
+                }
+
+                public Result Ldflda(Label pc, Field field, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Ldflda(ConvertLabel(pc), field, dest, obj, data);
+                }
+
+                public Result Ldlen(Label pc, UnitDest dest, UnitSource array, Data data)
+                {
+                    return visitor.Ldlen(ConvertLabel(pc), dest, array, data);
+                }
+
+                public Result Ldsfld(Label pc, Field field, bool @volatile, UnitDest dest, Data data)
+                {
+                    return visitor.Ldsfld(ConvertLabel(pc), field, @volatile, dest, data);
+                }
+
+                public Result Ldsflda(Label pc, Field field, UnitDest dest, Data data)
+                {
+                    return visitor.Ldsflda(ConvertLabel(pc), field, dest, data);
+                }
+
+                public Result Ldtypetoken(Label pc, Type type, UnitDest dest, Data data)
+                {
+                    return visitor.Ldtypetoken(ConvertLabel(pc), type, dest, data);
+                }
+
+                public Result Ldfieldtoken(Label pc, Field field, UnitDest dest, Data data)
+                {
+                    return visitor.Ldfieldtoken(ConvertLabel(pc), field, dest, data);
+                }
+
+                public Result Ldmethodtoken(Label pc, Method method, UnitDest dest, Data data)
+                {
+                    return visitor.Ldmethodtoken(ConvertLabel(pc), method, dest, data);
+                }
+
+                public Result Ldvirtftn(Label pc, Method method, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Ldvirtftn(ConvertLabel(pc), method, dest, obj, data);
+                }
+
+                public Result Mkrefany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Mkrefany(ConvertLabel(pc), type, dest, obj, data);
+                }
+
+                public Result Newarray<ArgList>(Label pc, Type type, UnitDest dest, ArgList lengths, Data data)
+                  where ArgList : IIndexable<UnitSource>
+                {
+                    return visitor.Newarray(ConvertLabel(pc), type, dest, lengths, data);
+                }
+
+                public Result Newobj<ArgList>(Label pc, Method ctor, UnitDest dest, ArgList args, Data data)
+                  where ArgList : IIndexable<UnitSource>
+                {
+                    return visitor.Newobj(ConvertLabel(pc), ctor, dest, args, data);
+                }
+
+                public Result Refanytype(Label pc, UnitDest dest, UnitSource source, Data data)
+                {
+                    return visitor.Refanytype(ConvertLabel(pc), dest, source, data);
+                }
+
+                public Result Refanyval(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
+                {
+                    return visitor.Refanyval(ConvertLabel(pc), type, dest, source, data);
+                }
+
+                public Result Rethrow(Label pc, Data data)
+                {
+                    return visitor.Rethrow(ConvertLabel(pc), data);
+                }
+
+                public Result Sizeof(Label pc, Type type, UnitDest dest, Data data)
+                {
+                    return visitor.Sizeof(ConvertLabel(pc), type, dest, data);
+                }
+
+                public Result Stelem(Label pc, Type type, UnitSource array, UnitSource index, UnitSource value, Data data)
+                {
+                    return visitor.Stelem(ConvertLabel(pc), type, array, index, value, data);
+                }
+
+                public Result Stfld(Label pc, Field field, bool @volatile, UnitSource obj, UnitSource value, Data data)
+                {
+                    return visitor.Stfld(ConvertLabel(pc), field, @volatile, obj, value, data);
+                }
+
+                public Result Stsfld(Label pc, Field field, bool @volatile, UnitSource value, Data data)
+                {
+                    return visitor.Stsfld(ConvertLabel(pc), field, @volatile, value, data);
+                }
+
+                public Result Throw(Label pc, UnitSource exn, Data data)
+                {
+                    return visitor.Throw(ConvertLabel(pc), exn, data);
+                }
+
+                public Result Unbox(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Unbox(ConvertLabel(pc), type, dest, obj, data);
+                }
+
+                public Result Unboxany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+                {
+                    return visitor.Unboxany(ConvertLabel(pc), type, dest, obj, data);
+                }
+
+
+                #region IVisitSynthIL<Label,Method2,Source,Dest,Data,Result> Members
+
+
+                public Result BeginOld(Label pc, Label matchingEnd, Data data)
+                {
+                    // special treatment of beginold decoding in the context of an old manifestation.
+                    if (originalPC.InsideOldManifestation)
+                    {
+                        return visitor.Nop(ConvertLabel(pc), data);
+                    }
+
+                    return visitor.BeginOld(ConvertLabel(pc), ConvertMatchingEndLabel(matchingEnd), data);
+                }
+
+                public Result EndOld(Label pc, Label matchingBegin, Type type, UnitDest dest, UnitSource source, Data data)
+                {
+                    // special treatment of beginold decoding is done in the stack decoder, as it 
+                    // needs to know the specialness of endOld to generate the appropriate copy
+                    return visitor.EndOld(ConvertLabel(pc), ConvertMatchingBeginLabel(matchingBegin), type, dest, source, data);
+                }
+
+                public Result Ldresult(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
+                {
+                    return visitor.Ldresult(ConvertLabel(pc), type, dest, source, data);
+                }
+
+                #endregion
+            }
+
+
+            #endregion
+
+            #endregion
+
+
+            /// <summary>
+            /// For debugging
+            /// </summary>
+            //^ [Confined]
+            public override string/*!*/ ToString()
+            {
+                return this.Index.ToString();
+            }
+
+            #region IEquatable<CFGBlock<Label>> Members
+
+            //^ [StateIndependent]
+            public bool Equals(BlockWithLabels<Label> other)
+            {
+                return this == other;
+            }
+
+            #endregion
+        }
+
+        internal class EnsuresBlock<Label> : BlockWithLabels<Label>
+        {
+            private const int BeginOldMask = unchecked((int)0x80000000);
+            private const int EndOldMask = 0x40000000;
+            private const int Mask = unchecked((int)0xC0000000);
+
+            /// <summary>
+            /// The integers are used as follows:
+            /// - if no Mask bits are set, then it's the index of a label in the underlying
+            ///   label list
+            /// - otherwise, the mask bits indicate if it is a begin old or an end old and
+            ///   the remaining bits provide the index of the corresponding end/begin within
+            ///   the corresponding block (which is stored on the subroutine).
+            /// </summary>
+            private List<int> overridingLabels;
+
+            public EnsuresBlock(SubroutineBase<Label> container, ref int idgen)
+              : base(container, ref idgen)
+            {
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
+                Contract.Ensures(idgen >= 0);
+            }
+
+            internal bool UsesOverriding { get { return overridingLabels != null; } }
+
+            private new EnsuresSubroutine<Label> Subroutine { get { return (EnsuresSubroutine<Label>)base.Subroutine; } }
+
+            public override int Count
+            {
+                get
+                {
+                    if (overridingLabels != null) return overridingLabels.Count;
+                    return base.Count;
+                }
+            }
+
+            private bool IsOriginal(int index, out int originalOffset)
+            {
+                Contract.Requires(index >= 0);
+
+                if (overridingLabels == null)
+                {
+                    originalOffset = index;
+                    return true;
+                }
+                if (index < overridingLabels.Count && (overridingLabels[index] & Mask) == 0)
+                {
+                    originalOffset = overridingLabels[index] & ~Mask;
+                    return true;
+                }
+                originalOffset = 0;
+                return false;
+            }
+
+            private bool IsBeginOld(int index, out int endOldIndex)
+            {
+                Contract.Requires(index >= 0);
+
+                if (overridingLabels == null || index >= overridingLabels.Count)
+                {
+                    endOldIndex = 0;
+                    return false;
+                }
+                if ((overridingLabels[index] & BeginOldMask) != 0)
+                {
+                    endOldIndex = overridingLabels[index] & ~Mask;
+                    return true;
+                }
+                endOldIndex = 0;
+                return false;
+            }
+
+            private bool IsEndOld(int index, out int beginOldIndex)
+            {
+                Contract.Requires(index >= 0);
+
+                if (overridingLabels == null || index >= overridingLabels.Count)
+                {
+                    beginOldIndex = 0;
+                    return false;
+                }
+                if ((overridingLabels[index] & EndOldMask) != 0)
+                {
+                    beginOldIndex = overridingLabels[index] & ~Mask;
+                    return true;
+                }
+                beginOldIndex = 0;
+                return false;
+            }
+
+            internal override bool UnderlyingLabelForward(int index, out Label label)
+            {
+                Contract.Assert(index >= 0);
+
+                int originalOffset;
+                if (IsOriginal(index, out originalOffset))
+                {
+                    Contract.Assume(originalOffset >= 0); // F: suggested by Clousot
+                    return base.UnderlyingLabelForward(originalOffset, out label);
+                }
+                label = default(Label);
+                return false;
+            }
+
+
+            internal Result OriginalForwardDecode<Data, Result, Visitor>(int index, Visitor visitor, Data data)
+              where Visitor : ICodeQuery<Label, Local, Parameter, Method, Field, Type, Data, Result>
+            {
+                Contract.Assume(index >= 0);
+                Label/*?*/ lab;
+                if (base.UnderlyingLabelForward(index, out lab))
+                {
+                    Contract.Assume(this.subroutine.CodeProvider != null); // F: made it an assumption
+                    return this.subroutine.CodeProvider.Decode<Visitor, Data, Result>(lab, visitor, data);
+                }
+                throw new NotImplementedException();
+            }
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                Label/*?*/ lab;
+                if (this.UnderlyingLabelForward(pc.Index, out lab))
+                {
+                    return base.ForwardDecode<Data, Result, Visitor>(pc, visitor, data);
+                }
+                int endOldIndex;
+                if (IsBeginOld(pc.Index, out endOldIndex))
+                {
+                    var endBlock = this.Subroutine.InferredBeginEndBijection(pc);
+                    return visitor.BeginOld(pc, new APC(endBlock, endOldIndex, pc.SubroutineContext), data);
+                }
+                int beginOldIndex;
+                if (IsEndOld(pc.Index, out beginOldIndex))
+                {
+                    Type endOldType;
+                    var beginBlock = this.Subroutine.InferredBeginEndBijection(pc, out endOldType);
+                    return visitor.EndOld(pc, new APC(beginBlock, beginOldIndex, pc.SubroutineContext), endOldType, Unit.Value, Unit.Value, data);
+                }
+                return visitor.Nop(pc, data);
+            }
+
+
+            internal void StartOverridingLabels()
+            {
+                Contract.Assume(overridingLabels == null); // F: as of Clousot Suggestion - but it seems something is wrong, so we make it an assume
+                Debug.Assert(overridingLabels == null);
+                overridingLabels = new List<int>();
+            }
+
+            internal void BeginOld(int index)
+            {
+                if (overridingLabels == null)
+                {
+                    StartOverridingLabels();
+                    for (int i = 0; i < index; i++)
+                    {
+                        overridingLabels.Add(i); // original instructions up to but not including index
+                    }
+                }
+                // temporary begin_old without corresponding end old index
+                overridingLabels.Add(BeginOldMask);
+            }
+
+            internal void AddInstruction(int index)
+            {
+                Contract.Assume(overridingLabels != null); // F: As of Clousot suggestion - It seems something is wrong with visibility check, so we made it an assume
+                                                           // add original instruction
+                overridingLabels.Add(index);
+            }
+
+
+            internal void EndOld(int index, Type nextEndOldType)
+            {
+                AddInstruction(index);
+                EndOldWithoutInstruction(nextEndOldType);
+            }
+
+            internal void EndOldWithoutInstruction(Type nextEndOldType)
+            {
+                Contract.Assume(overridingLabels != null); // F: As of Clousot suggestion - It seems something is wrong with visibility check, so we made it an assume
+
+                int endOldIndex = overridingLabels.Count;
+                CFGBlock beginBlock;
+                int correspondingBeginOldIndex = PatchPriorBeginOld(this, endOldIndex, out beginBlock);
+                overridingLabels.Add(EndOldMask | correspondingBeginOldIndex);
+                this.Subroutine.AddInferredOldMap(this.Index, endOldIndex, beginBlock, nextEndOldType);
+            }
+
+            private int PatchPriorBeginOld(CFGBlock endBlock, int endOldIndex, out CFGBlock beginBlock)
+            {
+                var startIndex = (this == endBlock) ? endOldIndex - 2 : this.Count - 1;
+                for (int i = startIndex; i >= 0; i--)
+                {
+                    int dummy;
+                    if (IsBeginOld(i, out dummy))
+                    {
+                        Contract.Assume(dummy == 0);
+                        Contract.Assume(i < overridingLabels.Count);
+                        overridingLabels[i] = BeginOldMask | endOldIndex;
+                        beginBlock = this;
+                        this.Subroutine.AddInferredOldMap(this.Index, i, endBlock, default(Type));
+                        return i;
+                    }
+                }
+                // if we get here the begin/end spans multiple blocks:
+                var preds = this.subroutine.PredecessorBlocks(this).GetEnumerator();
+                if (preds.MoveNext())
+                {
+                    var beginOldIndex = PatchPriorBeginOld(endBlock, endOldIndex, preds.Current, out beginBlock);
+                    var next = preds.MoveNext();
+                    Contract.Assume(!next); // F: made an assume
+                    return beginOldIndex;
+                }
+                throw new InvalidOperationException("missing begin_old");
+            }
+
+            private static int PatchPriorBeginOld(CFGBlock endBlock, int endOldIndex, CFGBlock current, out CFGBlock beginBlock)
+            {
+                Contract.Requires(current != null); // F: it seems it is a precondition?
+
+                EnsuresBlock<Label> pred = current as EnsuresBlock<Label>;
+                if (pred == null)
+                {
+                    // skip this block
+                    // if we get here the begin/end spans multiple blocks:
+
+                    var preds = current.Subroutine.PredecessorBlocks(current).GetEnumerator();
+                    if (preds.MoveNext())
+                    {
+                        var beginOldIndex = PatchPriorBeginOld(endBlock, endOldIndex, preds.Current, out beginBlock);
+                        bool next = preds.MoveNext();
+                        Contract.Assume(!next); // F: made an assume
+                        return beginOldIndex;
+                    }
+                    throw new InvalidOperationException("missing begin_old");
+                }
+                return pred.PatchPriorBeginOld(endBlock, endOldIndex, out beginBlock);
+            }
+        }
+
+
+        /// <summary>
+        /// Used for separate blocks that call methods for which we have pre/post conditions
+        /// </summary>
+        internal class MethodCallBlock<Label> : BlockWithLabels<Label>
+        {
+            public readonly Method CalledMethod;
+            public readonly bool Virtual;
+            private readonly int parameterCount;
+
+            public MethodCallBlock(Method method, bool virtcall, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, SubroutineBase<Label> container, ref int idgen)
+              : base(container, ref idgen)
+            {
+                Contract.Requires(mdDecoder != null);// F: Added as of Clousot suggestion
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
+                Contract.Ensures(idgen >= 0);
+
+                this.CalledMethod = method;
+                this.Virtual = virtcall;
+                parameterCount = mdDecoder.Parameters(method).AssumeNotNull().Count;
+            }
+
+            public override bool IsMethodCallBlock<Method2>(out Method2 calledMethod, out bool isNewObj, out bool isVirtual)
+            {
+                if (this.CalledMethod is Method2)
+                {
+                    calledMethod = (Method2)(object)this.CalledMethod;
+                    isNewObj = this.IsNewObj;
+                    isVirtual = this.Virtual;
+                    return true;
+                }
+                calledMethod = default(Method2);
+                isNewObj = false;
+                isVirtual = false;
+                return false;
+            }
+
+            internal virtual bool IsNewObj
+            {
+                get { return false; }
+            }
+        }
+
+
+        internal class NewObjCallBlock<Label> : MethodCallBlock<Label>
+        {
+            public NewObjCallBlock(Method method, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, SubroutineBase<Label> container, ref int idgen)
+              : base(method, false, mdDecoder, container, ref idgen)
+            {
+                Contract.Requires(mdDecoder != null);// F: As of Clousot suggestion
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
+
+                Contract.Ensures(idgen >= 0);
+            }
+
+            internal override bool IsNewObj
+            {
+                get
+                {
+                    return true;
+                }
+            }
         }
 
         /// <summary>
-        /// Map a label occurring in a begin_old/end_old to an apc.
+        /// an assume block that stores the return value of a function in the appropriate local var first
         /// </summary>
-        private APC ConvertMatchingLabel(Label underlying)
-        {
-          MethodCache<Local, Parameter, Type, Method, Field, Label, Handler>.EnsuresSubroutine subroutine = (MethodCache<Local, Parameter, Type, Method, Field, Label, Handler>.EnsuresSubroutine)this.originalPC.Block.Subroutine;
-
-          return subroutine.MapLabelToAPC(underlying, this.originalPC.SubroutineContext);
-        }
-
-
-        public Result Assert(Label pc, string tag, UnitSource condition, Data data)
-        {
-          return visitor.Assert(ConvertLabel(pc), tag, condition, data);
-        }
-
-        public Result Assume(Label pc, string tag, UnitSource source, Data data)
-        {
-          return visitor.Assume(ConvertLabel(pc), tag, source, data);
-        }
-
-        public Result Arglist(Label pc, UnitDest dest, Data data)
-        {
-          return visitor.Arglist(ConvertLabel(pc), dest, data);
-        }
-
-        public Result Binary(Label pc, BinaryOperator op, UnitDest dest, UnitSource s1, UnitSource s2, Data data)
-        {
-          return visitor.Binary(ConvertLabel(pc), op, dest, s1, s2, data);
-        }
-
-        public Result BranchCond(Label pc, Label target, BranchOperator bop, UnitSource value1, UnitSource value2, Data data)
-        {
-          // note: all binary branch conditions are evaluated to yield a value in value2 and use br.true
-          return this.visitor.Assume(this.originalPC, this.assumeLabel, value2, data);
-        }
-
-        public Result BranchTrue(Label pc, Label target, UnitSource cond, Data data) {
-          return this.visitor.Assume(this.originalPC, this.assumeLabel, cond, data);
-        }
-
-        public Result BranchFalse(Label pc, Label target, UnitSource cond, Data data) {
-          return this.visitor.Assume(this.originalPC, this.assumeLabel, cond, data);
-        }
-
-        public Result Branch(Label pc, Label target, bool leave, Data data)
-        {
-          return this.visitor.Nop(this.originalPC, data);
-        }
-
-        public Result Break(Label pc, Data data)
-        {
-          return visitor.Break(ConvertLabel(pc), data);
-        }
-
-        public Result Call<TypeList,ArgList>(Label pc, Method2 method, bool tail, bool virt, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.Call(ConvertLabel(pc), method, tail, virt, extraVarargs, dest, args, data);
-        }
-
-        public Result Calli<TypeList,ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, UnitDest dest, UnitSource fp, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.Calli(ConvertLabel(pc), returnType, argTypes, tail, dest, fp, args, data);
-        }
-
-        public Result Ckfinite(Label pc, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Ckfinite(ConvertLabel(pc), dest, source, data);
-        }
-
-        public Result Cpblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource srcaddr, UnitSource len, Data data)
-        {
-          return visitor.Cpblk(ConvertLabel(pc), @volatile, destaddr, srcaddr, len, data);
-        }
-
-        public Result Endfilter(Label pc, UnitSource decision, Data data)
-        {
-          return visitor.Endfilter(ConvertLabel(pc), decision, data);
-        }
-
-        public Result Endfinally(Label pc, Data data)
-        {
-          return visitor.Endfinally(ConvertLabel(pc), data);
-        }
-
-        public Result Entry(Label pc, Method2 method, Data data)
-        {
-          return visitor.Entry(ConvertLabel(pc), method, data);
-        }
-
-        public Result Initblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource value, UnitSource len, Data data)
-        {
-          return visitor.Initblk(ConvertLabel(pc), @volatile, destaddr, value, len, data);
-        }
-
-        public Result Jmp(Label pc, Method2 method, Data data)
-        {
-          return visitor.Jmp(ConvertLabel(pc), method, data);
-        }
-
-        public Result Ldarg(Label pc, Parameter argument, UnitDest dest, Data data)
-        {
-          return visitor.Ldarg(ConvertLabel(pc), argument, dest, data);
-        }
-
-        public Result Ldarga(Label pc, Parameter argument, UnitDest dest, Data data)
-        {
-          return visitor.Ldarga(ConvertLabel(pc), argument, dest, data);
-        }
-
-        public Result Ldconst(Label pc, object constant, Type type, UnitDest dest, Data data)
-        {
-          return visitor.Ldconst(ConvertLabel(pc), constant, type, dest, data);
-        }
-
-        public Result Ldnull(Label pc, UnitDest dest, Data data)
-        {
-          return visitor.Ldnull(ConvertLabel(pc), dest, data);
-        }
-
-        public Result Ldftn(Label pc, Method2 method, UnitDest dest, Data data)
-        {
-          return visitor.Ldftn(ConvertLabel(pc), method, dest, data);
-        }
-
-        public Result Ldind(Label pc, Type type, bool @volatile, UnitDest dest, UnitSource ptr, Data data)
-        {
-          return visitor.Ldind(ConvertLabel(pc), type, @volatile, dest, ptr, data);
-        }
-
-        public Result Ldloc(Label pc, Local local, UnitDest dest, Data data)
-        {
-          return visitor.Ldloc(ConvertLabel(pc), local, dest, data);
-        }
-
-        public Result Ldloca(Label pc, Local local, UnitDest dest, Data data)
-        {
-          return visitor.Ldloca(ConvertLabel(pc), local, dest, data);
-        }
-
-        public Result Ldstack(Label pc, int offset, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Ldstack(ConvertLabel(pc), offset, dest, source, data);
-        }
-
-        public Result Localloc(Label pc, UnitDest dest, UnitSource size, Data data)
-        {
-          return visitor.Localloc(ConvertLabel(pc), dest, size, data);
-        }
-
-        public Result Nop(Label pc, Data data)
-        {
-          return visitor.Nop(ConvertLabel(pc), data);
-        }
-
-        public Result Pop(Label pc, UnitSource source, Data data)
-        {
-          return visitor.Pop(ConvertLabel(pc), source, data);
-        }
-
-        public Result Return(Label pc, UnitSource source, Data data)
-        {
-          return visitor.Return(ConvertLabel(pc), source, data);
-        }
-
-        public Result Starg(Label pc, Parameter argument, UnitSource source, Data data)
-        {
-          return visitor.Starg(ConvertLabel(pc), argument, source, data);
-        }
-
-        public Result Stind(Label pc, Type type, bool @volatile, UnitSource ptr, UnitSource value, Data data)
-        {
-          return visitor.Stind(ConvertLabel(pc), type, @volatile, ptr, value, data);
-        }
-
-        public Result Stloc(Label pc, Local local, UnitSource source, Data data)
-        {
-          return visitor.Stloc(ConvertLabel(pc), local, source, data);
-        }
-
-        public Result Switch(Label pc, IEnumerable<Label> cases, UnitSource value, Data data)
-        {
-          string tag = this.assumeLabel == "false" ? "default" : this.assumeLabel;
-          return visitor.Assume(this.originalPC, tag, value, data);
-        }
-
-        public Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Unary(ConvertLabel(pc), op, overflow, unsigned, dest, source, data);
-        }
-
-        public Result Box(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Box(ConvertLabel(pc), type, dest, source, data);
-        }
-
-        public Result ConstrainedCallvirt<TypeList,ArgList>(Label pc, Method2 method, bool tail, Type constraint, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
-          where TypeList : IIndexable<Type>
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.ConstrainedCallvirt(ConvertLabel(pc), method, tail, constraint, extraVarargs, dest, args, data);
-        }
-
-        public Result Castclass(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Castclass(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Cpobj(Label pc, Type type, UnitSource destptr, UnitSource srcptr, Data data)
-        {
-          return visitor.Cpobj(ConvertLabel(pc), type, destptr, srcptr, data);
-        }
-
-        public Result Initobj(Label pc, Type type, UnitSource ptr, Data data)
-        {
-          return visitor.Initobj(ConvertLabel(pc), type, ptr, data);
-        }
-
-        public Result Isinst(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Isinst(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Ldelem(Label pc, Type type, UnitDest dest, UnitSource array, UnitSource index, Data data)
-        {
-          return visitor.Ldelem(ConvertLabel(pc), type, dest, array, index, data);
-        }
-
-        public Result Ldelema(Label pc, Type type, bool @readonly, UnitDest dest, UnitSource array, UnitSource index, Data data)
-        {
-          return visitor.Ldelema(ConvertLabel(pc), type, @readonly, dest, array, index, data);
-        }
-
-        public Result Ldfld(Label pc, Field field, bool @volatile, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Ldfld(ConvertLabel(pc), field, @volatile, dest, obj, data);
-        }
-
-        public Result Ldflda(Label pc, Field field, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Ldflda(ConvertLabel(pc), field, dest, obj, data);
-        }
-
-        public Result Ldlen(Label pc, UnitDest dest, UnitSource array, Data data)
-        {
-          return visitor.Ldlen(ConvertLabel(pc), dest, array, data);
-        }
-
-        public Result Ldsfld(Label pc, Field field, bool @volatile, UnitDest dest, Data data)
-        {
-          return visitor.Ldsfld(ConvertLabel(pc), field, @volatile, dest, data);
-        }
-
-        public Result Ldsflda(Label pc, Field field, UnitDest dest, Data data)
-        {
-          return visitor.Ldsflda(ConvertLabel(pc), field, dest, data);
-        }
-
-        public Result Ldtypetoken(Label pc, Type type, UnitDest dest, Data data)
-        {
-          return visitor.Ldtypetoken(ConvertLabel(pc), type, dest, data);
-        }
-
-        public Result Ldfieldtoken(Label pc, Field field, UnitDest dest, Data data)
-        {
-          return visitor.Ldfieldtoken(ConvertLabel(pc), field, dest, data);
-        }
-
-        public Result Ldmethodtoken(Label pc, Method2 method, UnitDest dest, Data data)
-        {
-          return visitor.Ldmethodtoken(ConvertLabel(pc), method, dest, data);
-        }
-
-        public Result Ldvirtftn(Label pc, Method2 method, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Ldvirtftn(ConvertLabel(pc), method, dest, obj, data);
-        }
-
-        public Result Mkrefany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Mkrefany(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Newarray(Label pc, Type type, UnitDest dest, UnitSource len, Data data)
-        {
-          return visitor.Newarray(ConvertLabel(pc), type, dest, len, data);
-        }
-
-        public Result Newobj<ArgList>(Label pc, Method2 ctor, UnitDest dest, ArgList args, Data data)
-          where ArgList : IIndexable<UnitSource>
-        {
-          return visitor.Newobj(ConvertLabel(pc), ctor, dest, args, data);
-        }
-
-        public Result Refanytype(Label pc, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Refanytype(ConvertLabel(pc), dest, source, data);
-        }
-
-        public Result Refanyval(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Refanyval(ConvertLabel(pc), type, dest, source, data);
-        }
-
-        public Result Rethrow(Label pc, Data data)
-        {
-          return visitor.Rethrow(ConvertLabel(pc), data);
-        }
-
-        public Result Sizeof(Label pc, Type type, UnitDest dest, Data data)
-        {
-          return visitor.Sizeof(ConvertLabel(pc), type, dest, data);
-        }
-
-        public Result Stelem(Label pc, Type type, UnitSource array, UnitSource index, UnitSource value, Data data)
-        {
-          return visitor.Stelem(ConvertLabel(pc), type, array, index, value, data);
-        }
-
-        public Result Stfld(Label pc, Field field, bool @volatile, UnitSource obj, UnitSource value, Data data)
-        {
-          return visitor.Stfld(ConvertLabel(pc), field, @volatile, obj, value, data);
-        }
-
-        public Result Stsfld(Label pc, Field field, bool @volatile, UnitSource value, Data data)
-        {
-          return visitor.Stsfld(ConvertLabel(pc), field, @volatile, value, data);
-        }
-
-        public Result Throw(Label pc, UnitSource exn, Data data)
-        {
-          return visitor.Throw(ConvertLabel(pc), exn, data);
-        }
-
-        public Result Unbox(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Unbox(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-        public Result Unboxany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
-        {
-          return visitor.Unboxany(ConvertLabel(pc), type, dest, obj, data);
-        }
-
-
-    #region IVisitSynthIL<Label,Method2,Source,Dest,Data,Result> Members
-
-
-        public Result BeginOld(Label pc, Label matchingEnd, Data data)
-        {
-          return visitor.BeginOld(ConvertLabel(pc), ConvertMatchingLabel(matchingEnd), data);
-        }
-
-        public Result EndOld(Label pc, Label matchingBegin, Type type, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.EndOld(ConvertLabel(pc), ConvertMatchingLabel(matchingBegin), type, dest, source, data);
-        }
-
-        public Result Ldresult(Label pc, UnitDest dest, UnitSource source, Data data)
-        {
-          return visitor.Ldresult(ConvertLabel(pc), dest, source, data);
+        /// <typeparam name="Label"></typeparam>
+        internal class AssumeAsPostConditionEntryBlock<Label> : BlockWithLabels<Label>
+        {
+            public readonly Tag Tag;
+            public readonly Local LocalRetval;
+            public readonly Parameter ParamRetval;
+            public readonly Field FieldRetval;
+            private readonly AssumeAsPostConditionSubroutine<Label>.RetvalType RetvalType;
+
+            public AssumeAsPostConditionEntryBlock(SubroutineBase<Label> container, Local localRetval, Parameter paramRetval, Field fieldRetval, AssumeAsPostConditionSubroutine<Label>.RetvalType retvalType, string tag, ref int idgen)
+              : base(container, ref idgen)
+            {
+                Contract.Requires(container != null);
+                Contract.Requires(idgen >= 0);
+
+                Contract.Ensures(idgen >= 0);
+
+                this.Tag = tag;
+                this.LocalRetval = localRetval;
+                this.ParamRetval = paramRetval;
+                this.FieldRetval = fieldRetval;
+                RetvalType = retvalType;
+            }
+
+            public override int Count { get { return 2; } } // synthetic instruction
+
+            #region ISelfDecode<Label,Method,Type> Members
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                if (pc.Index == 0)
+                {
+                    return visitor.Ldstack(pc, 0, Unit.Value, Unit.Value, false, data);
+                }
+                else if (pc.Index == 1)
+                {
+                    switch (RetvalType)
+                    {
+                        case (AssumeAsPostConditionSubroutine<Label>.RetvalType.LocalRetval):
+                            {
+                                return visitor.Stloc(pc, this.LocalRetval, Unit.Value, data);
+                            }
+                        case (AssumeAsPostConditionSubroutine<Label>.RetvalType.ParameterRetval):
+                            {
+                                return visitor.Starg(pc, this.ParamRetval, Unit.Value, data);
+                            }
+                        case (AssumeAsPostConditionSubroutine<Label>.RetvalType.FieldRetval):
+                            {
+                                return visitor.Stfld(pc, this.FieldRetval, false, Unit.Value, Unit.Value, data);
+                            }
+                        default:
+                            {
+                                return visitor.Nop(pc, data);
+                            }
+                    }
+                }
+                else
+                {
+                    return visitor.Nop(pc, data);
+                }
+            }
+            #endregion
+        }
+
+        internal class AssumeAsPostConditionExitBlock<Label> : BlockWithLabels<Label>
+        {
+            public readonly Tag Tag;
+            public readonly Local Retval;
+            public readonly Label BranchLabel;
+            public AssumeAsPostConditionExitBlock(SubroutineBase<Label> container, Local retval, Label label, string tag, ref int idgen)
+                : base(container, ref idgen)
+            {
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
+                Contract.Ensures(idgen >= 0);
+
+                this.Tag = tag;
+                this.BranchLabel = label;
+                this.Retval = retval;
+            }
+
+            public override int Count { get { return 1; } } // synthetic instruction
+
+            #region ISelfDecode<Label,Method,Type> Members
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                if (pc.Index == 0)
+                {
+                    return visitor.Ldloc(pc, this.Retval, Unit.Value, data);
+                }
+                else
+                {
+                    return visitor.Nop(pc, data);
+                }
+            }
+
+            #endregion
+        }
+
+        internal class AssumeBlock<Label> : BlockWithLabels<Label>
+        {
+            public readonly Tag Tag;
+            public readonly Label BranchLabel;
+            public AssumeBlock(SubroutineBase<Label> container, Label label, string tag, ref int idgen)
+              : base(container, ref idgen)
+            {
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
+
+                Contract.Ensures(idgen >= 0);
+
+                this.Tag = tag;
+                this.BranchLabel = label;
+            }
+
+            public override int Count { get { return 1; } } // synthetic instruction
+
+
+
+            #region ISelfDecode<Label,Method,Type> Members
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                if (pc.Index == 0)
+                {
+                    return visitor.Assume(pc, this.Tag, Unit.Value, null, data);
+                }
+                else
+                {
+                    return visitor.Nop(pc, data);
+                }
+            }
+
+            #endregion
+        }
+
+
+        /// <summary>
+        /// Encodes 3 synthetic instructions
+        ///
+        ///   ldc c
+        ///   ceq
+        ///   assume
+        ///
+        /// </summary>
+        internal class SwitchCaseAssumeBlock<Label> : BlockWithLabels<Label>
+        {
+            private readonly Label SwitchLabel;
+            private readonly object Pattern;
+            private readonly Type Type;
+
+            public SwitchCaseAssumeBlock(SubroutineBase<Label> container, Label switchLabel, object pattern, Type type, ref int idgen)
+              : base(container, ref idgen)
+            {
+                Contract.Requires(container != null);
+                Contract.Requires(idgen >= 0);
+                Contract.Ensures(idgen >= 0);
+
+                SwitchLabel = switchLabel;
+                Pattern = pattern;
+                Type = type;
+            }
+
+            public override int Count { get { return 3; } } // synthetic instructions
+
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                if (pc.Index == 0)
+                {
+                    return visitor.Ldconst(pc, Pattern, Type, Unit.Value, data);
+                }
+                else if (pc.Index == 1)
+                {
+                    return visitor.Binary(pc, BinaryOperator.Ceq, Unit.Value, Unit.Value, Unit.Value, data);
+                }
+                else if (pc.Index == 2)
+                {
+                    return visitor.Assume(pc, "true", Unit.Value, null, data);
+                }
+                else
+                {
+                    return visitor.Nop(pc, data);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Compares switched value against all constants c_i suing the following structure
+        /// </summary>
+        internal class SwitchDefaultAssumeBlock<Label> : BlockWithLabels<Label>
+        {
+            #region Object invariant
+            [ContractInvariantMethod]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(Patterns != null);
+            }
+            #endregion
+
+            private readonly Label SwitchLabel;
+            private readonly List<object> Patterns;
+            private readonly Type Type;
+
+            public SwitchDefaultAssumeBlock(SubroutineBase<Label> container, Label label, List<object> patterns, Type type, ref int idgen)
+              : base(container, ref idgen)
+            {
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
+
+                Contract.Ensures(idgen >= 0);
+
+                SwitchLabel = label;
+                Patterns = patterns;
+                Type = type;
+            }
+
+            public override int Count { get { return Patterns.Count * 4 + 1; } } // synthetic instruction
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                int caseNum = pc.Index / 4;
+                if (caseNum < Patterns.Count)
+                {
+                    int withinInstr = pc.Index % 4;
+                    switch (withinInstr)
+                    {
+                        case 0:
+                            return visitor.Ldstack(pc, 0, Unit.Value, Unit.Value, false, data);
+                        case 1:
+                            Contract.Assume(caseNum >= 0);
+                            return visitor.Ldconst(pc, Patterns[caseNum], Type, Unit.Value, data);
+                        case 2:
+                            return visitor.Binary(pc, BinaryOperator.Cne_Un, Unit.Value, Unit.Value, Unit.Value, data);
+                        case 3:
+                            return visitor.Assume(pc, "true", Unit.Value, null, data);
+                    }
+                }
+                else if (caseNum == Patterns.Count && pc.Index % 4 == 0)
+                {
+                    // finally pop it.
+                    return visitor.Pop(pc, Unit.Value, data);
+                }
+                return visitor.Nop(pc, data);
+            }
+        }
+
+        /// <summary>
+        /// Special entry and exit block that has one program point for Entry synthetic instruction or Ret
+        /// </summary>
+        internal class EntryExitBlock<Label> : BlockWithLabels<Label>
+        {
+            public EntryExitBlock(SubroutineBase<Label> container, ref int idGen) : base(container, ref idGen)
+            {
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idGen >= 0);// F: As of Clousot suggestion
+            }
+
+            public override int Count { get { return 1; } } /// synthetic instruction
+        }
+
+        /// <summary>
+        /// Special entry block that self decodes first instruction to Entry
+        /// </summary>
+        internal class EntryBlock<Label> : EntryExitBlock<Label>
+        {
+            public EntryBlock(SubroutineBase<Label> container, ref int idGen)
+              : base(container, ref idGen)
+            {
+                Contract.Requires(container != null);
+                Contract.Requires(idGen >= 0);
+
+                Contract.Ensures(idGen >= 0);
+            }
+
+            internal override Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+            {
+                if (pc.Index == 0 && pc.SubroutineContext == null && this.Subroutine.IsMethod)
+                {
+                    IMethodInfo<Method> ms = (IMethodInfo<Method>)this.Subroutine;
+                    return visitor.Entry(pc, ms.Method, data);
+                }
+                return visitor.Nop(pc, data);
+            }
+        }
+
+        /// <summary>
+        /// Used to mark catch filter header blocks.
+        /// </summary>
+        internal class CatchFilterEntryBlock<Label> : BlockWithLabels<Label>
+        {
+            public CatchFilterEntryBlock(SubroutineBase<Label> container, ref int idgen)
+              : base(container, ref idgen)
+            {
+                Contract.Requires(container != null);// F: As of Clousot suggestion
+                Contract.Requires(idgen >= 0);// F: As of Clousot suggestion
+            }
+        }
+
+
+
+        internal abstract class SubroutineBase<Label> : Subroutine, IGraph<CFGBlock, Unit>, IStackInfo, IEdgeSubroutineAdaptor
+        {
+            #region -------------- Fields ------------------------
+
+            private BlockWithLabels<Label> entry;
+            private readonly BlockWithLabels<Label> exit;
+            private readonly CatchFilterEntryBlock<Label> exceptionExit;
+            protected readonly Label startLabel;
+            private BlockWithLabels<Label> entryAfterRequires; // possibly null
+
+            protected int blockIdGenerator = 0;
+
+            /// <summary>
+            /// Holds the map from labels that start a block to their block
+            /// </summary>
+            protected Dictionary<Label, BlockWithLabels<Label>> BlockStart = new Dictionary<Label, BlockWithLabels<Label>>();
+
+            protected readonly MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> MethodCache;
+            protected SubroutineBuilder<Label> Builder;
+
+            private readonly List<Pair<CFGBlock, Pair<string, CFGBlock>>> successors = new List<Pair<CFGBlock, Pair<string, CFGBlock>>>();
+
+            internal readonly ICodeProvider<Label, Local, Parameter, Method, Field, Type> CodeProvider; // F: it seems it may be null
+
+            protected CFGBlock[] blocks;
+
+            /// <summary>
+            /// Stored in last to first order (thus easy to append)
+            ///
+            /// The string is a tag for what kind of call-edge it is.
+            /// </summary>
+            protected OnDemandMap<Pair<CFGBlock, CFGBlock>, FList<Pair<string, Subroutine>>> edgeSubroutines;
+
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(successors != null);
+                Contract.Invariant(this.MethodCache != null);
+                Contract.Invariant(entry != null);
+                Contract.Invariant(exit != null);
+                Contract.Invariant(exceptionExit != null);
+                Contract.Invariant(this.blockIdGenerator >= 0);
+                Contract.Invariant(this.BlockStart != null || this.Builder == null);
+            }
+
+            #endregion // fields
+
+            #region -------------- Private helpers --------------
+
+            internal AssumeAsPostConditionEntryBlock<Label> NewAssumeAsPostConditionEntryBlock(Local localRetval, Parameter paramRetval, Field fieldRetval, AssumeAsPostConditionSubroutine<Label>.RetvalType retvalType, Tag tag)
+            {
+                return new AssumeAsPostConditionEntryBlock<Label>(this, localRetval, paramRetval, fieldRetval, retvalType, tag, ref this.blockIdGenerator);
+            }
+
+            internal AssumeAsPostConditionExitBlock<Label> NewAssumeAsPostConditionExitBlock(Local retval, Label assume, Tag tag)
+            {
+                return new AssumeAsPostConditionExitBlock<Label>(this, retval, assume, tag, ref this.blockIdGenerator);
+            }
+
+            internal AssumeBlock<Label> NewAssumeBlock(Label current, Tag tag)
+            {
+                return new AssumeBlock<Label>(this, current, tag, ref this.blockIdGenerator);
+            }
+
+            internal SwitchCaseAssumeBlock<Label> NewSwitchCaseAssumeBlock(Label current, object pattern, Type type)
+            {
+                return new SwitchCaseAssumeBlock<Label>(this, current, pattern, type, ref this.blockIdGenerator);
+            }
+
+            internal SwitchDefaultAssumeBlock<Label> NewSwitchDefaultAssumeBlock(Label current, List<object> patterns, Type type)
+            {
+                return new SwitchDefaultAssumeBlock<Label>(this, current, patterns, type, ref this.blockIdGenerator);
+            }
+
+            #endregion -------------------------------------------
+
+            #region ------------ Protected Helpers -------------
+
+            internal virtual BlockWithLabels<Label> NewBlock()
+            {
+                Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
+
+                return new BlockWithLabels<Label>(this, ref this.blockIdGenerator);
+            }
+
+            protected SubroutineBase(
+              MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache
+            )
+            {
+                Contract.Requires(methodCache != null);
+
+                this.MethodCache = methodCache;
+                entry = new EntryBlock<Label>(this, ref this.blockIdGenerator);
+                exit = new EntryExitBlock<Label>(this, ref this.blockIdGenerator);
+                exceptionExit = new CatchFilterEntryBlock<Label>(this, ref this.blockIdGenerator);
+            }
+            protected SubroutineBase(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                     Label startLabel,
+                                     SubroutineBuilder<Label> builder)
+              : this(methodCache)
+            {
+                Contract.Requires(methodCache != null);
+                Contract.Requires(builder != null); // F: added because of Clousot suggestion
+
+                this.startLabel = startLabel;
+                this.Builder = builder;
+                this.CodeProvider = builder.CodeProvider;
+
+                // link entry block to start label
+                entryAfterRequires = this.GetTargetBlock(startLabel);
+                AddSuccessor(entry, "entry", entryAfterRequires);
+            }
+
+            internal abstract override void Initialize();
+
+            internal virtual void Commit()
+            {
+                Contract.Assume(blocks == null); // make sure we don't double commit
+
+                if (this.Builder != null)
+                {
+                    this.Builder.InsertPreConditionEdges(entry, entryAfterRequires, this);
+                }
+                // cleanup
+                PostProcessBlocks();
+            }
+
+            internal void AddSuccessor(CFGBlock from, Tag tag, CFGBlock target)
+            {
+                Contract.Requires(from != null);
+                Contract.Requires(target != null);
+                Contract.Requires(from.Subroutine == target.Subroutine);
+
+                Contract.Assume(from != this.Exit);// F: requires added because of Clousot suggestion. 
+                                                   // F: updated: made an assumption as there are too many places were we should fix it. 
+                                                   // TODO: think to a way of improving it
+
+                Debug.Assert(from.Subroutine == target.Subroutine);
+                this.AddNormalControlFlowEdge(successors, from, tag, target);
+            }
+
+            internal BlockWithLabels<Label> GetTargetBlock(Label label)
+            {
+                Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
+
+                Contract.Assume(this.Builder != null); // should not get called otherwise
+                Contract.Assume(this.Builder.IsTargetLabel(label));
+                return GetBlock(label);
+            }
+
+            internal BlockWithLabels<Label> GetBlock(Label label)
+            {
+                Contract.Ensures(Contract.Result<BlockWithLabels<Label>>() != null);
+
+                Contract.Assume(this.Builder != null); // should not get called otherwise
+
+                BlockWithLabels<Label> newBlock;
+                if (!this.BlockStart.TryGetValue(label, out newBlock))
+                {
+#if ENABLE_ASSERTIONS
+                    Debug.Assert(this.MethodInfo.IsBlockStart(label));
+#endif
+                    Pair<Method, bool> calledMethodVirtPair;
+                    Method calledMethod;
+                    if (this.Builder.IsMethodCallSite(label, out calledMethodVirtPair))
+                    {
+                        newBlock = new MethodCallBlock<Label>(calledMethodVirtPair.One, calledMethodVirtPair.Two, this.MethodCache.MetadataDecoder.AssumeNotNull(), this, ref this.blockIdGenerator);
+                    }
+                    else if (this.Builder.IsNewObjSite(label, out calledMethod))
+                    {
+                        newBlock = new NewObjCallBlock<Label>(calledMethod, this.MethodCache.MetadataDecoder.AssumeNotNull(), this, ref this.blockIdGenerator);
+                    }
+                    else
+                    {
+                        newBlock = this.NewBlock();
+                    }
+                    // only add branch targets to this map
+                    Contract.Assume(this.Builder != null); // we need history invariants
+                    if (this.Builder.IsTargetLabel(label))
+                    {
+                        this.BlockStart.Add(label, newBlock);
+                    }
+                }
+                else
+                {
+                    Contract.Assume(newBlock != null);
+                }
+                return newBlock;
+            }
+
+
+            /// <summary>
+            /// Note that subroutine can be null, in which case we add nothing.
+            /// </summary>
+            sealed public override void AddEdgeSubroutine(CFGBlock from, CFGBlock to, Subroutine subroutine, string callTag)
+            {
+                if (subroutine == null) return;
+                FList<Pair<string, Subroutine>> sofar;
+                Pair<CFGBlock, CFGBlock> edge = new Pair<CFGBlock, CFGBlock>(from, to);
+                this.edgeSubroutines.TryGetValue(edge, out sofar);
+                this.edgeSubroutines[edge] = FList<Pair<string, Subroutine>>.Cons(new Pair<string, Subroutine>(callTag, subroutine), sofar);
+            }
+
+            /// <summary>
+            /// Returns registered edge subroutines in last to first order.
+            ///
+            /// The context is used to filter subroutines on this list as follows:
+            /// - Any contract subroutines returned are distinct from the current subroutine and any subroutines in the context
+            /// </summary>
+            FList<Pair<string, Subroutine>> IEdgeSubroutineAdaptor.GetOrdinaryEdgeSubroutinesInternal(CFGBlock from, CFGBlock to, SubroutineContext context)
+            {
+                FList<Pair<string, Subroutine>> sofar;
+                Pair<CFGBlock, CFGBlock> edge = new Pair<CFGBlock, CFGBlock>(from, to);
+                this.edgeSubroutines.TryGetValue(edge, out sofar);
+                if (sofar != null && context != null)
+                {
+                    sofar = sofar.Filter(FilterRecursiveContracts(to, context));
+                }
+                return sofar;
+            }
+
+            /// <summary>
+            /// Used to specialize ensures subroutines based on calling context.
+            /// We are looking for a stack of contract calls (ensures/requires) where each call is on "this" except maybe 
+            /// the outermost one. Since the calls are on "this", we can use the declaring type of the called method as
+            /// a possible improvement of the dynamic type other than the final declaring type. E.g., the ensures about to be
+            /// inserted might be the ensures of ICollection.Count, called from within ICollection.CopyTo's requires.
+            /// But the call to CopyTo happens to be a call to Array.CopyTo (inheriting ICollection.CopyTo's requires). Thus,
+            /// we can determine that the Count ensures to be used is the one from Array, which specializes ICollection.Count's 
+            /// ensures to relate the Count to the array length.
+            /// </summary>
+            [ContractVerification(false)]
+            public override FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, FList<STuple<CFGBlock, CFGBlock, string>> context)
+            {
+                var toAPC = new APC(to, 0, context);
+                CallAdaption.Push(this);
+                try
+                {
+                    var origContext = context;
+                    var result = CallAdaption.Dispatch<IEdgeSubroutineAdaptor>(this).GetOrdinaryEdgeSubroutinesInternal(from, to, context);
+
+                    if (toAPC.InsideContract)
+                    {
+                        if (context != null)
+                        {
+                            if (result != null)
+                            {
+                                #region inside a contract
+                                var mdDecoder = this.MethodCache.MetadataDecoder;
+                                Method calledMethod;
+                                bool isNewObj;
+                                bool isVirtualCall;
+                                if (from.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall) && isVirtualCall)
+                                {
+                                    // try to specialize any ensures based on calling context
+
+                                    // find out if call is on "this" (using Stack provider information)
+                                    if (CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(from, 0, null)))
+                                    {
+                                        Type bestType = mdDecoder.DeclaringType(calledMethod); // so far
+                                                                                               // find best declaring type on outer calls and use it to specialize ensures.
+                                        do
+                                        {
+                                            // this is really a do loop (as we tested for context != null on the outside
+                                            if (context.Head.Three.StartsWith("inherited") || context.Head.Three.StartsWith("extra") || context.Head.Three.StartsWith("old")) { context = context.Tail; continue; }
+                                            Method outerCalledMethod;
+                                            bool dummy;
+                                            bool dummy2;
+
+                                            if (context.Head.Three.StartsWith("after") && context.Head.One.IsMethodCallBlock(out outerCalledMethod, out dummy, out dummy2))
+                                            {
+                                                Type candidateType = mdDecoder.DeclaringType(outerCalledMethod);
+                                                if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
+                                                {
+                                                    bestType = candidateType;
+                                                }
+                                                // we can try for even better types if the outer call is also on this
+                                                if (!CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(context.Head.One, 0, null)))
+                                                {
+                                                    break; // get out of do loop
+                                                }
+                                            }
+                                            else if (context.Head.Three.StartsWith("before") && context.Head.Two.IsMethodCallBlock(out outerCalledMethod, out dummy, out dummy2))
+                                            {
+                                                Type candidateType = mdDecoder.DeclaringType(outerCalledMethod);
+                                                if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
+                                                {
+                                                    bestType = candidateType;
+                                                }
+                                                // we can try for even better types if the outer call is also on this
+                                                if (!CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(context.Head.Two, 0, null)))
+                                                {
+                                                    break; // get out of do loop
+                                                }
+                                            }
+                                            else if (context.Head.Three == "exit")
+                                            {
+                                                // specialize by method we are in.
+                                                var im = context.Head.One.Subroutine as IMethodInfo<Method>;
+                                                if (im != null)
+                                                {
+                                                    var candidateType = mdDecoder.DeclaringType(im.Method);
+                                                    if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
+                                                    {
+                                                        bestType = candidateType;
+                                                    }
+                                                }
+                                                break; // get out of do loop
+                                            }
+                                            else if (context.Head.Three == "entry")
+                                            {
+                                                // specialize by method we are in.
+                                                var im = context.Head.One.Subroutine as IMethodInfo<Method>;
+                                                if (im != null)
+                                                {
+                                                    var candidateType = mdDecoder.DeclaringType(im.Method);
+                                                    if (mdDecoder.DerivesFromIgnoringTypeArguments(candidateType, bestType))
+                                                    {
+                                                        bestType = candidateType;
+                                                    }
+                                                }
+                                                break; // get out of do loop
+                                            }
+                                            else
+                                            {
+                                                // no specialization possible
+                                                return result;
+                                            }
+                                            // loop around
+                                            context = context.Tail;
+                                        } while (context != null);
+                                        // if we get here, we may have found a better type:
+                                        if (!mdDecoder.Equal(bestType, mdDecoder.DeclaringType(calledMethod)))
+                                        {
+                                            Method specializedMethod;
+                                            if (mdDecoder.TryGetImplementingMethod(bestType, calledMethod, out specializedMethod))
+                                            {
+                                                result = SpecializeEnsures(result, this.MethodCache.GetEnsures(calledMethod), this.MethodCache.GetEnsures(specializedMethod), from, origContext);
+                                            }
+                                        }
+                                    }
+                                }
+                                #endregion
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // context could be finally
+                        var mdDecoder = this.MethodCache.MetadataDecoder;
+                        Method calledMethod;
+                        bool isNewObj;
+                        bool isVirtualCall;
+                        if (from.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall))
+                        {
+                            // try to specialize any ensures/invariant based on current method
+                            // find out if call is on "this" (using Stack provider information)
+                            if (CallAdaption.Dispatch<IStackInfo>(this).IsCallOnThis(new APC(from, 0, null)))
+                            {
+                                // specialize by method we are in.
+                                var im = from.Subroutine as IMethodInfo<Method>;
+                                if (im != null)
+                                {
+                                    var bestType = mdDecoder.DeclaringType(im.Method);
+                                    if (isVirtualCall)
+                                    {
+                                        Method specializedMethod;
+                                        if (mdDecoder.TryGetImplementingMethod(bestType, calledMethod, out specializedMethod))
+                                        {
+                                            result = SpecializeEnsures(result, this.MethodCache.GetEnsures(calledMethod), this.MethodCache.GetEnsures(specializedMethod), from, origContext);
+                                        }
+                                    }
+                                    // insert invariant call if there is one and we are not calling an auto setter
+                                    result = InsertInvariant(from, result, mdDecoder, calledMethod, im, ref bestType, context);
+                                }
+                            }
+                            else if (this.MethodCache.IsMonitorWaitOrExit(calledMethod))
+                            {
+                                // special handling of Monitor.Exit and Monitor.Wait. These methods cause havocing of the
+                                // running object and we'd like to reestablish the invariant
+                                Method containingMethod;
+                                if (toAPC.TryGetContainingMethod<Method>(out containingMethod))
+                                {
+                                    var candidate = this.MethodCache.GetInvariant(mdDecoder.DeclaringType(containingMethod));
+                                    if (candidate != null)
+                                    {
+                                        // use entry tag to use current "this" as the target object
+                                        result = result.Cons(new Pair<string, Subroutine>("entry", candidate));
+                                    }
+                                }
+                            }
+                            result = TryInsertAssumeInvariant(from, result, mdDecoder, calledMethod, context);
+                        }
+                    }
+                    return result;
+                }
+                finally
+                {
+                    CallAdaption.Pop(this);
+                }
+            }
+
+            private FList<Pair<string, Subroutine>> InsertInvariant(CFGBlock from, FList<Pair<string, Subroutine>> result, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Method calledMethod, IMethodInfo<Method> im, ref Type bestType, SubroutineContext context)
+            {
+                Contract.Requires(from != null);
+                Contract.Requires(mdDecoder != null);
+
+                Contract.Assume(this.MethodCache.MetadataDecoder != null); // Should add a postcondition to MethodCache instead
+
+                if (this.MethodCache.MetadataDecoder.IsPropertySetter(calledMethod) && (this.MethodCache.MetadataDecoder.IsAutoPropertyMember(calledMethod) || WithinConstructor(from, context)))
+                {
+                    return result;
+                }
+                // if the call is a ctor call, then this is the base call and we should not specialize
+                if (mdDecoder.IsConstructor(calledMethod))
+                {
+                    bestType = mdDecoder.DeclaringType(calledMethod);
+                }
+                var candidate = this.MethodCache.GetInvariant(bestType);
+                if (candidate != null)
+                {
+                    MethodCallBlock<Label> callBlock = from as MethodCallBlock<Label>;
+                    if (callBlock != null)
+                    {
+                        string tag = callBlock.IsNewObj ? "afterNewObj" : "afterCall";
+
+                        result = result.Cons(new Pair<string, Subroutine>(tag, candidate));
+                    }
+                }
+                return result;
+            }
+
+            private FList<Pair<string, Subroutine>> TryInsertAssumeInvariant(CFGBlock from, FList<Pair<string, Subroutine>> result, IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder, Method calledMethod, SubroutineContext context)
+            {
+                Contract.Requires(from != null);
+                Contract.Requires(mdDecoder != null);
+
+                var unspecMethod = mdDecoder.Unspecialized(calledMethod);
+                if (!mdDecoder.IsVoidMethod(unspecMethod)) return result;
+                // if the call is a ctor call, then this is the base call and we should not specialize
+                if (mdDecoder.IsConstructor(unspecMethod))
+                {
+                    return result;
+                }
+
+                if (mdDecoder.Name(unspecMethod) != "AssumeInvariant") return result;
+                var parameters = mdDecoder.Parameters(calledMethod);
+                Contract.Assume(parameters != null);
+                if (parameters.Count != 1) return result;
+
+                var p = parameters[0];
+                var invariantType = this.MethodCache.MetadataDecoder.ParameterType(p);
+                var candidate = this.MethodCache.GetInvariant(invariantType);
+                if (candidate != null)
+                {
+                    MethodCallBlock<Label> callBlock = from as MethodCallBlock<Label>;
+                    if (callBlock != null)
+                    {
+                        if (callBlock.IsNewObj) return result; // no insertion here
+                        string tag = "assumeInvariant";
+
+                        result = result.Cons(new Pair<string, Subroutine>(tag, candidate));
+                    }
+                }
+                return result;
+            }
+
+            private bool WithinConstructor(CFGBlock from, SubroutineContext context)
+            {
+                Contract.Requires(from != null);// F: As of Clousot suggestion
+                return new APC(from, 0, context).InsideConstructor;
+            }
+
+            /// <summary>
+            /// Make sure not to specialize to a subroutine already in the context, otherwise we create a recursive context.
+            /// </summary>
+            private FList<Pair<string, Subroutine>> SpecializeEnsures(FList<Pair<string, Subroutine>> subs, Subroutine toReplace, Subroutine specializedEnsures, CFGBlock from, SubroutineContext context)
+            {
+                return subs.Map(pair =>
+                {
+                    var specialized = SpecializeEnsures(pair.Two, toReplace, specializedEnsures);
+                    if (from.Subroutine == specialized) return pair;
+                    for (var list = context; list != null; list = list.Tail)
+                    {
+                        if (list.Head.One.Subroutine == specialized) return pair;
+                    }
+                    return new Pair<string, Subroutine>(pair.One, specialized);
+                });
+            }
+
+            /// <summary>
+            /// Ensures can only be specialized if the call is virtual. Invariants, we always do.
+            /// </summary>
+            private Subroutine SpecializeEnsures(Subroutine sub, Subroutine toReplace, Subroutine specializedEnsures)
+            {
+                var mdDecoder = this.MethodCache.MetadataDecoder;
+                if (sub == toReplace)
+                {
+                    return specializedEnsures;
+                }
+                return sub;
+            }
+
+            bool IStackInfo.IsCallOnThis(APC pc)
+            {
+                // default implementation does not try to refine
+                return false;
+            }
+
+            private static Predicate<Pair<string, Subroutine>> FilterRecursiveContracts(CFGBlock from, SubroutineContext context)
+            {
+                return delegate (Pair<string, Subroutine> candidatePair)
+                {
+                    var candidate = candidatePair.Two;
+                    if (!candidate.IsContract) return true;
+                    if (candidate == from.Subroutine) return false; // direct recursion
+                    for (var filter = context; filter != null; filter = filter.Tail)
+                    {
+                        if (candidate == filter.Head.One.Subroutine) return false;
+                    }
+                    return true;
+                };
+            }
+
+            /// <summary>
+            /// Call back when a return statement is found. Usually ignored but MethodSubroutine wants to know about it
+            /// </summary>
+            internal virtual void AddReturnBlock(BlockWithLabels<Label> block) { }
+
+            #endregion ------------------------------------
+
+
+            public override CFGBlock Entry
+            {
+                get { return entry; }
+            }
+
+            public void SetEntry(CFGBlock newEntry)
+            {
+                entry = newEntry as BlockWithLabels<Label>;
+            }
+
+            public override CFGBlock EntryAfterRequires
+            {
+                get { if (entryAfterRequires != null) { return entryAfterRequires; } else { return this.Entry; } }
+            }
+
+            public override CFGBlock Exit
+            {
+                get { return exit; }
+            }
+
+            public override CFGBlock ExceptionExit
+            {
+                get { return exceptionExit; }
+            }
+
+            public override bool HasReturnValue
+            {
+                get { return false; } // default
+            }
+
+            public override bool HasContextDependentStackDepth
+            {
+                get { return true; } // default
+            }
+
+            public override IEnumerable<CFGBlock> SuccessorBlocks(CFGBlock block)
+            {
+                foreach (Pair<Tag, CFGBlock> edge in this.SuccessorEdges[block])
+                {
+                    yield return edge.Two;
+                }
+            }
+
+            public override IEnumerable<CFGBlock> PredecessorBlocks(CFGBlock block)
+            {
+                foreach (Pair<Tag, CFGBlock> edge in this.PredecessorEdges[block])
+                {
+                    yield return edge.Two;
+                }
+            }
+
+            public override bool IsCatchFilterHeader(CFGBlock block)
+            {
+                return block is CatchFilterEntryBlock<Label>;
+            }
+
+            /// <summary>
+            /// Number of distinct syntactic blocks.
+            /// </summary>
+            public override int BlockCount
+            {
+                get
+                {
+                    Contract.Assume(this.blocks != null, "otherwise Commit has not been called");
+
+                    return this.blocks.Length;
+                }
+            }
+
+            /// <summary>
+            /// The blocks are numbered from 0-n. For syntactic analysis (ignoring finally context)
+            /// an array can be used to map from block to information by using the block.index as key.
+            /// </summary>
+            public override IEnumerable<CFGBlock> Blocks { get { return this.blocks; } }
+
+            public override string Name
+            {
+                get { return "SR" + this.Id.ToString(); }
+            }
+
+            #region ------------ Internal overrides ------------------
+
+
+            public override bool IsSubroutineStart(CFGBlock block)
+            {
+                return block == entry;
+            }
+
+            public override bool IsSubroutineEnd(CFGBlock block)
+            {
+                return block == exit || block == exceptionExit;
+            }
+
+            public override bool IsJoinPoint(CFGBlock block)
+            {
+                // catch and filter handler starts are join points
+                if (this.IsCatchFilterHeader(block)) return true;
+                // prevents us from stepping in/out of straight line code across subroutines
+                if (this.IsSubroutineStart(block)) return true;
+                if (this.IsSubroutineEnd(block)) return true;
+                return (this.PredecessorEdges[block].Count > 1);
+            }
+
+            public override bool IsSplitPoint(CFGBlock block)
+            {
+                // prevents us from stepping in/out of straight line code across subroutines
+                if (this.IsSubroutineStart(block)) return true;
+                if (this.IsSubroutineEnd(block)) return true;
+                return (SuccessorEdges[block].Count > 1);
+            }
+
+            internal override DepthFirst.Visitor<CFGBlock, Unit>/*?*/ EdgeInfo
+            {
+                get
+                {
+                    Contract.Assume(edgeInfo != null, "otherwise PostProcess has not been called yet");
+                    return edgeInfo;
+                }
+            }
+
+            internal string SourceContext(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    var len = this.CodeProvider.SourceLength(label);
+                    if (0 < len)
+                        return String.Format("{0}({1},{2}-{3},{4})",
+                          this.CodeProvider.SourceDocument(label),
+                          this.CodeProvider.SourceStartLine(label),
+                          this.CodeProvider.SourceStartColumn(label),
+                          this.CodeProvider.SourceEndLine(label),
+                          this.CodeProvider.SourceEndColumn(label)
+                          );
+                    else
+                        return String.Format("{0}({1},{2})", this.CodeProvider.SourceDocument(label), this.CodeProvider.SourceStartLine(label), this.CodeProvider.SourceStartColumn(label));
+                }
+                return null;
+            }
+            internal string SourceDocument(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    return this.CodeProvider.SourceDocument(label);
+                }
+                return null;
+            }
+            internal int SourceStartLine(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    return this.CodeProvider.SourceStartLine(label);
+                }
+                return 0;
+            }
+            internal int SourceEndLine(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    return this.CodeProvider.SourceEndLine(label);
+                }
+                return 0;
+            }
+            internal int SourceStartColumn(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    return this.CodeProvider.SourceStartColumn(label);
+                }
+                return 0;
+            }
+            internal int SourceEndColumn(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    return this.CodeProvider.SourceEndColumn(label);
+                }
+                return 0;
+            }
+            internal int SourceStartIndex(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    return this.CodeProvider.SourceStartIndex(label);
+                }
+                return 0;
+            }
+            internal int SourceLength(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                if (this.CodeProvider.HasSourceContext(label))
+                {
+                    return this.CodeProvider.SourceLength(label);
+                }
+                return 0;
+            }
+
+            internal int ILOffset(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                return this.CodeProvider.ILOffset(label);
+            }
+
+            public override int StackDelta
+            {
+                get { return 0; }
+            }
+
+            #endregion --------------------------------------
+
+            #region Code scanning and block building
+
+
+
+            private void AddNormalControlFlowEdge(List<Pair<CFGBlock, Pair<string, CFGBlock>>> succs,
+                                                  CFGBlock from, string tag, CFGBlock to)
+            {
+                Contract.Requires(succs != null); // F: added because of Clousot suggestion
+                Contract.Requires(from != this.Exit); // F: added because of Clousot suggestion
+
+                Debug.Assert(from != this.Exit);
+                succs.Add(new Pair<CFGBlock, Pair<string, CFGBlock>>(from, new Pair<string, CFGBlock>(tag, to)));
+            }
+
+
+            #endregion
+
+            #region Subroutine computations
+            internal override bool HasSingleSuccessor(APC ppoint, out APC next, DConsCache consCache)
+            {
+                Contract.Assert(consCache != null);
+                //
+                // This works as follows:
+                //  1) determine if we are at the end of a block, if not, just provide the successor
+                //  2) if this point ends a finally handler, find the next handler or pop the stack
+                //  3) determine syntactic successor labels
+                //     a) for each such label, determine finally nesting difference with current finally scope
+                //     b) push executed finallies onto finally stack and make top be the new current PC
+                // If this is an endfinally, there must be at least one label
+
+                // We allow stepping past the last instruction in this block!
+                if (ppoint.Index < ppoint.Block.Count)
+                {
+                    next = new APC(ppoint.Block, ppoint.Index + 1, ppoint.SubroutineContext);
+                    return true;
+                }
+
+                if (IsSubroutineEnd(ppoint.Block))
+                {
+                    // Could be end of entire CFG
+                    if (ppoint.SubroutineContext == null)
+                    {
+                        next = APC.Dummy;
+                        return false;
+                    }
+                    next = ComputeSubroutineContinuation(ppoint, consCache);
+                    return true;
+                }
+
+                BlockWithLabels<Label> singleSucc = null;
+                foreach (BlockWithLabels<Label> succ in ppoint.Block.Subroutine.SuccessorBlocks(ppoint.Block))
+                {
+                    if (singleSucc == null)
+                    {
+                        singleSucc = succ;
+                    }
+                    else
+                    {
+                        // more than one
+                        next = APC.Dummy;
+                        return false;
+                    }
+                }
+                if (singleSucc != null)
+                {
+                    next = ComputeTargetFinallyContext(ppoint, singleSucc, consCache);
+                    return true;
+                }
+
+                // zero
+                next = APC.Dummy;
+                return false;
+            }
+
+            internal override bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, DConsCache consCache, bool skipContracts)
+            {
+                //
+                // This works as follows:
+                //  1) determine if we are at the beginning of a block, if not, just provide the predecessor
+                //  2) if this point starts a finally handler, find the previous handler or pop the stack
+                //     NOTE: if the popping is necessary and the target of the edge is a catch handler, then
+                //           the predecessors are all indices in the block where the exception is thrown.
+                //  3) determine syntactic predecessors
+                //     a) for each such label, determine finally nesting difference with current finally scope
+                //     b) push edge onto finally stack and make top be the new current PC
+                if (ppoint.Index > 0)
+                {
+                    singlePredecessor = new APC(ppoint.Block, ppoint.Index - 1, ppoint.SubroutineContext);
+                    return true;
+                }
+
+                // If this is the beginning of the subroutine, get the next one
+                if (IsSubroutineStart(ppoint.Block))
+                {
+                    // could be beginning of entire CFG
+                    if (ppoint.SubroutineContext == null)
+                    {
+                        singlePredecessor = APC.Dummy;
+                        return false;
+                    }
+                    bool hasSinglePred;
+                    singlePredecessor = this.ComputeSubroutinePreContinuation(ppoint, out hasSinglePred, consCache, skipContracts);
+                    return hasSinglePred;
+                }
+
+                CFGBlock/*?*/ singlePred = null;
+                foreach (CFGBlock pred in ppoint.Block.Subroutine.PredecessorBlocks(ppoint.Block))
+                {
+                    if (singlePred != null)
+                    {
+                        singlePredecessor = APC.Dummy;
+                        return false;
+                    }
+                    singlePred = pred;
+                }
+                if (singlePred == null)
+                {
+                    // 0
+                    singlePredecessor = APC.Dummy;
+                    return false;
+                }
+
+                FList<Pair<string, Subroutine>> diffs = EdgeSubroutinesOuterToInner(singlePred, ppoint.Block, ppoint.SubroutineContext);
+
+                diffs = SkipContracts(skipContracts, diffs);
+                if (diffs == null)
+                {
+                    singlePredecessor = APC.ForEnd(singlePred, ppoint.SubroutineContext);
+                    return true;
+                }
+
+                // now diff is in outermost to inner most order of fault/finallies we are traversing.
+                // 1) push edge onto fault/finally context stack
+                // 2) for each endfinally in innermost handler, yield a program point
+                // IMPORTANT: the Finally context must be hash consed so that APC's have Equal working properly!
+                //
+
+                Contract.Assert(consCache != null); // F: made the assumption explicit
+                SubroutineContext newFinallyContext = consCache(new SubroutineEdge(singlePred, ppoint.Block, diffs.Head.One), ppoint.SubroutineContext);
+
+                // 3) find outermost handler (Head) and its subroutine
+                // 4) transfer control to end of first (outermost) fault/finally
+                //     (NOTE: diffs only contains finallies unless ppoint.Block is a catch/filter header)
+
+                Subroutine subroutine = diffs.Head.Two;
+                Contract.Assume(subroutine != null);
+
+                singlePredecessor = APC.ForEnd(subroutine.Exit, newFinallyContext);
+                return true;
+            }
+
+            internal override APC PredecessorPCPriorToRequires(APC pc, DConsCache consCache)
+            {
+                // must be at head of block
+                if (pc.Index != 0) return pc;
+
+                var currBlock = pc.Block;
+                Method dummy;
+                bool dummyBool;
+                bool dummyIsVirtual;
+                if (currBlock.IsMethodCallBlock(out dummy, out dummyBool, out dummyIsVirtual))
+                {
+                    var preds = this.PredecessorBlocks(currBlock).AsIndexable(1);
+                    if (preds.Count == 1)
+                    {
+                        var predBlock = preds[0];
+                        Contract.Assume(predBlock != null);
+                        return APC.ForEnd(predBlock, pc.SubroutineContext);
+                    }
+                }
+                return pc;
+#if false
+                var subs = EdgeSubroutinesOuterToInner(predBlock, currBlock, pc.SubroutineContext);
+
+                for (; subs != null; subs = subs.Tail)
+                {
+                    var sub = subs.Head.Two;
+                    if (sub.IsRequires) continue;
+                    // non requires sub could be ensures/invariant, etc. Need to use this as last pc
+                    SubroutineContext newFinallyContext = consCache(new SubroutineEdge(predBlock, currBlock, subs.Head.One), pc.SubroutineContext);
+                    return APC.ForEnd(sub.Exit, newFinallyContext);
+                }
+#endif
+            }
+
+            /// <summary>
+            /// Returns all normal control flow successors
+            /// </summary>
+            internal override IEnumerable<APC>/*!*/ Successors(APC ppoint, DConsCache consCache)
+            {
+                APC singleNext;
+                if (HasSingleSuccessor(ppoint, out singleNext, consCache))
+                {
+                    yield return singleNext;
+                    yield break;
+                }
+                //
+                //  determine syntactic successor labels
+                //     a) for each such label, determine finally nesting difference with current finally scope
+                //     b) push executed finallies onto finally stack and make top be the new current PC
+
+                int successors = 0;
+                foreach (BlockWithLabels<Label> succ in ppoint.Block.Subroutine.SuccessorBlocks(ppoint.Block))
+                {
+                    successors++;
+                    yield return ppoint.Block.Subroutine.ComputeTargetFinallyContext(ppoint, succ, consCache);
+                }
+
+                if (successors == 0)
+                {
+                    // The following is too strong, as throw in a finally block aborts the finally continuation
+                    // System.Diagnostics.Debug.Assert(ppoint.FaultFinallyContext == null);
+
+                    // the following is too strong, as the current pc could also be a throw.
+                    // However, we don't know how to compute this.
+                    // System.Diagnostics.Debug.Assert(ppoint.Block == this.normalExit || ppoint.Block == this.exceptionExit);
+                }
+            }
+
+            internal override IEnumerable<APC> Predecessors(APC ppoint, DConsCache consCache, bool skipContracts)
+            {
+                //
+                // This works as follows:
+                //  1) determine if we are at the beginning of a block, if not, just provide the predecessor
+                //  2) if this point starts a finally handler, find the previous handler or pop the stack
+                //  3) determine syntactic predecessors
+                //     a) for each such label, determine finally nesting difference with current finally scope
+                //     b) push edge onto finally stack and make top be the new current PC
+                if (ppoint.Index > 0)
+                {
+                    yield return new APC(ppoint.Block, ppoint.Index - 1, ppoint.SubroutineContext);
+                    yield break;
+                }
+
+                if (IsSubroutineStart(ppoint.Block))
+                {
+                    // Could be start of entire CFG
+                    if (ppoint.SubroutineContext == null)
+                    {
+                        yield break;
+                    }
+                    // 
+                    foreach (APC nestedpred in this.ComputeSubroutinePreContinuation(ppoint, consCache, skipContracts))
+                    {
+                        yield return nestedpred;
+                    }
+                    yield break;
+                }
+
+                foreach (CFGBlock pred in ppoint.Block.Subroutine.PredecessorBlocks(ppoint.Block))
+                {
+                    FList<Pair<string, Subroutine>> diffs = EdgeSubroutinesOuterToInner(pred, ppoint.Block, ppoint.SubroutineContext);
+
+                    diffs = SkipContracts(skipContracts, diffs);
+                    if (diffs == null)
+                    {
+                        yield return APC.ForEnd(pred, ppoint.SubroutineContext);
+                    }
+                    else
+                    {
+                        // now diff is in outermost to inner most order of fault/finallies we are traversing.
+                        // 1) push edge onto fault/finally context stack
+                        // 2) yield exit of subroutine as program point
+                        // IMPORTANT: the Finally context must be hash consed so that APC's have Equal working properly!
+                        //
+                        SubroutineContext newFinallyContext = consCache(new SubroutineEdge(pred, ppoint.Block, diffs.Head.One), ppoint.SubroutineContext);
+
+                        // 2) find outermost handler (Head)
+                        // 3) transfer control to end of first (outermost) fault/finally
+                        Subroutine subroutine = diffs.Head.Two;
+                        yield return APC.ForEnd(subroutine.Exit, newFinallyContext);
+                    }
+                }
+            }
+
+            private static FList<Pair<Tag, Subroutine>> SkipContracts(bool skipContracts, FList<Pair<string, Subroutine>> diffs)
+            {
+                if (skipContracts)
+                {
+                    while (diffs != null && (diffs.Head.Two.IsContract || diffs.Head.Two.IsOldValue))
+                    {
+                        diffs = diffs.Tail;
+                    }
+                }
+                return diffs;
+            }
+
+            /// <summary>
+            /// Called when ppoint is beginning of a subroutine on backwards walk.
+            ///
+            /// Finds next subroutine on current edge, or pops edge
+            ///
+            /// Note: we distinguish between edges that target an exception handler and thus need
+            /// to execute fault and finally handlers and other edges that only execute finally handlers
+            /// by the target block. In the former case, the target block is a SpecialCatchFilterHeader
+            /// block. These blocks are needed, as the start of a catch handler could also be the normal
+            /// goto/leave target of some try finally within the catch handler itself. Thus, the special
+            /// block disinguishes between a throw target where faults must be traversed, and a normal
+            /// leave target to the beginning of a catch handler.
+            /// </summary>
+            private IEnumerable<APC> ComputeSubroutinePreContinuation(APC ppoint, DConsCache consCache, bool skipContracts)
+            // ^ requires ppoint.FinallyEdges != null;
+            {
+                SubroutineEdge edge = ppoint.SubroutineContext.Head;
+                bool isHandlerEdge;
+                FList<Pair<string, Subroutine>> diffs = EdgeSubroutinesOuterToInner(edge.One, edge.Two, out isHandlerEdge, ppoint.SubroutineContext.Tail);
+                Debug.Assert(diffs != null);
+                while (diffs.Head.Two != this)
+                {
+                    diffs = diffs.Tail;
+                }
+
+                // skip this
+                diffs = diffs.Tail;
+
+                diffs = SkipContracts(skipContracts, diffs);
+                // diffs.Head is new handler or none
+                if (diffs == null)
+                {
+                    // If isHandlerEdge, then each label in the source block of the edge is a target
+                    if (isHandlerEdge)
+                    {
+                        for (int index = 0; index == 0 || index < edge.One.Count; index++)
+                        {
+                            yield return new APC(edge.One, index, ppoint.SubroutineContext.Tail);
+                        }
+                    }
+                    else
+                    {
+                        yield return APC.ForEnd(edge.One, ppoint.SubroutineContext.Tail);
+                    }
+                    yield break;
+                }
+                // predecessor is end of the next inner handler
+                Subroutine nextSubroutine = diffs.Head.Two;
+                yield return APC.ForEnd(nextSubroutine.Exit, consCache(new SubroutineEdge(edge.One, edge.Two, diffs.Head.One), ppoint.SubroutineContext.Tail));
+            }
+
+            /// <summary>
+            /// Called when ppoint is beginning of a finally on backwards walk.
+            ///
+            /// Finds next handler on current edge, or pops edge
+            ///
+            /// Note: we distinguish between edges that target an exception handler and thus need
+            /// to execute fault and finally handlers and other edges that only execute finally handlers
+            /// by the target block. In the former case, the target block is a SpecialCatchFilterHeader
+            /// block. These blocks are needed, as the start of a catch handler could also be the normal
+            /// goto/leave target of some try finally within the catch handler itself. Thus, the special
+            /// block disinguishes between a throw target where faults must be traversed, and a normal
+            /// leave target to the beginning of a catch handler.
+            /// </summary>
+            [ContractVerification(false)]
+            private APC ComputeSubroutinePreContinuation(APC ppoint, out bool hasSinglePred, DConsCache consCache, bool skipContracts)
+            // ^ requires ppoint.FinallyEdges != null;
+            {
+                SubroutineEdge edge = ppoint.SubroutineContext.Head;
+                bool isHandlerEdge;
+                FList<Pair<string, Subroutine>> diffs = EdgeSubroutinesOuterToInner(edge.One, edge.Two, out isHandlerEdge, ppoint.SubroutineContext.Tail);
+                Contract.Assume(diffs != null);
+                while (diffs.Head.Two != this)
+                {
+                    diffs = diffs.Tail;
+                }
+                diffs = diffs.Tail; // skip this
+
+                diffs = SkipContracts(skipContracts, diffs);
+                // diffs.Head is new handler or none
+                if (diffs == null)
+                {
+                    // If isHandlerEdge, then each label in the source block of the edge is a target
+                    if (isHandlerEdge && edge.One.Count > 1)
+                    {
+                        // no single pred
+                        hasSinglePred = false;
+                        return APC.Dummy;
+                    }
+                    hasSinglePred = true;
+                    return APC.ForEnd(edge.One, ppoint.SubroutineContext.Tail);
+                }
+                // predecessor is end of the next inner handler
+                Subroutine nextSubroutine = diffs.Head.Two;
+                // only one end
+                hasSinglePred = true;
+                return APC.ForEnd(nextSubroutine.Exit, consCache(new SubroutineEdge(edge.One, edge.Two, diffs.Head.One), ppoint.SubroutineContext.Tail));
+            }
+
+            /// <summary>
+            /// Called when ppoint is an endfinally.
+            ///
+            /// Finds next handler on current edge, or pops edge
+            ///
+            /// Note: we distinguish between edges that target an exception handler and thus need
+            /// to execute fault and finally handlers and other edges that only execute finally handlers
+            /// by the target block. In the former case, the target block is a SpecialCatchFilterHeader
+            /// block. These blocks are needed, as the start of a catch handler could also be the normal
+            /// goto/leave target of some try finally within the catch handler itself. Thus, the special
+            /// block disinguishes between a throw target where faults must be traversed, and a normal
+            /// leave target to the beginning of a catch handler.
+            /// </summary>
+            [ContractVerification(false)]
+            private APC ComputeSubroutineContinuation(APC ppoint, DConsCache consCache)
+            // ^ requires ppoint.SubroutineContext != null;
+            {
+                SubroutineEdge edge = ppoint.SubroutineContext.Head;
+
+                FList<Pair<string, Subroutine>> diffs = EdgeSubroutinesOuterToInner(edge.One, edge.Two, ppoint.SubroutineContext.Tail);
+                Contract.Assume(diffs != null);
+                if (diffs.Head.Two == this)
+                {
+                    // last handler executed.
+                    // pop finally edge
+                    return new APC(edge.Two, 0, ppoint.SubroutineContext.Tail);
+                }
+                while (diffs.Tail.Head.Two != this)
+                {
+                    diffs = diffs.Tail;
+                }
+                // diffs.Head is new handler
+                Subroutine nextSubroutine = diffs.Head.Two;
+                return new APC(nextSubroutine.Entry, 0, consCache(new SubroutineEdge(edge.One, edge.Two, diffs.Head.One), ppoint.SubroutineContext.Tail));
+            }
+
+            /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
+            private FList<Pair<string, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, SubroutineContext context)
+            {
+                bool isExnHandler;
+                return EdgeSubroutinesOuterToInner(current, succ, out isExnHandler, context);
+            }
+
+            /// <summary>
+            /// Returns the difference in fault/finally handlers between the given program point and the
+            /// given successor. Normally, the list only includes finally handlers, except in the case 
+            /// where succ is a special catch/filter header block, indicating that this edge represents
+            /// the execution on a throw, and thus fault handlers are included
+            /// </summary>
+            /// <param name="isExceptionHandlerEdge">is true, if the successor is a catch/filter handler</param>
+            /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
+            public override FList<Pair<string, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context)
+            {
+                if (current.Subroutine != this)
+                {
+                    // dispatch
+                    return current.Subroutine.EdgeSubroutinesOuterToInner(current, succ, out isExceptionHandlerEdge, context);
+                }
+
+                bool includeFaults = IsCatchFilterHeader(succ);
+                isExceptionHandlerEdge = includeFaults;
+
+                return this.GetOrdinaryEdgeSubroutines(current, succ, context);
+            }
+
+            internal override APC ComputeTargetFinallyContext(APC ppoint, CFGBlock succ, DConsCache consCache)
+            {
+                FList<Pair<string, Subroutine>> diffs = EdgeSubroutinesOuterToInner(ppoint.Block, succ, ppoint.SubroutineContext);
+
+                if (diffs == null)
+                {
+                    return new APC(succ, 0, ppoint.SubroutineContext);
+                }
+                // now diff is in outermost to inner most order of finallies we are traversing.
+                // 1) push edge onto fault/finally context stack
+                // 2) make innermost handler start current program point
+                // IMPORTANT: the Finally context must be hash consed so that APC's have Equal working properly!
+                //
+
+                // 2) find innermost handler
+                while (diffs.Length() > 1)
+                {
+                    diffs = diffs.Tail;
+                }
+
+                Subroutine innerMost = diffs.Head.Two;
+                Contract.Assume(innerMost != null);
+                SubroutineContext newFinallyContext = consCache(new SubroutineEdge(ppoint.Block, succ, diffs.Head.One), ppoint.SubroutineContext);
+
+                // 3) transfer control to last (innermost) finally
+                return new APC(innerMost.Entry, 0, newFinallyContext);
+            }
+
+            /// <summary>
+            /// Returns a set of program points that are possible execution continuations if 
+            /// an exception is raised at the given ppoint.
+            ///
+            /// The supplied predicate allows the client to determine which handlers are possible
+            /// candidates. The predicate is called from closest enclosing to outermost.
+            /// </summary>
+            /// <param name="data">Arbitrary client data passed to the handler predicate</param>
+            /// <returns>A set of continuation program points that represent how execution continues to a chosen handler.
+            /// The continuation includes Finally and Fault executions that intervene between the given ppoint and a
+            /// chosen handler.
+            ///
+            /// Hack. This only works if Type2 is Type. We do this because we don't want to expose Type in Subroutine and thus
+            /// CFGBlock.
+            /// </returns>
+            internal override IEnumerable<CFGBlock> ExceptionHandlers<Data, Type2>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type2, Data> handlerPredicateArg)
+            {
+                // This kind of subroutine has no handlers except the exceptional exit point
+                yield return exceptionExit;
+            }
+
+            #endregion
+
+            #region Post Cleanup
+
+            private DepthFirst.Visitor<CFGBlock, Unit>/*?*/ edgeInfo = null;
+
+            private bool IsEdgeUsed(Pair<CFGBlock, Pair<string, CFGBlock>> edge)
+            {
+                return (edge.One.Index != UnusedBlockIndex);
+            }
+
+            private EdgeMap<string> successorEdges;
+            private EdgeMap<string> predecessorEdges; // cache
+
+            internal override EdgeMap<string> SuccessorEdges
+            {
+                get { return successorEdges; }
+            }
+
+            internal override EdgeMap<string> PredecessorEdges
+            {
+                get
+                {
+                    if (predecessorEdges == null)
+                    {
+                        //  compute predecessor map on demand
+                        predecessorEdges = this.SuccessorEdges.ReversedEdges();
+                    }
+                    return predecessorEdges;
+                }
+            }
+
+            private const int UnusedBlockIndex = Int16.MaxValue - 10;
+
+
+            /// <summary>
+            /// Removes unreachable blocks and reorders them in reverse post order for easier reading
+            /// and for analysis.
+            /// </summary>
+            [ContractVerification(false)] // because this is like Dispose and it violates some invariants.
+            protected void PostProcessBlocks()
+            {
+                Stack<CFGBlock> blockStack = new Stack<CFGBlock>();
+
+                successorEdges = new EdgeMap<string>(successors);
+
+                // choose only reachable blocks
+                edgeInfo = new DepthFirst.Visitor<CFGBlock, Unit>(
+                   this,
+                   null,
+                   // we use the post visit for the post order
+                   delegate (CFGBlock block)
+                   {
+                       // we use a stack to obtain reverse post order
+                       blockStack.Push(block);
+
+                       // we approximate the backwards reverse post order here as the forward pre-order
+                       // block.SetBackwardReversePostOrderIndex(ref backwardIndexGen);
+                   },
+                   null);
+
+                // Make sure that the exception exit block appears last and the normal exit block 2nd to last
+                // This also makes sure that these nodes appear in our list.
+                edgeInfo.VisitSubGraphNonRecursive(exceptionExit);
+                edgeInfo.VisitSubGraphNonRecursive(exit);
+                edgeInfo.VisitSubGraphNonRecursive(entry);
+
+                //
+                //  Now, we have unreachable blocks (and unused edges)
+                //  1) unnumber all the blocks so we can recognize which ones are dead
+                foreach (Pair<CFGBlock, Pair<Tag, CFGBlock>> edge in successorEdges)
+                {
+                    int unused = UnusedBlockIndex;
+                    edge.One.Renumber(ref unused);
+                }
+                //  2) renumber the blocks in the reverse post order
+                int blockRenumber = 0;
+                foreach (BlockWithLabels<Label> block in blockStack)
+                {
+                    Contract.Assume(block != null);
+                    block.Renumber(ref blockRenumber);
+                }
+
+                //  3) remove edges that are of unused blocks
+                this.SuccessorEdges.Filter(IsEdgeUsed);
+
+                // 3a) compute reversed graph
+                predecessorEdges = this.SuccessorEdges.ReversedEdges();
+
+                int finishTime = 0;
+                // 3b) renumber according to reverse post order 
+                var predvisit = new DepthFirst.Visitor<CFGBlock, string>(
+                   predecessorEdges,
+                   null,
+                   delegate (CFGBlock block)
+                   {
+                       block.SetReversePostOrderIndex(finishTime++);
+                   },
+                   null);
+
+                predvisit.VisitSubGraphNonRecursive(exit);
+
+                foreach (var block in blockStack)
+                {
+                    predvisit.VisitSubGraphNonRecursive(block);
+                }
+
+
+                //  4) resort the edges according to the new numbering
+                //
+                this.SuccessorEdges.ReSort();
+
+                //  5) persist blocks as array
+                this.blocks = blockStack.ToArray();
+
+                //  6) cleanup
+                this.BlockStart = null;
+                this.Builder = null;
+
+                // for testing:
+                // Dominators.Compute(this, this.entry);
+            }
+            #endregion
+
+            #region IGraph<CFGBlock<Label>,Pair<CFGBlock<Label>,CFGBlock<Label>>> Members
+
+            IEnumerable<CFGBlock>/*!*/ IGraph<CFGBlock, Unit>.Nodes
+            {
+                get { return this.blocks; }
+            }
+
+            bool IGraph<CFGBlock, Unit>.Contains(CFGBlock node)
+            {
+                for (int i = 0; i < blocks.Length; i++)
+                {
+                    if (blocks[i] == node) return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Provide all successors, normal and exceptional
+            /// </summary>
+            public virtual IEnumerable<Pair<Unit, CFGBlock>>/*!*/ Successors(CFGBlock node)
+            {
+                foreach (Pair<Tag, CFGBlock> normalSucc in this.SuccessorEdges[node])
+                {
+                    yield return new Pair<Unit, CFGBlock>(Unit.Value, normalSucc.Two);
+                }
+
+                if (node != exceptionExit)
+                {
+                    yield return new Pair<Unit, CFGBlock>(Unit.Value, exceptionExit);
+                }
+            }
+
+
+            #endregion
+
+            public override void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed)
+            {
+                var identifier = new Pair<Subroutine, SubroutineContext>(this, context);
+                if (printed.Contains(identifier)) return; // already printed
+                printed.Add(identifier);
+                IMutableSet<Subroutine> subs = new Set<Subroutine>();
+                IMethodInfo<Method> mi = this as IMethodInfo<Method>;
+                string extraSRIdentification = (mi != null) ? String.Format("({0})", this.MethodCache.MetadataDecoder.FullName(mi.Method)) : null;
+
+                Contract.Assume(tw != null); // F: Added. Should it be a precondition?
+
+                if (context == null)
+                {
+                    tw.WriteLine("Subroutine SR{0} {1} {2}", this.Id, this.Kind, extraSRIdentification);
+                }
+                else
+                {
+                    tw.WriteLine("Subroutine SR{0} {1} {2} {3}", this.Id, this.Kind, new APC(this.Entry, 0, context), extraSRIdentification);
+                }
+                tw.WriteLine("-----------------");
+
+                foreach (BlockWithLabels<Label> block in this.Blocks.AssumeNotNull())
+                {
+                    tw.Write("Block {0} ({1})", block.Index, block.ReversePostOrderIndex);
+                    // revisit this. How should we print CFGs with subroutines?
+                    if (this.EdgeInfo.DepthFirstInfo(block).TargetOfBackEdge)
+                    {
+                        tw.WriteLine(" (target of backedge)");
+                        Debug.Assert(this.IsJoinPoint(block));
+                    }
+                    else if (this.IsJoinPoint(block))
+                    {
+                        tw.WriteLine(" (join point)");
+                    }
+                    else
+                    {
+                        tw.WriteLine();
+                    }
+                    tw.Write("  Predecessors: ");
+                    foreach (Pair<string, CFGBlock> taggedPred in block.Subroutine.PredecessorEdges[block])
+                    {
+                        tw.Write("({0}, {1}) ", taggedPred.One, taggedPred.Two.Index);
+                    }
+                    tw.WriteLine();
+                    PrintHandlers(tw, block);
+                    tw.WriteLine("  Code:");
+                    foreach (APC apc in block.APCs(context))
+                    {
+                        string sc = apc.PrimarySourceContext();
+                        if (sc != null) tw.WriteLine(sc);
+
+                        Contract.Assume(ilPrinter != null);
+
+                        ilPrinter(apc, "    ", tw);
+                    }
+                    tw.Write("  Successors: ");
+                    foreach (Pair<Tag, CFGBlock> taggedSucc in this.SuccessorEdges[block])
+                    {
+                        tw.Write("({0},{1}", taggedSucc.One, taggedSucc.Two.Index);
+                        if (this.EdgeInfo.IsBackEdge(block, Unit.Value, taggedSucc.Two))
+                        {
+                            tw.Write(" BE");
+                        }
+                        FList<Pair<string, Subroutine>> edgesubs = this.GetOrdinaryEdgeSubroutines(block, taggedSucc.Two, context);
+                        while (edgesubs != null)
+                        {
+                            subs.Add(edgesubs.Head.Two);
+                            tw.Write(" SR{0}({1})", edgesubs.Head.Two.Id, edgesubs.Head.One);
+                            edgesubs = edgesubs.Tail;
+                        }
+                        tw.Write(") ");
+                    }
+                    tw.WriteLine();
+                    if (blockInfoPrinter != null)
+                    {
+                        blockInfoPrinter(new APC(block, block.Last.Index, context), "  ", tw);
+                    }
+                    tw.WriteLine();
+                }
+
+                PrintReferencedSubroutines(tw, subs, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
+            }
+
+            [ContractVerification(false)] // We cannot prove the invariant this.BlockStart == null ==> this.Builder == null
+            protected virtual void PrintReferencedSubroutines(TextWriter tw, IMutableSet<Subroutine> subs, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed)
+            {
+                Contract.Requires(subs != null);
+
+                // print edge subroutines
+                foreach (Subroutine sb in subs)
+                {
+                    if (contextLookup == null)
+                    {
+                        sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, null, printed);
+                    }
+                    else
+                    {
+                        foreach (SubroutineContext newContext in contextLookup(sb.Entry))
+                        {
+                            sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, newContext, printed);
+                        }
+                    }
+                }
+            }
+
+            protected virtual void PrintHandlers(TextWriter tw, BlockWithLabels<Label> block)
+            {
+                Contract.Requires(tw != null);
+
+                tw.Write("  Handlers: ");
+                // print out method wide handler (implicitly added in the appropriate query on CFGs)
+                if (block != exceptionExit)
+                {
+                    tw.Write("{0} ", exceptionExit.Index);
+                }
+                tw.WriteLine();
+            }
+
+            internal override IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadyFound)
+            {
+                foreach (var sublist in this.edgeSubroutines.Values)
+                {
+                    var list = sublist;
+                    for (; list != null; list = list.Tail)
+                    {
+                        var sub = list.Head.Two;
+                        if (alreadyFound.Contains(sub.Id)) continue;
+                        alreadyFound.Add(sub.Id);
+                        yield return sub;
+                    }
+                }
+            }
+
+            internal virtual string SourceAssertionCondition(Label label)
+            {
+                Contract.Assume(this.CodeProvider != null, "At this point expecting the CodeProvider != null");
+                return this.CodeProvider.SourceAssertionCondition(label);
+            }
+        }
+
+        internal abstract class SubroutineWithHandlers<Label, Handler> : SubroutineBase<Label>
+        {
+            /// <summary>
+            /// Used during scanning to compute the protecting handlers in this subroutine only
+            /// </summary>
+            internal FList<Handler> CurrentProtectingHandlers = FList<Handler>.Empty; // protecting the current block
+                                                                                      /// <summary>
+                                                                                      /// Holds the block starting the filter code for filter handlers.
+                                                                                      /// Materialized on demand.
+                                                                                      /// </summary>
+            protected OnDemandMap<Handler, BlockWithLabels<Label>> FilterCodeBlocks;
+            protected OnDemandMap<Handler, BlockWithLabels<Label>> CatchFilterHeaders;
+            internal OnDemandMap<Handler, Subroutine> FaultFinallySubroutines;
+            /// <summary>
+            /// For each block, this provides the enclosing handlers (finally,fault, and exceptions) targeted by an exception raised in this block.
+            /// </summary>
+            internal OnDemandMap<CFGBlock, FList<Handler>> ProtectingHandlers;
+
+
+            new protected IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> CodeProvider
+            {
+                get
+                {
+                    Contract.Ensures(Contract.Result<IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler>>() != null);
+
+                    return (IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler>)base.CodeProvider;
+                }
+            }
+
+            internal SubroutineWithHandlers(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
+             : base(methodCache)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+            }
+
+            internal SubroutineWithHandlers(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                            SubroutineWithHandlersBuilder<Label, Handler> builder,
+                                            Label entry)
+              : base(methodCache, entry, builder)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+            }
+
+
+            private bool IsFault(Handler handler)
+            {
+                return this.CodeProvider.IsFaultHandler(handler);
+            }
+
+            private FList<Handler> ProtectingHandlersList(CFGBlock block)
+            {
+                FList<Handler>/*?*/ result;
+                ProtectingHandlers.TryGetValue(block, out result);
+                return result;
+            }
+
+            private IEnumerable<Handler> GetProtectingHandlers(CFGBlock block)
+            {
+                return ProtectingHandlersList(block).GetEnumerable();
+            }
+
+
+            internal BlockWithLabels<Label> CreateCatchFilterHeader(Handler handler, Label label)
+            {
+                BlockWithLabels<Label> newBlock;
+                if (!this.BlockStart.TryGetValue(label, out newBlock))
+                {
+#if ENABLE_ASSERTIONS
+                    Debug.Assert(this.MethodInfo.IsBlockStart(label));
+#endif
+                    newBlock = new CatchFilterEntryBlock<Label>(this, ref this.blockIdGenerator);
+                    this.CatchFilterHeaders.Add(handler, newBlock);
+                    this.BlockStart.Add(label, newBlock);
+                    if (this.CodeProvider.IsFilterHandler(handler))
+                    {
+                        // cache the filter code block which we need to lookup during exception paths
+                        var filterCodeBlock = GetTargetBlock(this.CodeProvider.FilterDecisionStart(handler));
+                        this.FilterCodeBlocks.Add(handler, filterCodeBlock);
+                    }
+                }
+                return newBlock;
+            }
+
+            internal override IEnumerable<Subroutine> UsedSubroutines(IMutableSet<int> alreadySeen)
+            {
+                foreach (Subroutine ffsr in this.FaultFinallySubroutines.Values)
+                {
+                    yield return ffsr;
+                }
+                foreach (var sub in BaseUsedSubroutines(alreadySeen))
+                {
+                    yield return sub;
+                }
+            }
+            private IEnumerable<Subroutine> BaseUsedSubroutines(IMutableSet<int> alreadySeen)
+            {
+                return base.UsedSubroutines(alreadySeen);
+            }
+
+            /// <param name="context">APC where edge is being considered. Used for filtering recursive calls.</param>
+            public override FList<Pair<string, Subroutine>> EdgeSubroutinesOuterToInner(CFGBlock current, CFGBlock succ, out bool isExceptionHandlerEdge, SubroutineContext context)
+            {
+                if (current.Subroutine != this)
+                {
+                    // dispatch
+                    return current.Subroutine.EdgeSubroutinesOuterToInner(current, succ, out isExceptionHandlerEdge, context);
+                }
+                // determine finally nesting difference
+                FList<Handler> currentHandlers = this.ProtectingHandlersList(current);
+                FList<Handler> newHandlers = this.ProtectingHandlersList(succ);
+
+                bool includeFaults = IsCatchFilterHeader(succ);
+                isExceptionHandlerEdge = includeFaults;
+
+                // now we could pop some, push some, or both (pop then push)
+                FList<Pair<string, Subroutine>>/*?*/ subroutines = this.GetOrdinaryEdgeSubroutines(current, succ, context);
+                while (currentHandlers != newHandlers)
+                {
+                    if (currentHandlers.Length() >= newHandlers.Length())
+                    {
+                        Contract.Assume(currentHandlers != null);
+                        // definite pop
+                        Handler eh = currentHandlers.Head;
+                        if (this.IsFaultOrFinally(eh))
+                        {
+                            if (!IsFault(eh) || includeFaults)
+                            {
+                                subroutines = FList<Pair<string, Subroutine>>.Cons(new Pair<string, Subroutine>("finally", this.FaultFinallySubroutines[eh]), subroutines);
+                            }
+                        }
+                        currentHandlers = currentHandlers.Tail;
+                    }
+                    else
+                    {
+                        // definite push
+                        newHandlers = newHandlers.Tail;
+                    }
+                }
+                return subroutines;
+            }
+
+            public bool IsFaultOrFinally(Handler handler)
+            {
+                return this.CodeProvider.IsFaultHandler(handler) || this.CodeProvider.IsFinallyHandler(handler);
+            }
+
+            internal override IEnumerable<CFGBlock> ExceptionHandlers<Data, Type2>(CFGBlock ppoint, Subroutine innerSubroutine, Data data, IHandlerFilter<Type2, Data> handlerPredicateArg)
+            {
+                // Hack: cast to expected Type.
+                IHandlerFilter<Type, Data> handlerPredicate = (IHandlerFilter<Type, Data>)handlerPredicateArg;
+
+                // First, find handlers that protect ppoint, while being further out than innerSubroutine
+                FList<Handler> protectingHandlers = this.ProtectingHandlersList(ppoint);
+
+                if (innerSubroutine != null && innerSubroutine.IsFaultFinally)
+                {
+                    while (protectingHandlers != null)
+                    {
+                        if (this.IsFaultOrFinally(protectingHandlers.Head) && this.FaultFinallySubroutines[protectingHandlers.Head] == innerSubroutine)
+                        {
+                            protectingHandlers = protectingHandlers.Tail;
+                            // found remaining handlers
+                            break;
+                        }
+                        protectingHandlers = protectingHandlers.Tail;
+                    }
+                }
+
+                // now we have the remaining handlers that protect the program point
+
+                while (protectingHandlers != null)
+                {
+                    Handler handler = protectingHandlers.Head;
+                    if (!this.IsFaultOrFinally(handler))
+                    {
+                        if (handlerPredicate != null)
+                        {
+                            bool stopPropagation = false;
+                            if (this.CodeProvider.IsCatchHandler(handler))
+                            {
+                                if (handlerPredicate.Catch(data, this.CodeProvider.CatchType(handler), out stopPropagation))
+                                {
+                                    yield return this.CatchFilterHeaders[handler];
+                                }
+                            }
+                            else
+                            {
+                                Debug.Assert(this.CodeProvider.IsFilterHandler(handler));
+                                if (handlerPredicate.Filter(data, new APC(this.FilterCodeBlocks[handler], 0, null), out stopPropagation))
+                                {
+                                    yield return this.CatchFilterHeaders[handler];
+                                }
+                            }
+                            if (stopPropagation) yield break; // no further handlers
+                        }
+                        else
+                        {
+                            // no predicate, add all handlers
+                            yield return this.CatchFilterHeaders[handler];
+                        }
+                        if (this.CodeProvider.IsCatchAllHandler(handler))
+                        {
+                            yield break; // no further handlers
+                        }
+                    }
+                    protectingHandlers = protectingHandlers.Tail;
+                }
+
+                // if we get here, the exception can escape the subroutine
+                yield return this.ExceptionExit;
+            }
+
+            /// <summary>
+            /// Provide all successors, normal and exceptional
+            /// </summary>
+            public override IEnumerable<Pair<Unit, CFGBlock>>/*!*/ Successors(CFGBlock node)
+            {
+                foreach (Pair<Tag, CFGBlock> normalSucc in this.SuccessorEdges[node])
+                {
+                    yield return new Pair<Unit, CFGBlock>(Unit.Value, normalSucc.Two);
+                }
+
+                foreach (Handler handler in this.GetProtectingHandlers(node))
+                {
+                    // Careful: for fault finally the block belongs to a different subroutine, so we ignore it here
+                    //          for filter/catch, it is the special header block
+                    if (this.IsFaultOrFinally(handler))
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        yield return new Pair<Unit, CFGBlock>(Unit.Value, this.CatchFilterHeaders[handler]);
+                    }
+                }
+                if (node != this.ExceptionExit)
+                {
+                    yield return new Pair<Unit, CFGBlock>(Unit.Value, this.ExceptionExit);
+                }
+            }
+
+            protected override void PrintReferencedSubroutines(TextWriter tw, IMutableSet<Subroutine> subs, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> blockInfoPrinter, Func<CFGBlock, IEnumerable<FList<STuple<CFGBlock, CFGBlock, string>>>> contextLookup, SubroutineContext context, IMutableSet<Pair<Subroutine, SubroutineContext>> printed)
+            {
+                foreach (Subroutine sb in this.FaultFinallySubroutines.Values)
+                {
+                    if (contextLookup == null)
+                    {
+                        sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
+                    }
+                    else
+                    {
+                        foreach (SubroutineContext newContext in contextLookup(sb.Entry))
+                        {
+                            sb.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, newContext, printed);
+                        }
+                    }
+                }
+                base.PrintReferencedSubroutines(tw, subs, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
+            }
+
+            protected override void PrintHandlers(TextWriter tw, BlockWithLabels<Label> block)
+            {
+                tw.Write("  Handlers: ");
+                foreach (Handler handler in this.GetProtectingHandlers(block))
+                {
+                    if (this.IsFaultOrFinally(handler))
+                    {
+                        Subroutine sb = this.FaultFinallySubroutines[handler];
+                        Contract.Assume(sb != null, "Making the assumption explicit");
+                        tw.Write("SR{0} ", sb.Id);
+                    }
+                    else
+                    {
+                        BlockWithLabels<Label> handlerStart = this.CatchFilterHeaders[handler];
+                        Contract.Assume(handlerStart != null);
+                        tw.Write("{0} ", handlerStart.Index);
+                    }
+                }
+                // print out method wide handler (implicitly added in the appropriate query on CFGs)
+                if (block != this.ExceptionExit)
+                {
+                    tw.Write("{0} ", this.ExceptionExit.Index);
+                }
+                tw.WriteLine();
+            }
+        }
+
+        /// <summary>
+        /// Represents an entire method
+        /// </summary>
+        internal class MethodSubroutine<Label, Handler> : SubroutineWithHandlers<Label, Handler>, IMethodInfo<Method>
+        {
+            #region Object invariant
+
+            [ContractInvariantMethod]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(this.MethodCache.MetadataDecoder != null);
+            }
+
+            #endregion
+
+            private Set<BlockWithLabels<Label>> blocksEndingInReturn;
+
+            /// <summary>
+            /// Dummy one without a body
+            /// </summary>
+            internal MethodSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, Method method)
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                this.method = method;
+            }
+
+            private Method method;
+
+            [ContractVerification(false)] // We cannot prove the invariant this.BlockStart == null ==> this.Builder == null
+            public MethodSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                    Method method,
+                                    SubroutineWithHandlersBuilder<Label, Handler> builder,
+                                    Label startLabel)
+              : base(methodCache, builder, startLabel)
+            {
+                Contract.Requires(builder != null);// F: Added as of Clousot suggestion
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                this.method = method;
+
+                builder.BuildBlocks(startLabel, this);
+
+                BlockWithLabels<Label> startLabelBlock = this.GetTargetBlock(startLabel);
+
+                this.Commit();
+                Type declaringType = MethodCache.MetadataDecoder.DeclaringType(method);
+
+                Subroutine invariant = MethodCache.GetInvariant(declaringType);
+
+                if (invariant != null && !MethodCache.MetadataDecoder.IsConstructor(method) && !MethodCache.MetadataDecoder.IsStatic(method))
+                {
+                    this.AddEdgeSubroutine(this.Entry, startLabelBlock, invariant, "entry"); // first assume invariant as that might validate some implicit obligations in requires
+                    var requires = MethodCache.GetRequires(method);
+                    if (requires != null)
+                    {
+                        this.AddEdgeSubroutine(this.Entry, startLabelBlock, requires, "entry");
+                        this.AddEdgeSubroutine(this.Entry, startLabelBlock, MethodCache.GetRedundantInvariant(invariant, declaringType), "entry"); // redudant invariant assumption to handle disjunctions implied by requires better
+                    }
+                }
+                else
+                {
+                    this.AddEdgeSubroutine(this.Entry, startLabelBlock, MethodCache.GetRequires(method), "entry");
+                }
+                if (blocksEndingInReturn != null)
+                {
+                    var ensuresSub = MethodCache.GetEnsures(method);
+
+                    foreach (BlockWithLabels<Label> retBlock in blocksEndingInReturn)
+                    {
+                        if (!MethodCache.MetadataDecoder.IsStatic(method) &&
+                            !MethodCache.ContractDecoder.IsPure(method) &&
+                            !MethodCache.MetadataDecoder.IsFinalizer(method) &&
+                            !MethodCache.MetadataDecoder.IsDispose(method))
+                        {
+                            this.AddEdgeSubroutine(retBlock, this.Exit, invariant, "exit");
+                        }
+                        this.AddEdgeSubroutine(retBlock, this.Exit, ensuresSub, "exit");
+                    }
+
+                    // insert dummy Old subroutine calls at beginning to materialize for Clousot
+#if !CCI2_CONTROLFLOW_DIST
+                    if (ensuresSub != null)
+                    {
+                        foreach (var nestedEnsuresSub in ensuresSub.UsedSubroutines())
+                        {
+                            if (nestedEnsuresSub.IsOldValue)
+                            {
+                                this.AddEdgeSubroutine(this.Entry, startLabelBlock, Microsoft.Research.CodeAnalysis.ILCodeProvider.Predefined.OldEvalPopSubroutine(MethodCache, nestedEnsuresSub), "oldmanifest");
+                            }
+                        }
+                    }
+#endif
+                    // cleanup
+                    blocksEndingInReturn = null;
+                }
+            }
+
+            public override string Kind
+            {
+                get { return "method"; }
+            }
+            /// <summary>
+            /// Method subroutines are eagerly initialized
+            /// </summary>
+            internal override void Initialize()
+            {
+            }
+
+            /// <summary>
+            /// Record which blocks end in returns
+            /// </summary>
+            internal override void AddReturnBlock(BlockWithLabels<Label> block)
+            {
+                if (blocksEndingInReturn == null)
+                {
+                    blocksEndingInReturn = new Set<BlockWithLabels<Label>>();
+                }
+                blocksEndingInReturn.Add(block);
+                base.AddReturnBlock(block);
+            }
+
+            public override bool HasReturnValue
+            {
+                get
+                {
+                    return !this.MethodCache.MetadataDecoder.AssumeNotNull().IsVoidMethod(method);
+                }
+            }
+
+            public override bool IsMethod
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override bool IsConstructor
+            {
+                get
+                {
+                    return (this.MethodCache.MetadataDecoder.IsConstructor(method));
+                }
+            }
+
+            internal override bool IsCompilerGenerated
+            {
+                get
+                {
+                    return this.MethodCache.MetadataDecoder.IsCompilerGenerated(method);
+                }
+            }
+
+            public override string Name
+            {
+                get
+                {
+                    return this.MethodCache.MetadataDecoder.FullName(method);
+                }
+            }
+
+            public Method Method { get { return method; } }
+        }
+
+        internal abstract class FaultFinallySubroutineBase<Label, Handler> : SubroutineWithHandlers<Label, Handler>
+        {
+            protected FaultFinallySubroutineBase(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                                 SubroutineWithHandlersBuilder<Label, Handler> builder,
+                                                 Label startLabel)
+              : base(methodCache, builder, startLabel)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+            }
+
+            internal override void Initialize()
+            {
+                // nothing to do. MethodSubroutine finalizes the fault finally subroutines.
+            }
+
+            public override bool HasContextDependentStackDepth
+            {
+                get
+                {
+                    return false; // always starts at 0
+                }
+            }
+
+            public override bool IsFaultFinally
+            {
+                get
+                {
+                    return true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Represents a fault region within a method
+        /// </summary>
+        internal class FaultSubroutine<Label, Handler> : FaultFinallySubroutineBase<Label, Handler>
+        {
+            public FaultSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                   SubroutineWithHandlersBuilder<Label, Handler> builder,
+                                   Label startLabel)
+              : base(methodCache, builder, startLabel)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+            }
+
+            public override string Kind
+            {
+                get { return "fault"; }
+            }
+        }
+
+
+        /// <summary>
+        /// Represents a finally region within a method
+        /// </summary>
+        internal class FinallySubroutine<Label, Handler> : FaultFinallySubroutineBase<Label, Handler>
+        {
+            public FinallySubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                     SubroutineWithHandlersBuilder<Label, Handler> builder,
+                                     Label startLabel)
+              : base(methodCache, builder, startLabel)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+            }
+
+            public override string Kind
+            {
+                get { return "finally"; }
+            }
+        }
+
+        internal abstract class CallingContractSubroutine<Label> : SubroutineBase<Label>, IMethodInfo<Method>
+        {
+            private Method methodWithThisContract;
+            new protected SimpleSubroutineBuilder<Label> Builder;
+
+            public CallingContractSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                             Method method)
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
+
+
+                methodWithThisContract = method;
+            }
+
+            public CallingContractSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                             Method method,
+                                             SimpleSubroutineBuilder<Label> builder,
+                                             Label startLabel)
+              : base(methodCache, startLabel, builder)
+            {
+                Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+
+                this.Builder = builder;
+                methodWithThisContract = method;
+            }
+
+            #region IMethodInfo<Method> Members
+
+            public Method Method
+            {
+                get { return methodWithThisContract; }
+            }
+
+            #endregion
+
+            public override bool IsContract
+            {
+                get
+                {
+                    return true;
+                }
+            }
+        }
+
+        internal class RequiresSubroutine<Label> : CallingContractSubroutine<Label>, IEquatable<RequiresSubroutine<Label>>
+        {
+            public RequiresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                      Method method,
+                                      SimpleSubroutineBuilder<Label> builder, Label startLabel, IFunctionalSet<Subroutine> inherited)
+              : base(methodCache, method, builder, startLabel)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+                Contract.Requires(inherited != null);// F: As of Clousot suggestion
+                this.AddBaseRequires(this.GetTargetBlock(startLabel), inherited);
+            }
+
+            public override string Kind
+            {
+                get { return "requires"; }
+            }
+
+            internal override void Initialize()
+            {
+                if (Builder == null) return;
+
+                Builder.BuildBlocks(startLabel, this);
+                this.Commit();
+                Builder = null;
+            }
+
+            public RequiresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, Method method, IFunctionalSet<Subroutine> inherited)
+              : base(methodCache, method)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(inherited != null);// F: As of Clousot suggestion
+                this.AddSuccessor(this.Entry, "entry", this.Exit);
+                this.AddBaseRequires(this.Exit, inherited);
+                this.Commit(); // do it here, since we have no builder it won't get called later
+            }
+
+            /// <summary>
+            /// Add subroutine calls to
+            ///  - non-abstract virtual methods
+            ///  - abstract methods with HasRequires
+            /// </summary>
+            private void AddBaseRequires(CFGBlock targetOfEntry, IFunctionalSet<Subroutine> inherited)
+            {
+                Contract.Requires(inherited != null);// F: As of Clousot suggestion
+
+                foreach (Subroutine rs in inherited.Elements)
+                {
+                    this.AddEdgeSubroutine(this.Entry, targetOfEntry, rs, "inherited");
+                }
+            }
+
+            public override bool IsRequires
+            {
+                get { return true; }
+            }
+
+            public override bool IsContract
+            {
+                get { return true; }
+            }
+
+            public bool Equals(RequiresSubroutine<Label> that)
+            {
+                return this.Id == that.Id;
+            }
+        }
+
+        internal class SimpleSubroutine<Label> : SubroutineBase<Label>
+        {
+            public SimpleSubroutine(
+              int stackDelta,
+              MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+              Label startLabel,
+              SimpleSubroutineBuilder<Label> builder
+            )
+              : base(methodCache, startLabel, builder)
+            {
+                Contract.Requires(builder != null);// F: Added as of Clousot suggestion
+                Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
+
+                this.stackDelta = stackDelta;
+                builder.BuildBlocks(startLabel, this);
+
+                this.Commit();
+            }
+
+            private int stackDelta;
+
+            public override int StackDelta
+            {
+                get
+                {
+                    return stackDelta;
+                }
+            }
+
+            internal override void Initialize()
+            {
+            }
+
+            public override string Kind
+            {
+                get { return "simple"; }
+            }
+        }
+
+
+        internal class AssumeAsPostConditionSubroutine<Label> : SubroutineBase<Label>
+        {
+            public enum RetvalType { LocalRetval, ParameterRetval, FieldRetval };
+
+            public AssumeAsPostConditionSubroutine(
+              int stackDelta,
+              MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+              Local retvalLocal,
+              Parameter retvalParameter,
+              Field retvalField,
+              Label startLabel,
+              AssumeAsPostConditionSubroutineBuilder<Label> builder,
+              RetvalType retvalType
+            )
+                : base(methodCache, startLabel, builder)
+            {
+                Contract.Requires(builder != null);
+                Contract.Requires(methodCache != null);
+
+                this.stackDelta = stackDelta;
+                // if a local / param is assigned the return value of a function, we must put the symbolic var for return value into the appropriate local in order to compute the correct assume result
+                var assumeEntryBlk = base.NewAssumeAsPostConditionEntryBlock(retvalLocal, retvalParameter, retvalField, retvalType, "assumeAsPostEntry");
+                // HACK! had to change Entry to be mutable. This is probably bad, but is the only solution I could get to work. Will investigate alternatives later.
+                this.SetEntry(assumeEntryBlk);
+                var blk = builder.BuildBlocks(startLabel, assumeEntryBlk, this); // force decoding of assume
+                this.Commit();
+            }
+
+            private int stackDelta;
+
+            public override int StackDelta
+            {
+                get
+                {
+                    return stackDelta;
+                }
+            }
+
+            internal override void Initialize()
+            {
+            }
+
+            public override string Kind
+            {
+                get { return "assumeAsPost"; }
+            }
+
+            public override bool IsContract
+            {
+                get
+                {
+                    return true;
+                }
+            }
+        }
+
+        internal class OldValueSubroutine<Label> : CallingContractSubroutine<Label>
+        {
+            private BlockWithLabels<Label> beginOldBlock;
+            private BlockWithLabels<Label> endOldBlock;
+
+            public OldValueSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                      Method method,
+                                      SimpleSubroutineBuilder<Label> builder, Label startLabel)
+              : base(methodCache, method, builder, startLabel)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+            }
+
+            public override string Kind
+            {
+                get { return "old"; }
+            }
+
+            public override int StackDelta
+            {
+                get
+                {
+                    return 1;
+                }
+            }
+
+            public override bool IsOldValue
+            {
+                get { return true; }
+            }
+
+            internal override void Initialize()
+            {
+                // nothing to do. EnsuresSubroutine finalizes this subroutines.
+            }
+
+
+            internal void Commit(BlockWithLabels<Label> endOldBlock)
+            {
+                this.endOldBlock = endOldBlock;
+                this.Commit();
+            }
+
+            internal void RegisterBeginBlock(BlockWithLabels<Label> newBlock)
+            {
+                beginOldBlock = newBlock;
+            }
+
+            internal APC BeginOldAPC(SubroutineContext context)
+            {
+                return new APC(beginOldBlock, 0, context);
+            }
+
+            internal APC EndOldAPC(SubroutineContext context)
+            {
+                Contract.Assume(endOldBlock != null); // F: made an assumption
+                return new APC(endOldBlock, endOldBlock.Count - 1, context);
+            }
+        }
+
+        internal class EnsuresSubroutine<Label> : CallingContractSubroutine<Label>, IEquatable<EnsuresSubroutine<Label>>
+        {
+            /// <summary>
+            /// Requires call to Initialize eventually before use
+            /// </summary>
+            public EnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                     Method method,
+                                     SimpleSubroutineBuilder<Label> builder, Label startLabel, IFunctionalSet<Subroutine> inherited)
+              : base(methodCache, method, builder, startLabel)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+
+                CFGBlock startBlock = this.GetTargetBlock(startLabel);
+                this.AddBaseEnsures(this.Entry, startBlock, inherited);
+            }
+
+            public override string Kind
+            {
+                get { return "ensures"; }
+            }
+
+            internal override void Initialize()
+            {
+                if (Builder == null) return;
+
+                Builder.BuildBlocks(startLabel, this);
+
+                this.Commit();
+                Builder = null;
+            }
+
+            public EnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                    Method method,
+                                    IFunctionalSet<Subroutine> inherited)
+              : base(methodCache, method)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+
+                this.AddSuccessor(this.Entry, "entry", this.Exit);
+                this.AddBaseEnsures(this.Entry, this.Exit, inherited);
+                this.Commit();
+            }
+
+
+            internal override BlockWithLabels<Label> NewBlock()
+            {
+                return new EnsuresBlock<Label>(this, ref this.blockIdGenerator);
+            }
+
+            /// <summary>
+            /// Add subroutine calls to
+            ///  - non-abstract virtual methods
+            ///  - abstract methods with HasRequires
+            /// </summary>
+            private void AddBaseEnsures(CFGBlock fromBlock, CFGBlock toBlock, IFunctionalSet<Subroutine> inherited)
+            {
+                if (inherited == null) return;
+                foreach (Subroutine es in inherited.Elements)
+                {
+                    this.AddEdgeSubroutine(fromBlock, toBlock, es, "inherited");
+                }
+            }
+
+
+            /// <summary>
+            /// This map is used by inferred old regions to map (index lsh 16) + block_id to the corresponding 
+            /// block and type (for end old)
+            /// </summary>
+            private OnDemandMap<int, Pair<CFGBlock, Type>> inferredOldLabelReverseMap;
+
+            internal static int GetKey(EnsuresSubroutine<Label> rs)
+            {
+                Contract.Requires(rs != null);// F: As of Clousot suggestion
+                return rs.Id;
+            }
+
+            public override bool IsEnsures
+            {
+                get { return true; }
+            }
+
+            public override bool IsContract
+            {
+                get { return true; }
+            }
+
+            public bool Equals(EnsuresSubroutine<Label> that)
+            {
+                return this.Id == that.Id;
+            }
+
+            #region Committing
+
+            private enum ScanState { OutsideOld, InsideOld, InsertingOld, InsertingOldAfterCall }
+
+            /// <summary>
+            /// Fixes up sequences of ldarga ...  ... to wrap them with begin_old end_old
+            /// Visitor returns true if we are adding instructions to underlying block. Argument is original block index.
+            ///
+            /// We have to be very careful when the old sequence ends in a method call. If the method has arguments
+            /// other than the old address, then we can't evaluate the method call in the old scope, since we wouldn't find
+            /// all the arguments to it.
+            /// So we have to prematurely end the old scope at such method calls.
+            /// </summary>
+            private class CommitScanState : MSILVisitor<Label, Local, Parameter, Method, Field, Type, Unit, Unit, int, bool>,
+              ICodeQuery<Label, Local, Parameter, Method, Field, Type, int, bool>
+            {
+                private ScanState state;
+                private Type nextEndOldType;
+                private EnsuresBlock<Label> currentBlock;
+                private EnsuresSubroutine<Label> parent;
+
+                private OnDemandMap<CFGBlock, ScanState> blockStartState;
+
+                public CommitScanState(EnsuresSubroutine<Label> parent)
+                {
+                    this.parent = parent;
+                    state = ScanState.OutsideOld;
+                }
+
+                public void StartBlock(EnsuresBlock<Label> block)
+                {
+                    Contract.Requires(block != null);
+
+                    if (!blockStartState.TryGetValue(block, out state))
+                    {
+                        state = ScanState.OutsideOld; // default
+                        blockStartState.Add(block, state); // remember in case of bad control flow
+                    }
+                    if (state == ScanState.InsertingOld)
+                    {
+                        block.StartOverridingLabels();
+                    }
+                    if (state == ScanState.InsertingOldAfterCall)
+                    {
+                        // insert end old at head of block
+                        block.StartOverridingLabels();
+                        block.EndOldWithoutInstruction(nextEndOldType);
+                        state = ScanState.OutsideOld;
+                    }
+                    currentBlock = block;
+                }
+
+                public void SetStartState(CFGBlock succ)
+                {
+                    // Debug.Assert(this.state != ScanState.InsertingOld); // can't insert old spanning blocks.
+                    ScanState start;
+                    if (!blockStartState.TryGetValue(succ, out start))
+                    {
+                        blockStartState.Add(succ, state);
+                    }
+                    else
+                    {
+                        Contract.Assume(start == state); // F: made an assume
+                    }
+                }
+
+                #region Visitor
+                protected override bool Default(Label pc, int index)
+                {
+                    if (state == ScanState.InsertingOld)
+                    {
+                        // something's odd: need to end old scope here. Could be loading only the address of
+                        // a parameter and never dereferencing it, or passing it to a method among other parameters,
+                        // in which case, we can't do much (mix of old and new in a method use).
+
+                        // the end old type is actually a pointer
+                        state = ScanState.OutsideOld;
+                        var oldType = parent.MethodCache.AssumeNotNull().MetadataDecoder.ManagedPointer(nextEndOldType);
+                        currentBlock.EndOldWithoutInstruction(oldType);
+
+                        // still insert the current instruction (now after the end old)
+                        return true;
+                    }
+                    return currentBlock.UsesOverriding;
+                }
+
+                public bool Aggregate(Label pc, Label aggStart, bool branchTarget, int data)
+                {
+                    return this.Nop(pc, data);
+                }
+
+                public override bool Nop(Label pc, int data)
+                {
+                    return currentBlock.UsesOverriding;
+                }
+
+                public override bool BeginOld(Label pc, Label matchingEnd, int index)
+                {
+                    Contract.Assume(state == ScanState.OutsideOld);
+                    state = ScanState.InsideOld;
+                    return currentBlock.UsesOverriding;
+                }
+
+                public override bool EndOld(Label pc, Label matchingBegin, Type type, Unit dest, Unit source, int index)
+                {
+                    Contract.Assume(state == ScanState.InsideOld);
+                    state = ScanState.OutsideOld;
+                    return currentBlock.UsesOverriding;
+                }
+
+                public override bool Ldarga(Label pc, Parameter argument, bool dummyIsOld, Unit dest, int index)
+                {
+                    if (state == ScanState.OutsideOld)
+                    {
+                        state = ScanState.InsertingOld;
+                        currentBlock.BeginOld(index);
+                        nextEndOldType = parent.MethodCache.AssumeNotNull().MetadataDecoder.ParameterType(argument);
+                    }
+                    return currentBlock.UsesOverriding;
+                }
+
+                public override bool Ldind(Label pc, Type type, bool @volatile, Unit dest, Unit ptr, int index)
+                {
+                    if (state == ScanState.InsertingOld)
+                    {
+                        // ends the old scope
+                        state = ScanState.OutsideOld;
+                        currentBlock.EndOld(index, nextEndOldType);
+                        return false; // we already had to add this instruction before the end_old.
+                    }
+                    return currentBlock.UsesOverriding;
+                }
+
+                public override bool Ldfld(Label pc, Field field, bool @volatile, Unit dest, Unit obj, int index)
+                {
+                    if (state == ScanState.InsertingOld)
+                    {
+                        // ends the old scope
+                        state = ScanState.OutsideOld;
+                        currentBlock.EndOld(index, parent.MethodCache.AssumeNotNull().MetadataDecoder.FieldType(field));
+                        return false; // we already had to add this instruction before the end_old.
+                    }
+                    return currentBlock.UsesOverriding;
+                }
+
+                public override bool Ldflda(Label pc, Field field, Unit dest, Unit obj, int data)
+                {
+                    if (state == ScanState.InsertingOld)
+                    {
+                        // keep track of eventual type in old
+                        nextEndOldType = parent.MethodCache.AssumeNotNull().MetadataDecoder.FieldType(field);
+                    }
+                    return currentBlock.UsesOverriding;
+                }
+
+                /// <summary>
+                /// Ends sequence of inserted old. Call is on struct address passed by value, thus in the old state
+                /// Trickyness:
+                ///  - Because Call statements appear in their own block, and post-conditions of the call need to be
+                ///    evaluated also in the old state, we need to insert the EndOld statement in the next block
+                ///  - The CFG construction is making sure that there are no back-to-back call blocks in ensures.
+                /// </summary>
+                public override bool Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, int index)
+                {
+                    Contract.Assume(false, "we should not be decoding method call blocks");
+                    return false;
+                }
+                #endregion
+
+
+                /// <summary>
+                /// If we are inserting old, and this method has more than 1 parameter (including this), then
+                /// we are out of luck. We cannot evaluate it in the oldstate, as the other parameters were pushed in 
+                /// the new state.
+                /// </summary>
+                /// <param name="block"></param>
+                internal void HandlePotentialCallBlock(MethodCallBlock<Label> block, EnsuresBlock<Label> priorBlock)
+                {
+                    // We comment this preconditon has it always brings to a violation. We did not saw it before because runtimechecking was not enabled for the ControlFlow Project
+                    // Contract.Requires(priorBlock != null); 
+
+                    if (block == null) return;
+
+                    if (state == ScanState.InsertingOld)
+                    {
+                        // ends scope. Figure out if before call, or after call.
+                        var paramCount = parent.MethodCache.AssumeNotNull().MetadataDecoder.AssumeNotNull().Parameters(block.CalledMethod).AssumeNotNull().Count;
+                        if (!parent.MethodCache.AssumeNotNull().MetadataDecoder.AssumeNotNull().IsStatic(block.CalledMethod))
+                        {
+                            paramCount++;
+                        }
+                        Contract.Assert(parent.MethodCache != null);
+                        Contract.Assume(parent.MethodCache.MetadataDecoder != null);
+                        if (paramCount > 1)
+                        {
+                            if (priorBlock == null)
+                            {
+                                return; // F: nothing to do?
+                            }
+
+                            // end old in prior block (block before call block).
+                            state = ScanState.OutsideOld;
+
+                            // the end old type is actually a pointer
+                            var oldType = parent.MethodCache.MetadataDecoder.ManagedPointer(nextEndOldType);
+                            priorBlock.EndOldWithoutInstruction(oldType);
+                        }
+                        else
+                        {
+                            state = ScanState.InsertingOldAfterCall;
+                            nextEndOldType = parent.MethodCache.MetadataDecoder.ReturnType(block.CalledMethod);
+                        }
+                    }
+                }
+            }
+
+            [ContractVerification(false)] // We cannot prove the invariant this.BlockStart == null ==> this.Builder == null
+            internal override void Commit()
+            {
+                base.Commit();
+                var scan = new CommitScanState(this);
+
+                EnsuresBlock<Label> priorBlock = null;
+
+                foreach (var block in this.Blocks)
+                {
+                    // skip blocks that are not our special blocks.
+                    EnsuresBlock<Label> b = block as EnsuresBlock<Label>;
+                    if (b != null)
+                    {
+                        // save block in case next block is a call block. 
+                        // (we assume that block order is sequential for straight line code)
+                        priorBlock = b;
+                        // scan block, keeping track if we are in old, inserting old, or outside old
+                        // decode each instruction
+                        // if ldarg or ldarga and we are not in old, add a begin_old bubble and start inserting_old
+                        //   if inserting_old and current instruction is a memory deref (ldfld, ldind), add end_old after instruction 
+                        //   and state is now outside old
+                        // if reaching end of block while inserting old, insert an end_old (could be passing address by ref to a method)
+                        int originalCount = b.Count; // do this before scan.StartBlock
+                        scan.StartBlock(b);
+
+                        for (int i = 0; i < originalCount; i++)
+                        {
+                            bool addInstruction = b.OriginalForwardDecode<int, bool, CommitScanState>(i, scan, i);
+                            if (addInstruction)
+                            {
+                                b.AddInstruction(i);
+                            }
+                        }
+                    }
+                    else // might be a method call block
+                    {
+                        // Method call blocks end the old scope if we are in one
+                        scan.HandlePotentialCallBlock(block as MethodCallBlock<Label>, priorBlock);
+                    }
+                    foreach (var succ in this.SuccessorBlocks(block))
+                    {
+                        scan.SetStartState(succ);
+                    }
+                }
+            }
+            #endregion
+
+
+            internal void AddInferredOldMap(int blockIndex, int instructionIndex, CFGBlock otherBlock, Type endOldType)
+            {
+                inferredOldLabelReverseMap.Add(OverlayInstructionKey(blockIndex, instructionIndex), new Pair<CFGBlock, Type>(otherBlock, endOldType));
+            }
+
+            private static int OverlayInstructionKey(int blockIndex, int instruction)
+            {
+                var result = (instruction << 16) + blockIndex;
+                return result;
+            }
+
+            internal CFGBlock InferredBeginEndBijection(APC pc)
+            {
+                Type dummy;
+                return InferredBeginEndBijection(pc, out dummy);
+            }
+
+            internal CFGBlock InferredBeginEndBijection(APC pc, out Type endOldType)
+            {
+                Contract.Assume(pc.Block != null, "Assuming the object invariant");
+
+                var key = OverlayInstructionKey(pc.Block.Index, pc.Index);
+                Pair<CFGBlock, Type> data;
+                if (!inferredOldLabelReverseMap.TryGetValue(key, out data))
+                {
+                    throw new ApplicationException("Fatal bug in ensures CFG begin/end old map");
+                }
+                endOldType = data.Two;
+                return data.One;
+            }
+        }
+
+        internal class ModelEnsuresSubroutine<Label> : EnsuresSubroutine<Label>
+        {
+            public ModelEnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                          Method method,
+                                          SimpleSubroutineBuilder<Label> builder, Label startLabel, IFunctionalSet<Subroutine> inherited)
+              : base(methodCache, method, builder, startLabel, inherited)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+            }
+
+            public ModelEnsuresSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache, Method method, IFunctionalSet<Subroutine> inherited)
+              : base(methodCache, method, inherited)
+            {
+                Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+            }
+
+            public override bool IsModelEnsures
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public override string Kind
+            {
+                get { return "model-ensures"; }
+            }
+        }
+
+        internal class InvariantSubroutine<Label> : SubroutineBase<Label>, ITypeInfo<Type>
+        {
+            private new SimpleSubroutineBuilder<Label> Builder;
+            private Type associatedType;
+
+            public InvariantSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+                                       SimpleSubroutineBuilder<Label> builder, Label startLabel,
+                                       Subroutine baseInv, Type associatedType
+            )
+              : base(methodCache, startLabel, builder)
+            {
+                Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
+                Contract.Requires(builder != null);// F: As of Clousot suggestion
+
+                Builder = builder;
+                this.associatedType = associatedType;
+                CFGBlock startBlock = this.GetTargetBlock(startLabel);
+                this.AddBaseInvariant(this.Entry, startBlock, baseInv);
+            }
+
+            public InvariantSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+              Subroutine inherited, Type associatedType)
+              : base(methodCache)
+            {
+                Contract.Requires(methodCache != null);// F: Added as of Clousot suggestion
+
+                this.AddSuccessor(this.Entry, "entry", this.Exit);
+                this.AddBaseInvariant(this.Entry, this.Exit, inherited);
+                this.Commit(); // do it here, since we have no builder it won't get called later
+            }
+
+            public override string Kind
+            {
+                get { return "invariant"; }
+            }
+
+            internal override void Initialize()
+            {
+                if (Builder == null) return;
+
+                Builder.BuildBlocks(startLabel, this);
+                this.Commit();
+                Builder = null;
+            }
+
+            /// <summary>
+            /// Add subroutine calls to base invariant if non-null
+            /// </summary>
+            private void AddBaseInvariant(CFGBlock fromBlock, CFGBlock toBlock, Subroutine inherited)
+            {
+                this.AddEdgeSubroutine(fromBlock, toBlock, inherited, "inherited");
+            }
+
+            public override bool IsInvariant
+            {
+                get { return true; }
+            }
+            public override bool IsContract
+            {
+                get { return true; }
+            }
+
+            #region ITypeInfo<Type> Members
+
+            Type ITypeInfo<Type>.AssociatedType
+            {
+                get { return associatedType; }
+            }
+
+            #endregion
+        }
+
+        #endregion // ------------- Nested Types --------------------
+
+        /// <summary>
+        /// Try to add a requires to a method. If the method inherits a requires, then this is not possible.
+        /// </summary>
+        /// <param name="identifying">Identifiying string (e.g. of pre-condition). Used to eliminate dups</param>
+        /// <returns>true if added or already present</returns>
+        public bool AddPreCondition<Label>(Method method, Label precondition, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
+        {
+            // TODO: figure out whether we already analyzed a caller to this method. In that case, we can't strengthen the pre-condition.
+
+            var original = GetRequires(method);
+
+            if (original != null)
+            {
+                IMethodInfo<Method> mi = original as IMethodInfo<Method>;
+                if (mi != null && !this.MetadataDecoder.Equal(mi.Method, method))
+                {
+                    // inherited, can't add
+                    return false;
+                }
+            }
+
+            var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, precondition);
+
+            var newPre = new RequiresSubroutine<Label>(this, method, builder, precondition, FunctionalSet<Subroutine>.Empty());
+            newPre.Initialize(); // not going through cache and lazy initialized
+            if (original == null)
+            {
+                requiresCache.Install(method, newPre);
+                return true;
+            }
+            else
+            {
+                foreach (var pred in original.PredecessorBlocks(original.Exit))
+                {
+                    original.AddEdgeSubroutine(pred, original.Exit, newPre, "extra");
+                }
+                return true;
+            }
+        }
+
+        public bool RemovePreCondition(Method method)
+        {
+            return requiresCache.Remove(method);
+        }
+
+        public bool AddPostCondition<Label>(Method method, Label postCondition, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
+        {
+            var original = GetEnsures(method);
+            var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, postCondition);
+            var newPost = new EnsuresSubroutine<Label>(this, method, builder, postCondition, FunctionalSet<Subroutine>.Empty());
+            newPost.Initialize();
+
+            if (original == null)
+            {
+                ensuresCache.Install(method, newPost);
+                return true;
+            }
+            else
+            {
+                foreach (var pred in original.PredecessorBlocks(original.Exit))
+                {
+                    original.AddEdgeSubroutine(pred, original.Exit, newPost, "extra");
+                }
+                return true;
+            }
+        }
+
+
+
+        public bool AddWitness(Method method, bool mayReturnNull)
+        {
+            methodWitnesses[method] = mayReturnNull;
+
+            return true; // Always succeed in this easy case
+        }
+
+        /// <summary>
+        /// At the moment, we only say if a method may return null. TODO: expand to witnesses
+        /// </summary>
+        public bool GetWitnessForMayReturnNull(Method method)
+        {
+            bool mayReturnNull;
+            return methodWitnesses.TryGetValue(method, out mayReturnNull) && mayReturnNull;
+        }
+
+        public bool AddEntryAssume<Label>(ICFG cfg, Method caller, Label assume, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
+        {
+            Contract.Requires(cfg != null);
+
+            if (cfg.Subroutine.Blocks == null)
+            {
+                // Should not happen?
+                return false;
+            }
+
+            bool installed = false;
+
+            var from = cfg.Entry.Block.AssumeNotNull();
+            var next = cfg.EntryAfterRequires.Block;
+
+            var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, assume);
+            var assumeSub = new RequiresSubroutine<Label>(this, caller, builder, assume, FunctionalSet<Subroutine>.Empty());
+            assumeSub.Initialize();
+            assumeSub.IsNecessaryAssumption = true;
+            // install assume
+            from.Subroutine.AddEdgeSubroutine(from, next, assumeSub, "entry");
+            installed = true;
+            return installed;
+        }
+
+        public bool AddCalleeAssumeAsPostCondition<Label>(ICFG cfg, Method caller, Method callee, Label assume, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
+        {
+            Contract.Requires(cfg != null);
+
+            if (cfg.Subroutine.Blocks == null)
+            {
+                // Should not happen?
+                return false;
+            }
+
+            // (1) find the method that the assume is a postcondition of
+            // (2) validate that the context is ok (vars reference in assume exist, are initialized, e.t.c) TODO
+            // (3) install the assume 
+            bool installed = false;
+            // TODO: perform deeper traversal in case a subroutine contains our call of interest?
+            foreach (var from in cfg.Subroutine.Blocks)
+            {
+                Method methodCall;
+                bool constructor, virtualCall;
+                if (from.IsMethodCallBlock(out methodCall, out constructor, out virtualCall))
+                {
+                    if (methodCall.Equals(callee)) // found method we were looking for
+                    {
+                        CFGBlock next = null;
+                        // Hyp: there should be only one successor block, the ensures block
+                        foreach (var cand in from.Subroutine.SuccessorBlocks(from)) // should be single successor here
+                        {
+                            next = cand;
+                            break;
+                        }
+                        if (next == null) continue; // make sure we found *some* successor of the call; otherwise don't try to install
+
+                        var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, assume);
+                        var assumeSub = new EnsuresSubroutine<Label>(this, callee, builder, assume, null);
+                        assumeSub.Initialize();
+                        assumeSub.IsNecessaryAssumption = true;
+#if false
+                        var builder = new AssumeAsPostConditionSubroutineBuilder<Label>(codeProvider, this, assume);
+
+                        // find return value of the function (for now, we only infer assumes for method postconditions, so it should exist...)
+                        // TODO: use Contract.Result when we generate the code fix. 
+                        var retvalFinder = new ReturnValueFinderVisitor<Local, Parameter, Method, Field, Property, Event, Type, UnitSource, UnitDest, APC, APC, APC, Unit>();
+                        this.DecodeForReturnValue<APC, Unit, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, APC, Unit>>(next.First, retvalFinder.Visitor(), next.First);
+
+
+                        // By now, we case split to see which kinds of variable the result value is. In the future, with Contract.Result (as above) we will not need it
+                        AssumeAsPostConditionSubroutine<Label> assumeSub;
+                        Local retvalLocal = default(Local);
+                        Parameter retvalParam = default(Parameter);
+                        Field retvalField = default(Field);
+                        if (retvalFinder.GetLocalReturnValue(out retvalLocal))
+                        {
+                            assumeSub = new AssumeAsPostConditionSubroutine<Label>(0, this, retvalLocal, retvalParam, retvalField, assume, builder, AssumeAsPostConditionSubroutine<Label>.RetvalType.LocalRetval);
+                        }
+                        else if (retvalFinder.GetParameterReturnValue(out retvalParam))
+                        {
+                            assumeSub = new AssumeAsPostConditionSubroutine<Label>(0, this, retvalLocal, retvalParam, retvalField, assume, builder, AssumeAsPostConditionSubroutine<Label>.RetvalType.ParameterRetval);
+                        }
+                        // Field case commented out, as it does not work for now
+                        //else if (retvalFinder.GetFieldReturnValue(out retvalField)) assumeSub = new AssumeAsPostConditionSubroutine<Label>(0, this, retvalLocal, retvalParam, retvalField, assume, builder, AssumeAsPostConditionSubroutine<Label>.RetvalType.FieldRetval);
+                        else
+                        {
+                            return false; // abort install if we can't find return value
+                        }
+#endif
+                        // install assume
+                        from.Subroutine.AddEdgeSubroutine(from, next, assumeSub, "afterCallAssume");
+                        installed = true;
+                    }
+                }
+            }
+            return installed;
+        }
+
+        public bool AddInvariant<Label>(Type type, Label invariant, ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider)
+        {
+            var original = GetInvariant(type);
+
+            if (original != null)
+            {
+                ITypeInfo<Type> ti = original as ITypeInfo<Type>;
+                if (ti != null && !this.MetadataDecoder.Equal(ti.AssociatedType, type))
+                {
+                    // inherited, can't add
+                    return false;
+                }
+            }
+
+            var builder = new SimpleSubroutineBuilder<Label>(codeProvider, this, invariant);
+
+            var newInvariant = new InvariantSubroutine<Label>(this, builder, invariant, original, type);
+            newInvariant.Initialize();
+
+            if (original == null)
+            {
+                invariantCache.Install(type, newInvariant);
+                return true;
+            }
+            else
+            {
+                foreach (var pred in original.PredecessorBlocks(original.Exit))
+                {
+                    original.AddEdgeSubroutine(pred, original.Exit, newInvariant, "extra");
+                }
+                return true;
+            }
+        }
+
+
+        internal Subroutine BuildSubroutine<Label>(
+          int stackDelta,
+          ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider,
+          Label entryPoint)
+        {
+            var sb = new SimpleSubroutineBuilder<Label>(codeProvider, this, entryPoint);
+            return new SimpleSubroutine<Label>(stackDelta, this, entryPoint, sb);
+        }
+
+        private static readonly IEnumerable<Field> emptyFields = new Field[0];
+        private static readonly IEnumerable<Method> emptyMethods = new Method[0];
+
+        /// <summary>
+        /// We assume that we only call this on methods under analysis (never on methods from other assemblies)
+        /// </summary>
+        internal IEnumerable<Field> GetModifies(Method method)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
+
+            // make sure we computed the modifies info
+            if (this.MetadataDecoder.HasBody(method))
+            {
+                this.GetCFG(method);
+
+                Set<Field> result;
+                if (methodModifies.TryGetValue(method, out result))
+                {
+                    Contract.Assume(result != null);
+                    return result;
+                }
+            }
+            return emptyFields;
+        }
+
+        /// <summary>
+        /// We assume that we only call this on methods under analysis (never on methods from other assemblies)
+        /// </summary>
+        internal IEnumerable<Field> GetReads(Method method)
+        {
+            // make sure we computed the modifies info
+            if (this.MetadataDecoder.HasBody(method))
+            {
+                this.GetCFG(method);
+
+                Set<Field> result;
+                if (methodReads.TryGetValue(method, out result))
+                {
+                    return result;
+                }
+            }
+            return emptyFields;
+        }
+
+        /// <summary>
+        /// We assume that we only call this on fields of types under analysis (never on fields from other assemblies)
+        /// </summary>
+        internal IEnumerable<Method> GetAffectedGetters(Field field)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+
+            // we can't really ensure that we computed this set for all methods in the type
+            Set<Method> result;
+            if (propertyReads.TryGetValue(field, out result))
+            {
+                Contract.Assume(result != null);
+                return result;
+            }
+
+            return emptyMethods;
+        }
+        private Set<Field> ModifiesSet(Method method)
+        {
+            Contract.Ensures(Contract.Result<Set<Field>>() != null);
+
+            Set<Field> result;
+            if (!methodModifies.TryGetValue(method, out result))
+            {
+                result = new Set<Field>();
+                methodModifies.Add(method, result);
+            }
+            Contract.Assume(result != null);
+            return result;
+        }
+
+        private Set<Field> ReadSet(Method method)
+        {
+            Contract.Ensures(Contract.Result<Set<Field>>() != null);
+            Set<Field> result;
+            if (!methodReads.TryGetValue(method, out result))
+            {
+                result = new Set<Field>();
+                methodReads.Add(method, result);
+            }
+            Contract.Assume(result != null);
+            return result;
+        }
+
+        private Set<Method> PropertySet(Field field)
+        {
+            Contract.Ensures(Contract.Result<Set<Method>>() != null);
+
+            Set<Method> result;
+            if (!propertyReads.TryGetValue(field, out result))
+            {
+                result = new Set<Method>();
+                propertyReads.Add(field, result);
+            }
+            Contract.Assume(result != null);
+            return result;
+        }
+
+
+        internal void AddModifies(Method method, Field field)
+        {
+            ModifiesSet(method).Add(field);
+        }
+
+        public bool IsMonitorWaitOrExit(Method method)
+        {
+            var t = this.MetadataDecoder.DeclaringType(method);
+            if (this.MetadataDecoder.Name(t) != "Monitor") return false;
+            var name = this.MetadataDecoder.Name(method);
+            if (name == "Exit" || name == "Wait") return true;
+            return false;
+        }
+
+        internal void AddReads(Method method, Field field)
+        {
+            this.ReadSet(method).Add(field);
+            this.PropertySet(field).Add(method);
+        }
+
+        public void RemoveContractsFor(Method method)
+        {
+            if (methodCache.ContainsKey(method))
+            {
+                methodCache.Remove(method);
+            }
+            if (methodModifies.ContainsKey(method))
+            {
+                methodModifies.Remove(method);
+            }
+            if (methodReads.ContainsKey(method))
+            {
+                methodReads.Remove(method);
+            }
+            requiresCache.Remove(method);
+            ensuresCache.Remove(method);
+            modelEnsuresCache.Remove(method);
+        }
+    }
+
+
+    public class ControlFlow<Method, Type> : ICFG
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(contextCache != null);
+            Contract.Invariant(consCache != null);
+            Contract.Invariant(methodSubroutine != null); // F: because of many precondition suggestions, made it an object invariant
+        }
+
+
+        #region Private
+
+        private readonly Subroutine methodSubroutine;
+        private readonly object methodCache;
+
+        private CFGBlock entry { get { return methodSubroutine.Entry; } }
+        private CFGBlock normalExit { get { return methodSubroutine.Exit; } }
+        private CFGBlock exceptionExit { get { return methodSubroutine.ExceptionExit; } }
+
+
+        #endregion
+
+        /// <summary>
+        /// The control flow class provides an overlay of logical control flow over a syntactic
+        /// code structure by making control flow explicit, including block entry/exit, and 
+        /// finally block execution.
+        /// </summary>
+        /// <param name="start">Entry point for method</param>
+        //^ [NotDelayed]
+        internal ControlFlow(Subroutine subroutine, object methodCache)
+        {
+            Contract.Requires(subroutine != null); // F: As suggested by Clousot
+
+            methodSubroutine = subroutine;
+            consCache = contextCache.Cons;
+            this.methodCache = methodCache;
+        }
+
+
+        #region ICFG<Code,Label,Handler,APC> Members
+
+        public Method CFGMethod
+        {
+            get
+            {
+                IMethodInfo<Method> mi = methodSubroutine as IMethodInfo<Method>;
+                if (mi != null) return mi.Method;
+                throw new Exception("CFG has bad subroutine that is not a method");
+            }
+        }
+        public APC Entry
+        {
+            get { return new APC(this.entry, 0, null); }
+        }
+
+        public APC EntryAfterRequires
+        {
+            get { return new APC(methodSubroutine.EntryAfterRequires, 0, null); }
+        }
+
+        public APC NormalExit
+        {
+            get { return new APC(this.normalExit, 0, null); }
+        }
+
+        public APC ExceptionExit
+        {
+            get { return new APC(methodSubroutine.ExceptionExit, 0, null); }
+        }
+
+        public APC Post(APC pc)
+        {
+            APC succ;
+            if (this.HasSingleSuccessor(pc, out succ))
+            {
+                return succ;
+            }
+            return pc;
+        }
+
+        public bool HasSingleSuccessor(APC ppoint, out APC next)
+        {
+            return ppoint.Block.Subroutine.HasSingleSuccessor(ppoint, out next, consCache);
+        }
+
+        public bool HasSinglePredecessor(APC ppoint, out APC next, bool skipContracts)
+        {
+            return ppoint.Block.Subroutine.HasSinglePredecessor(ppoint, out next, consCache, skipContracts);
+        }
+
+        public APC PredecessorPCPriorToRequires(APC ppoint)
+        {
+            return ppoint.Block.Subroutine.PredecessorPCPriorToRequires(ppoint, consCache);
+        }
+
+        /// <summary>
+        /// Returns all normal control flow successors
+        /// </summary>
+        public IEnumerable<APC>/*!*/ Successors(APC ppoint)
+        {
+            return ppoint.Block.Subroutine.Successors(ppoint, consCache);
+        }
+
+
+        public IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts)
+        {
+            return ppoint.Block.Subroutine.Predecessors(ppoint, consCache, skipContracts);
+        }
+
+        public FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
+        {
+            return from.Subroutine.GetOrdinaryEdgeSubroutines(from, to, context);
+        }
+
+
+        /// <summary>
+        /// Used to hash cons subroutine context edge lists
+        /// </summary>
+        private readonly SubroutineContextCache contextCache = new SubroutineContextCache();
+        private readonly DConsCache consCache;
+
+        private class SubroutineContextCache
+        {
+            private DoubleTable<SubroutineEdge, SubroutineContext, SubroutineContext> subroutineContextHashMap = new DoubleTable<STuple<CFGBlock, CFGBlock, string>, FList<STuple<CFGBlock, CFGBlock, string>>, FList<STuple<CFGBlock, CFGBlock, string>>>();
+            private Dictionary<SubroutineEdge, SubroutineContext> subroutineContextHashMapSingleton = new Dictionary<STuple<CFGBlock, CFGBlock, string>, FList<STuple<CFGBlock, CFGBlock, string>>>();
+
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(subroutineContextHashMap != null);
+                Contract.Invariant(subroutineContextHashMapSingleton != null);
+            }
+
+            public SubroutineContext Cons(SubroutineEdge edge, SubroutineContext tail)
+            {
+                SubroutineContext/*?*/ result;
+                if (tail != null)
+                {
+                    Debug.Assert(tail.Head.One.Subroutine != edge.One.Subroutine);
+                    if (!subroutineContextHashMap.TryGetValue(edge, tail, out result))
+                    {
+                        result = SubroutineContext.Cons(edge, tail);
+                        subroutineContextHashMap.Add(edge, tail, result);
+                    }
+                }
+                else
+                {
+                    if (!subroutineContextHashMapSingleton.TryGetValue(edge, out result))
+                    {
+                        result = SubroutineContext.Cons(edge, null);
+                        subroutineContextHashMapSingleton[edge] = result;
+                    }
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Returns a set of program points that are possible execution continuations if 
+        /// an exception is raised at the given ppoint.
+        ///
+        /// The supplied predicate allows the client to determine which handlers are possible
+        /// candidates. The predicate is called from closest enclosing to outermost.
+        /// </summary>
+        /// <param name="data">Arbitrary client data passed to the handler predicate</param>
+        /// <returns>A set of continuation program points that represent how execution continues to a chosen handler.
+        /// The continuation includes Finally and Fault executions that intervene between the given ppoint and a
+        /// chosen handler.
+        /// </returns>
+        public IEnumerable<APC> ExceptionHandlers<Type2, Data>(APC ppoint, Data data, IHandlerFilter<Type2, Data> handlerPredicate)
+        {
+            // This is a cross-subroutine operation. We need to ask for the handlers guarding the current block,
+            // followed by the handlers guarding the source of each edge on the subroutine stack.
+
+            // Ask the innermost subroutine for its handler continuations
+            bool escapesFromSubroutine = false;
+            foreach (CFGBlock handlerBlock in ppoint.Block.Subroutine.ExceptionHandlers(ppoint.Block, null, data, handlerPredicate))
+            {
+                if (handlerBlock != ppoint.Block.Subroutine.ExceptionExit)
+                {
+                    yield return ppoint.Block.Subroutine.ComputeTargetFinallyContext(ppoint, handlerBlock, consCache);
+                }
+                else
+                {
+                    escapesFromSubroutine = true;
+                }
+            }
+
+            if (!escapesFromSubroutine)
+            {
+                yield break; // no more outer handlers needed
+            }
+
+
+            // Now find handlers in surrounding subroutines, from inner to outer.
+            //
+            SubroutineContext outerContext = ppoint.SubroutineContext;
+            FList<Pair<string, CFGBlock>> innerAbortingContext = null;
+            APC innermostAbortingAPC = ppoint.Block.Subroutine.ComputeTargetFinallyContext(ppoint.WithoutContext, ppoint.Block.Subroutine.ExceptionExit, consCache);
+            SubroutineContext innerMostReversedContext = SubroutineContext.Reverse(innermostAbortingAPC.SubroutineContext);
+            Subroutine innerSubroutine = ppoint.Block.Subroutine;
+            while (outerContext != null)
+            {
+                escapesFromSubroutine = false;
+
+                CFGBlock from = outerContext.Head.One;
+                foreach (CFGBlock handlerBlock in from.Subroutine.ExceptionHandlers(from, innerSubroutine, data, handlerPredicate))
+                {
+                    if (handlerBlock == from.Subroutine.ExceptionExit)
+                    {
+                        escapesFromSubroutine = true;
+                    }
+                    else
+                    {
+                        yield return this.ComputeExceptionTarget(innermostAbortingAPC.Block, innermostAbortingAPC.Index, innerMostReversedContext,
+                                                  innerAbortingContext,
+                                                  consCache(new SubroutineEdge(from, handlerBlock, "exception"), outerContext.Tail),
+                                                  consCache);
+                    }
+                }
+                if (!escapesFromSubroutine)
+                {
+                    yield break; // no more outer handlers needed
+                }
+                innerAbortingContext = FList<Pair<string, CFGBlock>>.Cons(new Pair<string, CFGBlock>(outerContext.Head.Three, from), innerAbortingContext);
+                outerContext = outerContext.Tail;
+            }
+            // if we get here, we are throwing out of the outermost context
+            yield return this.ComputeExceptionTarget(innermostAbortingAPC.Block, innermostAbortingAPC.Index, innerMostReversedContext,
+                                      innerAbortingContext,
+                                      null,
+                                      consCache);
+        }
+
+        /// <summary>
+        /// Computes new APC corresponding to a concatenation of exectuion from the current abortPoint (and its subroutine execution, provided in reversed from as innerMostReversedContext)
+        /// with the innerAbortingContext and the outerAbortingContext.
+        /// The innerAbortingContext is a set of blocks from outer to inner surrounding the abort point.
+        /// The resulting APC starts with the abort point and the innermost context (in proper order), followed by (x,exit_x) edges for all points in the innerAbortingContext (from inner to outer)
+        /// This entire context is pre-pended to the outer subroutine context.
+        /// </summary>
+        private APC ComputeExceptionTarget(CFGBlock abortPoint, int abortIndex,
+                                           SubroutineContext innerMostReversedContext,
+                                           FList<Pair<string, CFGBlock>> innerAbortingContext,
+                                           SubroutineContext outerSubroutineContext,
+                                           DConsCache consCache)
+        {
+            while (innerAbortingContext != null)
+            {
+                outerSubroutineContext = this.consCache(new SubroutineEdge(innerAbortingContext.Head.Two, innerAbortingContext.Head.Two.Subroutine.ExceptionExit, innerAbortingContext.Head.One), outerSubroutineContext);
+                innerAbortingContext = innerAbortingContext.Tail;
+            }
+            while (innerMostReversedContext != null)
+            {
+                outerSubroutineContext = this.consCache(innerMostReversedContext.Head, outerSubroutineContext);
+                innerMostReversedContext = innerMostReversedContext.Tail;
+            }
+            return new APC(abortPoint, abortIndex, outerSubroutineContext);
+        }
+
+
+
+        public void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ blockInfoPrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context)
+        {
+            var printed = new Set<Pair<Subroutine, SubroutineContext>>();
+            methodSubroutine.Print(tw, ilPrinter, blockInfoPrinter, contextLookup, context, printed);
+        }
+
+#if false
+        public void EmitTransferEquations(TextWriter tw, InvariantQuery<APC> invariantDB, AssumptionFinder<APC> assumptionfinder,
+          CrossBlockRenamings<APC> renamings, RenamedVariables<APC> renamed)
+        {
+            methodSubroutine.EmitTransferEquations(tw, invariantDB, assumptionfinder, renamings, renamed);
+        }
+#endif
+
+        private string FormatSourceContext(string doc, int line, int col)
+        {
+            return String.Format("{0}({1},{2})", doc, line, col);
+        }
+
+
+        public Subroutine Subroutine { get { return methodSubroutine; } }
+
+        public bool IsJoinPoint(CFGBlock block)
+        {
+            Contract.Requires(block != null);// F: Added as of Clousot suggestion
+
+            return block.Subroutine.IsJoinPoint(block);
+        }
+
+        public bool IsJoinPoint(APC ppoint)
+        {
+            if (ppoint.Index != 0) return false;
+            return IsJoinPoint(ppoint.Block);
+        }
+
+        public bool IsSplitPoint(CFGBlock block)
+        {
+            Contract.Requires(block != null);// F: Added as of Clousot suggestion
+            return block.Subroutine.IsSplitPoint(block);
+        }
+
+        public bool IsSplitPoint(APC ppoint)
+        {
+            if (ppoint.Index != ppoint.Block.Count) return false;
+
+            return IsSplitPoint(ppoint.Block);
+        }
+
+        public bool IsForwardBackEdgeTarget(APC ppoint)
+        {
+            CFGBlock block = ppoint.Block;
+            if (ppoint.Index != 0) return false; // not at beginning.
+            return ppoint.Block.Subroutine.EdgeInfo.DepthFirstInfo(block).TargetOfBackEdge;
+        }
+
+        public bool IsForwardBackEdgeTarget(CFGBlock block)
+        {
+            Contract.Requires(block != null); // F: Added as of Clousot suggestion
+            return block.Subroutine.EdgeInfo.DepthFirstInfo(block).TargetOfBackEdge;
+        }
+
+        public bool IsBackwardBackEdgeTarget(APC ppoint)
+        {
+            CFGBlock block = ppoint.Block;
+            if (ppoint.Index != block.Count) return false; // not at end.
+            return ppoint.Block.Subroutine.EdgeInfo.DepthFirstInfo(block).SourceOfBackEdge;
+        }
+
+        public bool IsForwardBackEdge(APC from, APC to)
+        {
+            if (to.Index != 0) return false;
+            return IsForwardBackEdgeHelper(from, to);
+        }
+
+        public bool IsBackwardBackEdge(APC from, APC to)
+        {
+            if (from.Index != 0) return false;
+            return IsBackwardBackEdgeHelper(from, to);
+        }
+
+        private bool IsForwardBackEdgeHelper(APC from, APC to)
+        {
+            Contract.Assume(to.Block != null, "assuming the object invariant");
+            Contract.Assume(from.Block != null, "assuming the object invariant");
+            if (to.Block.Subroutine.EdgeInfo.IsBackEdge(from.Block, Unit.Value, to.Block)) return true;
+
+            // in case of an end finally we consult the original edge
+            // If this is an endfinally, there must be at least one label
+            if (from.SubroutineContext != null && from.SubroutineContext.Tail == to.SubroutineContext)
+            {
+                // it was a pop
+                SubroutineEdge edge = from.SubroutineContext.Head;
+                return edge.Two.Subroutine.EdgeInfo.IsBackEdge(edge.One, Unit.Value, edge.Two);
+            }
+            return false;
+        }
+
+        private bool IsBackwardBackEdgeHelper(APC from, APC to)
+        {
+            // use symmetry
+            Contract.Assume(from.Block != null); // F: made an assumption
+
+            if (from.Block.Subroutine.EdgeInfo.IsBackEdge(to.Block, Unit.Value, from.Block)) return true;
+
+            // in case of an end finally we consult the original edge
+            // If this is an endfinally, there must be at least one label
+            if (to.SubroutineContext != null && to.SubroutineContext.Tail == from.SubroutineContext)
+            {
+                // it was a pop
+                SubroutineEdge reversedEdge = to.SubroutineContext.Head;
+                // ask reversed question
+                return reversedEdge.One.Subroutine.EdgeInfo.IsBackEdge(reversedEdge.Two, Unit.Value, reversedEdge.One);
+            }
+            return false;
+        }
+
+
+        public bool IsBlockStart(APC ppoint)
+        {
+            return (ppoint.Index == 0);
+        }
+
+        public bool IsBlockEnd(APC ppoint)
+        {
+            return (ppoint.Index == ppoint.Block.Count);
         }
 
         #endregion
-      }
 
-#endif
 
-    public Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
-      where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result>
-    {
-      return methodCache.ForwardDecode<Data, Result, RemoveBranchDelegator<Data, Result, Visitor>>(pc, new RemoveBranchDelegator<Data, Result, Visitor>(visitor, this.mdDecoder), data);
-    }
+        #region IGraph of APCs (forward only)
+
+        public IGraph<APC, Unit> AsForwardGraph(bool includeExceptionEdges)
+        {
+            var forwardGraphCache = new GraphWrapper<APC, Unit>(
+                      new APC[0], // we don't provide the set of all apcs
+                      (pc) => SuccessorEdges(pc, includeExceptionEdges));
+            return forwardGraphCache;
+        }
+
+        private IEnumerable<Pair<Unit, APC>> SuccessorEdges(APC pc, bool includeExceptionEdges)
+        {
+            var normalized = pc.LastInBlock();
+            foreach (APC succ in this.Successors(normalized))
+            {
+                yield return new Pair<Unit, APC>(Unit.Value, succ);
+            }
+            if (!includeExceptionEdges) yield break;
+
+            foreach (APC succ in this.ExceptionHandlers<Type, int>(pc, 0, null))
+            {
+                yield return new Pair<Unit, APC>(Unit.Value, succ);
+            }
+        }
+
+
+        public IGraph<APC, Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
+        {
+            if (includeExceptionEdges) throw new NotSupportedException();
+
+            var backwardGraph = new GraphWrapper<APC, Unit>(
+                new APC[0], // we don't provide the set of all apcs
+                (pc) => PredecessorEdges(pc, includeExceptionEdges, skipContracts));
+
+            return backwardGraph;
+        }
+
+        private IEnumerable<Pair<Unit, APC>> PredecessorEdges(APC pc, bool includeExceptionEdges, bool skipContracts)
+        {
+            var normalized = pc.FirstInBlock();
+            foreach (APC pred in this.Predecessors(normalized, skipContracts))
+            {
+                yield return new Pair<Unit, APC>(Unit.Value, pred.FirstInBlock());
+            }
+
+            // TOOD: support backwards exception edges.
+        }
+
+        #endregion
+
+
+        #region ICFG<Label,Handler,APC> Members
+
+        public IDecodeMSIL<APC, Local, Parameter, Method2, Field, Type2, Unit, Unit, IMethodContext<Field, Method2>, Unit>
+          GetDecoder<Local, Parameter, Method2, Field, Property, Event, Type2, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method2, Field, Property, Event, Type2, Attribute, Assembly> mdDecoder)
+        {
+            var mcache = methodCache as MethodCache<Local, Parameter, Type2, Method2, Field, Property, Event, Attribute, Assembly>;
+            return new APCDecoder<Local, Parameter, Method2, Field, Property, Event, Type2, Attribute, Assembly>(
+                       (ControlFlow<Method2, Type2>)(object)this,
+                       mdDecoder,
+                       mcache);
+        }
+
+
 #if false
-      public Transformer<APC, Data, Result> CacheForwardDecoder<Data, Result>(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result> visitor)
-      {
-        // can't cache further down, as we depend on the pc
-        return delegate(APC lab, Data data) { return this.ForwardDecode<Data, Result, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result>>(lab, visitor, data); };
-      }
+        public IDecodeMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest>
+        GetDecoder<Local, Parameter, Method2, Field, Type, Source, Dest>(
+          IDecodeMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying)
+        {
+            return new AssumeDecoder<Local, Parameter, Method2, Field, Type, Source, Dest>(this, underlying);
+        }
+
+        public ITransformer<APC, Local, Parameter, Method2, Field, Type, Source, Dest>
+        GetTransformer<Local, Parameter, Method2, Field, Type, Source, Dest>(
+          ITransformer<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying)
+        {
+            return new AssumeTransformer<Local, Parameter, Method2, Field, Type, Source, Dest>(this, underlying);
+        }
+
+        private class AssumeDecoder<Local, Parameter, Method2, Field, Type, Source, Dest> :
+          IDecodeMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest>
+        {
+            ControlFlow<Method, Label, Handler> parent;
+            IDecodeMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying;
+
+            public AssumeDecoder(
+              ControlFlow<Method, Label, Handler> parent,
+              IDecodeMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying
+            )
+            {
+                this.parent = parent;
+                this.underlying = underlying;
+            }
+
+
+            #region IDecodeMSIL<AbstractPC,Local,Parameter,Method,Field,Type,Source,Dest> Members
+
+            private class NoBranchDelegator<Data, Result> :
+              MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, APC, Source, Dest, Data>
+            {
+
+                protected override Data Convert(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    return data.One;
+                }
+                protected override Dest ConvertDest(Label pc, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Dest dest)
+                {
+                    return dest;
+                }
+                protected override IIndexable<Source> Convert(Label pc, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IIndexable<Source> sources)
+                {
+                    return sources;
+                }
+                protected override Source ConvertSource(Label pc, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Source source)
+                {
+                    return source;
+                }
+                protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    return data.Two;
+                }
+                protected override APC ConvertLabel(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Label label)
+                {
+                    throw new Exception("Should not get here");
+                }
+                protected override IEnumerable<APC> Convert(Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IEnumerable<Label> label)
+                {
+                    throw new Exception("Should not get here");
+                }
+                public NoBranchDelegator()
+                {
+                }
+
+                public override Result Branch(Label pc, Label target, bool leave, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    // branches are no-ops in the CFG IL
+                    return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
+                }
+
+                public override Result BranchCond(Label pc, Label target, Source cond, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    // branches are no-ops in the CFG IL
+                    return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
+                }
+
+                public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    // branches are no-ops in the CFG IL
+                    return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
+                }
+            }
+
+            private class AssumeDelegator<Data, Result> :
+              MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Pair<Tag, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, APC, Source, Dest, Data>
+            {
+
+                #region Overrides
+                protected override Data Convert(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    return data.One.Two;
+                }
+
+                protected override Source ConvertSource(Label pc, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Source source)
+                {
+                    return source;
+                }
+
+                protected override Dest ConvertDest(Label pc, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Dest dest)
+                {
+                    return dest;
+                }
+
+                protected override IIndexable<Source> Convert(Label pc, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IIndexable<Source> sources)
+                {
+                    return sources;
+                }
+
+                protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    return data.Two;
+                }
+
+                protected override APC ConvertLabel(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, Label label)
+                {
+                    throw new NotImplementedException("Should not be called");
+                }
+
+                protected override IEnumerable<APC> Convert(Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data, IEnumerable<Label> label)
+                {
+                    throw new NotImplementedException("Should not be called");
+                }
+
+                public override Result Branch(Label pc, Label target, bool leave, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    // unconditional branch has no assume, thus is a nop
+                    return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
+                }
+
+                public override Result BranchCond(Label pc, Label target, Source cond, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    return Delegatee(data).Assume(ConvertLabel(data, pc), data.One.One, cond, Convert(data));
+                }
+
+                public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> data)
+                {
+                    return Delegatee(data).Assume(ConvertLabel(data, pc), data.One.One, value, Convert(data));
+                }
+
+                #endregion
+            }
+
+            public ILDecoder<APC, Data, Result, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>> GetDecoder<Data, Result>()
+            {
+                ILDecoder<Label, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, IVisitMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result>> decoder1 = underlying.GetDecoder<Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result>();
+                ILDecoder<Label, Pair<Pair<Tag, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result, IVisitMSIL<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Pair<Tag, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result>> decoder2 = underlying.GetDecoder<Pair<Pair<Tag, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>, Result>();
+
+                NoBranchDelegator<Data, Result> delegator = new NoBranchDelegator<Data, Result>();
+                AssumeDelegator<Data, Result> assumeDelegator = new AssumeDelegator<Data, Result>();
+
+                return delegate (APC pc, Data data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> visitor)
+                {
+                    Label/*?*/ lab;
+                    if (parent.UnderlyingLabel(pc, out lab))
+                    {
+                        return decoder1(lab, new Pair<Data, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>(data, visitor), delegator);
+                    }
+                    AssumeBlock/*?*/ ab = pc.Block as AssumeBlock;
+                    if (ab != null)
+                    {
+                        return decoder2(ab.Label, new Pair<Pair<string, Data>, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result>>(new Pair<Tag, Data>(ab.Tag, data), visitor), assumeDelegator);
+                    }
+                    return visitor.Nop(pc, data);
+                };
+            }
+
+            #endregion
+        }
+
+        class AssumeTransformer<Local, Parameter, Method2, Field, Type, Source, Dest> : ITransformer<APC, Local, Parameter, Method2, Field, Type, Source, Dest>
+        {
+            ControlFlow<Method, Label, Handler> parent;
+            ITransformer<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying;
+
+            public AssumeTransformer(
+              ControlFlow<Method, Label, Handler> parent,
+              ITransformer<Label, Local, Parameter, Method2, Field, Type, Source, Dest> underlying
+            )
+            {
+                this.parent = parent;
+                this.underlying = underlying;
+            }
+
+
+            #region ITransformer<APC,Local,Parameter,Method2,Field,Type,Source,Dest> Members
+
+            private class NoBranchDelegator<Data, Result> :
+              MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<APC, Data>, Result, APC, Source, Dest, Data>
+            {
+                // We need to funnel the original apc through, although the underlying decoder will call us with a label only.
+                // Thus, we pass the original APC in the data part and take it out in the label converter.
+                // We just need to check that the underlying label actually agrees.
+
+                IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee;
+
+                public NoBranchDelegator(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee)
+                {
+                    this.delegatee = delegatee;
+                }
+
+                protected override Data Convert(Pair<APC, Data> data)
+                {
+                    return data.Two;
+                }
+                protected override Dest ConvertDest(Label pc, Pair<APC, Data> data, Dest dest)
+                {
+                    return dest;
+                }
+                protected override IIndexable<Source> Convert(Label pc, Pair<APC, Data> data, IIndexable<Source> sources)
+                {
+                    return sources;
+                }
+                protected override Source ConvertSource(Label pc, Pair<APC, Data> data, Source source)
+                {
+                    return source;
+                }
+                protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<APC, Data> data)
+                {
+                    return delegatee;
+                }
+                protected override APC ConvertLabel(Pair<APC, Data> data, Label label)
+                {
+                    // check that the underlying label in the data part is indeed the current label
+                    Label/*?*/ underlying;
+                    if (data.One.UnderlyingLabel(out underlying))
+                    {
+                        if (underlying.Equals(label))
+                        {
+                            return data.One;
+                        }
+                    }
+                    throw new Exception("Should not get here");
+                }
+                protected override IEnumerable<APC> Convert(Pair<APC, Data> data, IEnumerable<Label> label)
+                {
+                    throw new Exception("Should not get here");
+                }
+
+
+                public override Result Branch(Label pc, Label target, bool leave, Pair<APC, Data> data)
+                {
+                    // branches are no-ops in the CFG IL
+                    return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
+                }
+
+                public override Result BranchCond(Label pc, Label target, Source cond, Pair<APC, Data> data)
+                {
+                    // branches are no-ops in the CFG IL
+                    return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
+                }
+
+                public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<APC, Data> data)
+                {
+                    // branches are no-ops in the CFG IL
+                    return Delegatee(data).Nop(ConvertLabel(data, pc), Convert(data));
+                }
+            }
+
+            /// <summary>
+            /// We need to funnel the original APC through with the data as well as the assume label.
+            /// </summary>
+            private class AssumeDelegator<Data, Result> :
+              MSILVisitDelegator<Label, Local, Parameter, Method2, Field, Type, Source, Dest, Pair<Pair<APC, Tag>, Data>, Result, APC, Source, Dest, Data>
+            {
+                IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee;
+
+                public AssumeDelegator(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> delegatee)
+                {
+                    this.delegatee = delegatee;
+                }
+
+                #region Overrides
+                protected override Data Convert(Pair<Pair<APC, Tag>, Data> data)
+                {
+                    return data.Two;
+                }
+
+                protected override Source ConvertSource(Label pc, Pair<Pair<APC, Tag>, Data> data, Source source)
+                {
+                    return source;
+                }
+
+                protected override Dest ConvertDest(Label pc, Pair<Pair<APC, Tag>, Data> data, Dest dest)
+                {
+                    return dest;
+                }
+
+                protected override IIndexable<Source> Convert(Label pc, Pair<Pair<APC, Tag>, Data> data, IIndexable<Source> sources)
+                {
+                    return sources;
+                }
+
+                protected override IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> Delegatee(Pair<Pair<APC, Tag>, Data> data)
+                {
+                    return delegatee;
+                }
+
+                protected override APC ConvertLabel(Pair<Pair<APC, Tag>, Data> data, Label label)
+                {
+                    // check that the underlying label in the data part is indeed the current label
+                    Label/*?*/ underlying;
+                    if (data.One.One.UnderlyingLabel(out underlying))
+                    {
+                        if (underlying.Equals(label))
+                        {
+                            return data.One.One;
+                        }
+                    }
+                    throw new NotImplementedException("Should not be called");
+                }
+
+                protected override IEnumerable<APC> Convert(Pair<Pair<APC, Tag>, Data> data, IEnumerable<Label> label)
+                {
+                    throw new NotImplementedException("Should not be called");
+                }
+
+                public override Result Branch(Label pc, Label target, bool leave, Pair<Pair<APC, Tag>, Data> data)
+                {
+                    // unconditional branch has no assume, thus is a nop
+
+                    // NOTE: pick the apc out of the data part, as we are decoding the branch that gave rise to the Assume,
+                    // but the assume is at a different apc.
+                    return Delegatee(data).Nop(data.One.One, Convert(data));
+                }
+
+                public override Result BranchCond(Label pc, Label target, Source cond, Pair<Pair<APC, Tag>, Data> data)
+                {
+                    // NOTE: pick the apc out of the data part, as we are decoding the branch that gave rise to the Assume,
+                    // but the assume is at a different apc.
+                    return Delegatee(data).Assume(data.One.One, data.One.Two, cond, Convert(data));
+                }
+
+                public override Result Switch(Label pc, IEnumerable<Label> cases, Source value, Pair<Pair<APC, Tag>, Data> data)
+                {
+                    // NOTE: pick the apc out of the data part, as we are decoding the branch that gave rise to the Assume,
+                    // but the assume is at a different apc.
+                    return Delegatee(data).Assume(data.One.One, data.One.Two, value, Convert(data));
+                }
+
+                #endregion
+            }
+
+            public Transformer<APC, Data, Result> GetTransformer<Data, Result>(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, Source, Dest, Data, Result> visitor)
+            {
+#if SPECSHARP
+                NoBranchDelegator<Data, Result> noBranchDelegator = null; // new NoBranchDelegator<Data, Result>(visitor);
+                AssumeDelegator<Data, Result> assumeDelegator = null; // new AssumeDelegator<Data, Result>(visitor);
+
+                Transformer<Label, Pair<APC, Data>, Result> decoder1 = null; // underlying.GetTransformer(noBranchDelegator);
+                Transformer<Label, Pair<Pair<APC, Tag>, Data>, Result> decoder2 = null; // underlying.GetTransformer(assumeDelegator);
+#else
+                NoBranchDelegator<Data, Result> noBranchDelegator = new NoBranchDelegator<Data, Result>(visitor);
+                AssumeDelegator<Data, Result> assumeDelegator = new AssumeDelegator<Data, Result>(visitor);
+
+                Transformer<Label, Pair<APC, Data>, Result> decoder1 = underlying.GetTransformer(noBranchDelegator);
+                Transformer<Label, Pair<Pair<APC, Tag>, Data>, Result> decoder2 = underlying.GetTransformer(assumeDelegator);
 #endif
 
-    public IMethodContext<Field, Method> Context
-    {
-      get { return this; }
-    }
+                return delegate (APC pc, Data data)
+                {
+                    Label/*?*/ lab;
+                    if (parent.UnderlyingLabel(pc, out lab))
+                    {
+                        return decoder1(lab, new Pair<APC, Data>(pc, data));
+                    }
+                    AssumeBlock/*?*/ ab = pc.Block as AssumeBlock;
+                    if (ab != null)
+                    {
+                        return decoder2(ab.Label, new Pair<Pair<APC, Tag>, Data>(new Pair<APC, Tag>(pc, ab.Tag), data));
+                    }
+                    return visitor.Nop(pc, data);
+                };
+            }
 
-    public bool IsUnreachable(APC pc) { return false; }
-
-    #endregion
-
-    #region IMethodContext<Method> Members
-    public IMethodContextData<Field, Method> MethodContext { get { return this; } }
-    #endregion
-
-    #region IMethodContextData<Method> Members
-
-    public Method CurrentMethod
-    {
-      get { return this.parent.CFGMethod; }
-    }
-
-    public ICFG CFG { get { return this.parent; } }
-
-    public string SourceContext(APC pc)
-    {
-      return pc.PrimarySourceContext();
-    }
-
-    public string SourceDocument(APC pc)
-    {
-      return pc.Block.SourceDocument(pc);
-    }
-
-    public int SourceStartLine(APC pc)
-    {
-      return pc.Block.SourceStartLine(pc);
-    }
-
-    public int SourceEndLine(APC pc)
-    {
-      return pc.Block.SourceEndLine(pc);
-    }
-
-    public int SourceStartColumn(APC pc)
-    {
-      return pc.Block.SourceStartColumn(pc);
-    }
-
-    public int SourceEndColumn(APC pc)
-    {
-      return pc.Block.SourceEndColumn(pc);
-    }
-
-    public IEnumerable<Field> Modifies(Method method)
-    {
-      method = this.mdDecoder.Unspecialized(method);
-      return this.methodCache.GetModifies(method);
-    }
-
-    public IEnumerable<Method> AffectedGetters(Field field)
-    {
-      field = this.mdDecoder.Unspecialized(field);
-      return this.methodCache.GetAffectedGetters(field);
-    }
-
-    #endregion
-
-    #region IDecodeMSIL<APC,Local,Parameter,Method,Field,Type,UnitDest,UnitDest,IMethodContext<Field,Method>,Unit> Members
-
-
-    public UnitDest EdgeData(APC from, APC to)
-    {
-      return Unit.Value;
-    }
-
-    public void Display(TextWriter tw, string prefix, Unit data) { }
-
-    #endregion
-  }
-
-
-  /// <summary>
-  /// Represents edges as just an array ordered by the index of the cfg block where the edge starts.
-  /// </summary>
-  internal class EdgeMap<Tag> : IEnumerable<Pair<CFGBlock,Pair<Tag, CFGBlock>>>, IGraph<CFGBlock, Tag>
-  {
-    List<Pair<CFGBlock, Pair<Tag,CFGBlock>>> edges;
-
-    [ContractInvariantMethod]
-    void ObjectInvariant()
-    {
-      Contract.Invariant(edges != null);
-    }
-
-    public EdgeMap(List<Pair<CFGBlock, Pair<Tag, CFGBlock>>> edges) {
-      Contract.Requires(edges != null);
-
-      this.edges = edges;
-      edges.Sort(CompareFirstBlockIndex);
-      CheckSort();
-    }
-    private void CheckSort() {
-      int lastSeen = 0;
-      for (int i = 0; i < edges.Count; i++) {
-        Contract.Assume(edges[i].One != null);
-        int currentIndex = edges[i].One.Index;
-        Contract.Assume(currentIndex >= lastSeen);
-        lastSeen = currentIndex;
-      }
-    }
-    private static int CompareFirstBlockIndex(Pair<CFGBlock, Pair<Tag, CFGBlock>> e1, Pair<CFGBlock, Pair<Tag, CFGBlock>> e2) {
-      if (e1.One.Index == e2.One.Index) {
-        return e1.Two.Two.Index - e2.Two.Two.Index;
-      }
-      return e1.One.Index - e2.One.Index;
-    }
-
-    private struct Successors : ICollection<Pair<Tag,CFGBlock>>
-    {
-      EdgeMap<Tag> underlying;
-      int startIndex;
-
-      public Successors(EdgeMap<Tag> underlying, int startIndex) {
-        Contract.Requires(startIndex >= 0);
-        Contract.Requires(underlying != null);// F: As of Clousot suggestion
-        Contract.Assume(underlying.edges != null, "Assuming the object invariant for underlying");
-
-        this.underlying = underlying;
-        this.startIndex = startIndex;
-      }
-
-      [ContractInvariantMethod]
-      void ObjectInvariant()
-      {
-        Contract.Invariant(startIndex >= 0);
-        Contract.Invariant(underlying.edges != null);
-      }
-
-      #region ICollection<Pair<Tag,CFGBlock>> Members
-
-      public void Add(Pair<Tag,CFGBlock> item) {
-        throw new Exception("The method or operation is not implemented.");
-      }
-
-      public void Clear() {
-        throw new Exception("The method or operation is not implemented.");
-      }
-
-      //^ [Confined]
-      public bool Contains(Pair<Tag,CFGBlock> item) {
-        throw new Exception("The method or operation is not implemented.");
-      }
-
-      public void CopyTo(Pair<Tag,CFGBlock>[] array, int arrayIndex) {
-        throw new Exception("The method or operation is not implemented.");
-      }
-
-      public int Count {
-        [ContractVerification(false)]
-        get {
-          int edgeIndex = startIndex;
-          if (edgeIndex < underlying.edges.Count) {
-            // count equal first
-            int blockIndex = underlying.edges[edgeIndex].One.Index;
-            int count = 0;
-            do {
-              count++;
-              edgeIndex++;
-            } while (edgeIndex < underlying.edges.Count && underlying.edges[edgeIndex].One.Index == blockIndex);
-            return count;
-          }
-          return 0;
+            #endregion
         }
-      }
+#endif
 
-      public bool IsReadOnly {
-        get { return true; }
-      }
+        #endregion
 
-      public bool Remove(Pair<Tag,CFGBlock> item) {
-        throw new Exception("The method or operation is not implemented.");
-      }
+        #region ICFG<Type,APC> Members
 
-      #endregion
 
-      #region IEnumerable<Pair<Tag,CFGBlock>> Members
-
-      //^ [Pure]
-      public IEnumerator<Pair<Tag,CFGBlock>> GetEnumerator() {
-        if (startIndex >= underlying.edges.Count) { yield break; }
-        int edgeIndex = startIndex;
-        int blockIndex = underlying.edges[edgeIndex].One.Index;
-        do {
-          yield return underlying.edges[edgeIndex].Two;
-          edgeIndex++;
+        public string ToString(APC pc)
+        {
+            return pc.ToString();
         }
-        while (edgeIndex < underlying.edges.Count && underlying.edges[edgeIndex].One.Index == blockIndex);
-      }
 
-      #endregion
-
-      #region IEnumerable Members
-
-      //^ [Pure]
-      System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-        throw new Exception("The method or operation is not implemented.");
-      }
-
-      #endregion
-    }
-
-    public ICollection<Pair<Tag,CFGBlock>> this[CFGBlock from] {
-      get {
-        return new Successors(this, FindStartIndex(from));
-      }
-    }
-
-    [ContractVerification(false)]
-    private int FindStartIndex(CFGBlock from) {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      Contract.Ensures(Contract.Result<int>() <= this.edges.Count);
-
-      // binary search
-      int lo = 0;
-      int hi = edges.Count;
-      while (lo < hi) {
-        Contract.Assert(lo >= 0);
-        Contract.Assert(hi <= edges.Count);
-        int mid = lo + (hi - lo) / 2;
-        Contract.Assume(mid < edges.Count, "why can't we prove this");
-
-        Contract.Assume(edges[mid].One != null);
-        int indexAtMid = edges[mid].One.Index;
-        if (indexAtMid == from.Index) {
-          // now find beginning of sequence
-          while (mid > 0 && edges[mid - 1].One.Index == indexAtMid) {
-            mid--;
-          }
-          return mid;
+        public IEnumerable<CFGBlock> LoopHeads
+        {
+            get
+            {
+                foreach (var sub in this.Subroutine.SubroutineTree())
+                {
+                    foreach (var block in sub.Blocks)
+                    {
+                        if (this.IsForwardBackEdgeTarget(block)) yield return block;
+                    }
+                }
+            }
         }
-        if (indexAtMid < from.Index) {
-          lo = mid + 1;
-          continue;
-        }
-        Debug.Assert(indexAtMid > from.Index);
-        hi = mid;
-      }
-      // if we fall out, we didn't find any. Return index past last
-      return edges.Count;
-    }
-
-
-    public EdgeMap<Tag> ReversedEdges() {
-      List<Pair<CFGBlock, Pair<Tag,CFGBlock>>> reversed = new List<Pair<CFGBlock, Pair<Tag, CFGBlock>>>(edges.Count);
-
-      foreach (Pair<CFGBlock, Pair<Tag, CFGBlock>> edge in edges) {
-        reversed.Add(new Pair<CFGBlock, Pair<Tag,CFGBlock>>(edge.Two.Two, new Pair<Tag,CFGBlock>(edge.Two.One, edge.One)));
-      }
-      return new EdgeMap<Tag>(reversed);
-    }
-
-    public void ReSort() {
-      edges.Sort(CompareFirstBlockIndex);
+        #endregion
     }
 
     /// <summary>
-    /// Removes the unwanted edges
+    /// We know that Source and Dest are Unit
     /// </summary>
-    public void Filter(Predicate<Pair<CFGBlock, Pair<Tag, CFGBlock>>> keep) {
-      Contract.Requires(keep != null);
-  
-      // must separately build a list of indices to remove, as we can't change the list while traversing it or we'll skip
-      // elements
-      FList<int> toRemove = null;
-      for (int i = 0; i < edges.Count; i++) {
-        if (!keep(edges[i])) {
-          toRemove = FList<int>.Cons(i, toRemove);
+    internal class APCDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> :
+      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, IMethodContext<Field, Method>, Unit>,
+      IMethodContext<Field, Method>, IMethodContextData<Field, Method>
+    {
+        private ControlFlow<Method, Type> parent;
+        private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+        private MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache;
+
+        public APCDecoder(
+          ControlFlow<Method, Type> parent,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache
+        )
+        {
+            this.parent = parent;
+            this.mdDecoder = mdDecoder;
+            this.methodCache = methodCache;
         }
-      }
-      toRemove.Apply(delegate(int i) { edges.RemoveAt(i); });
+
+
+        #region IMSILDecoder<APC,Local,Parameter,Method,Field,Type,Source,Dest> Members
+
+        /// <summary>
+        /// * Removes unconditional branches and branch true, branch false.
+        /// * Turns binary conditional branches into their condition evaluation
+        /// * Computes proper polarity of assume/assert based on tag and context
+        /// * Turns Object.ReferenceEquals into binary Ceq
+        /// </summary>
+        private struct RemoveBranchDelegator<Data, Result, Visitor> :
+          IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result>
+          where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result>
+        {
+            private Visitor visitor;
+            private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(mdDecoder != null);
+            }
+
+            public RemoveBranchDelegator(
+              Visitor visitor,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+            )
+            {
+                Contract.Requires(mdDecoder != null);
+
+                this.visitor = visitor;
+                this.mdDecoder = mdDecoder;
+            }
+
+            /// <summary>
+            /// If original block is a method contract block, then invert assume/assert
+            /// </summary>
+            public Result Assume(APC pc, string tag, UnitSource source, object provenance, Data data)
+            {
+                if ((tag == "requires" && pc.InsideRequiresAtCall) || (tag == "invariant" && pc.InsideInvariantOnExit))
+                {
+                    return visitor.Assert(pc, tag, source, provenance, data);
+                }
+                if (tag == "assume" && pc.InsideRequiresAtCall)
+                {
+                    // extra clousot extractor assume false in legacy requires. At call-site, need to null it out.
+                    return visitor.Pop(pc, source, data);
+                }
+                return visitor.Assume(pc, tag, source, provenance, data);
+            }
+
+
+            /// <summary>
+            /// If original block is a method contract block, then invert assume/assert
+            /// </summary>
+            public Result Assert(APC pc, string tag, UnitSource source, object provenance, Data data)
+            {
+                if (pc.InsideEnsuresAtCall)
+                {
+                    return visitor.Assume(pc, tag, source, provenance, data);
+                }
+                return visitor.Assert(pc, tag, source, provenance, data);
+            }
+
+            public Result Arglist(APC pc, UnitDest dest, Data data)
+            {
+                return visitor.Arglist(pc, dest, data);
+            }
+
+            public Result Binary(APC pc, BinaryOperator op, UnitDest dest, UnitSource s1, UnitSource s2, Data data)
+            {
+                return visitor.Binary(pc, op, dest, s1, s2, data);
+            }
+
+            public Result BranchCond(APC pc, APC target, BranchOperator bop, UnitSource value1, UnitSource value2, Data data)
+            {
+                UnitDest dest = UnitDest.Value;
+                switch (bop)
+                {
+                    case BranchOperator.Beq:
+                        // equal to Ceq followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Ceq, dest, value1, value2, data);
+
+                    case BranchOperator.Bge:
+                        // equal to Cge followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Cge, dest, value1, value2, data);
+
+                    case BranchOperator.Bge_un:
+                        // equal to Cge_un followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Cge_Un, dest, value1, value2, data);
+
+                    case BranchOperator.Bgt:
+                        // equal to Cgt followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Cgt, dest, value1, value2, data);
+
+                    case BranchOperator.Bgt_un:
+                        // equal to Cgt_un followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Cgt_Un, dest, value1, value2, data);
+
+                    case BranchOperator.Ble:
+                        // equal to Cle followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Cle, dest, value1, value2, data);
+
+                    case BranchOperator.Ble_un:
+                        // equal to Cle_un followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Cle_Un, dest, value1, value2, data);
+
+                    case BranchOperator.Blt:
+                        // equal to Clt followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Clt, dest, value1, value2, data);
+
+                    case BranchOperator.Blt_un:
+                        // equal to Clt_un followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Clt_Un, dest, value1, value2, data);
+
+                    case BranchOperator.Bne_un:
+                        // equal to Cne_un followed by br.true
+                        return visitor.Binary(pc, BinaryOperator.Cne_Un, dest, value1, value2, data);
+                }
+                return visitor.Nop(pc, data);
+            }
+
+            public Result BranchTrue(APC pc, APC target, UnitSource cond, Data data)
+            {
+                return visitor.Nop(pc, data);
+            }
+
+            public Result BranchFalse(APC pc, APC target, UnitSource cond, Data data)
+            {
+                return visitor.Nop(pc, data);
+            }
+
+            public Result Branch(APC pc, APC target, bool leave, Data data)
+            {
+                return visitor.Nop(pc, data);
+            }
+
+            public Result Break(APC pc, Data data)
+            {
+                return visitor.Break(pc, data);
+            }
+
+            public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<UnitSource>
+            {
+                Type declaringType = mdDecoder.DeclaringType(method);
+                if (
+                    mdDecoder.IsStatic(method))
+                {
+                    if (args.Count == 2 && mdDecoder.Equal(declaringType, mdDecoder.System_Object) &&
+                        mdDecoder.Name(method) == "ReferenceEquals"
+                        )
+                    {
+                        // special case equal here
+                        return visitor.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
+                    }
+                    // special case Decimal methods to operators
+                    if (mdDecoder.Equal(declaringType, mdDecoder.System_Decimal))
+                    {
+                        switch (mdDecoder.Name(method))
+                        {
+                            case "op_Addition":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Add, dest, args[0], args[1], data);
+
+                            case "op_Division":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Div, dest, args[0], args[1], data);
+
+                            case "op_Equality":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
+
+                            case "op_GreaterThan":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Cgt, dest, args[0], args[1], data);
+
+                            case "op_GreaterThanOrEqual":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Cge, dest, args[0], args[1], data);
+
+                            case "op_Inequality":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Cne_Un, dest, args[0], args[1], data);
+
+                            case "op_LessThan":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Clt, dest, args[0], args[1], data);
+
+                            case "op_LessThanOrEqual":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Cle, dest, args[0], args[1], data);
+
+                            case "op_Modulus":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Rem, dest, args[0], args[1], data);
+
+                            case "op_Multiply":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Mul, dest, args[0], args[1], data);
+
+                            case "op_Subtraction":
+                                Contract.Assume(args.Count >= 2);
+                                return visitor.Binary(pc, BinaryOperator.Sub, dest, args[0], args[1], data);
+
+                            case "op_UnaryNegation":
+                                Contract.Assume(args.Count >= 1);
+                                return visitor.Unary(pc, UnaryOperator.Neg, false, false, dest, args[0], data);
+
+                            default:
+                                break;
+                        }
+                    }
+                }
+                return visitor.Call(pc, method, tail, virt, extraVarargs, dest, args, data);
+            }
+
+            public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, UnitDest dest, UnitSource fp, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<UnitSource>
+            {
+                return visitor.Calli(pc, returnType, argTypes, tail, isInstance, dest, fp, args, data);
+            }
+
+            public Result Ckfinite(APC pc, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Ckfinite(pc, dest, source, data);
+            }
+
+            public Result Cpblk(APC pc, bool @volatile, UnitSource destaddr, UnitSource srcaddr, UnitSource len, Data data)
+            {
+                return visitor.Cpblk(pc, @volatile, destaddr, srcaddr, len, data);
+            }
+
+            public Result Endfilter(APC pc, UnitSource decision, Data data)
+            {
+                return visitor.Endfilter(pc, decision, data);
+            }
+
+            public Result Endfinally(APC pc, Data data)
+            {
+                return visitor.Endfinally(pc, data);
+            }
+
+            public Result Entry(APC pc, Method method, Data data)
+            {
+                return visitor.Entry(pc, method, data);
+            }
+
+            public Result Initblk(APC pc, bool @volatile, UnitSource destaddr, UnitSource value, UnitSource len, Data data)
+            {
+                return visitor.Initblk(pc, @volatile, destaddr, value, len, data);
+            }
+
+            public Result Jmp(APC pc, Method method, Data data)
+            {
+                return visitor.Jmp(pc, method, data);
+            }
+
+            public Result Ldarg(APC pc, Parameter argument, bool isOld, UnitDest dest, Data data)
+            {
+                return visitor.Ldarg(pc, argument, isOld, dest, data);
+            }
+
+            public Result Ldarga(APC pc, Parameter argument, bool isOld, UnitDest dest, Data data)
+            {
+                return visitor.Ldarga(pc, argument, isOld, dest, data);
+            }
+
+            public Result Ldconst(APC pc, object constant, Type type, UnitDest dest, Data data)
+            {
+                return visitor.Ldconst(pc, constant, type, dest, data);
+            }
+
+            public Result Ldnull(APC pc, UnitDest dest, Data data)
+            {
+                return visitor.Ldnull(pc, dest, data);
+            }
+
+            public Result Ldftn(APC pc, Method method, UnitDest dest, Data data)
+            {
+                return visitor.Ldftn(pc, method, dest, data);
+            }
+
+            public Result Ldind(APC pc, Type type, bool @volatile, UnitDest dest, UnitSource ptr, Data data)
+            {
+                return visitor.Ldind(pc, type, @volatile, dest, ptr, data);
+            }
+
+            public Result Ldloc(APC pc, Local local, UnitDest dest, Data data)
+            {
+                return visitor.Ldloc(pc, local, dest, data);
+            }
+
+            public Result Ldloca(APC pc, Local local, UnitDest dest, Data data)
+            {
+                return visitor.Ldloca(pc, local, dest, data);
+            }
+
+            public Result Ldstack(APC pc, int offset, UnitDest dest, UnitSource source, bool isOld, Data data)
+            {
+                return visitor.Ldstack(pc, offset, dest, source, isOld, data);
+            }
+
+            public Result Ldstacka(APC pc, int offset, UnitDest dest, UnitSource source, Type type, bool isOld, Data data)
+            {
+                return visitor.Ldstacka(pc, offset, dest, source, type, isOld, data);
+            }
+
+            public Result Localloc(APC pc, UnitDest dest, UnitSource size, Data data)
+            {
+                return visitor.Localloc(pc, dest, size, data);
+            }
+
+            public Result Nop(APC pc, Data data)
+            {
+                return visitor.Nop(pc, data);
+            }
+
+            public Result Pop(APC pc, UnitSource source, Data data)
+            {
+                return visitor.Pop(pc, source, data);
+            }
+
+            public Result Return(APC pc, UnitSource source, Data data)
+            {
+                return visitor.Return(pc, source, data);
+            }
+
+            public Result Starg(APC pc, Parameter argument, UnitSource source, Data data)
+            {
+                return visitor.Starg(pc, argument, source, data);
+            }
+
+            public Result Stind(APC pc, Type type, bool @volatile, UnitSource ptr, UnitSource value, Data data)
+            {
+                return visitor.Stind(pc, type, @volatile, ptr, value, data);
+            }
+
+            public Result Stloc(APC pc, Local local, UnitSource source, Data data)
+            {
+                return visitor.Stloc(pc, local, source, data);
+            }
+
+            public Result Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, UnitSource value, Data data)
+            {
+                return visitor.Nop(pc, data);
+            }
+
+            public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Unary(pc, op, overflow, unsigned, dest, source, data);
+            }
+
+            public Result Box(APC pc, Type type, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Box(pc, type, dest, source, data);
+            }
+
+            public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<UnitSource>
+            {
+                return visitor.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, dest, args, data);
+            }
+
+            public Result Castclass(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Castclass(pc, type, dest, obj, data);
+            }
+
+            public Result Cpobj(APC pc, Type type, UnitSource destptr, UnitSource srcptr, Data data)
+            {
+                return visitor.Cpobj(pc, type, destptr, srcptr, data);
+            }
+
+            public Result Initobj(APC pc, Type type, UnitSource ptr, Data data)
+            {
+                return visitor.Initobj(pc, type, ptr, data);
+            }
+
+            public Result Isinst(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Isinst(pc, type, dest, obj, data);
+            }
+
+            public Result Ldelem(APC pc, Type type, UnitDest dest, UnitSource array, UnitSource index, Data data)
+            {
+                return visitor.Ldelem(pc, type, dest, array, index, data);
+            }
+
+            public Result Ldelema(APC pc, Type type, bool @readonly, UnitDest dest, UnitSource array, UnitSource index, Data data)
+            {
+                return visitor.Ldelema(pc, type, @readonly, dest, array, index, data);
+            }
+
+            public Result Ldfld(APC pc, Field field, bool @volatile, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Ldfld(pc, field, @volatile, dest, obj, data);
+            }
+
+            public Result Ldflda(APC pc, Field field, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Ldflda(pc, field, dest, obj, data);
+            }
+
+            public Result Ldlen(APC pc, UnitDest dest, UnitSource array, Data data)
+            {
+                return visitor.Ldlen(pc, dest, array, data);
+            }
+
+            public Result Ldsfld(APC pc, Field field, bool @volatile, UnitDest dest, Data data)
+            {
+                return visitor.Ldsfld(pc, field, @volatile, dest, data);
+            }
+
+            public Result Ldsflda(APC pc, Field field, UnitDest dest, Data data)
+            {
+                return visitor.Ldsflda(pc, field, dest, data);
+            }
+
+            public Result Ldtypetoken(APC pc, Type type, UnitDest dest, Data data)
+            {
+                return visitor.Ldtypetoken(pc, type, dest, data);
+            }
+
+            public Result Ldfieldtoken(APC pc, Field field, UnitDest dest, Data data)
+            {
+                return visitor.Ldfieldtoken(pc, field, dest, data);
+            }
+
+            public Result Ldmethodtoken(APC pc, Method method, UnitDest dest, Data data)
+            {
+                return visitor.Ldmethodtoken(pc, method, dest, data);
+            }
+
+            public Result Ldvirtftn(APC pc, Method method, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Ldvirtftn(pc, method, dest, obj, data);
+            }
+
+            public Result Mkrefany(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Mkrefany(pc, type, dest, obj, data);
+            }
+
+            public Result Newarray<ArgList>(APC pc, Type type, UnitDest dest, ArgList lengths, Data data)
+              where ArgList : IIndexable<UnitSource>
+            {
+                return visitor.Newarray(pc, type, dest, lengths, data);
+            }
+
+            public Result Newobj<ArgList>(APC pc, Method ctor, UnitDest dest, ArgList args, Data data)
+              where ArgList : IIndexable<UnitSource>
+            {
+                Type declaringType = mdDecoder.DeclaringType(ctor);
+                if (args.Count == 2 && mdDecoder.Equal(declaringType, mdDecoder.System_Decimal))
+                {
+                    // note: ctor first arg is object, but not on stack during newobj.
+                    // special case equal here
+                    return visitor.Unary(pc, UnaryOperator.Conv_dec, false, false, dest, args[1], data);
+                }
+
+                return visitor.Newobj(pc, ctor, dest, args, data);
+            }
+
+            public Result Refanytype(APC pc, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Refanytype(pc, dest, source, data);
+            }
+
+            public Result Refanyval(APC pc, Type type, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Refanyval(pc, type, dest, source, data);
+            }
+
+            public Result Rethrow(APC pc, Data data)
+            {
+                return visitor.Rethrow(pc, data);
+            }
+
+            public Result Sizeof(APC pc, Type type, UnitDest dest, Data data)
+            {
+                return visitor.Sizeof(pc, type, dest, data);
+            }
+
+            public Result Stelem(APC pc, Type type, UnitSource array, UnitSource index, UnitSource value, Data data)
+            {
+                return visitor.Stelem(pc, type, array, index, value, data);
+            }
+
+            public Result Stfld(APC pc, Field field, bool @volatile, UnitSource obj, UnitSource value, Data data)
+            {
+                return visitor.Stfld(pc, field, @volatile, obj, value, data);
+            }
+
+            public Result Stsfld(APC pc, Field field, bool @volatile, UnitSource value, Data data)
+            {
+                return visitor.Stsfld(pc, field, @volatile, value, data);
+            }
+
+            public Result Throw(APC pc, UnitSource exn, Data data)
+            {
+                return visitor.Throw(pc, exn, data);
+            }
+
+            public Result Unbox(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Unbox(pc, type, dest, obj, data);
+            }
+
+            public Result Unboxany(APC pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Unboxany(pc, type, dest, obj, data);
+            }
+
+
+            #region IVisitSynthIL<Label,Method2,Source,Dest,Data,Result> Members
+
+
+            public Result BeginOld(APC pc, APC matchingEnd, Data data)
+            {
+                return visitor.BeginOld(pc, matchingEnd, data);
+            }
+
+            public Result EndOld(APC pc, APC matchingBegin, Type type, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.EndOld(pc, matchingBegin, type, dest, source, data);
+            }
+
+            public Result Ldresult(APC pc, Type type, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Ldresult(pc, type, dest, source, data);
+            }
+
+            #endregion
+        }
+
+#if false
+        struct AssumeDelegator<Data, Result, Visitor> :
+          IVisitMSIL<Label, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result>
+          where Visitor : IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result>
+        {
+            Visitor visitor;
+            Tag assumeLabel;
+            APC originalPC;
+
+            public AssumeDelegator(
+              Visitor visitor,
+              Tag assumeLabel,
+              APC origPC)
+            {
+                this.visitor = visitor;
+                this.assumeLabel = assumeLabel;
+                originalPC = origPC;
+            }
+
+            APC ConvertLabel(Label pc)
+            {
+                // we return the stored pc here, as the underlying decoder only dealt with a label
+                // this works because we never translate branch target labels.
+                return originalPC;
+            }
+
+            /// <summary>
+            /// Map a label occurring in a begin_old/end_old to an apc.
+            /// </summary>
+            private APC ConvertMatchingLabel(Label underlying)
+            {
+                MethodCache<Local, Parameter, Type, Method, Field, Label, Handler>.EnsuresSubroutine subroutine = (MethodCache<Local, Parameter, Type, Method, Field, Label, Handler>.EnsuresSubroutine)originalPC.Block.Subroutine;
+
+                return subroutine.MapLabelToAPC(underlying, originalPC.SubroutineContext);
+            }
+
+
+            public Result Assert(Label pc, string tag, UnitSource condition, Data data)
+            {
+                return visitor.Assert(ConvertLabel(pc), tag, condition, data);
+            }
+
+            public Result Assume(Label pc, string tag, UnitSource source, Data data)
+            {
+                return visitor.Assume(ConvertLabel(pc), tag, source, data);
+            }
+
+            public Result Arglist(Label pc, UnitDest dest, Data data)
+            {
+                return visitor.Arglist(ConvertLabel(pc), dest, data);
+            }
+
+            public Result Binary(Label pc, BinaryOperator op, UnitDest dest, UnitSource s1, UnitSource s2, Data data)
+            {
+                return visitor.Binary(ConvertLabel(pc), op, dest, s1, s2, data);
+            }
+
+            public Result BranchCond(Label pc, Label target, BranchOperator bop, UnitSource value1, UnitSource value2, Data data)
+            {
+                // note: all binary branch conditions are evaluated to yield a value in value2 and use br.true
+                return visitor.Assume(originalPC, assumeLabel, value2, data);
+            }
+
+            public Result BranchTrue(Label pc, Label target, UnitSource cond, Data data)
+            {
+                return visitor.Assume(originalPC, assumeLabel, cond, data);
+            }
+
+            public Result BranchFalse(Label pc, Label target, UnitSource cond, Data data)
+            {
+                return visitor.Assume(originalPC, assumeLabel, cond, data);
+            }
+
+            public Result Branch(Label pc, Label target, bool leave, Data data)
+            {
+                return visitor.Nop(originalPC, data);
+            }
+
+            public Result Break(Label pc, Data data)
+            {
+                return visitor.Break(ConvertLabel(pc), data);
+            }
+
+            public Result Call<TypeList, ArgList>(Label pc, Method2 method, bool tail, bool virt, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<UnitSource>
+            {
+                return visitor.Call(ConvertLabel(pc), method, tail, virt, extraVarargs, dest, args, data);
+            }
+
+            public Result Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, UnitDest dest, UnitSource fp, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<UnitSource>
+            {
+                return visitor.Calli(ConvertLabel(pc), returnType, argTypes, tail, dest, fp, args, data);
+            }
+
+            public Result Ckfinite(Label pc, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Ckfinite(ConvertLabel(pc), dest, source, data);
+            }
+
+            public Result Cpblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource srcaddr, UnitSource len, Data data)
+            {
+                return visitor.Cpblk(ConvertLabel(pc), @volatile, destaddr, srcaddr, len, data);
+            }
+
+            public Result Endfilter(Label pc, UnitSource decision, Data data)
+            {
+                return visitor.Endfilter(ConvertLabel(pc), decision, data);
+            }
+
+            public Result Endfinally(Label pc, Data data)
+            {
+                return visitor.Endfinally(ConvertLabel(pc), data);
+            }
+
+            public Result Entry(Label pc, Method2 method, Data data)
+            {
+                return visitor.Entry(ConvertLabel(pc), method, data);
+            }
+
+            public Result Initblk(Label pc, bool @volatile, UnitSource destaddr, UnitSource value, UnitSource len, Data data)
+            {
+                return visitor.Initblk(ConvertLabel(pc), @volatile, destaddr, value, len, data);
+            }
+
+            public Result Jmp(Label pc, Method2 method, Data data)
+            {
+                return visitor.Jmp(ConvertLabel(pc), method, data);
+            }
+
+            public Result Ldarg(Label pc, Parameter argument, UnitDest dest, Data data)
+            {
+                return visitor.Ldarg(ConvertLabel(pc), argument, dest, data);
+            }
+
+            public Result Ldarga(Label pc, Parameter argument, UnitDest dest, Data data)
+            {
+                return visitor.Ldarga(ConvertLabel(pc), argument, dest, data);
+            }
+
+            public Result Ldconst(Label pc, object constant, Type type, UnitDest dest, Data data)
+            {
+                return visitor.Ldconst(ConvertLabel(pc), constant, type, dest, data);
+            }
+
+            public Result Ldnull(Label pc, UnitDest dest, Data data)
+            {
+                return visitor.Ldnull(ConvertLabel(pc), dest, data);
+            }
+
+            public Result Ldftn(Label pc, Method2 method, UnitDest dest, Data data)
+            {
+                return visitor.Ldftn(ConvertLabel(pc), method, dest, data);
+            }
+
+            public Result Ldind(Label pc, Type type, bool @volatile, UnitDest dest, UnitSource ptr, Data data)
+            {
+                return visitor.Ldind(ConvertLabel(pc), type, @volatile, dest, ptr, data);
+            }
+
+            public Result Ldloc(Label pc, Local local, UnitDest dest, Data data)
+            {
+                return visitor.Ldloc(ConvertLabel(pc), local, dest, data);
+            }
+
+            public Result Ldloca(Label pc, Local local, UnitDest dest, Data data)
+            {
+                return visitor.Ldloca(ConvertLabel(pc), local, dest, data);
+            }
+
+            public Result Ldstack(Label pc, int offset, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Ldstack(ConvertLabel(pc), offset, dest, source, data);
+            }
+
+            public Result Localloc(Label pc, UnitDest dest, UnitSource size, Data data)
+            {
+                return visitor.Localloc(ConvertLabel(pc), dest, size, data);
+            }
+
+            public Result Nop(Label pc, Data data)
+            {
+                return visitor.Nop(ConvertLabel(pc), data);
+            }
+
+            public Result Pop(Label pc, UnitSource source, Data data)
+            {
+                return visitor.Pop(ConvertLabel(pc), source, data);
+            }
+
+            public Result Return(Label pc, UnitSource source, Data data)
+            {
+                return visitor.Return(ConvertLabel(pc), source, data);
+            }
+
+            public Result Starg(Label pc, Parameter argument, UnitSource source, Data data)
+            {
+                return visitor.Starg(ConvertLabel(pc), argument, source, data);
+            }
+
+            public Result Stind(Label pc, Type type, bool @volatile, UnitSource ptr, UnitSource value, Data data)
+            {
+                return visitor.Stind(ConvertLabel(pc), type, @volatile, ptr, value, data);
+            }
+
+            public Result Stloc(Label pc, Local local, UnitSource source, Data data)
+            {
+                return visitor.Stloc(ConvertLabel(pc), local, source, data);
+            }
+
+            public Result Switch(Label pc, IEnumerable<Label> cases, UnitSource value, Data data)
+            {
+                string tag = assumeLabel == "false" ? "default" : assumeLabel;
+                return visitor.Assume(originalPC, tag, value, data);
+            }
+
+            public Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Unary(ConvertLabel(pc), op, overflow, unsigned, dest, source, data);
+            }
+
+            public Result Box(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Box(ConvertLabel(pc), type, dest, source, data);
+            }
+
+            public Result ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method2 method, bool tail, Type constraint, TypeList extraVarargs, UnitDest dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<UnitSource>
+            {
+                return visitor.ConstrainedCallvirt(ConvertLabel(pc), method, tail, constraint, extraVarargs, dest, args, data);
+            }
+
+            public Result Castclass(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Castclass(ConvertLabel(pc), type, dest, obj, data);
+            }
+
+            public Result Cpobj(Label pc, Type type, UnitSource destptr, UnitSource srcptr, Data data)
+            {
+                return visitor.Cpobj(ConvertLabel(pc), type, destptr, srcptr, data);
+            }
+
+            public Result Initobj(Label pc, Type type, UnitSource ptr, Data data)
+            {
+                return visitor.Initobj(ConvertLabel(pc), type, ptr, data);
+            }
+
+            public Result Isinst(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Isinst(ConvertLabel(pc), type, dest, obj, data);
+            }
+
+            public Result Ldelem(Label pc, Type type, UnitDest dest, UnitSource array, UnitSource index, Data data)
+            {
+                return visitor.Ldelem(ConvertLabel(pc), type, dest, array, index, data);
+            }
+
+            public Result Ldelema(Label pc, Type type, bool @readonly, UnitDest dest, UnitSource array, UnitSource index, Data data)
+            {
+                return visitor.Ldelema(ConvertLabel(pc), type, @readonly, dest, array, index, data);
+            }
+
+            public Result Ldfld(Label pc, Field field, bool @volatile, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Ldfld(ConvertLabel(pc), field, @volatile, dest, obj, data);
+            }
+
+            public Result Ldflda(Label pc, Field field, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Ldflda(ConvertLabel(pc), field, dest, obj, data);
+            }
+
+            public Result Ldlen(Label pc, UnitDest dest, UnitSource array, Data data)
+            {
+                return visitor.Ldlen(ConvertLabel(pc), dest, array, data);
+            }
+
+            public Result Ldsfld(Label pc, Field field, bool @volatile, UnitDest dest, Data data)
+            {
+                return visitor.Ldsfld(ConvertLabel(pc), field, @volatile, dest, data);
+            }
+
+            public Result Ldsflda(Label pc, Field field, UnitDest dest, Data data)
+            {
+                return visitor.Ldsflda(ConvertLabel(pc), field, dest, data);
+            }
+
+            public Result Ldtypetoken(Label pc, Type type, UnitDest dest, Data data)
+            {
+                return visitor.Ldtypetoken(ConvertLabel(pc), type, dest, data);
+            }
+
+            public Result Ldfieldtoken(Label pc, Field field, UnitDest dest, Data data)
+            {
+                return visitor.Ldfieldtoken(ConvertLabel(pc), field, dest, data);
+            }
+
+            public Result Ldmethodtoken(Label pc, Method2 method, UnitDest dest, Data data)
+            {
+                return visitor.Ldmethodtoken(ConvertLabel(pc), method, dest, data);
+            }
+
+            public Result Ldvirtftn(Label pc, Method2 method, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Ldvirtftn(ConvertLabel(pc), method, dest, obj, data);
+            }
+
+            public Result Mkrefany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Mkrefany(ConvertLabel(pc), type, dest, obj, data);
+            }
+
+            public Result Newarray(Label pc, Type type, UnitDest dest, UnitSource len, Data data)
+            {
+                return visitor.Newarray(ConvertLabel(pc), type, dest, len, data);
+            }
+
+            public Result Newobj<ArgList>(Label pc, Method2 ctor, UnitDest dest, ArgList args, Data data)
+              where ArgList : IIndexable<UnitSource>
+            {
+                return visitor.Newobj(ConvertLabel(pc), ctor, dest, args, data);
+            }
+
+            public Result Refanytype(Label pc, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Refanytype(ConvertLabel(pc), dest, source, data);
+            }
+
+            public Result Refanyval(Label pc, Type type, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Refanyval(ConvertLabel(pc), type, dest, source, data);
+            }
+
+            public Result Rethrow(Label pc, Data data)
+            {
+                return visitor.Rethrow(ConvertLabel(pc), data);
+            }
+
+            public Result Sizeof(Label pc, Type type, UnitDest dest, Data data)
+            {
+                return visitor.Sizeof(ConvertLabel(pc), type, dest, data);
+            }
+
+            public Result Stelem(Label pc, Type type, UnitSource array, UnitSource index, UnitSource value, Data data)
+            {
+                return visitor.Stelem(ConvertLabel(pc), type, array, index, value, data);
+            }
+
+            public Result Stfld(Label pc, Field field, bool @volatile, UnitSource obj, UnitSource value, Data data)
+            {
+                return visitor.Stfld(ConvertLabel(pc), field, @volatile, obj, value, data);
+            }
+
+            public Result Stsfld(Label pc, Field field, bool @volatile, UnitSource value, Data data)
+            {
+                return visitor.Stsfld(ConvertLabel(pc), field, @volatile, value, data);
+            }
+
+            public Result Throw(Label pc, UnitSource exn, Data data)
+            {
+                return visitor.Throw(ConvertLabel(pc), exn, data);
+            }
+
+            public Result Unbox(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Unbox(ConvertLabel(pc), type, dest, obj, data);
+            }
+
+            public Result Unboxany(Label pc, Type type, UnitDest dest, UnitSource obj, Data data)
+            {
+                return visitor.Unboxany(ConvertLabel(pc), type, dest, obj, data);
+            }
+
+
+            #region IVisitSynthIL<Label,Method2,Source,Dest,Data,Result> Members
+
+
+            public Result BeginOld(Label pc, Label matchingEnd, Data data)
+            {
+                return visitor.BeginOld(ConvertLabel(pc), ConvertMatchingLabel(matchingEnd), data);
+            }
+
+            public Result EndOld(Label pc, Label matchingBegin, Type type, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.EndOld(ConvertLabel(pc), ConvertMatchingLabel(matchingBegin), type, dest, source, data);
+            }
+
+            public Result Ldresult(Label pc, UnitDest dest, UnitSource source, Data data)
+            {
+                return visitor.Ldresult(ConvertLabel(pc), dest, source, data);
+            }
+
+            #endregion
+        }
+
+#endif
+
+        public Result ForwardDecode<Data, Result, Visitor>(APC pc, Visitor visitor, Data data)
+          where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, UnitSource, UnitDest, Data, Result>
+        {
+            return methodCache.ForwardDecode<Data, Result, RemoveBranchDelegator<Data, Result, Visitor>>(pc, new RemoveBranchDelegator<Data, Result, Visitor>(visitor, mdDecoder), data);
+        }
+#if false
+        public Transformer<APC, Data, Result> CacheForwardDecoder<Data, Result>(IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result> visitor)
+        {
+            // can't cache further down, as we depend on the pc
+            return delegate (APC lab, Data data) { return this.ForwardDecode<Data, Result, IVisitMSIL<APC, Local, Parameter, Method2, Field, Type, UnitSource, UnitDest, Data, Result>>(lab, visitor, data); };
+        }
+#endif
+
+        public IMethodContext<Field, Method> Context
+        {
+            get { return this; }
+        }
+
+        public bool IsUnreachable(APC pc) { return false; }
+
+        #endregion
+
+        #region IMethodContext<Method> Members
+        public IMethodContextData<Field, Method> MethodContext { get { return this; } }
+        #endregion
+
+        #region IMethodContextData<Method> Members
+
+        public Method CurrentMethod
+        {
+            get { return parent.CFGMethod; }
+        }
+
+        public ICFG CFG { get { return parent; } }
+
+        public string SourceContext(APC pc)
+        {
+            return pc.PrimarySourceContext();
+        }
+
+        public string SourceDocument(APC pc)
+        {
+            return pc.Block.SourceDocument(pc);
+        }
+
+        public int SourceStartLine(APC pc)
+        {
+            return pc.Block.SourceStartLine(pc);
+        }
+
+        public int SourceEndLine(APC pc)
+        {
+            return pc.Block.SourceEndLine(pc);
+        }
+
+        public int SourceStartColumn(APC pc)
+        {
+            return pc.Block.SourceStartColumn(pc);
+        }
+
+        public int SourceEndColumn(APC pc)
+        {
+            return pc.Block.SourceEndColumn(pc);
+        }
+
+        public IEnumerable<Field> Modifies(Method method)
+        {
+            method = mdDecoder.Unspecialized(method);
+            return methodCache.GetModifies(method);
+        }
+
+        public IEnumerable<Method> AffectedGetters(Field field)
+        {
+            field = mdDecoder.Unspecialized(field);
+            return methodCache.GetAffectedGetters(field);
+        }
+
+        #endregion
+
+        #region IDecodeMSIL<APC,Local,Parameter,Method,Field,Type,UnitDest,UnitDest,IMethodContext<Field,Method>,Unit> Members
+
+
+        public UnitDest EdgeData(APC from, APC to)
+        {
+            return Unit.Value;
+        }
+
+        public void Display(TextWriter tw, string prefix, Unit data) { }
+
+        #endregion
     }
 
-    #region IEnumerable<Pair<CFGBlock,Pair<Tag>,CFGBlock>> Members
 
-    //^ [Pure]
-    public IEnumerator<Pair<CFGBlock, Pair<Tag, CFGBlock>>> GetEnumerator() {
-      return edges.GetEnumerator();
-    }
-
-    #endregion
-
-    #region IEnumerable Members
-
-    //^ [Pure]
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-      throw new Exception("The method or operation is not implemented.");
-    }
-
-    #endregion
-
-    #region IGraph<CFGBlock,Tag> Members
-
-    IEnumerable<CFGBlock> IGraph<CFGBlock, Tag>.Nodes
+    /// <summary>
+    /// Represents edges as just an array ordered by the index of the cfg block where the edge starts.
+    /// </summary>
+    internal class EdgeMap<Tag> : IEnumerable<Pair<CFGBlock, Pair<Tag, CFGBlock>>>, IGraph<CFGBlock, Tag>
     {
-      get { throw new NotImplementedException(); }
+        private List<Pair<CFGBlock, Pair<Tag, CFGBlock>>> edges;
+
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(edges != null);
+        }
+
+        public EdgeMap(List<Pair<CFGBlock, Pair<Tag, CFGBlock>>> edges)
+        {
+            Contract.Requires(edges != null);
+
+            this.edges = edges;
+            edges.Sort(CompareFirstBlockIndex);
+            CheckSort();
+        }
+        private void CheckSort()
+        {
+            int lastSeen = 0;
+            for (int i = 0; i < edges.Count; i++)
+            {
+                Contract.Assume(edges[i].One != null);
+                int currentIndex = edges[i].One.Index;
+                Contract.Assume(currentIndex >= lastSeen);
+                lastSeen = currentIndex;
+            }
+        }
+        private static int CompareFirstBlockIndex(Pair<CFGBlock, Pair<Tag, CFGBlock>> e1, Pair<CFGBlock, Pair<Tag, CFGBlock>> e2)
+        {
+            if (e1.One.Index == e2.One.Index)
+            {
+                return e1.Two.Two.Index - e2.Two.Two.Index;
+            }
+            return e1.One.Index - e2.One.Index;
+        }
+
+        private struct Successors : ICollection<Pair<Tag, CFGBlock>>
+        {
+            private EdgeMap<Tag> underlying;
+            private int startIndex;
+
+            public Successors(EdgeMap<Tag> underlying, int startIndex)
+            {
+                Contract.Requires(startIndex >= 0);
+                Contract.Requires(underlying != null);// F: As of Clousot suggestion
+                Contract.Assume(underlying.edges != null, "Assuming the object invariant for underlying");
+
+                this.underlying = underlying;
+                this.startIndex = startIndex;
+            }
+
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(startIndex >= 0);
+                Contract.Invariant(underlying.edges != null);
+            }
+
+            #region ICollection<Pair<Tag,CFGBlock>> Members
+
+            public void Add(Pair<Tag, CFGBlock> item)
+            {
+                throw new Exception("The method or operation is not implemented.");
+            }
+
+            public void Clear()
+            {
+                throw new Exception("The method or operation is not implemented.");
+            }
+
+            //^ [Confined]
+            public bool Contains(Pair<Tag, CFGBlock> item)
+            {
+                throw new Exception("The method or operation is not implemented.");
+            }
+
+            public void CopyTo(Pair<Tag, CFGBlock>[] array, int arrayIndex)
+            {
+                throw new Exception("The method or operation is not implemented.");
+            }
+
+            public int Count
+            {
+                [ContractVerification(false)]
+                get
+                {
+                    int edgeIndex = startIndex;
+                    if (edgeIndex < underlying.edges.Count)
+                    {
+                        // count equal first
+                        int blockIndex = underlying.edges[edgeIndex].One.Index;
+                        int count = 0;
+                        do
+                        {
+                            count++;
+                            edgeIndex++;
+                        } while (edgeIndex < underlying.edges.Count && underlying.edges[edgeIndex].One.Index == blockIndex);
+                        return count;
+                    }
+                    return 0;
+                }
+            }
+
+            public bool IsReadOnly
+            {
+                get { return true; }
+            }
+
+            public bool Remove(Pair<Tag, CFGBlock> item)
+            {
+                throw new Exception("The method or operation is not implemented.");
+            }
+
+            #endregion
+
+            #region IEnumerable<Pair<Tag,CFGBlock>> Members
+
+            //^ [Pure]
+            public IEnumerator<Pair<Tag, CFGBlock>> GetEnumerator()
+            {
+                if (startIndex >= underlying.edges.Count) { yield break; }
+                int edgeIndex = startIndex;
+                int blockIndex = underlying.edges[edgeIndex].One.Index;
+                do
+                {
+                    yield return underlying.edges[edgeIndex].Two;
+                    edgeIndex++;
+                }
+                while (edgeIndex < underlying.edges.Count && underlying.edges[edgeIndex].One.Index == blockIndex);
+            }
+
+            #endregion
+
+            #region IEnumerable Members
+
+            //^ [Pure]
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            {
+                throw new Exception("The method or operation is not implemented.");
+            }
+
+            #endregion
+        }
+
+        public ICollection<Pair<Tag, CFGBlock>> this[CFGBlock from]
+        {
+            get
+            {
+                return new Successors(this, FindStartIndex(from));
+            }
+        }
+
+        [ContractVerification(false)]
+        private int FindStartIndex(CFGBlock from)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            Contract.Ensures(Contract.Result<int>() <= edges.Count);
+
+            // binary search
+            int lo = 0;
+            int hi = edges.Count;
+            while (lo < hi)
+            {
+                Contract.Assert(lo >= 0);
+                Contract.Assert(hi <= edges.Count);
+                int mid = lo + (hi - lo) / 2;
+                Contract.Assume(mid < edges.Count, "why can't we prove this");
+
+                Contract.Assume(edges[mid].One != null);
+                int indexAtMid = edges[mid].One.Index;
+                if (indexAtMid == from.Index)
+                {
+                    // now find beginning of sequence
+                    while (mid > 0 && edges[mid - 1].One.Index == indexAtMid)
+                    {
+                        mid--;
+                    }
+                    return mid;
+                }
+                if (indexAtMid < from.Index)
+                {
+                    lo = mid + 1;
+                    continue;
+                }
+                Debug.Assert(indexAtMid > from.Index);
+                hi = mid;
+            }
+            // if we fall out, we didn't find any. Return index past last
+            return edges.Count;
+        }
+
+
+        public EdgeMap<Tag> ReversedEdges()
+        {
+            List<Pair<CFGBlock, Pair<Tag, CFGBlock>>> reversed = new List<Pair<CFGBlock, Pair<Tag, CFGBlock>>>(edges.Count);
+
+            foreach (Pair<CFGBlock, Pair<Tag, CFGBlock>> edge in edges)
+            {
+                reversed.Add(new Pair<CFGBlock, Pair<Tag, CFGBlock>>(edge.Two.Two, new Pair<Tag, CFGBlock>(edge.Two.One, edge.One)));
+            }
+            return new EdgeMap<Tag>(reversed);
+        }
+
+        public void ReSort()
+        {
+            edges.Sort(CompareFirstBlockIndex);
+        }
+
+        /// <summary>
+        /// Removes the unwanted edges
+        /// </summary>
+        public void Filter(Predicate<Pair<CFGBlock, Pair<Tag, CFGBlock>>> keep)
+        {
+            Contract.Requires(keep != null);
+
+            // must separately build a list of indices to remove, as we can't change the list while traversing it or we'll skip
+            // elements
+            FList<int> toRemove = null;
+            for (int i = 0; i < edges.Count; i++)
+            {
+                if (!keep(edges[i]))
+                {
+                    toRemove = FList<int>.Cons(i, toRemove);
+                }
+            }
+            toRemove.Apply(delegate (int i) { edges.RemoveAt(i); });
+        }
+
+        #region IEnumerable<Pair<CFGBlock,Pair<Tag>,CFGBlock>> Members
+
+        //^ [Pure]
+        public IEnumerator<Pair<CFGBlock, Pair<Tag, CFGBlock>>> GetEnumerator()
+        {
+            return edges.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        //^ [Pure]
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            throw new Exception("The method or operation is not implemented.");
+        }
+
+        #endregion
+
+        #region IGraph<CFGBlock,Tag> Members
+
+        IEnumerable<CFGBlock> IGraph<CFGBlock, Tag>.Nodes
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IGraph<CFGBlock, Tag>.Contains(CFGBlock node)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Pair<Tag, CFGBlock>> IGraph<CFGBlock, Tag>.Successors(CFGBlock node)
+        {
+            return this[node];
+        }
+
+        #endregion
     }
 
-    bool IGraph<CFGBlock, Tag>.Contains(CFGBlock node)
+    public interface IEdgeSubroutineAdaptor
     {
-      throw new NotImplementedException();
+        FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutinesInternal(CFGBlock from, CFGBlock to, SubroutineContext context);
     }
 
-    IEnumerable<Pair<Tag, CFGBlock>> IGraph<CFGBlock, Tag>.Successors(CFGBlock node)
+    /// <summary>
+    /// special visitor to identify the return value of a function
+    /// </summary>
+    public class ReturnValueFinderVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly, ContextData, EdgeData>
+    : MSILVisitor<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData>
     {
-      return this[node];
+        private Local retvalLocal; // the local var holding the return value (if any) of the function in the preceding block
+        private Parameter retvalParam; // the parameter holding the return value (if any) of the function in the preceding block
+        private Field retvalField; // the field holding the return value (if any) of the function in the preceding block
+        private bool foundLocalRetval = false;
+        private bool foundParamRetval = false;
+        private bool foundFieldRetval = false;
+
+        public bool GetLocalReturnValue(out Local returnValue)
+        {
+            returnValue = retvalLocal;
+            return foundLocalRetval;
+        }
+
+        public bool GetParameterReturnValue(out Parameter returnValue)
+        {
+            returnValue = retvalParam;
+            return foundParamRetval;
+        }
+
+        public bool GetFieldReturnValue(out Field returnValue)
+        {
+            returnValue = retvalField;
+            return foundFieldRetval;
+        }
+
+        public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> Visitor() { return this; }
+
+        protected override EdgeData Default(APC pc, ContextData data)
+        {
+            return default(EdgeData);
+        }
+
+        // the block after a function call stores the return value of the function in the appropriate local variable. capture the identity of this local variable
+        public override EdgeData Stloc(APC pc, Local local, Expression source, ContextData data)
+        {
+            //Console.WriteLine("found stloc " + local);
+            retvalLocal = local;
+            foundLocalRetval = true;
+            return default(EdgeData);
+        }
+
+        // the block after a function call stores the return value of the function in the appropriate local variable, which may be a parameter to the caller. captrue the identity of this local variable
+        public override EdgeData Starg(APC pc, Parameter argument, Expression source, ContextData data)
+        {
+            retvalParam = argument;
+            foundParamRetval = true;
+            return default(EdgeData);
+        }
+
+        public override EdgeData Stfld(APC pc, Field field, bool @volatile, Expression obj, Expression value, ContextData data)
+        {
+            retvalField = field;
+            foundFieldRetval = true;
+            return default(EdgeData);
+        }
     }
-
-    #endregion
-  }
-
-  public interface IEdgeSubroutineAdaptor
-  {
-    FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutinesInternal(CFGBlock from, CFGBlock to, SubroutineContext context);
-  }
-
-  /// <summary>
-  /// special visitor to identify the return value of a function
-  /// </summary>
-  public class ReturnValueFinderVisitor<Local, Parameter, Method, Field, Property, Event, Type, Variable, Expression, Attribute, Assembly, ContextData, EdgeData>
-  : MSILVisitor<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData>
-  {
-      private Local retvalLocal; // the local var holding the return value (if any) of the function in the preceding block
-      private Parameter retvalParam; // the parameter holding the return value (if any) of the function in the preceding block
-      private Field retvalField; // the field holding the return value (if any) of the function in the preceding block
-      private bool foundLocalRetval = false;
-      private bool foundParamRetval = false;
-      private bool foundFieldRetval = false;
-
-      public bool GetLocalReturnValue(out Local returnValue)
-      {
-        returnValue = retvalLocal;
-        return foundLocalRetval;
-      }
-
-      public bool GetParameterReturnValue(out Parameter returnValue)
-      {
-        returnValue = retvalParam;
-        return foundParamRetval;
-      }
-
-      public bool GetFieldReturnValue(out Field returnValue)
-      {
-        returnValue = retvalField;
-        return foundFieldRetval;
-      }
-
-      public IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Expression, Variable, ContextData, EdgeData> Visitor() { return this; }
-
-      protected override EdgeData Default(APC pc, ContextData data)
-      {
-        return default(EdgeData);
-      }
-
-      // the block after a function call stores the return value of the function in the appropriate local variable. capture the identity of this local variable
-      public override EdgeData Stloc(APC pc, Local local, Expression source, ContextData data)
-      {
-          //Console.WriteLine("found stloc " + local);
-        retvalLocal = local;
-        foundLocalRetval = true;
-        return default(EdgeData);
-      }
-
-      // the block after a function call stores the return value of the function in the appropriate local variable, which may be a parameter to the caller. captrue the identity of this local variable
-      public override EdgeData Starg(APC pc, Parameter argument, Expression source, ContextData data)
-      {
-        retvalParam = argument;
-        foundParamRetval = true;
-        return default(EdgeData);
-      }
-
-      public override EdgeData Stfld(APC pc, Field field, bool @volatile, Expression obj, Expression value, ContextData data)
-      { 
-        retvalField = field;
-        foundFieldRetval = true;
-        return default(EdgeData);
-      }
-  }
-
- 
-
 }

--- a/Microsoft.Research/ControlFlow/ControlFlowInterface.cs
+++ b/Microsoft.Research/ControlFlow/ControlFlowInterface.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.IO;
@@ -22,552 +11,558 @@ using Microsoft.Research.Graphs;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using Tag = System.String;
-  using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
-  using System.Diagnostics.Contracts;
-
-  /// <summary>
-  /// Used to pass a handler to emit warnings
-  /// </summary>
-  public delegate void ErrorHandler(string format, params string[] args);
-
-  /// <summary>
-  /// Represents a filter that determines what handlers apply to a given context.
-  /// </summary>
-  /// <typeparam name="Label">Underlying program point representation</typeparam>
-  /// <typeparam name="Data">Client data type for auxiliary client information</typeparam>
-  /// <typeparam name="Type">Type for exception filter</typeparam>
-  public interface IHandlerFilter<Type, Data>
-  {
-    /// <summary>Given handler is a catch handler with given exception filter.</summary>
-    /// <param name="data">Client specific data that helps client determine match</param>
-    /// <param name="exception">Catch type</param>
-    /// <param name="stopPropagation">Client should set this to true if no outer enclosing handlers are possible</param>
-    /// <returns>true if handler applies, false, if handler does not apply</returns>
-    bool Catch(Data data, Type exception, out bool stopPropagation);
-
-    /// <summary>Given handler is a filter handler with filter code.</summary>
-    /// <param name="data">Client specific data that helps client determine match</param>
-    /// <param name="filterCode">Code determining applicability of filter</param>
-    /// <param name="stopPropagation">Client should set this to true if no outer enclosing handlers are possible</param>
-    /// <returns>true if handler applies, false, if handler does not apply</returns>
-    bool Filter(Data data, APC filterCode, out bool stopPropagation);
-  }
-  /// <summary>
-  /// An abstract view of a control flow graph, generic over underlying code.
-  /// </summary>
-  public partial interface ICFG
-  {
-    /// <summary>
-    /// The entry point of the method
-    /// </summary>
-    APC Entry { get; }
+    using Tag = System.String;
+    using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
+    using System.Diagnostics.Contracts;
 
     /// <summary>
-    /// The entry point of the method after all requires contracts
+    /// Used to pass a handler to emit warnings
     /// </summary>
-    APC EntryAfterRequires { get; }
+    public delegate void ErrorHandler(string format, params string[] args);
 
     /// <summary>
-    /// The normal exit point of the method
+    /// Represents a filter that determines what handlers apply to a given context.
     /// </summary>
-    APC NormalExit { get; }
+    /// <typeparam name="Label">Underlying program point representation</typeparam>
+    /// <typeparam name="Data">Client data type for auxiliary client information</typeparam>
+    /// <typeparam name="Type">Type for exception filter</typeparam>
+    public interface IHandlerFilter<Type, Data>
+    {
+        /// <summary>Given handler is a catch handler with given exception filter.</summary>
+        /// <param name="data">Client specific data that helps client determine match</param>
+        /// <param name="exception">Catch type</param>
+        /// <param name="stopPropagation">Client should set this to true if no outer enclosing handlers are possible</param>
+        /// <returns>true if handler applies, false, if handler does not apply</returns>
+        bool Catch(Data data, Type exception, out bool stopPropagation);
 
+        /// <summary>Given handler is a filter handler with filter code.</summary>
+        /// <param name="data">Client specific data that helps client determine match</param>
+        /// <param name="filterCode">Code determining applicability of filter</param>
+        /// <param name="stopPropagation">Client should set this to true if no outer enclosing handlers are possible</param>
+        /// <returns>true if handler applies, false, if handler does not apply</returns>
+        bool Filter(Data data, APC filterCode, out bool stopPropagation);
+    }
     /// <summary>
-    /// The exceptional exit point of the method
+    /// An abstract view of a control flow graph, generic over underlying code.
     /// </summary>
-    APC ExceptionExit { get; }
-
-    /// <summary>
-    /// If the label has a single successor, then this returns the unique post pc.
-    /// Otherwise the result is equal to label.
-    /// </summary>
-    APC Post(APC label);
-
-    /// <summary>
-    /// Returns the immediate normal successor program point if there is a single one.
-    /// Otherwise, must use Successors which returns all (or 0).
-    /// </summary>
-    [Pure]
-    bool HasSingleSuccessor(APC ppoint, out APC singleSuccessor);
-
-    /// <summary>
-    /// Provides the immediate normal successor program points of the given ppoint
-    /// </summary>
-    [Pure]
-    IEnumerable<APC> Successors(APC ppoint);
-
-    /// <summary>
-    /// Returns the immediate normal predecessor program point if there is a single one.
-    /// Otherwise, must use Predecessor which returns all (or 0).
-    /// </summary>
-    [Pure]
-    bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts = false);
-
-    /// <summary>
-    /// Provides the immediate normal predecessor program points of the given ppoint
-    /// </summary>
-    [Pure]
-    IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts = false);
-
-    /// <summary>
-    /// If ppoint is the beginning of a call instruction, then this provides the first PC prior to 
-    /// ppoint and prior to any requires of the call
-    /// </summary>
-    [Pure]
-    APC PredecessorPCPriorToRequires(APC ppoint);
-
-    /// <summary>
-    /// Returns true if the given program point is the target of multiple forward control
-    /// transfers.
-    /// </summary>
-    [Pure]
-    bool IsJoinPoint(APC ppoint);
-
-    /// <summary>
-    /// Returns true if the given program point is the target of multiple backward control
-    /// transfers.
-    /// </summary>
-    [Pure]
-    bool IsSplitPoint(APC ppoint);
-
-    /// <summary>
-    /// Returns true if the given program point is a back edge target in a forward traversal
-    /// </summary>
-    [Pure]
-    bool IsForwardBackEdgeTarget(APC ppoint);
-
-    /// <summary>
-    /// Returns true if the given program point is a back edge target in a backward traversal
-    /// </summary>
-    [Pure]
-    bool IsBackwardBackEdgeTarget(APC ppoint);
-
-    /// <summary>
-    /// Returns true if the edge described by the two program points is a back edge in a forward
-    /// traversal of the CFG.
-    /// NOTE: the edge must be an edge related by the Successors relation above, not
-    /// an arbitrary pair.
-    /// </summary>
-    [Pure]
-    bool IsForwardBackEdge(APC from, APC to);
-
-    /// <summary>
-    /// Returns true if the edge described by the two program points is a back edge in a backward
-    /// traversal of the CFG.
-    /// NOTE: the edge must be an edge related by the Predecessor relation above, not
-    /// an arbitrary pair.
-    /// </summary>
-    [Pure]
-    bool IsBackwardBackEdge(APC from, APC to);
-
-    /// <summary>
-    /// Returns the APC corresponding to loop heads.
-    /// </summary>
-    IEnumerable<CFGBlock> LoopHeads { get; }
-
-    /// <summary>
-    /// Returns true if the program point is the first point in a logical block
-    /// </summary>
-    [Pure]
-    bool IsBlockStart(APC ppoint);
-
-    /// <summary>
-    /// Returns true if the program point is the last point in a logical block
-    /// </summary>
-    [Pure]
-    bool IsBlockEnd(APC ppoint);
-
-    /// <summary>
-    /// Returns a set of program points that are possible execution continuations if 
-    /// an exception is raised at the given ppoint.
-    ///
-    /// The supplied predicate allows the client to determine which handlers are possible
-    /// candidates. The predicate is called from closest enclosing to outermost.
-    /// </summary>
-    /// <param name="data">Arbitrary client data passed to the handler predicate</param>
-    /// <returns>A set of continuation program points that represent how execution continues to a chosen handler.
-    /// The continuation includes Finally and Fault executions that intervene between the given ppoint and a
-    /// chosen handler.
-    /// </returns>
-    [Pure]
-    IEnumerable<APC> ExceptionHandlers<Type, Data>(APC ppoint, Data data, IHandlerFilter<Type, Data> handlerPredicate);
-
-    /// <summary>
-    /// Returns a graph wrapper for the cfg that can be used with standard graph algorithms.
-    /// There's only one APC used per block (the first in the block), and the set of nodes is not
-    /// explicitly given.
-    /// </summary>
-    [Pure]
-    IGraph<APC, Unit> AsForwardGraph(bool includeExceptionEdges);
-
-    /// <summary>
-    /// Returns a graph wrapper for the cfg that can be used with standard graph algorithms.
-    /// There's only one APC used per block (the first in the block), and the set of nodes is not
-    /// explicitly given.
-    /// </summary>
-    [Pure]
-    IGraph<APC, Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts);
-
-    [Pure]
-    IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit>
-      GetDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder);
-
-
-    /// <summary>
-    /// Get a subroutine view of the CFG for block level operations
-    /// </summary>
-    Subroutine Subroutine { get; }
-
-    /// <summary>
-    /// Get the subroutines on the edge from ---> to
-    /// </summary>
-    FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context);
-
-    /// <summary>
-    /// Returns a textual representation of an abstract PC
-    /// </summary>
-    [Pure]
-    string ToString(APC pc);
-
-    /// <summary>
-    /// Prints out a textual representation of the CFG
-    ///
-    /// Also decodes the synthetic IL from the CFG generation
-    /// eg. Assumes
-    /// </summary>
-    /// <param name="tw">Target for output</param>
-    /// <param name="edgePrinter">Optional info printer for successor edges</param>
-    void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ edgePrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context);
-
-  }
-
-  #region ICFG contract binding
-  [ContractClass(typeof(ICFGContract))]
-  public partial interface ICFG
-  {
-
-  }
-
-  [ContractClassFor(typeof(ICFG))]
-  abstract class ICFGContract : ICFG
-  {
-    #region ICFG Members
-
-    public APC Entry
+    public partial interface ICFG
     {
-      get {
-        throw new NotImplementedException();
-      }
+        /// <summary>
+        /// The entry point of the method
+        /// </summary>
+        APC Entry { get; }
+
+        /// <summary>
+        /// The entry point of the method after all requires contracts
+        /// </summary>
+        APC EntryAfterRequires { get; }
+
+        /// <summary>
+        /// The normal exit point of the method
+        /// </summary>
+        APC NormalExit { get; }
+
+        /// <summary>
+        /// The exceptional exit point of the method
+        /// </summary>
+        APC ExceptionExit { get; }
+
+        /// <summary>
+        /// If the label has a single successor, then this returns the unique post pc.
+        /// Otherwise the result is equal to label.
+        /// </summary>
+        APC Post(APC label);
+
+        /// <summary>
+        /// Returns the immediate normal successor program point if there is a single one.
+        /// Otherwise, must use Successors which returns all (or 0).
+        /// </summary>
+        [Pure]
+        bool HasSingleSuccessor(APC ppoint, out APC singleSuccessor);
+
+        /// <summary>
+        /// Provides the immediate normal successor program points of the given ppoint
+        /// </summary>
+        [Pure]
+        IEnumerable<APC> Successors(APC ppoint);
+
+        /// <summary>
+        /// Returns the immediate normal predecessor program point if there is a single one.
+        /// Otherwise, must use Predecessor which returns all (or 0).
+        /// </summary>
+        [Pure]
+        bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts = false);
+
+        /// <summary>
+        /// Provides the immediate normal predecessor program points of the given ppoint
+        /// </summary>
+        [Pure]
+        IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts = false);
+
+        /// <summary>
+        /// If ppoint is the beginning of a call instruction, then this provides the first PC prior to 
+        /// ppoint and prior to any requires of the call
+        /// </summary>
+        [Pure]
+        APC PredecessorPCPriorToRequires(APC ppoint);
+
+        /// <summary>
+        /// Returns true if the given program point is the target of multiple forward control
+        /// transfers.
+        /// </summary>
+        [Pure]
+        bool IsJoinPoint(APC ppoint);
+
+        /// <summary>
+        /// Returns true if the given program point is the target of multiple backward control
+        /// transfers.
+        /// </summary>
+        [Pure]
+        bool IsSplitPoint(APC ppoint);
+
+        /// <summary>
+        /// Returns true if the given program point is a back edge target in a forward traversal
+        /// </summary>
+        [Pure]
+        bool IsForwardBackEdgeTarget(APC ppoint);
+
+        /// <summary>
+        /// Returns true if the given program point is a back edge target in a backward traversal
+        /// </summary>
+        [Pure]
+        bool IsBackwardBackEdgeTarget(APC ppoint);
+
+        /// <summary>
+        /// Returns true if the edge described by the two program points is a back edge in a forward
+        /// traversal of the CFG.
+        /// NOTE: the edge must be an edge related by the Successors relation above, not
+        /// an arbitrary pair.
+        /// </summary>
+        [Pure]
+        bool IsForwardBackEdge(APC from, APC to);
+
+        /// <summary>
+        /// Returns true if the edge described by the two program points is a back edge in a backward
+        /// traversal of the CFG.
+        /// NOTE: the edge must be an edge related by the Predecessor relation above, not
+        /// an arbitrary pair.
+        /// </summary>
+        [Pure]
+        bool IsBackwardBackEdge(APC from, APC to);
+
+        /// <summary>
+        /// Returns the APC corresponding to loop heads.
+        /// </summary>
+        IEnumerable<CFGBlock> LoopHeads { get; }
+
+        /// <summary>
+        /// Returns true if the program point is the first point in a logical block
+        /// </summary>
+        [Pure]
+        bool IsBlockStart(APC ppoint);
+
+        /// <summary>
+        /// Returns true if the program point is the last point in a logical block
+        /// </summary>
+        [Pure]
+        bool IsBlockEnd(APC ppoint);
+
+        /// <summary>
+        /// Returns a set of program points that are possible execution continuations if 
+        /// an exception is raised at the given ppoint.
+        ///
+        /// The supplied predicate allows the client to determine which handlers are possible
+        /// candidates. The predicate is called from closest enclosing to outermost.
+        /// </summary>
+        /// <param name="data">Arbitrary client data passed to the handler predicate</param>
+        /// <returns>A set of continuation program points that represent how execution continues to a chosen handler.
+        /// The continuation includes Finally and Fault executions that intervene between the given ppoint and a
+        /// chosen handler.
+        /// </returns>
+        [Pure]
+        IEnumerable<APC> ExceptionHandlers<Type, Data>(APC ppoint, Data data, IHandlerFilter<Type, Data> handlerPredicate);
+
+        /// <summary>
+        /// Returns a graph wrapper for the cfg that can be used with standard graph algorithms.
+        /// There's only one APC used per block (the first in the block), and the set of nodes is not
+        /// explicitly given.
+        /// </summary>
+        [Pure]
+        IGraph<APC, Unit> AsForwardGraph(bool includeExceptionEdges);
+
+        /// <summary>
+        /// Returns a graph wrapper for the cfg that can be used with standard graph algorithms.
+        /// There's only one APC used per block (the first in the block), and the set of nodes is not
+        /// explicitly given.
+        /// </summary>
+        [Pure]
+        IGraph<APC, Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts);
+
+        [Pure]
+        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit>
+          GetDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder);
+
+
+        /// <summary>
+        /// Get a subroutine view of the CFG for block level operations
+        /// </summary>
+        Subroutine Subroutine { get; }
+
+        /// <summary>
+        /// Get the subroutines on the edge from ---> to
+        /// </summary>
+        FList<Pair<string, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context);
+
+        /// <summary>
+        /// Returns a textual representation of an abstract PC
+        /// </summary>
+        [Pure]
+        string ToString(APC pc);
+
+        /// <summary>
+        /// Prints out a textual representation of the CFG
+        ///
+        /// Also decodes the synthetic IL from the CFG generation
+        /// eg. Assumes
+        /// </summary>
+        /// <param name="tw">Target for output</param>
+        /// <param name="edgePrinter">Optional info printer for successor edges</param>
+        void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC>/*?*/ edgePrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context);
     }
 
-    public APC EntryAfterRequires
+    #region ICFG contract binding
+    [ContractClass(typeof(ICFGContract))]
+    public partial interface ICFG
     {
-      get {
-        throw new NotImplementedException();
-      }
     }
 
-    public APC NormalExit
+    [ContractClassFor(typeof(ICFG))]
+    internal abstract class ICFGContract : ICFG
     {
-      get {
-        throw new NotImplementedException();
-      }
+        #region ICFG Members
+
+        public APC Entry
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public APC EntryAfterRequires
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public APC NormalExit
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public APC ExceptionExit
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public APC Post(APC label)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasSingleSuccessor(APC ppoint, out APC singleSuccessor)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<APC> Successors(APC ppoint)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public APC PredecessorPCPriorToRequires(APC ppoint)
+        {
+            Contract.Requires(ppoint.Index == 0);
+
+            throw new NotImplementedException();
+        }
+
+        public bool IsJoinPoint(APC ppoint)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSplitPoint(APC ppoint)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsForwardBackEdgeTarget(APC ppoint)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsBackwardBackEdgeTarget(APC ppoint)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsForwardBackEdge(APC from, APC to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsBackwardBackEdge(APC from, APC to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<CFGBlock> LoopHeads
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool IsBlockStart(APC ppoint)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsBlockEnd(APC ppoint)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<APC> ExceptionHandlers<Type, Data>(APC ppoint, Data data, IHandlerFilter<Type, Data> handlerPredicate)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IGraph<APC, Unit> AsForwardGraph(bool includeExceptionEdges)
+        {
+            Contract.Ensures(Contract.Result<IGraph<APC, Unit>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IGraph<APC, Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
+        {
+            Contract.Ensures(Contract.Result<IGraph<APC, Unit>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit> GetDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Ensures(Contract.Result<IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public Subroutine Subroutine
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Subroutine>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public Tag ToString(APC pc)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> edgePrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+
+        public FList<Pair<Tag, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
+        {
+            Contract.Requires(from != null);
+            Contract.Requires(to != null);
+            throw new NotImplementedException();
+        }
     }
-
-    public APC ExceptionExit
-    {
-      get {
-        throw new NotImplementedException();
-      }
-    }
-
-    public APC Post(APC label)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasSingleSuccessor(APC ppoint, out APC singleSuccessor)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<APC> Successors(APC ppoint)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<APC> Predecessors(APC ppoint, bool skipContracts)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public APC PredecessorPCPriorToRequires(APC ppoint)
-    {
-      Contract.Requires(ppoint.Index == 0);
-
-      throw new NotImplementedException();
-    }
-
-    public bool IsJoinPoint(APC ppoint)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSplitPoint(APC ppoint)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsForwardBackEdgeTarget(APC ppoint)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsBackwardBackEdgeTarget(APC ppoint)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsForwardBackEdge(APC from, APC to)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsBackwardBackEdge(APC from, APC to)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<CFGBlock> LoopHeads
-    {
-      get {
-        Contract.Ensures(Contract.Result<IEnumerable<CFGBlock>>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    public bool IsBlockStart(APC ppoint)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsBlockEnd(APC ppoint)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<APC> ExceptionHandlers<Type, Data>(APC ppoint, Data data, IHandlerFilter<Type, Data> handlerPredicate)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<APC>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IGraph<APC, Unit> AsForwardGraph(bool includeExceptionEdges)
-    {
-      Contract.Ensures(Contract.Result<IGraph<APC, Unit>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IGraph<APC, Unit> AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
-    {
-      Contract.Ensures(Contract.Result<IGraph<APC, Unit>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit> GetDecoder<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Ensures(Contract.Result<IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, IMethodContext<Field, Method>, Unit>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public Subroutine Subroutine
-    {
-      get {
-        Contract.Ensures(Contract.Result<Subroutine>() != null);
-        throw new NotImplementedException();
-      }
-    }
-
-    public Tag ToString(APC pc)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public void Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> edgePrinter, Func<CFGBlock, IEnumerable<SubroutineContext>> contextLookup, SubroutineContext context)
-    {
-      throw new NotImplementedException();
-    }
-
     #endregion
 
-
-    public FList<Pair<Tag, Subroutine>> GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
+    /// <summary>
+    /// Code query 
+    /// </summary>
+    public interface ICodeQuery<Label, Local, Parameter, Method, Field, Type, Data, Result> : IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
     {
-      Contract.Requires(from != null);
-      Contract.Requires(to != null);
-      throw new NotImplementedException();
+        /// <summary>
+        /// Called if Code represents a nested code aggregate
+        /// </summary>
+        /// <param name="aggregateStart">Start label of aggregate</param>
+        /// <param name="data">Client specific data threaded through the dispatch</param>
+        /// <param name="current">Label where instruction is decoded</param>
+        /// <param name="canBeTargetOfBranch">true if current can be a branch target. If not, the CFG can remove unnecessary program points </param>
+        Result Aggregate(Label current, Label aggregateStart, bool canBeTargetOfBranch, Data data);
     }
-  }
-  #endregion
 
-  /// <summary>
-  /// Code query 
-  /// </summary>
-  public interface ICodeQuery<Label, Local, Parameter, Method, Field, Type, Data, Result> : IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Unit,Unit, Data, Result>
-  {
-    /// <summary>
-    /// Called if Code represents a nested code aggregate
-    /// </summary>
-    /// <param name="aggregateStart">Start label of aggregate</param>
-    /// <param name="data">Client specific data threaded through the dispatch</param>
-    /// <param name="current">Label where instruction is decoded</param>
-    /// <param name="canBeTargetOfBranch">true if current can be a branch target. If not, the CFG can remove unnecessary program points </param>
-    Result Aggregate(Label current, Label aggregateStart, bool canBeTargetOfBranch, Data data);
+    public interface ICodeProvider<Label, Local, Parameter, Method, Field, Type>
+    {
+        /// <summary>
+        /// Dispatches to the appropriate method in query based on the code at the given label
+        /// </summary>
+        R Decode<Visitor, T, R>(Label label, Visitor query, T data)
+          where Visitor : ICodeQuery<Label, Local, Parameter, Method, Field, Type, T, R>;
 
-  }
+        //    Code Lookup(Label label);
+        /// <summary>
+        /// Returns the label of the code textually following the code at the given location (if sensible)
+        /// </summary>
+        /// <returns>true if next label is meaningful.</returns>
+        bool Next(Label current, out Label nextLabel);
 
-  public interface ICodeProvider<Label, Local, Parameter, Method, Field, Type> 
-  {
-    /// <summary>
-    /// Dispatches to the appropriate method in query based on the code at the given label
-    /// </summary>
-    R Decode<Visitor, T, R>(Label label, Visitor query, T data)
-      where Visitor : ICodeQuery<Label, Local, Parameter, Method, Field, Type, T, R>;
+        /// <summary>
+        /// Returns true if pc has source context associated with it
+        /// </summary>
+        bool HasSourceContext(Label pc);
 
-    //    Code Lookup(Label label);
-    /// <summary>
-    /// Returns the label of the code textually following the code at the given location (if sensible)
-    /// </summary>
-    /// <returns>true if next label is meaningful.</returns>
-    bool Next(Label current, out Label nextLabel);
+        /// <summary>
+        /// Returns the name of the associated document of the source context for this pc
+        /// </summary>
+        string SourceDocument(Label pc);
 
-    /// <summary>
-    /// Returns true if pc has source context associated with it
-    /// </summary>
-    bool HasSourceContext(Label pc);
+        /// <summary>
+        /// Returns the first line number in the source context of this pc.
+        /// </summary>
+        int SourceStartLine(Label pc);
 
-    /// <summary>
-    /// Returns the name of the associated document of the source context for this pc
-    /// </summary>
-    string SourceDocument(Label pc);
+        /// <summary>
+        /// Returns the last line number in the source context of this pc.
+        /// </summary>
+        int SourceEndLine(Label pc);
 
-    /// <summary>
-    /// Returns the first line number in the source context of this pc.
-    /// </summary>
-    int SourceStartLine(Label pc);
+        /// <summary>
+        /// Returns the first column number in the source context of this pc.
+        /// </summary>
+        int SourceStartColumn(Label pc);
 
-    /// <summary>
-    /// Returns the last line number in the source context of this pc.
-    /// </summary>
-    int SourceEndLine(Label pc);
+        /// <summary>
+        /// Returns the first column number in the source context of this pc.
+        /// </summary>
+        int SourceEndColumn(Label pc);
 
-    /// <summary>
-    /// Returns the first column number in the source context of this pc.
-    /// </summary>
-    int SourceStartColumn(Label pc);
+        /// <summary>
+        /// The character index of the first character of the source context of this pc,
+        /// when treating the source document as a single string.
+        /// </summary>
+        int SourceStartIndex(Label pc);
 
-    /// <summary>
-    /// Returns the first column number in the source context of this pc.
-    /// </summary>
-    int SourceEndColumn(Label pc);
+        /// <summary>
+        /// The number of characters in the source context of this pc.
+        /// </summary>
+        int SourceLength(Label pc);
 
-    /// <summary>
-    /// The character index of the first character of the source context of this pc,
-    /// when treating the source document as a single string.
-    /// </summary>
-    int SourceStartIndex(Label pc);
+        /// <summary>
+        /// Returns the IL offset within the method of the given instruction or 0
+        /// </summary>
+        int ILOffset(Label pc);
 
-    /// <summary>
-    /// The number of characters in the source context of this pc.
-    /// </summary>
-    int SourceLength(Label pc);
+        /// <summary>
+        /// If the label corresponds to a contract (assert/requires, etc), this 
+        /// may provide the user or tool provided condition.
+        /// </summary>
+        string SourceAssertionCondition(Label label);
+    }
 
-    /// <summary>
-    /// Returns the IL offset within the method of the given instruction or 0
-    /// </summary>
-    int ILOffset(Label pc);
+    public interface IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> : ICodeProvider<Label, Local, Parameter, Method, Field, Type>
+    {
+        /// <summary>
+        /// Returns the handlers associated with the provided method
+        /// </summary>
+        IEnumerable<Handler> TryBlocks(Method method);
 
-    /// <summary>
-    /// If the label corresponds to a contract (assert/requires, etc), this 
-    /// may provide the user or tool provided condition.
-    /// </summary>
-    string SourceAssertionCondition(Label label);
-  }
+        /// <summary>
+        /// Decodes ExceptionInfo for the kind of handler
+        /// </summary>
+        bool IsFaultHandler(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the kind of handler
+        /// </summary>
+        bool IsFinallyHandler(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the kind of handler
+        /// </summary>
+        bool IsCatchHandler(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the kind of handler
+        /// </summary>
+        bool IsFilterHandler(Handler info);
 
-  public interface IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> : ICodeProvider<Label, Local, Parameter, Method, Field, Type> {
-    /// <summary>
-    /// Returns the handlers associated with the provided method
-    /// </summary>
-    IEnumerable<Handler> TryBlocks(Method method);
+        /// <summary>
+        /// If the handler is a CatchHandler, this method returns the type of exception caught.
+        /// Fails if !IsCatchHandler
+        /// </summary>
+        Type CatchType(Handler info);
 
-    /// <summary>
-    /// Decodes ExceptionInfo for the kind of handler
-    /// </summary>
-    bool IsFaultHandler(Handler info);
-    /// <summary>
-    /// Decodes ExceptionInfo for the kind of handler
-    /// </summary>
-    bool IsFinallyHandler(Handler info);
-    /// <summary>
-    /// Decodes ExceptionInfo for the kind of handler
-    /// </summary>
-    bool IsCatchHandler(Handler info);
-    /// <summary>
-    /// Decodes ExceptionInfo for the kind of handler
-    /// </summary>
-    bool IsFilterHandler(Handler info);
+        /// <summary>
+        /// Should return true if this handler catches all Exceptions
+        /// </summary>
+        bool IsCatchAllHandler(Handler info);
 
-    /// <summary>
-    /// If the handler is a CatchHandler, this method returns the type of exception caught.
-    /// Fails if !IsCatchHandler
-    /// </summary>
-    Type CatchType(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the Label corresponding to the start of try block
+        /// </summary>
+        Label TryStart(Handler info);
 
-    /// <summary>
-    /// Should return true if this handler catches all Exceptions
-    /// </summary>
-    bool IsCatchAllHandler(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the Label corresponding to the end of try block
+        /// </summary>
+        Label TryEnd(Handler info);
 
-    /// <summary>
-    /// Decodes ExceptionInfo for the Label corresponding to the start of try block
-    /// </summary>
-    Label TryStart(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the Label corresponding to the start of filter decision block (if any)
+        /// </summary>
+        Label FilterDecisionStart(Handler info);
 
-    /// <summary>
-    /// Decodes ExceptionInfo for the Label corresponding to the end of try block
-    /// </summary>
-    Label TryEnd(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the Label corresponding to the start of handler block
+        /// </summary>
+        Label HandlerStart(Handler info);
 
-    /// <summary>
-    /// Decodes ExceptionInfo for the Label corresponding to the start of filter decision block (if any)
-    /// </summary>
-    Label FilterDecisionStart(Handler info);
+        /// <summary>
+        /// Decodes ExceptionInfo for the Label corresponding to the end of handler block
+        /// </summary>
+        Label HandlerEnd(Handler info);
+    }
 
-    /// <summary>
-    /// Decodes ExceptionInfo for the Label corresponding to the start of handler block
-    /// </summary>
-    Label HandlerStart(Handler info);
+    public interface ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result>
+    {
+        Result Accept<Label>(ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider, Label entryPoint, Data data);
+    }
 
-    /// <summary>
-    /// Decodes ExceptionInfo for the Label corresponding to the end of handler block
-    /// </summary>
-    Label HandlerEnd(Handler info);
-  }
-
-  public interface ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> {
-    Result Accept<Label>(ICodeProvider<Label, Local, Parameter, Method, Field, Type> codeProvider, Label entryPoint, Data data);
-  }
-
-  public interface IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> {
-    Result Accept<Label, Handler>(IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> codeProvider, Label entryPoint, Method method, Data data);
-  }
+    public interface IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result>
+    {
+        Result Accept<Label, Handler>(IMethodCodeProvider<Label, Local, Parameter, Method, Field, Type, Handler> codeProvider, Label entryPoint, Method method, Data data);
+    }
 }

--- a/Microsoft.Research/ControlFlow/LoopUtils.cs
+++ b/Microsoft.Research/ControlFlow/LoopUtils.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,80 +10,80 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public static class LoopAnalysis
-  {
-    public static Dictionary<CFGBlock, List<CFGBlock>> ComputeContainingLoopMap(ICFG cfg)
+    public static class LoopAnalysis
     {
-      Contract.Requires(cfg != null);
-      Contract.Ensures(Contract.Result<Dictionary<CFGBlock, List<CFGBlock>>>() != null);
-
-      var result = new Dictionary<CFGBlock, List<CFGBlock>>();
-      var visitedSubroutines = new Set<int>();
-      var pendingSubroutines = new Stack<Subroutine>();
-      var pendingAPCs = new Stack<APC>();
-
-      var graph = cfg.AsBackwardGraph(includeExceptionEdges:false, skipContracts:true);
-      foreach (var loophead in cfg.LoopHeads)
-      {
-        // push back-edge sources
-        var loopPC = new APC(loophead, 0, null);
-        foreach (var pred in cfg.Predecessors(loopPC))
+        public static Dictionary<CFGBlock, List<CFGBlock>> ComputeContainingLoopMap(ICFG cfg)
         {
-          if (cfg.IsForwardBackEdge(pred, loopPC))
-          {
-            var normalizedPred = new APC(pred.Block, 0, null);
-            pendingAPCs.Push(normalizedPred);
-          }
-        }
-        var visit = new DepthFirst.Visitor<APC, Unit>(graph,
-          (APC pc) =>
-          {
-            if (pc.SubroutineContext != null)
+            Contract.Requires(cfg != null);
+            Contract.Ensures(Contract.Result<Dictionary<CFGBlock, List<CFGBlock>>>() != null);
+
+            var result = new Dictionary<CFGBlock, List<CFGBlock>>();
+            var visitedSubroutines = new Set<int>();
+            var pendingSubroutines = new Stack<Subroutine>();
+            var pendingAPCs = new Stack<APC>();
+
+            var graph = cfg.AsBackwardGraph(includeExceptionEdges: false, skipContracts: true);
+            foreach (var loophead in cfg.LoopHeads)
             {
-              // push continuation PC
-              pendingAPCs.Push(new APC(pc.SubroutineContext.Head.One, 0, null));
-              if (visitedSubroutines.AddQ(pc.Block.Subroutine.Id))
-              {
-                pendingSubroutines.Push(pc.Block.Subroutine);
-              }
-              return false; // stop exploration
+                // push back-edge sources
+                var loopPC = new APC(loophead, 0, null);
+                foreach (var pred in cfg.Predecessors(loopPC))
+                {
+                    if (cfg.IsForwardBackEdge(pred, loopPC))
+                    {
+                        var normalizedPred = new APC(pred.Block, 0, null);
+                        pendingAPCs.Push(normalizedPred);
+                    }
+                }
+                var visit = new DepthFirst.Visitor<APC, Unit>(graph,
+                  (APC pc) =>
+                  {
+                      if (pc.SubroutineContext != null)
+                      {
+                          // push continuation PC
+                          pendingAPCs.Push(new APC(pc.SubroutineContext.Head.One, 0, null));
+                          if (visitedSubroutines.AddQ(pc.Block.Subroutine.Id))
+                          {
+                              pendingSubroutines.Push(pc.Block.Subroutine);
+                          }
+                          return false; // stop exploration
+                      }
+                      return !pc.Equals(loopPC);
+                  });
+
+                while (pendingAPCs.Count > 0)
+                {
+                    var root = pendingAPCs.Pop();
+                    visit.VisitSubGraphNonRecursive(root);
+
+                    while (pendingSubroutines.Count > 0)
+                    {
+                        var sub = pendingSubroutines.Pop();
+                        pendingAPCs.Push(new APC(sub.Exit, 0, null));
+                    }
+                }
+
+                foreach (var visited in visit.Visited)
+                {
+                    if (visited.SubroutineContext != null) continue; // ignore non-primary pcs
+                    MaterializeContainingLoop(result, visited.Block).AssumeNotNull().Add(loophead);
+                }
             }
-            return !pc.Equals(loopPC);
-          });
 
-        while (pendingAPCs.Count > 0)
-        {
-          var root = pendingAPCs.Pop();
-          visit.VisitSubGraphNonRecursive(root);
-
-          while (pendingSubroutines.Count > 0)
-          {
-            var sub = pendingSubroutines.Pop();
-            pendingAPCs.Push(new APC(sub.Exit, 0, null));
-          }
+            return result;
         }
 
-        foreach (var visited in visit.Visited)
+        private static List<CFGBlock> MaterializeContainingLoop(Dictionary<CFGBlock, List<CFGBlock>> map, CFGBlock block)
         {
-          if (visited.SubroutineContext != null) continue; // ignore non-primary pcs
-          MaterializeContainingLoop(result, visited.Block).AssumeNotNull().Add(loophead);
+            Contract.Requires(map != null);// F: Added as of Clousot suggestion
+
+            List<CFGBlock> result;
+            if (!map.TryGetValue(block, out result))
+            {
+                result = new List<CFGBlock>();
+                map.Add(block, result);
+            }
+            return result;
         }
-      }
-
-      return result;
     }
-
-    static List<CFGBlock> MaterializeContainingLoop(Dictionary<CFGBlock, List<CFGBlock>> map, CFGBlock block)
-    {
-      Contract.Requires(map != null);// F: Added as of Clousot suggestion
-
-      List<CFGBlock> result;
-      if (!map.TryGetValue(block, out result))
-      {
-        result = new List<CFGBlock>();
-        map.Add(block, result);
-      }
-      return result;
-    }
-  }
 }

--- a/Microsoft.Research/ControlFlow/MSILVisitor.cs
+++ b/Microsoft.Research/ControlFlow/MSILVisitor.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -18,378 +7,376 @@ using Microsoft.Research.DataStructures;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  public abstract class MSILVisitor<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result> :
-    IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result>
-  {
-
-    protected abstract Result Default(Label pc, Data data);
-
-
-    #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,Source,Dest,Data,Result> Members
-
-    public virtual Result Arglist(Label pc, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result BranchFalse(Label pc, Label target, Source cond, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result BranchTrue(Label pc, Label target, Source cond, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Branch(Label pc, Label target, bool leave, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Break(Label pc, Data data)
-    {
-      throw new Exception("The method or operation is not implemented.");
-    }
-
-    public virtual Result Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
-      where TypeList : IIndexable<Type>
-      where ArgList : IIndexable<Source>
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, Data data)
-      where TypeList : IIndexable<Type>
-      where ArgList : IIndexable<Source>
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ckfinite(Label pc, Dest dest, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Endfilter(Label pc, Source decision, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Endfinally(Label pc, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Jmp(Label pc, Method method, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldconst(Label pc, object constant, Type type, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldnull(Label pc, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldftn(Label pc, Method method, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldloc(Label pc, Local local, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldloca(Label pc, Local local, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldstack(Label pc, int offset, Dest dest, Source source, bool isOld, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldstacka(Label pc, int offset, Dest dest, Source source, Type type, bool isOld, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Localloc(Label pc, Dest dest, Source size, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Pop(Label pc, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Return(Label pc, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Starg(Label pc, Parameter argument, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Stloc(Label pc, Local local, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Switch(Label pc, Type type, IEnumerable<Pair<object,Label>> cases, Source value, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Box(Label pc, Type type, Dest dest, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, Data data)
-      where TypeList : IIndexable<Type>
-      where ArgList : IIndexable<Source>
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Castclass(Label pc, Type type, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Cpobj(Label pc, Type type, Source destptr, Source srcptr, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Initobj(Label pc, Type type, Source ptr, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Isinst(Label pc, Type type, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldelem(Label pc, Type type, Dest dest, Source array, Source index, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldflda(Label pc, Field field, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldlen(Label pc, Dest dest, Source array, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldsfld(Label pc, Field field, bool @volatile, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldsflda(Label pc, Field field, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldtypetoken(Label pc, Type type, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldfieldtoken(Label pc, Field type, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldmethodtoken(Label pc, Method type, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldvirtftn(Label pc, Method method, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Mkrefany(Label pc, Type type, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList lengths, Data data)
-      where ArgList : IIndexable<Source>
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, Data data)
-      where ArgList : IIndexable<Source>
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Refanytype(Label pc, Dest dest, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Refanyval(Label pc, Type type, Dest dest, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Rethrow(Label pc, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Sizeof(Label pc, Type type, Dest dest, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Stelem(Label pc, Type type, Source array, Source index, Source value, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Stfld(Label pc, Field field, bool @volatile, Source obj, Source value, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Stsfld(Label pc, Field field, bool @volatile, Source value, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Throw(Label pc, Source exn, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Unbox(Label pc, Type type, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Unboxany(Label pc, Type type, Dest dest, Source obj, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    #endregion
-
-    #region IVisitSynthIL<Source,Data,Result> Members
-
-    public virtual Result Assume(Label pc, string tag, Source condition, object provenance, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Nop(Label pc, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Assert(Label pc, string tag, Source condition, object provenance, Data data)
-    {
-      return Default(pc, data);
+    public abstract class MSILVisitor<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result> :
+      IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result>
+    {
+        protected abstract Result Default(Label pc, Data data);
+
+
+        #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,Source,Dest,Data,Result> Members
+
+        public virtual Result Arglist(Label pc, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result BranchFalse(Label pc, Label target, Source cond, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result BranchTrue(Label pc, Label target, Source cond, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Branch(Label pc, Label target, bool leave, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Break(Label pc, Data data)
+        {
+            throw new Exception("The method or operation is not implemented.");
+        }
+
+        public virtual Result Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
+          where TypeList : IIndexable<Type>
+          where ArgList : IIndexable<Source>
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, Data data)
+          where TypeList : IIndexable<Type>
+          where ArgList : IIndexable<Source>
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ckfinite(Label pc, Dest dest, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Endfilter(Label pc, Source decision, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Endfinally(Label pc, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Jmp(Label pc, Method method, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldconst(Label pc, object constant, Type type, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldnull(Label pc, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldftn(Label pc, Method method, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldloc(Label pc, Local local, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldloca(Label pc, Local local, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldstack(Label pc, int offset, Dest dest, Source source, bool isOld, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldstacka(Label pc, int offset, Dest dest, Source source, Type type, bool isOld, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Localloc(Label pc, Dest dest, Source size, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Pop(Label pc, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Return(Label pc, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Starg(Label pc, Parameter argument, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Stloc(Label pc, Local local, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Source value, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Box(Label pc, Type type, Dest dest, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, Data data)
+          where TypeList : IIndexable<Type>
+          where ArgList : IIndexable<Source>
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Castclass(Label pc, Type type, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Cpobj(Label pc, Type type, Source destptr, Source srcptr, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Initobj(Label pc, Type type, Source ptr, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Isinst(Label pc, Type type, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldelem(Label pc, Type type, Dest dest, Source array, Source index, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldflda(Label pc, Field field, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldlen(Label pc, Dest dest, Source array, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldsfld(Label pc, Field field, bool @volatile, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldsflda(Label pc, Field field, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldtypetoken(Label pc, Type type, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldfieldtoken(Label pc, Field type, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldmethodtoken(Label pc, Method type, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldvirtftn(Label pc, Method method, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Mkrefany(Label pc, Type type, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList lengths, Data data)
+          where ArgList : IIndexable<Source>
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, Data data)
+          where ArgList : IIndexable<Source>
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Refanytype(Label pc, Dest dest, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Refanyval(Label pc, Type type, Dest dest, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Rethrow(Label pc, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Sizeof(Label pc, Type type, Dest dest, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Stelem(Label pc, Type type, Source array, Source index, Source value, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Stfld(Label pc, Field field, bool @volatile, Source obj, Source value, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Stsfld(Label pc, Field field, bool @volatile, Source value, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Throw(Label pc, Source exn, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Unbox(Label pc, Type type, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Unboxany(Label pc, Type type, Dest dest, Source obj, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        #endregion
+
+        #region IVisitSynthIL<Source,Data,Result> Members
+
+        public virtual Result Assume(Label pc, string tag, Source condition, object provenance, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Nop(Label pc, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Assert(Label pc, string tag, Source condition, object provenance, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Entry(Label pc, Method method, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result BeginOld(Label pc, Label matchingEnd, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        public virtual Result Ldresult(Label pc, Type type, Dest dest, Source source, Data data)
+        {
+            return Default(pc, data);
+        }
+
+        #endregion
     }
-
-    public virtual Result Entry(Label pc, Method method, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result BeginOld(Label pc, Label matchingEnd, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    public virtual Result Ldresult(Label pc, Type type, Dest dest, Source source, Data data)
-    {
-      return Default(pc, data);
-    }
-
-    #endregion
-  }
-
 }

--- a/Microsoft.Research/ControlFlow/MetadataInterfaces.cs
+++ b/Microsoft.Research/ControlFlow/MetadataInterfaces.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -21,4956 +10,4953 @@ using StackTemp = System.Int32;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using System.Diagnostics.Contracts;
+    using System.Diagnostics.Contracts;
 
-  #region Delegate types
-  /// <summary>
-  /// Prints data on given output where each line is prefixed by prefix
-  /// 
-  /// </summary>
-  /// <param name="tw">Output stream</param>
-  /// <param name="prefix">Prefix to be printed on each new line</param>
-  public delegate void Printer<Data>(TextWriter writer, string prefix, Data data);
-
-  /// <summary>
-  /// Generates a textual representation of code at label (none if label is a skip instruction)
-  /// </summary>
-  /// <param name="tw">Output stream</param>
-  /// <param name="prefix">Prefix to be printed on each new line</param>
-  /// <param name="lab">Label of code to be printed</param>
-  public delegate void ILPrinter<Label>(Label label, string prefix, TextWriter writer);
-
-  /// <summary>
-  /// Used to print extra info associated with the end of control flow blocks.
-  /// </summary>
-  public delegate void BlockInfoPrinter<Label>(Label at, string prefix, TextWriter writer);
-
-  #endregion
-
-  #region IL visitor data types
-
-  /// <summary>
-  /// The binary branch operators
-  /// </summary>
-  public enum BranchOperator
-  {
-    Beq,
-    Bge,
-    Bge_un,
-    Bgt,
-    Bgt_un,
-    Ble,
-    Ble_un,
-    Blt,
-    Blt_un,
-    Bne_un,
-  }
-
-  /// <summary>
-  /// Slightly uniformized version of unary operations in IL
-  /// </summary>
-  [Serializable]
-  public enum UnaryOperator
-  {
-    Conv_i,
-    Conv_i1,
-    Conv_i2,
-    Conv_i4,
-    Conv_i8,
-    Conv_r4,
-    Conv_r8,
-    Conv_u,
-    Conv_u1,
-    Conv_u2,
-    Conv_u4,
-    Conv_u8,
-    Conv_r_un,
-    Neg,
-    Not,
-    /// <summary>
-    /// A unary operator on pointers to express contracts about the writeable region extending forward from the pointer.
-    /// The argument is of pointer type, the result type ulong.
-    /// </summary>
-    WritableBytes,
-    /// <summary>
-    /// A synthetic conversion to Decimal. We insert this instead of Decimal constructors.
-    /// </summary>
-    Conv_dec,
-  }
-
-  /// <summary>
-  /// Slightly uniformized version of binary operations in IL
-  /// </summary>
-  [Serializable]
-  public enum BinaryOperator
-  {
-    Add,
-    Add_Ovf,
-    Add_Ovf_Un,
-    And,
-    Ceq,
-    Cobjeq,  // corresponds to Object.Equals, which behaves differently for some values from Ceq (NaN)
-    Cne_Un,  // for semantics, consult Ceq in part III ECMA and negate condition
-    Cge,     // for semantics, consult Bge in part III ECMA
-    Cge_Un,  // for semantics, consult Bge_un in part III ECMA
-    Cgt,
-    Cgt_Un,
-    Cle,     // for semantics, consult Ble in part III ECMA 
-    Cle_Un,  // for semantics, consult Ble_un in part III ECMA
-    Clt,
-    Clt_Un,
-    Div,
-    Div_Un,
-    LogicalAnd, // F: I've added those two for use in the refinement of expression involving boolean connectors
-    LogicalOr,
-    Mul,
-    Mul_Ovf,
-    Mul_Ovf_Un,
-    Or,
-    Rem,
-    Rem_Un,
-    Shl,
-    Shr,
-    Shr_Un,
-    Sub,
-    Sub_Ovf,
-    Sub_Ovf_Un,
-    Xor,
-  }
-
-  public static class OperatorExtensions
-  {
-    public static string ToCodeString(this BinaryOperator bop)
-    {
-      switch (bop)
-      {
-        case BinaryOperator.Add:
-        case BinaryOperator.Add_Ovf:
-        case BinaryOperator.Add_Ovf_Un:
-          return "+";
-        case BinaryOperator.And:
-          return "&";
-        case BinaryOperator.Cobjeq:
-          return "=="; // TODO: eventually need something else here.
-        case BinaryOperator.Ceq:
-          return "==";
-        case BinaryOperator.Cge:
-        case BinaryOperator.Cge_Un:
-          return ">=";
-        case BinaryOperator.Cgt:
-        case BinaryOperator.Cgt_Un:
-          return ">";
-        case BinaryOperator.Cle:
-        case BinaryOperator.Cle_Un:
-          return "<=";
-        case BinaryOperator.Clt:
-        case BinaryOperator.Clt_Un:
-          return "<";
-        case BinaryOperator.Cne_Un:
-          return "!=";
-        case BinaryOperator.Div:
-        case BinaryOperator.Div_Un:
-          return "/";
-        case BinaryOperator.LogicalAnd:
-          return "&&";
-        case BinaryOperator.LogicalOr:
-          return "||";
-        case BinaryOperator.Mul:
-        case BinaryOperator.Mul_Ovf:
-        case BinaryOperator.Mul_Ovf_Un:
-          return "*";
-        case BinaryOperator.Or:
-          return "|";
-        case BinaryOperator.Rem:
-        case BinaryOperator.Rem_Un:
-          return "%";
-        case BinaryOperator.Shl:
-          return "<<";
-        case BinaryOperator.Shr:
-        case BinaryOperator.Shr_Un:
-          return ">>";
-        case BinaryOperator.Sub:
-        case BinaryOperator.Sub_Ovf:
-        case BinaryOperator.Sub_Ovf_Un:
-          return "-";
-        case BinaryOperator.Xor:
-          return "^";
-
-        default:
-          throw new InvalidOperationException("Unknown binary operator");
-      }
-    }
-
-    public static string ToCodeString(this UnaryOperator op)
-    {
-      switch (op)
-      {
-        case UnaryOperator.Conv_i:
-          return "(UIntPtr)";
-        case UnaryOperator.Conv_i1:
-          return "(sbyte)";
-        case UnaryOperator.Conv_i2:
-          return "(short)";
-        case UnaryOperator.Conv_i4:
-          return "(int)";
-        case UnaryOperator.Conv_i8:
-          return "(long)";
-        case UnaryOperator.Conv_r_un:
-          return "(double)";
-        case UnaryOperator.Conv_r4:
-          return "(float)";
-        case UnaryOperator.Conv_r8:
-          return "(double)";
-        case UnaryOperator.Conv_u:
-          return "(UIntPtr)";
-        case UnaryOperator.Conv_u1:
-          return "(byte)";
-        case UnaryOperator.Conv_u2:
-          return "(ushort)";
-        case UnaryOperator.Conv_u4:
-          return "(uint)";
-        case UnaryOperator.Conv_u8:
-          return "(ulong)";
-        case UnaryOperator.Neg:
-          return "-";
-        case UnaryOperator.Not:
-          return "!";
-        case UnaryOperator.WritableBytes:
-          return "Contracts.WritableBytes";
-        case UnaryOperator.Conv_dec:
-          return "new Decimal";
-        default:
-          throw new InvalidOperationException("Unknown unary op");
-      }
-    }
-
-    [Pure]
-    public static bool IsComparisonBinaryOperator(this BinaryOperator op)
-    {
-      switch (op)
-      {
-        case BinaryOperator.Ceq:
-        case BinaryOperator.Cge:
-        case BinaryOperator.Cge_Un:
-        case BinaryOperator.Cgt:
-        case BinaryOperator.Cgt_Un:
-        case BinaryOperator.Cle:
-        case BinaryOperator.Cle_Un:
-        case BinaryOperator.Clt:
-        case BinaryOperator.Clt_Un:
-        case BinaryOperator.Cne_Un:
-        case BinaryOperator.Cobjeq:
-          return true;
-        default:
-          return false;
-      }
-    }
-
-    [Pure]
-    public static bool IsEqualityOrDisequality(this BinaryOperator bop)
-    {
-      return bop == BinaryOperator.Ceq || bop == BinaryOperator.Cne_Un;
-    }
-
-    public static bool IsBooleanBinaryOperator(this BinaryOperator op)
-    {
-      switch (op)
-      {
-        case BinaryOperator.LogicalAnd:
-        case BinaryOperator.LogicalOr:
-          return true;
-        default:
-          return false;
-      }
-    }
-
-    public static bool IsBitwiseBinaryOperator(this BinaryOperator op)
-    {
-      switch (op)
-      {
-        case BinaryOperator.And:
-        case BinaryOperator.Or:
-        case BinaryOperator.Xor:
-          return true;
-        default:
-          return false;
-      }
-    }
-
-    public static bool IsArithmeticBinaryOperator(this BinaryOperator op)
-    {
-      switch (op)
-      {
-        case BinaryOperator.Add:
-        case BinaryOperator.Add_Ovf:
-        case BinaryOperator.Add_Ovf_Un:
-        case BinaryOperator.Div:
-        case BinaryOperator.Div_Un:
-        case BinaryOperator.Mul:
-        case BinaryOperator.Mul_Ovf:
-        case BinaryOperator.Mul_Ovf_Un:
-        case BinaryOperator.Rem:
-        case BinaryOperator.Rem_Un:
-        case BinaryOperator.Sub:
-        case BinaryOperator.Sub_Ovf:
-        case BinaryOperator.Sub_Ovf_Un:
-          {
-            return true;
-          }
-        default:
-          {
-            return false;
-          }
-      }
-    }
-
-    public static bool IsOverflowChecked(this BinaryOperator op)
-    {
-      return op == BinaryOperator.Add_Ovf || op == BinaryOperator.Add_Ovf_Un ||
-            op == BinaryOperator.Sub_Ovf || op == BinaryOperator.Sub_Ovf_Un ||
-            op == BinaryOperator.Mul_Ovf || op == BinaryOperator.Mul_Ovf_Un;
-    }
-
-    public static bool TryNegate(this BinaryOperator op, out BinaryOperator negated)
-    {
-      switch (op)
-      {
-        case BinaryOperator.Ceq:
-          {
-            negated = BinaryOperator.Cne_Un;
-            return true;
-          }
-
-        case BinaryOperator.Cge:
-          {
-            negated = BinaryOperator.Clt;
-            return true;
-          }
-
-        case BinaryOperator.Cge_Un:
-          {
-            negated = BinaryOperator.Clt_Un;
-            return true;
-          }
-        case BinaryOperator.Cgt:
-          {
-            negated = BinaryOperator.Cle;
-            return true;
-          }
-        case BinaryOperator.Cgt_Un:
-          {
-            negated = BinaryOperator.Cle_Un;
-            return true;
-          }
-        case BinaryOperator.Cle:
-          {
-            negated = BinaryOperator.Cgt;
-            return true;
-          }
-        case BinaryOperator.Cle_Un:
-          {
-            negated = BinaryOperator.Cgt_Un;
-            return true;
-          }
-        case BinaryOperator.Clt:
-          {
-            negated = BinaryOperator.Cge;
-            return true;
-          }
-        case BinaryOperator.Clt_Un:
-          {
-            negated = BinaryOperator.Cge_Un;
-            return true;
-          }
-        case BinaryOperator.Cne_Un:
-          {
-            negated = BinaryOperator.Ceq;
-            return true;
-          }
-        default:
-          {
-            negated = BinaryOperator.Add;
-            return false;
-          }
-      }
-    }
-
-    public static bool TryInvert(this BinaryOperator op, out BinaryOperator inverted)
-    {
-      switch (op)
-      {
-        case BinaryOperator.Ceq:
-          {
-            inverted = BinaryOperator.Ceq;
-            return true;
-          }
-
-        case BinaryOperator.Cge:
-          {
-            inverted = BinaryOperator.Cle;
-            return true;
-          }
-
-        case BinaryOperator.Cge_Un:
-          {
-            inverted = BinaryOperator.Cle_Un;
-            return true;
-          }
-        case BinaryOperator.Cgt:
-          {
-            inverted = BinaryOperator.Clt;
-            return true;
-          }
-        case BinaryOperator.Cgt_Un:
-          {
-            inverted = BinaryOperator.Clt_Un;
-            return true;
-          }
-        case BinaryOperator.Cle:
-          {
-            inverted = BinaryOperator.Cge;
-            return true;
-          }
-        case BinaryOperator.Cle_Un:
-          {
-            inverted = BinaryOperator.Cge_Un;
-            return true;
-          }
-        case BinaryOperator.Clt:
-          {
-            inverted = BinaryOperator.Cgt;
-            return true;
-          }
-        case BinaryOperator.Clt_Un:
-          {
-            inverted = BinaryOperator.Cgt_Un;
-            return true;
-          }
-        case BinaryOperator.Cne_Un:
-          {
-            inverted = BinaryOperator.Cne_Un;
-            return true;
-          }
-        default:
-          {
-            inverted = default(BinaryOperator);
-            return false;
-          }
-      }
-    }
-
-
-    public static bool IsConversionOperator(this UnaryOperator op)
-    {
-      switch (op)
-      {
-        case UnaryOperator.Conv_i:
-        case UnaryOperator.Conv_i1:
-        case UnaryOperator.Conv_i2:
-        case UnaryOperator.Conv_i4:
-        case UnaryOperator.Conv_i8:
-        case UnaryOperator.Conv_r4:
-        case UnaryOperator.Conv_r8:
-        case UnaryOperator.Conv_u:
-        case UnaryOperator.Conv_u1:
-        case UnaryOperator.Conv_u2:
-        case UnaryOperator.Conv_u4:
-        case UnaryOperator.Conv_u8:
-        case UnaryOperator.Conv_r_un:
-          return true;
-
-        default:
-          return false;
-      }
-    }
-  }
-  #endregion
-
-  #region IDecodeMethods contract binding
-  [ContractClass(typeof(IDecodeMethodsContract<>))]
-  public partial interface IDecodeMethods<Method>
-  {
-    /// <summary>
-    /// Short name of method without namespace and outer types
-    /// </summary>
-    [Pure]
-    string Name(Method method);
-
-    /// <summary>
-    /// Full name of method including namespace and outer types
-    /// </summary>
-    [Pure]
-    string FullName(Method method);
-
-    /// <summary>
-    /// Obtain the Documentation Id for the method
-    /// </summary>
-    [Pure]
-    string DocumentationId(Method method);
-
-    /// <summary>
-    /// Get the canonical name of the member associated with this method. 
-    /// A member can be a method, an event or a property. 
-    /// This name is aimed at beeing created by the visual studio package
-    /// </summary>
-    [Pure]
-    string DeclaringMemberCanonicalName(Method method);
-
-    /// <summary>
-    /// True iff method is the entry point of an executable
-    /// </summary>
-    [Pure]
-    bool IsMain(Method method);
-
-    /// <summary>
-    /// True if method is static.
-    /// </summary>
-    [Pure]
-    bool IsStatic(Method method);
-
-    /// <summary>
-    /// True if method is private
-    /// </summary>
-    [Pure]
-    bool IsPrivate(Method method);
-
-    /// <summary>
-    /// True if method is protected
-    /// </summary>
-    [Pure]
-    bool IsProtected(Method method);
-
-    /// <summary>
-    /// True if method is public
-    /// </summary>
-    [Pure]
-    bool IsPublic(Method method);
-
-    /// <summary>
-    /// True if method is virtual
-    /// </summary>
-    [Pure]
-    bool IsVirtual(Method method);
-
-    /// <summary>
-    /// True if method is declared as "new"
-    /// </summary>
-    [Pure]
-    bool IsNewSlot(Method method);
-
-    /// <summary>
-    /// True if method is "override"
-    /// </summary>
-    [Pure]
-    bool IsOverride(Method method);
-
-    /// <summary>
-    /// True if method is sealed
-    /// </summary>
-    [Pure]
-    bool IsSealed(Method method);
-
-    /// <summary>
-    /// True if the return type of the method is void
-    /// </summary>
-    [Pure]
-    bool IsVoidMethod(Method method);
-
-    /// <summary>
-    /// Returns true if the method is an instance constructor
-    /// </summary>
-    [Pure]
-    bool IsConstructor(Method method);
-
-    /// <summary>
-    /// Returns true if the method is a finalizer
-    /// </summary>
-    [Pure]
-    bool IsFinalizer(Method method);
-
-    /// <summary>
-    /// Returns true if the method is a Dispose implementation
-    /// </summary>
-    [Pure]
-    bool IsDispose(Method method);
-
-    /// <summary>
-    /// Returns true if the method is internal
-    /// </summary>
-    [Pure]
-    bool IsInternal(Method method);
-
-    /// <summary>
-    /// True if method is visible outside assembly within which it is declared
-    /// E.g., public methods, or protected methods of publicly visible types, etc.
-    /// </summary>
-    [Pure]
-    bool IsVisibleOutsideAssembly(Method method);
-
-    /// <summary>
-    /// True if method is abstract and has no body
-    /// </summary>
-    [Pure]
-    bool IsAbstract(Method method);
-
-    /// <summary>
-    /// True if method is declared extern and has no body
-    /// </summary>
-    [Pure]
-    bool IsExtern(Method method);
-
-    /// <summary>
-    /// Returns true if the method is a property setter
-    /// </summary>
-    [Pure]
-    bool IsPropertySetter(Method method);
-
-    /// <summary>
-    /// Returns true if the method is a property getter
-    /// </summary>
-    [Pure]
-    bool IsPropertyGetter(Method method);
-
-    /// <summary>
-    /// For an async generated MoveNext methods, returns true
-    /// </summary>
-    [Pure]
-    bool IsAsyncMoveNext(Method method);
-
-    /// <summary>
-    /// For a MoveNext method from async or iterators, returns the start state (-1 or 0). Otherwise returns null.
-    /// </summary>
-    [Pure]
-    int? MoveNextStartState(Method method);
-
-  }
-
-  [ContractClassFor(typeof(IDecodeMethods<>))]
-  abstract class IDecodeMethodsContract<Method> : IDecodeMethods<Method>
-  {
-    public string Name(Method method)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return null;
-    }
-
-    public string FullName(Method method)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return null;
-    }
-
-    public string DocumentationId(Method method)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      return null;
-    }
-
-    public string DeclaringMemberCanonicalName(Method method)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public bool IsMain(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsStatic(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPrivate(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsProtected(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPublic(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVirtual(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsNewSlot(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsOverride(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSealed(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVoidMethod(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsConstructor(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsFinalizer(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsDispose(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsInternal(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleOutsideAssembly(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsAbstract(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsExtern(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPropertySetter(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPropertyGetter(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    #region IDecodeMethods<Method> Members
-
-
-    public bool IsAsyncMoveNext(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public int? MoveNextStartState(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-  }
-  #endregion
-
-  [ContractClass(typeof(IDecodeMetaDataContracts<,,,,,,,,>))]
-  public partial interface IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> : IDecodeMethods<Method>
-  {
-    #region Methods
-
-    /// <summary>
-    /// Returns the return type of a method
-    /// </summary>
-    [Pure]
-    Type ReturnType(Method method);
-
-    /// <summary>
-    /// Returns the parameters of a method, NOT including "this" (even if the method is an instance method)
-    /// </summary>
-    [Pure]
-    IIndexable<Parameter> Parameters(Method method);
-
-    /// <summary>
-    /// For non-static methods, returns a parameter corresponding to "this or arg0".
-    /// Can throw if the method is static.
-    /// </summary>
-    [Pure]
-    Parameter This(Method method);
-
-    /// <summary>
-    /// True if property is visible outside assembly within which it is declared
-    /// </summary>
-    [Pure]
-    bool IsVisibleOutsideAssembly(Property property);
-
-    /// <summary>
-    /// True if event is visible outside assembly within which it is declared
-    /// </summary>
-    [Pure]
-    bool IsVisibleOutsideAssembly(Event @event);
-
-    /// <summary>
-    /// True if field is visible outside assembly within which it is declared
-    /// </summary>
-    [Pure]
-    bool IsVisibleOutsideAssembly(Field field);
-
-    /// <summary>
-    /// Returns the property containing the getter/setter if the method is actually a getter/setter.
-    /// </summary>
-    /// <param name="method"></param>
-    /// <returns></returns>
-    [Pure]
-    Property GetPropertyFromAccessor(Method method);
-
-    /// <summary>
-    /// Returns true if the method is compiler generated
-    /// </summary>
-    [Pure]
-    bool IsCompilerGenerated(Method method);
-
-    /// <summary>
-    /// Returns true if the method is marked with the DebuggerNonUserCode attribute
-    /// </summary>
-    [Pure]
-    bool IsDebuggerNonUserCode(Method method);
-
-    /// <summary>
-    /// Returns true if the type is marked with the DebuggerNonUserCode attribute
-    /// </summary>
-    [Pure]
-    bool IsDebuggerNonUserCode(Type t);
-
-    /// <summary>
-    /// Returns true if the method is an auto property getter or setter
-    /// </summary>
-    [Pure]
-    bool IsAutoPropertyMember(Method method);
-
-    /// <summary>
-    /// Returns true if the method is an auto property setter
-    /// </summary>
-    [Pure]
-    bool IsAutoPropertySetter(Method method, out Field backingField);
-
-    /// <summary>
-    /// Returns true if the type is compiler generated
-    /// </summary>
-    [Pure]
-    bool IsCompilerGenerated(Type type);
-
-    /// <summary>
-    /// Returns true if the type was generated from C++
-    /// </summary>
-    [Pure]
-    bool IsNativeCpp(Type type);
-
-    /// <summary>
-    /// Returns the declaring type containing this method
-    /// </summary>
-    [Pure]
-    Type DeclaringType(Method method);
-
-    /// <summary>
-    /// Returns the declaring assembly containing this method
-    /// </summary>
-    [Pure]
-    Assembly DeclaringAssembly(Method method);
-
-    /// <summary>
-    /// Returns the method def/ref token of the method if possible.
-    /// </summary>
-    [Pure]
-    int MethodToken(Method method);
-
-    /// <summary>
-    /// Returns true if this method reference is specialized w.r.t. type parameters, either
-    /// because the method is generic and instantiated, or because a declaring/parent type is
-    /// instantiated.
-    /// </summary>
-    [Pure]
-    bool IsSpecialized(Method method);
-
-    /// <summary>
-    /// Returns true if this method reference is specialized w.r.t. type parameters, either
-    /// because the method is generic and instantiated, or because a declaring/parent type is
-    /// instantiated.
-    /// </summary>
-    /// <param name="specialization">the map is updated with all the specializations
-    /// (mapping formal type arguments to actuals)</param>
-    [Pure]
-    bool IsSpecialized(Method method, ref IFunctionalMap<Type, Type> specialization);
-
-    /// <summary>
-    /// Returns true if this method reference is specialized w.r.t. type parameters, either
-    /// because the method is generic and instantiated, or because a declaring/parent type is
-    /// instantiated.
-    /// </summary>
-    [Pure]
-    bool IsSpecialized(Method method, out Method genericMethod, out IIndexable<Type> methodTypeArguments);
-
-    /// <summary>
-    /// Returns true if method is a template method with formal type arguments. 
-    /// NOTE: only the method type parameter of the given method are reported, no type parameters of
-    /// enclosing types.
-    /// </summary>
-    [Pure]
-    bool IsGeneric(Method method, out IIndexable<Type> formals);
-
-    /// <summary>
-    /// For specialized methods, this returns the original template method, otherwise identity
-    /// </summary>
-    [Pure]
-    Method Unspecialized(Method method);
-
-    /// <summary>
-    /// Specializes a generic method with the given type arguments
-    /// </summary>
-    [Pure]
-    Method Specialize(Method method, Type[] methodTypeArguments);
-
-    /// <summary>
-    /// Returns the set of methods that are immediately overridden from a base class (no intermediate override)
-    /// </summary>
-    [Pure]
-    IEnumerable<Method> OverriddenMethods(Method method);
-
-    /// <summary>
-    /// Returns the set of methods that are interface methods implemented explicitly or implicitly by this method
-    /// </summary>
-    [Pure]
-    IEnumerable<Method> ImplementedMethods(Method method);
-
-    /// <summary>
-    /// Returns the set of methods that are either
-    ///  - immediately overridden from a base class (no intermediate override)
-    ///  - interface methods implemented explicitly or implicitly by this method 
-    /// </summary>
-    [Pure]
-    IEnumerable<Method> OverriddenAndImplementedMethods(Method method);
-
-    /// <summary>
-    /// Returns true if method implements a method from an interface implicitly (as opposed to explict implementations)
-    /// </summary>
-    [Pure]
-    bool IsImplicitImplementation(Method method);
-
-    /// <summary>
-    /// Returns true if the method has a body and Entry(method) can be called.
-    /// </summary>
-    [Pure]
-    bool HasBody(Method method);
-
-    /// <summary>
-    /// Provides access to a method body (if HasBody returned true), existentially abstracting the
-    /// internal code representation of Labels and Handlers.
-    /// </summary>
-    [Pure]
-    Result AccessMethodBody<Data, Result>(Method method, IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
-
-    /// <summary>
-    /// Equality between methods
-    /// </summary>
-    [Pure]
-    bool Equal(Method m1, Method m2);
-
-    /// <summary>
-    /// Returns true if two types, type1 and type2, are equivalent types, as interpreted by the underlying 
-    /// object model. 
-    /// </summary>
-    /// <param name="type1"></param>
-    /// <param name="type2"></param>
-    /// <returns></returns>
-    [Pure]
-    bool Equal(Type type1, Type type2);
-
-    /// <summary>
-    /// Returns true if any context that can see m2 can also see m1
-    /// </summary>
-    [Pure]
-    bool IsAsVisibleAs(Method m1, Method m2);
-
-    /// <summary>
-    /// Returns true if any context that can see m can also see t
-    /// </summary>
-    [Pure]
-    bool IsAsVisibleAs(Type t, Method m);
-
-    /// <summary>
-    /// Returns true if m can be seen from the type t
-    /// </summary>
-    [Pure]
-    bool IsVisibleFrom(Method m, Type t);
-
-    /// <summary>
-    /// Returns true if f can be seen from the type t
-    /// </summary>
-    [Pure]
-    bool IsVisibleFrom(Field f, Type t);
-
-    /// <summary>
-    /// Returns true if t can be seen from the body of tfrom
-    /// </summary>
-    [Pure]
-    bool IsVisibleFrom(Type t, Type tfrom);
-
-
-    /// <summary>
-    /// Tries to find the method that implements baseMethod for type. This is either an
-    /// explicit implementation in type, an implicit method in type, or an implicit or explicit
-    /// implementation in the base-type of type.
-    /// </summary>
-    [Pure]
-    bool TryGetImplementingMethod(Type type, Method baseMethod, out Method implementingMethod);
-
-    /// <summary>
-    /// Returns the locals of a given method
-    /// </summary>
-    [Pure]
-    IIndexable<Local> Locals(Method method);
-
-    /// <summary>
-    /// If method is overriding another base method, then this returns the root method of the inheritance 
-    /// hierarchy.
-    /// </summary>
-    bool TryGetRootMethod(Method method, out Method rootMethod);
-
-
-    #endregion
-
-    #region Fields
-
-    /// <summary>
-    /// Returns the type of the field
-    /// </summary>
-    [Pure]
-    Type FieldType(Field field);
-
-    /// <summary>
-    /// Returns the full name of the field including surrounding types and namespaces
-    /// </summary>
-    [Pure]
-    string FullName(Field field);
-
-    /// <summary>
-    /// Returns the short name of a field
-    /// </summary>
-    [Pure]
-    string Name(Field field);
-
-    /// <summary>
-    /// Obtain the Documentation Id for the method
-    /// </summary>
-    [Pure]
-    string DocumentationId(Field field);
-
-    /// <summary>
-    /// True if the field is static
-    /// </summary>
-    [Pure]
-    bool IsStatic(Field field);
-
-    /// <summary>
-    /// Returns true if field is private
-    /// </summary>
-    [Pure]
-    bool IsPrivate(Field field);
-
-    /// <summary>
-    /// Returns true if field is protected
-    /// </summary>
-    [Pure]
-    bool IsProtected(Field field);
-
-    /// <summary>
-    /// Returns true if field is public
-    /// </summary>
-    [Pure]
-    bool IsPublic(Field field);
-
-    /// <summary>
-    /// true if field is internal
-    /// </summary>
-    [Pure]
-    bool IsInternal(Field field);
-
-    /// <summary>
-    /// true if field is volatile
-    /// </summary>
-    [Pure]
-    bool IsVolatile(Field field);
-
-    /// <summary>
-    /// true if field is declared as "new"
-    /// </summary>
-    [Pure]
-    bool IsNewSlot(Field field);
-
-    /// <summary>
-    /// Returns the declaring type containing this field
-    /// </summary>
-    [Pure]
-    Type DeclaringType(Field field);
-
-    /// <summary>
-    /// Returns true if the field is declared readonly
-    /// </summary>
-    [Pure]
-    bool IsReadonly(Field field);
-
-    /// <summary>
-    /// Returns true if any context that can see method can also see field.
-    /// </summary>
-    [Pure]
-    bool IsAsVisibleAs(Field field, Method method);
-
-    /// <summary>
-    /// Returns true if this field reference is specialized w.r.t. type parameters, 
-    /// because the a declaring/parent type is instantiated.
-    /// </summary>
-    [Pure]
-    bool IsSpecialized(Field field);
-
-    /// <summary>
-    /// Returns the unspecialized field corresponding to this field, if the field
-    /// is specialized due to parent types being instantiated. Acts as an identity
-    /// for non-specialized fields.
-    /// </summary>
-    [Pure]
-    Field Unspecialized(Field field);
-
-    /// <summary>
-    /// Returns the initial value of the field. Note: if field is an enum field, returns its value.
-    /// </summary>
-    [Pure]
-    bool TryInitialValue(Field field, out object value);
-
-    /// <summary>
-    /// Returns if the two fields are equal
-    /// </summary>
-    [Pure]
-    bool Equal(Field f1, Field f2);
-
-    /// <summary>
-    /// Return true if the field is compiler generated
-    /// </summary>
-    [Pure]
-    bool IsCompilerGenerated(Field f);
-
-    #endregion
-
-    #region Properties
-    [Pure]
-    string Name(Property property);
-
-    [Pure]
-    bool HasGetter(Property property, out Method getter);
-    [Pure]
-    bool HasSetter(Property property, out Method setter);
-
-    [Pure]
-    IEnumerable<Property> Properties(Type type);
-
-    [Pure]
-    bool IsStatic(Property p);
-    [Pure]
-    bool IsOverride(Property p);
-    [Pure]
-    bool IsNewSlot(Property p);
-    [Pure]
-    bool IsSealed(Property p);
-
-    [Pure]
-    Type DeclaringType(Property p);
-    [Pure]
-    Type PropertyType(Property property);
-
-    /// <summary>
-    /// Returns if the two properties are the same
-    /// </summary>
-    [Pure]
-    bool Equal(Property p1, Property p2);
-
-    #endregion
-
-    #region Events
-    [Pure]
-    string Name(Event @event);
-
-    [Pure]
-    bool HasAdder(Event @event, out Method adder);
-    [Pure]
-    bool HasRemover(Event @event, out Method remover);
-
-    [Pure]
-    IEnumerable<Event> Events(Type type);
-
-    [Pure]
-    bool IsStatic(Event e);
-    [Pure]
-    bool IsOverride(Event e);
-    [Pure]
-    bool IsNewSlot(Event e);
-    [Pure]
-    bool IsSealed(Event e);
-
-    [Pure]
-    Type DeclaringType(Event e);
-    [Pure]
-    Type HandlerType(Event e);
-
-    /// <summary>
-    /// Returns if the two events are the same
-    /// </summary>
-    [Pure]
-    bool Equal(Event e1, Event e2);
-
-    bool IsEventAdder(Method method, out Event @event);
-
-    bool IsEventRemover(Method method, out Event @event);
-
-    #endregion
-
-    #region Types
-
-    /// <summary>
-    /// True if this is the framework System.Void type, ignoring surrounding optional/required modifiers
-    /// </summary>
-    [Pure]
-    bool IsVoid(Type/*!*/ type);
-
-    /// <summary>
-    /// True if this is an unmanaged pointer, ignoring surrounding optional/required modifiers
-    /// </summary>
-    [Pure]
-    bool IsUnmanagedPointer(Type/*!*/ type);   // * type
-
-    /// <summary>
-    /// True if this is a managed pointer, ignoring surrounding optional/required modifiers
-    /// </summary>
-    [Pure]
-    bool IsManagedPointer(Type/*!*/ type);     // & type
-
-    /// <summary>
-    /// True if this is a primitive type, ignoring surrounding optional/required modifiers
-    /// </summary>
-    [Pure]
-    bool IsPrimitive(Type/*!*/ type);
-
-    /// <summary>
-    /// True if this is a struct/value type type, ignoring surrounding optional/required modifiers
-    /// </summary>
-    //^ [Confined]
-    [Pure]
-    bool IsStruct(Type/*!*/ type);
-
-    /// <summary>
-    /// True if this is an array type, ignoring surrounding optional/required modifiers
-    /// </summary>
-    //^ [Confined]
-    [Pure]
-    bool IsArray(Type/*!*/ type);
-
-    /// <summary>
-    /// Returns the number of dimensions if the type is an array.
-    /// Requires IsArray
-    /// </summary>
-    /// <param name="type"></param>
-    /// <returns></returns>
-    [Pure]
-    int Rank(Type type);
-
-    /// <summary>
-    /// Returns true if type is an interface
-    /// </summary>
-    [Pure]
-    bool IsInterface(Type/*!*/ type);
-
-    /// <summary>
-    /// Returns true if type is static
-    /// </summary>
-    [Pure]
-    bool IsStatic(Type type);
-
-    /// <summary>
-    /// Returns true if type is a class
-    /// </summary>
-    [Pure]
-    bool IsClass(Type/*!*/ type);
-
-    /// <summary>
-    /// Returns true if type is declared abstract
-    /// </summary>
-    [Pure]
-    bool IsAbstract(Type type);
-
-    /// <summary>
-    /// Returns true if type is declared public
-    /// </summary>
-    [Pure]
-    bool IsPublic(Type type);
-
-    /// <summary>
-    /// Returns true if type is declared internal
-    /// </summary>
-    [Pure]
-    bool IsInternal(Type type);
-
-    /// <summary>
-    /// Returns true if type is declared protected
-    /// </summary>
-    [Pure]
-    bool IsProtected(Type type);
-
-    /// <summary>
-    /// Returns true if type is private
-    /// </summary>
-    [Pure]
-    bool IsPrivate(Type type);
-
-    /// <summary>
-    /// Returns true if type is sealed
-    /// </summary>
-    [Pure]
-    bool IsSealed(Type type);
-
-    /// <summary>
-    /// Returns the parent type and true if the given type is nested.
-    /// </summary>
-    [Pure]
-    bool IsNested(Type/*!*/ type, out Type/*?*/ parentType);
-
-    /// <summary>
-    /// Returns true if the formal generic argument is reference constrained. Either class or method formal argument.
-    /// </summary>
-    [Pure]
-    bool IsReferenceConstrained(Type type);
-
-    /// <summary>
-    /// Returns true if the formal generic argument is value constrained. Either class or method formal argument.
-    /// </summary>
-    [Pure]
-    bool IsValueConstrained(Type type);
-
-    /// <summary>
-    /// Returns true if the formal generic argument is constructor constrained. Either class or method formal argument.
-    /// </summary>
-    [Pure]
-    bool IsConstructorConstrained(Type type);
-
-
-    /// <summary>
-    /// Returns true if the given type is a type bound formal type parameter
-    /// </summary>
-    [Pure]
-    bool IsFormalTypeParameter(Type type);
-
-    /// <summary>
-    /// Returns true if the given type is a method bound formal type parameter
-    /// </summary>
-    [Pure]
-    bool IsMethodFormalTypeParameter(Type type);
-
-    /// <summary>
-    /// Returns true if type represents a modified type with the given set of 
-    /// optional and required modifiers. The pairings of the modifiers with a boolean indicates 
-    /// if the modifier is optional (bool is true), or required (bool is false).
-    /// </summary>
-    [Pure]
-    bool IsModified(Type type, out Type modified, out IIndexable<Pair<bool, Type>> modifiers);
-
-    /// <summary>
-    /// Returns true if type is a template type with formal type arguments. NOTE: if normalized is true,
-    /// this provides the IL/Metadata view where nested types inherit the type formals of their enclosing types.
-    /// Otherwise, only the type parameter of the given type are reported.
-    /// </summary>
-    [Pure]
-    bool IsGeneric(Type type, out IIndexable<Type> formals, bool normalized);
-
-    /// <summary>
-    /// Returns true if the type is a delegate
-    /// </summary>
-    [Pure]
-    bool IsDelegate(Type type);
-
-    /// <summary>
-    /// For type bound type parameters, provides the normalized index of the type parameter.
-    /// For nested types, they are normalized to include all parent type parameters.
-    /// </summary>
-    [Pure]
-    int NormalizedFormalTypeParameterIndex(Type type);
-
-    /// <summary>
-    /// For type bound type parameters, provides the defined type of the type parameter
-    /// </summary>
-    [Pure]
-    Type FormalTypeParameterDefiningType(Type type);
-
-    /// <summary>
-    /// Returns the actual type arguments of type (including parent type arguments).
-    /// If type isn't an instance, result is of length 0.
-    /// </summary>
-    [Pure]
-    IIndexable<Type> NormalizedActualTypeArguments(Type type);
-
-    /// <summary>
-    /// Returns the actual type arguments of the method (NOT including declaring type or parent types).
-    /// If method isn't a generic method instance, result is of length 0.
-    /// </summary>
-    [Pure]
-    IIndexable<Type> ActualTypeArguments(Method method);
-
-    /// <summary>
-    /// For method bound formal type parameters, this method returns the index of the type parameter on the method.
-    /// </summary>
-    [Pure]
-    int MethodFormalTypeParameterIndex(Type type);
-
-    /// <summary>
-    /// For method bound formal type parameters, this method returns the method defining the type parameter
-    /// </summary>
-    [Pure]
-    Method MethodFormalTypeDefiningMethod(Type type);
-
-    /// <summary>
-    /// Returns true if type represents an enum
-    /// </summary>
-    [Pure]
-    bool IsEnum(Type type);
-
-    /// <summary>
-    /// Returns true if the Flags attribute is specified for that type
-    /// </summary>
-    /// <param name="type"></param>
-    /// <returns></returns>
-    [Pure]
-    bool HasFlagsAttribute(Type type);
-
-    /// <summary>
-    /// Returns the underlying type if type is an enum
-    /// </summary>
-    [Pure]
-    Type TypeEnum(Type type);
-
-    /// <summary>
-    /// Returns the MVID of the declaring module (if nested type, of the declaring module of the container)
-    /// </summary>
-    [Pure]
-    System.Guid DeclaringModule(Type/*!*/ type);
-
-
-    /// <summary>
-    /// Returns the module name defining this type (if nested, the declaring module of the container)
-    /// </summary>
-    [Pure]
-    string DeclaringModuleName(Type type);
-
-    /// <summary>
-    /// Returns the fields of a type
-    /// </summary>
-    [Pure]
-    IEnumerable<Field/*!*/> Fields(Type/*!*/ type);
-
-    /// <summary>
-    /// Returns the methods of a type
-    /// </summary>
-    [Pure]
-    IEnumerable<Method> Methods(Type type);
-
-    /// <summary>
-    /// Returns the nested types of a type
-    /// </summary>
-    [Pure]
-    IEnumerable<Type> NestedTypes(Type type);
-
-    /// <summary>
-    /// Returns the short name of the type
-    /// </summary>
-    [Pure]
-    string Name(Type type);
-
-    /// <summary>
-    /// Returns the full name including surrounding types and namespaces
-    /// </summary>
-    [Pure]
-    string FullName(Type/*!*/ type);
-
-
-    /// <summary>
-    /// Obtain the Documentation Id for the method
-    /// </summary>
-    [Pure]
-    string DocumentationId(Type type);
-    
-
-    /// <summary>
-    /// Returns the namespace of the type (if not a nested type)
-    /// </summary>
-    [Pure]
-    string Namespace(Type type);
-
-    /// <summary>
-    /// Constructs an array type with the given element type and rank
-    /// </summary>
-    [Pure]
-    Type/*!*/ ArrayType(Type/*!*/ type, int rank);  // type[]...
-
-    /// <summary>
-    /// Constructs a managed pointer type with the given element type
-    /// </summary>
-    [Pure]
-    Type/*!*/ ManagedPointer(Type/*!*/ type);       // type&
-
-    /// <summary>
-    /// Constructs an unmanaged pointer type with the given element type
-    /// </summary>
-    [Pure]
-    Type/*!*/ UnmanagedPointer(Type/*!*/ type);       // type&
-
-    /// <summary>
-    /// For managed and unmanaged pointers and arrays, returns the type pointed to (in the array)
-    /// </summary>
-    [Pure]
-    Type/*!*/ ElementType(Type/*!*/ type);
-
-    /// <summary>
-    /// If the type has explicit layout information, it returns the size of the type. Otherwise -1.
-    /// </summary>
-    [Pure]
-    int TypeSize(Type/*!*/ type);
-
-    /// <summary>
-    /// Returns true if the type is a class and has a base class (e.g., not Object)
-    /// </summary>
-    [Pure]
-    bool HasBaseClass(Type type);
-
-    /// <summary>
-    /// Returns the base class of the given type, or fails if the type has no base class
-    /// </summary>
-    [Pure]
-    Type BaseClass(Type type);
-
-    /// <summary>
-    /// If type is a class or struct, returns the implemented interfaces
-    /// </summary>
-    [Pure]
-    IEnumerable<Type> Interfaces(Type type);
-
-    /// <summary>
-    /// If type is a type or method parameter, return the list of type constraints
-    /// </summary>
-    [Pure]
-    IEnumerable<Type> TypeParameterConstraints(Type type);
-
-    /// <summary>
-    /// Returns true if the type reference is a specialized type with type arguments.
-    /// NOTE: if this is a nested type, it will return true even if only parent types are specialized.
-    ///       In that case, typeArguments returned might be of lenth 0.
-    /// </summary>
-    [Pure]
-    bool IsSpecialized(Type type, out IIndexable<Type> typeArguments);
-
-    /// <summary>
-    /// Returns true if the type reference is a specialized type with type arguments.
-    /// NOTE: if this is a nested type, it will return true even if only parent types are specialized.
-    ///       In that case, typeArguments will inherit the type arguments of the parent types
-    /// </summary>
-    [Pure]
-    bool NormalizedIsSpecialized(Type type, out IIndexable<Type> typeArguments);
-
-    /// <summary>
-    /// For instantiated types, this returns the original template type
-    /// </summary>
-    [Pure]
-    Type Unspecialized(Type type);
-
-    /// <summary>
-    /// Returns true if type is definetely represented as a reference (pointer),
-    /// not a value type.
-    /// </summary>
-    [Pure]
-    bool IsReferenceType(Type type);
-
-    /// <summary>
-    /// Returns true if type is uintptr, intptr, or X*
-    /// </summary>
-    [Pure]
-    bool IsNativePointerType(Type declaringType);
-
-    /// <summary>
-    /// Returns true if sub derives from super directly or indirectly
-    /// </summary>
-    [Pure]
-    bool DerivesFrom(Type sub, Type super);
-
-    /// <summary>
-    /// For non-generic types this is exactly the same as DerivesFrom.
-    /// For generic-types, it checks whether the template of sub derives
-    /// from the template of super, without considering their type
-    /// arguments.
-    /// This method is needed only because inherited contracts are not specialized
-    /// into their inheriting context. If they were, then DerivesFrom would
-    /// be exactly the right test and this method should be removed.
-    /// </summary>
-    [Pure]
-    bool DerivesFromIgnoringTypeArguments(Type sub, Type super);
-
-    /// <summary>
-    /// Returns the number of (non-static) constructors in this specific type
-    /// </summary>
-    [Pure]
-    int ConstructorsCount(Type type);
-
-    /// <summary>
-    /// Returns true if type is visible outside assembly
-    /// </summary>
-    [Pure]
-    bool IsVisibleOutsideAssembly(Type type);
-
-    /// <summary>
-    /// Specializes a generic type with the given type arguments. This should work for normalized specializations too.
-    /// </summary>
-    [Pure]
-    Type Specialize(Type type, Type[] typeArguments);
-
-    #endregion
-
-    #region Modules
-
-    /// <summary>
-    /// Loads the given assembly loaded from file.
-    /// The assemblyCache is a hack to give the code provider a chance to reuse the same assembly if referenced
-    /// multiple times and it also contains contract assemblies for out-of-band contracts.
-    /// </summary>
-    /// <returns>false if assembly cannot be loaded.</returns>
-    [Pure]
-    bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractSourceText);
-
-    /// <summary>
-    /// Returns all (and only) the top-level types in the given assembly.
-    /// </summary>
-    [Pure]
-    IEnumerable<Type> GetTypes(Assembly assembly);
-
-    /// <summary>
-    /// Returns the set of assembly references of an assembly
-    /// </summary>
-    [Pure]
-    IEnumerable<Assembly> AssemblyReferences(Assembly assembly);
-
-    /// <summary>
-    /// Returns the string representing the short name of the assembly
-    /// </summary>
-    [Pure]
-    string Name(Assembly assembly);
-
-    /// <summary>
-    /// Returns the version of the assembly
-    /// </summary>
-    [Pure]
-    Version Version(Assembly assembly);
-
-    [Pure]
-    Guid AssemblyGuid(Assembly assembly);
-    #endregion
-
-    #region Well-known types (alphabetical)
-
-    Type/*!*/ System_Array { get; }
-    Type/*!*/ System_Boolean { get; }
-    Type/*!*/ System_Char { get; }
-    Type/*!*/ System_DynamicallyTypedReference { get; }
-    Type/*!*/ System_Double { get; }
-    Type/*!*/ System_Decimal { get; }
-    Type/*!*/ System_Int8 { get; }
-    Type/*!*/ System_Int16 { get; }
-    Type/*!*/ System_Int32 { get; }
-    Type/*!*/ System_Int64 { get; }
-    Type/*!*/ System_IntPtr { get; }
-    Type/*!*/ System_Object { get; }
-    Type/*!*/ System_RuntimeArgumentHandle { get; }
-    Type/*!*/ System_RuntimeFieldHandle { get; }
-    Type/*!*/ System_RuntimeMethodHandle { get; }
-    Type/*!*/ System_RuntimeTypeHandle { get; }
-    Type/*!*/ System_Single { get; }
-    Type/*!*/ System_String { get; }
-    Type/*!*/ System_Type { get; }
-    Type/*!*/ System_UInt8 { get; }
-    Type/*!*/ System_UInt16 { get; }
-    Type/*!*/ System_UInt32 { get; }
-    Type/*!*/ System_UInt64 { get; }
-    Type/*!*/ System_UIntPtr { get; }
-    Type/*!*/ System_Void { get; }
-
-    [Pure]
-    bool TryGetSystemType(string fullName, out Type type);
-
-    #endregion
-
-    #region Parameter
-
-    /// <summary>
-    /// Returns the name of the given parameter
-    /// </summary>
-    [Pure]
-    string Name(Parameter param);
-
-    /// <summary>
-    /// Returns the type of the parameter
-    /// </summary>
-    [Pure]
-    Type ParameterType(Parameter p);
-
-    /// <summary>
-    /// True if the parameter was declared as an "out" parameter
-    /// </summary>
-    [Pure]
-    bool IsOut(Parameter p);
-
-    /// <summary>
-    /// Return the argument index as used in the IL.
-    /// </summary>
-    [Pure]
-    int ArgumentIndex(Parameter p);
-
-    /// <summary>
-    /// Return the offset on the stack of this parameter at a call site.
-    /// The offset is essentially #method-args + (IsStatic?0:1) - argumentIndex
-    /// For example: a method with a "this" parameter and another parameter x would
-    /// have offset 0 for x and offset 1 for this.
-    /// </summary>
-    [Pure]
-    int ArgumentStackIndex(Parameter p);
-
-    /// <summary>
-    /// Returns the method declaring this parameter.
-    /// </summary>
-    [Pure]
-    Method DeclaringMethod(Parameter p);
-
-    #endregion
-
-    #region Local
-
-    /// <summary>
-    /// Returns the name of the local
-    /// </summary>
-    [Pure]
-    string Name(Local local);
-
-    /// <summary>
-    /// Returns the declared type of the local
-    /// </summary>
-    [Pure]
-    Type LocalType(Local local);
-
-    /// <summary>
-    /// Is the local a pinned variable?
-    /// </summary>
-    /// <param name="local"></param>
-    /// <returns></returns>
-    [Pure]
-    bool IsPinned(Local local);
-
-    #endregion
-
-    #region Attributes
-    [Pure]
-    IEnumerable<Attribute> GetAttributes(Type type);
-
-    [Pure]
-    IEnumerable<Attribute> GetAttributes(Method method);
-
-    [Pure]
-    IEnumerable<Attribute> GetAttributes(Field field);
-
-    [Pure]
-    IEnumerable<Attribute> GetAttributes(Property field);
-
-    [Pure]
-    IEnumerable<Attribute> GetAttributes(Event @event);
-
-    [Pure]
-    IEnumerable<Attribute> GetAttributes(Assembly assembly);
-
-    [Pure]
-    IEnumerable<Attribute> GetAttributes(Parameter parameter);
-
-    [Pure]
-    Type AttributeType(Attribute attribute);
-
-    [Pure]
-    Method AttributeConstructor(Attribute attribute);
-
-    [Pure]
-    IIndexable<object> PositionalArguments(Attribute attribute);
-
-    [Pure]
-    object NamedArgument(string name, Attribute attribute);
-
-    #endregion
-
-    #region Platform
-
-    bool IsPlatformInitialized { get; }
-    /// <summary>
-    /// Set the platform and search paths for assembly resolution.
-    /// </summary>
-    void SetTargetPlatform(string framework, System.Collections.IDictionary assemblyCache, string platform, IEnumerable<string> resolved, IEnumerable<string> libPaths, Action<System.CodeDom.Compiler.CompilerError> errorHandler, bool trace);
-
-    /// <summary>
-    /// To override default Microsoft.Contracts.dll or mscorlib or current. Needs to be done prior to SetTargetPlatform
-    /// </summary>
-    string SharedContractClassAssembly
-    {
-      get;
-      set;
-    }
-    #endregion
-
-
-  }
-
-  #region Contracts for IDecodeMetaData
-  [ContractClassFor(typeof(IDecodeMetaData<,,,,,,,,>))]
-  abstract class IDecodeMetaDataContracts<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
-    : IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
-  {
-    #region IDecodeMetaData<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly> Members
-
-    public Type ReturnType(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IIndexable<Parameter> Parameters(Method method)
-    {
-      Contract.Ensures(Contract.Result<IIndexable<Parameter>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public Parameter This(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleOutsideAssembly(Property property)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleOutsideAssembly(Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleOutsideAssembly(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-
-    [Pure]
-    public Property GetPropertyFromAccessor(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsCompilerGenerated(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsDebuggerNonUserCode(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsDebuggerNonUserCode(Type t)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsAutoPropertyMember(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsAutoPropertySetter(Method method, out Field backingField)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsCompilerGenerated(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsNativeCpp(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type DeclaringType(Method method)
-    {
-      Contract.Ensures(Contract.Result<Type>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public Assembly DeclaringAssembly(Method method)
-    {
-      Contract.Ensures(Contract.Result<Assembly>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public StackTemp MethodToken(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSpecialized(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSpecialized(Method method, ref IFunctionalMap<Type, Type> specialization)
-    {
-      Contract.Requires(specialization != null);
-
-      throw new NotImplementedException();
-    }
-
-    public bool IsSpecialized(Method method, out Method genericMethod, out IIndexable<Type> methodTypeArguments)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out methodTypeArguments) != null));
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out genericMethod) != null));
-
-      throw new NotImplementedException();
-    }
-
-    public bool IsGeneric(Method method, out IIndexable<Type> formals)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out formals) != null);
-      throw new NotImplementedException();
-    }
-
-    public Method Unspecialized(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Method Specialize(Method method, Type[] methodTypeArguments)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Method> OverriddenMethods(Method method)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
-
-      return null;
-    }
-
-    public IEnumerable<Method> ImplementedMethods(Method method)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
-
-      return null;
-    }
-
-    public IEnumerable<Method> OverriddenAndImplementedMethods(Method method)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
-
-      return null;
-    }
-
-    public bool IsImplicitImplementation(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasBody(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Result AccessMethodBody<Data, Result>(Method method, IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool Equal(Method m1, Method m2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool Equal(Type type1, Type type2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsAsVisibleAs(Method m1, Method m2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsAsVisibleAs(Type t, Method m)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleFrom(Method m, Type t)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleFrom(Field f, Type t)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleFrom(Type t, Type tfrom)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryGetImplementingMethod(Type type, Method baseMethod, out Method implementingMethod)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IIndexable<Local> Locals(Method method)
-    {
-      Contract.Ensures(Contract.Result<IIndexable<Local>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool TryGetRootMethod(Method method, out Method rootMethod)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type FieldType(Field field)
-    {
-      Contract.Ensures(Contract.Result<Type>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public string FullName(Field field)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public string Name(Field field)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool IsStatic(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPrivate(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsProtected(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPublic(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsInternal(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVolatile(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsNewSlot(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type DeclaringType(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsReadonly(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsAsVisibleAs(Field field, Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSpecialized(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Field Unspecialized(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-
-    public bool Equal(Field f1, Field f2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsCompilerGenerated(Field f)
-    {
-      throw new NotImplementedException();
-    }
-
-    public string Name(Property property)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool HasGetter(Property property, out Method getter)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasSetter(Property property, out Method setter)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Property> Properties(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsStatic(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsOverride(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsNewSlot(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSealed(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type DeclaringType(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type PropertyType(Property property)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool Equal(Property p1, Property p2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public string Name(Event @event)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool HasAdder(Event @event, out Method adder)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasRemover(Event @event, out Method remover)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Event> Events(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsStatic(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsOverride(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsNewSlot(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSealed(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type DeclaringType(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type HandlerType(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool Equal(Event e1, Event e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsEventAdder(Method method, out Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsEventRemover(Method method, out Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVoid(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsUnmanagedPointer(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsManagedPointer(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPrimitive(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsStruct(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsArray(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public StackTemp Rank(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsInterface(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsStatic(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsClass(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsAbstract(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPublic(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsInternal(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsProtected(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPrivate(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsSealed(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsNested(Type type, out Type parentType)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsReferenceConstrained(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsValueConstrained(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsConstructorConstrained(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsFormalTypeParameter(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsMethodFormalTypeParameter(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsModified(Type type, out Type modified, out IIndexable<Pair<bool, Type>> modifiers)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out modifiers) != null);
-      throw new NotImplementedException();
-    }
-
-    public bool IsGeneric(Type type, out IIndexable<Type> formals, bool normalized)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out formals) != null);
-      throw new NotImplementedException();
-    }
-
-    public bool IsDelegate(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public int NormalizedFormalTypeParameterIndex(Type type)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      throw new NotImplementedException();
-    }
-
-    public Type FormalTypeParameterDefiningType(Type type)
-    {
-      Contract.Ensures(Contract.Result<Type>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IIndexable<Type> NormalizedActualTypeArguments(Type type)
-    {
-      Contract.Ensures(Contract.Result<IIndexable<Type>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IIndexable<Type> ActualTypeArguments(Method method)
-    {
-      Contract.Ensures(Contract.Result<IIndexable<Type>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public int MethodFormalTypeParameterIndex(Type type)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      throw new NotImplementedException();
-    }
-
-    public Method MethodFormalTypeDefiningMethod(Type type)
-    {
-      Contract.Ensures(Contract.Result<Method>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool IsEnum(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasFlagsAttribute(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type TypeEnum(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Guid DeclaringModule(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public string DeclaringModuleName(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Field> Fields(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Method> Methods(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Type> NestedTypes(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public string Name(Type type)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public string FullName(Type type)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public string Namespace(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type ArrayType(Type type, StackTemp rank)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type ManagedPointer(Type type)
-    {
-      Contract.Ensures(Contract.Result<Type>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public Type UnmanagedPointer(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type ElementType(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public StackTemp TypeSize(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasBaseClass(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type BaseClass(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Type> Interfaces(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Type> TypeParameterConstraints(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool IsSpecialized(Type type, out IIndexable<Type> typeArguments)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out typeArguments) != null);
-      throw new NotImplementedException();
-    }
-
-    public bool NormalizedIsSpecialized(Type type, out IIndexable<Type> typeArguments)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out typeArguments) != null && Contract.ValueAtReturn(out typeArguments).Count > 0));
-      throw new NotImplementedException();
-    }
-
-    public Type Unspecialized(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsReferenceType(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsNativePointerType(Type declaringType)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool DerivesFrom(Type sub, Type super)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool DerivesFromIgnoringTypeArguments(Type sub, Type super)
-    {
-      throw new NotImplementedException();
-    }
-
-    public StackTemp ConstructorsCount(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsVisibleOutsideAssembly(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type Specialize(Type type, Type[] typeArguments)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Type> GetTypes(Assembly assembly)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Assembly> AssemblyReferences(Assembly assembly)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Assembly>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public string Name(Assembly assembly)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public Version Version(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Guid AssemblyGuid(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Type System_Array
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Boolean
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Char
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_DynamicallyTypedReference
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Double
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Decimal
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Int8
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Int16
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Int32
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Int64
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_IntPtr
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Object
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_RuntimeArgumentHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_RuntimeFieldHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_RuntimeMethodHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_RuntimeTypeHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Single
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_String
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Type
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_UInt8
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_UInt16
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_UInt32
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_UInt64
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_UIntPtr
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public Type System_Void
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    public bool TryGetSystemType(string fullName, out Type type)
-    {
-      Contract.Ensures(Contract.ValueAtReturn(out type) != null || !Contract.Result<bool>());
-      throw new NotImplementedException();
-    }
-
-    public string Name(Parameter param)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public Type ParameterType(Parameter p)
-    {
-      Contract.Ensures(Contract.Result<Type>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public bool IsOut(Parameter p)
-    {
-      throw new NotImplementedException();
-    }
-
-    public int ArgumentIndex(Parameter p)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      throw new NotImplementedException();
-    }
-
-    public StackTemp ArgumentStackIndex(Parameter p)
-    {
-      Contract.Ensures(Contract.Result<int>() >= 0);
-      throw new NotImplementedException();
-    }
-
-    public Method DeclaringMethod(Parameter p)
-    {
-      throw new NotImplementedException();
-    }
-
-    public string Name(Local local)
-    {
-      Contract.Ensures(Contract.Result<string>() != null);
-      throw new NotImplementedException();
-    }
-
-    public Type LocalType(Local local)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Attribute> GetAttributes(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Attribute> GetAttributes(Method method)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Attribute> GetAttributes(Field field)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Attribute> GetAttributes(Property field)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Attribute> GetAttributes(Event @event)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Attribute> GetAttributes(Assembly assembly)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Attribute> GetAttributes(Parameter parameter)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
-
-      throw new NotImplementedException();
-    }
-
-    public Type AttributeType(Attribute attribute)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Method AttributeConstructor(Attribute attribute)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IIndexable<object> PositionalArguments(Attribute attribute)
-    {
-      Contract.Ensures(Contract.Result<IIndexable<object>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public object NamedArgument(string name, Attribute attribute)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPlatformInitialized { get { return false; } }
-
-    public void SetTargetPlatform(string framework, System.Collections.IDictionary assemblyCache, string platform, IEnumerable<string> resolved, IEnumerable<string> libPaths, Action<System.CodeDom.Compiler.CompilerError> errorHandler, bool trace)
-    {
-      Contract.Requires(assemblyCache != null);
-      Contract.Requires(resolved != null);
-      Contract.Requires(libPaths != null);
-    }
-
-    public string SharedContractClassAssembly
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-    public bool TryInitialValue(Field field, out object value)
-    {
-      //Contract.Requires(field != null);
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
-
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-
-    string IDecodeMethods<Method>.DocumentationId(Method method)
-    {
-      return null;
-    }
-
-    string IDecodeMethods<Method>.Name(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMethods<Method>.FullName(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMethods<Method>.DeclaringMemberCanonicalName(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsMain(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsStatic(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsPrivate(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsProtected(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsPublic(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsVirtual(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsNewSlot(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsOverride(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsSealed(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsVoidMethod(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsConstructor(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsFinalizer(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsDispose(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsInternal(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsVisibleOutsideAssembly(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsAbstract(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsExtern(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsPropertySetter(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMethods<Method>.IsPropertyGetter(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    #region IDecodeMethods<Method> Members
-
-
-    public bool IsAsyncMoveNext(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public StackTemp? MoveNextStartState(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    #endregion
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ReturnType(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    IIndexable<Parameter> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Parameters(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    Parameter IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.This(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Property property)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    Property IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetPropertyFromAccessor(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsCompilerGenerated(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsDebuggerNonUserCode(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsDebuggerNonUserCode(Type t)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAutoPropertyMember(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAutoPropertySetter(Method method, out Field backingField)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsCompilerGenerated(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNativeCpp(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    Assembly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringAssembly(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.MethodToken(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Method method, ref IFunctionalMap<Type, Type> specialization)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Method method, out Method genericMethod, out IIndexable<Type> methodTypeArguments)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsGeneric(Method method, out IIndexable<Type> formals)
-    {
-      throw new NotImplementedException();
-    }
-
-    Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Unspecialized(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Specialize(Method method, Type[] methodTypeArguments)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.OverriddenMethods(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ImplementedMethods(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.OverriddenAndImplementedMethods(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsImplicitImplementation(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasBody(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    Result IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AccessMethodBody<Data, Result>(Method method, IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Method m1, Method m2)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Type type1, Type type2)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAsVisibleAs(Method m1, Method m2)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAsVisibleAs(Type t, Method m)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleFrom(Method m, Type t)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleFrom(Field f, Type t)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleFrom(Type t, Type tfrom)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryGetImplementingMethod(Type type, Method baseMethod, out Method implementingMethod)
-    {
-      throw new NotImplementedException();
-    }
-
-    IIndexable<Local> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Locals(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryGetRootMethod(Method method, out Method rootMethod)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FieldType(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FullName(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPrivate(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsProtected(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPublic(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsInternal(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVolatile(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNewSlot(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsReadonly(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAsVisibleAs(Field field, Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    Field IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Unspecialized(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryInitialValue(Field field, out object value)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Field f1, Field f2)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsCompilerGenerated(Field f)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Property property)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasGetter(Property property, out Method getter)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasSetter(Property property, out Method setter)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Property> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Properties(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsOverride(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNewSlot(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSealed(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Property p)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.PropertyType(Property property)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Property p1, Property p2)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasAdder(Event @event, out Method adder)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasRemover(Event @event, out Method remover)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Event> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Events(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsOverride(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNewSlot(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSealed(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HandlerType(Event e)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Event e1, Event e2)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsEventAdder(Method method, out Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsEventRemover(Method method, out Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVoid(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsUnmanagedPointer(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsManagedPointer(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPrimitive(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStruct(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsArray(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Rank(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsInterface(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsClass(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAbstract(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPublic(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsInternal(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsProtected(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPrivate(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSealed(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNested(Type type, out Type parentType)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsReferenceConstrained(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsValueConstrained(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsConstructorConstrained(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsFormalTypeParameter(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsMethodFormalTypeParameter(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsModified(Type type, out Type modified, out IIndexable<Pair<bool, Type>> modifiers)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsGeneric(Type type, out IIndexable<Type> formals, bool normalized)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsDelegate(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NormalizedFormalTypeParameterIndex(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FormalTypeParameterDefiningType(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IIndexable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NormalizedActualTypeArguments(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IIndexable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ActualTypeArguments(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.MethodFormalTypeParameterIndex(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.MethodFormalTypeDefiningMethod(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsEnum(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasFlagsAttribute(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TypeEnum(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Guid IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringModule(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringModuleName(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Field> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Fields(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Methods(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NestedTypes(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FullName(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DocumentationId(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Namespace(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ArrayType(Type type, StackTemp rank)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ManagedPointer(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.UnmanagedPointer(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ElementType(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TypeSize(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasBaseClass(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.BaseClass(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Interfaces(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TypeParameterConstraints(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Type type, out IIndexable<Type> typeArguments)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NormalizedIsSpecialized(Type type, out IIndexable<Type> typeArguments)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Unspecialized(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsReferenceType(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNativePointerType(Type declaringType)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DerivesFrom(Type sub, Type super)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DerivesFromIgnoringTypeArguments(Type sub, Type super)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ConstructorsCount(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Specialize(Type type, Type[] typeArguments)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetTypes(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Assembly> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AssemblyReferences(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    Version IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Version(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    Guid IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AssemblyGuid(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Array
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Boolean
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Char
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_DynamicallyTypedReference
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Double
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Decimal
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int8
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int16
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int32
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int64
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_IntPtr
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Object
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeArgumentHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeFieldHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeMethodHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeTypeHandle
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Single
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_String
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Type
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt8
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt16
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt32
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt64
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UIntPtr
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Void
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryGetSystemType(string fullName, out Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Parameter param)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ParameterType(Parameter p)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsOut(Parameter p)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ArgumentIndex(Parameter p)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ArgumentStackIndex(Parameter p)
-    {
-      throw new NotImplementedException();
-    }
-
-    Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringMethod(Parameter p)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Local local)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.LocalType(Local local)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Property field)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Event @event)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Assembly assembly)
-    {
-      throw new NotImplementedException();
-    }
-
-    IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Parameter parameter)
-    {
-      throw new NotImplementedException();
-    }
-
-    Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AttributeType(Attribute attribute)
-    {
-      throw new NotImplementedException();
-    }
-
-    Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AttributeConstructor(Attribute attribute)
-    {
-      throw new NotImplementedException();
-    }
-
-    IIndexable<object> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.PositionalArguments(Attribute attribute)
-    {
-      throw new NotImplementedException();
-    }
-
-    object IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NamedArgument(string name, Attribute attribute)
-    {
-      throw new NotImplementedException();
-    }
-
-    bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPlatformInitialized
-    {
-      get { throw new NotImplementedException(); }
-    }
-
-    void IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.SetTargetPlatform(string framework, System.Collections.IDictionary assemblyCache, string platform, IEnumerable<string> resolved, IEnumerable<string> libPaths, Action<System.CodeDom.Compiler.CompilerError> errorHandler, bool trace)
-    {
-      throw new NotImplementedException();
-    }
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.SharedContractClassAssembly
-    {
-      get
-      {
-        throw new NotImplementedException();
-      }
-      set
-      {
-        throw new NotImplementedException();
-      }
-    }
-
-
-    bool IDecodeMethods<Method>.IsAsyncMoveNext(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    StackTemp? IDecodeMethods<Method>.MoveNextStartState(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-
-    string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DocumentationId(Field field)
-    {
-      throw new NotImplementedException();
-    }
-
-
-    public bool IsPinned(Local local)
-    {
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
-
-  /// <summary>
-  /// Access to contracts, encoded in whatever form
-  /// </summary>
-  [ContractClass(typeof(IDecodeContractsContracts<,,,,>))]
-  public partial interface IDecodeContracts<Local, Parameter, Method, Field, Type>
-  {
-
-    #region Methods
-
-    /// <summary>
-    /// Should be informed by ContractVerification attribute and defaults
-    /// </summary>
-    bool VerifyMethod(Method method, bool analyzeNonUserCode, bool namespaceSelected, bool typeSelected, bool memberSelected);
-
-    /// <summary>
-    /// Do we have a source option specific for Clousot?
-    /// </summary>
-    bool HasOptionForClousot(Method method, string optionName, out string optionValue);
-
-    /// <summary>
-    /// Returns true if this method has explictit pre-conditions
-    /// </summary>
-    bool HasRequires(Method method);
-
-    /// <summary>
-    /// Provides access to the pre-conditions of a method, provided HasRequires returns true.
-    /// </summary>
-    Result AccessRequires<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
-
-    /// <summary>
-    /// Returns true if this method has explicit post-conditions
-    /// </summary>
-    bool HasEnsures(Method method);
-
-    /// <summary>
-    /// Provides access to the post-conditions of a method, provided HasEnsures returns true.
-    /// </summary>
-    Result AccessEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
-
-    /// <summary>
-    /// Returns true if this method has explicit model post-conditions
-    /// </summary>
-    bool HasModelEnsures(Method method);
-
-    /// <summary>
-    /// Provides access to the model post-conditions of a method, provided HasModelEnsures returns true.
-    /// </summary>
-    Result AccessModelEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
-
-    /// <summary>
-    /// Returns true if the declaring type of this method has an invariant observed by this method
-    /// </summary>
-    bool HasInvariant(Method method);
-
-
-    /// <summary>
-    /// Returns true, if method is pure (no visible side effects), and the result of the method
-    /// depends only on data that does not change, even if the heap changes.
-    /// E.g., Object.GetType, Array.get_Rank, etc.
-    /// TODO TODO TODO: Implementations should probably cache this.
-    /// </summary>
-    bool IsMutableHeapIndependent(Method method);
-
-    /// <summary>
-    /// Returns true, if method is pure (no visible side effects).
-    /// </summary>
-    bool IsPure(Method method);
-
-    /// <summary>
-    /// True if method may inherit contracts from base methods or interface contract declarations.
-    /// Can be controled with ContractOption("Contract", "Inheritance", true/false) attributes.
-    /// </summary>
-    bool CanInheritContracts(Method method);
-
-    /// <summary>
-    /// True if method is marked with ContractModel
-    /// </summary>
-    bool IsModel(Method method);
-
-    /// <summary>
-    /// Retrieves any model fields that might exist for this type.
-    /// </summary>
-    [Pure]
-    IEnumerable<Field> ModelFields(Type type);
-
-    /// <summary>
-    /// Retrieves any model methods that might exist for this type.
-    /// </summary>
-    [Pure]
-    IEnumerable<Method> ModelMethods(Type type);
-
-    #endregion
-
-    #region Types
-    /// <summary>
-    /// Returns true if the type has an invariant 
-    /// </summary>
-    bool HasInvariant(Type type);
-
-    /// <summary>
-    /// Provides access to the object invariant of a type, provided HasInvariant returns true.
-    /// </summary>
-    Result AccessInvariant<Data, Result>(Type type, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
-
-    /// <summary>
-    /// True if type may inherit contracts from base types or interfaces.
-    /// Can be controled with ContractOption("Contract", "Inheritance", true/false) attributes.
-    /// </summary>
-    bool CanInheritContracts(Type type);
-
-    /// <summary>
-    /// True if the method returns a fresh object. Used in conjunction with Pure to tell
-    /// static checker that the return value should not be cached.
-    /// </summary>
-    bool IsFreshResult(Method method);
-
-    #endregion
-  }
-
-  #region Contracts for IDecodeContracts
-  [ContractClassFor(typeof(IDecodeContracts<,,,,>))]
-  abstract class IDecodeContractsContracts<Local, Parameter, Method, Field, Type>
-    : IDecodeContracts<Local, Parameter, Method, Field, Type>
-  {
-    public bool VerifyMethod(Method method, bool analyzeNonUserCode, bool namespaceSelected, bool typeSelected, bool memberSelected)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasOptionForClousot(Method method, string optionName, out string optionValue)
-    {
-      Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out optionValue) != null);
-
-      throw new NotImplementedException();
-    }
-
-
-    public bool HasRequires(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Result AccessRequires<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasEnsures(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Result AccessEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasModelEnsures(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Result AccessModelEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool HasInvariant(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsPure(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsMutableHeapIndependent(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool CanInheritContracts(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsModel(Method method)
-    {
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Field> ModelFields(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public IEnumerable<Method> ModelMethods(Type type)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
-      throw new NotImplementedException();
-    }
-
-    public bool HasInvariant(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public Result AccessInvariant<Data, Result>(Type type, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool CanInheritContracts(Type type)
-    {
-      throw new NotImplementedException();
-    }
-
-    public bool IsFreshResult(Method method)
-    {
-      throw new NotImplementedException();
-    }
-  }
-  #endregion
-
-  /// <summary>
-  /// General decoder interface for MSIL
-  /// </summary>
-  /// <typeparam name="Source">Type of IL source operands</typeparam>
-  /// <typeparam name="Dest">Type of IL destinations</typeparam>
-  /// <typeparam name="Context">Context provided by the particular decoder</typeparam>
-  /// <typeparam name="EdgeConversionData">Extra info for control flow edges, like renamings etc.</typeparam>
-  public interface IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, ContextData, EdgeConversionData>
-  {
-    /// <summary>
-    /// Decode the instruction immediately following the label on a forward path.
-    /// </summary>
-    Result ForwardDecode<Data, Result, Visitor>(Label lab, Visitor visitor, Data data)
-     where Visitor : IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result>;
-
-    /// <summary>
-    /// Extra information about Source, Dest, or the controlflow provided by this decoder
-    /// </summary>
-    ContextData Context { get; }
-
-    /// <summary>
-    /// Lookup EdgeData
-    /// </summary>
-    EdgeConversionData EdgeData(Label from, Label to);
-
-    /// <summary>
-    /// Show the edge conversion data
-    /// </summary>
-    void Display(TextWriter tw, string prefix, EdgeConversionData data);
-
-    /// <summary>
-    /// Allows to stop decoding/traversing if a given pc is unreachable.
-    /// Some abstraction layer have non-trivial reachability info, whereas base layers can always return false here.
-    /// </summary>
-    bool IsUnreachable(Label pc);
-  }
-
-
-  public interface IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result>
-    : IVisitSynthIL<Label, Method, Type, Source, Dest, Data, Result>, IVisitExprIL<Label, Type, Source, Dest, Data, Result>
-  {
-    #region Basic IL
-    Result Arglist(Label pc, Dest dest, Data data);
-    Result BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, Data data);
-    Result BranchTrue(Label pc, Label target, Source cond, Data data);
-    Result BranchFalse(Label pc, Label target, Source cond, Data data);
-    Result Branch(Label pc, Label target, bool leave, Data data);
-    Result Break(Label pc, Data data);
-    /// <summary>
-    /// A Call or Callvirt instruction
-    /// </summary>
-    /// <typeparam name="TypeList">IIndexable of Type"/></typeparam>
-    /// <typeparam name="ArgList">IIndexable of Source</typeparam>
-    Result Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
-      where TypeList : IIndexable<Type>
-      where ArgList : IIndexable<Source>; // could be dummy dest
+    #region Delegate types
     /// <summary>
-    /// A Calli instruction.
+    /// Prints data on given output where each line is prefixed by prefix
     /// 
-    /// Note: the argument type list does not contain the type of the first instance parameter if the
-    /// method calling convention is Instance.
     /// </summary>
-    /// <typeparam name="TypeList">IIndexable of Type"/></typeparam>
-    /// <typeparam name="ArgList">IIndexable of Source</typeparam>
-    Result Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool instance, Dest dest, Source fp, ArgList args, Data data)
-      where TypeList : IIndexable<Type>
-      where ArgList : IIndexable<Source>; // could be dummy dest
-    Result Ckfinite(Label pc, Dest dest, Source source, Data data);
-    Result Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, Data data);
-    // For Dup instruction, see Ldstack in IVisitSynthIL
-    Result Endfilter(Label pc, Source decision, Data data);
-    Result Endfinally(Label pc, Data data);
-    Result Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, Data data);
-    Result Jmp(Label pc, Method method, Data data);
+    /// <param name="tw">Output stream</param>
+    /// <param name="prefix">Prefix to be printed on each new line</param>
+    public delegate void Printer<Data>(TextWriter writer, string prefix, Data data);
+
     /// <summary>
-    /// Load argument onto stack.
+    /// Generates a textual representation of code at label (none if label is a skip instruction)
     /// </summary>
-    /// <param name="argument">parameter being loaded</param>
-    /// <param name="isOld">true if this load refers to loading the original value of the parameter on entry
-    /// to the method.</param>
-    Result Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, Data data);
-    Result Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, Data data);
-    Result Ldftn(Label pc, Method method, Dest dest, Data data);
-    Result Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, Data data);
-    Result Ldloc(Label pc, Local local, Dest dest, Data data);
-    Result Ldloca(Label pc, Local local, Dest dest, Data data);
-    Result Localloc(Label pc, Dest dest, Source size, Data data);
-    Result Nop(Label pc, Data data);
-    Result Pop(Label pc, Source source, Data data);
-    Result Return(Label pc, Source source, Data data); // could be dummy source
-    Result Starg(Label pc, Parameter argument, Source source, Data data);
-    Result Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, Data data);
-    Result Stloc(Label pc, Local local, Source source, Data data);
+    /// <param name="tw">Output stream</param>
+    /// <param name="prefix">Prefix to be printed on each new line</param>
+    /// <param name="lab">Label of code to be printed</param>
+    public delegate void ILPrinter<Label>(Label label, string prefix, TextWriter writer);
+
     /// <summary>
-    /// Generalization of switch on ints, can switch on other data constants as well.
+    /// Used to print extra info associated with the end of control flow blocks.
     /// </summary>
-    /// <param name="type">Type of data being switched on, typically int32</param>
-    Result Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Source value, Data data);
+    public delegate void BlockInfoPrinter<Label>(Label at, string prefix, TextWriter writer);
+
     #endregion
 
-    #region Object level instructions
-    /// <summary>
-    /// A Constrained.Callvirt instruction
-    /// </summary>
-    /// <typeparam name="TypeList">IIndexable of Type"/></typeparam>
-    /// <typeparam name="ArgList">IIndexable of Source</typeparam>
-    Result ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, Data data)
-      where TypeList : IIndexable<Type>
-      where ArgList : IIndexable<Source>; // could be dummy dest
-    Result Castclass(Label pc, Type type, Dest dest, Source obj, Data data);
-    Result Cpobj(Label pc, Type type, Source destptr, Source srcptr, Data data);
-    Result Initobj(Label pc, Type type, Source ptr, Data data);
-    Result Ldelem(Label pc, Type type, Dest dest, Source array, Source index, Data data);
-    Result Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, Data data);
-    Result Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source obj, Data data);
-    Result Ldflda(Label pc, Field field, Dest dest, Source obj, Data data);
-    Result Ldlen(Label pc, Dest dest, Source array, Data data);
+    #region IL visitor data types
 
-    // Handled by Ldind
-    // Result Ldobj(Label pc, Type type, bool @volatile, Dest dest, Source ptr, Data data);
-    Result Ldsfld(Label pc, Field field, bool @volatile, Dest dest, Data data);
-    Result Ldsflda(Label pc, Field field, Dest dest, Data data);
-    Result Ldtypetoken(Label pc, Type type, Dest dest, Data data);
-    Result Ldfieldtoken(Label pc, Field field, Dest dest, Data data);
-    Result Ldmethodtoken(Label pc, Method method, Dest dest, Data data);
-    Result Ldvirtftn(Label pc, Method method, Dest dest, Source obj, Data data);
-    Result Mkrefany(Label pc, Type type, Dest dest, Source obj, Data data);
-    Result Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList len, Data data)
-      where ArgList : IIndexable<Source>;
     /// <summary>
-    /// A newobj instruction
+    /// The binary branch operators
     /// </summary>
-    /// <typeparam name="ArgList">IIndexable of Source</typeparam>
-    Result Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, Data data)
-      where ArgList : IIndexable<Source>;
-    Result Refanytype(Label pc, Dest dest, Source source, Data data);
-    Result Refanyval(Label pc, Type type, Dest dest, Source source, Data data);
-    Result Rethrow(Label pc, Data data);
-    Result Stelem(Label pc, Type type, Source array, Source index, Source value, Data data);
-    Result Stfld(Label pc, Field field, bool @volatile, Source obj, Source value, Data data);
+    public enum BranchOperator
+    {
+        Beq,
+        Bge,
+        Bge_un,
+        Bgt,
+        Bgt_un,
+        Ble,
+        Ble_un,
+        Blt,
+        Blt_un,
+        Bne_un,
+    }
 
-    // Handled by stind
-    // Result Stobj(Label pc, Type type, bool @volatile, Source ptr, Source value, Data data);
-    Result Stsfld(Label pc, Field field, bool @volatile, Source value, Data data);
-    Result Throw(Label pc, Source exn, Data data);
-    Result Unbox(Label pc, Type type, Dest dest, Source obj, Data data);
-    Result Unboxany(Label pc, Type type, Dest dest, Source obj, Data data);
+    /// <summary>
+    /// Slightly uniformized version of unary operations in IL
+    /// </summary>
+    [Serializable]
+    public enum UnaryOperator
+    {
+        Conv_i,
+        Conv_i1,
+        Conv_i2,
+        Conv_i4,
+        Conv_i8,
+        Conv_r4,
+        Conv_r8,
+        Conv_u,
+        Conv_u1,
+        Conv_u2,
+        Conv_u4,
+        Conv_u8,
+        Conv_r_un,
+        Neg,
+        Not,
+        /// <summary>
+        /// A unary operator on pointers to express contracts about the writeable region extending forward from the pointer.
+        /// The argument is of pointer type, the result type ulong.
+        /// </summary>
+        WritableBytes,
+        /// <summary>
+        /// A synthetic conversion to Decimal. We insert this instead of Decimal constructors.
+        /// </summary>
+        Conv_dec,
+    }
+
+    /// <summary>
+    /// Slightly uniformized version of binary operations in IL
+    /// </summary>
+    [Serializable]
+    public enum BinaryOperator
+    {
+        Add,
+        Add_Ovf,
+        Add_Ovf_Un,
+        And,
+        Ceq,
+        Cobjeq,  // corresponds to Object.Equals, which behaves differently for some values from Ceq (NaN)
+        Cne_Un,  // for semantics, consult Ceq in part III ECMA and negate condition
+        Cge,     // for semantics, consult Bge in part III ECMA
+        Cge_Un,  // for semantics, consult Bge_un in part III ECMA
+        Cgt,
+        Cgt_Un,
+        Cle,     // for semantics, consult Ble in part III ECMA 
+        Cle_Un,  // for semantics, consult Ble_un in part III ECMA
+        Clt,
+        Clt_Un,
+        Div,
+        Div_Un,
+        LogicalAnd, // F: I've added those two for use in the refinement of expression involving boolean connectors
+        LogicalOr,
+        Mul,
+        Mul_Ovf,
+        Mul_Ovf_Un,
+        Or,
+        Rem,
+        Rem_Un,
+        Shl,
+        Shr,
+        Shr_Un,
+        Sub,
+        Sub_Ovf,
+        Sub_Ovf_Un,
+        Xor,
+    }
+
+    public static class OperatorExtensions
+    {
+        public static string ToCodeString(this BinaryOperator bop)
+        {
+            switch (bop)
+            {
+                case BinaryOperator.Add:
+                case BinaryOperator.Add_Ovf:
+                case BinaryOperator.Add_Ovf_Un:
+                    return "+";
+                case BinaryOperator.And:
+                    return "&";
+                case BinaryOperator.Cobjeq:
+                    return "=="; // TODO: eventually need something else here.
+                case BinaryOperator.Ceq:
+                    return "==";
+                case BinaryOperator.Cge:
+                case BinaryOperator.Cge_Un:
+                    return ">=";
+                case BinaryOperator.Cgt:
+                case BinaryOperator.Cgt_Un:
+                    return ">";
+                case BinaryOperator.Cle:
+                case BinaryOperator.Cle_Un:
+                    return "<=";
+                case BinaryOperator.Clt:
+                case BinaryOperator.Clt_Un:
+                    return "<";
+                case BinaryOperator.Cne_Un:
+                    return "!=";
+                case BinaryOperator.Div:
+                case BinaryOperator.Div_Un:
+                    return "/";
+                case BinaryOperator.LogicalAnd:
+                    return "&&";
+                case BinaryOperator.LogicalOr:
+                    return "||";
+                case BinaryOperator.Mul:
+                case BinaryOperator.Mul_Ovf:
+                case BinaryOperator.Mul_Ovf_Un:
+                    return "*";
+                case BinaryOperator.Or:
+                    return "|";
+                case BinaryOperator.Rem:
+                case BinaryOperator.Rem_Un:
+                    return "%";
+                case BinaryOperator.Shl:
+                    return "<<";
+                case BinaryOperator.Shr:
+                case BinaryOperator.Shr_Un:
+                    return ">>";
+                case BinaryOperator.Sub:
+                case BinaryOperator.Sub_Ovf:
+                case BinaryOperator.Sub_Ovf_Un:
+                    return "-";
+                case BinaryOperator.Xor:
+                    return "^";
+
+                default:
+                    throw new InvalidOperationException("Unknown binary operator");
+            }
+        }
+
+        public static string ToCodeString(this UnaryOperator op)
+        {
+            switch (op)
+            {
+                case UnaryOperator.Conv_i:
+                    return "(UIntPtr)";
+                case UnaryOperator.Conv_i1:
+                    return "(sbyte)";
+                case UnaryOperator.Conv_i2:
+                    return "(short)";
+                case UnaryOperator.Conv_i4:
+                    return "(int)";
+                case UnaryOperator.Conv_i8:
+                    return "(long)";
+                case UnaryOperator.Conv_r_un:
+                    return "(double)";
+                case UnaryOperator.Conv_r4:
+                    return "(float)";
+                case UnaryOperator.Conv_r8:
+                    return "(double)";
+                case UnaryOperator.Conv_u:
+                    return "(UIntPtr)";
+                case UnaryOperator.Conv_u1:
+                    return "(byte)";
+                case UnaryOperator.Conv_u2:
+                    return "(ushort)";
+                case UnaryOperator.Conv_u4:
+                    return "(uint)";
+                case UnaryOperator.Conv_u8:
+                    return "(ulong)";
+                case UnaryOperator.Neg:
+                    return "-";
+                case UnaryOperator.Not:
+                    return "!";
+                case UnaryOperator.WritableBytes:
+                    return "Contracts.WritableBytes";
+                case UnaryOperator.Conv_dec:
+                    return "new Decimal";
+                default:
+                    throw new InvalidOperationException("Unknown unary op");
+            }
+        }
+
+        [Pure]
+        public static bool IsComparisonBinaryOperator(this BinaryOperator op)
+        {
+            switch (op)
+            {
+                case BinaryOperator.Ceq:
+                case BinaryOperator.Cge:
+                case BinaryOperator.Cge_Un:
+                case BinaryOperator.Cgt:
+                case BinaryOperator.Cgt_Un:
+                case BinaryOperator.Cle:
+                case BinaryOperator.Cle_Un:
+                case BinaryOperator.Clt:
+                case BinaryOperator.Clt_Un:
+                case BinaryOperator.Cne_Un:
+                case BinaryOperator.Cobjeq:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        [Pure]
+        public static bool IsEqualityOrDisequality(this BinaryOperator bop)
+        {
+            return bop == BinaryOperator.Ceq || bop == BinaryOperator.Cne_Un;
+        }
+
+        public static bool IsBooleanBinaryOperator(this BinaryOperator op)
+        {
+            switch (op)
+            {
+                case BinaryOperator.LogicalAnd:
+                case BinaryOperator.LogicalOr:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsBitwiseBinaryOperator(this BinaryOperator op)
+        {
+            switch (op)
+            {
+                case BinaryOperator.And:
+                case BinaryOperator.Or:
+                case BinaryOperator.Xor:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsArithmeticBinaryOperator(this BinaryOperator op)
+        {
+            switch (op)
+            {
+                case BinaryOperator.Add:
+                case BinaryOperator.Add_Ovf:
+                case BinaryOperator.Add_Ovf_Un:
+                case BinaryOperator.Div:
+                case BinaryOperator.Div_Un:
+                case BinaryOperator.Mul:
+                case BinaryOperator.Mul_Ovf:
+                case BinaryOperator.Mul_Ovf_Un:
+                case BinaryOperator.Rem:
+                case BinaryOperator.Rem_Un:
+                case BinaryOperator.Sub:
+                case BinaryOperator.Sub_Ovf:
+                case BinaryOperator.Sub_Ovf_Un:
+                    {
+                        return true;
+                    }
+                default:
+                    {
+                        return false;
+                    }
+            }
+        }
+
+        public static bool IsOverflowChecked(this BinaryOperator op)
+        {
+            return op == BinaryOperator.Add_Ovf || op == BinaryOperator.Add_Ovf_Un ||
+                  op == BinaryOperator.Sub_Ovf || op == BinaryOperator.Sub_Ovf_Un ||
+                  op == BinaryOperator.Mul_Ovf || op == BinaryOperator.Mul_Ovf_Un;
+        }
+
+        public static bool TryNegate(this BinaryOperator op, out BinaryOperator negated)
+        {
+            switch (op)
+            {
+                case BinaryOperator.Ceq:
+                    {
+                        negated = BinaryOperator.Cne_Un;
+                        return true;
+                    }
+
+                case BinaryOperator.Cge:
+                    {
+                        negated = BinaryOperator.Clt;
+                        return true;
+                    }
+
+                case BinaryOperator.Cge_Un:
+                    {
+                        negated = BinaryOperator.Clt_Un;
+                        return true;
+                    }
+                case BinaryOperator.Cgt:
+                    {
+                        negated = BinaryOperator.Cle;
+                        return true;
+                    }
+                case BinaryOperator.Cgt_Un:
+                    {
+                        negated = BinaryOperator.Cle_Un;
+                        return true;
+                    }
+                case BinaryOperator.Cle:
+                    {
+                        negated = BinaryOperator.Cgt;
+                        return true;
+                    }
+                case BinaryOperator.Cle_Un:
+                    {
+                        negated = BinaryOperator.Cgt_Un;
+                        return true;
+                    }
+                case BinaryOperator.Clt:
+                    {
+                        negated = BinaryOperator.Cge;
+                        return true;
+                    }
+                case BinaryOperator.Clt_Un:
+                    {
+                        negated = BinaryOperator.Cge_Un;
+                        return true;
+                    }
+                case BinaryOperator.Cne_Un:
+                    {
+                        negated = BinaryOperator.Ceq;
+                        return true;
+                    }
+                default:
+                    {
+                        negated = BinaryOperator.Add;
+                        return false;
+                    }
+            }
+        }
+
+        public static bool TryInvert(this BinaryOperator op, out BinaryOperator inverted)
+        {
+            switch (op)
+            {
+                case BinaryOperator.Ceq:
+                    {
+                        inverted = BinaryOperator.Ceq;
+                        return true;
+                    }
+
+                case BinaryOperator.Cge:
+                    {
+                        inverted = BinaryOperator.Cle;
+                        return true;
+                    }
+
+                case BinaryOperator.Cge_Un:
+                    {
+                        inverted = BinaryOperator.Cle_Un;
+                        return true;
+                    }
+                case BinaryOperator.Cgt:
+                    {
+                        inverted = BinaryOperator.Clt;
+                        return true;
+                    }
+                case BinaryOperator.Cgt_Un:
+                    {
+                        inverted = BinaryOperator.Clt_Un;
+                        return true;
+                    }
+                case BinaryOperator.Cle:
+                    {
+                        inverted = BinaryOperator.Cge;
+                        return true;
+                    }
+                case BinaryOperator.Cle_Un:
+                    {
+                        inverted = BinaryOperator.Cge_Un;
+                        return true;
+                    }
+                case BinaryOperator.Clt:
+                    {
+                        inverted = BinaryOperator.Cgt;
+                        return true;
+                    }
+                case BinaryOperator.Clt_Un:
+                    {
+                        inverted = BinaryOperator.Cgt_Un;
+                        return true;
+                    }
+                case BinaryOperator.Cne_Un:
+                    {
+                        inverted = BinaryOperator.Cne_Un;
+                        return true;
+                    }
+                default:
+                    {
+                        inverted = default(BinaryOperator);
+                        return false;
+                    }
+            }
+        }
+
+
+        public static bool IsConversionOperator(this UnaryOperator op)
+        {
+            switch (op)
+            {
+                case UnaryOperator.Conv_i:
+                case UnaryOperator.Conv_i1:
+                case UnaryOperator.Conv_i2:
+                case UnaryOperator.Conv_i4:
+                case UnaryOperator.Conv_i8:
+                case UnaryOperator.Conv_r4:
+                case UnaryOperator.Conv_r8:
+                case UnaryOperator.Conv_u:
+                case UnaryOperator.Conv_u1:
+                case UnaryOperator.Conv_u2:
+                case UnaryOperator.Conv_u4:
+                case UnaryOperator.Conv_u8:
+                case UnaryOperator.Conv_r_un:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
     #endregion
-  }
 
-
-  /// <summary>
-  /// Some synthetic IL instructions
-  /// </summary>
-  public interface IVisitSynthIL<Label, Method, Type, Source, Dest, Data, Result>
-  {
-    /// <summary>
-    /// Instruction is visited on entry to a method as the first instruction.
-    /// </summary>
-    Result Entry(Label pc, Method method, Data data);
-
-    /// <summary>
-    /// Appears at targets of conditional control transfers (branches and switch)
-    /// to express the branch condition in a uniform accessible way.
-    ///
-    /// Can also appear due to preconditions in a method and due to post conditions after a method call
-    /// or invariants on field reads.
-    /// </summary>
-    /// <param name="tag">Is the tag selected by the code provider for a control transfer, or "false"
-    /// for the fallthrough of a conditional branch or the default target of a switch.</param>
-    /// <param name="source">The conditional value deciding the branch</param>
-    /// <param name="provenance">An opaque object (possibly null) explaining where this assert comes from.</param>
-    Result Assume(Label pc, string tag, Source condition, object provenance, Data data);
-
-    /// <summary>
-    /// Can appear due to explicit asserts in the code or due to post conditions in a method, or due
-    /// to preconditions at method calls, or due to invariants at field updates.
-    /// </summary>
-    /// <param name="tag">Is a tag indicating what kind of assert it is, e.g., requires, ensures, inline, etc.</param>
-    /// <param name="provenance">An opaque object (possibly null) explaining where this assert comes from.</param>
-    Result Assert(Label pc, string tag, Source condition, object provenance, Data data);
-
-    /// <summary>
-    /// This is a generalized Dup instruction, where dup is equal to ldstack 0. ldstack i duplicates the i-th element on
-    /// the evaluation stack and pushes it onto the evaluation stack.
-    /// </summary>
-    /// <param name="offset">0 based offset from the top of the evaluation stack.</param>
-    /// <param name="isOld">if true, the stack access should happen in the pre-state of the method (or surrounding call)</param>
-    Result Ldstack(Label pc, int offset, Dest dest, Source source, bool isOld, Data data);
-
-    /// <summary>
-    /// Similar to ldstack.i but pretends that stack locations also have an address and gets that address.
-    /// This is mainly used to deal with access to struct parameters in pre/post conditions and for uni-
-    /// formity.
-    /// </summary>
-    Result Ldstacka(Label pc, int offset, Dest dest, Source source, Type origParamType, bool isOld, Data data);
-
-    /// <summary>
-    /// This instruction provides access to the result of a method in the context of a post condition.
-    /// Typically, this accesses the top of the evaluation stack, however, there may be other temporaries
-    /// above the result. CodeProviders generate this instruction for accessing the result and the
-    /// analysis infrastructure can compute the proper offsets, turning it essentially into a ldstack/copy.
-    /// </summary>
-    Result Ldresult(Label pc, Type type, Dest dest, Source source, Data data);
-
-    /// <summary>
-    /// Marks the beginning of an old expression, ie., a code sequence evaluating in the state of the machine
-    /// as it was at the beginning of the current method call
-    /// This operation should push the current machine state onto a temporary machine stack (to be popped by EndOld),
-    /// and switch state to the state at the beginning of the current method call.
-    /// </summary>
-    Result BeginOld(Label pc, Label matchingEnd, Data data);
-
-    /// <summary>
-    /// Marks the end of an old expression evaluation, where the result of the expression is read in the current state
-    /// from Source. The instruction should then switch to the machine state that is on top of the machine state stack
-    /// (pushed by BeginOld), and store the result read from the old store into this store at the destination.
-    /// </summary>
-    /// <param name="matchingBegin">Label of the matching BeginOld</param>
-    /// <param name="dest">Destination to store result of old expression in the restored current state</param>
-    /// <param name="source">Result of old expression as read from the old state</param>
-    Result EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, Data data);
-  }
-
-  /// <summary>
-  /// Factored these operations out as they are the ones used by an expression visitor.
-  /// If need be, we can move more ops from IVisitMSIL to here without breaking code depending on IVisitMSIL.
-  /// </summary>
-  public interface IVisitExprIL<Label, Type, Source, Dest, Data, Result>
-  {
-    Result Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, Data data);
-    Result Box(Label pc, Type type, Dest dest, Source source, Data data);
-    Result Isinst(Label pc, Type type, Dest dest, Source obj, Data data);
-    Result Ldconst(Label pc, Object constant, Type type, Dest dest, Data data);
-    Result Ldnull(Label pc, Dest dest, Data data);
-    Result Sizeof(Label pc, Type type, Dest dest, Data data);
-    Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Source source, Data data);
-  }
-
-  [ContractClass(typeof(IMethodContextContracts<,>))]
-  public interface IMethodContext<Field, Method>
-  {
-    IMethodContextData<Field, Method> MethodContext { get; }
-  }
-
-  #region Contracts for IMethodContext
-  [ContractClassFor(typeof(IMethodContext<,>))]
-  abstract class IMethodContextContracts<Field, Method> : IMethodContext<Field, Method>
-  {
-    public IMethodContextData<Field, Method> MethodContext
+    #region IDecodeMethods contract binding
+    [ContractClass(typeof(IDecodeMethodsContract<>))]
+    public partial interface IDecodeMethods<Method>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<IMethodContextData<Field, Method>>() != null);
+        /// <summary>
+        /// Short name of method without namespace and outer types
+        /// </summary>
+        [Pure]
+        string Name(Method method);
 
-        return null;
-      }
-    }
-  }
-  #endregion
+        /// <summary>
+        /// Full name of method including namespace and outer types
+        /// </summary>
+        [Pure]
+        string FullName(Method method);
 
-  public partial interface IMethodContextData<Field, Method>
-  {
-    Method CurrentMethod { get; }
+        /// <summary>
+        /// Obtain the Documentation Id for the method
+        /// </summary>
+        [Pure]
+        string DocumentationId(Method method);
 
-    ICFG CFG { get; }
+        /// <summary>
+        /// Get the canonical name of the member associated with this method. 
+        /// A member can be a method, an event or a property. 
+        /// This name is aimed at beeing created by the visual studio package
+        /// </summary>
+        [Pure]
+        string DeclaringMemberCanonicalName(Method method);
 
-    /// <summary>
-    /// Returns closest source context for this label
-    /// </summary>
-    string SourceContext(APC label);
+        /// <summary>
+        /// True iff method is the entry point of an executable
+        /// </summary>
+        [Pure]
+        bool IsMain(Method method);
 
-    /// <summary>
-    /// Returns the name of the associated document of the source context for this pc
-    /// </summary>
-    string SourceDocument(APC pc);
+        /// <summary>
+        /// True if method is static.
+        /// </summary>
+        [Pure]
+        bool IsStatic(Method method);
 
-    /// <summary>
-    /// Returns the first line number in the source context of this pc.
-    /// </summary>
-    int SourceStartLine(APC pc);
+        /// <summary>
+        /// True if method is private
+        /// </summary>
+        [Pure]
+        bool IsPrivate(Method method);
 
-    /// <summary>
-    /// Returns the last line number in the source context of this pc.
-    /// </summary>
-    int SourceEndLine(APC pc);
+        /// <summary>
+        /// True if method is protected
+        /// </summary>
+        [Pure]
+        bool IsProtected(Method method);
 
-    /// <summary>
-    /// Returns the first column number in the source context of this pc.
-    /// </summary>
-    int SourceStartColumn(APC pc);
+        /// <summary>
+        /// True if method is public
+        /// </summary>
+        [Pure]
+        bool IsPublic(Method method);
 
-    /// <summary>
-    /// Returns the first column number in the source context of this pc.
-    /// </summary>
-    int SourceEndColumn(APC pc);
-    /// <summary>
-    /// Returns the IL offset within the method of the given instruction or 0
-    /// </summary>
+        /// <summary>
+        /// True if method is virtual
+        /// </summary>
+        [Pure]
+        bool IsVirtual(Method method);
 
-    IEnumerable<Field> Modifies(Method method);
+        /// <summary>
+        /// True if method is declared as "new"
+        /// </summary>
+        [Pure]
+        bool IsNewSlot(Method method);
 
-    IEnumerable<Method> AffectedGetters(Field field);
-  }
+        /// <summary>
+        /// True if method is "override"
+        /// </summary>
+        [Pure]
+        bool IsOverride(Method method);
 
-  #region IMethodContextData<Field, Method> contract binding
-  [ContractClass(typeof(IMethodContextDataContract<,>))]
-  public partial interface IMethodContextData<Field, Method>
-  {
+        /// <summary>
+        /// True if method is sealed
+        /// </summary>
+        [Pure]
+        bool IsSealed(Method method);
 
-  }
+        /// <summary>
+        /// True if the return type of the method is void
+        /// </summary>
+        [Pure]
+        bool IsVoidMethod(Method method);
 
-  [ContractClassFor(typeof(IMethodContextData<,>))]
-  abstract class IMethodContextDataContract<Field, Method> : IMethodContextData<Field, Method>
-  {
-    #region IMethodContextData<Field,Method> Members
+        /// <summary>
+        /// Returns true if the method is an instance constructor
+        /// </summary>
+        [Pure]
+        bool IsConstructor(Method method);
 
-    public Method CurrentMethod
-    {
-      get { throw new NotImplementedException(); }
+        /// <summary>
+        /// Returns true if the method is a finalizer
+        /// </summary>
+        [Pure]
+        bool IsFinalizer(Method method);
+
+        /// <summary>
+        /// Returns true if the method is a Dispose implementation
+        /// </summary>
+        [Pure]
+        bool IsDispose(Method method);
+
+        /// <summary>
+        /// Returns true if the method is internal
+        /// </summary>
+        [Pure]
+        bool IsInternal(Method method);
+
+        /// <summary>
+        /// True if method is visible outside assembly within which it is declared
+        /// E.g., public methods, or protected methods of publicly visible types, etc.
+        /// </summary>
+        [Pure]
+        bool IsVisibleOutsideAssembly(Method method);
+
+        /// <summary>
+        /// True if method is abstract and has no body
+        /// </summary>
+        [Pure]
+        bool IsAbstract(Method method);
+
+        /// <summary>
+        /// True if method is declared extern and has no body
+        /// </summary>
+        [Pure]
+        bool IsExtern(Method method);
+
+        /// <summary>
+        /// Returns true if the method is a property setter
+        /// </summary>
+        [Pure]
+        bool IsPropertySetter(Method method);
+
+        /// <summary>
+        /// Returns true if the method is a property getter
+        /// </summary>
+        [Pure]
+        bool IsPropertyGetter(Method method);
+
+        /// <summary>
+        /// For an async generated MoveNext methods, returns true
+        /// </summary>
+        [Pure]
+        bool IsAsyncMoveNext(Method method);
+
+        /// <summary>
+        /// For a MoveNext method from async or iterators, returns the start state (-1 or 0). Otherwise returns null.
+        /// </summary>
+        [Pure]
+        int? MoveNextStartState(Method method);
     }
 
-    public ICFG CFG
+    [ContractClassFor(typeof(IDecodeMethods<>))]
+    internal abstract class IDecodeMethodsContract<Method> : IDecodeMethods<Method>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<ICFG>() != null);
-        throw new NotImplementedException();
-      }
-    }
+        public string Name(Method method)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
 
-    public string SourceContext(APC label)
-    {
-      throw new NotImplementedException();
-    }
+            return null;
+        }
 
-    public string SourceDocument(APC pc)
-    {
-      throw new NotImplementedException();
-    }
+        public string FullName(Method method)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
 
-    public StackTemp SourceStartLine(APC pc)
-    {
-      throw new NotImplementedException();
-    }
+            return null;
+        }
 
-    public StackTemp SourceEndLine(APC pc)
-    {
-      throw new NotImplementedException();
-    }
+        public string DocumentationId(Method method)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            return null;
+        }
 
-    public StackTemp SourceStartColumn(APC pc)
-    {
-      throw new NotImplementedException();
-    }
+        public string DeclaringMemberCanonicalName(Method method)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
 
-    public StackTemp SourceEndColumn(APC pc)
-    {
-      throw new NotImplementedException();
-    }
+            throw new NotImplementedException();
+        }
 
-    public IEnumerable<Field> Modifies(Method method)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
-      throw new NotImplementedException();
-    }
+        public bool IsMain(Method method)
+        {
+            throw new NotImplementedException();
+        }
 
-    public IEnumerable<Method> AffectedGetters(Field field)
-    {
-      Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
-      throw new NotImplementedException();
-    }
+        public bool IsStatic(Method method)
+        {
+            throw new NotImplementedException();
+        }
 
+        public bool IsPrivate(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsProtected(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPublic(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVirtual(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsNewSlot(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsOverride(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSealed(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVoidMethod(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsConstructor(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsFinalizer(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDispose(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsInternal(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleOutsideAssembly(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAbstract(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsExtern(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPropertySetter(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPropertyGetter(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        #region IDecodeMethods<Method> Members
+
+
+        public bool IsAsyncMoveNext(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int? MoveNextStartState(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
     #endregion
-  }
-  #endregion
 
-  static public class IDecodeMetadataExtensionsForPurityInfo
-  {
-    [ThreadStatic]
-    private static Dictionary<string, long> additionalPurityInfo;
-
-    // Need lazy-initialization because of ThreadStatic
-    private static Dictionary<string, long> AdditionalPurityInfo
+    [ContractClass(typeof(IDecodeMetaDataContracts<,,,,,,,,>))]
+    public partial interface IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> : IDecodeMethods<Method>
     {
-      get
-      {
-        if (additionalPurityInfo == null)
-          additionalPurityInfo = new Dictionary<string, long>();
-        return additionalPurityInfo;
-      }
-    }
+        #region Methods
 
-    [Pure]
-    static public bool TryInferredPureParametersMask(string methodName, out long mask)
-    {
-      return AdditionalPurityInfo.TryGetValue(methodName, out mask);
-    }
+        /// <summary>
+        /// Returns the return type of a method
+        /// </summary>
+        [Pure]
+        Type ReturnType(Method method);
 
-    [Pure]
-    static public void SetPureParametersMask(string methodName, long mask)
-    {
-      AdditionalPurityInfo[methodName] = mask;
-    }
+        /// <summary>
+        /// Returns the parameters of a method, NOT including "this" (even if the method is an instance method)
+        /// </summary>
+        [Pure]
+        IIndexable<Parameter> Parameters(Method method);
 
-    [Pure]
-    static public void AddPure<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder,
-      Method m, int parameterPosition)
-    {
-      Contract.Requires(parameterPosition <= 64);
+        /// <summary>
+        /// For non-static methods, returns a parameter corresponding to "this or arg0".
+        /// Can throw if the method is static.
+        /// </summary>
+        [Pure]
+        Parameter This(Method method);
 
-      if (metaDataDecoder == null)
-      {
-        return;
-      }
+        /// <summary>
+        /// True if property is visible outside assembly within which it is declared
+        /// </summary>
+        [Pure]
+        bool IsVisibleOutsideAssembly(Property property);
 
-      var name = metaDataDecoder.FullName(m);
+        /// <summary>
+        /// True if event is visible outside assembly within which it is declared
+        /// </summary>
+        [Pure]
+        bool IsVisibleOutsideAssembly(Event @event);
 
-      /*
-      if (name == null)
-      {
-        return;
-      }
-      */
+        /// <summary>
+        /// True if field is visible outside assembly within which it is declared
+        /// </summary>
+        [Pure]
+        bool IsVisibleOutsideAssembly(Field field);
 
-      long prevMask, mask = 1L << parameterPosition;
-      if (AdditionalPurityInfo.TryGetValue(name, out prevMask))
-      {
-        mask |= prevMask;
-      }
+        /// <summary>
+        /// Returns the property containing the getter/setter if the method is actually a getter/setter.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        [Pure]
+        Property GetPropertyFromAccessor(Method method);
 
-      AdditionalPurityInfo[name] = mask;
-    }
+        /// <summary>
+        /// Returns true if the method is compiler generated
+        /// </summary>
+        [Pure]
+        bool IsCompilerGenerated(Method method);
 
-    /// <param name="parameterPosition">The position of the parameter counting this</param>
-    /// <returns>
-    /// true if the parameter in that position is marked with Pure
-    /// </returns>
-    [Pure]
-    static public bool IsPure<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder,
-      Method method, int parameterPosition)
-      where Type : IEquatable<Type>
-    {
-      Contract.Requires(metaDataDecoder != null);
-      Contract.Requires(parameterPosition >= 0);
+        /// <summary>
+        /// Returns true if the method is marked with the DebuggerNonUserCode attribute
+        /// </summary>
+        [Pure]
+        bool IsDebuggerNonUserCode(Method method);
 
-      long purityMask;
-      if (AdditionalPurityInfo.TryGetValue(metaDataDecoder.FullName(method), out purityMask) && (purityMask & (1L << parameterPosition)) != 0)
-      {
-        return true;
-      }
+        /// <summary>
+        /// Returns true if the type is marked with the DebuggerNonUserCode attribute
+        /// </summary>
+        [Pure]
+        bool IsDebuggerNonUserCode(Type t);
 
-      Parameter p;
-      if (metaDataDecoder.IsStatic(method))
-      {
-        var args = metaDataDecoder.Parameters(method);
-        Contract.Assume(args != null);
-        // F: I've added this check because in some code from Midori the invariant was violated
-        if (parameterPosition < args.Count)
+        /// <summary>
+        /// Returns true if the method is an auto property getter or setter
+        /// </summary>
+        [Pure]
+        bool IsAutoPropertyMember(Method method);
+
+        /// <summary>
+        /// Returns true if the method is an auto property setter
+        /// </summary>
+        [Pure]
+        bool IsAutoPropertySetter(Method method, out Field backingField);
+
+        /// <summary>
+        /// Returns true if the type is compiler generated
+        /// </summary>
+        [Pure]
+        bool IsCompilerGenerated(Type type);
+
+        /// <summary>
+        /// Returns true if the type was generated from C++
+        /// </summary>
+        [Pure]
+        bool IsNativeCpp(Type type);
+
+        /// <summary>
+        /// Returns the declaring type containing this method
+        /// </summary>
+        [Pure]
+        Type DeclaringType(Method method);
+
+        /// <summary>
+        /// Returns the declaring assembly containing this method
+        /// </summary>
+        [Pure]
+        Assembly DeclaringAssembly(Method method);
+
+        /// <summary>
+        /// Returns the method def/ref token of the method if possible.
+        /// </summary>
+        [Pure]
+        int MethodToken(Method method);
+
+        /// <summary>
+        /// Returns true if this method reference is specialized w.r.t. type parameters, either
+        /// because the method is generic and instantiated, or because a declaring/parent type is
+        /// instantiated.
+        /// </summary>
+        [Pure]
+        bool IsSpecialized(Method method);
+
+        /// <summary>
+        /// Returns true if this method reference is specialized w.r.t. type parameters, either
+        /// because the method is generic and instantiated, or because a declaring/parent type is
+        /// instantiated.
+        /// </summary>
+        /// <param name="specialization">the map is updated with all the specializations
+        /// (mapping formal type arguments to actuals)</param>
+        [Pure]
+        bool IsSpecialized(Method method, ref IFunctionalMap<Type, Type> specialization);
+
+        /// <summary>
+        /// Returns true if this method reference is specialized w.r.t. type parameters, either
+        /// because the method is generic and instantiated, or because a declaring/parent type is
+        /// instantiated.
+        /// </summary>
+        [Pure]
+        bool IsSpecialized(Method method, out Method genericMethod, out IIndexable<Type> methodTypeArguments);
+
+        /// <summary>
+        /// Returns true if method is a template method with formal type arguments. 
+        /// NOTE: only the method type parameter of the given method are reported, no type parameters of
+        /// enclosing types.
+        /// </summary>
+        [Pure]
+        bool IsGeneric(Method method, out IIndexable<Type> formals);
+
+        /// <summary>
+        /// For specialized methods, this returns the original template method, otherwise identity
+        /// </summary>
+        [Pure]
+        Method Unspecialized(Method method);
+
+        /// <summary>
+        /// Specializes a generic method with the given type arguments
+        /// </summary>
+        [Pure]
+        Method Specialize(Method method, Type[] methodTypeArguments);
+
+        /// <summary>
+        /// Returns the set of methods that are immediately overridden from a base class (no intermediate override)
+        /// </summary>
+        [Pure]
+        IEnumerable<Method> OverriddenMethods(Method method);
+
+        /// <summary>
+        /// Returns the set of methods that are interface methods implemented explicitly or implicitly by this method
+        /// </summary>
+        [Pure]
+        IEnumerable<Method> ImplementedMethods(Method method);
+
+        /// <summary>
+        /// Returns the set of methods that are either
+        ///  - immediately overridden from a base class (no intermediate override)
+        ///  - interface methods implemented explicitly or implicitly by this method 
+        /// </summary>
+        [Pure]
+        IEnumerable<Method> OverriddenAndImplementedMethods(Method method);
+
+        /// <summary>
+        /// Returns true if method implements a method from an interface implicitly (as opposed to explict implementations)
+        /// </summary>
+        [Pure]
+        bool IsImplicitImplementation(Method method);
+
+        /// <summary>
+        /// Returns true if the method has a body and Entry(method) can be called.
+        /// </summary>
+        [Pure]
+        bool HasBody(Method method);
+
+        /// <summary>
+        /// Provides access to a method body (if HasBody returned true), existentially abstracting the
+        /// internal code representation of Labels and Handlers.
+        /// </summary>
+        [Pure]
+        Result AccessMethodBody<Data, Result>(Method method, IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
+
+        /// <summary>
+        /// Equality between methods
+        /// </summary>
+        [Pure]
+        bool Equal(Method m1, Method m2);
+
+        /// <summary>
+        /// Returns true if two types, type1 and type2, are equivalent types, as interpreted by the underlying 
+        /// object model. 
+        /// </summary>
+        /// <param name="type1"></param>
+        /// <param name="type2"></param>
+        /// <returns></returns>
+        [Pure]
+        bool Equal(Type type1, Type type2);
+
+        /// <summary>
+        /// Returns true if any context that can see m2 can also see m1
+        /// </summary>
+        [Pure]
+        bool IsAsVisibleAs(Method m1, Method m2);
+
+        /// <summary>
+        /// Returns true if any context that can see m can also see t
+        /// </summary>
+        [Pure]
+        bool IsAsVisibleAs(Type t, Method m);
+
+        /// <summary>
+        /// Returns true if m can be seen from the type t
+        /// </summary>
+        [Pure]
+        bool IsVisibleFrom(Method m, Type t);
+
+        /// <summary>
+        /// Returns true if f can be seen from the type t
+        /// </summary>
+        [Pure]
+        bool IsVisibleFrom(Field f, Type t);
+
+        /// <summary>
+        /// Returns true if t can be seen from the body of tfrom
+        /// </summary>
+        [Pure]
+        bool IsVisibleFrom(Type t, Type tfrom);
+
+
+        /// <summary>
+        /// Tries to find the method that implements baseMethod for type. This is either an
+        /// explicit implementation in type, an implicit method in type, or an implicit or explicit
+        /// implementation in the base-type of type.
+        /// </summary>
+        [Pure]
+        bool TryGetImplementingMethod(Type type, Method baseMethod, out Method implementingMethod);
+
+        /// <summary>
+        /// Returns the locals of a given method
+        /// </summary>
+        [Pure]
+        IIndexable<Local> Locals(Method method);
+
+        /// <summary>
+        /// If method is overriding another base method, then this returns the root method of the inheritance 
+        /// hierarchy.
+        /// </summary>
+        bool TryGetRootMethod(Method method, out Method rootMethod);
+
+
+        #endregion
+
+        #region Fields
+
+        /// <summary>
+        /// Returns the type of the field
+        /// </summary>
+        [Pure]
+        Type FieldType(Field field);
+
+        /// <summary>
+        /// Returns the full name of the field including surrounding types and namespaces
+        /// </summary>
+        [Pure]
+        string FullName(Field field);
+
+        /// <summary>
+        /// Returns the short name of a field
+        /// </summary>
+        [Pure]
+        string Name(Field field);
+
+        /// <summary>
+        /// Obtain the Documentation Id for the method
+        /// </summary>
+        [Pure]
+        string DocumentationId(Field field);
+
+        /// <summary>
+        /// True if the field is static
+        /// </summary>
+        [Pure]
+        bool IsStatic(Field field);
+
+        /// <summary>
+        /// Returns true if field is private
+        /// </summary>
+        [Pure]
+        bool IsPrivate(Field field);
+
+        /// <summary>
+        /// Returns true if field is protected
+        /// </summary>
+        [Pure]
+        bool IsProtected(Field field);
+
+        /// <summary>
+        /// Returns true if field is public
+        /// </summary>
+        [Pure]
+        bool IsPublic(Field field);
+
+        /// <summary>
+        /// true if field is internal
+        /// </summary>
+        [Pure]
+        bool IsInternal(Field field);
+
+        /// <summary>
+        /// true if field is volatile
+        /// </summary>
+        [Pure]
+        bool IsVolatile(Field field);
+
+        /// <summary>
+        /// true if field is declared as "new"
+        /// </summary>
+        [Pure]
+        bool IsNewSlot(Field field);
+
+        /// <summary>
+        /// Returns the declaring type containing this field
+        /// </summary>
+        [Pure]
+        Type DeclaringType(Field field);
+
+        /// <summary>
+        /// Returns true if the field is declared readonly
+        /// </summary>
+        [Pure]
+        bool IsReadonly(Field field);
+
+        /// <summary>
+        /// Returns true if any context that can see method can also see field.
+        /// </summary>
+        [Pure]
+        bool IsAsVisibleAs(Field field, Method method);
+
+        /// <summary>
+        /// Returns true if this field reference is specialized w.r.t. type parameters, 
+        /// because the a declaring/parent type is instantiated.
+        /// </summary>
+        [Pure]
+        bool IsSpecialized(Field field);
+
+        /// <summary>
+        /// Returns the unspecialized field corresponding to this field, if the field
+        /// is specialized due to parent types being instantiated. Acts as an identity
+        /// for non-specialized fields.
+        /// </summary>
+        [Pure]
+        Field Unspecialized(Field field);
+
+        /// <summary>
+        /// Returns the initial value of the field. Note: if field is an enum field, returns its value.
+        /// </summary>
+        [Pure]
+        bool TryInitialValue(Field field, out object value);
+
+        /// <summary>
+        /// Returns if the two fields are equal
+        /// </summary>
+        [Pure]
+        bool Equal(Field f1, Field f2);
+
+        /// <summary>
+        /// Return true if the field is compiler generated
+        /// </summary>
+        [Pure]
+        bool IsCompilerGenerated(Field f);
+
+        #endregion
+
+        #region Properties
+        [Pure]
+        string Name(Property property);
+
+        [Pure]
+        bool HasGetter(Property property, out Method getter);
+        [Pure]
+        bool HasSetter(Property property, out Method setter);
+
+        [Pure]
+        IEnumerable<Property> Properties(Type type);
+
+        [Pure]
+        bool IsStatic(Property p);
+        [Pure]
+        bool IsOverride(Property p);
+        [Pure]
+        bool IsNewSlot(Property p);
+        [Pure]
+        bool IsSealed(Property p);
+
+        [Pure]
+        Type DeclaringType(Property p);
+        [Pure]
+        Type PropertyType(Property property);
+
+        /// <summary>
+        /// Returns if the two properties are the same
+        /// </summary>
+        [Pure]
+        bool Equal(Property p1, Property p2);
+
+        #endregion
+
+        #region Events
+        [Pure]
+        string Name(Event @event);
+
+        [Pure]
+        bool HasAdder(Event @event, out Method adder);
+        [Pure]
+        bool HasRemover(Event @event, out Method remover);
+
+        [Pure]
+        IEnumerable<Event> Events(Type type);
+
+        [Pure]
+        bool IsStatic(Event e);
+        [Pure]
+        bool IsOverride(Event e);
+        [Pure]
+        bool IsNewSlot(Event e);
+        [Pure]
+        bool IsSealed(Event e);
+
+        [Pure]
+        Type DeclaringType(Event e);
+        [Pure]
+        Type HandlerType(Event e);
+
+        /// <summary>
+        /// Returns if the two events are the same
+        /// </summary>
+        [Pure]
+        bool Equal(Event e1, Event e2);
+
+        bool IsEventAdder(Method method, out Event @event);
+
+        bool IsEventRemover(Method method, out Event @event);
+
+        #endregion
+
+        #region Types
+
+        /// <summary>
+        /// True if this is the framework System.Void type, ignoring surrounding optional/required modifiers
+        /// </summary>
+        [Pure]
+        bool IsVoid(Type/*!*/ type);
+
+        /// <summary>
+        /// True if this is an unmanaged pointer, ignoring surrounding optional/required modifiers
+        /// </summary>
+        [Pure]
+        bool IsUnmanagedPointer(Type/*!*/ type);   // * type
+
+        /// <summary>
+        /// True if this is a managed pointer, ignoring surrounding optional/required modifiers
+        /// </summary>
+        [Pure]
+        bool IsManagedPointer(Type/*!*/ type);     // & type
+
+        /// <summary>
+        /// True if this is a primitive type, ignoring surrounding optional/required modifiers
+        /// </summary>
+        [Pure]
+        bool IsPrimitive(Type/*!*/ type);
+
+        /// <summary>
+        /// True if this is a struct/value type type, ignoring surrounding optional/required modifiers
+        /// </summary>
+        //^ [Confined]
+        [Pure]
+        bool IsStruct(Type/*!*/ type);
+
+        /// <summary>
+        /// True if this is an array type, ignoring surrounding optional/required modifiers
+        /// </summary>
+        //^ [Confined]
+        [Pure]
+        bool IsArray(Type/*!*/ type);
+
+        /// <summary>
+        /// Returns the number of dimensions if the type is an array.
+        /// Requires IsArray
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        [Pure]
+        int Rank(Type type);
+
+        /// <summary>
+        /// Returns true if type is an interface
+        /// </summary>
+        [Pure]
+        bool IsInterface(Type/*!*/ type);
+
+        /// <summary>
+        /// Returns true if type is static
+        /// </summary>
+        [Pure]
+        bool IsStatic(Type type);
+
+        /// <summary>
+        /// Returns true if type is a class
+        /// </summary>
+        [Pure]
+        bool IsClass(Type/*!*/ type);
+
+        /// <summary>
+        /// Returns true if type is declared abstract
+        /// </summary>
+        [Pure]
+        bool IsAbstract(Type type);
+
+        /// <summary>
+        /// Returns true if type is declared public
+        /// </summary>
+        [Pure]
+        bool IsPublic(Type type);
+
+        /// <summary>
+        /// Returns true if type is declared internal
+        /// </summary>
+        [Pure]
+        bool IsInternal(Type type);
+
+        /// <summary>
+        /// Returns true if type is declared protected
+        /// </summary>
+        [Pure]
+        bool IsProtected(Type type);
+
+        /// <summary>
+        /// Returns true if type is private
+        /// </summary>
+        [Pure]
+        bool IsPrivate(Type type);
+
+        /// <summary>
+        /// Returns true if type is sealed
+        /// </summary>
+        [Pure]
+        bool IsSealed(Type type);
+
+        /// <summary>
+        /// Returns the parent type and true if the given type is nested.
+        /// </summary>
+        [Pure]
+        bool IsNested(Type/*!*/ type, out Type/*?*/ parentType);
+
+        /// <summary>
+        /// Returns true if the formal generic argument is reference constrained. Either class or method formal argument.
+        /// </summary>
+        [Pure]
+        bool IsReferenceConstrained(Type type);
+
+        /// <summary>
+        /// Returns true if the formal generic argument is value constrained. Either class or method formal argument.
+        /// </summary>
+        [Pure]
+        bool IsValueConstrained(Type type);
+
+        /// <summary>
+        /// Returns true if the formal generic argument is constructor constrained. Either class or method formal argument.
+        /// </summary>
+        [Pure]
+        bool IsConstructorConstrained(Type type);
+
+
+        /// <summary>
+        /// Returns true if the given type is a type bound formal type parameter
+        /// </summary>
+        [Pure]
+        bool IsFormalTypeParameter(Type type);
+
+        /// <summary>
+        /// Returns true if the given type is a method bound formal type parameter
+        /// </summary>
+        [Pure]
+        bool IsMethodFormalTypeParameter(Type type);
+
+        /// <summary>
+        /// Returns true if type represents a modified type with the given set of 
+        /// optional and required modifiers. The pairings of the modifiers with a boolean indicates 
+        /// if the modifier is optional (bool is true), or required (bool is false).
+        /// </summary>
+        [Pure]
+        bool IsModified(Type type, out Type modified, out IIndexable<Pair<bool, Type>> modifiers);
+
+        /// <summary>
+        /// Returns true if type is a template type with formal type arguments. NOTE: if normalized is true,
+        /// this provides the IL/Metadata view where nested types inherit the type formals of their enclosing types.
+        /// Otherwise, only the type parameter of the given type are reported.
+        /// </summary>
+        [Pure]
+        bool IsGeneric(Type type, out IIndexable<Type> formals, bool normalized);
+
+        /// <summary>
+        /// Returns true if the type is a delegate
+        /// </summary>
+        [Pure]
+        bool IsDelegate(Type type);
+
+        /// <summary>
+        /// For type bound type parameters, provides the normalized index of the type parameter.
+        /// For nested types, they are normalized to include all parent type parameters.
+        /// </summary>
+        [Pure]
+        int NormalizedFormalTypeParameterIndex(Type type);
+
+        /// <summary>
+        /// For type bound type parameters, provides the defined type of the type parameter
+        /// </summary>
+        [Pure]
+        Type FormalTypeParameterDefiningType(Type type);
+
+        /// <summary>
+        /// Returns the actual type arguments of type (including parent type arguments).
+        /// If type isn't an instance, result is of length 0.
+        /// </summary>
+        [Pure]
+        IIndexable<Type> NormalizedActualTypeArguments(Type type);
+
+        /// <summary>
+        /// Returns the actual type arguments of the method (NOT including declaring type or parent types).
+        /// If method isn't a generic method instance, result is of length 0.
+        /// </summary>
+        [Pure]
+        IIndexable<Type> ActualTypeArguments(Method method);
+
+        /// <summary>
+        /// For method bound formal type parameters, this method returns the index of the type parameter on the method.
+        /// </summary>
+        [Pure]
+        int MethodFormalTypeParameterIndex(Type type);
+
+        /// <summary>
+        /// For method bound formal type parameters, this method returns the method defining the type parameter
+        /// </summary>
+        [Pure]
+        Method MethodFormalTypeDefiningMethod(Type type);
+
+        /// <summary>
+        /// Returns true if type represents an enum
+        /// </summary>
+        [Pure]
+        bool IsEnum(Type type);
+
+        /// <summary>
+        /// Returns true if the Flags attribute is specified for that type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        [Pure]
+        bool HasFlagsAttribute(Type type);
+
+        /// <summary>
+        /// Returns the underlying type if type is an enum
+        /// </summary>
+        [Pure]
+        Type TypeEnum(Type type);
+
+        /// <summary>
+        /// Returns the MVID of the declaring module (if nested type, of the declaring module of the container)
+        /// </summary>
+        [Pure]
+        System.Guid DeclaringModule(Type/*!*/ type);
+
+
+        /// <summary>
+        /// Returns the module name defining this type (if nested, the declaring module of the container)
+        /// </summary>
+        [Pure]
+        string DeclaringModuleName(Type type);
+
+        /// <summary>
+        /// Returns the fields of a type
+        /// </summary>
+        [Pure]
+        IEnumerable<Field/*!*/> Fields(Type/*!*/ type);
+
+        /// <summary>
+        /// Returns the methods of a type
+        /// </summary>
+        [Pure]
+        IEnumerable<Method> Methods(Type type);
+
+        /// <summary>
+        /// Returns the nested types of a type
+        /// </summary>
+        [Pure]
+        IEnumerable<Type> NestedTypes(Type type);
+
+        /// <summary>
+        /// Returns the short name of the type
+        /// </summary>
+        [Pure]
+        string Name(Type type);
+
+        /// <summary>
+        /// Returns the full name including surrounding types and namespaces
+        /// </summary>
+        [Pure]
+        string FullName(Type/*!*/ type);
+
+
+        /// <summary>
+        /// Obtain the Documentation Id for the method
+        /// </summary>
+        [Pure]
+        string DocumentationId(Type type);
+
+
+        /// <summary>
+        /// Returns the namespace of the type (if not a nested type)
+        /// </summary>
+        [Pure]
+        string Namespace(Type type);
+
+        /// <summary>
+        /// Constructs an array type with the given element type and rank
+        /// </summary>
+        [Pure]
+        Type/*!*/ ArrayType(Type/*!*/ type, int rank);  // type[]...
+
+        /// <summary>
+        /// Constructs a managed pointer type with the given element type
+        /// </summary>
+        [Pure]
+        Type/*!*/ ManagedPointer(Type/*!*/ type);       // type&
+
+        /// <summary>
+        /// Constructs an unmanaged pointer type with the given element type
+        /// </summary>
+        [Pure]
+        Type/*!*/ UnmanagedPointer(Type/*!*/ type);       // type&
+
+        /// <summary>
+        /// For managed and unmanaged pointers and arrays, returns the type pointed to (in the array)
+        /// </summary>
+        [Pure]
+        Type/*!*/ ElementType(Type/*!*/ type);
+
+        /// <summary>
+        /// If the type has explicit layout information, it returns the size of the type. Otherwise -1.
+        /// </summary>
+        [Pure]
+        int TypeSize(Type/*!*/ type);
+
+        /// <summary>
+        /// Returns true if the type is a class and has a base class (e.g., not Object)
+        /// </summary>
+        [Pure]
+        bool HasBaseClass(Type type);
+
+        /// <summary>
+        /// Returns the base class of the given type, or fails if the type has no base class
+        /// </summary>
+        [Pure]
+        Type BaseClass(Type type);
+
+        /// <summary>
+        /// If type is a class or struct, returns the implemented interfaces
+        /// </summary>
+        [Pure]
+        IEnumerable<Type> Interfaces(Type type);
+
+        /// <summary>
+        /// If type is a type or method parameter, return the list of type constraints
+        /// </summary>
+        [Pure]
+        IEnumerable<Type> TypeParameterConstraints(Type type);
+
+        /// <summary>
+        /// Returns true if the type reference is a specialized type with type arguments.
+        /// NOTE: if this is a nested type, it will return true even if only parent types are specialized.
+        ///       In that case, typeArguments returned might be of lenth 0.
+        /// </summary>
+        [Pure]
+        bool IsSpecialized(Type type, out IIndexable<Type> typeArguments);
+
+        /// <summary>
+        /// Returns true if the type reference is a specialized type with type arguments.
+        /// NOTE: if this is a nested type, it will return true even if only parent types are specialized.
+        ///       In that case, typeArguments will inherit the type arguments of the parent types
+        /// </summary>
+        [Pure]
+        bool NormalizedIsSpecialized(Type type, out IIndexable<Type> typeArguments);
+
+        /// <summary>
+        /// For instantiated types, this returns the original template type
+        /// </summary>
+        [Pure]
+        Type Unspecialized(Type type);
+
+        /// <summary>
+        /// Returns true if type is definetely represented as a reference (pointer),
+        /// not a value type.
+        /// </summary>
+        [Pure]
+        bool IsReferenceType(Type type);
+
+        /// <summary>
+        /// Returns true if type is uintptr, intptr, or X*
+        /// </summary>
+        [Pure]
+        bool IsNativePointerType(Type declaringType);
+
+        /// <summary>
+        /// Returns true if sub derives from super directly or indirectly
+        /// </summary>
+        [Pure]
+        bool DerivesFrom(Type sub, Type super);
+
+        /// <summary>
+        /// For non-generic types this is exactly the same as DerivesFrom.
+        /// For generic-types, it checks whether the template of sub derives
+        /// from the template of super, without considering their type
+        /// arguments.
+        /// This method is needed only because inherited contracts are not specialized
+        /// into their inheriting context. If they were, then DerivesFrom would
+        /// be exactly the right test and this method should be removed.
+        /// </summary>
+        [Pure]
+        bool DerivesFromIgnoringTypeArguments(Type sub, Type super);
+
+        /// <summary>
+        /// Returns the number of (non-static) constructors in this specific type
+        /// </summary>
+        [Pure]
+        int ConstructorsCount(Type type);
+
+        /// <summary>
+        /// Returns true if type is visible outside assembly
+        /// </summary>
+        [Pure]
+        bool IsVisibleOutsideAssembly(Type type);
+
+        /// <summary>
+        /// Specializes a generic type with the given type arguments. This should work for normalized specializations too.
+        /// </summary>
+        [Pure]
+        Type Specialize(Type type, Type[] typeArguments);
+
+        #endregion
+
+        #region Modules
+
+        /// <summary>
+        /// Loads the given assembly loaded from file.
+        /// The assemblyCache is a hack to give the code provider a chance to reuse the same assembly if referenced
+        /// multiple times and it also contains contract assemblies for out-of-band contracts.
+        /// </summary>
+        /// <returns>false if assembly cannot be loaded.</returns>
+        [Pure]
+        bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractSourceText);
+
+        /// <summary>
+        /// Returns all (and only) the top-level types in the given assembly.
+        /// </summary>
+        [Pure]
+        IEnumerable<Type> GetTypes(Assembly assembly);
+
+        /// <summary>
+        /// Returns the set of assembly references of an assembly
+        /// </summary>
+        [Pure]
+        IEnumerable<Assembly> AssemblyReferences(Assembly assembly);
+
+        /// <summary>
+        /// Returns the string representing the short name of the assembly
+        /// </summary>
+        [Pure]
+        string Name(Assembly assembly);
+
+        /// <summary>
+        /// Returns the version of the assembly
+        /// </summary>
+        [Pure]
+        Version Version(Assembly assembly);
+
+        [Pure]
+        Guid AssemblyGuid(Assembly assembly);
+        #endregion
+
+        #region Well-known types (alphabetical)
+
+        Type/*!*/ System_Array { get; }
+        Type/*!*/ System_Boolean { get; }
+        Type/*!*/ System_Char { get; }
+        Type/*!*/ System_DynamicallyTypedReference { get; }
+        Type/*!*/ System_Double { get; }
+        Type/*!*/ System_Decimal { get; }
+        Type/*!*/ System_Int8 { get; }
+        Type/*!*/ System_Int16 { get; }
+        Type/*!*/ System_Int32 { get; }
+        Type/*!*/ System_Int64 { get; }
+        Type/*!*/ System_IntPtr { get; }
+        Type/*!*/ System_Object { get; }
+        Type/*!*/ System_RuntimeArgumentHandle { get; }
+        Type/*!*/ System_RuntimeFieldHandle { get; }
+        Type/*!*/ System_RuntimeMethodHandle { get; }
+        Type/*!*/ System_RuntimeTypeHandle { get; }
+        Type/*!*/ System_Single { get; }
+        Type/*!*/ System_String { get; }
+        Type/*!*/ System_Type { get; }
+        Type/*!*/ System_UInt8 { get; }
+        Type/*!*/ System_UInt16 { get; }
+        Type/*!*/ System_UInt32 { get; }
+        Type/*!*/ System_UInt64 { get; }
+        Type/*!*/ System_UIntPtr { get; }
+        Type/*!*/ System_Void { get; }
+
+        [Pure]
+        bool TryGetSystemType(string fullName, out Type type);
+
+        #endregion
+
+        #region Parameter
+
+        /// <summary>
+        /// Returns the name of the given parameter
+        /// </summary>
+        [Pure]
+        string Name(Parameter param);
+
+        /// <summary>
+        /// Returns the type of the parameter
+        /// </summary>
+        [Pure]
+        Type ParameterType(Parameter p);
+
+        /// <summary>
+        /// True if the parameter was declared as an "out" parameter
+        /// </summary>
+        [Pure]
+        bool IsOut(Parameter p);
+
+        /// <summary>
+        /// Return the argument index as used in the IL.
+        /// </summary>
+        [Pure]
+        int ArgumentIndex(Parameter p);
+
+        /// <summary>
+        /// Return the offset on the stack of this parameter at a call site.
+        /// The offset is essentially #method-args + (IsStatic?0:1) - argumentIndex
+        /// For example: a method with a "this" parameter and another parameter x would
+        /// have offset 0 for x and offset 1 for this.
+        /// </summary>
+        [Pure]
+        int ArgumentStackIndex(Parameter p);
+
+        /// <summary>
+        /// Returns the method declaring this parameter.
+        /// </summary>
+        [Pure]
+        Method DeclaringMethod(Parameter p);
+
+        #endregion
+
+        #region Local
+
+        /// <summary>
+        /// Returns the name of the local
+        /// </summary>
+        [Pure]
+        string Name(Local local);
+
+        /// <summary>
+        /// Returns the declared type of the local
+        /// </summary>
+        [Pure]
+        Type LocalType(Local local);
+
+        /// <summary>
+        /// Is the local a pinned variable?
+        /// </summary>
+        /// <param name="local"></param>
+        /// <returns></returns>
+        [Pure]
+        bool IsPinned(Local local);
+
+        #endregion
+
+        #region Attributes
+        [Pure]
+        IEnumerable<Attribute> GetAttributes(Type type);
+
+        [Pure]
+        IEnumerable<Attribute> GetAttributes(Method method);
+
+        [Pure]
+        IEnumerable<Attribute> GetAttributes(Field field);
+
+        [Pure]
+        IEnumerable<Attribute> GetAttributes(Property field);
+
+        [Pure]
+        IEnumerable<Attribute> GetAttributes(Event @event);
+
+        [Pure]
+        IEnumerable<Attribute> GetAttributes(Assembly assembly);
+
+        [Pure]
+        IEnumerable<Attribute> GetAttributes(Parameter parameter);
+
+        [Pure]
+        Type AttributeType(Attribute attribute);
+
+        [Pure]
+        Method AttributeConstructor(Attribute attribute);
+
+        [Pure]
+        IIndexable<object> PositionalArguments(Attribute attribute);
+
+        [Pure]
+        object NamedArgument(string name, Attribute attribute);
+
+        #endregion
+
+        #region Platform
+
+        bool IsPlatformInitialized { get; }
+        /// <summary>
+        /// Set the platform and search paths for assembly resolution.
+        /// </summary>
+        void SetTargetPlatform(string framework, System.Collections.IDictionary assemblyCache, string platform, IEnumerable<string> resolved, IEnumerable<string> libPaths, Action<System.CodeDom.Compiler.CompilerError> errorHandler, bool trace);
+
+        /// <summary>
+        /// To override default Microsoft.Contracts.dll or mscorlib or current. Needs to be done prior to SetTargetPlatform
+        /// </summary>
+        string SharedContractClassAssembly
         {
-          p = args[parameterPosition];
+            get;
+            set;
         }
-        else
-        {
-          return false;
-        }
-      }
-      else
-      {
-        if (parameterPosition == 0)
-        {
-          return false;
-        }
-        p = metaDataDecoder.Parameters(method).AssumeNotNull()[parameterPosition - 1];
-      }
+        #endregion
 
-      foreach (var attrib in metaDataDecoder.GetAttributes(p).AssumeNotNull())
-      {
-        var attibType = metaDataDecoder.AttributeType(attrib);
-        if (metaDataDecoder.Name(attibType) == "PureAttribute")
-        {
-          return true;
-        }
-      }
 
-      return false;
     }
 
-    [Pure]
-    static public bool IsPure<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-     this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder,
-      Method method, Parameter p)
-    where Type : IEquatable<Type>
+    #region Contracts for IDecodeMetaData
+    [ContractClassFor(typeof(IDecodeMetaData<,,,,,,,,>))]
+    internal abstract class IDecodeMetaDataContracts<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
+      : IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
     {
-      Contract.Requires(metaDataDecoder != null);
+        #region IDecodeMetaData<Local,Parameter,Method,Field,Property,Event,Type,Attribute,Assembly> Members
 
-      foreach (var attrib in metaDataDecoder.GetAttributes(p).AssumeNotNull())
-      {
-        var attibType = metaDataDecoder.AttributeType(attrib);
-        if (metaDataDecoder.Name(attibType) == "PureAttribute")
+        public Type ReturnType(Method method)
         {
-          return true;
+            throw new NotImplementedException();
         }
-      }
 
-      return false;
+        public IIndexable<Parameter> Parameters(Method method)
+        {
+            Contract.Ensures(Contract.Result<IIndexable<Parameter>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public Parameter This(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleOutsideAssembly(Property property)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleOutsideAssembly(Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleOutsideAssembly(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        [Pure]
+        public Property GetPropertyFromAccessor(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsCompilerGenerated(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDebuggerNonUserCode(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDebuggerNonUserCode(Type t)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAutoPropertyMember(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAutoPropertySetter(Method method, out Field backingField)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsCompilerGenerated(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsNativeCpp(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type DeclaringType(Method method)
+        {
+            Contract.Ensures(Contract.Result<Type>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public Assembly DeclaringAssembly(Method method)
+        {
+            Contract.Ensures(Contract.Result<Assembly>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public StackTemp MethodToken(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSpecialized(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSpecialized(Method method, ref IFunctionalMap<Type, Type> specialization)
+        {
+            Contract.Requires(specialization != null);
+
+            throw new NotImplementedException();
+        }
+
+        public bool IsSpecialized(Method method, out Method genericMethod, out IIndexable<Type> methodTypeArguments)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out methodTypeArguments) != null));
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out genericMethod) != null));
+
+            throw new NotImplementedException();
+        }
+
+        public bool IsGeneric(Method method, out IIndexable<Type> formals)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out formals) != null);
+            throw new NotImplementedException();
+        }
+
+        public Method Unspecialized(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Method Specialize(Method method, Type[] methodTypeArguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Method> OverriddenMethods(Method method)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+
+            return null;
+        }
+
+        public IEnumerable<Method> ImplementedMethods(Method method)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+
+            return null;
+        }
+
+        public IEnumerable<Method> OverriddenAndImplementedMethods(Method method)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+
+            return null;
+        }
+
+        public bool IsImplicitImplementation(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasBody(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Result AccessMethodBody<Data, Result>(Method method, IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Equal(Method m1, Method m2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Equal(Type type1, Type type2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAsVisibleAs(Method m1, Method m2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAsVisibleAs(Type t, Method m)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleFrom(Method m, Type t)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleFrom(Field f, Type t)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleFrom(Type t, Type tfrom)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetImplementingMethod(Type type, Method baseMethod, out Method implementingMethod)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IIndexable<Local> Locals(Method method)
+        {
+            Contract.Ensures(Contract.Result<IIndexable<Local>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetRootMethod(Method method, out Method rootMethod)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type FieldType(Field field)
+        {
+            Contract.Ensures(Contract.Result<Type>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public string FullName(Field field)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public string Name(Field field)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool IsStatic(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPrivate(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsProtected(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPublic(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsInternal(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVolatile(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsNewSlot(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type DeclaringType(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsReadonly(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAsVisibleAs(Field field, Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSpecialized(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Field Unspecialized(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public bool Equal(Field f1, Field f2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsCompilerGenerated(Field f)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string Name(Property property)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool HasGetter(Property property, out Method getter)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasSetter(Property property, out Method setter)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Property> Properties(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsStatic(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsOverride(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsNewSlot(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSealed(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type DeclaringType(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type PropertyType(Property property)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Equal(Property p1, Property p2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string Name(Event @event)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool HasAdder(Event @event, out Method adder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasRemover(Event @event, out Method remover)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Event> Events(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsStatic(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsOverride(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsNewSlot(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSealed(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type DeclaringType(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type HandlerType(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Equal(Event e1, Event e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsEventAdder(Method method, out Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsEventRemover(Method method, out Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVoid(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsUnmanagedPointer(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsManagedPointer(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPrimitive(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsStruct(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsArray(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp Rank(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsInterface(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsStatic(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsClass(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAbstract(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPublic(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsInternal(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsProtected(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPrivate(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSealed(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsNested(Type type, out Type parentType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsReferenceConstrained(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsValueConstrained(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsConstructorConstrained(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsFormalTypeParameter(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsMethodFormalTypeParameter(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsModified(Type type, out Type modified, out IIndexable<Pair<bool, Type>> modifiers)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out modifiers) != null);
+            throw new NotImplementedException();
+        }
+
+        public bool IsGeneric(Type type, out IIndexable<Type> formals, bool normalized)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out formals) != null);
+            throw new NotImplementedException();
+        }
+
+        public bool IsDelegate(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int NormalizedFormalTypeParameterIndex(Type type)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            throw new NotImplementedException();
+        }
+
+        public Type FormalTypeParameterDefiningType(Type type)
+        {
+            Contract.Ensures(Contract.Result<Type>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IIndexable<Type> NormalizedActualTypeArguments(Type type)
+        {
+            Contract.Ensures(Contract.Result<IIndexable<Type>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IIndexable<Type> ActualTypeArguments(Method method)
+        {
+            Contract.Ensures(Contract.Result<IIndexable<Type>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public int MethodFormalTypeParameterIndex(Type type)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            throw new NotImplementedException();
+        }
+
+        public Method MethodFormalTypeDefiningMethod(Type type)
+        {
+            Contract.Ensures(Contract.Result<Method>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool IsEnum(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasFlagsAttribute(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type TypeEnum(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Guid DeclaringModule(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string DeclaringModuleName(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Field> Fields(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Method> Methods(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Type> NestedTypes(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public string Name(Type type)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public string FullName(Type type)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public string Namespace(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type ArrayType(Type type, StackTemp rank)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type ManagedPointer(Type type)
+        {
+            Contract.Ensures(Contract.Result<Type>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public Type UnmanagedPointer(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type ElementType(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp TypeSize(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasBaseClass(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type BaseClass(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Type> Interfaces(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Type> TypeParameterConstraints(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool IsSpecialized(Type type, out IIndexable<Type> typeArguments)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out typeArguments) != null);
+            throw new NotImplementedException();
+        }
+
+        public bool NormalizedIsSpecialized(Type type, out IIndexable<Type> typeArguments)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || (Contract.ValueAtReturn(out typeArguments) != null && Contract.ValueAtReturn(out typeArguments).Count > 0));
+            throw new NotImplementedException();
+        }
+
+        public Type Unspecialized(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsReferenceType(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsNativePointerType(Type declaringType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool DerivesFrom(Type sub, Type super)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool DerivesFromIgnoringTypeArguments(Type sub, Type super)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp ConstructorsCount(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsVisibleOutsideAssembly(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type Specialize(Type type, Type[] typeArguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Type> GetTypes(Assembly assembly)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Type>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Assembly> AssemblyReferences(Assembly assembly)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Assembly>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public string Name(Assembly assembly)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public Version Version(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Guid AssemblyGuid(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type System_Array
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Boolean
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Char
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_DynamicallyTypedReference
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Double
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Decimal
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Int8
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Int16
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Int32
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Int64
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_IntPtr
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Object
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_RuntimeArgumentHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_RuntimeFieldHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_RuntimeMethodHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_RuntimeTypeHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Single
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_String
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Type
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_UInt8
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_UInt16
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_UInt32
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_UInt64
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_UIntPtr
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Type System_Void
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool TryGetSystemType(string fullName, out Type type)
+        {
+            Contract.Ensures(Contract.ValueAtReturn(out type) != null || !Contract.Result<bool>());
+            throw new NotImplementedException();
+        }
+
+        public string Name(Parameter param)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public Type ParameterType(Parameter p)
+        {
+            Contract.Ensures(Contract.Result<Type>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public bool IsOut(Parameter p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int ArgumentIndex(Parameter p)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            throw new NotImplementedException();
+        }
+
+        public StackTemp ArgumentStackIndex(Parameter p)
+        {
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            throw new NotImplementedException();
+        }
+
+        public Method DeclaringMethod(Parameter p)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string Name(Local local)
+        {
+            Contract.Ensures(Contract.Result<string>() != null);
+            throw new NotImplementedException();
+        }
+
+        public Type LocalType(Local local)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Attribute> GetAttributes(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Attribute> GetAttributes(Method method)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Attribute> GetAttributes(Field field)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Attribute> GetAttributes(Property field)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Attribute> GetAttributes(Event @event)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Attribute> GetAttributes(Assembly assembly)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Attribute> GetAttributes(Parameter parameter)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Attribute>>() != null);
+
+            throw new NotImplementedException();
+        }
+
+        public Type AttributeType(Attribute attribute)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Method AttributeConstructor(Attribute attribute)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IIndexable<object> PositionalArguments(Attribute attribute)
+        {
+            Contract.Ensures(Contract.Result<IIndexable<object>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public object NamedArgument(string name, Attribute attribute)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPlatformInitialized { get { return false; } }
+
+        public void SetTargetPlatform(string framework, System.Collections.IDictionary assemblyCache, string platform, IEnumerable<string> resolved, IEnumerable<string> libPaths, Action<System.CodeDom.Compiler.CompilerError> errorHandler, bool trace)
+        {
+            Contract.Requires(assemblyCache != null);
+            Contract.Requires(resolved != null);
+            Contract.Requires(libPaths != null);
+        }
+
+        public string SharedContractClassAssembly
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool TryInitialValue(Field field, out object value)
+        {
+            //Contract.Requires(field != null);
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out value) != null);
+
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+
+        string IDecodeMethods<Method>.DocumentationId(Method method)
+        {
+            return null;
+        }
+
+        string IDecodeMethods<Method>.Name(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMethods<Method>.FullName(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMethods<Method>.DeclaringMemberCanonicalName(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsMain(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsStatic(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsPrivate(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsProtected(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsPublic(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsVirtual(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsNewSlot(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsOverride(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsSealed(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsVoidMethod(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsConstructor(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsFinalizer(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsDispose(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsInternal(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsVisibleOutsideAssembly(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsAbstract(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsExtern(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsPropertySetter(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMethods<Method>.IsPropertyGetter(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        #region IDecodeMethods<Method> Members
+
+
+        public bool IsAsyncMoveNext(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp? MoveNextStartState(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ReturnType(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        IIndexable<Parameter> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Parameters(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        Parameter IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.This(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Property property)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        Property IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetPropertyFromAccessor(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsCompilerGenerated(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsDebuggerNonUserCode(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsDebuggerNonUserCode(Type t)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAutoPropertyMember(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAutoPropertySetter(Method method, out Field backingField)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsCompilerGenerated(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNativeCpp(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        Assembly IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringAssembly(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.MethodToken(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Method method, ref IFunctionalMap<Type, Type> specialization)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Method method, out Method genericMethod, out IIndexable<Type> methodTypeArguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsGeneric(Method method, out IIndexable<Type> formals)
+        {
+            throw new NotImplementedException();
+        }
+
+        Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Unspecialized(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Specialize(Method method, Type[] methodTypeArguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.OverriddenMethods(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ImplementedMethods(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.OverriddenAndImplementedMethods(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsImplicitImplementation(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasBody(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        Result IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AccessMethodBody<Data, Result>(Method method, IMethodCodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Method m1, Method m2)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Type type1, Type type2)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAsVisibleAs(Method m1, Method m2)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAsVisibleAs(Type t, Method m)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleFrom(Method m, Type t)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleFrom(Field f, Type t)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleFrom(Type t, Type tfrom)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryGetImplementingMethod(Type type, Method baseMethod, out Method implementingMethod)
+        {
+            throw new NotImplementedException();
+        }
+
+        IIndexable<Local> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Locals(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryGetRootMethod(Method method, out Method rootMethod)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FieldType(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FullName(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPrivate(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsProtected(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPublic(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsInternal(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVolatile(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNewSlot(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsReadonly(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAsVisibleAs(Field field, Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        Field IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Unspecialized(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryInitialValue(Field field, out object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Field f1, Field f2)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsCompilerGenerated(Field f)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Property property)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasGetter(Property property, out Method getter)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasSetter(Property property, out Method setter)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Property> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Properties(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsOverride(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNewSlot(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSealed(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Property p)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.PropertyType(Property property)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Property p1, Property p2)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasAdder(Event @event, out Method adder)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasRemover(Event @event, out Method remover)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Event> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Events(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsOverride(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNewSlot(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSealed(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringType(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HandlerType(Event e)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Equal(Event e1, Event e2)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsEventAdder(Method method, out Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsEventRemover(Method method, out Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVoid(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsUnmanagedPointer(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsManagedPointer(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPrimitive(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStruct(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsArray(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Rank(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsInterface(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsStatic(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsClass(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsAbstract(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPublic(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsInternal(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsProtected(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPrivate(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSealed(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNested(Type type, out Type parentType)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsReferenceConstrained(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsValueConstrained(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsConstructorConstrained(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsFormalTypeParameter(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsMethodFormalTypeParameter(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsModified(Type type, out Type modified, out IIndexable<Pair<bool, Type>> modifiers)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsGeneric(Type type, out IIndexable<Type> formals, bool normalized)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsDelegate(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NormalizedFormalTypeParameterIndex(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FormalTypeParameterDefiningType(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IIndexable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NormalizedActualTypeArguments(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IIndexable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ActualTypeArguments(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.MethodFormalTypeParameterIndex(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.MethodFormalTypeDefiningMethod(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsEnum(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasFlagsAttribute(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TypeEnum(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Guid IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringModule(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringModuleName(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Field> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Fields(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Method> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Methods(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NestedTypes(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.FullName(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DocumentationId(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Namespace(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ArrayType(Type type, StackTemp rank)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ManagedPointer(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.UnmanagedPointer(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ElementType(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TypeSize(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.HasBaseClass(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.BaseClass(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Interfaces(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TypeParameterConstraints(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsSpecialized(Type type, out IIndexable<Type> typeArguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NormalizedIsSpecialized(Type type, out IIndexable<Type> typeArguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Unspecialized(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsReferenceType(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsNativePointerType(Type declaringType)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DerivesFrom(Type sub, Type super)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DerivesFromIgnoringTypeArguments(Type sub, Type super)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ConstructorsCount(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsVisibleOutsideAssembly(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Specialize(Type type, Type[] typeArguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryLoadAssembly(string fileName, System.Collections.IDictionary assemblyCache, Action<System.CodeDom.Compiler.CompilerError> errorHandler, out Assembly assembly, bool legacyContractMode, List<string> referencedAssemblies, bool extractContractText)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Type> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetTypes(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Assembly> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AssemblyReferences(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        Version IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Version(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        Guid IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AssemblyGuid(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Array
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Boolean
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Char
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_DynamicallyTypedReference
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Double
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Decimal
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int8
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int16
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int32
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Int64
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_IntPtr
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Object
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeArgumentHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeFieldHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeMethodHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_RuntimeTypeHandle
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Single
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_String
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Type
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt8
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt16
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt32
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UInt64
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_UIntPtr
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.System_Void
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.TryGetSystemType(string fullName, out Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Parameter param)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ParameterType(Parameter p)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsOut(Parameter p)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ArgumentIndex(Parameter p)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.ArgumentStackIndex(Parameter p)
+        {
+            throw new NotImplementedException();
+        }
+
+        Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DeclaringMethod(Parameter p)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.Name(Local local)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.LocalType(Local local)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Property field)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Event @event)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Assembly assembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerable<Attribute> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.GetAttributes(Parameter parameter)
+        {
+            throw new NotImplementedException();
+        }
+
+        Type IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AttributeType(Attribute attribute)
+        {
+            throw new NotImplementedException();
+        }
+
+        Method IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.AttributeConstructor(Attribute attribute)
+        {
+            throw new NotImplementedException();
+        }
+
+        IIndexable<object> IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.PositionalArguments(Attribute attribute)
+        {
+            throw new NotImplementedException();
+        }
+
+        object IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.NamedArgument(string name, Attribute attribute)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.IsPlatformInitialized
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        void IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.SetTargetPlatform(string framework, System.Collections.IDictionary assemblyCache, string platform, IEnumerable<string> resolved, IEnumerable<string> libPaths, Action<System.CodeDom.Compiler.CompilerError> errorHandler, bool trace)
+        {
+            throw new NotImplementedException();
+        }
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.SharedContractClassAssembly
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+
+        bool IDecodeMethods<Method>.IsAsyncMoveNext(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        StackTemp? IDecodeMethods<Method>.MoveNextStartState(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        string IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>.DocumentationId(Field field)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public bool IsPinned(Local local)
+        {
+            throw new NotImplementedException();
+        }
     }
-  }
+    #endregion
 
-  /// <summary>
-  /// A slice is an analyzable subset of an assembly. The subset is a set
-  /// of methods whose bodies are to be analyzed.
-  /// </summary>
-
-  [ContractClass(typeof(ISliceContracts<,,,>))]
-  public interface ISlice<Method, Field, Type, Assembly>
-  {
     /// <summary>
-    /// The name of the slice. Used, e.g., as the module name
-    /// and file name for a slice persisted as an assembly on disk.
+    /// Access to contracts, encoded in whatever form
     /// </summary>
-    string Name { get; }
+    [ContractClass(typeof(IDecodeContractsContracts<,,,,>))]
+    public partial interface IDecodeContracts<Local, Parameter, Method, Field, Type>
+    {
+        #region Methods
+
+        /// <summary>
+        /// Should be informed by ContractVerification attribute and defaults
+        /// </summary>
+        bool VerifyMethod(Method method, bool analyzeNonUserCode, bool namespaceSelected, bool typeSelected, bool memberSelected);
+
+        /// <summary>
+        /// Do we have a source option specific for Clousot?
+        /// </summary>
+        bool HasOptionForClousot(Method method, string optionName, out string optionValue);
+
+        /// <summary>
+        /// Returns true if this method has explictit pre-conditions
+        /// </summary>
+        bool HasRequires(Method method);
+
+        /// <summary>
+        /// Provides access to the pre-conditions of a method, provided HasRequires returns true.
+        /// </summary>
+        Result AccessRequires<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
+
+        /// <summary>
+        /// Returns true if this method has explicit post-conditions
+        /// </summary>
+        bool HasEnsures(Method method);
+
+        /// <summary>
+        /// Provides access to the post-conditions of a method, provided HasEnsures returns true.
+        /// </summary>
+        Result AccessEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
+
+        /// <summary>
+        /// Returns true if this method has explicit model post-conditions
+        /// </summary>
+        bool HasModelEnsures(Method method);
+
+        /// <summary>
+        /// Provides access to the model post-conditions of a method, provided HasModelEnsures returns true.
+        /// </summary>
+        Result AccessModelEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
+
+        /// <summary>
+        /// Returns true if the declaring type of this method has an invariant observed by this method
+        /// </summary>
+        bool HasInvariant(Method method);
+
+
+        /// <summary>
+        /// Returns true, if method is pure (no visible side effects), and the result of the method
+        /// depends only on data that does not change, even if the heap changes.
+        /// E.g., Object.GetType, Array.get_Rank, etc.
+        /// TODO TODO TODO: Implementations should probably cache this.
+        /// </summary>
+        bool IsMutableHeapIndependent(Method method);
+
+        /// <summary>
+        /// Returns true, if method is pure (no visible side effects).
+        /// </summary>
+        bool IsPure(Method method);
+
+        /// <summary>
+        /// True if method may inherit contracts from base methods or interface contract declarations.
+        /// Can be controled with ContractOption("Contract", "Inheritance", true/false) attributes.
+        /// </summary>
+        bool CanInheritContracts(Method method);
+
+        /// <summary>
+        /// True if method is marked with ContractModel
+        /// </summary>
+        bool IsModel(Method method);
+
+        /// <summary>
+        /// Retrieves any model fields that might exist for this type.
+        /// </summary>
+        [Pure]
+        IEnumerable<Field> ModelFields(Type type);
+
+        /// <summary>
+        /// Retrieves any model methods that might exist for this type.
+        /// </summary>
+        [Pure]
+        IEnumerable<Method> ModelMethods(Type type);
+
+        #endregion
+
+        #region Types
+        /// <summary>
+        /// Returns true if the type has an invariant 
+        /// </summary>
+        bool HasInvariant(Type type);
+
+        /// <summary>
+        /// Provides access to the object invariant of a type, provided HasInvariant returns true.
+        /// </summary>
+        Result AccessInvariant<Data, Result>(Type type, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data);
+
+        /// <summary>
+        /// True if type may inherit contracts from base types or interfaces.
+        /// Can be controled with ContractOption("Contract", "Inheritance", true/false) attributes.
+        /// </summary>
+        bool CanInheritContracts(Type type);
+
+        /// <summary>
+        /// True if the method returns a fresh object. Used in conjunction with Pure to tell
+        /// static checker that the return value should not be cached.
+        /// </summary>
+        bool IsFreshResult(Method method);
+
+        #endregion
+    }
+
+    #region Contracts for IDecodeContracts
+    [ContractClassFor(typeof(IDecodeContracts<,,,,>))]
+    internal abstract class IDecodeContractsContracts<Local, Parameter, Method, Field, Type>
+      : IDecodeContracts<Local, Parameter, Method, Field, Type>
+    {
+        public bool VerifyMethod(Method method, bool analyzeNonUserCode, bool namespaceSelected, bool typeSelected, bool memberSelected)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasOptionForClousot(Method method, string optionName, out string optionValue)
+        {
+            Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out optionValue) != null);
+
+            throw new NotImplementedException();
+        }
+
+
+        public bool HasRequires(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Result AccessRequires<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasEnsures(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Result AccessEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasModelEnsures(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Result AccessModelEnsures<Data, Result>(Method method, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasInvariant(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPure(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsMutableHeapIndependent(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CanInheritContracts(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsModel(Method method)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Field> ModelFields(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Method> ModelMethods(Type type)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public bool HasInvariant(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Result AccessInvariant<Data, Result>(Type type, ICodeConsumer<Local, Parameter, Method, Field, Type, Data, Result> consumer, Data data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CanInheritContracts(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsFreshResult(Method method)
+        {
+            throw new NotImplementedException();
+        }
+    }
+    #endregion
+
     /// <summary>
-    /// The assembly that the methods and chains are defined in.
+    /// General decoder interface for MSIL
     /// </summary>
-    Assembly ContainingAssembly { get; }
+    /// <typeparam name="Source">Type of IL source operands</typeparam>
+    /// <typeparam name="Dest">Type of IL destinations</typeparam>
+    /// <typeparam name="Context">Context provided by the particular decoder</typeparam>
+    /// <typeparam name="EdgeConversionData">Extra info for control flow edges, like renamings etc.</typeparam>
+    public interface IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, ContextData, EdgeConversionData>
+    {
+        /// <summary>
+        /// Decode the instruction immediately following the label on a forward path.
+        /// </summary>
+        Result ForwardDecode<Data, Result, Visitor>(Label lab, Visitor visitor, Data data)
+         where Visitor : IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result>;
+
+        /// <summary>
+        /// Extra information about Source, Dest, or the controlflow provided by this decoder
+        /// </summary>
+        ContextData Context { get; }
+
+        /// <summary>
+        /// Lookup EdgeData
+        /// </summary>
+        EdgeConversionData EdgeData(Label from, Label to);
+
+        /// <summary>
+        /// Show the edge conversion data
+        /// </summary>
+        void Display(TextWriter tw, string prefix, EdgeConversionData data);
+
+        /// <summary>
+        /// Allows to stop decoding/traversing if a given pc is unreachable.
+        /// Some abstraction layer have non-trivial reachability info, whereas base layers can always return false here.
+        /// </summary>
+        bool IsUnreachable(Label pc);
+    }
+
+
+    public interface IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Data, Result>
+      : IVisitSynthIL<Label, Method, Type, Source, Dest, Data, Result>, IVisitExprIL<Label, Type, Source, Dest, Data, Result>
+    {
+        #region Basic IL
+        Result Arglist(Label pc, Dest dest, Data data);
+        Result BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, Data data);
+        Result BranchTrue(Label pc, Label target, Source cond, Data data);
+        Result BranchFalse(Label pc, Label target, Source cond, Data data);
+        Result Branch(Label pc, Label target, bool leave, Data data);
+        Result Break(Label pc, Data data);
+        /// <summary>
+        /// A Call or Callvirt instruction
+        /// </summary>
+        /// <typeparam name="TypeList">IIndexable of Type"/></typeparam>
+        /// <typeparam name="ArgList">IIndexable of Source</typeparam>
+        Result Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, Data data)
+          where TypeList : IIndexable<Type>
+          where ArgList : IIndexable<Source>; // could be dummy dest
+                                              /// <summary>
+                                              /// A Calli instruction.
+                                              /// 
+                                              /// Note: the argument type list does not contain the type of the first instance parameter if the
+                                              /// method calling convention is Instance.
+                                              /// </summary>
+                                              /// <typeparam name="TypeList">IIndexable of Type"/></typeparam>
+                                              /// <typeparam name="ArgList">IIndexable of Source</typeparam>
+        Result Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool instance, Dest dest, Source fp, ArgList args, Data data)
+          where TypeList : IIndexable<Type>
+          where ArgList : IIndexable<Source>; // could be dummy dest
+        Result Ckfinite(Label pc, Dest dest, Source source, Data data);
+        Result Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, Data data);
+        // For Dup instruction, see Ldstack in IVisitSynthIL
+        Result Endfilter(Label pc, Source decision, Data data);
+        Result Endfinally(Label pc, Data data);
+        Result Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, Data data);
+        Result Jmp(Label pc, Method method, Data data);
+        /// <summary>
+        /// Load argument onto stack.
+        /// </summary>
+        /// <param name="argument">parameter being loaded</param>
+        /// <param name="isOld">true if this load refers to loading the original value of the parameter on entry
+        /// to the method.</param>
+        Result Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, Data data);
+        Result Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, Data data);
+        Result Ldftn(Label pc, Method method, Dest dest, Data data);
+        Result Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, Data data);
+        Result Ldloc(Label pc, Local local, Dest dest, Data data);
+        Result Ldloca(Label pc, Local local, Dest dest, Data data);
+        Result Localloc(Label pc, Dest dest, Source size, Data data);
+        Result Nop(Label pc, Data data);
+        Result Pop(Label pc, Source source, Data data);
+        Result Return(Label pc, Source source, Data data); // could be dummy source
+        Result Starg(Label pc, Parameter argument, Source source, Data data);
+        Result Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, Data data);
+        Result Stloc(Label pc, Local local, Source source, Data data);
+        /// <summary>
+        /// Generalization of switch on ints, can switch on other data constants as well.
+        /// </summary>
+        /// <param name="type">Type of data being switched on, typically int32</param>
+        Result Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Source value, Data data);
+        #endregion
+
+        #region Object level instructions
+        /// <summary>
+        /// A Constrained.Callvirt instruction
+        /// </summary>
+        /// <typeparam name="TypeList">IIndexable of Type"/></typeparam>
+        /// <typeparam name="ArgList">IIndexable of Source</typeparam>
+        Result ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, Data data)
+          where TypeList : IIndexable<Type>
+          where ArgList : IIndexable<Source>; // could be dummy dest
+        Result Castclass(Label pc, Type type, Dest dest, Source obj, Data data);
+        Result Cpobj(Label pc, Type type, Source destptr, Source srcptr, Data data);
+        Result Initobj(Label pc, Type type, Source ptr, Data data);
+        Result Ldelem(Label pc, Type type, Dest dest, Source array, Source index, Data data);
+        Result Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, Data data);
+        Result Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source obj, Data data);
+        Result Ldflda(Label pc, Field field, Dest dest, Source obj, Data data);
+        Result Ldlen(Label pc, Dest dest, Source array, Data data);
+
+        // Handled by Ldind
+        // Result Ldobj(Label pc, Type type, bool @volatile, Dest dest, Source ptr, Data data);
+        Result Ldsfld(Label pc, Field field, bool @volatile, Dest dest, Data data);
+        Result Ldsflda(Label pc, Field field, Dest dest, Data data);
+        Result Ldtypetoken(Label pc, Type type, Dest dest, Data data);
+        Result Ldfieldtoken(Label pc, Field field, Dest dest, Data data);
+        Result Ldmethodtoken(Label pc, Method method, Dest dest, Data data);
+        Result Ldvirtftn(Label pc, Method method, Dest dest, Source obj, Data data);
+        Result Mkrefany(Label pc, Type type, Dest dest, Source obj, Data data);
+        Result Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList len, Data data)
+          where ArgList : IIndexable<Source>;
+        /// <summary>
+        /// A newobj instruction
+        /// </summary>
+        /// <typeparam name="ArgList">IIndexable of Source</typeparam>
+        Result Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, Data data)
+          where ArgList : IIndexable<Source>;
+        Result Refanytype(Label pc, Dest dest, Source source, Data data);
+        Result Refanyval(Label pc, Type type, Dest dest, Source source, Data data);
+        Result Rethrow(Label pc, Data data);
+        Result Stelem(Label pc, Type type, Source array, Source index, Source value, Data data);
+        Result Stfld(Label pc, Field field, bool @volatile, Source obj, Source value, Data data);
+
+        // Handled by stind
+        // Result Stobj(Label pc, Type type, bool @volatile, Source ptr, Source value, Data data);
+        Result Stsfld(Label pc, Field field, bool @volatile, Source value, Data data);
+        Result Throw(Label pc, Source exn, Data data);
+        Result Unbox(Label pc, Type type, Dest dest, Source obj, Data data);
+        Result Unboxany(Label pc, Type type, Dest dest, Source obj, Data data);
+        #endregion
+    }
+
+
     /// <summary>
-    /// A set of method definitions, all of which are defined in the containing
-    /// assembly. All of the methods must also appear within one of the Chains.
+    /// Some synthetic IL instructions
     /// </summary>
-    IEnumerable<Method> Methods { get; }
+    public interface IVisitSynthIL<Label, Method, Type, Source, Dest, Data, Result>
+    {
+        /// <summary>
+        /// Instruction is visited on entry to a method as the first instruction.
+        /// </summary>
+        Result Entry(Label pc, Method method, Data data);
+
+        /// <summary>
+        /// Appears at targets of conditional control transfers (branches and switch)
+        /// to express the branch condition in a uniform accessible way.
+        ///
+        /// Can also appear due to preconditions in a method and due to post conditions after a method call
+        /// or invariants on field reads.
+        /// </summary>
+        /// <param name="tag">Is the tag selected by the code provider for a control transfer, or "false"
+        /// for the fallthrough of a conditional branch or the default target of a switch.</param>
+        /// <param name="source">The conditional value deciding the branch</param>
+        /// <param name="provenance">An opaque object (possibly null) explaining where this assert comes from.</param>
+        Result Assume(Label pc, string tag, Source condition, object provenance, Data data);
+
+        /// <summary>
+        /// Can appear due to explicit asserts in the code or due to post conditions in a method, or due
+        /// to preconditions at method calls, or due to invariants at field updates.
+        /// </summary>
+        /// <param name="tag">Is a tag indicating what kind of assert it is, e.g., requires, ensures, inline, etc.</param>
+        /// <param name="provenance">An opaque object (possibly null) explaining where this assert comes from.</param>
+        Result Assert(Label pc, string tag, Source condition, object provenance, Data data);
+
+        /// <summary>
+        /// This is a generalized Dup instruction, where dup is equal to ldstack 0. ldstack i duplicates the i-th element on
+        /// the evaluation stack and pushes it onto the evaluation stack.
+        /// </summary>
+        /// <param name="offset">0 based offset from the top of the evaluation stack.</param>
+        /// <param name="isOld">if true, the stack access should happen in the pre-state of the method (or surrounding call)</param>
+        Result Ldstack(Label pc, int offset, Dest dest, Source source, bool isOld, Data data);
+
+        /// <summary>
+        /// Similar to ldstack.i but pretends that stack locations also have an address and gets that address.
+        /// This is mainly used to deal with access to struct parameters in pre/post conditions and for uni-
+        /// formity.
+        /// </summary>
+        Result Ldstacka(Label pc, int offset, Dest dest, Source source, Type origParamType, bool isOld, Data data);
+
+        /// <summary>
+        /// This instruction provides access to the result of a method in the context of a post condition.
+        /// Typically, this accesses the top of the evaluation stack, however, there may be other temporaries
+        /// above the result. CodeProviders generate this instruction for accessing the result and the
+        /// analysis infrastructure can compute the proper offsets, turning it essentially into a ldstack/copy.
+        /// </summary>
+        Result Ldresult(Label pc, Type type, Dest dest, Source source, Data data);
+
+        /// <summary>
+        /// Marks the beginning of an old expression, ie., a code sequence evaluating in the state of the machine
+        /// as it was at the beginning of the current method call
+        /// This operation should push the current machine state onto a temporary machine stack (to be popped by EndOld),
+        /// and switch state to the state at the beginning of the current method call.
+        /// </summary>
+        Result BeginOld(Label pc, Label matchingEnd, Data data);
+
+        /// <summary>
+        /// Marks the end of an old expression evaluation, where the result of the expression is read in the current state
+        /// from Source. The instruction should then switch to the machine state that is on top of the machine state stack
+        /// (pushed by BeginOld), and store the result read from the old store into this store at the destination.
+        /// </summary>
+        /// <param name="matchingBegin">Label of the matching BeginOld</param>
+        /// <param name="dest">Destination to store result of old expression in the restored current state</param>
+        /// <param name="source">Result of old expression as read from the old state</param>
+        Result EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, Data data);
+    }
+
     /// <summary>
-    /// A set of specifications of members whose metadata is needed in order to
-    /// have the slice be a valid .NET assembly. Chains are structured so that
-    /// all members belonging to the same type are contained within the chain
-    /// of that type.
+    /// Factored these operations out as they are the ones used by an expression visitor.
+    /// If need be, we can move more ops from IVisitMSIL to here without breaking code depending on IVisitMSIL.
     /// </summary>
-    IEnumerable<IChain<Method, Field, Type>> Chains { get; }
-  }
-
-  #region Contracts
-
-  [ContractClassFor(typeof(ISlice<,,,>))]
-  abstract class ISliceContracts<Method, Field, Type, Assembly> : ISlice<Method, Field, Type, Assembly>
-  {
-
-    public string Name
+    public interface IVisitExprIL<Label, Type, Source, Dest, Data, Result>
     {
-      get { throw new NotImplementedException(); }
+        Result Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, Data data);
+        Result Box(Label pc, Type type, Dest dest, Source source, Data data);
+        Result Isinst(Label pc, Type type, Dest dest, Source obj, Data data);
+        Result Ldconst(Label pc, Object constant, Type type, Dest dest, Data data);
+        Result Ldnull(Label pc, Dest dest, Data data);
+        Result Sizeof(Label pc, Type type, Dest dest, Data data);
+        Result Unary(Label pc, UnaryOperator op, bool overflow, bool unsigned, Dest dest, Source source, Data data);
     }
 
-    public Assembly ContainingAssembly
+    [ContractClass(typeof(IMethodContextContracts<,>))]
+    public interface IMethodContext<Field, Method>
     {
-      get {
-        Contract.Ensures(Contract.Result<Assembly>() != null);
-        throw new NotImplementedException(); }
+        IMethodContextData<Field, Method> MethodContext { get; }
     }
 
-    public IEnumerable<Method> Methods
+    #region Contracts for IMethodContext
+    [ContractClassFor(typeof(IMethodContext<,>))]
+    internal abstract class IMethodContextContracts<Field, Method> : IMethodContext<Field, Method>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+        public IMethodContextData<Field, Method> MethodContext
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IMethodContextData<Field, Method>>() != null);
 
-        throw new NotImplementedException();
-      }
+                return null;
+            }
+        }
+    }
+    #endregion
+
+    public partial interface IMethodContextData<Field, Method>
+    {
+        Method CurrentMethod { get; }
+
+        ICFG CFG { get; }
+
+        /// <summary>
+        /// Returns closest source context for this label
+        /// </summary>
+        string SourceContext(APC label);
+
+        /// <summary>
+        /// Returns the name of the associated document of the source context for this pc
+        /// </summary>
+        string SourceDocument(APC pc);
+
+        /// <summary>
+        /// Returns the first line number in the source context of this pc.
+        /// </summary>
+        int SourceStartLine(APC pc);
+
+        /// <summary>
+        /// Returns the last line number in the source context of this pc.
+        /// </summary>
+        int SourceEndLine(APC pc);
+
+        /// <summary>
+        /// Returns the first column number in the source context of this pc.
+        /// </summary>
+        int SourceStartColumn(APC pc);
+
+        /// <summary>
+        /// Returns the first column number in the source context of this pc.
+        /// </summary>
+        int SourceEndColumn(APC pc);
+        /// <summary>
+        /// Returns the IL offset within the method of the given instruction or 0
+        /// </summary>
+
+        IEnumerable<Field> Modifies(Method method);
+
+        IEnumerable<Method> AffectedGetters(Field field);
     }
 
-    public IEnumerable<IChain<Method, Field, Type>> Chains
+    #region IMethodContextData<Field, Method> contract binding
+    [ContractClass(typeof(IMethodContextDataContract<,>))]
+    public partial interface IMethodContextData<Field, Method>
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<IEnumerable<IChain<Method, Field, Type>>>() != null);
-
-        throw new NotImplementedException();
-      }
     }
-  }
-  #endregion
 
-  #region MB: suggested change for IChain
+    [ContractClassFor(typeof(IMethodContextData<,>))]
+    internal abstract class IMethodContextDataContract<Field, Method> : IMethodContextData<Field, Method>
+    {
+        #region IMethodContextData<Field,Method> Members
+
+        public Method CurrentMethod
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ICFG CFG
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ICFG>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public string SourceContext(APC label)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string SourceDocument(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp SourceStartLine(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp SourceEndLine(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp SourceStartColumn(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StackTemp SourceEndColumn(APC pc)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Field> Modifies(Method method)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Field>>() != null);
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Method> AffectedGetters(Field field)
+        {
+            Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+    #endregion
+
+    static public class IDecodeMetadataExtensionsForPurityInfo
+    {
+        [ThreadStatic]
+        private static Dictionary<string, long> additionalPurityInfo;
+
+        // Need lazy-initialization because of ThreadStatic
+        private static Dictionary<string, long> AdditionalPurityInfo
+        {
+            get
+            {
+                if (additionalPurityInfo == null)
+                    additionalPurityInfo = new Dictionary<string, long>();
+                return additionalPurityInfo;
+            }
+        }
+
+        [Pure]
+        static public bool TryInferredPureParametersMask(string methodName, out long mask)
+        {
+            return AdditionalPurityInfo.TryGetValue(methodName, out mask);
+        }
+
+        [Pure]
+        static public void SetPureParametersMask(string methodName, long mask)
+        {
+            AdditionalPurityInfo[methodName] = mask;
+        }
+
+        [Pure]
+        static public void AddPure<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder,
+          Method m, int parameterPosition)
+        {
+            Contract.Requires(parameterPosition <= 64);
+
+            if (metaDataDecoder == null)
+            {
+                return;
+            }
+
+            var name = metaDataDecoder.FullName(m);
+
+            /*
+            if (name == null)
+            {
+              return;
+            }
+            */
+
+            long prevMask, mask = 1L << parameterPosition;
+            if (AdditionalPurityInfo.TryGetValue(name, out prevMask))
+            {
+                mask |= prevMask;
+            }
+
+            AdditionalPurityInfo[name] = mask;
+        }
+
+        /// <param name="parameterPosition">The position of the parameter counting this</param>
+        /// <returns>
+        /// true if the parameter in that position is marked with Pure
+        /// </returns>
+        [Pure]
+        static public bool IsPure<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder,
+          Method method, int parameterPosition)
+          where Type : IEquatable<Type>
+        {
+            Contract.Requires(metaDataDecoder != null);
+            Contract.Requires(parameterPosition >= 0);
+
+            long purityMask;
+            if (AdditionalPurityInfo.TryGetValue(metaDataDecoder.FullName(method), out purityMask) && (purityMask & (1L << parameterPosition)) != 0)
+            {
+                return true;
+            }
+
+            Parameter p;
+            if (metaDataDecoder.IsStatic(method))
+            {
+                var args = metaDataDecoder.Parameters(method);
+                Contract.Assume(args != null);
+                // F: I've added this check because in some code from Midori the invariant was violated
+                if (parameterPosition < args.Count)
+                {
+                    p = args[parameterPosition];
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (parameterPosition == 0)
+                {
+                    return false;
+                }
+                p = metaDataDecoder.Parameters(method).AssumeNotNull()[parameterPosition - 1];
+            }
+
+            foreach (var attrib in metaDataDecoder.GetAttributes(p).AssumeNotNull())
+            {
+                var attibType = metaDataDecoder.AttributeType(attrib);
+                if (metaDataDecoder.Name(attibType) == "PureAttribute")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [Pure]
+        static public bool IsPure<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+         this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> metaDataDecoder,
+          Method method, Parameter p)
+        where Type : IEquatable<Type>
+        {
+            Contract.Requires(metaDataDecoder != null);
+
+            foreach (var attrib in metaDataDecoder.GetAttributes(p).AssumeNotNull())
+            {
+                var attibType = metaDataDecoder.AttributeType(attrib);
+                if (metaDataDecoder.Name(attibType) == "PureAttribute")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// A slice is an analyzable subset of an assembly. The subset is a set
+    /// of methods whose bodies are to be analyzed.
+    /// </summary>
+
+    [ContractClass(typeof(ISliceContracts<,,,>))]
+    public interface ISlice<Method, Field, Type, Assembly>
+    {
+        /// <summary>
+        /// The name of the slice. Used, e.g., as the module name
+        /// and file name for a slice persisted as an assembly on disk.
+        /// </summary>
+        string Name { get; }
+        /// <summary>
+        /// The assembly that the methods and chains are defined in.
+        /// </summary>
+        Assembly ContainingAssembly { get; }
+        /// <summary>
+        /// A set of method definitions, all of which are defined in the containing
+        /// assembly. All of the methods must also appear within one of the Chains.
+        /// </summary>
+        IEnumerable<Method> Methods { get; }
+        /// <summary>
+        /// A set of specifications of members whose metadata is needed in order to
+        /// have the slice be a valid .NET assembly. Chains are structured so that
+        /// all members belonging to the same type are contained within the chain
+        /// of that type.
+        /// </summary>
+        IEnumerable<IChain<Method, Field, Type>> Chains { get; }
+    }
+
+    #region Contracts
+
+    [ContractClassFor(typeof(ISlice<,,,>))]
+    internal abstract class ISliceContracts<Method, Field, Type, Assembly> : ISlice<Method, Field, Type, Assembly>
+    {
+        public string Name
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public Assembly ContainingAssembly
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<Assembly>() != null);
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<Method> Methods
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<Method>>() != null);
+
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<IChain<Method, Field, Type>> Chains
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<IEnumerable<IChain<Method, Field, Type>>>() != null);
+
+                throw new NotImplementedException();
+            }
+        }
+    }
+    #endregion
+
+    #region MB: suggested change for IChain
 #if false
-  public interface IType<M, F, T>
-  {
-    T Type { get; }
-    IEnumerable<F> Fields { get; }
-    IEnumerable<M> Methods { get; }
-    IEnumerable<IType<M, F, T>> NestedTypes { get; }
-  }
+    public interface IType<M, F, T>
+    {
+        T Type { get; }
+        IEnumerable<F> Fields { get; }
+        IEnumerable<M> Methods { get; }
+        IEnumerable<IType<M, F, T>> NestedTypes { get; }
+    }
 #endif
-  #endregion
+    #endregion
 
-  public enum ChainTag
-  {
-    Field,
-    Method,
-    Type,
-  }
-
-  /// <summary>
-  /// A chain is a tree specifying a set of members whose metadata is needed
-  /// in a slice. It is a tree because each member (type, method, field) must
-  /// be contained within the chain of its declaring type.
-  /// For instance, a method T.Nested.M, must be represented as
-  /// Chain("type", T, [Chain("type", Nested, [Chain("method", M)])])
-  /// where the quoted strings are values of type <see cref="ChainTag"/>.
-  /// The sequences are so that multiple subtrees can be specified.
-  /// </summary>
-  /// <typeparam name="M">The type representing a method.</typeparam>
-  /// <typeparam name="F">The type representing a field.</typeparam>
-  /// <typeparam name="T">The type representing a type.</typeparam>
-  [ContractClass(typeof(IChainContract<,,>))]
-  public interface IChain<M, F, T>
-  {
-    ChainTag Tag { get; }
-    F Field { get; }
-    M Method { get; }
-    MethodHashAttribute MethodHashAttribute { get; }
-    T Type { get; }
-    IEnumerable<IChain<M, F, T>>/*?*/ Children { get; }
-  }
-  #region IChain contract binding
-  [ContractClassFor(typeof(IChain<,,>))]
-  abstract class IChainContract<M2, F2, T2> : IChain<M2, F2, T2>
-  {
-    public ChainTag Tag
+    public enum ChainTag
     {
-      get { throw new NotImplementedException(); }
+        Field,
+        Method,
+        Type,
     }
 
-    public F2 Field
+    /// <summary>
+    /// A chain is a tree specifying a set of members whose metadata is needed
+    /// in a slice. It is a tree because each member (type, method, field) must
+    /// be contained within the chain of its declaring type.
+    /// For instance, a method T.Nested.M, must be represented as
+    /// Chain("type", T, [Chain("type", Nested, [Chain("method", M)])])
+    /// where the quoted strings are values of type <see cref="ChainTag"/>.
+    /// The sequences are so that multiple subtrees can be specified.
+    /// </summary>
+    /// <typeparam name="M">The type representing a method.</typeparam>
+    /// <typeparam name="F">The type representing a field.</typeparam>
+    /// <typeparam name="T">The type representing a type.</typeparam>
+    [ContractClass(typeof(IChainContract<,,>))]
+    public interface IChain<M, F, T>
     {
-      get
-      {
-        Contract.Requires(Tag == ChainTag.Field);
-        throw new NotImplementedException();
-      }
+        ChainTag Tag { get; }
+        F Field { get; }
+        M Method { get; }
+        MethodHashAttribute MethodHashAttribute { get; }
+        T Type { get; }
+        IEnumerable<IChain<M, F, T>>/*?*/ Children { get; }
     }
-
-    public M2 Method
+    #region IChain contract binding
+    [ContractClassFor(typeof(IChain<,,>))]
+    internal abstract class IChainContract<M2, F2, T2> : IChain<M2, F2, T2>
     {
-      get
-      {
-        Contract.Requires(Tag == ChainTag.Method);
-        throw new NotImplementedException();
-      }
-    }
+        public ChainTag Tag
+        {
+            get { throw new NotImplementedException(); }
+        }
 
-    public MethodHashAttribute MethodHashAttribute
+        public F2 Field
+        {
+            get
+            {
+                Contract.Requires(Tag == ChainTag.Field);
+                throw new NotImplementedException();
+            }
+        }
+
+        public M2 Method
+        {
+            get
+            {
+                Contract.Requires(Tag == ChainTag.Method);
+                throw new NotImplementedException();
+            }
+        }
+
+        public MethodHashAttribute MethodHashAttribute
+        {
+            get
+            {
+                Contract.Requires(Tag == ChainTag.Method);
+                throw new NotImplementedException();
+            }
+        }
+
+        public T2 Type
+        {
+            get
+            {
+                Contract.Requires(Tag == ChainTag.Type);
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<IChain<M2, F2, T2>> Children
+        {
+            get
+            {
+                Contract.Requires(Tag == ChainTag.Type);
+                throw new NotImplementedException();
+            }
+        }
+    }
+    #endregion
+
+    public interface ICodeWriter<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
     {
-      get
-      {
-        Contract.Requires(Tag == ChainTag.Method);
-        throw new NotImplementedException();
-      }
+        bool WriteSliceToFile(ISlice<Method, Field, Type, Assembly> slice, string directory, out string dll);
     }
-
-    public T2 Type
-    {
-      get
-      {
-        Contract.Requires(Tag == ChainTag.Type);
-        throw new NotImplementedException();
-      }
-    }
-
-    public IEnumerable<IChain<M2, F2, T2>> Children
-    {
-      get
-      {
-        Contract.Requires(Tag == ChainTag.Type);
-        throw new NotImplementedException();
-      }
-    }
-  }
-  #endregion
-
-  public interface ICodeWriter<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>
-  {
-    bool WriteSliceToFile(ISlice<Method, Field, Type, Assembly> slice, string directory, out string dll);
-  }
-
 }

--- a/Microsoft.Research/ControlFlow/PrinterFactory.cs
+++ b/Microsoft.Research/ControlFlow/PrinterFactory.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.IO;
@@ -23,566 +12,562 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-
-  public static class PrinterFactory
-  {
-
-    public static ILPrinter<Label> Create<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(
-      IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      Converter<Source, string> sourceName,
-      Converter<Dest, string> destName
-    )
+    public static class PrinterFactory
     {
-      Contract.Requires(ilDecoder != null);// F: Added as of Clousot suggestion
+        public static ILPrinter<Label> Create<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(
+          IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
+          IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          Converter<Source, string> sourceName,
+          Converter<Dest, string> destName
+        )
+        {
+            Contract.Requires(ilDecoder != null);// F: Added as of Clousot suggestion
 
-      ILPrinter<Label> printer = new Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(ilDecoder, mdDecoder, sourceName, destName).PrintCodeAt;
-      return printer;
+            ILPrinter<Label> printer = new Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>(ilDecoder, mdDecoder, sourceName, destName).PrintCodeAt;
+            return printer;
+        }
+
+        private class Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData> :
+          IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, TextWriter, Unit>
+        {
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(ilDecoder != null); // F: Added as of Clousot suggestions of preconditions
+            }
+
+            private string prefix = "";
+            private IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder;
+            private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+            private Converter<Source, string> sourceName;
+            private Converter<Dest, string> destName;
+
+            public Printer(
+              IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
+              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+              Converter<Source, string> sourceName,
+              Converter<Dest, string> destName
+            )
+            {
+                Contract.Requires(ilDecoder != null);// F: As of Clousot suggestion
+
+                this.ilDecoder = ilDecoder;
+                this.mdDecoder = mdDecoder;
+                this.sourceName = sourceName;
+                this.destName = destName;
+            }
+
+            public void PrintCodeAt(Label label, string prefix, TextWriter writer)
+            {
+                this.prefix = prefix;
+                ilDecoder.ForwardDecode<TextWriter, Unit, Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>>(label, this, writer);
+            }
+
+            #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,Source,Dest,TextWriter,Unit> Members
+
+            [Pure]
+            private string/*?*/ SourceName(Source src)
+            {
+                if (sourceName != null) { return sourceName(src); }
+                return null;
+            }
+
+            [Pure]
+            private string/*?*/ DestName(Dest dest)
+            {
+                if (destName != null) { return destName(dest); }
+                return null;
+            }
+
+            public Unit Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = {2} {3} {4}", prefix, DestName(dest), SourceName(s1), op.ToString(), SourceName(s2));
+                return Unit.Value;
+            }
+
+            public Unit Assert(Label pc, string tag, Source s, object provenance, TextWriter tw)
+            {
+                tw.WriteLine("{0}assert({1}) {2}", prefix, tag, SourceName(s));
+                return Unit.Value;
+            }
+
+            public Unit Assume(Label pc, string tag, Source s, object provenance, TextWriter tw)
+            {
+                tw.WriteLine("{0}assume({1}) {2}", prefix, tag, SourceName(s));
+                return Unit.Value;
+            }
+
+            public Unit Arglist(Label pc, Dest d, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = arglist", prefix, DestName(d));
+                return Unit.Value;
+            }
+
+            public Unit BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, TextWriter data)
+            {
+                data.WriteLine("{0}br.{1} {2},{3}", prefix, bop, SourceName(value1), SourceName(value2));
+                return Unit.Value;
+            }
+
+            public Unit BranchTrue(Label pc, Label target, Source cond, TextWriter data)
+            {
+                data.WriteLine("{0}br.true {1}", prefix, SourceName(cond));
+                return Unit.Value;
+            }
+
+            public Unit BranchFalse(Label pc, Label target, Source cond, TextWriter data)
+            {
+                data.WriteLine("{0}br.false {1}", prefix, SourceName(cond));
+                return Unit.Value;
+            }
+
+            public Unit Branch(Label pc, Label target, bool leave, TextWriter data)
+            {
+                data.WriteLine("{0}branch", prefix);
+                return Unit.Value;
+            }
+
+            public Unit Break(Label pc, TextWriter data)
+            {
+                data.WriteLine("{0}break", prefix);
+                return Unit.Value;
+            }
+
+            public Unit Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, TextWriter data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                data.Write("{0}{4} = {1}call{3} {2}(", prefix, tail ? "tail." : null, mdDecoder.FullName(method), virt ? "virt" : null, DestName(dest));
+                if (args != null)
+                {
+                    for (int i = 0; i < args.Count; i++)
+                    {
+                        var tmp = string.Format("{0} ", SourceName(args[i]));
+                        data.Write(tmp);
+                    }
+                }
+                data.WriteLine(")");
+                return Unit.Value;
+            }
+
+            public Unit Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, TextWriter data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                data.Write("{0}{2} = {1}calli {3}(", prefix, tail ? "tail." : null, DestName(dest), SourceName(fp));
+                if (args != null)
+                {
+                    for (int i = 0; i < args.Count; i++)
+                    {
+                        data.Write("{0} ", SourceName(args[i]));
+                    }
+                }
+                data.WriteLine(")");
+                return Unit.Value;
+            }
+
+            public Unit Ckfinite(Label pc, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = ckinite {2}", prefix, DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Unary(Label pc, UnaryOperator op, bool ovf, bool unsigned, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{4} = {3}{1}{2} {5}", prefix, ovf ? "_ovf" : null, unsigned ? "_un" : null, op.ToString(), DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, TextWriter data)
+            {
+                data.WriteLine("{0}{1}cpblk {2} {3} {4}", prefix, @volatile ? "volatile." : null, SourceName(destaddr), SourceName(srcaddr), SourceName(len));
+                return Unit.Value;
+            }
+
+            public Unit Endfilter(Label pc, Source condition, TextWriter data)
+            {
+                data.WriteLine("{0}endfilter {1}", prefix, SourceName(condition));
+                return Unit.Value;
+            }
+
+            public Unit Endfinally(Label pc, TextWriter data)
+            {
+                data.WriteLine("{0}endfinally", prefix);
+                return Unit.Value;
+            }
+
+            public Unit Entry(Label pc, Method method, TextWriter data)
+            {
+                data.WriteLine("{0}method_entry {1}", prefix, mdDecoder.FullName(method));
+                return Unit.Value;
+            }
+
+            public Unit Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, TextWriter data)
+            {
+                data.WriteLine("{0}{1}initblk {2} {3} {4}", prefix, @volatile ? "volatile." : null, SourceName(destaddr), SourceName(value), SourceName(len));
+                return Unit.Value;
+            }
+
+            public Unit Jmp(Label pc, Method method, TextWriter data)
+            {
+                data.WriteLine("{0}jmp {1}", prefix, mdDecoder.FullName(method));
+                return Unit.Value;
+            }
+
+            public Unit Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, TextWriter data)
+            {
+                string isOldPrefix = isOld ? "old." : null;
+                data.WriteLine("{0}{2} = {3}ldarg {1}", prefix, mdDecoder.Name(argument), DestName(dest), isOldPrefix);
+                return Unit.Value;
+            }
+
+            public Unit Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, TextWriter data)
+            {
+                string isOldPrefix = isOld ? "old." : null;
+                data.WriteLine("{0}{2} = {3}ldarga {1}", prefix, mdDecoder.Name(argument), DestName(dest), isOldPrefix);
+                return Unit.Value;
+            }
+
+            public Unit Ldconst(Label pc, object constant, Type type, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldc ({3})'{1}'", prefix, constant.ToString(), DestName(dest), mdDecoder.FullName(type));
+                return Unit.Value;
+            }
+
+            public Unit Ldnull(Label pc, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = ldnull", prefix, DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldftn(Label pc, Method method, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldftn {1}", prefix, mdDecoder.FullName(method), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, TextWriter data)
+            {
+                data.WriteLine("{0}{3} = {1}ldind {2} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(type), DestName(dest), SourceName(ptr));
+                return Unit.Value;
+            }
+
+            public Unit Ldloc(Label pc, Local local, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldloc {1}", prefix, mdDecoder.Name(local), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldloca(Label pc, Local local, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldloca {1}", prefix, mdDecoder.Name(local), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldresult(Label pc, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = ldresult {2}", prefix, DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Ldstack(Label pc, int offset, Dest dest, Source s, bool isOld, TextWriter data)
+            {
+                if (isOld)
+                {
+                    data.WriteLine("{0}{1} = old.ldstack.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
+                }
+                else
+                {
+                    data.WriteLine("{0}{1} = ldstack.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
+                }
+                return Unit.Value;
+            }
+
+            public Unit Ldstacka(Label pc, int offset, Dest dest, Source s, Type type, bool old, TextWriter data)
+            {
+                if (old)
+                {
+                    data.WriteLine("{0}{1} = old.ldstacka.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
+                }
+                else
+                {
+                    data.WriteLine("{0}{1} = ldstacka.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
+                }
+                return Unit.Value;
+            }
+
+            public Unit Localloc(Label pc, Dest dest, Source size, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = localloc {2}", prefix, DestName(dest), SourceName(size));
+                return Unit.Value;
+            }
+
+
+            public Unit Nop(Label pc, TextWriter data)
+            {
+                data.WriteLine("{0}nop", prefix);
+                return Unit.Value;
+            }
+
+            public Unit Pop(Label pc, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}pop {1}", prefix, SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Return(Label pc, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}ret {1}", prefix, SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Starg(Label pc, Parameter argument, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}starg {1} {2}", prefix, mdDecoder.Name(argument), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}{1}stind {2} {3} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(type), SourceName(ptr), SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Stloc(Label pc, Local local, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}stloc {1} {2}", prefix, mdDecoder.Name(local), SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}switch {1}", prefix, SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Box(Label pc, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = box {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, TextWriter data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Source>
+            {
+                data.Write("{0}{4} = {1}constrained({2}).callvirt {3}(", prefix, tail ? "tail." : null, mdDecoder.FullName(constraint), mdDecoder.FullName(method), DestName(dest));
+                if (args != null)
+                {
+                    for (int i = 0; i < args.Count; i++)
+                    {
+                        data.Write("{0} ", SourceName(args[i]));
+                    }
+                }
+                data.WriteLine(")");
+                return Unit.Value;
+            }
+
+            public Unit Castclass(Label pc, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = castclass {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Cpobj(Label pc, Type type, Source destptr, Source srcptr, TextWriter data)
+            {
+                data.WriteLine("{0}cpobj {1} {2} {3}", prefix, mdDecoder.FullName(type), SourceName(destptr), SourceName(srcptr));
+                return Unit.Value;
+            }
+
+            public Unit Initobj(Label pc, Type type, Source ptr, TextWriter data)
+            {
+                data.WriteLine("{0}initobj {1} {2}", prefix, mdDecoder.FullName(type), SourceName(ptr));
+                return Unit.Value;
+            }
+
+            public Unit Isinst(Label pc, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = isinst {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Ldelem(Label pc, Type type, Dest dest, Source array, Source index, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldelem {1} {3}[{4}]", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(array), SourceName(index));
+                return Unit.Value;
+            }
+
+            public Unit Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, TextWriter data)
+            {
+                data.WriteLine("{0}{3} = {1}ldelema {2} {4}[{5}]", prefix, @readonly ? "readonly." : null, mdDecoder.FullName(type), DestName(dest), SourceName(array), SourceName(index));
+                return Unit.Value;
+            }
+
+            public Unit Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source ptr, TextWriter data)
+            {
+                data.WriteLine("{0}{3} = {1}ldfld {2} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), DestName(dest), SourceName(ptr));
+                return Unit.Value;
+            }
+
+            public Unit Ldflda(Label pc, Field field, Dest dest, Source ptr, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldflda {1} {3}", prefix, mdDecoder.FullName(field), DestName(dest), SourceName(ptr));
+                return Unit.Value;
+            }
+
+            public Unit Ldlen(Label pc, Dest dest, Source array, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = ldlen {2}", prefix, DestName(dest), SourceName(array));
+                return Unit.Value;
+            }
+
+            public Unit Ldsfld(Label pc, Field field, bool @volatile, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{3} = {1}ldsfld {2}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldsflda(Label pc, Field field, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldsflda {1}", prefix, mdDecoder.FullName(field), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldtypetoken(Label pc, Type type, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldtoken {1}", prefix, mdDecoder.FullName(type), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldfieldtoken(Label pc, Field field, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldtoken {1}", prefix, mdDecoder.FullName(field), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldmethodtoken(Label pc, Method method, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldtoken {1}", prefix, mdDecoder.FullName(method), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Ldvirtftn(Label pc, Method method, Dest dest, Source obj, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = ldvirtftn {1} {3}", prefix, mdDecoder.FullName(method), DestName(dest), SourceName(obj));
+                return Unit.Value;
+            }
+
+            public Unit Mkrefany(Label pc, Type type, Dest dest, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = mkrefany {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList lengths, TextWriter data)
+              where ArgList : IIndexable<Source>
+            {
+                data.Write("{0}{2} = newarray {1}[", prefix, mdDecoder.FullName(type), DestName(dest));
+                for (int i = 0; i < lengths.Count; i++)
+                {
+                    data.Write("{0} ", SourceName(lengths[i]));
+                }
+                data.WriteLine("]");
+                return Unit.Value;
+            }
+
+            public Unit Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, TextWriter data)
+              where ArgList : IIndexable<Source>
+            {
+                data.Write("{0}{2} = newobj {1}(", prefix, mdDecoder.FullName(ctor), DestName(dest));
+                if (args != null)
+                {
+                    for (int i = 0; i < args.Count; i++)
+                    {
+                        data.Write("{0} ", SourceName(args[i]));
+                    }
+                }
+                data.WriteLine(")");
+                return Unit.Value;
+            }
+
+            public Unit Refanytype(Label pc, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = refanytype {2}", prefix, DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Refanyval(Label pc, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = refanyval {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Rethrow(Label pc, TextWriter data)
+            {
+                data.WriteLine("{0}rethrow", prefix);
+                return Unit.Value;
+            }
+
+            public Unit Sizeof(Label pc, Type type, Dest dest, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = sizeof {1}", prefix, mdDecoder.FullName(type), DestName(dest));
+                return Unit.Value;
+            }
+
+            public Unit Stelem(Label pc, Type type, Source array, Source index, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}stelem {1} {2}[{3}] = {4}", prefix, mdDecoder.FullName(type), SourceName(array), SourceName(index), SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Stfld(Label pc, Field field, bool @volatile, Source ptr, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}{1}stfld {2} {3} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), SourceName(ptr), SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Stsfld(Label pc, Field field, bool @volatile, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}{1}stsfld {2} {3}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Throw(Label pc, Source value, TextWriter data)
+            {
+                data.WriteLine("{0}throw {1}", prefix, SourceName(value));
+                return Unit.Value;
+            }
+
+            public Unit Unbox(Label pc, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = unbox {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            public Unit Unboxany(Label pc, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{2} = unbox_any {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            #endregion
+
+            #region IVisitSynthIL<Label,Method,Source,Dest,TextWriter,Unit> Members
+
+
+            public Unit BeginOld(Label pc, Label matchingEnd, TextWriter data)
+            {
+                data.WriteLine("{0}begin.old", prefix);
+                return Unit.Value;
+            }
+
+            public Unit EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, TextWriter data)
+            {
+                data.WriteLine("{0}{1} = end.old {2}", prefix, DestName(dest), SourceName(source));
+                return Unit.Value;
+            }
+
+            #endregion
+        }
     }
-
-    private class Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData> :
-      IVisitMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, TextWriter, Unit>
-    {
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(ilDecoder != null); // F: Added as of Clousot suggestions of preconditions
-      }
-
-      string prefix = "";
-      IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder;
-      IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-      Converter<Source, string> sourceName;
-      Converter<Dest, string> destName;
-
-      public Printer(
-        IDecodeMSIL<Label, Local, Parameter, Method, Field, Type, Source, Dest, Context, EdgeData> ilDecoder,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-        Converter<Source, string> sourceName,
-        Converter<Dest, string> destName
-      )
-      {
-        Contract.Requires(ilDecoder != null);// F: As of Clousot suggestion
-
-        this.ilDecoder = ilDecoder;
-        this.mdDecoder = mdDecoder;
-        this.sourceName = sourceName;
-        this.destName = destName;
-      }
-
-      public void PrintCodeAt(Label label, string prefix, TextWriter writer)
-      {
-        this.prefix = prefix;
-        this.ilDecoder.ForwardDecode<TextWriter, Unit, Printer<Label, Local, Parameter, Method, Field, Property, Event, Type, Source, Dest, Context, Attribute, Assembly, EdgeData>>(label, this, writer);
-      }
-
-      #region IVisitMSIL<Label,Local,Parameter,Method,Field,Type,Source,Dest,TextWriter,Unit> Members
-
-      [Pure]
-      private string/*?*/ SourceName(Source src)
-      {
-        if (this.sourceName != null) { return this.sourceName(src); }
-        return null;
-      }
-
-      [Pure]
-      private string/*?*/ DestName(Dest dest)
-      {
-        if (this.destName != null) { return this.destName(dest); }
-        return null;
-      }
-
-      public Unit Binary(Label pc, BinaryOperator op, Dest dest, Source s1, Source s2, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = {2} {3} {4}", prefix, DestName(dest), SourceName(s1), op.ToString(), SourceName(s2));
-        return Unit.Value;
-      }
-
-      public Unit Assert(Label pc, string tag, Source s, object provenance, TextWriter tw)
-      {
-        tw.WriteLine("{0}assert({1}) {2}", prefix, tag, SourceName(s));
-        return Unit.Value;
-      }
-
-      public Unit Assume(Label pc, string tag, Source s, object provenance, TextWriter tw)
-      {
-        tw.WriteLine("{0}assume({1}) {2}", prefix, tag, SourceName(s));
-        return Unit.Value;
-      }
-
-      public Unit Arglist(Label pc, Dest d, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = arglist", prefix, DestName(d));
-        return Unit.Value;
-      }
-
-      public Unit BranchCond(Label pc, Label target, BranchOperator bop, Source value1, Source value2, TextWriter data)
-      {
-        data.WriteLine("{0}br.{1} {2},{3}", prefix, bop, SourceName(value1), SourceName(value2));
-        return Unit.Value;
-      }
-
-      public Unit BranchTrue(Label pc, Label target, Source cond, TextWriter data)
-      {
-        data.WriteLine("{0}br.true {1}", prefix, SourceName(cond));
-        return Unit.Value;
-      }
-
-      public Unit BranchFalse(Label pc, Label target, Source cond, TextWriter data)
-      {
-        data.WriteLine("{0}br.false {1}", prefix, SourceName(cond));
-        return Unit.Value;
-      }
-
-      public Unit Branch(Label pc, Label target, bool leave, TextWriter data)
-      {
-        data.WriteLine("{0}branch", prefix);
-        return Unit.Value;
-      }
-
-      public Unit Break(Label pc, TextWriter data)
-      {
-        data.WriteLine("{0}break", prefix);
-        return Unit.Value;
-      }
-
-      public Unit Call<TypeList, ArgList>(Label pc, Method method, bool tail, bool virt, TypeList extraVarargs, Dest dest, ArgList args, TextWriter data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        data.Write("{0}{4} = {1}call{3} {2}(", prefix, tail ? "tail." : null, mdDecoder.FullName(method), virt ? "virt" : null, DestName(dest));
-        if (args != null)
-        {
-          for (int i = 0; i < args.Count; i++)
-          {
-            var tmp = string.Format("{0} ", SourceName(args[i]));
-            data.Write(tmp);
-          }
-        }
-        data.WriteLine(")");
-        return Unit.Value;
-      }
-
-      public Unit Calli<TypeList, ArgList>(Label pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Dest dest, Source fp, ArgList args, TextWriter data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        data.Write("{0}{2} = {1}calli {3}(", prefix, tail ? "tail." : null, DestName(dest), SourceName(fp));
-        if (args != null)
-        {
-          for (int i = 0; i < args.Count; i++)
-          {
-            data.Write("{0} ", SourceName(args[i]));
-          }
-        }
-        data.WriteLine(")");
-        return Unit.Value;
-      }
-
-      public Unit Ckfinite(Label pc, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = ckinite {2}", prefix, DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Unary(Label pc, UnaryOperator op, bool ovf, bool unsigned, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{4} = {3}{1}{2} {5}", prefix, ovf ? "_ovf" : null, unsigned ? "_un" : null, op.ToString(), DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Cpblk(Label pc, bool @volatile, Source destaddr, Source srcaddr, Source len, TextWriter data)
-      {
-        data.WriteLine("{0}{1}cpblk {2} {3} {4}", prefix, @volatile ? "volatile." : null, SourceName(destaddr), SourceName(srcaddr), SourceName(len));
-        return Unit.Value;
-      }
-
-      public Unit Endfilter(Label pc, Source condition, TextWriter data)
-      {
-        data.WriteLine("{0}endfilter {1}", prefix, SourceName(condition));
-        return Unit.Value;
-      }
-
-      public Unit Endfinally(Label pc, TextWriter data)
-      {
-        data.WriteLine("{0}endfinally", prefix);
-        return Unit.Value;
-      }
-
-      public Unit Entry(Label pc, Method method, TextWriter data)
-      {
-        data.WriteLine("{0}method_entry {1}", prefix, this.mdDecoder.FullName(method));
-        return Unit.Value;
-      }
-
-      public Unit Initblk(Label pc, bool @volatile, Source destaddr, Source value, Source len, TextWriter data)
-      {
-        data.WriteLine("{0}{1}initblk {2} {3} {4}", prefix, @volatile ? "volatile." : null, SourceName(destaddr), SourceName(value), SourceName(len));
-        return Unit.Value;
-      }
-
-      public Unit Jmp(Label pc, Method method, TextWriter data)
-      {
-        data.WriteLine("{0}jmp {1}", prefix, mdDecoder.FullName(method));
-        return Unit.Value;
-      }
-
-      public Unit Ldarg(Label pc, Parameter argument, bool isOld, Dest dest, TextWriter data)
-      {
-        string isOldPrefix = isOld ? "old." : null;
-        data.WriteLine("{0}{2} = {3}ldarg {1}", prefix, mdDecoder.Name(argument), DestName(dest), isOldPrefix);
-        return Unit.Value;
-      }
-
-      public Unit Ldarga(Label pc, Parameter argument, bool isOld, Dest dest, TextWriter data)
-      {
-        string isOldPrefix = isOld ? "old." : null;
-        data.WriteLine("{0}{2} = {3}ldarga {1}", prefix, mdDecoder.Name(argument), DestName(dest), isOldPrefix);
-        return Unit.Value;
-      }
-
-      public Unit Ldconst(Label pc, object constant, Type type, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldc ({3})'{1}'", prefix, constant.ToString(), DestName(dest), mdDecoder.FullName(type));
-        return Unit.Value;
-      }
-
-      public Unit Ldnull(Label pc, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = ldnull", prefix, DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldftn(Label pc, Method method, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldftn {1}", prefix, mdDecoder.FullName(method), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldind(Label pc, Type type, bool @volatile, Dest dest, Source ptr, TextWriter data)
-      {
-        data.WriteLine("{0}{3} = {1}ldind {2} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(type), DestName(dest), SourceName(ptr));
-        return Unit.Value;
-      }
-
-      public Unit Ldloc(Label pc, Local local, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldloc {1}", prefix, mdDecoder.Name(local), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldloca(Label pc, Local local, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldloca {1}", prefix, mdDecoder.Name(local), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldresult(Label pc, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = ldresult {2}", prefix, DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Ldstack(Label pc, int offset, Dest dest, Source s, bool isOld, TextWriter data)
-      {
-        if (isOld)
-        {
-          data.WriteLine("{0}{1} = old.ldstack.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
-        }
-        else
-        {
-          data.WriteLine("{0}{1} = ldstack.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
-        }
-        return Unit.Value;
-      }
-
-      public Unit Ldstacka(Label pc, int offset, Dest dest, Source s, Type type, bool old, TextWriter data)
-      {
-        if (old)
-        {
-          data.WriteLine("{0}{1} = old.ldstacka.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
-        }
-        else
-        {
-          data.WriteLine("{0}{1} = ldstacka.{2} {3}", prefix, DestName(dest), offset, SourceName(s));
-        }
-        return Unit.Value;
-      }
-
-      public Unit Localloc(Label pc, Dest dest, Source size, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = localloc {2}", prefix, DestName(dest), SourceName(size));
-        return Unit.Value;
-      }
-
-
-      public Unit Nop(Label pc, TextWriter data)
-      {
-        data.WriteLine("{0}nop", prefix);
-        return Unit.Value;
-      }
-
-      public Unit Pop(Label pc, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}pop {1}", prefix, SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Return(Label pc, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}ret {1}", prefix, SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Starg(Label pc, Parameter argument, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}starg {1} {2}", prefix, mdDecoder.Name(argument), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Stind(Label pc, Type type, bool @volatile, Source ptr, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}{1}stind {2} {3} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(type), SourceName(ptr), SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Stloc(Label pc, Local local, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}stloc {1} {2}", prefix, mdDecoder.Name(local), SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Switch(Label pc, Type type, IEnumerable<Pair<object, Label>> cases, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}switch {1}", prefix, SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Box(Label pc, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = box {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit ConstrainedCallvirt<TypeList, ArgList>(Label pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Dest dest, ArgList args, TextWriter data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Source>
-      {
-        data.Write("{0}{4} = {1}constrained({2}).callvirt {3}(", prefix, tail ? "tail." : null, mdDecoder.FullName(constraint), mdDecoder.FullName(method), DestName(dest));
-        if (args != null)
-        {
-          for (int i = 0; i < args.Count; i++)
-          {
-            data.Write("{0} ", SourceName(args[i]));
-          }
-        }
-        data.WriteLine(")");
-        return Unit.Value;
-      }
-
-      public Unit Castclass(Label pc, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = castclass {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Cpobj(Label pc, Type type, Source destptr, Source srcptr, TextWriter data)
-      {
-        data.WriteLine("{0}cpobj {1} {2} {3}", prefix, mdDecoder.FullName(type), SourceName(destptr), SourceName(srcptr));
-        return Unit.Value;
-      }
-
-      public Unit Initobj(Label pc, Type type, Source ptr, TextWriter data)
-      {
-        data.WriteLine("{0}initobj {1} {2}", prefix, mdDecoder.FullName(type), SourceName(ptr));
-        return Unit.Value;
-      }
-
-      public Unit Isinst(Label pc, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = isinst {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Ldelem(Label pc, Type type, Dest dest, Source array, Source index, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldelem {1} {3}[{4}]", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(array), SourceName(index));
-        return Unit.Value;
-      }
-
-      public Unit Ldelema(Label pc, Type type, bool @readonly, Dest dest, Source array, Source index, TextWriter data)
-      {
-        data.WriteLine("{0}{3} = {1}ldelema {2} {4}[{5}]", prefix, @readonly ? "readonly." : null, mdDecoder.FullName(type), DestName(dest), SourceName(array), SourceName(index));
-        return Unit.Value;
-      }
-
-      public Unit Ldfld(Label pc, Field field, bool @volatile, Dest dest, Source ptr, TextWriter data)
-      {
-        data.WriteLine("{0}{3} = {1}ldfld {2} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), DestName(dest), SourceName(ptr));
-        return Unit.Value;
-      }
-
-      public Unit Ldflda(Label pc, Field field, Dest dest, Source ptr, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldflda {1} {3}", prefix, mdDecoder.FullName(field), DestName(dest), SourceName(ptr));
-        return Unit.Value;
-      }
-
-      public Unit Ldlen(Label pc, Dest dest, Source array, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = ldlen {2}", prefix, DestName(dest), SourceName(array));
-        return Unit.Value;
-      }
-
-      public Unit Ldsfld(Label pc, Field field, bool @volatile, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{3} = {1}ldsfld {2}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldsflda(Label pc, Field field, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldsflda {1}", prefix, mdDecoder.FullName(field), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldtypetoken(Label pc, Type type, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldtoken {1}", prefix, mdDecoder.FullName(type), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldfieldtoken(Label pc, Field field, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldtoken {1}", prefix, mdDecoder.FullName(field), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldmethodtoken(Label pc, Method method, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldtoken {1}", prefix, mdDecoder.FullName(method), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Ldvirtftn(Label pc, Method method, Dest dest, Source obj, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = ldvirtftn {1} {3}", prefix, mdDecoder.FullName(method), DestName(dest), SourceName(obj));
-        return Unit.Value;
-      }
-
-      public Unit Mkrefany(Label pc, Type type, Dest dest, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = mkrefany {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Newarray<ArgList>(Label pc, Type type, Dest dest, ArgList lengths, TextWriter data)
-        where ArgList : IIndexable<Source>
-      {
-        data.Write("{0}{2} = newarray {1}[", prefix, mdDecoder.FullName(type), DestName(dest));
-        for (int i = 0; i < lengths.Count; i++)
-        {
-          data.Write("{0} ", SourceName(lengths[i]));
-        }
-        data.WriteLine("]");
-        return Unit.Value;
-      }
-
-      public Unit Newobj<ArgList>(Label pc, Method ctor, Dest dest, ArgList args, TextWriter data)
-        where ArgList : IIndexable<Source>
-      {
-        data.Write("{0}{2} = newobj {1}(", prefix, mdDecoder.FullName(ctor), DestName(dest));
-        if (args != null)
-        {
-          for (int i = 0; i < args.Count; i++)
-          {
-            data.Write("{0} ", SourceName(args[i]));
-          }
-        }
-        data.WriteLine(")");
-        return Unit.Value;
-      }
-
-      public Unit Refanytype(Label pc, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = refanytype {2}", prefix, DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Refanyval(Label pc, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = refanyval {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Rethrow(Label pc, TextWriter data)
-      {
-        data.WriteLine("{0}rethrow", prefix);
-        return Unit.Value;
-      }
-
-      public Unit Sizeof(Label pc, Type type, Dest dest, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = sizeof {1}", prefix, mdDecoder.FullName(type), DestName(dest));
-        return Unit.Value;
-      }
-
-      public Unit Stelem(Label pc, Type type, Source array, Source index, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}stelem {1} {2}[{3}] = {4}", prefix, mdDecoder.FullName(type), SourceName(array), SourceName(index), SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Stfld(Label pc, Field field, bool @volatile, Source ptr, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}{1}stfld {2} {3} {4}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), SourceName(ptr), SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Stsfld(Label pc, Field field, bool @volatile, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}{1}stsfld {2} {3}", prefix, @volatile ? "volatile." : null, mdDecoder.FullName(field), SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Throw(Label pc, Source value, TextWriter data)
-      {
-        data.WriteLine("{0}throw {1}", prefix, SourceName(value));
-        return Unit.Value;
-      }
-
-      public Unit Unbox(Label pc, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = unbox {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      public Unit Unboxany(Label pc, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{2} = unbox_any {1} {3}", prefix, mdDecoder.FullName(type), DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      #endregion
-
-      #region IVisitSynthIL<Label,Method,Source,Dest,TextWriter,Unit> Members
-
-
-      public Unit BeginOld(Label pc, Label matchingEnd, TextWriter data)
-      {
-        data.WriteLine("{0}begin.old", prefix);
-        return Unit.Value;
-      }
-
-      public Unit EndOld(Label pc, Label matchingBegin, Type type, Dest dest, Source source, TextWriter data)
-      {
-        data.WriteLine("{0}{1} = end.old {2}", prefix, DestName(dest), SourceName(source));
-        return Unit.Value;
-      }
-
-      #endregion
-    }
-
-  }
-
 }

--- a/Microsoft.Research/ControlFlow/Properties/AssemblyInfo.cs
+++ b/Microsoft.Research/ControlFlow/Properties/AssemblyInfo.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/Microsoft.Research/ControlFlow/SimpleILCodeProvider.cs
+++ b/Microsoft.Research/ControlFlow/SimpleILCodeProvider.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
@@ -23,188 +12,186 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Research.CodeAnalysis.ILCodeProvider
 {
-  enum Instruction
-  {
-    Pop,
-  }
-
-  static class Predefined
-  {
-    public static Subroutine OldEvalPopSubroutine<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(
-      MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
-      Subroutine oldEval
-    )
+    internal enum Instruction
     {
-      Contract.Requires(oldEval != null);// F: Added as of Clousot suggestion
-      Contract.Requires(oldEval.StackDelta == 1); // F: Added as of Clousot suggestion
-      Contract.Requires(methodCache != null);// F: As of Clousot suggestion
-      Debug.Assert(oldEval.StackDelta == 1);
-      var sub = new SimpleILCodeProvider<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(
-        new Instruction[]{ Instruction.Pop },
-        0).GetSubroutine(methodCache);
-
-      sub.AddEdgeSubroutine(sub.Entry, sub.EntryAfterRequires, oldEval, "oldmanifest");
-      return sub;
-    }
-  }
-
-  class SimpleILCodeProvider<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> 
-    : ICodeProvider<int, Local, Parameter, Method, Field, Type>
-    , IDecodeMSIL<int, Local, Parameter, Method, Field, Type, Unit, Unit, Unit, Unit>
-  {
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.instructions != null); // F: made an object invariant because of the many precondition suggestions
+        Pop,
     }
 
-
-    Instruction[] instructions;
-    int stackDelta;
-
-    /// <summary>
-    /// Build a code provider with the given instruction sequence
-    /// </summary>
-    /// <param name="instructions"></param>
-    /// <param name="stackDelta">The number of values on the stack left by this instruction sequence (can be negative)</param>
-    public SimpleILCodeProvider(Instruction[] instructions, int stackDelta)
+    internal static class Predefined
     {
-      Contract.Requires(instructions != null); // F: Clousot suggestion
+        public static Subroutine OldEvalPopSubroutine<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(
+          MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache,
+          Subroutine oldEval
+        )
+        {
+            Contract.Requires(oldEval != null);// F: Added as of Clousot suggestion
+            Contract.Requires(oldEval.StackDelta == 1); // F: Added as of Clousot suggestion
+            Contract.Requires(methodCache != null);// F: As of Clousot suggestion
+            Debug.Assert(oldEval.StackDelta == 1);
+            var sub = new SimpleILCodeProvider<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>(
+              new Instruction[] { Instruction.Pop },
+              0).GetSubroutine(methodCache);
 
-      this.instructions = instructions;
-      this.stackDelta = stackDelta;
+            sub.AddEdgeSubroutine(sub.Entry, sub.EntryAfterRequires, oldEval, "oldmanifest");
+            return sub;
+        }
     }
 
-    public Subroutine GetSubroutine(MethodCache<Local,Parameter,Type,Method,Field,Property,Event,Attribute,Assembly> methodCache) 
+    internal class SimpleILCodeProvider<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly>
+      : ICodeProvider<int, Local, Parameter, Method, Field, Type>
+      , IDecodeMSIL<int, Local, Parameter, Method, Field, Type, Unit, Unit, Unit, Unit>
     {
-      Contract.Requires(methodCache != null); // F: Added as of Clousot suggestion
-      return methodCache.BuildSubroutine(this.stackDelta, this, 0);
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(instructions != null); // F: made an object invariant because of the many precondition suggestions
+        }
+
+
+        private Instruction[] instructions;
+        private int stackDelta;
+
+        /// <summary>
+        /// Build a code provider with the given instruction sequence
+        /// </summary>
+        /// <param name="instructions"></param>
+        /// <param name="stackDelta">The number of values on the stack left by this instruction sequence (can be negative)</param>
+        public SimpleILCodeProvider(Instruction[] instructions, int stackDelta)
+        {
+            Contract.Requires(instructions != null); // F: Clousot suggestion
+
+            this.instructions = instructions;
+            this.stackDelta = stackDelta;
+        }
+
+        public Subroutine GetSubroutine(MethodCache<Local, Parameter, Type, Method, Field, Property, Event, Attribute, Assembly> methodCache)
+        {
+            Contract.Requires(methodCache != null); // F: Added as of Clousot suggestion
+            return methodCache.BuildSubroutine(stackDelta, this, 0);
+        }
+
+        #region ICodeProvider<int,Method,Type> Members
+
+        public R Decode<Visitor, T, R>(int label, Visitor query, T data)
+          where Visitor : ICodeQuery<int, Local, Parameter, Method, Field, Type, T, R>
+        {
+            switch (instructions[label])
+            {
+                case Instruction.Pop:
+                    return query.Pop(label, Unit.Value, data);
+
+                default:
+                    throw new NotImplementedException("unknown instruction");
+            }
+        }
+
+        public bool Next(int current, out int nextLabel)
+        {
+            current++;
+            if (current < instructions.Length)
+            {
+                nextLabel = current;
+                return true;
+            }
+            nextLabel = 0;
+            return false;
+        }
+
+        public void PrintCodeAt(int pc, string indent, System.IO.TextWriter tw)
+        {
+            Contract.Requires(tw != null);// F: Added as of Clousot suggestion
+            tw.Write("{0}{1}", indent, instructions[pc].ToString());
+        }
+
+        public string SourceAssertionCondition(int pc)
+        {
+            return null;
+        }
+
+        public bool HasSourceContext(int pc)
+        {
+            return false;
+        }
+
+        public string SourceDocument(int pc)
+        {
+            return null;
+        }
+
+        public int SourceStartLine(int pc)
+        {
+            return 0;
+        }
+
+        public int SourceEndLine(int pc)
+        {
+            return 0;
+        }
+
+        public int SourceStartColumn(int pc)
+        {
+            return 0;
+        }
+
+        public int SourceEndColumn(int pc)
+        {
+            return 0;
+        }
+
+        public int SourceStartIndex(int pc)
+        {
+            return 0;
+        }
+
+        public int SourceLength(int pc)
+        {
+            return 0;
+        }
+
+        public int ILOffset(int pc)
+        {
+            return 0;
+        }
+
+        #endregion
+
+
+        #region IDecodeMSIL<int,Local,Parameter,Method,Field,Type,Unit,Unit,Unit> Members
+
+        public Result ForwardDecode<Data, Result, Visitor>(int lab, Visitor visitor, Data data) where Visitor : IVisitMSIL<int, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
+        {
+            switch (instructions[lab])
+            {
+                case Instruction.Pop:
+                    return visitor.Pop(lab, Unit.Value, data);
+
+                default:
+                    throw new NotImplementedException("unknown instruction");
+            }
+        }
+
+        public bool IsUnreachable(int lab)
+        {
+            return lab < 0 || lab > instructions.Length;
+        }
+
+        public Unit Context
+        {
+            get { return Unit.Value; }
+        }
+
+        #endregion
+
+        #region IDecodeMSIL<int,Local,Parameter,Method,Field,Type,Unit,Unit,Unit,Unit> Members
+
+
+        public Unit EdgeData(int from, int to)
+        {
+            return Unit.Value;
+        }
+
+        public void Display(TextWriter tw, string prefix, Unit data) { }
+
+        #endregion
     }
-
-    #region ICodeProvider<int,Method,Type> Members
-
-    public R Decode<Visitor, T, R>(int label, Visitor query, T data)
-      where Visitor : ICodeQuery<int, Local, Parameter, Method, Field, Type, T, R> 
-    {
-      switch (instructions[label])
-      {
-        case Instruction.Pop:
-          return query.Pop(label, Unit.Value, data);
-          
-        default:
-          throw new NotImplementedException("unknown instruction");
-      }
-    }
-
-    public bool Next(int current, out int nextLabel)
-    {
-      current++;
-      if (current < instructions.Length)
-      {
-        nextLabel = current;
-        return true;
-      }
-      nextLabel = 0;
-      return false;
-    }
-
-    public void PrintCodeAt(int pc, string indent, System.IO.TextWriter tw)
-    {
-      Contract.Requires(tw != null);// F: Added as of Clousot suggestion
-      tw.Write("{0}{1}", indent, instructions[pc].ToString());
-    }
-
-    public string SourceAssertionCondition(int pc)
-    {
-      return null;
-    }
-
-    public bool HasSourceContext(int pc)
-    {
-      return false;
-    }
-
-    public string SourceDocument(int pc)
-    {
-      return null;
-    }
-
-    public int SourceStartLine(int pc)
-    {
-      return 0;
-    }
-
-    public int SourceEndLine(int pc)
-    {
-      return 0;
-    }
-
-    public int SourceStartColumn(int pc)
-    {
-      return 0;
-    }
-
-    public int SourceEndColumn(int pc)
-    {
-      return 0;
-    }
-
-    public int SourceStartIndex(int pc)
-    {
-      return 0;
-    }
-
-    public int SourceLength(int pc)
-    {
-      return 0;
-    }
-
-    public int ILOffset(int pc)
-    {
-      return 0;
-    }
-
-    #endregion
-
-
-    #region IDecodeMSIL<int,Local,Parameter,Method,Field,Type,Unit,Unit,Unit> Members
-
-    public Result ForwardDecode<Data, Result, Visitor>(int lab, Visitor visitor, Data data) where Visitor : IVisitMSIL<int, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
-    {
-      switch (instructions[lab])
-      {
-        case Instruction.Pop:
-          return visitor.Pop(lab, Unit.Value, data);
-
-        default:
-          throw new NotImplementedException("unknown instruction");
-      }
-    }
-
-    public bool IsUnreachable(int lab)
-    {
-      return lab < 0 || lab > instructions.Length;
-    }
-
-    public Unit Context
-    {
-      get { return Unit.Value; }
-    }
-
-    #endregion
-
-    #region IDecodeMSIL<int,Local,Parameter,Method,Field,Type,Unit,Unit,Unit,Unit> Members
-
-
-    public Unit EdgeData(int from, int to)
-    {
-      return Unit.Value;
-    }
-
-    public void Display(TextWriter tw, string prefix, Unit data) { }
-
-    #endregion
-  }
-
-
 }

--- a/Microsoft.Research/ControlFlow/StackDepthFactory.cs
+++ b/Microsoft.Research/ControlFlow/StackDepthFactory.cs
@@ -1,16 +1,5 @@
-// CodeContracts
-// 
-// Copyright (c) Microsoft Corporation
-// 
-// All rights reserved. 
-// 
-// MIT License
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.IO;
@@ -24,2596 +13,2595 @@ using StackTemp = System.Int32;
 
 namespace Microsoft.Research.CodeAnalysis
 {
-  using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
-  using SubroutineEdge = STuple<CFGBlock, CFGBlock, string>;
-  using System.Diagnostics.Contracts;
+    using SubroutineContext = FList<STuple<CFGBlock, CFGBlock, string>>;
+    using SubroutineEdge = STuple<CFGBlock, CFGBlock, string>;
+    using System.Diagnostics.Contracts;
 
-  public interface IStackContext<Field, Method> : IMethodContext<Field, Method>
-  {
-    IStackContextData<Field, Method> StackContext { get; }
-  }
-
-  public interface IStackContextData<Field, Method>
-  {
-    /// <summary>
-    /// Returns the evaluation stack depth prior to the given program point
-    /// </summary>
-    int StackDepth(APC at);
-
-    /// <summary>
-    /// Returns the evaluation stack depth prior to the given program point ignoring the context
-    /// </summary>
-    int LocalStackDepth(APC at);
-
-    /// <summary>
-    /// If APC is a call site, and some of the call arguments are delegates with known method targets,
-    /// then this method gives access to these method targets.
-    /// </summary>
-    bool TryGetCallArgumentDelegateTarget(APC at, int stackOffset, out Method method);
-  }
-
-  public static class MetadataExtensions
-  {
-    public static Method FindBaseOrImplementingMethod<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
-      this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
-      Method called,
-      Method targetMethod)
+    public interface IStackContext<Field, Method> : IMethodContext<Field, Method>
     {
-      Contract.Requires(mdDecoder != null);// F: Added as of Clousot suggestion
+        IStackContextData<Field, Method> StackContext { get; }
+    }
 
-      var calledType = mdDecoder.DeclaringType(called);
-      var targetMethodType = mdDecoder.DeclaringType(targetMethod);
+    public interface IStackContextData<Field, Method>
+    {
+        /// <summary>
+        /// Returns the evaluation stack depth prior to the given program point
+        /// </summary>
+        int StackDepth(APC at);
 
-      // no instance (same generic context)
-      if (mdDecoder.Equal(calledType, targetMethodType)) return called;
+        /// <summary>
+        /// Returns the evaluation stack depth prior to the given program point ignoring the context
+        /// </summary>
+        int LocalStackDepth(APC at);
 
-      // direct instance
-      if (mdDecoder.Equal(mdDecoder.Unspecialized(calledType), targetMethodType))
-      {
-        return called;
-      }
+        /// <summary>
+        /// If APC is a call site, and some of the call arguments are delegates with known method targets,
+        /// then this method gives access to these method targets.
+        /// </summary>
+        bool TryGetCallArgumentDelegateTarget(APC at, int stackOffset, out Method method);
+    }
 
-      // indirect instance because contract is inherited
-      // find out what method called is implementing
-      foreach (var candidate in mdDecoder.ImplementedMethods(called).AssumeNotNull())
-      {
-        var candidateType = mdDecoder.DeclaringType(candidate);
-        if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
+    public static class MetadataExtensions
+    {
+        public static Method FindBaseOrImplementingMethod<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly>(
+          this IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder,
+          Method called,
+          Method targetMethod)
         {
-          return candidate;
-        }
-      }
+            Contract.Requires(mdDecoder != null);// F: Added as of Clousot suggestion
 
-      FList<Method> baseMethodsToCheck = FList<Method>.Cons(called, null);
-      while (baseMethodsToCheck != null)
-      {
-        var baseMethod = baseMethodsToCheck.Head;
-        baseMethodsToCheck = baseMethodsToCheck.Tail;
+            var calledType = mdDecoder.DeclaringType(called);
+            var targetMethodType = mdDecoder.DeclaringType(targetMethod);
 
-        foreach (var candidate in mdDecoder.OverriddenMethods(baseMethod).AssumeNotNull())
-        {
-          baseMethodsToCheck = baseMethodsToCheck.Cons(candidate);
-          var candidateType = mdDecoder.DeclaringType(candidate);
-          if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
-          {
-            return candidate;
-          }
-        }
-      }
-      // couldn't find the instantiation
-      return called;
-    }
+            // no instance (same generic context)
+            if (mdDecoder.Equal(calledType, targetMethodType)) return called;
 
-  }
-
-  public static class StackDepthFactory
-  {
-    public static IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>
-      Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Context>(
-        IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Context, Unit> decoder,
-        IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
-      )
-      where Type : IEquatable<Type>
-      where Context : IMethodContext<Field, Method>
-    {
-      Contract.Requires(decoder != null);// F: Suggested by Clousot
-      Contract.Requires(mdDecoder != null); // F: Suggested by Clousot
-
-      return new StackDepthProvider<Local,Parameter,Method,Field,Property,Event,Type,Context,Attribute,Assembly>(decoder, mdDecoder);
-    }
-  }
-
-  #region Helper Structs
-  struct StackInfo
-  {
-    /// <summary>
-    /// the object pushed is either null, or "true" to indicte that the value is == "this", or
-    /// it is a method token of type Method to indicate either a ldftn ldvirtfn, or result of a delegate
-    /// construction from such a token.
-    /// </summary>
-    StackInfo<object> stack;
-
-    public StackInfo(int depth, int capacity)
-    {
-      this.stack = new StackInfo<object>(depth, capacity);
-    }
-    private StackInfo(StackInfo<object> copy)
-    {
-      this.stack = copy;
-    }
-
-    public int Depth { get { return this.stack.Depth; } }
-    public object this[int offset] { get { return this.stack[offset]; } }
-    public StackInfo Pop(int slots) {
-      Contract.Assume(slots <= this.stack.Depth); // F: If it fails something went wrong, very likely in the inference
-      return new StackInfo(this.stack.Pop(slots)); }
-    public StackInfo Push() { this.stack.Push(null); return this; }
-    public StackInfo PushThis() { this.stack.Push(true); return this; }
-    public StackInfo Push<Method>(Method method) { this.stack.Push(method); return this; }
-    public void Adjust(int delta)
-    {
-      Contract.Requires(delta != Int32.MinValue);
-
-      if (delta == 0) return;
-      if (delta < 0)
-      {
-        // pop
-        stack.Pop(-delta);
-      }
-      for (var i = 0; i < delta; i++)
-      {
-        this.Push();
-      }
-    }
-
-    public bool IsThis(int offset)
-    {
-      return As<bool>(offset);
-    }
-
-    public bool TryGetTarget<TargetType>(int offset, out TargetType target)
-    {
-      if (this[offset] is TargetType)
-      {
-        target = (TargetType)this[offset];
-        return true;
-      }
-      target = default(TargetType);
-      return false;
-    }
-
-    public TargetType As<TargetType>(int offset)
-    {
-      if (this[offset] is TargetType)
-      {
-        return (TargetType)this[offset];
-      }
-      return default(TargetType);
-    }
-
-    public StackInfo Copy()
-    {
-      return new StackInfo(new StackInfo<object>(this.stack));
-    }
-
-    public override string ToString()
-    {
-      return stack.ToString();
-    }
-  }
-
-  struct StackInfo<T>
-  {
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(stack != null); // F: Added as of Clousot suggestions of preconditions
-    }
-
-
-    int depth; // number of elements on stack
-    T[] stack;
-
-    public int Depth
-    {
-      get { return this.depth; }
-    }
-
-    public StackInfo(int depth, int capacity)
-    {
-      this.depth = depth;
-      this.stack = new T[capacity];
-    }
-
-    // Deep copy constructor
-    public StackInfo(StackInfo<T> that)
-    {
-      this.depth = that.Depth;
-      this.stack = (T[])that.stack.Clone();
-    }
-
-    public T this[int offset]
-    {
-      get
-      {
-        var top = depth - 1;
-        var index = top - offset;
-        if (index >= 0 && index < this.stack.Length)
-        {
-          return this.stack[index];
-        }
-        return default(T);
-      }
-    }
-
-    public StackInfo<T> Pop(int slots)
-    {
-      Contract.Requires(slots <= this.Depth); 
-
-      Debug.Assert(slots <= depth);
-      // clear stack info
-      var newDepth = depth - slots;
-      for (var i = newDepth; i < depth; i++)
-      {
-        if (i < stack.Length)
-        {
-          stack[i] = default(T);
-        }
-      }
-      depth = Math.Max(0, depth - slots);
-      return this;
-    }
-
-    public void Push(T info)
-    {
-      var index = this.depth;
-      if (index < stack.Length)
-      {
-        stack[index] = info;
-      }
-      depth++;
-    }
-
-    public override string ToString()
-    {
-      return this.depth.ToString();
-    }
-  }
-
-  #endregion 
-
-  /// <summary>
-  /// This class computes a stack depth at each program point of a subroutine and caches the result in a
-  /// typed property of the subroutine itself.
-  /// It then provides a way to traverse the full control flow of a CFG and obtain absolute stack positions
-  /// (temporaries) for each stack access.
-  /// Note that subroutines such as pre/post conditions are inserted in various positions with possibly
-  /// distinct stack depths. Thus the stack depth info per subroutine is parametric and we add the stack
-  /// depth of the surrounding edge to the parameteric depth when needed.
-  /// </summary>
-  public class StackDepthProvider<Local, Parameter, Method, Field, Property, Event, Type, ContextData, Attribute, Assembly> :
-    IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>,
-    IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>,
-    IStackContext<Field, Method>,
-    IStackContextData<Field, Method>,
-    IMethodContextData<Field, Method>,
-    ICFG,
-    IStackInfo
-    where ContextData : IMethodContext<Field, Method>
-    where Type : IEquatable<Type>
-  {
-
-    [ContractInvariantMethod]
-    private void ObjectInvariant()
-    {
-      Contract.Invariant(this.mdDecoder != null); // F: added because the many precondition suggestion
-      Contract.Invariant(this.ilDecoder != null);// F: added because the many precondition suggestion
-    }
-
-
-    #region privates
-    IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, ContextData, Unit> ilDecoder;
-    IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
-    ICFG cfg { get { return this.ilDecoder.Context.MethodContext.CFG; } }
-
-    private StackInfo ComputeBlockStartDepth(CFGBlock block)
-    {
-      Contract.Requires(block != null);// F: Added as of Clousot suggestion
-
-      if (block.Subroutine.IsCatchFilterHeader(block))
-      {
-        // starts an exception handler, thus the exception is on the stack
-        return new StackInfo(1, 2);
-      }
-      return new StackInfo(0, 4);
-    }
-
-    private const string StackDepthKey = "stackDepthKey";
-    private const string StackTypesKey = "stackTypesKey";
-
-    private APCMap<int> stackDepthMirrorForEndOld;
-
-    private ILPrinter<APC> printer;
-
-    /// <summary>
-    /// Avoid specialization during stack computation itself.
-    /// </summary>
-    bool recursionGuard = false;
-
-    private APCMap<int> ComputeStackDepth(Subroutine subroutine)
-    {
-      Contract.Requires(subroutine != null);
-
-      Contract.Assume(subroutine.Blocks != null, "should be a postcondition");
-      Contract.Assert(subroutine.BlockCount >= 0);
-
-      ArrayMap<StackInfo> startDepth = new ArrayMap<StackInfo>(subroutine.BlockCount);
-      // subroutine specific map
-      APCMap<int> stackDepth = stackDepthMirrorForEndOld = new APCMap<int>(subroutine);
-
-      StackInfo currentDepth;
-
-      foreach (CFGBlock block in subroutine.Blocks)
-      {
-        if (!startDepth.TryGetValue(block.Index, out currentDepth))
-        {
-          currentDepth = ComputeBlockStartDepth(block);
-        }
-        foreach (APC lab in block.APCs())
-        {
-          if (this.debugStack)
-          {
-            Console.WriteLine("Depth before {0}", currentDepth);
-            this.printer(lab, "  ", Console.Out);
-          }
-          stackDepth.Add(lab, currentDepth.Depth); // If you get an exception here, it means the underlying labels are not unique in a method.
-          currentDepth = this.ilDecoder.ForwardDecode<StackInfo, StackInfo, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>>(lab, this, currentDepth);
-          if (this.debugStack)
-          {
-            Console.WriteLine("Stack depth after {0}", currentDepth);
-          }
-        }
-        // also record last apc (past last instruction in block), unless present
-        if (!stackDepth.ContainsKey(block.Last))
-        {
-          stackDepth.Add(block.Last, currentDepth.Depth);
-        }
-
-        foreach (CFGBlock succ in subroutine.SuccessorBlocks(block))
-        {
-          // consider stack depth changes done by subroutines
-          bool isExn;
-          bool savedRecursionGuard = this.recursionGuard;
-          this.recursionGuard = true;
-          try
-          {
-            foreach (var sub in subroutine.EdgeSubroutinesOuterToInner(block, succ, out isExn, null).GetEnumerable())
+            // direct instance
+            if (mdDecoder.Equal(mdDecoder.Unspecialized(calledType), targetMethodType))
             {
-              currentDepth.Adjust(sub.Two.StackDelta);
+                return called;
             }
-          }
-          finally
-          {
-            this.recursionGuard = savedRecursionGuard;
-          }
-          AddStartDepth(startDepth, succ, currentDepth);
-        }
-      }
-      return stackDepth;
-    }
 
-    private static void AddStartDepth(ArrayMap<StackInfo> dict, CFGBlock block, StackInfo startDepth)
-    {
-      Contract.Requires(block != null);// F: Added as of Clousot suggestion
-      Contract.Requires(dict != null);// F: Added as of Clousot suggestion
-
-      Contract.Assert(block.Index >= 0, "assuming the invariant");
-
-      StackInfo oldDepth;    
-      if (dict.TryGetValue(block.Index, out oldDepth))
-      {
-        Contract.Assume(oldDepth.Depth == startDepth.Depth);
-      }
-      else
-      {
-        Contract.Assume(!dict.ContainsKey(block.Index), "assuming the behavior of Dictionary");
-        dict.Add(block.Index, startDepth.Copy());
-      }
-    }
-
-    /// <summary>
-    /// Specialized map for APCs without finally contexts
-    /// </summary>
-    class APCMap<T>
-    {
-
-      [ContractInvariantMethod]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.blockMap != null);// F: Added as of Clousot suggestions as precondition in many places
-        Contract.Invariant(this.callOnThisMap != null);// F: Added as of Clousot suggestions as precondition in many places
-        Contract.Invariant(this.callArgumentDelegateTargets != null);
-      }
-
-
-      ArrayMap<T>[] blockMap;
-      IFunctionalIntMap<bool> callOnThisMap; //indexed by block index, returns true if that call block is on this
-      DoubleFunctionalMap<int, int, Method> callArgumentDelegateTargets; // indexed by block index, then local stack offset
-
-      public APCMap(Subroutine parent)
-      {
-        Contract.Requires(parent != null);
-
-        blockMap = new ArrayMap<T>[parent.BlockCount];
-        callOnThisMap = FunctionalIntMap<bool>.EmptyMap;
-        callArgumentDelegateTargets = DoubleFunctionalMap<int, int, Method>.Empty(i => i);
-      }
-
-      public void Add(APC pc, T value)
-      {
-        Contract.Assume(pc.Block != null, "Assuming the object invariant");
-        Contract.Assume(pc.Index >= 0, "Assuming the object invariant");
-        ArrayMap<T> indexMap = blockMap[pc.Block.Index];
-        if (indexMap == null)
-        {
-          indexMap = new ArrayMap<T>(pc.Block.Count + 1); // including one past last
-          Contract.Assert(pc.Block.Index < blockMap.Length);
-          blockMap[pc.Block.Index] = indexMap;
-        }
-        Contract.Assume(pc.Index < indexMap.Count);
-        Contract.Assume(!indexMap.ContainsKey(pc.Index));
-        indexMap.Add(pc.Index, value);
-      }
-
-      public void RecordCallOnThis(APC pc)
-      {
-        Contract.Requires(pc.Block != null);  // F: As of Clousot suggestion
-        callOnThisMap = callOnThisMap.Add(pc.Block.Index, true);
-      }
-
-      public void RecordCallArgument(APC pc, int stackoffset, Method target)
-      {
-        Contract.Assume(pc.Block != null);
-        callArgumentDelegateTargets = callArgumentDelegateTargets.Add(pc.Block.Index, stackoffset, target);
-      }
-
-      public T this[APC key]
-      {
-        get
-        {
-          T result;
-          if (!TryGetValue(key, out result))
-          {
-            throw new NotSupportedException("key not in table");
-          }
-          return result;
-        }
-      }
-
-      public bool IsCallOnThis(APC key)
-      {
-        Contract.Assume(key.Block != null);
-        return this.callOnThisMap[key.Block.Index];
-      }
-
-      public bool TryGetArgumentDelegateTarget(APC key, int stackOffset, out Method method)
-      {
-        Contract.Assume(key.Block != null);
-        method = callArgumentDelegateTargets[key.Block.Index, stackOffset];
-        return callArgumentDelegateTargets.Contains(key.Block.Index, stackOffset);
-      }
-
-      public bool TryGetValue(APC pc, out T value)
-      {
-        Contract.Assume(pc.Block != null);
-        ArrayMap<T> indexMap = blockMap[pc.Block.Index];
-        if (indexMap == null)
-        {
-          value = default(T);
-          return false;
-        }
-        Contract.Assume(pc.Index < indexMap.Count);
-        return indexMap.TryGetValue(pc.Index, out value);
-      }
-
-      public bool ContainsKey(APC pc)
-      {
-        Contract.Assume(pc.Block != null, "Assuming object invariant");
-        ArrayMap<T> indexMap = blockMap[pc.Block.Index];
-        if (indexMap == null)
-        {
-          return false;
-        }
-        Contract.Assume(pc.Index < indexMap.Count);
-        return indexMap.ContainsKey(pc.Index);
-      }
-    }
-
-    #endregion
-
-    /// <summary>
-    /// Computes the stack depth for the given method CFG main blocks. Subroutine stack depth is computed on demand.
-    /// </summary>
-    public StackDepthProvider(IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, ContextData, Unit> ilDecoder,
-                              IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
-    {
-      Contract.Requires(mdDecoder != null); // F: As of Clousot suggestion
-      Contract.Requires(ilDecoder != null);// F: As of Clousot suggestion
-
-      this.ilDecoder = ilDecoder;
-      this.mdDecoder = mdDecoder;
-      // The stack depth is computed on demand
-    }
-
-    private bool DebugStack
-    {
-      get { return this.debugStack; }
-      set
-      {
-        this.debugStack = value;
-        if (value)
-        {
-          this.printer = PrinterFactory.Create(ilDecoder, mdDecoder, delegate(Unit i) { return ""; }, delegate(Unit i) { return ""; });
-        }
-        else
-        {
-          this.printer = null;
-        }
-      }
-    }
-
-    #region IVisitMSIL<APC,Variable,Constant,Method,Field,Type,Unit,Unit,int,int> Members
-
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Assert(APC pc, string tag, Unit condition, object provenance, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Assume(APC pc, string tag, Unit source, object provenance, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Arglist(APC pc, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Binary(APC pc, BinaryOperator op, Unit dest, Unit s1, Unit s2, StackInfo data)
-    {
-      return data.Pop(2).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.BranchCond(APC pc, APC target, BranchOperator bop, Unit value1, Unit value2, StackInfo data)
-    {
-      return data.Pop(2);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.BranchTrue(APC pc, APC target, Unit cond, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.BranchFalse(APC pc, APC target, Unit cond, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Branch(APC pc, APC target, bool leave, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Break(APC pc, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, StackInfo data)
-      //where TypeList : IIndexable<Type>
-      //where ArgList : IIndexable<Unit>
-    {
-      int pops = mdDecoder.Parameters(method).AssumeNotNull().Count + (extraVarargs == null ? 0 : extraVarargs.Count);
-      if (!mdDecoder.IsStatic(method))
-      {
-        // receiver
-        // record call on this
-        if (data.IsThis(pops))
-        {
-          // call on this
-          this.stackDepthMirrorForEndOld.RecordCallOnThis(pc);
-        }
-        pops++;
-      }
-      else
-      {
-        for (int i = 0; i < pops; i++)
-        {
-          // see if we are passing any method delegates with known targets
-          Method m;
-          if (data.TryGetTarget(i, out m))
-          {
-            this.stackDepthMirrorForEndOld.RecordCallArgument(pc, data.Depth - i - 1, m);
-          }
-        }
-      }
-      data = data.Pop(pops);
-      if (mdDecoder.IsVoid(mdDecoder.ReturnType(method)))
-      {
-        return data;
-      }
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Unit dest, Unit fp, ArgList args, StackInfo data)
-      //where TypeList : IIndexable<Type>
-      //where ArgList : IIndexable<Unit>
-    {
-      int pops = 1; // function pointer
-      if (isInstance) pops++; // instance this (not represented in type list)
-      pops += argTypes == null ? 0 : argTypes.Count;
-      data = data.Pop(pops);
-      if (mdDecoder.IsVoid(returnType))
-      {
-        return data;
-      }
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ckfinite(APC pc, Unit dest, Unit source, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Cpblk(APC pc, bool @volatile, Unit dest, Unit src, Unit len, StackInfo data)
-    {
-      return data.Pop(3);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Endfilter(APC pc, Unit source, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Endfinally(APC pc, StackInfo data)
-    {
-      return new StackInfo(0, 0);
-    }
-
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Entry(APC pc, Method method, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Initblk(APC pc, bool @volatile, Unit destaddr, Unit value, Unit size, StackInfo data)
-    {
-      return data.Pop(3);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Jmp(APC pc, Method method, StackInfo data)
-    {
-      return new StackInfo(0, 0);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldarg(APC pc, Parameter argument, bool isOld, Unit dest, StackInfo data)
-    {
-      if (!mdDecoder.IsStatic(mdDecoder.DeclaringMethod(argument)))
-      {
-        if (mdDecoder.ArgumentIndex(argument) == 0)
-        {
-          // this
-          return data.PushThis();
-        }
-      }
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldarga(APC pc, Parameter argument, bool isOld, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Ldconst(APC pc, Object constant, Type type, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Ldnull(APC pc, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldftn(APC pc, Method method, Unit dest, StackInfo data)
-    {
-      return data.Push(method);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldind(APC pc, Type type, bool @volatile, Unit dest, Unit ptr, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldloc(APC pc, Local local, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldloca(APC pc, Local local, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Ldstack(APC pc, int offset, Unit dest, Unit source, bool old, StackInfo data)
-    {
-      return data.Push(data[offset]);
-    }
-
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Ldstacka(APC pc, int offset, Unit dest, Unit source, Type type, bool old, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Localloc(APC pc, Unit dest, Unit size, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Nop(APC pc, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Pop(APC pc, Unit source, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Return(APC pc, Unit source, StackInfo data)
-    {
-      // we leave the return value on the stack here, as we consume it in the Exit block
-      // or leave it on the stack if inlining is used
-      int expectedExitStackDepth = pc.Block.Subroutine.StackDelta;
-
-      if (pc.Block.Subroutine.HasReturnValue)
-      {
-        expectedExitStackDepth++;
-      }
-      Contract.Assume(data.Depth == expectedExitStackDepth); // F: made an assume
-      return data; // leave stack
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Starg(APC pc, Parameter argument, Unit source, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stind(APC pc, Type type, bool @volatile, Unit ptr, Unit value, StackInfo data)
-    {
-      return data.Pop(2);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stloc(APC pc, Local local, Unit source, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, Unit value, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Unit dest, Unit source, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Box(APC pc, Type type, Unit dest, Unit source, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Unit dest, ArgList args, StackInfo data)
-      //where TypeList : IIndexable<Type>
-      //where ArgList : IIndexable<Unit>
-    {
-      int pops = mdDecoder.Parameters(method).AssumeNotNull().Count + (extraVarargs == null ? 0 : extraVarargs.Count);
-      if (!mdDecoder.IsStatic(method))
-      {
-        // receiver
-
-        // record call on this
-        if (data.IsThis(pops))
-        {
-          this.stackDepthMirrorForEndOld.RecordCallOnThis(pc);
-        }
-        pops++;
-      }
-      data = data.Pop(pops);
-      if (mdDecoder.IsVoid(mdDecoder.ReturnType(method)))
-      {
-        return data;
-      }
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Castclass(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Cpobj(APC pc, Type type, Unit destptr, Unit srcptr, StackInfo data)
-    {
-      return data.Pop(2);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Initobj(APC pc, Type type, Unit ptr, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Isinst(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldelem(APC pc, Type type, Unit dest, Unit array, Unit index, StackInfo data)
-    {
-      return data.Pop(2).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldelema(APC pc, Type type, bool @readonly, Unit dest, Unit array, Unit index, StackInfo data)
-    {
-      return data.Pop(2).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldfld(APC pc, Field field, bool @volatile, Unit dest, Unit obj, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldflda(APC pc, Field field, Unit dest, Unit obj, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldlen(APC pc, Unit dest, Unit array, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldsfld(APC pc, Field field, bool @volatile, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldsflda(APC pc, Field field, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldtypetoken(APC pc, Type type, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldfieldtoken(APC pc, Field field, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldmethodtoken(APC pc, Method method, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldvirtftn(APC pc, Method method, Unit dest, Unit obj, StackInfo data)
-    {
-      return data.Pop(1).Push(method);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Mkrefany(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
-    {
-      return data;
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Newarray<ArgList>(APC pc, Type type, Unit dest, ArgList lengths, StackInfo data)
-      //where ArgList : IIndexable<Unit>
-    {
-      return data.Pop(lengths.Count).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Newobj<ArgList>(APC pc, Method ctor, Unit dest, ArgList args, StackInfo data)
-      //where ArgList : IIndexable<Unit>
-    {
-      int pops = mdDecoder.Parameters(ctor).AssumeNotNull().Count;
-      if (pops == 2 && mdDecoder.IsDelegate(mdDecoder.DeclaringType(ctor)))
-      {
-        var mtoken = data.As<Method>(0); // last thing pushed was fn pointer
-        return data.Pop(2).Push(mtoken);
-      }
-      else
-      {
-        return data.Pop(pops).Push();
-      }
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Refanytype(APC pc, Unit dest, Unit source, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Refanyval(APC pc, Type type, Unit dest, Unit source, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Rethrow(APC pc, StackInfo data)
-    {
-      return new StackInfo(0, 0);
-    }
-
-    StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Sizeof(APC pc, Type type, Unit dest, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stelem(APC pc, Type type, Unit array, Unit index, Unit value, StackInfo data)
-    {
-      return data.Pop(3);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stfld(APC pc, Field field, bool @volatile, Unit obj, Unit value, StackInfo data)
-    {
-      return data.Pop(2);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stsfld(APC pc, Field field, bool @volatile, Unit value, StackInfo data)
-    {
-      return data.Pop(1);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Throw(APC pc, Unit exn, StackInfo data)
-    {
-      return new StackInfo(0, 0);
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Unbox(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Unboxany(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
-    {
-      return data.Pop(1).Push();
-    }
-
-    #region IVisitSynthIL<APC,Method,Unit,Unit,int,int> Members
-
-    int OldStartDepth(Subroutine subroutine)
-    {
-      Contract.Requires(subroutine != null);// F: Added as of Clousot suggestion
-
-      // must be an ensures which implements IMethodInfo
-      IMethodInfo<Method> mi = (IMethodInfo<Method>)subroutine;
-
-      int offset = this.mdDecoder.Parameters(mi.Method).AssumeNotNull().Count;
-      if (!this.mdDecoder.IsConstructor(mi.Method) && !this.mdDecoder.IsStatic(mi.Method)) offset++;
-      //if (!this.mdDecoder.IsVoidMethod(mi.Method)) offset--;
-      return offset;
-    }
-
-    /// <summary>
-    /// Here we have to switch to the stack depth present at call-site to the method of which we are analyzing
-    /// the post condition. During evaluation, the APC context will however be the exiting edge from the call-site,
-    /// thus the context stack depth will not contain the argument count, only the result count (0 or 1) depending on the 
-    /// Voidness of the method result.
-    /// In order to obtain the correct stack depth, we thus start the local stack depth with #args - (IsVoidMethod?0:1), so
-    /// that the proper offsets on the evaluation stack are going to be used without trashing the stack contents present
-    /// at the call site.
-    /// For the application of this ensures within its own method, the stack is initially empty, as the arguments are accessed
-    /// with ldarg, not with ldstack. Thus, having an offset other than starting at 0 is okay, except that we get into the corner
-    /// case of having to use stack offset -1, which can happen for a static method without arguments but a return value.
-    /// </summary>
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.BeginOld(APC pc, APC matchingEnd, StackInfo data)
-    {
-      return data; // we don't adjust the stack here.
-      //int offset = OldStartDepth(pc.Block.Subroutine);
-      //return new StackInfo(offset, 4);
-    }
-
-    /// <summary>
-    /// Continue with stack depth at matching begin + 1 for the old value.
-    ///
-    /// NOTE: the stack depth associated with pc is the stack depth at the end of the old expression, not the new
-    /// stack depth.
-    /// </summary>
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.EndOld(APC pc, APC matchingBegin, Type type, Unit dest, Unit source, StackInfo data)
-    {
-      // this is a pop and a push, so even.
-      return data.Pop(1).Push();
-      //int previousDepth = this.stackDepthMirrorForEndOld[matchingBegin];
-      //return new StackInfo(previousDepth + 1, 4);
-    }
-
-    StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Ldresult(APC pc, Type type, Unit dest, Unit source, StackInfo data)
-    {
-      return data.Push();
-    }
-
-    #endregion
-
-    #endregion
-
-
-
-    #region IMSILDecoder<Label,Local,Parameter,Method,Field,Type,int,int> Members
-
-    APCMap<int> GetStackDepthMap(Subroutine subroutine)
-    {
-      Contract.Requires(subroutine != null);
-      APCMap<int> localStackDepth;
-      if (!subroutine.TryGetValue(new TypedKey<APCMap<int>>(StackDepthKey), out localStackDepth))
-      {
-        try
-        {
-          localStackDepth = ComputeStackDepth(subroutine);
-        }
-        catch (Exception)
-        {
-#if DEBUG
-          Console.WriteLine("Probably bad code in subroutine: {0} ({1})", subroutine.Name, subroutine.Kind);
-          Console.WriteLine("running stack analysis again with debug");
-          System.Diagnostics.Debugger.Launch();
-          this.DebugStack = true;
-          this.ComputeStackDepth(subroutine);
-#endif
-          throw;
-        }
-        // store the stack depth map it in the subroutine properties
-        subroutine.Add(new TypedKey<APCMap<int>>(StackDepthKey), localStackDepth);
-      }
-      return localStackDepth;
-    }
-
-    APCMap<int> localStackDepthCache;
-    int cachedSubroutine;
-    private bool debugStack;
-
-    APCMap<int> LocalStackMap(Subroutine subroutine)
-    {
-      Contract.Requires(subroutine != null);
-      Contract.Ensures(Contract.Result<APCMap<int>>() != null);
-      
-      if (localStackDepthCache == null || cachedSubroutine != subroutine.Id)
-      {
-        APCMap<int> localStackDepth = GetStackDepthMap(subroutine);
-        localStackDepthCache = localStackDepth;
-        cachedSubroutine = subroutine.Id;
-      }
-
-      Contract.Assume(localStackDepthCache != null);
-      return localStackDepthCache;
-    }
-
-    public int LocalStackDepth(APC apc)
-    {
-      Contract.Assume(apc.Block != null);
-      APCMap<int> localStackDepth = LocalStackMap(apc.Block.Subroutine);
-      return localStackDepth[apc];
-    }
-
-    /// <summary>
-    /// Compute the stack depth at the given apc
-    /// </summary>
-    int Lookup(APC apc)
-    {
-      int localDepth = LocalStackDepth(apc);
-      if (apc.SubroutineContext == null || !apc.Block.Subroutine.HasContextDependentStackDepth)
-      {
-        return localDepth;
-      }
-      CFGBlock contextBlock = apc.SubroutineContext.Head.One;
-      return localDepth + Lookup(APC.ForEnd(contextBlock, apc.SubroutineContext.Tail));
-    }
-
-    struct StackDecoder<Data, Result, Visitor> :
-      IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
-      where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, Data, Result>
-    {
-
-      #region invariants
-
-      [ContractInvariantMethod]
-      [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
-      private void ObjectInvariant()
-      {
-        Contract.Invariant(this.parent != null);
-      }
-
-
-      #endregion
-
-      #region Privates
-      private Visitor delegatee;
-
-      [Pure]
-      private Data Convert(Data data)
-      {
-        return data;
-      }
-
-      StackDepthProvider<Local, Parameter, Method, Field, Property, Event, Type, ContextData, Attribute, Assembly> parent;
-
-      #endregion
-
-      public StackDecoder(StackDepthProvider<Local, Parameter, Method, Field, Property, Event, Type, ContextData, Attribute, Assembly> parent,
-                          Visitor delegatee)
-      {
-        Contract.Requires(parent != null); // F: added because of Clousot suggestion
-        this.delegatee = delegatee;
-        this.parent = parent;
-      }
-
-      int Pop(APC l, int offset)
-      {
-        Contract.Ensures(this.parent != null);
-
-        Contract.Assume(l.Block != null);
-
-        int top = this.parent.Lookup(l) - 1;
-        int result = top - offset;
-        Contract.Assume(l.Block.Subroutine.HasContextDependentStackDepth || result >= 0);
-        return result;
-      }
-
-      int Push(APC l, int args, Type type)
-      {
-        Contract.Assume(this.parent.mdDecoder != null, "Assumption form the base class object invariant");
-        if (parent.mdDecoder.IsVoid(type))
-        {
-          return -1;
-        }
-        return Push(l, args);
-      }
-
-      int Push(APC l, int args)
-      {
-        Contract.Assume(l.Block != null);
-        int top = this.parent.Lookup(l);
-        int result = top - args;
-        Contract.Assume(l.Block.Subroutine.HasContextDependentStackDepth || result >= 0);
-        return result;
-      }
-
-      int ComputeArgs(Method m, int extraVarargs)
-      {
-        Contract.Assume(this.parent.mdDecoder != null, "Assumption form the base class object invariant");
-
-        int count = extraVarargs;
-        IIndexable<Parameter> pars = this.parent.mdDecoder.Parameters(m).AssumeNotNull();
-        count += pars.Count;
-        if (!this.parent.mdDecoder.IsStatic(m))
-        {
-          count++;
-        }
-        return count;
-      }
-
-      struct SequenceGenerator : IIndexable<int>, IEnumerable<int>
-      {
-        short from, count;
-        // Generates an indexable starting at from, from+1, ..., for count elements
-        public SequenceGenerator(int from, int count)
-        {
-          this.from = checked((short)from);
-          this.count = checked((short)count);
-        }
-
-
-        #region IIndexable<int> Members
-
-        int IIndexable<int>.Count
-        {
-          get { return this.count; }
-        }
-
-        public int this[int index]
-        {
-          get { return this.from + index; }
-        }
-
-        #endregion
-
-        #region IEnumerable<int> Members
-
-        public IEnumerator<int> GetEnumerator()
-        {
-          for (int i = 0; i < this.count; i++)
-          {
-            yield return this[i];
-          }
-        }
-
-        #endregion
-
-        #region IEnumerable Members
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-          return this.GetEnumerator();
-        }
-
-        #endregion
-      }
-
-      SequenceGenerator PopSequence(APC l, int args, int offset)
-      {
-        int from = this.parent.Lookup(l) - args - offset;
-        return new SequenceGenerator(from, args);
-      }
-
-      #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Unit,Unit,Pair<Pair<APC,Data>,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,Data,Result>>,Result> Members
-
-      public Result Assert(APC pc, string tag, Unit condition, object provenance, Data data)
-      {
-        return delegatee.Assert(pc, tag, Pop(pc, 0), provenance, Convert(data));
-      }
-
-      public Result Assume(APC pc, string tag, Unit source, object provenance, Data data)
-      {
-        // Code either contains the conditional branch/switch or the assume, but not both, so this is a pop
-        return delegatee.Assume(pc, tag, Pop(pc, 0), provenance, Convert(data));
-      }
-
-      public Result Arglist(APC pc, Unit dest, Data data)
-      {
-        return delegatee.Arglist(pc, Push(pc, 0), Convert(data));
-      }
-
-      public Result Binary(APC pc, BinaryOperator op, Unit dest, Unit s1, Unit s2, Data data)
-      {
-        return delegatee.Binary(pc, op, Push(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result BranchCond(APC pc, APC target, BranchOperator bop, Unit value1, Unit value2, Data data)
-      {
-        return delegatee.BranchCond(pc, target, bop, Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result BranchTrue(APC pc, APC target, Unit cond, Data data)
-      {
-        return delegatee.BranchTrue(pc, target, Pop(pc, 0), Convert(data));
-      }
-
-      public Result BranchFalse(APC pc, APC target, Unit cond, Data data)
-      {
-        return delegatee.BranchFalse(pc, target, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Branch(APC pc, APC target, bool leave, Data data)
-      {
-        return delegatee.Branch(pc, target, leave, Convert(data));
-      }
-
-      public Result Break(APC pc, Data data)
-      {
-        return delegatee.Break(pc, Convert(data));
-      }
-
-      enum AssertAssumeKind
-      {
-        Assert, Assume, None
-      }
-
-      public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Unit>
-      {
-        var mdDecoder = this.parent.mdDecoder;
-        var declaringType = mdDecoder.DeclaringType(method);
-        var methodName = mdDecoder.Name(method);
-        int numArgs = ComputeArgs(method, extraVarargs.Count);
-        // special treatment of Assert methods. We treat all methods ending in Assert that have a boolean arg as an assume of that bool
-        if (this.parent.mdDecoder.IsVoid(this.parent.mdDecoder.ReturnType(method)))
-        {
-          var parentTypeName = mdDecoder.FullName(declaringType).AssumeNotNull();
-          if (parentTypeName.Contains("Contract") || parentTypeName == "System.Diagnostics.Debug")
-          {
-            AssertAssumeKind kind = AssertAssumeKind.None;
-            if (methodName.EndsWith("Assert")) { kind = AssertAssumeKind.Assert; }
-            else if (methodName.EndsWith("Assume")) { kind = AssertAssumeKind.Assume; }
-            if (kind != AssertAssumeKind.None)
+            // indirect instance because contract is inherited
+            // find out what method called is implementing
+            foreach (var candidate in mdDecoder.ImplementedMethods(called).AssumeNotNull())
             {
-              IIndexable<Parameter> pars = mdDecoder.Parameters(method).AssumeNotNull();
-              for (int i = 0; i < pars.Count; i++)
-              {
-                if (mdDecoder.ParameterType(pars[i]).Equals(mdDecoder.System_Boolean))
+                var candidateType = mdDecoder.DeclaringType(candidate);
+                if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
                 {
-                  int condition = Pop(pc, mdDecoder.ArgumentStackIndex(pars[i]));
-                  if (kind == AssertAssumeKind.Assert)
-                  {
-                    return delegatee.Assert(pc, "assert", condition, null, data);
-                  }
-                  else
-                  {
-                    return delegatee.Assume(pc, "assume", condition, null, data);
-                  }
+                    return candidate;
                 }
-              }
             }
-          }
-        }
-        #region explicit == operator overloads
-        if (args.Count > 1 && (mdDecoder.IsReferenceType(declaringType) || mdDecoder.IsNativePointerType(declaringType)))
-        {
-          if (methodName.EndsWith("op_Inequality"))
-          {
-            return this.Binary(pc, BinaryOperator.Cne_Un, dest, args[0], args[1], data);
-          }
-          else if (methodName.EndsWith("op_Equality"))
-          {
-            if (mdDecoder.IsNativePointerType(declaringType))
+
+            FList<Method> baseMethodsToCheck = FList<Method>.Cons(called, null);
+            while (baseMethodsToCheck != null)
             {
-              return this.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
+                var baseMethod = baseMethodsToCheck.Head;
+                baseMethodsToCheck = baseMethodsToCheck.Tail;
+
+                foreach (var candidate in mdDecoder.OverriddenMethods(baseMethod).AssumeNotNull())
+                {
+                    baseMethodsToCheck = baseMethodsToCheck.Cons(candidate);
+                    var candidateType = mdDecoder.DeclaringType(candidate);
+                    if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
+                    {
+                        return candidate;
+                    }
+                }
+            }
+            // couldn't find the instantiation
+            return called;
+        }
+    }
+
+    public static class StackDepthFactory
+    {
+        public static IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>
+          Create<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly, Context>(
+            IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Context, Unit> decoder,
+            IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder
+          )
+          where Type : IEquatable<Type>
+          where Context : IMethodContext<Field, Method>
+        {
+            Contract.Requires(decoder != null);// F: Suggested by Clousot
+            Contract.Requires(mdDecoder != null); // F: Suggested by Clousot
+
+            return new StackDepthProvider<Local, Parameter, Method, Field, Property, Event, Type, Context, Attribute, Assembly>(decoder, mdDecoder);
+        }
+    }
+
+    #region Helper Structs
+    internal struct StackInfo
+    {
+        /// <summary>
+        /// the object pushed is either null, or "true" to indicte that the value is == "this", or
+        /// it is a method token of type Method to indicate either a ldftn ldvirtfn, or result of a delegate
+        /// construction from such a token.
+        /// </summary>
+        private StackInfo<object> stack;
+
+        public StackInfo(int depth, int capacity)
+        {
+            stack = new StackInfo<object>(depth, capacity);
+        }
+        private StackInfo(StackInfo<object> copy)
+        {
+            stack = copy;
+        }
+
+        public int Depth { get { return stack.Depth; } }
+        public object this[int offset] { get { return stack[offset]; } }
+        public StackInfo Pop(int slots)
+        {
+            Contract.Assume(slots <= stack.Depth); // F: If it fails something went wrong, very likely in the inference
+            return new StackInfo(stack.Pop(slots));
+        }
+        public StackInfo Push() { stack.Push(null); return this; }
+        public StackInfo PushThis() { stack.Push(true); return this; }
+        public StackInfo Push<Method>(Method method) { stack.Push(method); return this; }
+        public void Adjust(int delta)
+        {
+            Contract.Requires(delta != Int32.MinValue);
+
+            if (delta == 0) return;
+            if (delta < 0)
+            {
+                // pop
+                stack.Pop(-delta);
+            }
+            for (var i = 0; i < delta; i++)
+            {
+                this.Push();
+            }
+        }
+
+        public bool IsThis(int offset)
+        {
+            return As<bool>(offset);
+        }
+
+        public bool TryGetTarget<TargetType>(int offset, out TargetType target)
+        {
+            if (this[offset] is TargetType)
+            {
+                target = (TargetType)this[offset];
+                return true;
+            }
+            target = default(TargetType);
+            return false;
+        }
+
+        public TargetType As<TargetType>(int offset)
+        {
+            if (this[offset] is TargetType)
+            {
+                return (TargetType)this[offset];
+            }
+            return default(TargetType);
+        }
+
+        public StackInfo Copy()
+        {
+            return new StackInfo(new StackInfo<object>(stack));
+        }
+
+        public override string ToString()
+        {
+            return stack.ToString();
+        }
+    }
+
+    internal struct StackInfo<T>
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(stack != null); // F: Added as of Clousot suggestions of preconditions
+        }
+
+
+        private int depth; // number of elements on stack
+        private T[] stack;
+
+        public int Depth
+        {
+            get { return depth; }
+        }
+
+        public StackInfo(int depth, int capacity)
+        {
+            this.depth = depth;
+            stack = new T[capacity];
+        }
+
+        // Deep copy constructor
+        public StackInfo(StackInfo<T> that)
+        {
+            depth = that.Depth;
+            stack = (T[])that.stack.Clone();
+        }
+
+        public T this[int offset]
+        {
+            get
+            {
+                var top = depth - 1;
+                var index = top - offset;
+                if (index >= 0 && index < stack.Length)
+                {
+                    return stack[index];
+                }
+                return default(T);
+            }
+        }
+
+        public StackInfo<T> Pop(int slots)
+        {
+            Contract.Requires(slots <= this.Depth);
+
+            Debug.Assert(slots <= depth);
+            // clear stack info
+            var newDepth = depth - slots;
+            for (var i = newDepth; i < depth; i++)
+            {
+                if (i < stack.Length)
+                {
+                    stack[i] = default(T);
+                }
+            }
+            depth = Math.Max(0, depth - slots);
+            return this;
+        }
+
+        public void Push(T info)
+        {
+            var index = depth;
+            if (index < stack.Length)
+            {
+                stack[index] = info;
+            }
+            depth++;
+        }
+
+        public override string ToString()
+        {
+            return depth.ToString();
+        }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// This class computes a stack depth at each program point of a subroutine and caches the result in a
+    /// typed property of the subroutine itself.
+    /// It then provides a way to traverse the full control flow of a CFG and obtain absolute stack positions
+    /// (temporaries) for each stack access.
+    /// Note that subroutines such as pre/post conditions are inserted in various positions with possibly
+    /// distinct stack depths. Thus the stack depth info per subroutine is parametric and we add the stack
+    /// depth of the surrounding edge to the parameteric depth when needed.
+    /// </summary>
+    public class StackDepthProvider<Local, Parameter, Method, Field, Property, Event, Type, ContextData, Attribute, Assembly> :
+      IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>,
+      IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, IStackContext<Field, Method>, Unit>,
+      IStackContext<Field, Method>,
+      IStackContextData<Field, Method>,
+      IMethodContextData<Field, Method>,
+      ICFG,
+      IStackInfo
+      where ContextData : IMethodContext<Field, Method>
+      where Type : IEquatable<Type>
+    {
+        [ContractInvariantMethod]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant(mdDecoder != null); // F: added because the many precondition suggestion
+            Contract.Invariant(ilDecoder != null);// F: added because the many precondition suggestion
+        }
+
+
+        #region privates
+        private IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, ContextData, Unit> ilDecoder;
+        private IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder;
+        private ICFG cfg { get { return ilDecoder.Context.MethodContext.CFG; } }
+
+        private StackInfo ComputeBlockStartDepth(CFGBlock block)
+        {
+            Contract.Requires(block != null);// F: Added as of Clousot suggestion
+
+            if (block.Subroutine.IsCatchFilterHeader(block))
+            {
+                // starts an exception handler, thus the exception is on the stack
+                return new StackInfo(1, 2);
+            }
+            return new StackInfo(0, 4);
+        }
+
+        private const string StackDepthKey = "stackDepthKey";
+        private const string StackTypesKey = "stackTypesKey";
+
+        private APCMap<int> stackDepthMirrorForEndOld;
+
+        private ILPrinter<APC> printer;
+
+        /// <summary>
+        /// Avoid specialization during stack computation itself.
+        /// </summary>
+        private bool recursionGuard = false;
+
+        private APCMap<int> ComputeStackDepth(Subroutine subroutine)
+        {
+            Contract.Requires(subroutine != null);
+
+            Contract.Assume(subroutine.Blocks != null, "should be a postcondition");
+            Contract.Assert(subroutine.BlockCount >= 0);
+
+            ArrayMap<StackInfo> startDepth = new ArrayMap<StackInfo>(subroutine.BlockCount);
+            // subroutine specific map
+            APCMap<int> stackDepth = stackDepthMirrorForEndOld = new APCMap<int>(subroutine);
+
+            StackInfo currentDepth;
+
+            foreach (CFGBlock block in subroutine.Blocks)
+            {
+                if (!startDepth.TryGetValue(block.Index, out currentDepth))
+                {
+                    currentDepth = ComputeBlockStartDepth(block);
+                }
+                foreach (APC lab in block.APCs())
+                {
+                    if (debugStack)
+                    {
+                        Console.WriteLine("Depth before {0}", currentDepth);
+                        printer(lab, "  ", Console.Out);
+                    }
+                    stackDepth.Add(lab, currentDepth.Depth); // If you get an exception here, it means the underlying labels are not unique in a method.
+                    currentDepth = ilDecoder.ForwardDecode<StackInfo, StackInfo, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>>(lab, this, currentDepth);
+                    if (debugStack)
+                    {
+                        Console.WriteLine("Stack depth after {0}", currentDepth);
+                    }
+                }
+                // also record last apc (past last instruction in block), unless present
+                if (!stackDepth.ContainsKey(block.Last))
+                {
+                    stackDepth.Add(block.Last, currentDepth.Depth);
+                }
+
+                foreach (CFGBlock succ in subroutine.SuccessorBlocks(block))
+                {
+                    // consider stack depth changes done by subroutines
+                    bool isExn;
+                    bool savedRecursionGuard = recursionGuard;
+                    recursionGuard = true;
+                    try
+                    {
+                        foreach (var sub in subroutine.EdgeSubroutinesOuterToInner(block, succ, out isExn, null).GetEnumerable())
+                        {
+                            currentDepth.Adjust(sub.Two.StackDelta);
+                        }
+                    }
+                    finally
+                    {
+                        recursionGuard = savedRecursionGuard;
+                    }
+                    AddStartDepth(startDepth, succ, currentDepth);
+                }
+            }
+            return stackDepth;
+        }
+
+        private static void AddStartDepth(ArrayMap<StackInfo> dict, CFGBlock block, StackInfo startDepth)
+        {
+            Contract.Requires(block != null);// F: Added as of Clousot suggestion
+            Contract.Requires(dict != null);// F: Added as of Clousot suggestion
+
+            Contract.Assert(block.Index >= 0, "assuming the invariant");
+
+            StackInfo oldDepth;
+            if (dict.TryGetValue(block.Index, out oldDepth))
+            {
+                Contract.Assume(oldDepth.Depth == startDepth.Depth);
             }
             else
             {
-              return this.Binary(pc, BinaryOperator.Cobjeq, dest, args[0], args[1], data);
+                Contract.Assume(!dict.ContainsKey(block.Index), "assuming the behavior of Dictionary");
+                dict.Add(block.Index, startDepth.Copy());
             }
-          }
-        }
-        #endregion
-        #region Identity functions
-        if ((mdDecoder.Equal(declaringType, mdDecoder.System_UIntPtr)
-          || mdDecoder.Equal(declaringType, mdDecoder.System_IntPtr))
-          && methodName.StartsWith("op_Explicit"))
-        {
-          Contract.Assert(0 <= args.Count);
-          return this.Ldstack(pc, 0, dest, args[0], false, data);
-        }
-        // VB's funny copy method that copies boxed objects to avoid aliasing by accident
-        if (methodName == "GetObjectValue" && mdDecoder.Name(declaringType) == "RuntimeHelpers")
-        {
-          return this.Ldstack(pc, 0, dest, args[0], false, data);
-        }
-        #endregion
-        return delegatee.Call(pc, method, tail, virt, extraVarargs, Push(pc, numArgs, parent.mdDecoder.ReturnType(method)), PopSequence(pc, numArgs, 0), Convert(data));
-      }
-
-      public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Unit dest, Unit fp, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Unit>
-      {
-        int numArgs = argTypes.Count + (isInstance ? 1 : 0);
-        return delegatee.Calli(pc, returnType, argTypes, tail, isInstance, Push(pc, numArgs + 1, returnType), Pop(pc, 0), PopSequence(pc, numArgs, 1), Convert(data));
-
-      }
-
-      public Result Ckfinite(APC pc, Unit dest, Unit source, Data data)
-      {
-        return delegatee.Ckfinite(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Cpblk(APC pc, bool @volatile, Unit destaddr, Unit srcaddr, Unit len, Data data)
-      {
-        return delegatee.Cpblk(pc, @volatile, Pop(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Endfilter(APC pc, Unit decision, Data data)
-      {
-        return delegatee.Endfilter(pc, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Endfinally(APC pc, Data data)
-      {
-        return delegatee.Endfinally(pc, Convert(data));
-      }
-
-      public Result Entry(APC pc, Method method, Data data)
-      {
-        return delegatee.Entry(pc, method, Convert(data));
-      }
-
-      public Result Initblk(APC pc, bool @volatile, Unit destaddr, Unit value, Unit len, Data data)
-      {
-        return delegatee.Initblk(pc, @volatile, Pop(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Jmp(APC pc, Method method, Data data)
-      {
-        return delegatee.Jmp(pc, method, Convert(data));
-      }
-
-      /// <summary>
-      /// This case is complicated by the fact that when requires/ensures/invariant/subroutines
-      /// are called around method calls, the argument loading must be translated into loads from
-      /// the evaluation stack.
-      /// Further complications arise due to constructors, where the constructor method pretends that 
-      /// "this" is the first argument, but for the caller, it is actually the result of the call.
-      /// Finally, more complications arise due to inheritance of pre/post conditions in that the 
-      /// argument identity is not identical to the argument of the method where the subroutine is called.
-      /// We thus need to remap.
-      ///
-      /// We have to distinguish 6 cases:
-      ///
-      /// 0) InsideRequiresAroundConstructorCall
-      ///    - rewire to proper offset on evaluation stack, taking into account that "this" is
-      ///      not on the caller stack
-      ///
-      /// 1) InsideRequiresAroundCall
-      ///     - rewire to proper offset on evaluation stack
-      ///
-      /// 2) InsideEnsuresOrInvariantAfterConstructorCall
-      ///     - access to "this" is ldresult
-      ///     - other parameter accesses are offset by 1 onto the stack because there is no
-      ///       this parameter.
-      ///
-      /// 3) InsideEnsuresOrInvariantAfterCall
-      ///     - find proper offset on the evaluation stack
-      ///
-      /// 4) Inside Contract subroutine at method boundaries, but requires.Method and calling Method differ
-      ///     - map to proper argument and delegate to ldarg
-      ///
-      /// 5) Normal ldarg otherwise
-      /// </summary>
-      public Result Ldarg(APC pc, Parameter argument, bool ignoredIsOld, Unit dest, Data data)
-      {
-        bool isLdResult;
-        int ldStackOffset;
-        bool isOld;
-        APC lookupPC;
-
-        Parameter oldArgument = argument;
-
-        if (RemapParameterToLdStack(pc, ref argument, out isLdResult, out ldStackOffset, out isOld, out lookupPC))
-        {
-          // ldstack
-          return delegatee.Ldstack(pc, ldStackOffset, Push(pc, 0), Pop(lookupPC, ldStackOffset), isOld, data);
         }
 
-        // F: TODOTODO Awfull fix!!!! But I do not really understand the code, I should talk with MAF about it
-        if (argument == null)
+        /// <summary>
+        /// Specialized map for APCs without finally contexts
+        /// </summary>
+        private class APCMap<T>
         {
-          argument = oldArgument;
-        }
-        // F: End
-
-        if (isLdResult)
-        {
-          // ldresult
-          // special case: if the parameter is typed address of struct, then we must be
-          // referring to the post state of a struct constructor. In this case, map it to ldstacka
-          if (this.parent.mdDecoder.IsStruct(this.parent.mdDecoder.DeclaringType(this.parent.mdDecoder.DeclaringMethod(argument))))
-          {
-            return delegatee.Ldstacka(pc, ldStackOffset, Push(pc, 0), Pop(pc, ldStackOffset), this.parent.mdDecoder.ParameterType(argument), isOld, data);
-          }
-          return delegatee.Ldresult(pc, this.parent.mdDecoder.ParameterType(argument), Push(pc, 0), Pop(pc, ldStackOffset), data);
-        }
-        return delegatee.Ldarg(pc, argument, isOld, Push(pc, 0), Convert(data));
-      }
-
-      /// <summary>
-      /// Remaps a parameter referenced in a subroutine to the parameter used in the calling context
-      /// This is needed e.g. when inheriting requires/ensures/invariant subroutines, as the parameter
-      /// identities are different in each override.
-      /// </summary>
-      /// <param name="p">Parameter as appearing in the subroutine</param>
-      /// <param name="parentMethodBlock">block in the method calling the subroutine</param>
-      /// <param name="subroutineBlock">block in the subroutine</param>
-      /// <returns>The equivalent parameter in the calling method's context</returns>
-      Parameter RemapParameter(Parameter p, CFGBlock parentMethodBlock, CFGBlock subroutineBlock)
-      {
-        Contract.Requires(subroutineBlock != null);// F: added because of Clousot suggestion
-        Contract.Requires(parentMethodBlock != null);// F: added because of Clousot suggestion
-
-        Contract.Assume(this.parent.mdDecoder != null, "Assumption from the base class object invariant");
-
-
-        IMethodInfo<Method> parentMethodInfo = (IMethodInfo<Method>)parentMethodBlock.Subroutine;
-        IMethodInfo<Method> subroutineMethodInfo = (IMethodInfo<Method>)subroutineBlock.Subroutine;
-
-        if (this.parent.mdDecoder.Equal(parentMethodInfo.Method, subroutineMethodInfo.Method))
-        {
-          return p;
-        }
-
-        int argIndex = this.parent.mdDecoder.ArgumentIndex(p);
-
-        if (this.parent.mdDecoder.IsStatic(parentMethodInfo.Method))
-        {
-          return this.parent.mdDecoder.Parameters(parentMethodInfo.Method).AssumeNotNull()[argIndex];
-        }
-        else
-        {
-          if (argIndex == 0)
-          {
-            // refers to "this"
-            return this.parent.mdDecoder.This(parentMethodInfo.Method);
-          }
-          Contract.Assume(argIndex -1 >= 0);
-          return this.parent.mdDecoder.Parameters(parentMethodInfo.Method).AssumeNotNull()[argIndex - 1];
-        }
-      }
-
-      /// <summary>
-      /// Implementes the logic outlined in Ldarg by mapping a parameter x APC context into one of
-      /// three cases:
-      ///   - ldresult         (indicated by setting isLdResult true and setting ldStackOffset)
-      ///   - ldstack offset   (indicated by returning true, and setting ldStackOffset)
-      ///   - ldarg P'         (otherwise, where the parameter ref contains p' on exit)
-      /// </summary>
-      /// <param name="isOld">set to true if the resulting instruction should execute in the pre-state of the
-      /// method.</param>
-      /// <param name="lookupPC">Set to the pc at which we need to consider the ldStackOffset. Valid on true return.</param>
-      /// <returns>true if the parameter access maps to ldresult</returns>
-      bool RemapParameterToLdStack(APC pc, ref Parameter p, out bool isLdResult, out int ldStackOffset, out bool isOld, out APC lookupPC)
-      {
-        if (pc.SubroutineContext != null)
-        {
-          #region Requires
-          if (pc.Block.Subroutine.IsRequires)
-          {
-            // find whether calling context is entry, newObj, or call. In the first case, also remap 
-            // the parameter if necessary
-
-            isLdResult = false;
-            isOld = false;
-            lookupPC = pc;
-
-            for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+            [ContractInvariantMethod]
+            private void ObjectInvariant()
             {
-              var callTag = scontext.Head.Three;
-              Contract.Assume(callTag != null);
-              if (callTag == "entry")
-              {
-                // keep as ldarg, but figure out whether we need to remap
-                Contract.Assume(scontext.Head.One != null);
-                p = RemapParameter(p, scontext.Head.One, pc.Block);
-                ldStackOffset = 0;
-                return false;
-              }
-              if (callTag.StartsWith("before")) // beforeCall | beforeNewObj
-              {
-                int localStackDepth = this.parent.LocalStackDepth(pc);
-                ldStackOffset = this.parent.mdDecoder.ArgumentStackIndex(p) + localStackDepth;
-                return true;
-              }
+                Contract.Invariant(blockMap != null);// F: Added as of Clousot suggestions as precondition in many places
+                Contract.Invariant(callOnThisMap != null);// F: Added as of Clousot suggestions as precondition in many places
+                Contract.Invariant(callArgumentDelegateTargets != null);
             }
-            throw new NotImplementedException();
-          }
-          #endregion
-          #region Ensures
-          else if (pc.Block.Subroutine.IsEnsuresOrOld)
-          {
-            // find whether calling context is exit, newObj, or call. In the first case, also remap 
-            // the parameter if necessary
-            isOld = true;
 
-            for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+
+            private ArrayMap<T>[] blockMap;
+            private IFunctionalIntMap<bool> callOnThisMap; //indexed by block index, returns true if that call block is on this
+            private DoubleFunctionalMap<int, int, Method> callArgumentDelegateTargets; // indexed by block index, then local stack offset
+
+            public APCMap(Subroutine parent)
             {
-              string callTag = scontext.Head.Three;
+                Contract.Requires(parent != null);
 
-              if (callTag == "exit")
-              {
-                // keep as ldarg, but figure out whether we need to remap
-                Contract.Assume(scontext.Head.One != null);
-                p = RemapParameter(p, scontext.Head.One, pc.Block);
-                isLdResult = false;
-                ldStackOffset = 0;
-                lookupPC = pc; // irrelevant
-                return false;
-              }
-              if (callTag == "afterCall")
-              {
-                // we need to compute the offset to the "parameter" on the stack. For this we must
-                // know what method is being called.
-                ldStackOffset = this.parent.mdDecoder.ArgumentStackIndex(p);
+                blockMap = new ArrayMap<T>[parent.BlockCount];
+                callOnThisMap = FunctionalIntMap<bool>.EmptyMap;
+                callArgumentDelegateTargets = DoubleFunctionalMap<int, int, Method>.Empty(i => i);
+            }
 
-                // no need to correct for local stack depth, as we lookup the stack in the old-state
-                isLdResult = false;
-                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                return true;
-              }
-              if (callTag == "afterNewObj")
-              {
-                // here we have to deal with the special case of referencing argument 0, which is the result
-                // of the construction. In that case we have to return "ldresult"
-                int parameterIndex = this.parent.mdDecoder.ArgumentIndex(p);
-                if (parameterIndex == 0)
+            public void Add(APC pc, T value)
+            {
+                Contract.Assume(pc.Block != null, "Assuming the object invariant");
+                Contract.Assume(pc.Index >= 0, "Assuming the object invariant");
+                ArrayMap<T> indexMap = blockMap[pc.Block.Index];
+                if (indexMap == null)
                 {
-                  ldStackOffset = this.parent.LocalStackDepth(pc);
-                  isLdResult = true;
-                  lookupPC = pc; // irrelevant
-                  isOld = false;
-                  return false;
+                    indexMap = new ArrayMap<T>(pc.Block.Count + 1); // including one past last
+                    Contract.Assert(pc.Block.Index < blockMap.Length);
+                    blockMap[pc.Block.Index] = indexMap;
                 }
-
-                // we need to compute the offset to the "parameter" on the stack. For this we must
-                // know what method is being called.
-                ldStackOffset = this.parent.mdDecoder.ArgumentStackIndex(p);
-
-                // no need to correct for local stack depth, as we lookup the stack in the old-state
-                isLdResult = false;
-                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                return true;
-              }
-
-              if (callTag == "oldmanifest")
-              {
-                // used to manifest the old values on entry to a method
-                // keep as ldarg, but figure out whether we need to remap
-                Contract.Assume(scontext.Tail.Head.One != null);
-
-                p = RemapParameter(p, scontext.Tail.Head.One, pc.Block);
-                isOld = false;
-                isLdResult = false;
-                ldStackOffset = 0;
-                lookupPC = pc; // irrelevant
-                return false;
-              }
-
-              if (callTag == "afterCallAssume")
-              {
-                // nothing to do as it won't refer to callee parameters
-                isOld = false;
-                isLdResult = false;
-                ldStackOffset = 0;
-                lookupPC = pc;
-                return false;
-              }
+                Contract.Assume(pc.Index < indexMap.Count);
+                Contract.Assume(!indexMap.ContainsKey(pc.Index));
+                indexMap.Add(pc.Index, value);
             }
-            throw new NotImplementedException();
-          }
-          #endregion
-          #region Invariant
-          else if (pc.Block.Subroutine.IsInvariant)
-          {
-            for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
-            {
-              string callTag = scontext.Head.Three;
-              Contract.Assume(this.parent.mdDecoder != null);
-              // must be "this"
-              Contract.Assume(this.parent.mdDecoder.ArgumentIndex(p) == 0);
 
-              if (callTag == "entry" || callTag == "exit")
-              {
-                // keep as ldarg, but remap to this of containing method
-                Method containingMethod;
-                if (pc.TryGetContainingMethod(out containingMethod))
+            public void RecordCallOnThis(APC pc)
+            {
+                Contract.Requires(pc.Block != null);  // F: As of Clousot suggestion
+                callOnThisMap = callOnThisMap.Add(pc.Block.Index, true);
+            }
+
+            public void RecordCallArgument(APC pc, int stackoffset, Method target)
+            {
+                Contract.Assume(pc.Block != null);
+                callArgumentDelegateTargets = callArgumentDelegateTargets.Add(pc.Block.Index, stackoffset, target);
+            }
+
+            public T this[APC key]
+            {
+                get
                 {
-                  p = this.parent.mdDecoder.This(containingMethod);
-                  isLdResult = false;
-                  ldStackOffset = 0;
-                  isOld = (callTag == "exit");
-                  lookupPC = pc; // irrelevant
-                  return false;
+                    T result;
+                    if (!TryGetValue(key, out result))
+                    {
+                        throw new NotSupportedException("key not in table");
+                    }
+                    return result;
+                }
+            }
+
+            public bool IsCallOnThis(APC key)
+            {
+                Contract.Assume(key.Block != null);
+                return callOnThisMap[key.Block.Index];
+            }
+
+            public bool TryGetArgumentDelegateTarget(APC key, int stackOffset, out Method method)
+            {
+                Contract.Assume(key.Block != null);
+                method = callArgumentDelegateTargets[key.Block.Index, stackOffset];
+                return callArgumentDelegateTargets.Contains(key.Block.Index, stackOffset);
+            }
+
+            public bool TryGetValue(APC pc, out T value)
+            {
+                Contract.Assume(pc.Block != null);
+                ArrayMap<T> indexMap = blockMap[pc.Block.Index];
+                if (indexMap == null)
+                {
+                    value = default(T);
+                    return false;
+                }
+                Contract.Assume(pc.Index < indexMap.Count);
+                return indexMap.TryGetValue(pc.Index, out value);
+            }
+
+            public bool ContainsKey(APC pc)
+            {
+                Contract.Assume(pc.Block != null, "Assuming object invariant");
+                ArrayMap<T> indexMap = blockMap[pc.Block.Index];
+                if (indexMap == null)
+                {
+                    return false;
+                }
+                Contract.Assume(pc.Index < indexMap.Count);
+                return indexMap.ContainsKey(pc.Index);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Computes the stack depth for the given method CFG main blocks. Subroutine stack depth is computed on demand.
+        /// </summary>
+        public StackDepthProvider(IDecodeMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, ContextData, Unit> ilDecoder,
+                                  IDecodeMetaData<Local, Parameter, Method, Field, Property, Event, Type, Attribute, Assembly> mdDecoder)
+        {
+            Contract.Requires(mdDecoder != null); // F: As of Clousot suggestion
+            Contract.Requires(ilDecoder != null);// F: As of Clousot suggestion
+
+            this.ilDecoder = ilDecoder;
+            this.mdDecoder = mdDecoder;
+            // The stack depth is computed on demand
+        }
+
+        private bool DebugStack
+        {
+            get { return debugStack; }
+            set
+            {
+                debugStack = value;
+                if (value)
+                {
+                    printer = PrinterFactory.Create(ilDecoder, mdDecoder, delegate (Unit i) { return ""; }, delegate (Unit i) { return ""; });
                 }
                 else
                 {
-                  Contract.Assume(false, "Not in a method context");
-                  // dont'r remap
-                  isLdResult = false;
-                  ldStackOffset = 0;
-                  isOld = false;
-                  lookupPC = pc;
-                  return false;
+                    printer = null;
                 }
-              }
-              if (callTag == "afterCall")
-              {
-                // we need to compute the offset to the "this" receiver on the stack. For this we must
-                // know what method is being called.
+            }
+        }
 
-                Method calledMethod;
-                bool isNewObj;
-                bool isVirtualCall;
-                bool success = scontext.Head.One.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall);
-                Contract.Assume(success); // must be a method call blcok
-                int parameterCount = this.parent.mdDecoder.Parameters(calledMethod).AssumeNotNull().Count;
+        #region IVisitMSIL<APC,Variable,Constant,Method,Field,Type,Unit,Unit,int,int> Members
 
-                ldStackOffset = parameterCount; // 0 is top, 1 is 1 step below top of stack, etc...
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Assert(APC pc, string tag, Unit condition, object provenance, StackInfo data)
+        {
+            return data.Pop(1);
+        }
 
-                // no need to correct for local stack depth, as we lookup the stack in the old-state
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Assume(APC pc, string tag, Unit source, object provenance, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Arglist(APC pc, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Binary(APC pc, BinaryOperator op, Unit dest, Unit s1, Unit s2, StackInfo data)
+        {
+            return data.Pop(2).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.BranchCond(APC pc, APC target, BranchOperator bop, Unit value1, Unit value2, StackInfo data)
+        {
+            return data.Pop(2);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.BranchTrue(APC pc, APC target, Unit cond, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.BranchFalse(APC pc, APC target, Unit cond, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Branch(APC pc, APC target, bool leave, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Break(APC pc, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, StackInfo data)
+        //where TypeList : IIndexable<Type>
+        //where ArgList : IIndexable<Unit>
+        {
+            int pops = mdDecoder.Parameters(method).AssumeNotNull().Count + (extraVarargs == null ? 0 : extraVarargs.Count);
+            if (!mdDecoder.IsStatic(method))
+            {
+                // receiver
+                // record call on this
+                if (data.IsThis(pops))
+                {
+                    // call on this
+                    stackDepthMirrorForEndOld.RecordCallOnThis(pc);
+                }
+                pops++;
+            }
+            else
+            {
+                for (int i = 0; i < pops; i++)
+                {
+                    // see if we are passing any method delegates with known targets
+                    Method m;
+                    if (data.TryGetTarget(i, out m))
+                    {
+                        stackDepthMirrorForEndOld.RecordCallArgument(pc, data.Depth - i - 1, m);
+                    }
+                }
+            }
+            data = data.Pop(pops);
+            if (mdDecoder.IsVoid(mdDecoder.ReturnType(method)))
+            {
+                return data;
+            }
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Unit dest, Unit fp, ArgList args, StackInfo data)
+        //where TypeList : IIndexable<Type>
+        //where ArgList : IIndexable<Unit>
+        {
+            int pops = 1; // function pointer
+            if (isInstance) pops++; // instance this (not represented in type list)
+            pops += argTypes == null ? 0 : argTypes.Count;
+            data = data.Pop(pops);
+            if (mdDecoder.IsVoid(returnType))
+            {
+                return data;
+            }
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ckfinite(APC pc, Unit dest, Unit source, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Cpblk(APC pc, bool @volatile, Unit dest, Unit src, Unit len, StackInfo data)
+        {
+            return data.Pop(3);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Endfilter(APC pc, Unit source, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Endfinally(APC pc, StackInfo data)
+        {
+            return new StackInfo(0, 0);
+        }
+
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Entry(APC pc, Method method, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Initblk(APC pc, bool @volatile, Unit destaddr, Unit value, Unit size, StackInfo data)
+        {
+            return data.Pop(3);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Jmp(APC pc, Method method, StackInfo data)
+        {
+            return new StackInfo(0, 0);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldarg(APC pc, Parameter argument, bool isOld, Unit dest, StackInfo data)
+        {
+            if (!mdDecoder.IsStatic(mdDecoder.DeclaringMethod(argument)))
+            {
+                if (mdDecoder.ArgumentIndex(argument) == 0)
+                {
+                    // this
+                    return data.PushThis();
+                }
+            }
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldarga(APC pc, Parameter argument, bool isOld, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Ldconst(APC pc, Object constant, Type type, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Ldnull(APC pc, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldftn(APC pc, Method method, Unit dest, StackInfo data)
+        {
+            return data.Push(method);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldind(APC pc, Type type, bool @volatile, Unit dest, Unit ptr, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldloc(APC pc, Local local, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldloca(APC pc, Local local, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Ldstack(APC pc, int offset, Unit dest, Unit source, bool old, StackInfo data)
+        {
+            return data.Push(data[offset]);
+        }
+
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Ldstacka(APC pc, int offset, Unit dest, Unit source, Type type, bool old, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Localloc(APC pc, Unit dest, Unit size, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Nop(APC pc, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Pop(APC pc, Unit source, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Return(APC pc, Unit source, StackInfo data)
+        {
+            // we leave the return value on the stack here, as we consume it in the Exit block
+            // or leave it on the stack if inlining is used
+            int expectedExitStackDepth = pc.Block.Subroutine.StackDelta;
+
+            if (pc.Block.Subroutine.HasReturnValue)
+            {
+                expectedExitStackDepth++;
+            }
+            Contract.Assume(data.Depth == expectedExitStackDepth); // F: made an assume
+            return data; // leave stack
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Starg(APC pc, Parameter argument, Unit source, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stind(APC pc, Type type, bool @volatile, Unit ptr, Unit value, StackInfo data)
+        {
+            return data.Pop(2);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stloc(APC pc, Local local, Unit source, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, Unit value, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Unit dest, Unit source, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Box(APC pc, Type type, Unit dest, Unit source, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Unit dest, ArgList args, StackInfo data)
+        //where TypeList : IIndexable<Type>
+        //where ArgList : IIndexable<Unit>
+        {
+            int pops = mdDecoder.Parameters(method).AssumeNotNull().Count + (extraVarargs == null ? 0 : extraVarargs.Count);
+            if (!mdDecoder.IsStatic(method))
+            {
+                // receiver
+
+                // record call on this
+                if (data.IsThis(pops))
+                {
+                    stackDepthMirrorForEndOld.RecordCallOnThis(pc);
+                }
+                pops++;
+            }
+            data = data.Pop(pops);
+            if (mdDecoder.IsVoid(mdDecoder.ReturnType(method)))
+            {
+                return data;
+            }
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Castclass(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Cpobj(APC pc, Type type, Unit destptr, Unit srcptr, StackInfo data)
+        {
+            return data.Pop(2);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Initobj(APC pc, Type type, Unit ptr, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Isinst(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldelem(APC pc, Type type, Unit dest, Unit array, Unit index, StackInfo data)
+        {
+            return data.Pop(2).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldelema(APC pc, Type type, bool @readonly, Unit dest, Unit array, Unit index, StackInfo data)
+        {
+            return data.Pop(2).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldfld(APC pc, Field field, bool @volatile, Unit dest, Unit obj, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldflda(APC pc, Field field, Unit dest, Unit obj, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldlen(APC pc, Unit dest, Unit array, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldsfld(APC pc, Field field, bool @volatile, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldsflda(APC pc, Field field, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldtypetoken(APC pc, Type type, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldfieldtoken(APC pc, Field field, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldmethodtoken(APC pc, Method method, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Ldvirtftn(APC pc, Method method, Unit dest, Unit obj, StackInfo data)
+        {
+            return data.Pop(1).Push(method);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Mkrefany(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
+        {
+            return data;
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Newarray<ArgList>(APC pc, Type type, Unit dest, ArgList lengths, StackInfo data)
+        //where ArgList : IIndexable<Unit>
+        {
+            return data.Pop(lengths.Count).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Newobj<ArgList>(APC pc, Method ctor, Unit dest, ArgList args, StackInfo data)
+        //where ArgList : IIndexable<Unit>
+        {
+            int pops = mdDecoder.Parameters(ctor).AssumeNotNull().Count;
+            if (pops == 2 && mdDecoder.IsDelegate(mdDecoder.DeclaringType(ctor)))
+            {
+                var mtoken = data.As<Method>(0); // last thing pushed was fn pointer
+                return data.Pop(2).Push(mtoken);
+            }
+            else
+            {
+                return data.Pop(pops).Push();
+            }
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Refanytype(APC pc, Unit dest, Unit source, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Refanyval(APC pc, Type type, Unit dest, Unit source, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Rethrow(APC pc, StackInfo data)
+        {
+            return new StackInfo(0, 0);
+        }
+
+        StackInfo IVisitExprIL<APC, Type, Unit, Unit, StackInfo, StackInfo>.Sizeof(APC pc, Type type, Unit dest, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stelem(APC pc, Type type, Unit array, Unit index, Unit value, StackInfo data)
+        {
+            return data.Pop(3);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stfld(APC pc, Field field, bool @volatile, Unit obj, Unit value, StackInfo data)
+        {
+            return data.Pop(2);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Stsfld(APC pc, Field field, bool @volatile, Unit value, StackInfo data)
+        {
+            return data.Pop(1);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Throw(APC pc, Unit exn, StackInfo data)
+        {
+            return new StackInfo(0, 0);
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Unbox(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        StackInfo IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, StackInfo, StackInfo>.Unboxany(APC pc, Type type, Unit dest, Unit obj, StackInfo data)
+        {
+            return data.Pop(1).Push();
+        }
+
+        #region IVisitSynthIL<APC,Method,Unit,Unit,int,int> Members
+
+        private int OldStartDepth(Subroutine subroutine)
+        {
+            Contract.Requires(subroutine != null);// F: Added as of Clousot suggestion
+
+            // must be an ensures which implements IMethodInfo
+            IMethodInfo<Method> mi = (IMethodInfo<Method>)subroutine;
+
+            int offset = mdDecoder.Parameters(mi.Method).AssumeNotNull().Count;
+            if (!mdDecoder.IsConstructor(mi.Method) && !mdDecoder.IsStatic(mi.Method)) offset++;
+            //if (!this.mdDecoder.IsVoidMethod(mi.Method)) offset--;
+            return offset;
+        }
+
+        /// <summary>
+        /// Here we have to switch to the stack depth present at call-site to the method of which we are analyzing
+        /// the post condition. During evaluation, the APC context will however be the exiting edge from the call-site,
+        /// thus the context stack depth will not contain the argument count, only the result count (0 or 1) depending on the 
+        /// Voidness of the method result.
+        /// In order to obtain the correct stack depth, we thus start the local stack depth with #args - (IsVoidMethod?0:1), so
+        /// that the proper offsets on the evaluation stack are going to be used without trashing the stack contents present
+        /// at the call site.
+        /// For the application of this ensures within its own method, the stack is initially empty, as the arguments are accessed
+        /// with ldarg, not with ldstack. Thus, having an offset other than starting at 0 is okay, except that we get into the corner
+        /// case of having to use stack offset -1, which can happen for a static method without arguments but a return value.
+        /// </summary>
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.BeginOld(APC pc, APC matchingEnd, StackInfo data)
+        {
+            return data; // we don't adjust the stack here.
+                         //int offset = OldStartDepth(pc.Block.Subroutine);
+                         //return new StackInfo(offset, 4);
+        }
+
+        /// <summary>
+        /// Continue with stack depth at matching begin + 1 for the old value.
+        ///
+        /// NOTE: the stack depth associated with pc is the stack depth at the end of the old expression, not the new
+        /// stack depth.
+        /// </summary>
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.EndOld(APC pc, APC matchingBegin, Type type, Unit dest, Unit source, StackInfo data)
+        {
+            // this is a pop and a push, so even.
+            return data.Pop(1).Push();
+            //int previousDepth = this.stackDepthMirrorForEndOld[matchingBegin];
+            //return new StackInfo(previousDepth + 1, 4);
+        }
+
+        StackInfo IVisitSynthIL<APC, Method, Type, Unit, Unit, StackInfo, StackInfo>.Ldresult(APC pc, Type type, Unit dest, Unit source, StackInfo data)
+        {
+            return data.Push();
+        }
+
+        #endregion
+
+        #endregion
+
+
+
+        #region IMSILDecoder<Label,Local,Parameter,Method,Field,Type,int,int> Members
+
+        private APCMap<int> GetStackDepthMap(Subroutine subroutine)
+        {
+            Contract.Requires(subroutine != null);
+            APCMap<int> localStackDepth;
+            if (!subroutine.TryGetValue(new TypedKey<APCMap<int>>(StackDepthKey), out localStackDepth))
+            {
+                try
+                {
+                    localStackDepth = ComputeStackDepth(subroutine);
+                }
+                catch (Exception)
+                {
+#if DEBUG
+                    Console.WriteLine("Probably bad code in subroutine: {0} ({1})", subroutine.Name, subroutine.Kind);
+                    Console.WriteLine("running stack analysis again with debug");
+                    System.Diagnostics.Debugger.Launch();
+                    this.DebugStack = true;
+                    this.ComputeStackDepth(subroutine);
+#endif
+                    throw;
+                }
+                // store the stack depth map it in the subroutine properties
+                subroutine.Add(new TypedKey<APCMap<int>>(StackDepthKey), localStackDepth);
+            }
+            return localStackDepth;
+        }
+
+        private APCMap<int> localStackDepthCache;
+        private int cachedSubroutine;
+        private bool debugStack;
+
+        private APCMap<int> LocalStackMap(Subroutine subroutine)
+        {
+            Contract.Requires(subroutine != null);
+            Contract.Ensures(Contract.Result<APCMap<int>>() != null);
+
+            if (localStackDepthCache == null || cachedSubroutine != subroutine.Id)
+            {
+                APCMap<int> localStackDepth = GetStackDepthMap(subroutine);
+                localStackDepthCache = localStackDepth;
+                cachedSubroutine = subroutine.Id;
+            }
+
+            Contract.Assume(localStackDepthCache != null);
+            return localStackDepthCache;
+        }
+
+        public int LocalStackDepth(APC apc)
+        {
+            Contract.Assume(apc.Block != null);
+            APCMap<int> localStackDepth = LocalStackMap(apc.Block.Subroutine);
+            return localStackDepth[apc];
+        }
+
+        /// <summary>
+        /// Compute the stack depth at the given apc
+        /// </summary>
+        private int Lookup(APC apc)
+        {
+            int localDepth = LocalStackDepth(apc);
+            if (apc.SubroutineContext == null || !apc.Block.Subroutine.HasContextDependentStackDepth)
+            {
+                return localDepth;
+            }
+            CFGBlock contextBlock = apc.SubroutineContext.Head.One;
+            return localDepth + Lookup(APC.ForEnd(contextBlock, apc.SubroutineContext.Tail));
+        }
+
+        private struct StackDecoder<Data, Result, Visitor> :
+          IVisitMSIL<APC, Local, Parameter, Method, Field, Type, Unit, Unit, Data, Result>
+          where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, Data, Result>
+        {
+            #region invariants
+
+            [ContractInvariantMethod]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+            private void ObjectInvariant()
+            {
+                Contract.Invariant(parent != null);
+            }
+
+
+            #endregion
+
+            #region Privates
+            private Visitor delegatee;
+
+            [Pure]
+            private Data Convert(Data data)
+            {
+                return data;
+            }
+
+            private StackDepthProvider<Local, Parameter, Method, Field, Property, Event, Type, ContextData, Attribute, Assembly> parent;
+
+            #endregion
+
+            public StackDecoder(StackDepthProvider<Local, Parameter, Method, Field, Property, Event, Type, ContextData, Attribute, Assembly> parent,
+                                Visitor delegatee)
+            {
+                Contract.Requires(parent != null); // F: added because of Clousot suggestion
+                this.delegatee = delegatee;
+                this.parent = parent;
+            }
+
+            private int Pop(APC l, int offset)
+            {
+                Contract.Ensures(parent != null);
+
+                Contract.Assume(l.Block != null);
+
+                int top = parent.Lookup(l) - 1;
+                int result = top - offset;
+                Contract.Assume(l.Block.Subroutine.HasContextDependentStackDepth || result >= 0);
+                return result;
+            }
+
+            private int Push(APC l, int args, Type type)
+            {
+                Contract.Assume(parent.mdDecoder != null, "Assumption form the base class object invariant");
+                if (parent.mdDecoder.IsVoid(type))
+                {
+                    return -1;
+                }
+                return Push(l, args);
+            }
+
+            private int Push(APC l, int args)
+            {
+                Contract.Assume(l.Block != null);
+                int top = parent.Lookup(l);
+                int result = top - args;
+                Contract.Assume(l.Block.Subroutine.HasContextDependentStackDepth || result >= 0);
+                return result;
+            }
+
+            private int ComputeArgs(Method m, int extraVarargs)
+            {
+                Contract.Assume(parent.mdDecoder != null, "Assumption form the base class object invariant");
+
+                int count = extraVarargs;
+                IIndexable<Parameter> pars = parent.mdDecoder.Parameters(m).AssumeNotNull();
+                count += pars.Count;
+                if (!parent.mdDecoder.IsStatic(m))
+                {
+                    count++;
+                }
+                return count;
+            }
+
+            private struct SequenceGenerator : IIndexable<int>, IEnumerable<int>
+            {
+                private short from, count;
+                // Generates an indexable starting at from, from+1, ..., for count elements
+                public SequenceGenerator(int from, int count)
+                {
+                    this.from = checked((short)from);
+                    this.count = checked((short)count);
+                }
+
+
+                #region IIndexable<int> Members
+
+                int IIndexable<int>.Count
+                {
+                    get { return count; }
+                }
+
+                public int this[int index]
+                {
+                    get { return from + index; }
+                }
+
+                #endregion
+
+                #region IEnumerable<int> Members
+
+                public IEnumerator<int> GetEnumerator()
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        yield return this[i];
+                    }
+                }
+
+                #endregion
+
+                #region IEnumerable Members
+
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+                {
+                    return this.GetEnumerator();
+                }
+
+                #endregion
+            }
+
+            private SequenceGenerator PopSequence(APC l, int args, int offset)
+            {
+                int from = parent.Lookup(l) - args - offset;
+                return new SequenceGenerator(from, args);
+            }
+
+            #region IVisitMSIL<APC,Local,Parameter,Method,Field,Type,Unit,Unit,Pair<Pair<APC,Data>,IVisitMSIL<APC,Local,Parameter,Method,Field,Type,int,int,Data,Result>>,Result> Members
+
+            public Result Assert(APC pc, string tag, Unit condition, object provenance, Data data)
+            {
+                return delegatee.Assert(pc, tag, Pop(pc, 0), provenance, Convert(data));
+            }
+
+            public Result Assume(APC pc, string tag, Unit source, object provenance, Data data)
+            {
+                // Code either contains the conditional branch/switch or the assume, but not both, so this is a pop
+                return delegatee.Assume(pc, tag, Pop(pc, 0), provenance, Convert(data));
+            }
+
+            public Result Arglist(APC pc, Unit dest, Data data)
+            {
+                return delegatee.Arglist(pc, Push(pc, 0), Convert(data));
+            }
+
+            public Result Binary(APC pc, BinaryOperator op, Unit dest, Unit s1, Unit s2, Data data)
+            {
+                return delegatee.Binary(pc, op, Push(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result BranchCond(APC pc, APC target, BranchOperator bop, Unit value1, Unit value2, Data data)
+            {
+                return delegatee.BranchCond(pc, target, bop, Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result BranchTrue(APC pc, APC target, Unit cond, Data data)
+            {
+                return delegatee.BranchTrue(pc, target, Pop(pc, 0), Convert(data));
+            }
+
+            public Result BranchFalse(APC pc, APC target, Unit cond, Data data)
+            {
+                return delegatee.BranchFalse(pc, target, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Branch(APC pc, APC target, bool leave, Data data)
+            {
+                return delegatee.Branch(pc, target, leave, Convert(data));
+            }
+
+            public Result Break(APC pc, Data data)
+            {
+                return delegatee.Break(pc, Convert(data));
+            }
+
+            private enum AssertAssumeKind
+            {
+                Assert, Assume, None
+            }
+
+            public Result Call<TypeList, ArgList>(APC pc, Method method, bool tail, bool virt, TypeList extraVarargs, Unit dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Unit>
+            {
+                var mdDecoder = parent.mdDecoder;
+                var declaringType = mdDecoder.DeclaringType(method);
+                var methodName = mdDecoder.Name(method);
+                int numArgs = ComputeArgs(method, extraVarargs.Count);
+                // special treatment of Assert methods. We treat all methods ending in Assert that have a boolean arg as an assume of that bool
+                if (parent.mdDecoder.IsVoid(parent.mdDecoder.ReturnType(method)))
+                {
+                    var parentTypeName = mdDecoder.FullName(declaringType).AssumeNotNull();
+                    if (parentTypeName.Contains("Contract") || parentTypeName == "System.Diagnostics.Debug")
+                    {
+                        AssertAssumeKind kind = AssertAssumeKind.None;
+                        if (methodName.EndsWith("Assert")) { kind = AssertAssumeKind.Assert; }
+                        else if (methodName.EndsWith("Assume")) { kind = AssertAssumeKind.Assume; }
+                        if (kind != AssertAssumeKind.None)
+                        {
+                            IIndexable<Parameter> pars = mdDecoder.Parameters(method).AssumeNotNull();
+                            for (int i = 0; i < pars.Count; i++)
+                            {
+                                if (mdDecoder.ParameterType(pars[i]).Equals(mdDecoder.System_Boolean))
+                                {
+                                    int condition = Pop(pc, mdDecoder.ArgumentStackIndex(pars[i]));
+                                    if (kind == AssertAssumeKind.Assert)
+                                    {
+                                        return delegatee.Assert(pc, "assert", condition, null, data);
+                                    }
+                                    else
+                                    {
+                                        return delegatee.Assume(pc, "assume", condition, null, data);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                #region explicit == operator overloads
+                if (args.Count > 1 && (mdDecoder.IsReferenceType(declaringType) || mdDecoder.IsNativePointerType(declaringType)))
+                {
+                    if (methodName.EndsWith("op_Inequality"))
+                    {
+                        return this.Binary(pc, BinaryOperator.Cne_Un, dest, args[0], args[1], data);
+                    }
+                    else if (methodName.EndsWith("op_Equality"))
+                    {
+                        if (mdDecoder.IsNativePointerType(declaringType))
+                        {
+                            return this.Binary(pc, BinaryOperator.Ceq, dest, args[0], args[1], data);
+                        }
+                        else
+                        {
+                            return this.Binary(pc, BinaryOperator.Cobjeq, dest, args[0], args[1], data);
+                        }
+                    }
+                }
+                #endregion
+                #region Identity functions
+                if ((mdDecoder.Equal(declaringType, mdDecoder.System_UIntPtr)
+                  || mdDecoder.Equal(declaringType, mdDecoder.System_IntPtr))
+                  && methodName.StartsWith("op_Explicit"))
+                {
+                    Contract.Assert(0 <= args.Count);
+                    return this.Ldstack(pc, 0, dest, args[0], false, data);
+                }
+                // VB's funny copy method that copies boxed objects to avoid aliasing by accident
+                if (methodName == "GetObjectValue" && mdDecoder.Name(declaringType) == "RuntimeHelpers")
+                {
+                    return this.Ldstack(pc, 0, dest, args[0], false, data);
+                }
+                #endregion
+                return delegatee.Call(pc, method, tail, virt, extraVarargs, Push(pc, numArgs, parent.mdDecoder.ReturnType(method)), PopSequence(pc, numArgs, 0), Convert(data));
+            }
+
+            public Result Calli<TypeList, ArgList>(APC pc, Type returnType, TypeList argTypes, bool tail, bool isInstance, Unit dest, Unit fp, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Unit>
+            {
+                int numArgs = argTypes.Count + (isInstance ? 1 : 0);
+                return delegatee.Calli(pc, returnType, argTypes, tail, isInstance, Push(pc, numArgs + 1, returnType), Pop(pc, 0), PopSequence(pc, numArgs, 1), Convert(data));
+            }
+
+            public Result Ckfinite(APC pc, Unit dest, Unit source, Data data)
+            {
+                return delegatee.Ckfinite(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Cpblk(APC pc, bool @volatile, Unit destaddr, Unit srcaddr, Unit len, Data data)
+            {
+                return delegatee.Cpblk(pc, @volatile, Pop(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Endfilter(APC pc, Unit decision, Data data)
+            {
+                return delegatee.Endfilter(pc, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Endfinally(APC pc, Data data)
+            {
+                return delegatee.Endfinally(pc, Convert(data));
+            }
+
+            public Result Entry(APC pc, Method method, Data data)
+            {
+                return delegatee.Entry(pc, method, Convert(data));
+            }
+
+            public Result Initblk(APC pc, bool @volatile, Unit destaddr, Unit value, Unit len, Data data)
+            {
+                return delegatee.Initblk(pc, @volatile, Pop(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Jmp(APC pc, Method method, Data data)
+            {
+                return delegatee.Jmp(pc, method, Convert(data));
+            }
+
+            /// <summary>
+            /// This case is complicated by the fact that when requires/ensures/invariant/subroutines
+            /// are called around method calls, the argument loading must be translated into loads from
+            /// the evaluation stack.
+            /// Further complications arise due to constructors, where the constructor method pretends that 
+            /// "this" is the first argument, but for the caller, it is actually the result of the call.
+            /// Finally, more complications arise due to inheritance of pre/post conditions in that the 
+            /// argument identity is not identical to the argument of the method where the subroutine is called.
+            /// We thus need to remap.
+            ///
+            /// We have to distinguish 6 cases:
+            ///
+            /// 0) InsideRequiresAroundConstructorCall
+            ///    - rewire to proper offset on evaluation stack, taking into account that "this" is
+            ///      not on the caller stack
+            ///
+            /// 1) InsideRequiresAroundCall
+            ///     - rewire to proper offset on evaluation stack
+            ///
+            /// 2) InsideEnsuresOrInvariantAfterConstructorCall
+            ///     - access to "this" is ldresult
+            ///     - other parameter accesses are offset by 1 onto the stack because there is no
+            ///       this parameter.
+            ///
+            /// 3) InsideEnsuresOrInvariantAfterCall
+            ///     - find proper offset on the evaluation stack
+            ///
+            /// 4) Inside Contract subroutine at method boundaries, but requires.Method and calling Method differ
+            ///     - map to proper argument and delegate to ldarg
+            ///
+            /// 5) Normal ldarg otherwise
+            /// </summary>
+            public Result Ldarg(APC pc, Parameter argument, bool ignoredIsOld, Unit dest, Data data)
+            {
+                bool isLdResult;
+                int ldStackOffset;
+                bool isOld;
+                APC lookupPC;
+
+                Parameter oldArgument = argument;
+
+                if (RemapParameterToLdStack(pc, ref argument, out isLdResult, out ldStackOffset, out isOld, out lookupPC))
+                {
+                    // ldstack
+                    return delegatee.Ldstack(pc, ldStackOffset, Push(pc, 0), Pop(lookupPC, ldStackOffset), isOld, data);
+                }
+
+                // F: TODOTODO Awfull fix!!!! But I do not really understand the code, I should talk with MAF about it
+                if (argument == null)
+                {
+                    argument = oldArgument;
+                }
+                // F: End
+
+                if (isLdResult)
+                {
+                    // ldresult
+                    // special case: if the parameter is typed address of struct, then we must be
+                    // referring to the post state of a struct constructor. In this case, map it to ldstacka
+                    if (parent.mdDecoder.IsStruct(parent.mdDecoder.DeclaringType(parent.mdDecoder.DeclaringMethod(argument))))
+                    {
+                        return delegatee.Ldstacka(pc, ldStackOffset, Push(pc, 0), Pop(pc, ldStackOffset), parent.mdDecoder.ParameterType(argument), isOld, data);
+                    }
+                    return delegatee.Ldresult(pc, parent.mdDecoder.ParameterType(argument), Push(pc, 0), Pop(pc, ldStackOffset), data);
+                }
+                return delegatee.Ldarg(pc, argument, isOld, Push(pc, 0), Convert(data));
+            }
+
+            /// <summary>
+            /// Remaps a parameter referenced in a subroutine to the parameter used in the calling context
+            /// This is needed e.g. when inheriting requires/ensures/invariant subroutines, as the parameter
+            /// identities are different in each override.
+            /// </summary>
+            /// <param name="p">Parameter as appearing in the subroutine</param>
+            /// <param name="parentMethodBlock">block in the method calling the subroutine</param>
+            /// <param name="subroutineBlock">block in the subroutine</param>
+            /// <returns>The equivalent parameter in the calling method's context</returns>
+            private Parameter RemapParameter(Parameter p, CFGBlock parentMethodBlock, CFGBlock subroutineBlock)
+            {
+                Contract.Requires(subroutineBlock != null);// F: added because of Clousot suggestion
+                Contract.Requires(parentMethodBlock != null);// F: added because of Clousot suggestion
+
+                Contract.Assume(parent.mdDecoder != null, "Assumption from the base class object invariant");
+
+
+                IMethodInfo<Method> parentMethodInfo = (IMethodInfo<Method>)parentMethodBlock.Subroutine;
+                IMethodInfo<Method> subroutineMethodInfo = (IMethodInfo<Method>)subroutineBlock.Subroutine;
+
+                if (parent.mdDecoder.Equal(parentMethodInfo.Method, subroutineMethodInfo.Method))
+                {
+                    return p;
+                }
+
+                int argIndex = parent.mdDecoder.ArgumentIndex(p);
+
+                if (parent.mdDecoder.IsStatic(parentMethodInfo.Method))
+                {
+                    return parent.mdDecoder.Parameters(parentMethodInfo.Method).AssumeNotNull()[argIndex];
+                }
+                else
+                {
+                    if (argIndex == 0)
+                    {
+                        // refers to "this"
+                        return parent.mdDecoder.This(parentMethodInfo.Method);
+                    }
+                    Contract.Assume(argIndex - 1 >= 0);
+                    return parent.mdDecoder.Parameters(parentMethodInfo.Method).AssumeNotNull()[argIndex - 1];
+                }
+            }
+
+            /// <summary>
+            /// Implementes the logic outlined in Ldarg by mapping a parameter x APC context into one of
+            /// three cases:
+            ///   - ldresult         (indicated by setting isLdResult true and setting ldStackOffset)
+            ///   - ldstack offset   (indicated by returning true, and setting ldStackOffset)
+            ///   - ldarg P'         (otherwise, where the parameter ref contains p' on exit)
+            /// </summary>
+            /// <param name="isOld">set to true if the resulting instruction should execute in the pre-state of the
+            /// method.</param>
+            /// <param name="lookupPC">Set to the pc at which we need to consider the ldStackOffset. Valid on true return.</param>
+            /// <returns>true if the parameter access maps to ldresult</returns>
+            private bool RemapParameterToLdStack(APC pc, ref Parameter p, out bool isLdResult, out int ldStackOffset, out bool isOld, out APC lookupPC)
+            {
+                if (pc.SubroutineContext != null)
+                {
+                    #region Requires
+                    if (pc.Block.Subroutine.IsRequires)
+                    {
+                        // find whether calling context is entry, newObj, or call. In the first case, also remap 
+                        // the parameter if necessary
+
+                        isLdResult = false;
+                        isOld = false;
+                        lookupPC = pc;
+
+                        for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+                        {
+                            var callTag = scontext.Head.Three;
+                            Contract.Assume(callTag != null);
+                            if (callTag == "entry")
+                            {
+                                // keep as ldarg, but figure out whether we need to remap
+                                Contract.Assume(scontext.Head.One != null);
+                                p = RemapParameter(p, scontext.Head.One, pc.Block);
+                                ldStackOffset = 0;
+                                return false;
+                            }
+                            if (callTag.StartsWith("before")) // beforeCall | beforeNewObj
+                            {
+                                int localStackDepth = parent.LocalStackDepth(pc);
+                                ldStackOffset = parent.mdDecoder.ArgumentStackIndex(p) + localStackDepth;
+                                return true;
+                            }
+                        }
+                        throw new NotImplementedException();
+                    }
+                    #endregion
+                    #region Ensures
+                    else if (pc.Block.Subroutine.IsEnsuresOrOld)
+                    {
+                        // find whether calling context is exit, newObj, or call. In the first case, also remap 
+                        // the parameter if necessary
+                        isOld = true;
+
+                        for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+                        {
+                            string callTag = scontext.Head.Three;
+
+                            if (callTag == "exit")
+                            {
+                                // keep as ldarg, but figure out whether we need to remap
+                                Contract.Assume(scontext.Head.One != null);
+                                p = RemapParameter(p, scontext.Head.One, pc.Block);
+                                isLdResult = false;
+                                ldStackOffset = 0;
+                                lookupPC = pc; // irrelevant
+                                return false;
+                            }
+                            if (callTag == "afterCall")
+                            {
+                                // we need to compute the offset to the "parameter" on the stack. For this we must
+                                // know what method is being called.
+                                ldStackOffset = parent.mdDecoder.ArgumentStackIndex(p);
+
+                                // no need to correct for local stack depth, as we lookup the stack in the old-state
+                                isLdResult = false;
+                                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                return true;
+                            }
+                            if (callTag == "afterNewObj")
+                            {
+                                // here we have to deal with the special case of referencing argument 0, which is the result
+                                // of the construction. In that case we have to return "ldresult"
+                                int parameterIndex = parent.mdDecoder.ArgumentIndex(p);
+                                if (parameterIndex == 0)
+                                {
+                                    ldStackOffset = parent.LocalStackDepth(pc);
+                                    isLdResult = true;
+                                    lookupPC = pc; // irrelevant
+                                    isOld = false;
+                                    return false;
+                                }
+
+                                // we need to compute the offset to the "parameter" on the stack. For this we must
+                                // know what method is being called.
+                                ldStackOffset = parent.mdDecoder.ArgumentStackIndex(p);
+
+                                // no need to correct for local stack depth, as we lookup the stack in the old-state
+                                isLdResult = false;
+                                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                return true;
+                            }
+
+                            if (callTag == "oldmanifest")
+                            {
+                                // used to manifest the old values on entry to a method
+                                // keep as ldarg, but figure out whether we need to remap
+                                Contract.Assume(scontext.Tail.Head.One != null);
+
+                                p = RemapParameter(p, scontext.Tail.Head.One, pc.Block);
+                                isOld = false;
+                                isLdResult = false;
+                                ldStackOffset = 0;
+                                lookupPC = pc; // irrelevant
+                                return false;
+                            }
+
+                            if (callTag == "afterCallAssume")
+                            {
+                                // nothing to do as it won't refer to callee parameters
+                                isOld = false;
+                                isLdResult = false;
+                                ldStackOffset = 0;
+                                lookupPC = pc;
+                                return false;
+                            }
+                        }
+                        throw new NotImplementedException();
+                    }
+                    #endregion
+                    #region Invariant
+                    else if (pc.Block.Subroutine.IsInvariant)
+                    {
+                        for (SubroutineContext scontext = pc.SubroutineContext; scontext != null; scontext = scontext.Tail)
+                        {
+                            string callTag = scontext.Head.Three;
+                            Contract.Assume(parent.mdDecoder != null);
+                            // must be "this"
+                            Contract.Assume(parent.mdDecoder.ArgumentIndex(p) == 0);
+
+                            if (callTag == "entry" || callTag == "exit")
+                            {
+                                // keep as ldarg, but remap to this of containing method
+                                Method containingMethod;
+                                if (pc.TryGetContainingMethod(out containingMethod))
+                                {
+                                    p = parent.mdDecoder.This(containingMethod);
+                                    isLdResult = false;
+                                    ldStackOffset = 0;
+                                    isOld = (callTag == "exit");
+                                    lookupPC = pc; // irrelevant
+                                    return false;
+                                }
+                                else
+                                {
+                                    Contract.Assume(false, "Not in a method context");
+                                    // dont'r remap
+                                    isLdResult = false;
+                                    ldStackOffset = 0;
+                                    isOld = false;
+                                    lookupPC = pc;
+                                    return false;
+                                }
+                            }
+                            if (callTag == "afterCall")
+                            {
+                                // we need to compute the offset to the "this" receiver on the stack. For this we must
+                                // know what method is being called.
+
+                                Method calledMethod;
+                                bool isNewObj;
+                                bool isVirtualCall;
+                                bool success = scontext.Head.One.IsMethodCallBlock(out calledMethod, out isNewObj, out isVirtualCall);
+                                Contract.Assume(success); // must be a method call blcok
+                                int parameterCount = parent.mdDecoder.Parameters(calledMethod).AssumeNotNull().Count;
+
+                                ldStackOffset = parameterCount; // 0 is top, 1 is 1 step below top of stack, etc...
+
+                                // no need to correct for local stack depth, as we lookup the stack in the old-state
+                                isLdResult = false;
+                                isOld = true;
+                                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                return true;
+                            }
+                            if (callTag == "afterNewObj")
+                            {
+                                // we need to map "this" to ldresult
+                                isLdResult = true;
+                                ldStackOffset = parent.LocalStackDepth(pc);
+                                isOld = false;
+                                lookupPC = pc;
+                                return false;
+                            }
+                            if (callTag == "assumeInvariant")
+                            {
+                                // we need to map "this" to ldstack.0 just prior to call (object must be on top of stack)
+                                isLdResult = false;
+                                ldStackOffset = 0;
+                                isOld = true;
+                                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
+                                return true;
+                            }
+                            if (callTag == "beforeCall")
+                            {
+                                throw new InvalidOperationException("This should never happen");
+                            }
+                            if (callTag == "beforeNewObj")
+                            {
+                                throw new InvalidOperationException("This should never happen");
+                            }
+                        }
+                        throw new NotImplementedException();
+                    }
+                    #endregion
+
+                }
                 isLdResult = false;
-                isOld = true;
-                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                return true;
-              }
-              if (callTag == "afterNewObj")
-              {
-                // we need to map "this" to ldresult
-                isLdResult = true;
-                ldStackOffset = this.parent.LocalStackDepth(pc);
+                ldStackOffset = 0;
                 isOld = false;
                 lookupPC = pc;
                 return false;
-              }
-              if (callTag == "assumeInvariant")
-              {
-                // we need to map "this" to ldstack.0 just prior to call (object must be on top of stack)
-                isLdResult = false;
-                ldStackOffset = 0;
-                isOld = true;
-                lookupPC = new APC(scontext.Head.One, 0, scontext.Tail);
-                return true;
-              }
-              if (callTag == "beforeCall")
-              {
-                throw new InvalidOperationException("This should never happen");
-              }
-              if (callTag == "beforeNewObj")
-              {
-                throw new InvalidOperationException("This should never happen");
-              }
             }
-            throw new NotImplementedException();
-          }
-          #endregion
 
-        }
-        isLdResult = false;
-        ldStackOffset = 0;
-        isOld = false;
-        lookupPC = pc;
-        return false;
-      }
-
-      /// <summary>
-      /// rewire to ldstacka.i if we are in a contract around a call contract
-      /// </summary>
-      public Result Ldarga(APC pc, Parameter argument, bool dummyOld, Unit dest, Data data)
-      {
-        bool isLdResult;
-        int ldStackOffset;
-        bool isOld;
-        APC lookupPC;
-        if (RemapParameterToLdStack(pc, ref argument, out isLdResult, out ldStackOffset, out isOld, out lookupPC))
-        {
-          // ldstacka
-          // Since we are not actually loading memory, just an address, we just compute the proper
-          // stack offset, that's it.
-          return delegatee.Ldstacka(pc, ldStackOffset, Push(pc, 0), Pop(lookupPC, ldStackOffset), this.parent.mdDecoder.ParameterType(argument), isOld, data);
-        }
-        if (isLdResult)
-        {
-          // ldresulta
-          throw new NotImplementedException();
-        }
-        return delegatee.Ldarga(pc, argument, isOld, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldconst(APC pc, object constant, Type type, Unit dest, Data data)
-      {
-        return delegatee.Ldconst(pc, constant, type, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldnull(APC pc, Unit dest, Data data)
-      {
-        return delegatee.Ldnull(pc, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldftn(APC pc, Method method, Unit dest, Data data)
-      {
-        return delegatee.Ldftn(pc, method, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldind(APC pc, Type type, bool @volatile, Unit dest, Unit ptr, Data data)
-      {
-        return delegatee.Ldind(pc, type, @volatile, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Ldloc(APC pc, Local local, Unit dest, Data data)
-      {
-        return delegatee.Ldloc(pc, local, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldloca(APC pc, Local local, Unit dest, Data data)
-      {
-        return delegatee.Ldloca(pc, local, Push(pc, 0), Convert(data));
-      }
-
-      /// <summary>
-      /// Ldresult instructions prior to stack analysis are intended to access the result in a method post condition.
-      /// </summary>
-      public Result Ldresult(APC pc, Type type, Unit dest, Unit source, Data data)
-      {
-        int depth = this.parent.LocalStackDepth(pc);
-        return delegatee.Ldresult(pc, type, Push(pc, 0), Pop(pc, depth), Convert(data));
-      }
-
-      public Result Ldstack(APC pc, int offset, Unit dest, Unit source, bool isOld, Data data)
-      {
-        return delegatee.Ldstack(pc, offset, Push(pc, 0), Pop(pc, offset), isOld, Convert(data));
-      }
-
-      public Result Ldstacka(APC pc, int offset, Unit dest, Unit source, Type type, bool old, Data data)
-      {
-        return delegatee.Ldstacka(pc, offset, Push(pc, 0), Pop(pc, offset), type, old, Convert(data));
-      }
-
-      public Result Localloc(APC pc, Unit dest, Unit size, Data data)
-      {
-        return delegatee.Localloc(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Nop(APC pc, Data data)
-      {
-        return delegatee.Nop(pc, Convert(data));
-      }
-
-      public Result Pop(APC pc, Unit source, Data data)
-      {
-        return delegatee.Pop(pc, Pop(pc, 0), Convert(data));
-      }
-
-      /// <summary>
-      /// Strip out returns except for common return on exti block (inserted by ForwardDecode)
-      /// </summary>
-      public Result Return(APC pc, Unit source, Data data)
-      {
-        return delegatee.Nop(pc, Convert(data));
-      }
-
-      public Result Starg(APC pc, Parameter argument, Unit source, Data data)
-      {
-        return delegatee.Starg(pc, argument, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Stind(APC pc, Type type, bool @volatile, Unit ptr, Unit value, Data data)
-      {
-        return delegatee.Stind(pc, type, @volatile, Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Stloc(APC pc, Local local, Unit source, Data data)
-      {
-        return delegatee.Stloc(pc, local, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, Unit value, Data data)
-      {
-        return delegatee.Switch(pc, type, cases, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Unit dest, Unit source, Data data)
-      {
-        return delegatee.Unary(pc, op, overflow, unsigned, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Box(APC pc, Type type, Unit dest, Unit source, Data data)
-      {
-        type = GetSpecializedType(pc, type);
-        if (this.IsReferenceType(pc, type))
-        {
-          return delegatee.Nop(pc, data);
-        }
-        return delegatee.Box(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      /// <summary>
-      /// Inside subroutines, we may use pc context to find the instantiation of
-      /// type parameters to provide more accurate classification of reference types
-      /// </summary>
-      private bool IsReferenceType(APC pc, Type type)
-      {
-        Contract.Assume(this.parent.mdDecoder != null, "Assumption form the base class object invariant");
-
-        return this.parent.mdDecoder.IsReferenceType(type);
-      }
-
-      private Type GetSpecializedType(APC pc, Type type)
-      {
-        Contract.Assume(pc.Block != null);
-        IMethodInfo<Method> calleeMI = pc.Block.Subroutine as IMethodInfo<Method>;
-        if (calleeMI == null) return type; // can't figure out current method
-        var target = calleeMI.Method;
-        
-        SubroutineContext context = pc.SubroutineContext;
-        while (context != null)
-        {
-          bool isNewObj;
-          bool isVirtualCall;
-          Method contextMethod;
-          SubroutineEdge edge = context.Head;
-          context = context.Tail;
-          var tag = edge.Three;
-          Contract.Assume(tag != null);
-          if (tag.StartsWith("after") || tag.StartsWith("assumeInvariant"))
-          {
-            if (!edge.One.IsMethodCallBlock(out contextMethod, out isNewObj, out isVirtualCall))
+            /// <summary>
+            /// rewire to ldstacka.i if we are in a contract around a call contract
+            /// </summary>
+            public Result Ldarga(APC pc, Parameter argument, bool dummyOld, Unit dest, Data data)
             {
-              return type; // no context found
-            }
-          }
-          else if (tag.StartsWith("before"))
-          {
-            if (!edge.Two.IsMethodCallBlock(out contextMethod, out isNewObj, out isVirtualCall))
-            {
-              return type; // no context found
-            }
-          }
-          else if (tag == "inherited" || tag == "extra") {
-            var mi = edge.Two.Subroutine as IMethodInfo<Method>;
-            if (mi == null) return type; // no context found
-            contextMethod = mi.Method;
-          }
-          else if (tag == "exit" || tag == "entry")
-          {
-            var mi = edge.Two.Subroutine as IMethodInfo<Method>;
-            if (mi == null) return type; // no context found
-            contextMethod = mi.Method;
-          }
-          else
-          {
-            // unrecognized context that we can specialize
-            return type;
-          }
-          var specialized = InstantiateTypeAtCalls(contextMethod, target, type);
-
-          // specialize further
-          type = specialized;
-          target = contextMethod;
-        }
-        return type;
-      }
-
-      private Type InstantiateTypeAtCalls(Method called, Method targetMethod, Type type)
-      {
-        Contract.Assume(this.parent.mdDecoder != null, "Assumption form the base class object invariant");
-
-        var mdDecoder = this.parent.mdDecoder;
-
-        if (mdDecoder.IsFormalTypeParameter(type))
-        {
-          var normalizedTypeParamIndex = this.parent.mdDecoder.NormalizedFormalTypeParameterIndex(type);
-          Contract.Assume(normalizedTypeParamIndex >= 0, "Problem in picking up the contract");
-          var calledType = mdDecoder.DeclaringType(called);
-          var targetMethodType = mdDecoder.DeclaringType(targetMethod);
-
-          // no instance (same generic context)
-          if (mdDecoder.Equal(calledType, targetMethodType)) return type;
-
-          // direct instance
-          if (mdDecoder.Equal(mdDecoder.Unspecialized(calledType), targetMethodType)) {
-            var actuals = mdDecoder.NormalizedActualTypeArguments(calledType);
-            Contract.Assume(actuals != null, "Missing contract");
-            if (normalizedTypeParamIndex < actuals.Count) {
-              return actuals[normalizedTypeParamIndex];
-            }
-            // something is wrong, don't crash
-            return type;
-          }
-
-          // indirect instance because contract is inherited
-          // find out what method called is implementing
-          foreach (var candidate in mdDecoder.ImplementedMethods(called).AssumeNotNull())
-          {
-            var candidateType = mdDecoder.DeclaringType(candidate);
-            if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
-            {
-              var actuals = mdDecoder.NormalizedActualTypeArguments(candidateType);
-              Contract.Assume(actuals != null);
-              if (normalizedTypeParamIndex < actuals.Count)
-              {
-                return actuals[normalizedTypeParamIndex];
-              }
-              // something is wrong, don't crash
-              return type;
-            }
-          }
-
-          FList<Method> baseMethodsToCheck = FList<Method>.Cons(called, null);
-          while (baseMethodsToCheck != null)
-          {
-            var baseMethod = baseMethodsToCheck.Head;
-            baseMethodsToCheck = baseMethodsToCheck.Tail;
-
-            foreach (var candidate in mdDecoder.OverriddenMethods(baseMethod).AssumeNotNull())
-            {
-              baseMethodsToCheck = baseMethodsToCheck.Cons(candidate);
-              var candidateType = mdDecoder.DeclaringType(candidate);
-              if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
-              {
-                var actuals = mdDecoder.NormalizedActualTypeArguments(candidateType);
-                Contract.Assume(actuals != null);
-                if (normalizedTypeParamIndex < actuals.Count)
+                bool isLdResult;
+                int ldStackOffset;
+                bool isOld;
+                APC lookupPC;
+                if (RemapParameterToLdStack(pc, ref argument, out isLdResult, out ldStackOffset, out isOld, out lookupPC))
                 {
-                  return actuals[normalizedTypeParamIndex];
+                    // ldstacka
+                    // Since we are not actually loading memory, just an address, we just compute the proper
+                    // stack offset, that's it.
+                    return delegatee.Ldstacka(pc, ldStackOffset, Push(pc, 0), Pop(lookupPC, ldStackOffset), parent.mdDecoder.ParameterType(argument), isOld, data);
                 }
-                // something is wrong, don't crash
-                return type;
-              }
+                if (isLdResult)
+                {
+                    // ldresulta
+                    throw new NotImplementedException();
+                }
+                return delegatee.Ldarga(pc, argument, isOld, Push(pc, 0), Convert(data));
             }
-          }
-          // couldn't find the instantiation
-          return type;
+
+            public Result Ldconst(APC pc, object constant, Type type, Unit dest, Data data)
+            {
+                return delegatee.Ldconst(pc, constant, type, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldnull(APC pc, Unit dest, Data data)
+            {
+                return delegatee.Ldnull(pc, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldftn(APC pc, Method method, Unit dest, Data data)
+            {
+                return delegatee.Ldftn(pc, method, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldind(APC pc, Type type, bool @volatile, Unit dest, Unit ptr, Data data)
+            {
+                return delegatee.Ldind(pc, type, @volatile, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Ldloc(APC pc, Local local, Unit dest, Data data)
+            {
+                return delegatee.Ldloc(pc, local, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldloca(APC pc, Local local, Unit dest, Data data)
+            {
+                return delegatee.Ldloca(pc, local, Push(pc, 0), Convert(data));
+            }
+
+            /// <summary>
+            /// Ldresult instructions prior to stack analysis are intended to access the result in a method post condition.
+            /// </summary>
+            public Result Ldresult(APC pc, Type type, Unit dest, Unit source, Data data)
+            {
+                int depth = parent.LocalStackDepth(pc);
+                return delegatee.Ldresult(pc, type, Push(pc, 0), Pop(pc, depth), Convert(data));
+            }
+
+            public Result Ldstack(APC pc, int offset, Unit dest, Unit source, bool isOld, Data data)
+            {
+                return delegatee.Ldstack(pc, offset, Push(pc, 0), Pop(pc, offset), isOld, Convert(data));
+            }
+
+            public Result Ldstacka(APC pc, int offset, Unit dest, Unit source, Type type, bool old, Data data)
+            {
+                return delegatee.Ldstacka(pc, offset, Push(pc, 0), Pop(pc, offset), type, old, Convert(data));
+            }
+
+            public Result Localloc(APC pc, Unit dest, Unit size, Data data)
+            {
+                return delegatee.Localloc(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Nop(APC pc, Data data)
+            {
+                return delegatee.Nop(pc, Convert(data));
+            }
+
+            public Result Pop(APC pc, Unit source, Data data)
+            {
+                return delegatee.Pop(pc, Pop(pc, 0), Convert(data));
+            }
+
+            /// <summary>
+            /// Strip out returns except for common return on exti block (inserted by ForwardDecode)
+            /// </summary>
+            public Result Return(APC pc, Unit source, Data data)
+            {
+                return delegatee.Nop(pc, Convert(data));
+            }
+
+            public Result Starg(APC pc, Parameter argument, Unit source, Data data)
+            {
+                return delegatee.Starg(pc, argument, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Stind(APC pc, Type type, bool @volatile, Unit ptr, Unit value, Data data)
+            {
+                return delegatee.Stind(pc, type, @volatile, Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Stloc(APC pc, Local local, Unit source, Data data)
+            {
+                return delegatee.Stloc(pc, local, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Switch(APC pc, Type type, IEnumerable<Pair<object, APC>> cases, Unit value, Data data)
+            {
+                return delegatee.Switch(pc, type, cases, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Unary(APC pc, UnaryOperator op, bool overflow, bool unsigned, Unit dest, Unit source, Data data)
+            {
+                return delegatee.Unary(pc, op, overflow, unsigned, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Box(APC pc, Type type, Unit dest, Unit source, Data data)
+            {
+                type = GetSpecializedType(pc, type);
+                if (this.IsReferenceType(pc, type))
+                {
+                    return delegatee.Nop(pc, data);
+                }
+                return delegatee.Box(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            /// <summary>
+            /// Inside subroutines, we may use pc context to find the instantiation of
+            /// type parameters to provide more accurate classification of reference types
+            /// </summary>
+            private bool IsReferenceType(APC pc, Type type)
+            {
+                Contract.Assume(parent.mdDecoder != null, "Assumption form the base class object invariant");
+
+                return parent.mdDecoder.IsReferenceType(type);
+            }
+
+            private Type GetSpecializedType(APC pc, Type type)
+            {
+                Contract.Assume(pc.Block != null);
+                IMethodInfo<Method> calleeMI = pc.Block.Subroutine as IMethodInfo<Method>;
+                if (calleeMI == null) return type; // can't figure out current method
+                var target = calleeMI.Method;
+
+                SubroutineContext context = pc.SubroutineContext;
+                while (context != null)
+                {
+                    bool isNewObj;
+                    bool isVirtualCall;
+                    Method contextMethod;
+                    SubroutineEdge edge = context.Head;
+                    context = context.Tail;
+                    var tag = edge.Three;
+                    Contract.Assume(tag != null);
+                    if (tag.StartsWith("after") || tag.StartsWith("assumeInvariant"))
+                    {
+                        if (!edge.One.IsMethodCallBlock(out contextMethod, out isNewObj, out isVirtualCall))
+                        {
+                            return type; // no context found
+                        }
+                    }
+                    else if (tag.StartsWith("before"))
+                    {
+                        if (!edge.Two.IsMethodCallBlock(out contextMethod, out isNewObj, out isVirtualCall))
+                        {
+                            return type; // no context found
+                        }
+                    }
+                    else if (tag == "inherited" || tag == "extra")
+                    {
+                        var mi = edge.Two.Subroutine as IMethodInfo<Method>;
+                        if (mi == null) return type; // no context found
+                        contextMethod = mi.Method;
+                    }
+                    else if (tag == "exit" || tag == "entry")
+                    {
+                        var mi = edge.Two.Subroutine as IMethodInfo<Method>;
+                        if (mi == null) return type; // no context found
+                        contextMethod = mi.Method;
+                    }
+                    else
+                    {
+                        // unrecognized context that we can specialize
+                        return type;
+                    }
+                    var specialized = InstantiateTypeAtCalls(contextMethod, target, type);
+
+                    // specialize further
+                    type = specialized;
+                    target = contextMethod;
+                }
+                return type;
+            }
+
+            private Type InstantiateTypeAtCalls(Method called, Method targetMethod, Type type)
+            {
+                Contract.Assume(parent.mdDecoder != null, "Assumption form the base class object invariant");
+
+                var mdDecoder = parent.mdDecoder;
+
+                if (mdDecoder.IsFormalTypeParameter(type))
+                {
+                    var normalizedTypeParamIndex = parent.mdDecoder.NormalizedFormalTypeParameterIndex(type);
+                    Contract.Assume(normalizedTypeParamIndex >= 0, "Problem in picking up the contract");
+                    var calledType = mdDecoder.DeclaringType(called);
+                    var targetMethodType = mdDecoder.DeclaringType(targetMethod);
+
+                    // no instance (same generic context)
+                    if (mdDecoder.Equal(calledType, targetMethodType)) return type;
+
+                    // direct instance
+                    if (mdDecoder.Equal(mdDecoder.Unspecialized(calledType), targetMethodType))
+                    {
+                        var actuals = mdDecoder.NormalizedActualTypeArguments(calledType);
+                        Contract.Assume(actuals != null, "Missing contract");
+                        if (normalizedTypeParamIndex < actuals.Count)
+                        {
+                            return actuals[normalizedTypeParamIndex];
+                        }
+                        // something is wrong, don't crash
+                        return type;
+                    }
+
+                    // indirect instance because contract is inherited
+                    // find out what method called is implementing
+                    foreach (var candidate in mdDecoder.ImplementedMethods(called).AssumeNotNull())
+                    {
+                        var candidateType = mdDecoder.DeclaringType(candidate);
+                        if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
+                        {
+                            var actuals = mdDecoder.NormalizedActualTypeArguments(candidateType);
+                            Contract.Assume(actuals != null);
+                            if (normalizedTypeParamIndex < actuals.Count)
+                            {
+                                return actuals[normalizedTypeParamIndex];
+                            }
+                            // something is wrong, don't crash
+                            return type;
+                        }
+                    }
+
+                    FList<Method> baseMethodsToCheck = FList<Method>.Cons(called, null);
+                    while (baseMethodsToCheck != null)
+                    {
+                        var baseMethod = baseMethodsToCheck.Head;
+                        baseMethodsToCheck = baseMethodsToCheck.Tail;
+
+                        foreach (var candidate in mdDecoder.OverriddenMethods(baseMethod).AssumeNotNull())
+                        {
+                            baseMethodsToCheck = baseMethodsToCheck.Cons(candidate);
+                            var candidateType = mdDecoder.DeclaringType(candidate);
+                            if (mdDecoder.Equal(mdDecoder.Unspecialized(candidateType), targetMethodType))
+                            {
+                                var actuals = mdDecoder.NormalizedActualTypeArguments(candidateType);
+                                Contract.Assume(actuals != null);
+                                if (normalizedTypeParamIndex < actuals.Count)
+                                {
+                                    return actuals[normalizedTypeParamIndex];
+                                }
+                                // something is wrong, don't crash
+                                return type;
+                            }
+                        }
+                    }
+                    // couldn't find the instantiation
+                    return type;
+                }
+                else if (mdDecoder.IsMethodFormalTypeParameter(type))
+                {
+                    int normalizedMethodParamIndex = parent.mdDecoder.MethodFormalTypeParameterIndex(type);
+                    Contract.Assume(normalizedMethodParamIndex >= 0);
+
+                    var actuals = mdDecoder.ActualTypeArguments(called);
+                    Contract.Assume(actuals != null);
+                    if (normalizedMethodParamIndex < actuals.Count)
+                    {
+                        return actuals[normalizedMethodParamIndex];
+                    }
+                    // something is wrong, don't crash
+                    return type;
+                }
+                // not a type variable
+                return type;
+            }
+
+            /// <summary>
+            /// searches the context for "before" or "after" calls. Leaves context pointing to the
+            /// remainder context, so it can be called again.
+            /// </summary>
+            private bool TryGetCalledInstanceMethod(ref SubroutineContext context, out Method m)
+            {
+                for (; context != null;)
+                {
+                    bool isNewObj;
+                    bool isVirtualCall;
+                    SubroutineEdge edge = context.Head;
+                    context = context.Tail;
+                    var tag = edge.Three;
+                    Contract.Assume(tag != null);
+                    if (tag.StartsWith("after"))
+                    {
+                        return (edge.One.IsMethodCallBlock(out m, out isNewObj, out isVirtualCall));
+                    }
+                    if (tag.StartsWith("before"))
+                    {
+                        return (edge.Two.IsMethodCallBlock(out m, out isNewObj, out isVirtualCall));
+                    }
+                    // TODO handle other call-like tags
+                }
+                m = default(Method);
+                return false;
+            }
+
+            public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Unit dest, ArgList args, Data data)
+              where TypeList : IIndexable<Type>
+              where ArgList : IIndexable<Unit>
+            {
+                int numargs = ComputeArgs(method, extraVarargs.Count);
+                return delegatee.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, Push(pc, numargs, parent.mdDecoder.ReturnType(method)), PopSequence(pc, numargs, 0), Convert(data));
+            }
+
+            public Result Castclass(APC pc, Type type, Unit dest, Unit obj, Data data)
+            {
+                return delegatee.Castclass(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Cpobj(APC pc, Type type, Unit destptr, Unit srcptr, Data data)
+            {
+                return delegatee.Cpobj(pc, type, Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Initobj(APC pc, Type type, Unit ptr, Data data)
+            {
+                return delegatee.Initobj(pc, type, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Isinst(APC pc, Type type, Unit dest, Unit obj, Data data)
+            {
+                return delegatee.Isinst(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Ldelem(APC pc, Type type, Unit dest, Unit array, Unit index, Data data)
+            {
+                return delegatee.Ldelem(pc, type, Push(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Ldelema(APC pc, Type type, bool @readonly, Unit dest, Unit array, Unit index, Data data)
+            {
+                return delegatee.Ldelema(pc, type, @readonly, Push(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Ldfld(APC pc, Field field, bool @volatile, Unit dest, Unit obj, Data data)
+            {
+                return delegatee.Ldfld(pc, field, @volatile, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Ldflda(APC pc, Field field, Unit dest, Unit obj, Data data)
+            {
+                return delegatee.Ldflda(pc, field, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Ldlen(APC pc, Unit dest, Unit array, Data data)
+            {
+                return delegatee.Ldlen(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Ldsfld(APC pc, Field field, bool @volatile, Unit dest, Data data)
+            {
+                return delegatee.Ldsfld(pc, field, @volatile, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldsflda(APC pc, Field field, Unit dest, Data data)
+            {
+                return delegatee.Ldsflda(pc, field, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldtypetoken(APC pc, Type type, Unit dest, Data data)
+            {
+                return delegatee.Ldtypetoken(pc, type, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldfieldtoken(APC pc, Field field, Unit dest, Data data)
+            {
+                return delegatee.Ldfieldtoken(pc, field, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldmethodtoken(APC pc, Method method, Unit dest, Data data)
+            {
+                return delegatee.Ldmethodtoken(pc, method, Push(pc, 0), Convert(data));
+            }
+
+            public Result Ldvirtftn(APC pc, Method method, Unit dest, Unit obj, Data data)
+            {
+                return delegatee.Ldvirtftn(pc, method, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Mkrefany(APC pc, Type type, Unit dest, Unit obj, Data data)
+            {
+                return delegatee.Mkrefany(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Newarray<ArgList>(APC pc, Type type, Unit dest, ArgList lengths, Data data)
+              where ArgList : IIndexable<Unit>
+            {
+                var numargs = lengths.Count;
+                return delegatee.Newarray(pc, type, Push(pc, numargs), PopSequence(pc, numargs, 0), Convert(data));
+            }
+
+            public Result Newobj<ArgList>(APC pc, Method ctor, Unit dest, ArgList args, Data data)
+              where ArgList : IIndexable<Unit>
+            {
+                int numargs = ComputeArgs(ctor, 0);
+                numargs--; // subtract receiver, as it is counted as a method parameter for construtors.
+                return delegatee.Newobj(pc, ctor, Push(pc, numargs), PopSequence(pc, numargs, 0), Convert(data));
+            }
+
+            public Result Refanytype(APC pc, Unit dest, Unit source, Data data)
+            {
+                return delegatee.Refanytype(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Refanyval(APC pc, Type type, Unit dest, Unit source, Data data)
+            {
+                return delegatee.Refanyval(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Rethrow(APC pc, Data data)
+            {
+                return delegatee.Rethrow(pc, Convert(data));
+            }
+
+            public Result Sizeof(APC pc, Type type, Unit dest, Data data)
+            {
+                return delegatee.Sizeof(pc, type, Push(pc, 0), Convert(data));
+            }
+
+            public Result Stelem(APC pc, Type type, Unit array, Unit index, Unit value, Data data)
+            {
+                return delegatee.Stelem(pc, type, Pop(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Stfld(APC pc, Field field, bool @volatile, Unit obj, Unit value, Data data)
+            {
+                return delegatee.Stfld(pc, field, @volatile, Pop(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Stsfld(APC pc, Field field, bool @volatile, Unit value, Data data)
+            {
+                return delegatee.Stsfld(pc, field, @volatile, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Throw(APC pc, Unit exn, Data data)
+            {
+                return delegatee.Throw(pc, Pop(pc, 0), Convert(data));
+            }
+
+            public Result Unbox(APC pc, Type type, Unit dest, Unit obj, Data data)
+            {
+                type = GetSpecializedType(pc, type);
+                return delegatee.Unbox(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            public Result Unboxany(APC pc, Type type, Unit dest, Unit obj, Data data)
+            {
+                type = GetSpecializedType(pc, type);
+                return delegatee.Unboxany(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
+            }
+
+            #endregion
+
+            #region IVisitSynthIL<APC,Method,Unit,Unit,Data,Result> Members
+
+
+            public Result BeginOld(APC pc, APC matchingEnd, Data data)
+            {
+                return delegatee.BeginOld(pc, matchingEnd, Convert(data));
+            }
+
+            /// <summary>
+            /// Note: stack depth associated with this pc is the stack depth at the end of the old expression
+            /// in the context of the method entry. Thus we can pop normally, but to push to the correct offset
+            /// we need to get the depth at the matching begin.
+            /// </summary>
+            public Result EndOld(APC pc, APC matchingBegin, Type type, Unit dest, Unit source, Data data)
+            {
+                if (pc.InsideOldManifestation)
+                {
+                    return delegatee.Ldstack(pc, 1, Push(matchingBegin, 0), Pop(pc, 0), false, Convert(data));
+                }
+
+                return delegatee.EndOld(pc, matchingBegin, type, Push(matchingBegin, 0), Pop(pc, 0), Convert(data));
+            }
+
+            #endregion
         }
-        else if (mdDecoder.IsMethodFormalTypeParameter(type))
+
+        public Result ForwardDecode<Data, Result, Visitor>(APC lab, Visitor visitor, Data data) where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, Data, Result>
         {
-          int normalizedMethodParamIndex = this.parent.mdDecoder.MethodFormalTypeParameterIndex(type);
-          Contract.Assume(normalizedMethodParamIndex >= 0);
-
-          var actuals = mdDecoder.ActualTypeArguments(called);
-          Contract.Assume(actuals != null);
-          if (normalizedMethodParamIndex < actuals.Count)
-          {
-            return actuals[normalizedMethodParamIndex];
-          }
-          // something is wrong, don't crash
-          return type;
+            // if this is an exit block, index is 0, insert a Return instruction (we remove all ordinary returns)
+            if (lab.Index == 0 && lab.SubroutineContext == null && lab.Block == lab.Block.Subroutine.Exit && lab.Block.Subroutine.IsMethod)
+            {
+                if (!lab.Block.Subroutine.HasReturnValue)
+                {
+                    return visitor.Return(lab, -1, data); // dummy arg
+                }
+                else
+                {
+                    int topOfStack = this.Lookup(lab) - 1;
+                    return visitor.Return(lab, topOfStack, data);
+                }
+            }
+            return ilDecoder.ForwardDecode<Data, Result, StackDecoder<Data, Result, Visitor>>(
+              lab, new StackDecoder<Data, Result, Visitor>(this, visitor), data);
         }
-        // not a type variable
-        return type;
-      }
-
-      /// <summary>
-      /// searches the context for "before" or "after" calls. Leaves context pointing to the
-      /// remainder context, so it can be called again.
-      /// </summary>
-      private bool TryGetCalledInstanceMethod(ref SubroutineContext context, out Method m)
-      {
-        for (; context != null; )
-        {
-          bool isNewObj;
-          bool isVirtualCall;
-          SubroutineEdge edge = context.Head;
-          context = context.Tail;
-          var tag = edge.Three;
-          Contract.Assume(tag != null);
-          if (tag.StartsWith("after"))
-          {
-            return (edge.One.IsMethodCallBlock(out m, out isNewObj, out isVirtualCall));
-          }
-          if (tag.StartsWith("before"))
-          {
-            return (edge.Two.IsMethodCallBlock(out m, out isNewObj, out isVirtualCall));
-          }
-          // TODO handle other call-like tags
-        }
-        m = default(Method);
-        return false;
-      }
-
-      public Result ConstrainedCallvirt<TypeList, ArgList>(APC pc, Method method, bool tail, Type constraint, TypeList extraVarargs, Unit dest, ArgList args, Data data)
-        where TypeList : IIndexable<Type>
-        where ArgList : IIndexable<Unit>
-      {
-        int numargs = ComputeArgs(method, extraVarargs.Count);
-        return delegatee.ConstrainedCallvirt(pc, method, tail, constraint, extraVarargs, Push(pc, numargs, parent.mdDecoder.ReturnType(method)), PopSequence(pc, numargs, 0), Convert(data));
-      }
-
-      public Result Castclass(APC pc, Type type, Unit dest, Unit obj, Data data)
-      {
-        return delegatee.Castclass(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Cpobj(APC pc, Type type, Unit destptr, Unit srcptr, Data data)
-      {
-        return delegatee.Cpobj(pc, type, Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Initobj(APC pc, Type type, Unit ptr, Data data)
-      {
-        return delegatee.Initobj(pc, type, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Isinst(APC pc, Type type, Unit dest, Unit obj, Data data)
-      {
-        return delegatee.Isinst(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Ldelem(APC pc, Type type, Unit dest, Unit array, Unit index, Data data)
-      {
-        return delegatee.Ldelem(pc, type, Push(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Ldelema(APC pc, Type type, bool @readonly, Unit dest, Unit array, Unit index, Data data)
-      {
-        return delegatee.Ldelema(pc, type, @readonly, Push(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Ldfld(APC pc, Field field, bool @volatile, Unit dest, Unit obj, Data data)
-      {
-        return delegatee.Ldfld(pc, field, @volatile, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Ldflda(APC pc, Field field, Unit dest, Unit obj, Data data)
-      {
-        return delegatee.Ldflda(pc, field, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Ldlen(APC pc, Unit dest, Unit array, Data data)
-      {
-        return delegatee.Ldlen(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Ldsfld(APC pc, Field field, bool @volatile, Unit dest, Data data)
-      {
-        return delegatee.Ldsfld(pc, field, @volatile, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldsflda(APC pc, Field field, Unit dest, Data data)
-      {
-        return delegatee.Ldsflda(pc, field, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldtypetoken(APC pc, Type type, Unit dest, Data data)
-      {
-        return delegatee.Ldtypetoken(pc, type, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldfieldtoken(APC pc, Field field, Unit dest, Data data)
-      {
-        return delegatee.Ldfieldtoken(pc, field, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldmethodtoken(APC pc, Method method, Unit dest, Data data)
-      {
-        return delegatee.Ldmethodtoken(pc, method, Push(pc, 0), Convert(data));
-      }
-
-      public Result Ldvirtftn(APC pc, Method method, Unit dest, Unit obj, Data data)
-      {
-        return delegatee.Ldvirtftn(pc, method, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Mkrefany(APC pc, Type type, Unit dest, Unit obj, Data data)
-      {
-        return delegatee.Mkrefany(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Newarray<ArgList>(APC pc, Type type, Unit dest, ArgList lengths, Data data)
-        where ArgList : IIndexable<Unit>
-      {
-          var numargs = lengths.Count;
-        return delegatee.Newarray(pc, type, Push(pc, numargs), PopSequence(pc, numargs, 0), Convert(data));
-      }
-
-      public Result Newobj<ArgList>(APC pc, Method ctor, Unit dest, ArgList args, Data data)
-        where ArgList : IIndexable<Unit>
-      {
-        int numargs = ComputeArgs(ctor, 0);
-        numargs--; // subtract receiver, as it is counted as a method parameter for construtors.
-        return delegatee.Newobj(pc, ctor, Push(pc, numargs), PopSequence(pc, numargs, 0), Convert(data));
-      }
-
-      public Result Refanytype(APC pc, Unit dest, Unit source, Data data)
-      {
-        return delegatee.Refanytype(pc, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Refanyval(APC pc, Type type, Unit dest, Unit source, Data data)
-      {
-        return delegatee.Refanyval(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Rethrow(APC pc, Data data)
-      {
-        return delegatee.Rethrow(pc, Convert(data));
-      }
-
-      public Result Sizeof(APC pc, Type type, Unit dest, Data data)
-      {
-        return delegatee.Sizeof(pc, type, Push(pc, 0), Convert(data));
-      }
-
-      public Result Stelem(APC pc, Type type, Unit array, Unit index, Unit value, Data data)
-      {
-        return delegatee.Stelem(pc, type, Pop(pc, 2), Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Stfld(APC pc, Field field, bool @volatile, Unit obj, Unit value, Data data)
-      {
-        return delegatee.Stfld(pc, field, @volatile, Pop(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Stsfld(APC pc, Field field, bool @volatile, Unit value, Data data)
-      {
-        return delegatee.Stsfld(pc, field, @volatile, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Throw(APC pc, Unit exn, Data data)
-      {
-        return delegatee.Throw(pc, Pop(pc, 0), Convert(data));
-      }
-
-      public Result Unbox(APC pc, Type type, Unit dest, Unit obj, Data data)
-      {
-        type = GetSpecializedType(pc, type);
-        return delegatee.Unbox(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      public Result Unboxany(APC pc, Type type, Unit dest, Unit obj, Data data)
-      {
-        type = GetSpecializedType(pc, type);
-        return delegatee.Unboxany(pc, type, Push(pc, 1), Pop(pc, 0), Convert(data));
-      }
-
-      #endregion
-
-      #region IVisitSynthIL<APC,Method,Unit,Unit,Data,Result> Members
-
-
-      public Result BeginOld(APC pc, APC matchingEnd, Data data)
-      {
-        return delegatee.BeginOld(pc, matchingEnd, Convert(data));
-      }
-
-      /// <summary>
-      /// Note: stack depth associated with this pc is the stack depth at the end of the old expression
-      /// in the context of the method entry. Thus we can pop normally, but to push to the correct offset
-      /// we need to get the depth at the matching begin.
-      /// </summary>
-      public Result EndOld(APC pc, APC matchingBegin, Type type, Unit dest, Unit source, Data data)
-      {
-        if (pc.InsideOldManifestation)
-        {
-          return delegatee.Ldstack(pc, 1, Push(matchingBegin, 0), Pop(pc, 0), false, Convert(data));
-        }
-
-        return delegatee.EndOld(pc, matchingBegin, type, Push(matchingBegin, 0), Pop(pc, 0), Convert(data));
-      }
-
-      #endregion
-    }
-
-    public Result ForwardDecode<Data, Result, Visitor>(APC lab, Visitor visitor, Data data) where Visitor : IVisitMSIL<APC, Local, Parameter, Method, Field, Type, int, int, Data, Result>
-    {
-      // if this is an exit block, index is 0, insert a Return instruction (we remove all ordinary returns)
-      if (lab.Index == 0 && lab.SubroutineContext == null && lab.Block == lab.Block.Subroutine.Exit && lab.Block.Subroutine.IsMethod)
-      {
-        if (!lab.Block.Subroutine.HasReturnValue)
-        {
-          return visitor.Return(lab, -1, data); // dummy arg
-        }
-        else
-        {
-          int topOfStack = this.Lookup(lab) - 1;
-          return visitor.Return(lab, topOfStack, data);
-        }
-      }
-      return ilDecoder.ForwardDecode<Data, Result, StackDecoder<Data, Result, Visitor>>(
-        lab, new StackDecoder<Data, Result, Visitor>(this, visitor), data);
-    }
 
 #if false
-    public Transformer<APC, Data, Result> CacheForwardDecoder<Data, Result>(IVisitMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, Data, Result> visitor)
-    {
-      return ilDecoder.CacheForwardDecoder<Data, Result>(new StackDecoder<Data, Result, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, Data, Result>>(this, visitor));
-    }
+        public Transformer<APC, Data, Result> CacheForwardDecoder<Data, Result>(IVisitMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, Data, Result> visitor)
+        {
+            return ilDecoder.CacheForwardDecoder<Data, Result>(new StackDecoder<Data, Result, IVisitMSIL<APC, Local, Parameter, Method, Field, Type, StackTemp, StackTemp, Data, Result>>(this, visitor));
+        }
 #endif
 
-    public IStackContext<Field, Method> Context { get { return this; } }
+        public IStackContext<Field, Method> Context { get { return this; } }
 
-    public bool IsUnreachable(APC pc) { return false; }
-    #endregion
-
-
-    #region IStackContext and IMethodContext<Label,Field, Method> Members
-
-    /// <summary>
-    /// We don't directly delegate to MethodContext, because we want to return a different CFG
-    /// </summary>
-    public IMethodContextData<Field, Method> MethodContext { get { return this; } }
-    public IStackContextData<Field, Method> StackContext { get { return this; } }
-    public int StackDepth(APC pc)
-    {
-      return this.Lookup(pc);
-    }
-
-    public bool TryGetCallArgumentDelegateTarget(APC pc, int stackOffset, out Method method)
-    {
-      int adjustedStackOffset = stackOffset;
-      var context = pc.SubroutineContext;
-      while (context != null)
-      {
-        adjustedStackOffset -= this.LocalStackDepth(new APC(context.Head.One, 0, null));
-        context = context.Tail;
-      }
-      APCMap<int> map = LocalStackMap(pc.Block.Subroutine);
-
-      return map.TryGetArgumentDelegateTarget(pc, adjustedStackOffset, out method);
-    }
-
-    public IEnumerable<Field> Modifies(Method method) { return this.ilDecoder.Context.MethodContext.Modifies(method); }
-    public IEnumerable<Method> AffectedGetters(Field field) { return this.ilDecoder.Context.MethodContext.AffectedGetters(field); }
-
-    #endregion
-
-    #region ICFG<Type,APC> Members
-
-    APC ICFG.Entry
-    {
-      get { return cfg.Entry; }
-    }
-
-    APC ICFG.EntryAfterRequires
-    {
-      get { return cfg.EntryAfterRequires; }
-    }
+        public bool IsUnreachable(APC pc) { return false; }
+        #endregion
 
 
-    APC ICFG.NormalExit
-    {
-      get { return cfg.NormalExit; }
-    }
+        #region IStackContext and IMethodContext<Label,Field, Method> Members
 
-    APC ICFG.ExceptionExit
-    {
-      get { return cfg.ExceptionExit; }
-    }
-
-    APC ICFG.Post(APC pc)
-    {
-      ICFG cfg = this;
-      APC succ;
-      if (cfg.HasSingleSuccessor(pc, out succ))
-      {
-        return succ;
-      }
-      return pc;
-    }
-
-    bool ICFG.HasSingleSuccessor(APC ppoint, out APC singleSuccessor)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        return cfg.HasSingleSuccessor(ppoint, out singleSuccessor);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    IEnumerable<APC> ICFG.Successors(APC ppoint)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        foreach (var succ in cfg.Successors(ppoint))
+        /// <summary>
+        /// We don't directly delegate to MethodContext, because we want to return a different CFG
+        /// </summary>
+        public IMethodContextData<Field, Method> MethodContext { get { return this; } }
+        public IStackContextData<Field, Method> StackContext { get { return this; } }
+        public int StackDepth(APC pc)
         {
-          yield return succ; // expanded to keep call adaption in MoveNext
+            return this.Lookup(pc);
         }
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
 
-    bool ICFG.HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        return cfg.HasSinglePredecessor(ppoint, out singlePredecessor, skipContracts);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
-
-    IEnumerable<APC> ICFG.Predecessors(APC ppoint, bool skipContracts)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        foreach (var pred in cfg.Predecessors(ppoint, skipContracts))
+        public bool TryGetCallArgumentDelegateTarget(APC pc, int stackOffset, out Method method)
         {
-          yield return pred; // expanded to keep call adaption
+            int adjustedStackOffset = stackOffset;
+            var context = pc.SubroutineContext;
+            while (context != null)
+            {
+                adjustedStackOffset -= this.LocalStackDepth(new APC(context.Head.One, 0, null));
+                context = context.Tail;
+            }
+            APCMap<int> map = LocalStackMap(pc.Block.Subroutine);
+
+            return map.TryGetArgumentDelegateTarget(pc, adjustedStackOffset, out method);
         }
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
 
-    APC ICFG.PredecessorPCPriorToRequires(APC ppoint)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        return cfg.PredecessorPCPriorToRequires(ppoint);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
+        public IEnumerable<Field> Modifies(Method method) { return ilDecoder.Context.MethodContext.Modifies(method); }
+        public IEnumerable<Method> AffectedGetters(Field field) { return ilDecoder.Context.MethodContext.AffectedGetters(field); }
 
-    FList<Pair<string, Subroutine>> ICFG.GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        return from.Subroutine.GetOrdinaryEdgeSubroutines(from, to, context);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
+        #endregion
+
+        #region ICFG<Type,APC> Members
+
+        APC ICFG.Entry
+        {
+            get { return cfg.Entry; }
+        }
+
+        APC ICFG.EntryAfterRequires
+        {
+            get { return cfg.EntryAfterRequires; }
+        }
 
 
-    bool ICFG.IsJoinPoint(APC ppoint)
-    {
-      return cfg.IsJoinPoint(ppoint);
-    }
+        APC ICFG.NormalExit
+        {
+            get { return cfg.NormalExit; }
+        }
 
-    bool ICFG.IsSplitPoint(APC ppoint)
-    {
-      return cfg.IsSplitPoint(ppoint);
-    }
+        APC ICFG.ExceptionExit
+        {
+            get { return cfg.ExceptionExit; }
+        }
 
-    bool ICFG.IsForwardBackEdgeTarget(APC ppoint)
-    {
-      return cfg.IsForwardBackEdgeTarget(ppoint);
-    }
+        APC ICFG.Post(APC pc)
+        {
+            ICFG cfg = this;
+            APC succ;
+            if (cfg.HasSingleSuccessor(pc, out succ))
+            {
+                return succ;
+            }
+            return pc;
+        }
 
-    bool ICFG.IsBackwardBackEdgeTarget(APC ppoint)
-    {
-      return cfg.IsBackwardBackEdgeTarget(ppoint);
-    }
+        bool ICFG.HasSingleSuccessor(APC ppoint, out APC singleSuccessor)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                return cfg.HasSingleSuccessor(ppoint, out singleSuccessor);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
 
-    bool ICFG.IsForwardBackEdge(APC from, APC to)
-    {
-      return cfg.IsForwardBackEdge(from, to);
-    }
+        IEnumerable<APC> ICFG.Successors(APC ppoint)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                foreach (var succ in cfg.Successors(ppoint))
+                {
+                    yield return succ; // expanded to keep call adaption in MoveNext
+                }
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
 
-    bool ICFG.IsBackwardBackEdge(APC from, APC to)
-    {
-      return cfg.IsBackwardBackEdge(from, to);
-    }
+        bool ICFG.HasSinglePredecessor(APC ppoint, out APC singlePredecessor, bool skipContracts)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                return cfg.HasSinglePredecessor(ppoint, out singlePredecessor, skipContracts);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
 
-    bool ICFG.IsBlockStart(APC ppoint)
-    {
-      return cfg.IsBlockStart(ppoint);
-    }
+        IEnumerable<APC> ICFG.Predecessors(APC ppoint, bool skipContracts)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                foreach (var pred in cfg.Predecessors(ppoint, skipContracts))
+                {
+                    yield return pred; // expanded to keep call adaption
+                }
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
 
-    bool ICFG.IsBlockEnd(APC ppoint)
-    {
-      return cfg.IsBlockEnd(ppoint);
-    }
+        APC ICFG.PredecessorPCPriorToRequires(APC ppoint)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                return cfg.PredecessorPCPriorToRequires(ppoint);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
 
-    IEnumerable<APC> ICFG.ExceptionHandlers<Type2, Data>(APC ppoint, Data data, IHandlerFilter<Type2, Data> handlerPredicate)
-    {
-      return cfg.ExceptionHandlers(ppoint, data, handlerPredicate);
-    }
+        FList<Pair<string, Subroutine>> ICFG.GetOrdinaryEdgeSubroutines(CFGBlock from, CFGBlock to, SubroutineContext context)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                return from.Subroutine.GetOrdinaryEdgeSubroutines(from, to, context);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
 
-    Microsoft.Research.Graphs.IGraph<APC, Unit> ICFG.AsForwardGraph(bool includeExceptionEdges)
-    {
-      return cfg.AsForwardGraph(includeExceptionEdges);
-    }
 
-    Microsoft.Research.Graphs.IGraph<APC, Unit> ICFG.AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
-    {
-      return cfg.AsBackwardGraph(includeExceptionEdges, skipContracts);
-    }
+        bool ICFG.IsJoinPoint(APC ppoint)
+        {
+            return cfg.IsJoinPoint(ppoint);
+        }
 
-    IDecodeMSIL<APC, Local2, Parameter2, Method2, Field2, Type2, Unit, Unit, IMethodContext<Field2, Method2>, Unit> ICFG.GetDecoder<Local2, Parameter2, Method2, Field2, Property2, Event2, Type2, Attribute2, Assembly2>(IDecodeMetaData<Local2, Parameter2, Method2, Field2, Property2, Event2, Type2, Attribute2, Assembly2> mdDecoder)
-    {
-      return cfg.GetDecoder(mdDecoder);
-    }
+        bool ICFG.IsSplitPoint(APC ppoint)
+        {
+            return cfg.IsSplitPoint(ppoint);
+        }
 
-    Subroutine ICFG.Subroutine
-    {
-      get { return cfg.Subroutine; }
-    }
+        bool ICFG.IsForwardBackEdgeTarget(APC ppoint)
+        {
+            return cfg.IsForwardBackEdgeTarget(ppoint);
+        }
 
-    string ICFG.ToString(APC pc)
-    {
-      return cfg.ToString(pc);
-    }
+        bool ICFG.IsBackwardBackEdgeTarget(APC ppoint)
+        {
+            return cfg.IsBackwardBackEdgeTarget(ppoint);
+        }
 
-    void ICFG.Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> edgePrinter, Func<CFGBlock, IEnumerable<FList<STuple<CFGBlock, CFGBlock, string>>>> contextLookup, FList<STuple<CFGBlock, CFGBlock, string>> context)
-    {
-      CallAdaption.Push(this);
-      try
-      {
-        cfg.Print(tw, ilPrinter, edgePrinter, contextLookup, context);
-      }
-      finally
-      {
-        CallAdaption.Pop(this);
-      }
-    }
+        bool ICFG.IsForwardBackEdge(APC from, APC to)
+        {
+            return cfg.IsForwardBackEdge(from, to);
+        }
 
-    IEnumerable<CFGBlock> ICFG.LoopHeads
-    {
-      get { return cfg.LoopHeads; }
-    }
+        bool ICFG.IsBackwardBackEdge(APC from, APC to)
+        {
+            return cfg.IsBackwardBackEdge(from, to);
+        }
+
+        bool ICFG.IsBlockStart(APC ppoint)
+        {
+            return cfg.IsBlockStart(ppoint);
+        }
+
+        bool ICFG.IsBlockEnd(APC ppoint)
+        {
+            return cfg.IsBlockEnd(ppoint);
+        }
+
+        IEnumerable<APC> ICFG.ExceptionHandlers<Type2, Data>(APC ppoint, Data data, IHandlerFilter<Type2, Data> handlerPredicate)
+        {
+            return cfg.ExceptionHandlers(ppoint, data, handlerPredicate);
+        }
+
+        Microsoft.Research.Graphs.IGraph<APC, Unit> ICFG.AsForwardGraph(bool includeExceptionEdges)
+        {
+            return cfg.AsForwardGraph(includeExceptionEdges);
+        }
+
+        Microsoft.Research.Graphs.IGraph<APC, Unit> ICFG.AsBackwardGraph(bool includeExceptionEdges, bool skipContracts)
+        {
+            return cfg.AsBackwardGraph(includeExceptionEdges, skipContracts);
+        }
+
+        IDecodeMSIL<APC, Local2, Parameter2, Method2, Field2, Type2, Unit, Unit, IMethodContext<Field2, Method2>, Unit> ICFG.GetDecoder<Local2, Parameter2, Method2, Field2, Property2, Event2, Type2, Attribute2, Assembly2>(IDecodeMetaData<Local2, Parameter2, Method2, Field2, Property2, Event2, Type2, Attribute2, Assembly2> mdDecoder)
+        {
+            return cfg.GetDecoder(mdDecoder);
+        }
+
+        Subroutine ICFG.Subroutine
+        {
+            get { return cfg.Subroutine; }
+        }
+
+        string ICFG.ToString(APC pc)
+        {
+            return cfg.ToString(pc);
+        }
+
+        void ICFG.Print(TextWriter tw, ILPrinter<APC> ilPrinter, BlockInfoPrinter<APC> edgePrinter, Func<CFGBlock, IEnumerable<FList<STuple<CFGBlock, CFGBlock, string>>>> contextLookup, FList<STuple<CFGBlock, CFGBlock, string>> context)
+        {
+            CallAdaption.Push(this);
+            try
+            {
+                cfg.Print(tw, ilPrinter, edgePrinter, contextLookup, context);
+            }
+            finally
+            {
+                CallAdaption.Pop(this);
+            }
+        }
+
+        IEnumerable<CFGBlock> ICFG.LoopHeads
+        {
+            get { return cfg.LoopHeads; }
+        }
 
 #if false
-    void ICFG.EmitTransferEquations(TextWriter tw, InvariantQuery<APC> invariantDB, AssumptionFinder<APC> assumptionFinder, CrossBlockRenamings<APC> renamings, RenamedVariables<APC> renamed)
-    {
-      cfg.EmitTransferEquations(tw, invariantDB, assumptionFinder, renamings, renamed);
-    }
+        void ICFG.EmitTransferEquations(TextWriter tw, InvariantQuery<APC> invariantDB, AssumptionFinder<APC> assumptionFinder, CrossBlockRenamings<APC> renamings, RenamedVariables<APC> renamed)
+        {
+            cfg.EmitTransferEquations(tw, invariantDB, assumptionFinder, renamings, renamed);
+        }
 #endif
-    #endregion
+        #endregion
 
 
 
-    #region IStackInfo Members
+        #region IStackInfo Members
 
-    bool IStackInfo.IsCallOnThis(APC pc)
-    {
-      if (this.recursionGuard) return false;
+        bool IStackInfo.IsCallOnThis(APC pc)
+        {
+            if (recursionGuard) return false;
 
-      // Specialize for ensures specialization
-      APCMap<int> map = LocalStackMap(pc.Block.Subroutine);
-      return map.IsCallOnThis(pc);
+            // Specialize for ensures specialization
+            APCMap<int> map = LocalStackMap(pc.Block.Subroutine);
+            return map.IsCallOnThis(pc);
+        }
+
+        #endregion
+
+        #region IMethodContextData<Field,Method> Members
+
+        Method IMethodContextData<Field, Method>.CurrentMethod
+        {
+            get { return ilDecoder.Context.MethodContext.CurrentMethod; }
+        }
+
+        ICFG IMethodContextData<Field, Method>.CFG
+        {
+            get { return this; }
+        }
+
+        string IMethodContextData<Field, Method>.SourceContext(APC label)
+        {
+            return ilDecoder.Context.MethodContext.SourceContext(label);
+        }
+
+        string IMethodContextData<Field, Method>.SourceDocument(APC pc)
+        {
+            return ilDecoder.Context.MethodContext.SourceDocument(pc);
+        }
+
+        StackTemp IMethodContextData<Field, Method>.SourceStartLine(APC pc)
+        {
+            return ilDecoder.Context.MethodContext.SourceStartLine(pc);
+        }
+
+        StackTemp IMethodContextData<Field, Method>.SourceEndLine(APC pc)
+        {
+            return ilDecoder.Context.MethodContext.SourceEndLine(pc);
+        }
+
+        StackTemp IMethodContextData<Field, Method>.SourceStartColumn(APC pc)
+        {
+            return ilDecoder.Context.MethodContext.SourceStartColumn(pc);
+        }
+
+        StackTemp IMethodContextData<Field, Method>.SourceEndColumn(APC pc)
+        {
+            return ilDecoder.Context.MethodContext.SourceEndColumn(pc);
+        }
+
+        IEnumerable<Field> IMethodContextData<Field, Method>.Modifies(Method method)
+        {
+            return ilDecoder.Context.MethodContext.Modifies(method);
+        }
+
+        IEnumerable<Method> IMethodContextData<Field, Method>.AffectedGetters(Field field)
+        {
+            return ilDecoder.Context.MethodContext.AffectedGetters(field);
+        }
+
+        #endregion
+
+        #region IDecodeMSIL<APC,Local,Parameter,Method,Field,Type,int,int,IStackContext<Field,Method>,Unit> Members
+
+
+        public Unit EdgeData(APC from, APC to)
+        {
+            return Unit.Value;
+        }
+
+        public void Display(TextWriter tw, string prefix, Unit data) { }
+
+        #endregion
     }
-
-    #endregion
-
-    #region IMethodContextData<Field,Method> Members
-
-    Method IMethodContextData<Field, Method>.CurrentMethod
-    {
-      get { return this.ilDecoder.Context.MethodContext.CurrentMethod; }
-    }
-
-    ICFG IMethodContextData<Field, Method>.CFG
-    {
-      get { return this; }
-    }
-
-    string IMethodContextData<Field, Method>.SourceContext(APC label)
-    {
-      return this.ilDecoder.Context.MethodContext.SourceContext(label);
-    }
-
-    string IMethodContextData<Field, Method>.SourceDocument(APC pc)
-    {
-      return this.ilDecoder.Context.MethodContext.SourceDocument(pc);
-    }
-
-    StackTemp IMethodContextData<Field, Method>.SourceStartLine(APC pc)
-    {
-      return this.ilDecoder.Context.MethodContext.SourceStartLine(pc);
-    }
-
-    StackTemp IMethodContextData<Field, Method>.SourceEndLine(APC pc)
-    {
-      return this.ilDecoder.Context.MethodContext.SourceEndLine(pc);
-    }
-
-    StackTemp IMethodContextData<Field, Method>.SourceStartColumn(APC pc)
-    {
-      return this.ilDecoder.Context.MethodContext.SourceStartColumn(pc);
-    }
-
-    StackTemp IMethodContextData<Field, Method>.SourceEndColumn(APC pc)
-    {
-      return this.ilDecoder.Context.MethodContext.SourceEndColumn(pc);
-    }
-
-    IEnumerable<Field> IMethodContextData<Field, Method>.Modifies(Method method)
-    {
-      return this.ilDecoder.Context.MethodContext.Modifies(method);
-    }
-
-    IEnumerable<Method> IMethodContextData<Field, Method>.AffectedGetters(Field field)
-    {
-      return this.ilDecoder.Context.MethodContext.AffectedGetters(field);
-    }
-
-    #endregion
-
-    #region IDecodeMSIL<APC,Local,Parameter,Method,Field,Type,int,int,IStackContext<Field,Method>,Unit> Members
-
-
-    public Unit EdgeData(APC from, APC to)
-    {
-      return Unit.Value;
-    }
-
-    public void Display(TextWriter tw, string prefix, Unit data) { }
-
-    #endregion
-  }
-
 }


### PR DESCRIPTION
This reformat operation used dotnet/codeformatter@1d719e4e with `/rule-:FieldNames`.